### PR TITLE
Adding extra links for EC2

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/links/ec2.py
+++ b/providers/src/airflow/providers/amazon/aws/links/ec2.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK, BaseAwsLink
+
+
+class EC2InstanceLink(BaseAwsLink):
+    """Helper class for constructing Amazon EC2 instance links."""
+
+    name = "Instance"
+    key = "_instance_id"
+    format_str = (
+        BASE_AWS_CONSOLE_LINK + "/ec2/home?region={region_name}#InstanceDetails:instanceId={instance_id}"
+    )
+
+
+class EC2InstanceDashboardLink(BaseAwsLink):
+    """
+    Helper class for constructing Amazon EC2 console links.
+
+    This is useful for displaying the list of EC2 instances, rather
+    than a single instance.
+    """
+
+    name = "EC2 Instances"
+    key = "_instance_dashboard"
+    format_str = BASE_AWS_CONSOLE_LINK + "/ec2/home?region={region_name}#Instances:instanceState={state}"

--- a/providers/src/airflow/providers/amazon/aws/links/ec2.py
+++ b/providers/src/airflow/providers/amazon/aws/links/ec2.py
@@ -39,4 +39,9 @@ class EC2InstanceDashboardLink(BaseAwsLink):
 
     name = "EC2 Instances"
     key = "_instance_dashboard"
-    format_str = BASE_AWS_CONSOLE_LINK + "/ec2/home?region={region_name}#Instances:instanceState={state}"
+    format_str = BASE_AWS_CONSOLE_LINK + "/ec2/home?region={region_name}#Instances:instanceId=:{instance_ids}"
+    # Instances:instanceId=:
+
+    @staticmethod
+    def format_instance_id_filter(instance_ids: list[str]) -> str:
+        return ",:".join(instance_ids)

--- a/providers/src/airflow/providers/amazon/aws/links/ec2.py
+++ b/providers/src/airflow/providers/amazon/aws/links/ec2.py
@@ -40,7 +40,6 @@ class EC2InstanceDashboardLink(BaseAwsLink):
     name = "EC2 Instances"
     key = "_instance_dashboard"
     format_str = BASE_AWS_CONSOLE_LINK + "/ec2/home?region={region_name}#Instances:instanceId=:{instance_ids}"
-    # Instances:instanceId=:
 
     @staticmethod
     def format_instance_id_filter(instance_ids: list[str]) -> str:

--- a/providers/src/airflow/providers/amazon/aws/operators/ec2.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/ec2.py
@@ -26,7 +26,6 @@ from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
 from airflow.providers.amazon.aws.links.ec2 import (
     EC2InstanceDashboardLink,
     EC2InstanceLink,
-    # format_instance_id_filter,
 )
 
 if TYPE_CHECKING:

--- a/providers/src/airflow/providers/amazon/aws/operators/ec2.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/ec2.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
+from airflow.providers.amazon.aws.links.ec2 import EC2InstanceDashboardLink, EC2InstanceLink
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -47,6 +48,7 @@ class EC2StartInstanceOperator(BaseOperator):
         between each instance state checks until operation is completed
     """
 
+    operator_extra_links = (EC2InstanceLink(),)
     template_fields: Sequence[str] = ("instance_id", "region_name")
     ui_color = "#eeaa11"
     ui_fgcolor = "#ffffff"
@@ -71,6 +73,13 @@ class EC2StartInstanceOperator(BaseOperator):
         self.log.info("Starting EC2 instance %s", self.instance_id)
         instance = ec2_hook.get_instance(instance_id=self.instance_id)
         instance.start()
+        EC2InstanceLink.persist(
+            context=context,
+            operator=self,
+            aws_partition=ec2_hook.conn_partition,
+            instance_id=self.instance_id,
+            region_name=ec2_hook.conn_region_name,
+        )
         ec2_hook.wait_for_state(
             instance_id=self.instance_id,
             target_state="running",
@@ -97,6 +106,7 @@ class EC2StopInstanceOperator(BaseOperator):
         between each instance state checks until operation is completed
     """
 
