### PR TITLE
Refactor dag processor for code clarity

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -132,6 +132,10 @@ def _resolve_path(instance: Any, attribute: attrs.Attribute, val: str | os.PathL
     return val
 
 
+def _shuffle(vals):
+    random.Random(get_hostname()).shuffle(vals)
+
+
 @attrs.define
 class DagFileProcessorManager(LoggingMixin):
     """
@@ -892,7 +896,7 @@ class DagFileProcessorManager(LoggingMixin):
         elif list_mode == "random_seeded_by_host":
             # Shuffle the list seeded by hostname so multiple DAG processors can work on different
             # set of files. Since we set the seed, the sort order will remain same per host
-            random.Random(get_hostname()).shuffle(file_infos)
+            _shuffle(file_infos)
 
         at_run_limit = [info for info, stat in self._file_stats.items() if stat.run_count == self.max_runs]
 

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -295,6 +295,8 @@ class DagFileProcessorManager(LoggingMixin):
 
         poll_time = 0.0
 
+        known_files: dict[str, set[DagFileInfo]] = {}
+
         while True:
             loop_start_time = time.monotonic()
 
@@ -302,7 +304,6 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._kill_timed_out_processors()
 
-            known_files: dict[str, set[DagFileInfo]] = {}
             self._refresh_dag_bundles(known_files=known_files)
 
             if not self._file_queue:

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -132,10 +132,6 @@ def _resolve_path(instance: Any, attribute: attrs.Attribute, val: str | os.PathL
     return val
 
 
-def _shuffle(vals):
-    random.Random(get_hostname()).shuffle(vals)
-
-
 @attrs.define
 class DagFileProcessorManager(LoggingMixin):
     """
@@ -896,7 +892,7 @@ class DagFileProcessorManager(LoggingMixin):
         elif list_mode == "random_seeded_by_host":
             # Shuffle the list seeded by hostname so multiple DAG processors can work on different
             # set of files. Since we set the seed, the sort order will remain same per host
-            _shuffle(file_infos)
+            random.Random(get_hostname()).shuffle(file_infos)
 
         at_run_limit = [info for info, stat in self._file_stats.items() if stat.run_count == self.max_runs]
 

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -200,7 +200,7 @@ class TestDagFileProcessorManager:
         manager._processors[file] = MagicMock()
         manager._file_stats[file] = DagFileStat()
 
-        manager.update_queues(["abc.txt"])
+        manager.handle_removed_files(["abc.txt"])
         assert manager._processors == {}
         assert file not in manager._file_stats
 
@@ -211,7 +211,7 @@ class TestDagFileProcessorManager:
 
         manager._processors[file] = mock_processor
 
-        manager.update_queues([file])
+        manager.handle_removed_files([file])
         assert manager._processors == {file: mock_processor}
 
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
@@ -223,7 +223,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.update_queues(dag_files)
+        manager.handle_removed_files(dag_files)
         assert manager._file_queue == deque()
         manager.prepare_file_queue()
         assert manager._file_queue == deque(ordered_dag_files)
@@ -235,7 +235,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.update_queues(dag_files)
+        manager.handle_removed_files(dag_files)
         assert manager._file_queue == deque()
         manager.prepare_file_queue()
 
@@ -258,7 +258,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.update_queues(dag_files)
+        manager.handle_removed_files(dag_files)
         assert manager._file_queue == deque()
         manager.prepare_file_queue()
         ordered_files = _get_dag_file_paths(["file_4.py", "file_1.py", "file_3.py", "file_2.py"])
@@ -273,7 +273,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.update_queues(dag_files)
+        manager.handle_removed_files(dag_files)
         manager.prepare_file_queue()
 
         ordered_files = _get_dag_file_paths(["file_2.py", "file_3.py"])
@@ -288,12 +288,12 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.update_queues(dag_files)
+        manager.handle_removed_files(dag_files)
         manager.prepare_file_queue()
         ordered_files = _get_dag_file_paths(["file_3.py", "file_2.py", "file_1.py"])
         assert manager._file_queue == deque(ordered_files)
 
-        manager.update_queues(
+        manager.handle_removed_files(
             [
                 *dag_files,
                 DagFileInfo(bundle_name="testing", rel_path=Path("file_4.py"), bundle_path=TEST_DAGS_FOLDER),
@@ -325,7 +325,7 @@ class TestDagFileProcessorManager:
             dag_file: DagFileStat(1, 0, last_finish_time, 1.0, 1, 1),
         }
         with time_machine.travel(freezed_base_time):
-            manager.update_queues(dag_files)
+            manager.handle_removed_files(dag_files)
             assert manager._file_queue == deque()
             # File Path Queue will be empty as the "modified time" < "last finish time"
             manager.prepare_file_queue()
@@ -336,7 +336,7 @@ class TestDagFileProcessorManager:
         file_1_new_mtime = freezed_base_time - timedelta(seconds=5)
         file_1_new_mtime_ts = file_1_new_mtime.timestamp()
         with time_machine.travel(freezed_base_time):
-            manager.update_queues(dag_files)
+            manager.handle_removed_files(dag_files)
             assert manager._file_queue == deque()
             # File Path Queue will be empty as the "modified time" < "last finish time"
             mock_getmtime.side_effect = [file_1_new_mtime_ts]
@@ -363,7 +363,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
 
-        manager.update_queues(dag_files)
+        manager.handle_removed_files(dag_files)
         manager._file_queue = deque(["file_2.py", "file_3.py", "file_4.py", "file_1.py"])
         manager._refresh_requested_filelocs()
         assert manager._file_queue == deque(["file_1.py", "file_2.py", "file_3.py", "file_4.py"])

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -200,7 +200,7 @@ class TestDagFileProcessorManager:
         manager._processors[file] = MagicMock()
         manager._file_stats[file] = DagFileStat()
 
-        manager.set_files(["abc.txt"])
+        manager.update_queues(["abc.txt"])
         assert manager._processors == {}
         assert file not in manager._file_stats
 
@@ -211,7 +211,7 @@ class TestDagFileProcessorManager:
 
         manager._processors[file] = mock_processor
 
-        manager.set_files([file])
+        manager.update_queues([file])
         assert manager._processors == {file: mock_processor}
 
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
@@ -223,7 +223,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.set_files(dag_files)
+        manager.update_queues(dag_files)
         assert manager._file_queue == deque()
         manager.prepare_file_queue()
         assert manager._file_queue == deque(ordered_dag_files)
@@ -235,7 +235,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.set_files(dag_files)
+        manager.update_queues(dag_files)
         assert manager._file_queue == deque()
         manager.prepare_file_queue()
 
@@ -258,7 +258,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.set_files(dag_files)
+        manager.update_queues(dag_files)
         assert manager._file_queue == deque()
         manager.prepare_file_queue()
         ordered_files = _get_dag_file_paths(["file_4.py", "file_1.py", "file_3.py", "file_2.py"])
@@ -273,7 +273,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.set_files(dag_files)
+        manager.update_queues(dag_files)
         manager.prepare_file_queue()
 
         ordered_files = _get_dag_file_paths(["file_2.py", "file_3.py"])
@@ -288,12 +288,12 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(max_runs=1)
 
-        manager.set_files(dag_files)
+        manager.update_queues(dag_files)
         manager.prepare_file_queue()
         ordered_files = _get_dag_file_paths(["file_3.py", "file_2.py", "file_1.py"])
         assert manager._file_queue == deque(ordered_files)
 
-        manager.set_files(
+        manager.update_queues(
             [
                 *dag_files,
                 DagFileInfo(bundle_name="testing", rel_path=Path("file_4.py"), bundle_path=TEST_DAGS_FOLDER),
@@ -325,7 +325,7 @@ class TestDagFileProcessorManager:
             dag_file: DagFileStat(1, 0, last_finish_time, 1.0, 1, 1),
         }
         with time_machine.travel(freezed_base_time):
-            manager.set_files(dag_files)
+            manager.update_queues(dag_files)
             assert manager._file_queue == deque()
             # File Path Queue will be empty as the "modified time" < "last finish time"
             manager.prepare_file_queue()
@@ -336,7 +336,7 @@ class TestDagFileProcessorManager:
         file_1_new_mtime = freezed_base_time - timedelta(seconds=5)
         file_1_new_mtime_ts = file_1_new_mtime.timestamp()
         with time_machine.travel(freezed_base_time):
-            manager.set_files(dag_files)
+            manager.update_queues(dag_files)
             assert manager._file_queue == deque()
             # File Path Queue will be empty as the "modified time" < "last finish time"
             mock_getmtime.side_effect = [file_1_new_mtime_ts]
@@ -363,7 +363,7 @@ class TestDagFileProcessorManager:
 
         manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
 
-        manager.set_files(dag_files)
+        manager.update_queues(dag_files)
         manager._file_queue = deque(["file_2.py", "file_3.py", "file_4.py", "file_1.py"])
         manager._refresh_requested_filelocs()
         assert manager._file_queue == deque(["file_1.py", "file_2.py", "file_3.py", "file_4.py"])

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1090,7 +1090,10 @@ class TestDag:
 
         assert orm_dag.is_active
 
-        DagModel.deactivate_deleted_dags(list_py_file_paths(settings.DAGS_FOLDER))
+        DagModel.deactivate_deleted_dags(
+            bundle_name=orm_dag.bundle_name,
+            rel_filelocs=list_py_file_paths(settings.DAGS_FOLDER),
+        )
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one()
         assert not orm_dag.is_active


### PR DESCRIPTION
Dag processor has experienced a lot of organic growth over the years and had gotten into a state where it became a bit hard to understand.  E.g. method `set_files` did not have a name that clearly indicated its purpose. And that's probably in part because it did a bunch of things and was called in a bunch of places.  I simplify that method and focus on just one aspect of its prior work, namely handling removed files, and call it `handle_removed_files`.

A lot of the behavior was driven by a data structure on the instance called file paths.  This contained all known files.  It's one thing that was modified in `set_files`.  From looking at the main loop it was not obvious where this structure was being used or modified.  So I made it a local variable instead of instance attr. And now we can easily see all the methods that are using it because it must be passed around.

I rename the `file_paths` to known_files because that is clearer about its meaning.  Previously it was file_paths and file_queue -- harder to understand the different purposes.  I make file_paths a dictionary because then it's easier to replace all the files in the bundle, something that was previously done by iterating through the files. 

In prepare file paths, I pull out the mtime mode logic into its own method because it's quite involved and made the prepare file paths method too big and complicated.  Along with this I simplify the logic to not exclude recently processed files if they were recently changed.

In some of the tests, I had to change the way we simulated mtime numbers because the input is now a set which does not guarantee order.  So I encode the mtime in the filename in the test.  And the one test dealing with zip file, this was apparently a flakey test.  I change it so we don't mock anything but just copy the file to a tmp dir and make a bundle there, then remove it and see what happens.

In clear_orphaned_import_errors I no longer pass the entire list of known dag files.  Cus there could be a lot of them.


