### PR TITLE
Add autorefresh to dags list page

### DIFF
--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -20,7 +20,11 @@ import { useDisclosure } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
-import { useDagServiceGetDagsKey, useDagServicePatchDag } from "openapi/queries";
+import {
+  UseDagServiceGetDagDetailsKeyFn,
+  useDagServiceGetDagsKey,
+  useDagServicePatchDag,
+} from "openapi/queries";
 import { useConfig } from "src/queries/useConfig";
 
 import { ConfirmationModal } from "./ConfirmationModal";
@@ -43,7 +47,7 @@ export const TogglePause = ({ dagDisplayName, dagId, isPaused, skipConfirm }: Pr
     });
 
     await queryClient.invalidateQueries({
-      queryKey: [useDagServiceGetDagsKey],
+      queryKey: UseDagServiceGetDagDetailsKeyFn({ dagId }),
     });
   };
 

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -20,12 +20,7 @@ import { useDisclosure } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
-import {
-  UseDagServiceGetDagDetailsKeyFn,
-  useDagServiceGetDagsKey,
-  useDagServicePatchDag,
-} from "openapi/queries";
-import type { DAGDetailsResponse } from "openapi/requests/types.gen";
+import { useDagServiceGetDagsKey, useDagServicePatchDag } from "openapi/queries";
 import { useConfig } from "src/queries/useConfig";
 
 import { ConfirmationModal } from "./ConfirmationModal";
@@ -43,17 +38,10 @@ export const TogglePause = ({ dagDisplayName, dagId, isPaused, skipConfirm }: Pr
   const { onClose, onOpen, open } = useDisclosure();
 
   const onSuccess = async () => {
-    // We can just update dag details
-    queryClient.setQueryData<DAGDetailsResponse>(UseDagServiceGetDagDetailsKeyFn({ dagId }), (oldData) =>
-      oldData
-        ? {
-            ...oldData,
-            is_paused: !oldData.is_paused,
-          }
-        : undefined,
-    );
+    await queryClient.invalidateQueries({
+      queryKey: [useDagServiceGetDagsKey],
+    });
 
-    // But we need to invalidate the dag list, or we need to check which exact query caches to update
     await queryClient.invalidateQueries({
       queryKey: [useDagServiceGetDagsKey],
     });

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -25,6 +25,7 @@ import {
   useDagServiceGetDagsKey,
   useDagServicePatchDag,
 } from "openapi/queries";
+import type { DAGDetailsResponse } from "openapi/requests/types.gen";
 import { useConfig } from "src/queries/useConfig";
 
 import { ConfirmationModal } from "./ConfirmationModal";
@@ -42,12 +43,19 @@ export const TogglePause = ({ dagDisplayName, dagId, isPaused, skipConfirm }: Pr
   const { onClose, onOpen, open } = useDisclosure();
 
   const onSuccess = async () => {
+    // We can just update dag details
+    queryClient.setQueryData<DAGDetailsResponse>(UseDagServiceGetDagDetailsKeyFn({ dagId }), (oldData) =>
+      oldData
+        ? {
+            ...oldData,
+            is_paused: !oldData.is_paused,
+          }
+        : undefined,
+    );
+
+    // But we need to invalidate the dag list, or we need to check which exact query caches to update
     await queryClient.invalidateQueries({
       queryKey: [useDagServiceGetDagsKey],
-    });
-
-    await queryClient.invalidateQueries({
-      queryKey: UseDagServiceGetDagDetailsKeyFn({ dagId }),
     });
   };
 

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, SimpleGrid, Link } from "@chakra-ui/react";
+import { Box, Flex, HStack, SimpleGrid, Link, Spinner } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
@@ -25,6 +25,7 @@ import { Stat } from "src/components/Stat";
 import { TogglePause } from "src/components/TogglePause";
 import TriggerDAGButton from "src/components/TriggerDag/TriggerDAGButton";
 import { Tooltip } from "src/components/ui";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import { DagTags } from "./DagTags";
 import { RecentRuns } from "./RecentRuns";
@@ -36,6 +37,8 @@ type Props = {
 
 export const DagCard = ({ dag }: Props) => {
   const [latestRun] = dag.latest_dag_runs;
+
+  const refetchInterval = useAutoRefresh({ dagId: dag.dag_id });
 
   return (
     <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden">
@@ -68,6 +71,7 @@ export const DagCard = ({ dag }: Props) => {
                   startDate={latestRun.start_date}
                   state={latestRun.state}
                 />
+                {isStatePending(latestRun.state) && Boolean(refetchInterval) ? <Spinner /> : undefined}
               </RouterLink>
             </Link>
           ) : undefined}

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -189,7 +189,7 @@ export const DagsList = () => {
     paused = false;
   }
 
-  const { data, error, isFetching, isLoading } = useDags({
+  const { data, error, isLoading } = useDags({
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? `${dagDisplayNamePattern}` : undefined,
     lastDagRunState,
     limit: pagination.pageSize,
@@ -244,7 +244,6 @@ export const DagsList = () => {
           displayMode={display}
           errorMessage={<ErrorAlert error={error} />}
           initialState={tableURLState}
-          isFetching={isFetching}
           isLoading={isLoading}
           modelName="Dag"
           onStateChange={setTableURLState}

--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -18,6 +18,7 @@
  */
 import { useDagServiceGetDags, useDagsServiceRecentDagRuns } from "openapi/queries";
 import type { DagRunState, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 export type DagWithLatest = {
   last_run_start_date: string;
@@ -39,16 +40,27 @@ export const useDags = (
 ) => {
   const { data, error, isFetching, isLoading } = useDagServiceGetDags(searchParams);
 
+  const refetchInterval = useAutoRefresh({});
+
   const { orderBy, ...runsParams } = searchParams;
   const {
     data: runsData,
     error: runsError,
     isFetching: isRunsFetching,
     isLoading: isRunsLoading,
-  } = useDagsServiceRecentDagRuns({
-    ...runsParams,
-    dagRunsLimit: 14,
-  });
+  } = useDagsServiceRecentDagRuns(
+    {
+      ...runsParams,
+      dagRunsLimit: 14,
+    },
+    undefined,
+    {
+      refetchInterval: (query) =>
+        query.state.data?.dags.some((dag) => dag.latest_dag_runs.some((dr) => isStatePending(dr.state)))
+          ? refetchInterval
+          : false,
+    },
+  );
 
   const dags = (data?.dags ?? []).map((dag) => {
     const dagWithRuns = runsData?.dags.find((runsDag) => runsDag.dag_id === dag.dag_id);


### PR DESCRIPTION
Add auto refresh to dags list.

Replace the isFetching progress bar with a spinner on each refreshing dag (has an active run and is not paused)

Update the dag details query cache instead of refreshing on toggling is_paused

<img width="1197" alt="Screenshot 2025-01-31 at 11 29 35 AM" src="https://github.com/user-attachments/assets/b5e4bdaa-57cb-4ba2-9d34-d0ed1e0c50b1" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
