### PR TITLE
Remove dag details requests from dag list page

### DIFF
--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -38,7 +38,7 @@ type Props = {
 export const DagCard = ({ dag }: Props) => {
   const [latestRun] = dag.latest_dag_runs;
 
-  const refetchInterval = useAutoRefresh({ dagId: dag.dag_id });
+  const refetchInterval = useAutoRefresh({ isPaused: dag.is_paused });
 
   return (
     <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden">

--- a/airflow/ui/src/utils/query.ts
+++ b/airflow/ui/src/utils/query.ts
@@ -52,7 +52,7 @@ export const doQueryKeysMatch = (query: Query, queryKeysToMatch: Array<PartialQu
     : true;
 };
 
-export const useAutoRefresh = ({ dagId }: { dagId?: string }) => {
+export const useAutoRefresh = ({ dagId, isPaused }: { dagId?: string; isPaused?: boolean }) => {
   const autoRefreshInterval = useConfig("auto_refresh_interval") as number | undefined;
   const { data: dag } = useDagServiceGetDagDetails(
     {
@@ -62,7 +62,9 @@ export const useAutoRefresh = ({ dagId }: { dagId?: string }) => {
     { enabled: dagId !== undefined },
   );
 
-  const canRefresh = autoRefreshInterval !== undefined && (dagId === undefined ? true : !dag?.is_paused);
+  const paused = isPaused ?? dag?.is_paused;
+
+  const canRefresh = autoRefreshInterval !== undefined && (dagId === undefined ? true : !paused);
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   return (canRefresh ? autoRefreshInterval * 1000 : false) as number | false;


### PR DESCRIPTION
The dag details check inside of useAutorefresh was firing too many requests on the dags list page. This is unnecessary since we already know if the dag is paused or not. So let's just pass `isPaused` instead of `dagId` and save time.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
