### PR TITLE
Reducing dedent to fix doc building issues in CI

### DIFF
--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -215,7 +215,7 @@ that row.
 
 .. exampleinclude:: /../../providers/tests/system/google/cloud/bigquery/example_bigquery_queries.py
     :language: python
-    :dedent: 8
+    :dedent: 4
     :start-after: [START howto_operator_bigquery_get_data]
     :end-before: [END howto_operator_bigquery_get_data]
 
@@ -313,7 +313,7 @@ with proper query job configuration that can be Jinja templated.
 
 .. exampleinclude:: /../../providers/tests/system/google/cloud/bigquery/example_bigquery_queries.py
     :language: python
-    :dedent: 8
+    :dedent: 4
     :start-after: [START howto_operator_bigquery_insert_job]
     :end-before: [END howto_operator_bigquery_insert_job]
 
@@ -336,7 +336,7 @@ language as follow:
 
 .. exampleinclude:: /../../providers/tests/system/google/cloud/bigquery/example_bigquery_queries.py
     :language: python
-    :dedent: 8
+    :dedent: 4
     :start-after: [START howto_operator_bigquery_select_job]
     :end-before: [END howto_operator_bigquery_select_job]
 
@@ -373,7 +373,7 @@ return ``False`` the check is failed and errors out.
 
 .. exampleinclude:: /../../providers/tests/system/google/cloud/bigquery/example_bigquery_queries.py
     :language: python
-    :dedent: 8
+    :dedent: 4
     :start-after: [START howto_operator_bigquery_check]
     :end-before: [END howto_operator_bigquery_check]
 
@@ -399,7 +399,7 @@ or numeric value. If numeric, you can also specify ``tolerance``.
 
 .. exampleinclude:: /../../providers/tests/system/google/cloud/bigquery/example_bigquery_queries.py
     :language: python
-    :dedent: 8
+    :dedent: 4
     :start-after: [START howto_operator_bigquery_value_check]
     :end-before: [END howto_operator_bigquery_value_check]
 
@@ -423,7 +423,7 @@ tolerance of the ones from ``days_back`` before you can either use
 
 .. exampleinclude:: /../../providers/tests/system/google/cloud/bigquery/example_bigquery_queries.py
     :language: python
-    :dedent: 8
+    :dedent: 4
     :start-after: [START howto_operator_bigquery_interval_check]
     :end-before: [END howto_operator_bigquery_interval_check]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

CI ran into failure:
```
############################## Start docs build errors summary ##############################

============================== apache-airflow-providers-google ==============================
------------------------------ Error   1 --------------------
 WARNING: non-whitespace stripped by dedent

File path: apache-airflow-providers-google/operators/cloud/bigquery.rst.rst (216)
------------------------------ Error   2 --------------------
 WARNING: non-whitespace stripped by dedent

File path: apache-airflow-providers-google/operators/cloud/bigquery.rst.rst (314)
------------------------------ Error   3 --------------------
 WARNING: non-whitespace stripped by dedent

File path: apache-airflow-providers-google/operators/cloud/bigquery.rst.rst (337)
------------------------------ Error   4 --------------------
 WARNING: non-whitespace stripped by dedent

File path: apache-airflow-providers-google/operators/cloud/bigquery.rst.rst (374)
------------------------------ Error   5 --------------------
 WARNING: non-whitespace stripped by dedent

File path: apache-airflow-providers-google/operators/cloud/bigquery.rst.rst (400)
------------------------------ Error   6 --------------------
 WARNING: non-whitespace stripped by dedent

File path: apache-airflow-providers-google/operators/cloud/bigquery.rst.rst (424)

############################## End docs build errors summary ##############################
```

Caused due to https://github.com/apache/airflow/pull/46244. Example failure: https://github.com/apache/airflow/actions/runs/13089095187/job/36523870095

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
