### PR TITLE
Account for None logical date in API

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -141,12 +141,17 @@ def find_task_relatives(tasks, downstream, upstream):
 @provide_session
 def get_run_ids(dag: DAG, run_id: str, future: bool, past: bool, session: SASession = NEW_SESSION):
     """Return DAG executions' run_ids."""
-    last_dagrun = dag.get_last_dagrun(include_externally_triggered=True, session=session)
     current_dagrun = dag.get_dagrun(run_id=run_id, session=session)
-    first_dagrun = session.scalar(
-        select(DagRun).filter(DagRun.dag_id == dag.dag_id).order_by(DagRun.logical_date.asc()).limit(1)
-    )
+    if current_dagrun.logical_date is None:
+        return [run_id]
 
+    last_dagrun = dag.get_last_dagrun(include_externally_triggered=True, session=session)
+    first_dagrun = session.scalar(
+        select(DagRun)
+        .where(DagRun.dag_id == dag.dag_id, DagRun.logical_date.is_not(None))
+        .order_by(DagRun.logical_date.asc())
+        .limit(1)
+    )
     if last_dagrun is None:
         raise ValueError(f"DagRun for {dag.dag_id} not found")
 

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 import pendulum
 from connexion import NoContent
 from marshmallow import ValidationError
-from sqlalchemy import delete, or_, select
+from sqlalchemy import and_, delete, or_, select
 
 from airflow.api.common.mark_tasks import (
     set_dag_run_state_to_failed,
@@ -333,7 +333,10 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
         select(DagRun)
         .where(
             DagRun.dag_id == dag_id,
-            or_(DagRun.run_id == run_id, DagRun.logical_date == logical_date),
+            or_(
+                DagRun.run_id == run_id,
+                and_(DagRun.logical_date.is_not(None), DagRun.logical_date == logical_date),
+            ),
         )
         .limit(1)
     )
@@ -371,7 +374,7 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
         except (ValueError, ParamValidationError) as ve:
             raise BadRequest(detail=str(ve))
 
-    if dagrun_instance.logical_date == logical_date:
+    if logical_date is not None and dagrun_instance.logical_date == logical_date:
         raise AlreadyExists(
             detail=(
                 f"DAGRun with DAG ID: '{dag_id}' and "
@@ -417,12 +420,8 @@ def update_dag_run_state(*, dag_id: str, dag_run_id: str, session: Session = NEW
 @provide_session
 def clear_dag_run(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Clear a dag run."""
-    dag_run: DagRun | None = session.scalar(
-        select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id)
-    )
-    if dag_run is None:
-        error_message = f"Dag Run id {dag_run_id} not found in dag   {dag_id}"
-        raise NotFound(error_message)
+    if not session.scalar(select(True).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id)):
+        raise NotFound(f"Run ID {dag_run_id!r} not found in DAG {dag_id!r}")
     try:
         post_body = clear_dagrun_form_schema.load(get_json_request_dict())
     except ValidationError as err:
@@ -430,28 +429,15 @@ def clear_dag_run(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSIO
 
     dry_run = post_body.get("dry_run", False)
     dag = get_airflow_app().dag_bag.get_dag(dag_id)
-    start_date = dag_run.logical_date
-    end_date = dag_run.logical_date
 
     if dry_run:
-        task_instances = dag.clear(
-            start_date=start_date,
-            end_date=end_date,
-            task_ids=None,
-            only_failed=False,
-            dry_run=True,
-        )
+        task_instances = dag.clear(run_id=dag_run_id, task_ids=None, only_failed=False, dry_run=True)
         return task_instance_reference_collection_schema.dump(
             TaskInstanceReferenceCollection(task_instances=task_instances)
         )
     else:
-        dag.clear(
-            start_date=start_date,
-            end_date=end_date,
-            task_ids=None,
-            only_failed=False,
-        )
-        dag_run = session.execute(select(DagRun).where(DagRun.id == dag_run.id)).scalar_one()
+        dag.clear(run_id=dag_run_id, task_ids=None, only_failed=False)
+        dag_run = session.scalar(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id))
         return dagrun_schema.dump(dag_run)
 
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -188,7 +188,7 @@ def get_last_dagrun(dag_id, session, include_externally_triggered=False):
     Overridden DagRuns are ignored.
     """
     DR = DagRun
-    query = select(DR).where(DR.dag_id == dag_id)
+    query = select(DR).where(DR.dag_id == dag_id, DR.logical_date.is_not(None))
     if not include_externally_triggered:
         query = query.where(DR.external_trigger == expression.false())
     query = query.order_by(DR.logical_date.desc())
@@ -1380,6 +1380,40 @@ class DAG(TaskSDKDag, LoggingMixin):
             )
 
         return altered
+
+    @overload
+    def clear(
+        self,
+        *,
+        dry_run: Literal[True],
+        task_ids: Collection[str | tuple[str, int]] | None = None,
+        run_id: str,
+        only_failed: bool = False,
+        only_running: bool = False,
+        confirm_prompt: bool = False,
+        dag_run_state: DagRunState = DagRunState.QUEUED,
+        session: Session = NEW_SESSION,
+        dag_bag: DagBag | None = None,
+        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
+        exclude_run_ids: frozenset[str] | None = frozenset(),
+    ) -> list[TaskInstance]: ...  # pragma: no cover
+
+    @overload
+    def clear(
+        self,
+        *,
+        task_ids: Collection[str | tuple[str, int]] | None = None,
+        run_id: str,
+        only_failed: bool = False,
+        only_running: bool = False,
+        confirm_prompt: bool = False,
+        dag_run_state: DagRunState = DagRunState.QUEUED,
+        dry_run: Literal[False] = False,
+        session: Session = NEW_SESSION,
+        dag_bag: DagBag | None = None,
+        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
+        exclude_run_ids: frozenset[str] | None = frozenset(),
+    ) -> int: ...  # pragma: no cover
 
     @overload
     def clear(


### PR DESCRIPTION
Laying some ground work for AIP-83 amendments. This changes implementation in API so a None logical_date is correctly handled when referenced.

A couple of overloads are added to `DAG.clear()` to clear one single DAG run selected by run_id. Previously, the API uses `start_date` and `end_date` to select a single DAG run (by logical_date), but this would not work if we want to select a run with logical_date set to None.