### PR TITLE
Timetable that runs on multiple cron expressions

### DIFF
--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import datetime
+import math
+import operator
 from typing import TYPE_CHECKING, Any
 
 from airflow.timetables._cron import CronMixin
@@ -187,3 +189,95 @@ class CronTriggerTimetable(CronMixin, Timetable):
             return past_run_time
         else:
             return next_run_time
+
+
+class MultipleCronTriggerTimetable(Timetable):
+    """
+    Timetable that triggers DAG runs according to multiple cron expressions.
+
+    This combines multiple ``CronTriggerTimetable`` instances underneath, and
+    triggers a DAG run whenever one of the timetables want to trigger a run.
+
+    Only at most one run is triggered for any given time, even if more than one
+    timetable fires at the same time.
+    """
+
+    def __init__(
+        self,
+        *crons: str,
+        timezone: str | Timezone | FixedTimezone,
+        interval: datetime.timedelta | relativedelta = datetime.timedelta(),
+        run_immediately: bool | datetime.timedelta = False,
+    ) -> None:
+        if not crons:
+            raise ValueError("cron expression required")
+        self._timetables = [
+            CronTriggerTimetable(cron, timezone=timezone, interval=interval, run_immediately=run_immediately)
+            for cron in crons
+        ]
+        self.description = ", ".join(t.description for t in self._timetables)
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> Timetable:
+        from airflow.serialization.serialized_objects import decode_timezone
+
+        return cls(
+            data["expressions"],
+            timezone=decode_timezone(data["timezone"]),
+            interval=_deserialize_interval(data["interval"]),
+            run_immediately=_deserialize_run_immediately(data["run_immediately"]),
+        )
+
+    def serialize(self) -> dict[str, Any]:
+        from airflow.serialization.serialized_objects import encode_timezone
+
+        # All timetables share the same timezone, interval, and run_immediately
+        # values, so we can just use the first to represent them.
+        timetable = self._timetables[0]
+        return {
+            "expressions": [t._expression for t in self._timetables],
+            "timezone": encode_timezone(timetable._timezone),
+            "interval": _serialize_interval(timetable._interval),
+            "run_immediately": _serialize_run_immediately(timetable.run_immediately),
+        }
+
+    @property
+    def summary(self) -> str:
+        return ", ".join(t.summary for t in self._timetables)
+
+    def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
+        return min(
+            (t.infer_manual_data_interval(run_after=run_after) for t in self._timetables),
+            key=operator.attrgetter("start"),
+        )
+
+    def next_dagrun_info(
+        self,
+        *,
+        last_automated_data_interval: DataInterval | None,
+        restriction: TimeRestriction,
+    ) -> DagRunInfo | None:
+        infos = (
+            timetable.next_dagrun_info(
+                last_automated_data_interval=last_automated_data_interval,
+                restriction=restriction,
+            )
+            for timetable in self._timetables
+        )
+        return min(infos, key=self._dagrun_info_sort_key)
+
+    @staticmethod
+    def _dagrun_info_sort_key(info: DagRunInfo | None) -> float:
+        """
+        Sort key for DagRunInfo values.
+
+        This is passed as the sort key to ``min`` in ``next_dagrun_info`` to
+        find the next closest run, ordered by logical date.
+
+        The sort is done by simply returning the logical date converted to a
+        Unix timestamp. If the input is *None* (no next run), *inf* is returned
+        so it's selected last.
+        """
+        if info is None:
+            return math.inf
+        return info.logical_date.timestamp()

--- a/docs/apache-airflow/authoring-and-scheduling/timetable.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/timetable.rst
@@ -105,6 +105,45 @@ must be a :class:`datetime.timedelta` or ``dateutil.relativedelta.relativedelta`
         pass
 
 
+.. _MultipleCronTriggerTimetable:
+
+MultipleCronTriggerTimetable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is similar to CronTriggerTimetable_ except it takes multiple cron expressions. A DAG run is scheduled whenever any of the expressions matches the time. It is particularly useful when the desired schedule cannot be expressed by one single cron expression.
+
+.. code-block:: python
+
+    from airflow.timetables.trigger import MultipleCronTriggerTimetable
+
+
+    # At 1:10 and 2:40 each day.
+    @dag(schedule=MultipleCronTriggerTimetable("10 1 * * *", "40 2 * * *", timezone="UTC"), ...)
+    def example_dag():
+        pass
+
+The same optional ``interval`` argument as CronTriggerTimetable_ is also available.
+
+.. code-block:: python
+
+    from datetime import timedelta
+
+    from airflow.timetables.trigger import MultipleCronTriggerTimetable
+
+
+    @dag(
+        schedule=MultipleCronTriggerTimetable(
+            "10 1 * * *",
+            "40 2 * * *",
+            timezone="UTC",
+            interval=timedelta(hours=1),
+        ),
+        ...,
+    )
+    def example_dag():
+        pass
+
+
 .. _DeltaDataIntervalTimetable:
 
 DeltaDataIntervalTimetable


### PR DESCRIPTION
This adds a new `MultipleCronTriggerTimetable` that takes multiple cron expressions, and schedule runs whenever the time matches at least one of the expressions. Internally, this just uses `CronTriggerTimetable` and check which instance gives the closest “next” run.

I specifically choose `CronTriggerTimetable`, not the more traditional `CronDataIntervalTimetable`, since the latter needs to have data interval logic, and it is very unclear how data interval should be calculated when more than one cron expression is involved.