### PR TITLE
Update Kubernetes version used in the system test `example_emr_eks`

### DIFF
--- a/providers/tests/system/amazon/aws/example_emr_eks.py
+++ b/providers/tests/system/amazon/aws/example_emr_eks.py
@@ -234,6 +234,7 @@ with DAG(
         # The launch template enforces IMDSv2 and is required for internal
         # compliance when running these system tests on AWS infrastructure.
         create_nodegroup_kwargs={"launchTemplate": {"name": launch_template_name}},
+        create_cluster_kwargs={"version": "1.32"},
     )
 
     await_create_nodegroup = EksNodegroupStateSensor(


### PR DESCRIPTION
The default Kubernetes version used in EKS is `1.31`. This version will be deprecated in November 2025. Plus, for various reason, using the `1.31` version makes the system test `example_emr_eks` fail with the error:

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the CreateVirtualCluster operation: Cluster env40beb96b-cluster is not reachable as its connection is currently being updated
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
