### PR TITLE
Fix disk space issues on github runners

### DIFF
--- a/.github/actions/prepare_all_ci_images/action.yml
+++ b/.github/actions/prepare_all_ci_images/action.yml
@@ -29,7 +29,8 @@ runs:
   using: "composite"
   steps:
     - name: "Cleanup docker"
-      run: ./scripts/ci/cleanup_docker.sh
+      # Move docker space to second partition to have more space
+      run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       shell: bash
     # TODO: Currently we cannot loop through the list of python versions and have dynamic list of
     #       tasks. Instead we hardcode all possible python versions and they - but

--- a/.github/actions/prepare_all_ci_images/action.yml
+++ b/.github/actions/prepare_all_ci_images/action.yml
@@ -22,6 +22,9 @@ inputs:
   python-versions-list-as-string:
     description: 'Stringified array of all Python versions to test - separated by spaces.'
     required: true
+  docker-volume-location:
+    description: File system location where to move docker space to
+    default: /mnt/var-lib-docker
   platform:
     description: 'Platform for the build - linux/amd64 or linux/arm64'
     required: true
@@ -29,8 +32,9 @@ runs:
   using: "composite"
   steps:
     - name: "Cleanup docker"
-      # Move docker space to second partition to have more space
-      run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+      run: ./scripts/ci/cleanup_docker.sh
+      env:
+        TARGET_DOCKER_VOLUME_LOCATION: ${{ inputs.docker-volume-location }}
       shell: bash
     # TODO: Currently we cannot loop through the list of python versions and have dynamic list of
     #       tasks. Instead we hardcode all possible python versions and they - but

--- a/.github/actions/prepare_breeze_and_image/action.yml
+++ b/.github/actions/prepare_breeze_and_image/action.yml
@@ -39,7 +39,8 @@ runs:
   using: "composite"
   steps:
     - name: "Cleanup docker"
-      run: ./scripts/ci/cleanup_docker.sh
+      # Move docker space to second partition to have more space
+      run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       shell: bash
     - name: "Install Breeze"
       uses: ./.github/actions/breeze

--- a/.github/actions/prepare_breeze_and_image/action.yml
+++ b/.github/actions/prepare_breeze_and_image/action.yml
@@ -40,7 +40,9 @@ runs:
   steps:
     - name: "Cleanup docker"
       # Move docker space to second partition to have more space
-      run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+      run: ./scripts/ci/cleanup_docker.sh
+      env:
+        TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       shell: bash
     - name: "Install Breeze"
       uses: ./.github/actions/breeze

--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -143,7 +143,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -142,7 +142,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -117,7 +117,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Prepare breeze & PROD image: ${{ inputs.default-python-version }}"
         uses: ./.github/actions/prepare_breeze_and_image
         with:

--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -116,7 +116,8 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Prepare breeze & PROD image: ${{ inputs.default-python-version }}"
         uses: ./.github/actions/prepare_breeze_and_image
         with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -78,7 +78,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -100,7 +102,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2  # v4.0.0
         with:
@@ -168,7 +172,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Setup node"
         uses: actions/setup-node@v4
         with:
@@ -237,7 +243,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -293,7 +301,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -373,7 +383,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -77,7 +77,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -98,7 +99,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2  # v4.0.0
         with:
@@ -165,7 +167,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Setup node"
         uses: actions/setup-node@v4
         with:
@@ -233,7 +236,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -288,7 +292,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -367,7 +372,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -126,10 +126,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (0)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (0)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Cleanup repo"
         shell: bash
@@ -138,10 +138,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (1)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (1)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Checkout target branch"
         uses: actions/checkout@v4
@@ -151,10 +151,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (2)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (2)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Cleanup docker"
         run: ./scripts/ci/cleanup_docker.sh
@@ -162,10 +162,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (3)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (3)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
@@ -175,10 +175,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (4)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (4)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Restore ci-cache mount image ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/restore@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -201,10 +201,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (5)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (5)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Import mount-cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
@@ -222,10 +222,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (6)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (6)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: >
           Build ${{ inputs.push-image == 'true' && ' & push ' || '' }}
@@ -253,10 +253,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (org)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (org)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: Make /mnt/ directory writeable
         run: sudo chown -R ${USER} /mnt
