### PR TITLE
Fix poolbar icon and colour post Stateicon changes

### DIFF
--- a/airflow/ui/src/pages/Pools/PoolBar.tsx
+++ b/airflow/ui/src/pages/Pools/PoolBar.tsx
@@ -27,12 +27,12 @@ import { Tooltip } from "src/components/ui";
 import { capitalize } from "src/utils";
 
 const slots = {
-  open_slots: { color: "success", icon: <StateIcon state="success" /> },
-  occupied_slots: { color: "up_for_retry", icon: <FiXCircle /> },
-  running_slots: { color: "running", icon: <StateIcon state="running" /> },
-  queued_slots: { color: "queued", icon: <StateIcon state="queued" /> },
-  scheduled_slots: { color: "scheduled", icon: <StateIcon state="scheduled" /> },
-  deferred_slots: { color: "deferred", icon: <StateIcon state="deferred" /> },
+  open_slots: { color: "success", icon: <StateIcon color="white" state="success" /> },
+  occupied_slots: { color: "up_for_retry", icon: <FiXCircle color="white" /> },
+  running_slots: { color: "running", icon: <StateIcon color="white" state="running" /> },
+  queued_slots: { color: "queued", icon: <StateIcon color="white" state="queued" /> },
+  scheduled_slots: { color: "scheduled", icon: <StateIcon color="white" state="scheduled" /> },
+  deferred_slots: { color: "deferred", icon: <StateIcon color="white" state="deferred" /> },
 };
 
 type PoolBarProps = {
@@ -76,7 +76,7 @@ const PoolBar = ({ pool }: PoolBarProps) => (
             <Tooltip content={`${capitalize(slotKey.replace("_", " "))}: ${slotValue}`} key={slotKey}>
               <Flex
                 alignItems="center"
-                colorPalette={color}
+                bg={`${color}.solid`}
                 flex={flexValue}
                 h="100%"
                 justifyContent="center"


### PR DESCRIPTION
related: #43706 

Before:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5c0b4b5f-5897-4ca8-bb48-def6cca1527b" />


Updated UI:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bf884620-0553-4ec8-aad4-b402802a7b52" />




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
