### PR TITLE
Fix attribute error on accessing Gitbundle.repo_url

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -120,11 +120,12 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             self._dag_bundle_root_storage_path / "git" / (self.name + f"+{self.version or self.tracking_ref}")
         )
         self.git_conn_id = git_conn_id
+        self.repo_url = repo_url
         try:
             self.hook = GitHook(git_conn_id=self.git_conn_id)
-            self.repo_url = repo_url or self.hook.repo_url
+            self.repo_url = self.repo_url or self.hook.repo_url
         except AirflowException as e:
-            self.log.error("Error creating GitHook: %s", e)
+            self.log.warning("Could not create GitHook for connection %s : %s", self.git_conn_id, e)
 
     def _initialize(self):
         self._clone_bare_repo_if_required()

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -508,12 +508,12 @@ class TestGitDagBundle:
                 assert "Repository path: %s not found" in str(exc_info.value)
 
     @mock.patch("airflow.dag_processing.bundles.git.GitDagBundle.log")
-    def test_repo_url_access_doesnt_error(self, mock_log):
+    def test_repo_url_access_missing_connection_doesnt_error(self, mock_log):
         bundle = GitDagBundle(
             name="testa",
             tracking_ref="main",
             git_conn_id="unknown",
-            repo_url="repo_url",
+            repo_url="some_repo_url",
         )
-        assert bundle.repo_url
+        assert bundle.repo_url == "some_repo_url"
         assert "Could not create GitHook for connection" in mock_log.warning.call_args[0][0]

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -506,3 +506,14 @@ class TestGitDagBundle:
                     bundle._clone_repo_if_required()
 
                 assert "Repository path: %s not found" in str(exc_info.value)
+
+    @mock.patch("airflow.dag_processing.bundles.git.GitDagBundle.log")
+    def test_repo_url_access_doesnt_error(self, mock_log):
+        bundle = GitDagBundle(
+            name="testa",
+            tracking_ref="main",
+            git_conn_id="unknown",
+            repo_url="repo_url",
+        )
+        assert bundle.repo_url
+        assert "Could not create GitHook for connection" in mock_log.warning.call_args[0][0]


### PR DESCRIPTION
The position where we added the repo_url makes it unavailable on the GitBundle instance when the connection id is not defined. This PR fixes it and added a test to check that it has the attribute when the connection ID is not defined