@@ -270,10 +270,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (7)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (7)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Stash CI docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -287,10 +287,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (8)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (8)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Export mount cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
@@ -303,10 +303,10 @@ jobs:
         run: df -H
         shell: bash
       - name: Disk space consumption details (9)
-        run: du -sm /* 2>/dev/null || true
+        run: sudo du -sm /* 2>/dev/null || true
         shell: bash
       - name: Disk space consumption details - detailed (9)
-        run: du -sm /*/* 2>/dev/null || true
+        run: sudo du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Stash cache mount ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -122,6 +122,12 @@ jobs:
       GITHUB_USERNAME: ${{ github.actor }}
       VERBOSE: "true"
     steps:
+      - name: Want more details of disks of runner
+        run: sudo blkid
+        shell: bash
+      - name: Want more details of partitions of runner
+        run: sudo fdisk -l
+        shell: bash
       - name: Check free space (0)
         run: df -H
         shell: bash
@@ -169,7 +175,8 @@ jobs:
           || true
         shell: bash
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: Check free space (3)
         run: df -H
         shell: bash

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -130,7 +130,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (0)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Cleanup repo"
@@ -144,7 +146,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (1)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Checkout target branch"
@@ -159,7 +163,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (2)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Cleanup docker"
@@ -172,7 +178,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (3)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Install Breeze"
@@ -187,7 +195,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (4)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Restore ci-cache mount image ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
@@ -215,7 +225,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (5)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Import mount-cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
@@ -238,7 +250,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (6)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: >
@@ -271,7 +285,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (org)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: Make /mnt/ directory writeable
@@ -290,7 +306,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (7)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Stash CI docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
@@ -309,7 +327,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (8)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Export mount cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
@@ -327,7 +347,9 @@ jobs:
         shell: bash
       - name: Disk space consumption details - some drill down (9)
         run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
+          echo ----------------------------;
+          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
           || true
         shell: bash
       - name: "Stash cache mount ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -125,11 +125,23 @@ jobs:
       - name: Check free space (0)
         run: df -H
         shell: bash
+      - name: Disk space consumption details (0)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (0)
+        run: du -sm /*/* 2>/dev/null || true
+        shell: bash
       - name: "Cleanup repo"
         shell: bash
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
       - name: Check free space (1)
         run: df -H
+        shell: bash
+      - name: Disk space consumption details (1)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (1)
+        run: du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Checkout target branch"
         uses: actions/checkout@v4
@@ -138,10 +150,22 @@ jobs:
       - name: Check free space (2)
         run: df -H
         shell: bash
+      - name: Disk space consumption details (2)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (2)
+        run: du -sm /*/* 2>/dev/null || true
+        shell: bash
       - name: "Cleanup docker"
         run: ./scripts/ci/cleanup_docker.sh
       - name: Check free space (3)
         run: df -H
+        shell: bash
+      - name: Disk space consumption details (3)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (3)
+        run: du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
@@ -149,6 +173,12 @@ jobs:
           use-uv: ${{ inputs.use-uv }}
       - name: Check free space (4)
         run: df -H
+        shell: bash
+      - name: Disk space consumption details (4)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (4)
+        run: du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Restore ci-cache mount image ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/restore@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -170,6 +200,12 @@ jobs:
       - name: Check free space (5)
         run: df -H
         shell: bash
+      - name: Disk space consumption details (5)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (5)
+        run: du -sm /*/* 2>/dev/null || true
+        shell: bash
       - name: "Import mount-cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
           PYTHON_MAJOR_MINOR_VERSION: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
@@ -184,6 +220,12 @@ jobs:
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u ${ACTOR} --password-stdin
       - name: Check free space (6)
         run: df -H
+        shell: bash
+      - name: Disk space consumption details (6)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (6)
+        run: du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: >
           Build ${{ inputs.push-image == 'true' && ' & push ' || '' }}
@@ -210,6 +252,12 @@ jobs:
       - name: Check free space (org)
         run: df -H
         shell: bash
+      - name: Disk space consumption details (org)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (org)
+        run: du -sm /*/* 2>/dev/null || true
+        shell: bash
       - name: Make /mnt/ directory writeable
         run: sudo chown -R ${USER} /mnt
         shell: bash
