### PR TITLE
Render a pod spec using the `pod_template_file` override, if passed to the executor

### DIFF
--- a/providers/cncf/kubernetes/docs/kubernetes_executor.rst
+++ b/providers/cncf/kubernetes/docs/kubernetes_executor.rst
@@ -155,6 +155,7 @@ name ``base`` and a second container containing your desired sidecar.
 
 You can also create custom ``pod_template_file`` on a per-task basis so that you can recycle the same base values between multiple tasks.
 This will replace the default ``pod_template_file`` named in the airflow.cfg and then override that template using the ``pod_override``.
+That ``pod_template_file`` will also be used to generate the Pod K8s Spec visible in the Airflow UI.
 
 Here is an example of a task with both features:
 

--- a/providers/cncf/kubernetes/tests/provider_tests/cncf/kubernetes/test_template_rendering.py
+++ b/providers/cncf/kubernetes/tests/provider_tests/cncf/kubernetes/test_template_rendering.py
@@ -20,6 +20,8 @@ import os
 from unittest import mock
 
 import pytest
+import yaml
+from kubernetes.client import models as k8s
 from sqlalchemy.orm import make_transient
 
 from airflow.models.renderedtifields import RenderedTaskInstanceFields, RenderedTaskInstanceFields as RTIF
@@ -84,9 +86,67 @@ def test_render_k8s_pod_yaml(pod_mutation_hook, create_task_instance):
             ]
         },
     }
-
     assert render_k8s_pod_yaml(ti) == expected_pod_spec
     pod_mutation_hook.assert_called_once_with(mock.ANY)
+
+
+@mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
+@mock.patch("airflow.settings.pod_mutation_hook")
+def test_render_k8s_pod_yaml_with_custom_pod_template(pod_mutation_hook, create_task_instance, tmp_path):
+    with open(f"{tmp_path}/custom_pod_template.yaml", "w") as ptf:
+        template = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"labels": {"custom_label": "custom_value"}},
+        }
+        ptf.write(yaml.dump(template))
+
+    ti = create_task_instance(
+        dag_id="test_render_k8s_pod_yaml",
+        run_id="test_run_id",
+        task_id="op1",
+        logical_date=DEFAULT_DATE,
+        executor_config={"pod_template_file": f"{tmp_path}/custom_pod_template.yaml"},
+    )
+
+    ti_pod_yaml = render_k8s_pod_yaml(ti)
+    assert "custom_label" in ti_pod_yaml["metadata"]["labels"]
+    assert ti_pod_yaml["metadata"]["labels"]["custom_label"] == "custom_value"
+
+
+@mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
+@mock.patch("airflow.settings.pod_mutation_hook")
+def test_render_k8s_pod_yaml_with_custom_pod_template_and_pod_override(
+    pod_mutation_hook, create_task_instance, tmp_path
+):
+    with open(f"{tmp_path}/custom_pod_template.yaml", "w") as ptf:
+        template = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"labels": {"custom_label": "custom_value"}},
+        }
+        ptf.write(yaml.dump(template))
+
+    pod_override = k8s.V1Pod(
+        metadata=k8s.V1ObjectMeta(annotations={"test": "annotation"}, labels={"custom_label": "override"})
+    )
+    ti = create_task_instance(
+        dag_id="test_render_k8s_pod_yaml",
+        run_id="test_run_id",
+        task_id="op1",
+        logical_date=DEFAULT_DATE,
+        executor_config={
+            "pod_template_file": f"{tmp_path}/custom_pod_template.yaml",
+            "pod_override": pod_override,
+        },
+    )
+
+    ti_pod_yaml = render_k8s_pod_yaml(ti)
+    assert "custom_label" in ti_pod_yaml["metadata"]["labels"]
+    # The initial value associated with the custom_label label in the pod_template_file
+    # was overridden by the pod_override
+    assert ti_pod_yaml["metadata"]["labels"]["custom_label"] == "override"
+    assert ti_pod_yaml["metadata"]["annotations"]["test"] == "annotation"
 
 
 @mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})


### PR DESCRIPTION
If a task was created by a custom `executor_options['pod_template_file']` option, we make sure to render the `TaskInstance`'s associated `k8s_pod_spec` with this specific `pod_template_file`, to avoid seeing discrepancies between the spec visible in airflow and the one deployed to Kubernetes.

After having deployed this patch to my test instance running in our Kubernetes cluster, the 2 fields that were missing from the `K8s Pod Spec` pane were now visible (namely, the `kubeapi_enabled` label in the following screenshot).
 
<img width="865" alt="Screenshot 2025-02-03 at 12 43 40" src="https://github.com/user-attachments/assets/b7826b3e-8853-44de-845f-f88e6726fb8a" />


closes: #46373



<!-- Please keep an empty line above the dashes. -->
---
