### PR TITLE
Add basic autorefresh to grid and graph

### DIFF
--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -24,6 +24,7 @@ import { useParams } from "react-router-dom";
 import { useGridServiceGridData, useStructureServiceStructureData } from "openapi/queries";
 import { useColorMode } from "src/context/colorMode";
 import { useOpenGroups } from "src/context/openGroups";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import Edge from "./Edge";
 import { JoinNode } from "./JoinNode";
@@ -87,6 +88,8 @@ export const Graph = () => {
     openGroupIds,
   });
 
+  const refetchInterval = useAutoRefresh({ dagId });
+
   const { data: gridData } = useGridServiceGridData(
     {
       dagId,
@@ -97,6 +100,8 @@ export const Graph = () => {
     undefined,
     {
       enabled: Boolean(runId),
+      refetchInterval: (query) =>
+        query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) && refetchInterval,
     },
   );
 

--- a/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -27,6 +27,7 @@ import { useParams, useSearchParams } from "react-router-dom";
 import { useGridServiceGridData, useStructureServiceStructureData } from "openapi/queries";
 import type { GridResponse } from "openapi/requests/types.gen";
 import { useOpenGroups } from "src/context/openGroups";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import { Bar } from "./Bar";
 import { DurationAxis } from "./DurationAxis";
@@ -47,6 +48,7 @@ export const Grid = () => {
   });
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const refetchInterval = useAutoRefresh({ dagId });
 
   const offset = parseInt(searchParams.get("offset") ?? "0", 10);
 
@@ -62,6 +64,8 @@ export const Grid = () => {
     undefined,
     {
       placeholderData: keepPreviousData,
+      refetchInterval: (query) =>
+        query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) && refetchInterval,
     },
   );
 


### PR DESCRIPTION
Add very basic auto refresh to the grid and graph views. We can do more here later if each request is too cumbersome for large dags.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