@@ -220,6 +268,12 @@ jobs:
         if: inputs.upload-image-artifact == 'true'
       - name: Check free space (7)
         run: df -H
+        shell: bash
+      - name: Disk space consumption details (7)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (7)
+        run: du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Stash CI docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -232,6 +286,12 @@ jobs:
       - name: Check free space (8)
         run: df -H
         shell: bash
+      - name: Disk space consumption details (8)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (8)
+        run: du -sm /*/* 2>/dev/null || true
+        shell: bash
       - name: "Export mount cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
           PYTHON_MAJOR_MINOR_VERSION: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
@@ -241,6 +301,12 @@ jobs:
         if: inputs.upload-mount-cache-artifact == 'true'
       - name: Check free space (9)
         run: df -H
+        shell: bash
+      - name: Disk space consumption details (9)
+        run: du -sm /* 2>/dev/null || true
+        shell: bash
+      - name: Disk space consumption details - detailed (9)
+        run: du -sm /*/* 2>/dev/null || true
         shell: bash
       - name: "Stash cache mount ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -122,19 +122,34 @@ jobs:
       GITHUB_USERNAME: ${{ github.actor }}
       VERBOSE: "true"
     steps:
+      - name: Check free space (0)
+        run: df -H
+        shell: bash
       - name: "Cleanup repo"
         shell: bash
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - name: Check free space (1)
+        run: df -H
+        shell: bash
       - name: "Checkout target branch"
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Check free space (2)
+        run: df -H
+        shell: bash
       - name: "Cleanup docker"
         run: ./scripts/ci/cleanup_docker.sh
+      - name: Check free space (3)
+        run: df -H
+        shell: bash
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
           use-uv: ${{ inputs.use-uv }}
+      - name: Check free space (4)
+        run: df -H
+        shell: bash
       - name: "Restore ci-cache mount image ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/restore@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:
@@ -152,6 +167,9 @@ jobs:
             exit 1
           fi
         shell: bash
+      - name: Check free space (5)
+        run: df -H
+        shell: bash
       - name: "Import mount-cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
           PYTHON_MAJOR_MINOR_VERSION: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
@@ -164,6 +182,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u ${ACTOR} --password-stdin
+      - name: Check free space (6)
+        run: df -H
+        shell: bash
       - name: >
           Build ${{ inputs.push-image == 'true' && ' & push ' || '' }}
           ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }} image
@@ -186,7 +207,7 @@ jobs:
           PUSH: ${{ inputs.push-image }}
           VERBOSE: "true"
           PLATFORM: ${{ inputs.platform }}
-      - name: Check free space
+      - name: Check free space (org)
         run: df -H
         shell: bash
       - name: Make /mnt/ directory writeable
@@ -197,6 +218,9 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
         run: breeze ci-image save --platform "${PLATFORM}" --image-file-dir "/mnt"
         if: inputs.upload-image-artifact == 'true'
+      - name: Check free space (7)
+        run: df -H
+        shell: bash
       - name: "Stash CI docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:
@@ -205,6 +229,9 @@ jobs:
           if-no-files-found: 'error'
           retention-days: '2'
         if: inputs.upload-image-artifact == 'true'
+      - name: Check free space (8)
+        run: df -H
+        shell: bash
       - name: "Export mount cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
           PYTHON_MAJOR_MINOR_VERSION: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
@@ -212,6 +239,9 @@ jobs:
           breeze ci-image export-mount-cache
           --cache-file /tmp/ci-cache-mount-save-v2-${PYTHON_MAJOR_MINOR_VERSION}.tar.gz
         if: inputs.upload-mount-cache-artifact == 'true'
+      - name: Check free space (9)
+        run: df -H
+        shell: bash
       - name: "Stash cache mount ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -131,7 +131,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -128,8 +128,10 @@ jobs:
       - name: Disk space consumption details (0)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (0)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (0)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Cleanup repo"
         shell: bash
@@ -140,8 +142,10 @@ jobs:
       - name: Disk space consumption details (1)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (1)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (1)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Checkout target branch"
         uses: actions/checkout@v4
