### PR TITLE
Make constraints compatible with Airflow 3.0

### DIFF
--- a/constraints-3.10.txt
+++ b/constraints-3.10.txt
@@ -34,7 +34,7 @@ Authlib==1.3.1
 ConfigUpdater==3.2
 Deprecated==1.2.18
 Events==0.5
-Flask-AppBuilder==4.5.2
+Flask-AppBuilder==4.5.3
 Flask-Babel==2.0.0
 Flask-Bcrypt==1.0.1
 Flask-Caching==2.3.0

--- a/constraints-3.11.txt
+++ b/constraints-3.11.txt
@@ -34,7 +34,7 @@ Authlib==1.3.1
 ConfigUpdater==3.2
 Deprecated==1.2.18
 Events==0.5
-Flask-AppBuilder==4.5.2
+Flask-AppBuilder==4.5.3
 Flask-Babel==2.0.0
 Flask-Bcrypt==1.0.1
 Flask-Caching==2.3.0

--- a/constraints-3.12.txt
+++ b/constraints-3.12.txt
@@ -34,7 +34,7 @@ Authlib==1.3.1
 ConfigUpdater==3.2
 Deprecated==1.2.18
 Events==0.5
-Flask-AppBuilder==4.5.2
+Flask-AppBuilder==4.5.3
 Flask-Babel==2.0.0
 Flask-Bcrypt==1.0.1
 Flask-Caching==2.3.0

--- a/constraints-3.9.txt
+++ b/constraints-3.9.txt
@@ -34,7 +34,7 @@ Authlib==1.3.1
 ConfigUpdater==3.2
 Deprecated==1.2.18
 Events==0.5
-Flask-AppBuilder==4.5.2
+Flask-AppBuilder==4.5.3
 Flask-Babel==2.0.0
 Flask-Bcrypt==1.0.1
 Flask-Caching==2.3.0


### PR DESCRIPTION
Due to dependency conflicts we need to make the constraint compatible manually -

```
The conflict is caused by:
    apache-airflow 3.0.0 depends on flask-appbuilder==4.5.3
    The user requested (constraint) flask-appbuilder==4.5.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```