### PR TITLE
Add DB exeption handler to Execution API

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -79,6 +79,7 @@ def create_app(apps: str = "all") -> FastAPI:
 
     if "execution" in apps_list or "all" in apps_list:
         task_exec_api_app = create_task_execution_api_app(app)
+        init_error_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 
     init_config(app)


### PR DESCRIPTION
Exception handlers attached to the root app do not handle exceptions of subapplications.

Explicitely add the db exeptions handlers to the Execution API app.

https://github.com/fastapi/fastapi/issues/5300