### PR TITLE
Remove deprecated get_link signature support

### DIFF
--- a/airflow/models/baseoperatorlink.py
+++ b/airflow/models/baseoperatorlink.py
@@ -26,8 +26,8 @@ from airflow.models.xcom import BaseXCom
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
+    from airflow.sdk.definitions.baseoperator import BaseOperator
 
 
 @attrs.define()
@@ -98,9 +98,6 @@ class BaseOperatorLink(metaclass=ABCMeta):
     def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
         """
         Link to external system.
-
-        Note: The old signature of this function was ``(self, operator, dttm: datetime)``. That is still
-        supported at runtime but is deprecated.
 
         :param operator: The Airflow operator object this link is associated to.
         :param ti_key: TaskInstance ID to return link for.

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1200,7 +1200,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
     def extra_links(self) -> list[str]:
         return sorted(set(self.operator_extra_link_dict).union(self.global_operator_extra_link_dict))
 
-    def get_extra_links(self, ti: TaskInstance, link_name: str) -> str | None:
+    def get_extra_links(self, ti: TaskInstance, name: str) -> str | None:
         """
         For an operator, gets the URLs that the ``extra_links`` entry points to.
 
@@ -1212,11 +1212,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         :param link_name: The name of the link we're looking for the URL for. Should be
             one of the options specified in ``extra_links``.
         """
-        link = self.operator_extra_link_dict.get(link_name)
+        link = self.operator_extra_link_dict.get(name) or self.global_operator_extra_link_dict.get(name)
         if not link:
-            link = self.global_operator_extra_link_dict.get(link_name)
-            if not link:
-                return None
+            return None
         return link.get_link(self.unmap(None), ti_key=ti.key)
 
     @property

--- a/newsfragments/46415.significant.rst
+++ b/newsfragments/46415.significant.rst
@@ -1,0 +1,16 @@
+Legacy signature for operator link is removed.
+
+``BaseOperatorLink.get_link`` used to accept execution date as an argument. This
+has been changed to accept ``ti_key`` to identify a task instance instead. The
+old signature, supported at runtime for compatibility, has been removed.
+
+* Types of change
+
+  * [x] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [x] Code interface changes

--- a/newsfragments/46415.significant.rst
+++ b/newsfragments/46415.significant.rst
@@ -14,3 +14,12 @@ old signature, supported at runtime for compatibility, has been removed.
   * [ ] Plugin changes
   * [ ] Dependency changes
   * [x] Code interface changes
+
+* Migration rules needed
+
+  * ruff
+
+    * AIR302
+
+      * [ ] Signature of ``airflow.models.baseoperatorlink.BaseOperatorLink.get_link`` changed
+      .. detailed in https://github.com/apache/airflow/pull/46415#issuecomment-2636186625

--- a/tests/api_connexion/endpoints/test_extra_link_endpoint.py
+++ b/tests/api_connexion/endpoints/test_extra_link_endpoint.py
@@ -209,17 +209,17 @@ class TestGetExtraLinks:
         class GoogleLink(BaseOperatorLink):
             name = "Google"
 
-            def get_link(self, operator, dttm):
+            def get_link(self, operator, *, ti_key):
                 return "https://www.google.com"
 
         class S3LogLink(BaseOperatorLink):
             name = "S3"
             operators = [CustomOperator]
 
-            def get_link(self, operator, dttm):
+            def get_link(self, operator, *, ti_key):
                 return (
                     f"https://s3.amazonaws.com/airflow-logs/{operator.dag_id}/"
-                    f"{operator.task_id}/{quote_plus(dttm.isoformat())}"
+                    f"{operator.task_id}/{quote_plus(ti_key.run_id)}"
                 )
 
         class AirflowTestPlugin(AirflowPlugin):
@@ -241,8 +241,5 @@ class TestGetExtraLinks:
             assert response.json == {
                 "Google Custom": None,
                 "Google": "https://www.google.com",
-                "S3": (
-                    "https://s3.amazonaws.com/airflow-logs/"
-                    "TEST_DAG_ID/TEST_SINGLE_LINK/2020-01-01T00%3A00%3A00%2B00%3A00"
-                ),
+                "S3": "https://s3.amazonaws.com/airflow-logs/TEST_DAG_ID/TEST_SINGLE_LINK/TEST_DAG_RUN_ID",
             }


### PR DESCRIPTION
Operator link currently supports two signatures, one modern using TaskInstanceKey, the other old using execution_date. The old signature will have a problem after the AIP-83 amendments where None is a possibility. Airflow 3.0 is a good chance to just get rid of this problem entirely.

TODO:

* [x] Emit deprecation warning in 2.x. #46448
* [x] News fragment
* [x] Migration tool