### PR TITLE
AIP-65 structure endpoint rename dag_version to version_number

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -258,14 +258,14 @@ paths:
           type: boolean
           default: false
           title: External Dependencies
-      - name: dag_version
+      - name: version_number
         in: query
         required: false
         schema:
           anyOf:
           - type: integer
           - type: 'null'
-          title: Dag Version
+          title: Version Number
       responses:
         '200':
           description: Successful Response

--- a/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -44,27 +44,27 @@ def structure_data(
     include_downstream: QueryIncludeDownstream = False,
     root: str | None = None,
     external_dependencies: bool = False,
-    dag_version: int | None = None,
+    version_number: int | None = None,
 ) -> StructureDataResponse:
     """Get Structure Data."""
-    if dag_version is None:
+    if version_number is None:
         dag_version_model = DagVersion.get_latest_version(dag_id)
         if dag_version_model is None:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND,
                 f"Dag with id {dag_id} was not found",
             )
-        dag_version = dag_version_model.version_number
+        version_number = dag_version_model.version_number
 
     serialized_dag: SerializedDagModel = session.scalar(
         select(SerializedDagModel)
         .join(DagVersion)
-        .where(SerializedDagModel.dag_id == dag_id, DagVersion.version_number == dag_version)
+        .where(SerializedDagModel.dag_id == dag_id, DagVersion.version_number == version_number)
     )
     if serialized_dag is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
-            f"Dag with id {dag_id} and version {dag_version} was not found",
+            f"Dag with id {dag_id} and version number {version_number} was not found",
         )
     dag = serialized_dag.dag
 

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -359,23 +359,23 @@ export const useStructureServiceStructureDataKey = "StructureServiceStructureDat
 export const UseStructureServiceStructureDataKeyFn = (
   {
     dagId,
-    dagVersion,
     externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
+    versionNumber,
   }: {
     dagId: string;
-    dagVersion?: number;
     externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
+    versionNumber?: number;
   },
   queryKey?: Array<unknown>,
 ) => [
   useStructureServiceStructureDataKey,
-  ...(queryKey ?? [{ dagId, dagVersion, externalDependencies, includeDownstream, includeUpstream, root }]),
+  ...(queryKey ?? [{ dagId, externalDependencies, includeDownstream, includeUpstream, root, versionNumber }]),
 ];
 export type BackfillServiceListBackfillsDefaultResponse = Awaited<
   ReturnType<typeof BackfillService.listBackfills>

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -475,7 +475,7 @@ export const prefetchUseDashboardServiceHistoricalMetrics = (
  * @param data.includeDownstream
  * @param data.root
  * @param data.externalDependencies
- * @param data.dagVersion
+ * @param data.versionNumber
  * @returns StructureDataResponse Successful Response
  * @throws ApiError
  */
@@ -483,37 +483,37 @@ export const prefetchUseStructureServiceStructureData = (
   queryClient: QueryClient,
   {
     dagId,
-    dagVersion,
     externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
+    versionNumber,
   }: {
     dagId: string;
-    dagVersion?: number;
     externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
+    versionNumber?: number;
   },
 ) =>
   queryClient.prefetchQuery({
     queryKey: Common.UseStructureServiceStructureDataKeyFn({
       dagId,
-      dagVersion,
       externalDependencies,
       includeDownstream,
       includeUpstream,
       root,
+      versionNumber,
     }),
     queryFn: () =>
       StructureService.structureData({
         dagId,
-        dagVersion,
         externalDependencies,
         includeDownstream,
         includeUpstream,
         root,
+        versionNumber,
       }),
   });
 /**

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -585,7 +585,7 @@ export const useDashboardServiceHistoricalMetrics = <
  * @param data.includeDownstream
  * @param data.root
  * @param data.externalDependencies
- * @param data.dagVersion
+ * @param data.versionNumber
  * @returns StructureDataResponse Successful Response
  * @throws ApiError
  */
@@ -596,35 +596,35 @@ export const useStructureServiceStructureData = <
 >(
   {
     dagId,
-    dagVersion,
     externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
+    versionNumber,
   }: {
     dagId: string;
-    dagVersion?: number;
     externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
+    versionNumber?: number;
   },
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
     queryKey: Common.UseStructureServiceStructureDataKeyFn(
-      { dagId, dagVersion, externalDependencies, includeDownstream, includeUpstream, root },
+      { dagId, externalDependencies, includeDownstream, includeUpstream, root, versionNumber },
       queryKey,
     ),
     queryFn: () =>
       StructureService.structureData({
         dagId,
-        dagVersion,
         externalDependencies,
         includeDownstream,
         includeUpstream,
         root,
+        versionNumber,
       }) as TData,
     ...options,
   });

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -564,7 +564,7 @@ export const useDashboardServiceHistoricalMetricsSuspense = <
  * @param data.includeDownstream
  * @param data.root
  * @param data.externalDependencies
