### PR TITLE
Limiting retryhttp to not use 1.3.0 to fix CI mypy checks

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -526,7 +526,7 @@
     "deps": [
       "apache-airflow>=2.10.0",
       "pydantic>=2.10.2",
-      "retryhttp>=1.2.0"
+      "retryhttp>=1.2.0,!=1.3.0"
     ],
     "devel-deps": [],
     "plugins": [

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -526,7 +526,7 @@
     "deps": [
       "apache-airflow>=2.10.0",
       "pydantic>=2.10.2",
-      "retryhttp>=1.2.0,!=1.3.0"
+      "retryhttp>=1.2.0,<1.3.0"
     ],
     "devel-deps": [],
     "plugins": [

--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -51,13 +51,13 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-==================  ===================
+==================  ==================
 PIP package         Version required
-==================  ===================
+==================  ==================
 ``apache-airflow``  ``>=2.10.0``
 ``pydantic``        ``>=2.10.2``
-``retryhttp``       ``>=1.2.0,!=1.3.0``
-==================  ===================
+``retryhttp``       ``>=1.2.0,<1.3.0``
+==================  ==================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.12.0pre0/changelog.html>`_.

--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -51,13 +51,13 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-==================  ==================
+==================  ===================
 PIP package         Version required
-==================  ==================
+==================  ===================
 ``apache-airflow``  ``>=2.10.0``
 ``pydantic``        ``>=2.10.2``
-``retryhttp``       ``>=1.2.0``
-==================  ==================
+``retryhttp``       ``>=1.2.0,!=1.3.0``
+==================  ===================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.12.0pre0/changelog.html>`_.

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -57,8 +57,8 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "pydantic>=2.10.2",
-    # retryhttp has issues with 1.3.0 with mypy, remove when fixes in retryhttp
-    "retryhttp>=1.2.0,!=1.3.0",
+    # retryhttp has issues with 1.3.0 with mypy, remove when fixed in retryhttp
+    "retryhttp>=1.2.0,<1.3.0",
 ]
 
 [project.urls]

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -57,7 +57,8 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "pydantic>=2.10.2",
-    "retryhttp>=1.2.0",
+    # retryhttp has issues with 1.3.0 with mypy, remove when fixes in retryhttp
+    "retryhttp>=1.2.0,!=1.3.0",
 ]
 
 [project.urls]

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -99,5 +99,5 @@ def get_provider_info():
                 },
             }
         },
-        "dependencies": ["apache-airflow>=2.10.0", "pydantic>=2.10.2", "retryhttp>=1.2.0"],
+        "dependencies": ["apache-airflow>=2.10.0", "pydantic>=2.10.2", "retryhttp>=1.2.0,!=1.3.0"],
     }

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -99,5 +99,5 @@ def get_provider_info():
                 },
             }
         },
-        "dependencies": ["apache-airflow>=2.10.0", "pydantic>=2.10.2", "retryhttp>=1.2.0,!=1.3.0"],
+        "dependencies": ["apache-airflow>=2.10.0", "pydantic>=2.10.2", "retryhttp>=1.2.0,<1.3.0"],
     }

--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     "msgspec>=0.19.0",
     "psutil>=6.1.0",
     "structlog>=24.4.0",
-    # retryhttp has issues with 1.3.0 with mypy, remove when fixes in retryhttp
-    "retryhttp>=1.2.0,!=1.3.0",
+    # retryhttp has issues with 1.3.0 with mypy, remove when fixed in retryhttp
+    "retryhttp>=1.2.0,<1.3.0",
 ]
 classifiers = [
   "Framework :: Apache Airflow",

--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "msgspec>=0.19.0",
     "psutil>=6.1.0",
     "structlog>=24.4.0",
-    "retryhttp>=1.2.0",
+    # retryhttp has issues with 1.3.0 with mypy, remove when fixes in retryhttp
+    "retryhttp>=1.2.0,!=1.3.0",
 ]
 classifiers = [
   "Framework :: Apache Airflow",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

retryhttp released 1.3.0 and seems like clients using it run into mypy issues 
```
providers/edge/src/airflow/providers/edge/cli/api_client.py:66: error: Never
not callable  [misc]
    @retry(
     ^
Found 1 error in 1 file (checked [36](https://github.com/apache/airflow/actions/runs/13148605736/job/36692383263#step:6:37)88 source files)
Error 1 returned
```

Example https://github.com/apache/airflow/actions/runs/13148605736/job/36692383263


The issue is either mypy or retryhttp, testing this as a potential fix.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