@@ -153,8 +157,10 @@ jobs:
       - name: Disk space consumption details (2)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (2)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (2)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Cleanup docker"
         run: ./scripts/ci/cleanup_docker.sh
@@ -164,8 +170,10 @@ jobs:
       - name: Disk space consumption details (3)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (3)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (3)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
@@ -177,8 +185,10 @@ jobs:
       - name: Disk space consumption details (4)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (4)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (4)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Restore ci-cache mount image ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/restore@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -203,8 +213,10 @@ jobs:
       - name: Disk space consumption details (5)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (5)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (5)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Import mount-cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
@@ -224,8 +236,10 @@ jobs:
       - name: Disk space consumption details (6)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (6)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (6)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: >
           Build ${{ inputs.push-image == 'true' && ' & push ' || '' }}
@@ -255,8 +269,10 @@ jobs:
       - name: Disk space consumption details (org)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (org)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (org)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: Make /mnt/ directory writeable
         run: sudo chown -R ${USER} /mnt
@@ -272,8 +288,10 @@ jobs:
       - name: Disk space consumption details (7)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (7)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (7)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Stash CI docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -289,8 +307,10 @@ jobs:
       - name: Disk space consumption details (8)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (8)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (8)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Export mount cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
@@ -305,8 +325,10 @@ jobs:
       - name: Disk space consumption details (9)
         run: sudo du -sm /* 2>/dev/null || true
         shell: bash
-      - name: Disk space consumption details - detailed (9)
-        run: sudo du -sm /*/* 2>/dev/null || true
+      - name: Disk space consumption details - some drill down (9)
+        run: >
+          sudo du -sm /home/* /mnt/* /opt/* /usr/* /usr/local/* /user/share/* /var/* /var/lib/* 2>/dev/null
+          || true
         shell: bash
       - name: "Stash cache mount ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -122,91 +122,20 @@ jobs:
       GITHUB_USERNAME: ${{ github.actor }}
       VERBOSE: "true"
     steps:
-      - name: Want more details of disks of runner
-        run: sudo blkid
-        shell: bash
-      - name: Want more details of partitions of runner
-        run: sudo fdisk -l
-        shell: bash
-      - name: Check free space (0)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (0)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (0)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Cleanup repo"
         shell: bash
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
-      - name: Check free space (1)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (1)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (1)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Checkout target branch"
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Check free space (2)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (2)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (2)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
         run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
-      - name: Check free space (3)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (3)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (3)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
           use-uv: ${{ inputs.use-uv }}
-      - name: Check free space (4)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (4)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (4)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Restore ci-cache mount image ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/restore@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:
@@ -224,19 +153,6 @@ jobs:
             exit 1
           fi
         shell: bash
-      - name: Check free space (5)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (5)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (5)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Import mount-cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
           PYTHON_MAJOR_MINOR_VERSION: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
@@ -249,19 +165,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u ${ACTOR} --password-stdin
-      - name: Check free space (6)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (6)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (6)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: >
           Build ${{ inputs.push-image == 'true' && ' & push ' || '' }}
           ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }} image
@@ -284,18 +187,8 @@ jobs:
           PUSH: ${{ inputs.push-image }}
           VERBOSE: "true"
           PLATFORM: ${{ inputs.platform }}
-      - name: Check free space (org)
+      - name: Check free space
         run: df -H
-        shell: bash
-      - name: Disk space consumption details (org)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (org)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
         shell: bash
       - name: Make /mnt/ directory writeable
         run: sudo chown -R ${USER} /mnt
@@ -305,19 +198,6 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
         run: breeze ci-image save --platform "${PLATFORM}" --image-file-dir "/mnt"
         if: inputs.upload-image-artifact == 'true'
-      - name: Check free space (7)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (7)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (7)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Stash CI docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:
@@ -326,19 +206,6 @@ jobs:
           if-no-files-found: 'error'
           retention-days: '2'
         if: inputs.upload-image-artifact == 'true'
-      - name: Check free space (8)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (8)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (8)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Export mount cache ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         env:
           PYTHON_MAJOR_MINOR_VERSION: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
@@ -346,19 +213,6 @@ jobs:
           breeze ci-image export-mount-cache
           --cache-file /tmp/ci-cache-mount-save-v2-${PYTHON_MAJOR_MINOR_VERSION}.tar.gz
         if: inputs.upload-mount-cache-artifact == 'true'
-      - name: Check free space (9)
-        run: df -H
-        shell: bash
-      - name: Disk space consumption details (9)
-        run: sudo du -sm /* 2>/dev/null || true
-        shell: bash
-      - name: Disk space consumption details - some drill down (9)
-        run: >
-          sudo du -sm /home/* /mnt/* /opt/* /usr/* /var/* 2>/dev/null;
-          echo ----------------------------;
-          sudo du -sm /usr/local/* /user/share/* /var/lib/* 2>/dev/null
-          || true
-        shell: bash
       - name: "Stash cache mount ${{ inputs.platform }}:${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -325,7 +325,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Download docs prepared as artifacts"
         uses: actions/download-artifact@v4
         with:
@@ -407,7 +409,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -324,7 +324,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Download docs prepared as artifacts"
         uses: actions/download-artifact@v4
         with:
@@ -405,7 +406,8 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: Fetch incoming commit ${{ github.sha }} with its parent
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: Fetch incoming commit ${{ github.sha }} with its parent
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/finalize-tests.yml
+++ b/.github/workflows/finalize-tests.yml
@@ -104,7 +104,8 @@ jobs:
           # Needed to perform push action
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Set constraints branch name"
         id: constraints-branch
         run: ./scripts/ci/constraints/ci_branch_constraints.sh >> ${GITHUB_OUTPUT}
@@ -192,7 +193,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Free up disk space"
         shell: bash
         run: ./scripts/tools/free_up_disk_space.sh

--- a/.github/workflows/finalize-tests.yml
+++ b/.github/workflows/finalize-tests.yml
@@ -105,7 +105,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Set constraints branch name"
         id: constraints-branch
         run: ./scripts/ci/constraints/ci_branch_constraints.sh >> ${GITHUB_OUTPUT}
@@ -194,7 +196,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Free up disk space"
         shell: bash
         run: ./scripts/tools/free_up_disk_space.sh

--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           platform: "linux/amd64"
           python-versions-list-as-string: ${{ inputs.python-versions-list-as-string }}
+          docker-volume-location: ""  # TODO(jscheffl): Understand why it fails here and fix it
       - name: "Verify all CI images ${{ inputs.python-versions-list-as-string }}"
         run: breeze ci-image verify --run-in-parallel
       - name: "Source constraints"

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -97,7 +97,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -98,7 +98,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -138,7 +138,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
         if: inputs.upload-package-artifact == 'true'
       - name: "Cleanup dist and context file"
         shell: bash
@@ -224,7 +226,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -137,7 +137,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
         if: inputs.upload-package-artifact == 'true'
       - name: "Cleanup dist and context file"
         shell: bash
@@ -222,7 +223,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -127,7 +127,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -204,7 +206,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -126,7 +126,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -202,7 +203,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -61,7 +61,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -101,7 +103,9 @@ jobs:
           persist-credentials: false
       - name: "Cleanup docker"
         # Move docker space to second partition to have more space
-        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
+        run: ./scripts/ci/cleanup_docker.sh
+        env:
+          TARGET_DOCKER_VOLUME_LOCATION: /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -60,7 +60,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:
@@ -99,7 +100,8 @@ jobs:
         with:
           persist-credentials: false
       - name: "Cleanup docker"
-        run: ./scripts/ci/cleanup_docker.sh
+        # Move docker space to second partition to have more space
+        run: ./scripts/ci/cleanup_docker.sh /mnt/var-lib-docker
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         with:

--- a/scripts/ci/cleanup_docker.sh
+++ b/scripts/ci/cleanup_docker.sh
@@ -19,13 +19,13 @@ function cleanup_docker {
     # This is faster than docker prune
     sudo systemctl stop docker
     sudo rm -rf /var/lib/docker
-    # If a path is provided, bind mount it to /var/lib/docker
-    if [ -n "$1" ]; then
-        echo "Mounting $1 to /var/lib/docker"
-        sudo mkdir -p "$1" /var/lib/docker
-        sudo mount --bind "$1" /var/lib/docker
+    # If a path is provided in ENV, bind mount it to /var/lib/docker
+    if [ -n "${TARGET_DOCKER_VOLUME_LOCATION}" ]; then
+        echo "Mounting ${TARGET_DOCKER_VOLUME_LOCATION} to /var/lib/docker"
+        sudo mkdir -p "${TARGET_DOCKER_VOLUME_LOCATION}" /var/lib/docker
+        sudo mount --bind "${TARGET_DOCKER_VOLUME_LOCATION}" /var/lib/docker
     fi
     sudo systemctl start docker
 }
 
-cleanup_docker "$1"
+cleanup_docker

--- a/scripts/ci/cleanup_docker.sh
+++ b/scripts/ci/cleanup_docker.sh
@@ -21,7 +21,8 @@ function cleanup_docker {
     sudo rm -rf /var/lib/docker
     # If a path is provided, bind mount it to /var/lib/docker
     if [ -n "$1" ]; then
-        sudo mkdir -p "$1"
+        echo "Mounting $1 to /var/lib/docker"
+        sudo mkdir -p "$1" /var/lib/docker
         sudo mount --bind "$1" /var/lib/docker
     fi
     sudo systemctl start docker

--- a/scripts/ci/cleanup_docker.sh
+++ b/scripts/ci/cleanup_docker.sh
@@ -19,7 +19,12 @@ function cleanup_docker {
     # This is faster than docker prune
     sudo systemctl stop docker
     sudo rm -rf /var/lib/docker
+    # If a path is provided, bind mount it to /var/lib/docker
+    if [ -n "$1" ]; then
+        sudo mkdir -p "$1"
+        sudo mount --bind "$1" /var/lib/docker
+    fi
     sudo systemctl start docker
 }
 
-cleanup_docker
+cleanup_docker "$1"


### PR DESCRIPTION
Main is failing e.g. in https://github.com/apache/airflow/actions/runs/13101805105/job/36550974189 as runners are "out of disk space".
This seems to be caused as only 23GB are free on /root disk where main artifacts like docker is produced. When the runner starts the following disk space is available:
```
Run df -H
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        78G   56G   23G  72% /
tmpfs           8.4G  177k  8.4G   1% /dev/shm
tmpfs           3.4G  1.2M  3.4G   1% /run
tmpfs           5.3M     0  5.3M   0% /run/lock
/dev/sda15      110M  6.4M  104M   6% /boot/efi
/dev/sdb1        79G  4.3G   71G   6% /mnt
tmpfs           1.7G   13k  1.7G   1% /run/user/1001
```
(A lot of build tools are already on CI image - see more debug info from the additional debug steps in https://github.com/apache/airflow/actions/runs/13102704519/job/36552932758 where the disk space onthe image is allocated.)

...but this means that after building the image only ~5GB are free and in some corner cases (e.g. main) the build fails. Disk space at then of building pipelines is:
```
Run df -H
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        78G   73G  5.2G  94% /
tmpfs           8.4G  177k  8.4G   1% /dev/shm
tmpfs           3.4G  1.2M  3.4G   1% /run
tmpfs           5.3M     0  5.3M   0% /run/lock
/dev/sdb15      110M  6.4M  104M   6% /boot/efi
/dev/sda1        79G  8.2G   67G  11% /mnt
tmpfs           1.7G   13k  1.7G   1% /run/user/1001
```

...and as it seems a LOT of disk space is on the second drive in /mnt and the larged data chunk from triaging is the docker workspace, this PR adds a bind mout to use the second drive in /var/lib/docker. With this at the end of the build of the image the following free space is available:
```
Run df -H
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        78G   54G   25G  69% /
tmpfs           8.4G  177k  8.4G   1% /dev/shm
tmpfs           3.4G  1.2M  3.4G   1% /run
tmpfs           5.3M     0  5.3M   0% /run/lock
/dev/sda15      110M  6.4M  104M   6% /boot/efi
/dev/sdb1        79G   28G   48G  37% /mnt
tmpfs           1.7G   13k  1.7G   1% /run/user/1001
```
Adding this as a function to the docker cleanup script and making this to all pipelines.
(Numbers were taken from Python 3.9)