+    operator_extra_links = (EC2InstanceLink(),)
     template_fields: Sequence[str] = ("instance_id", "region_name")
     ui_color = "#eeaa11"
     ui_fgcolor = "#ffffff"
@@ -120,7 +130,15 @@ class EC2StopInstanceOperator(BaseOperator):
         ec2_hook = EC2Hook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
         self.log.info("Stopping EC2 instance %s", self.instance_id)
         instance = ec2_hook.get_instance(instance_id=self.instance_id)
+        EC2InstanceLink.persist(
+            context=context,
+            operator=self,
+            aws_partition=ec2_hook.conn_partition,
+            instance_id=self.instance_id,
+            region_name=ec2_hook.conn_region_name,
+        )
         instance.stop()
+
         ec2_hook.wait_for_state(
             instance_id=self.instance_id,
             target_state="stopped",
@@ -154,6 +172,7 @@ class EC2CreateInstanceOperator(BaseOperator):
         in the `running` state before returning.
     """
 
+    operator_extra_links = (EC2InstanceDashboardLink(),)
     template_fields: Sequence[str] = (
         "image_id",
         "max_count",
@@ -197,6 +216,14 @@ class EC2CreateInstanceOperator(BaseOperator):
             **self.config,
         )["Instances"]
 
+        # Console link is for EC2 dashboard list, not individual instances
+        EC2InstanceDashboardLink.persist(
+            context=context,
+            operator=self,
+            region_name=ec2_hook.conn_region_name,
+            aws_partition=ec2_hook.conn_partition,
+            state="running",
+        )
         instance_ids = self._on_kill_instance_ids = [instance["InstanceId"] for instance in instances]
         for instance_id in instance_ids:
             self.log.info("Created EC2 instance %s", instance_id)
@@ -311,6 +338,7 @@ class EC2RebootInstanceOperator(BaseOperator):
         in the `running` state before returning.
     """
 
+    operator_extra_links = (EC2InstanceDashboardLink(),)
     template_fields: Sequence[str] = ("instance_ids", "region_name")
     ui_color = "#eeaa11"
     ui_fgcolor = "#ffffff"
@@ -341,6 +369,14 @@ class EC2RebootInstanceOperator(BaseOperator):
         self.log.info("Rebooting EC2 instances %s", ", ".join(self.instance_ids))
         ec2_hook.conn.reboot_instances(InstanceIds=self.instance_ids)
 
+        # Console link is for EC2 dashboard list, not individual instances
+        EC2InstanceDashboardLink.persist(
+            context=context,
+            operator=self,
+            region_name=ec2_hook.conn_region_name,
+            aws_partition=ec2_hook.conn_partition,
+            state="running",
+        )
         if self.wait_for_completion:
             ec2_hook.get_waiter("instance_running").wait(
                 InstanceIds=self.instance_ids,
@@ -374,6 +410,7 @@ class EC2HibernateInstanceOperator(BaseOperator):
         in the `stopped` state before returning.
     """
 
+    operator_extra_links = (EC2InstanceDashboardLink(),)
     template_fields: Sequence[str] = ("instance_ids", "region_name")
     ui_color = "#eeaa11"
     ui_fgcolor = "#ffffff"
@@ -403,6 +440,15 @@ class EC2HibernateInstanceOperator(BaseOperator):
         ec2_hook = EC2Hook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, api_type="client_type")
         self.log.info("Hibernating EC2 instances %s", ", ".join(self.instance_ids))
         instances = ec2_hook.get_instances(instance_ids=self.instance_ids)
+
+        # Console link is for EC2 dashboard list, not individual instances
+        EC2InstanceDashboardLink.persist(
+            context=context,
+            operator=self,
+            region_name=ec2_hook.conn_region_name,
+            aws_partition=ec2_hook.conn_partition,
+            state="stopping",
+        )
 
         for instance in instances:
             hibernation_options = instance.get("HibernationOptions")

--- a/providers/src/airflow/providers/amazon/provider.yaml
+++ b/providers/src/airflow/providers/amazon/provider.yaml
@@ -891,7 +891,8 @@ extra-links:
   - airflow.providers.amazon.aws.links.comprehend.ComprehendDocumentClassifierLink
   - airflow.providers.amazon.aws.links.datasync.DataSyncTaskLink
   - airflow.providers.amazon.aws.links.datasync.DataSyncTaskExecutionLink
-
+  - airflow.providers.amazon.aws.links.ec2.EC2InstanceLink
+  - airflow.providers.amazon.aws.links.ec2.EC2InstanceDashboardLink
 
 connection-types:
   - hook-class-name: airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook

--- a/providers/tests/amazon/aws/links/test_ec2.py
+++ b/providers/tests/amazon/aws/links/test_ec2.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.amazon.aws.links.ec2 import EC2InstanceDashboardLink, EC2InstanceLink
+
+from providers.tests.amazon.aws.links.test_base_aws import BaseAwsLinksTestCase
+
+
+class TestEC2InstanceLink(BaseAwsLinksTestCase):
+    link_class = EC2InstanceLink
+
+    INSTANCE_ID = "i-xxxxxxxxxxxx"
+
+    def test_extra_link(self):
+        self.assert_extra_link_url(
+            expected_url=(
+                "https://console.aws.amazon.com/ec2/home"
+                f"?region=eu-west-1#InstanceDetails:instanceId={self.INSTANCE_ID}"
+            ),
+            region_name="eu-west-1",
+            aws_partition="aws",
+            instance_id=self.INSTANCE_ID,
+        )
+
+
+class TestEC2InstanceDashboardLink(BaseAwsLinksTestCase):
+    link_class = EC2InstanceDashboardLink
+
+    STATE = "running"
+    BASE_URL = "https://console.aws.amazon.com/ec2/home"
+
+    def test_extra_link(self):
+        self.assert_extra_link_url(
+            expected_url=(f"{self.BASE_URL}?region=eu-west-1#Instances:instanceState={self.STATE}"),
+            region_name="eu-west-1",
+            aws_partition="aws",
+            state=self.STATE,
+        )

--- a/providers/tests/amazon/aws/links/test_ec2.py
+++ b/providers/tests/amazon/aws/links/test_ec2.py
@@ -41,7 +41,6 @@ class TestEC2InstanceLink(BaseAwsLinksTestCase):
 class TestEC2InstanceDashboardLink(BaseAwsLinksTestCase):
     link_class = EC2InstanceDashboardLink
 
-    # STATE = "running"
     BASE_URL = "https://console.aws.amazon.com/ec2/home"
     INSTANCE_IDS = ["i-xxxxxxxxxxxx", "i-yyyyyyyyyyyy"]
 

--- a/providers/tests/amazon/aws/links/test_ec2.py
+++ b/providers/tests/amazon/aws/links/test_ec2.py
@@ -41,13 +41,20 @@ class TestEC2InstanceLink(BaseAwsLinksTestCase):
 class TestEC2InstanceDashboardLink(BaseAwsLinksTestCase):
     link_class = EC2InstanceDashboardLink
 
-    STATE = "running"
+    # STATE = "running"
     BASE_URL = "https://console.aws.amazon.com/ec2/home"
+    INSTANCE_IDS = ["i-xxxxxxxxxxxx", "i-yyyyyyyyyyyy"]
+
+    def test_instance_id_filter(self):
+        instance_list = ",:".join(self.INSTANCE_IDS)
+        result = EC2InstanceDashboardLink.format_instance_id_filter(self.INSTANCE_IDS)
+        assert result == instance_list
 
     def test_extra_link(self):
+        instance_list = ",:".join(self.INSTANCE_IDS)
         self.assert_extra_link_url(
-            expected_url=(f"{self.BASE_URL}?region=eu-west-1#Instances:instanceState={self.STATE}"),
+            expected_url=(f"{self.BASE_URL}?region=eu-west-1#Instances:instanceId=:{instance_list}"),
             region_name="eu-west-1",
             aws_partition="aws",
-            state=self.STATE,
+            instance_ids=EC2InstanceDashboardLink.format_instance_id_filter(self.INSTANCE_IDS),
         )


### PR DESCRIPTION

---
Added extra links to EC2 operators. For operators w/ single instance id, the link directs the user to the specific instance's page. For multiple instances, the link directs the user to the instance list.