### PR TITLE
AIP-72: Enhancing task SDK to support nested tuples in template fields

### DIFF
--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -46,6 +46,16 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
         else:
             return True
 
+    def translate_tuples_to_lists(obj: Any):
+        """Recursively convert tuples to lists."""
+        if isinstance(obj, tuple):
+            return [translate_tuples_to_lists(item) for item in obj]
+        elif isinstance(obj, list):
+            return [translate_tuples_to_lists(item) for item in obj]
+        elif isinstance(obj, dict):
+            return {key: translate_tuples_to_lists(value) for key, value in obj.items()}
+        return obj
+
     max_length = conf.getint("core", "max_templated_field_length")
 
     if not is_jsonable(template_field):
@@ -63,6 +73,7 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
     else:
         if not template_field:
             return template_field
+        template_field = translate_tuples_to_lists(template_field)
         serialized = str(template_field)
         if len(serialized) > max_length:
             rendered = redact(serialized, name)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/46393


As part of https://github.com/apache/airflow/commit/ff7e70056e5b4e6e61d20215eec00054415d4a77, I had realised that there is an issue in the way tuples were handled and I had made a change for that:


To quote from that commit:
- Handling special case of `tuples` - they are json serialisable but we used to store them as lists when passed as tuples, because of usage of json.dumps(). It has been made like this now:
```
    def is_jsonable(x):
        try:
            json.dumps(x)
            if isinstance(x, tuple):
                # Tuple is converted to list in json.dumps
                # so while it is jsonable, it changes the type which might be a surprise
                # for the user, so instead we return False here -- which will convert it to string
                return False
```

Historically, all tuples in RTIF were converted to lists and this PR is bringing back that behaviour. It is just more natural to do that. So no major impact to anyone who is using it, if its a pure tuple, it will be kept as a tuple, if nested, it will be list-ified.

## Testing Results
1. Simple DAG:
```
import sys
from time import sleep

from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator
from datetime import datetime, timedelta
from airflow.exceptions import AirflowTaskTimeout


def print_hello(*args):
    print(args)

with DAG(
    dag_id="atul_rendered",
    schedule=None,
    catchup=False,
    tags=["demo"],
) as dag:
    PythonOperator(
        task_id="matts_assert",
        python_callable=print_hello,
        op_args=[("a", "b", "c")]
    )
```

![image](https://github.com/user-attachments/assets/c5fb470d-599b-4f90-9956-d46c09f5d2cb)



2. Slightly more nested DAG:
```
import sys
from time import sleep

from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator
from datetime import datetime, timedelta
from airflow.exceptions import AirflowTaskTimeout


def print_hello(*args):
    print(args)

with DAG(
    dag_id="atul_rendered",
    schedule=None,
    catchup=False,
    tags=["demo"],
) as dag:
    PythonOperator(
        task_id="matts_assert",
        python_callable=print_hello,
        op_args=[
            [("t0.task_id", "t1.task_id", "branch one"),
             ("t0.task_id", "t2.task_id", "branch two"),
             ("t0.task_id", "t3.task_id", "branch three")
             ]]
    )
```

![image](https://github.com/user-attachments/assets/c5fb470d-599b-4f90-9956-d46c09f5d2cb)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
