### PR TITLE
Fix DAGs being deactivated as "deleted"

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -542,7 +542,7 @@ class DagFileProcessorManager:
         """
 
         for info in active_files:
-            for path in _iter_dag_filelocs(str(info.absolute_path)):
+            for path in _iter_dag_filelocs(str(info.rel_path)):
                 active_subpaths.add((info.bundle_name, path))
 
         DagModel.deactivate_deleted_dags(active_subpaths)


### PR DESCRIPTION
We missed a spot when switching to using relative_fileloc during parsing, and it was causing all DAGs to be deactivated because Airflow thought the file they were is was deleted. This fixes it so we are using relative_fileloc on both sides.