### PR TITLE
AIP-84 Remove unecessary datamodels config and from_attributes

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/dag_tags.py
+++ b/airflow/api_fastapi/core_api/datamodels/dag_tags.py
@@ -17,15 +17,11 @@
 
 from __future__ import annotations
 
-from pydantic import ConfigDict
-
 from airflow.api_fastapi.core_api.base import BaseModel
 
 
 class DagTagResponse(BaseModel):
     """DAG Tag serializer for responses."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     name: str
     dag_id: str

--- a/airflow/api_fastapi/core_api/datamodels/event_logs.py
+++ b/airflow/api_fastapi/core_api/datamodels/event_logs.py
@@ -19,15 +19,13 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from airflow.api_fastapi.core_api.base import BaseModel
 
 
 class EventLogResponse(BaseModel):
     """Event Log Response."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     id: int = Field(alias="event_log_id")
     dttm: datetime = Field(alias="when")

--- a/airflow/api_fastapi/core_api/datamodels/import_error.py
+++ b/airflow/api_fastapi/core_api/datamodels/import_error.py
@@ -18,15 +18,13 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from airflow.api_fastapi.core_api.base import BaseModel
 
 
 class ImportErrorResponse(BaseModel):
     """Import Error Response."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     id: int = Field(alias="import_error_id")
     timestamp: datetime

--- a/airflow/api_fastapi/core_api/datamodels/pools.py
+++ b/airflow/api_fastapi/core_api/datamodels/pools.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Annotated, Callable
 
-from pydantic import BeforeValidator, ConfigDict, Field
+from pydantic import BeforeValidator, Field
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 
@@ -62,8 +62,6 @@ class PoolCollectionResponse(BaseModel):
 
 class PoolPatchBody(StrictBaseModel):
     """Pool serializer for patch bodies."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     name: str | None = Field(default=None, alias="pool")
     slots: int | None = None

--- a/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -23,7 +23,6 @@ from pydantic import (
     AliasPath,
     AwareDatetime,
     BeforeValidator,
-    ConfigDict,
     Field,
     NonNegativeInt,
     StringConstraints,
@@ -40,8 +39,6 @@ from airflow.utils.state import TaskInstanceState
 
 class TaskInstanceResponse(BaseModel):
     """TaskInstance serializer for responses."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     id: str
     task_id: str
@@ -123,8 +120,6 @@ class TaskInstancesBatchBody(StrictBaseModel):
 
 class TaskInstanceHistoryResponse(BaseModel):
     """TaskInstanceHistory serializer for responses."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     task_id: str
     dag_id: str

--- a/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.models.base import ID_LEN
@@ -29,8 +29,6 @@ from airflow.utils.log.secrets_masker import redact
 
 class VariableResponse(BaseModel):
     """Variable serializer for responses."""
-
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     key: str
     val: str = Field(alias="value")

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -37,7 +37,6 @@ from airflow.api_fastapi.common.parameters import (
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.job import (
     JobCollectionResponse,
-    JobResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.jobs.job import Job
@@ -124,12 +123,6 @@ def get_jobs(
         jobs = [job for job in jobs if job.is_alive()]
 
     return JobCollectionResponse(
-        jobs=[
-            JobResponse.model_validate(
-                job,
-                from_attributes=True,
-            )
-            for job in jobs
-        ],
+        jobs=jobs,
         total_entries=total_entries,
     )

--- a/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -651,13 +651,7 @@ def post_clear_task_instances(
         )
 
     return TaskInstanceCollectionResponse(
-        task_instances=[
-            TaskInstanceResponse.model_validate(
-                ti,
-                from_attributes=True,
-            )
-            for ti in task_instances
-        ],
+        task_instances=task_instances,
         total_entries=len(task_instances),
     )
 
@@ -767,7 +761,6 @@ def patch_task_instance_dry_run(
         task_instances=[
             TaskInstanceResponse.model_validate(
                 ti,
-                from_attributes=True,
             )
             for ti in tis
         ],
@@ -832,4 +825,4 @@ def patch_task_instance(
                     ti.task_instance_note.user_id = None
                 session.commit()
 
-    return TaskInstanceResponse.model_validate(ti, from_attributes=True)
+    return TaskInstanceResponse.model_validate(ti)

--- a/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -30,7 +30,6 @@ from sqlalchemy.sql import select
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
-    DagRun,
     PrevSuccessfulDagRunResponse,
     TIDeferredStatePayload,
     TIEnterRunningPayload,
@@ -170,7 +169,7 @@ def ti_run(
             )
 
         return TIRunContext(
-            dag_run=DagRun.model_validate(dr, from_attributes=True),
+            dag_run=dr,
             max_tries=max_tries,
             # TODO: Add variables and connections that are needed (and has perms) for the task
             variables=[],


### PR DESCRIPTION
I realized we had some remnant of `from_attributes=True` on some datamodels. This is not needed anymore because it is the base class default behavior.