### PR TITLE
Fix TypeError when importing operators from airflow.providers.google.cloud.operators.dataproc

### DIFF
--- a/providers/src/airflow/providers/google/cloud/openlineage/utils.py
+++ b/providers/src/airflow/providers/google/cloud/openlineage/utils.py
@@ -332,7 +332,7 @@ class BigQueryJobRunFacet(RunFacet):
 
     cached: bool
     billedBytes: int | None = field(default=None)
-    properties: str | None = field(default=None)
+    properties: dict | None = field(default=None)
 
     @staticmethod
     def _get_schema() -> str:


### PR DESCRIPTION
Fixes #46357

Update `BigQueryJobRunFacet` class in `providers/src/airflow/providers/google/cloud/openlineage/utils.py` to handle `properties` as a `dict` instead of a `str`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/apache/airflow/pull/46360?shareId=2c7ef92a-aac1-4d88-b309-05d58fe4cc70).