- * @param data.dagVersion
+ * @param data.versionNumber
  * @returns StructureDataResponse Successful Response
  * @throws ApiError
  */
@@ -575,35 +575,35 @@ export const useStructureServiceStructureDataSuspense = <
 >(
   {
     dagId,
-    dagVersion,
     externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
+    versionNumber,
   }: {
     dagId: string;
-    dagVersion?: number;
     externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
+    versionNumber?: number;
   },
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseStructureServiceStructureDataKeyFn(
-      { dagId, dagVersion, externalDependencies, includeDownstream, includeUpstream, root },
+      { dagId, externalDependencies, includeDownstream, includeUpstream, root, versionNumber },
       queryKey,
     ),
     queryFn: () =>
       StructureService.structureData({
         dagId,
-        dagVersion,
         externalDependencies,
         includeDownstream,
         includeUpstream,
         root,
+        versionNumber,
       }) as TData,
     ...options,
   });

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -740,7 +740,7 @@ export class StructureService {
    * @param data.includeDownstream
    * @param data.root
    * @param data.externalDependencies
-   * @param data.dagVersion
+   * @param data.versionNumber
    * @returns StructureDataResponse Successful Response
    * @throws ApiError
    */
@@ -754,7 +754,7 @@ export class StructureService {
         include_downstream: data.includeDownstream,
         root: data.root,
         external_dependencies: data.externalDependencies,
-        dag_version: data.dagVersion,
+        version_number: data.versionNumber,
       },
       errors: {
         404: "Not Found",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1667,11 +1667,11 @@ export type HistoricalMetricsResponse = HistoricalMetricDataResponse;
 
 export type StructureDataData = {
   dagId: string;
-  dagVersion?: number | null;
   externalDependencies?: boolean;
   includeDownstream?: boolean;
   includeUpstream?: boolean;
   root?: string | null;
+  versionNumber?: number | null;
 };
 
 export type StructureDataResponse2 = StructureDataResponse;

--- a/tests/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_structure.py
@@ -481,17 +481,17 @@ class TestStructureDataEndpoint:
                 id="get_default_version",
             ),
             pytest.param(
-                {"dag_id": DAG_ID, "dag_version": 1},
+                {"dag_id": DAG_ID, "version_number": 1},
                 FIRST_VERSION_DAG_RESPONSE,
                 id="get_oldest_version",
             ),
             pytest.param(
-                {"dag_id": DAG_ID, "dag_version": 2},
+                {"dag_id": DAG_ID, "version_number": 2},
                 SECOND_VERSION_DAG_RESPONSE,
                 id="get_specific_version",
             ),
             pytest.param(
-                {"dag_id": DAG_ID, "dag_version": 3},
+                {"dag_id": DAG_ID, "version_number": 3},
                 LATEST_VERSION_DAG_RESPONSE,
                 id="get_latest_version",
             ),
@@ -510,7 +510,7 @@ class TestStructureDataEndpoint:
 
     def test_should_return_404_when_dag_version_not_found(self, test_client):
         response = test_client.get(
-            "/ui/structure/structure_data", params={"dag_id": DAG_ID, "dag_version": 999}
+            "/ui/structure/structure_data", params={"dag_id": DAG_ID, "version_number": 999}
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == "Dag with id test_dag_id and version 999 was not found"
+        assert response.json()["detail"] == "Dag with id test_dag_id and version number 999 was not found"


### PR DESCRIPTION
Followup of https://github.com/apache/airflow/pull/46279

`dag_version` is a weird name because it's the name of the ORM object / table. It is hard to know from a client side if this is the `dag_version_id` (pk) or the `version_number` that we expect.

Updated it to `version_number` to avoid confusion as this is also what we are doing on the public api side.