### PR TITLE
fix get_classes_from_file

### DIFF
--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -266,7 +266,8 @@ class ProjectStructureTest:
                     continue
 
                 if is_new:
-                    results[f"{module[module.find('airflow.providers'):]}.{current_node.name}"] = current_node
+                    module_path = module[module.find("airflow.providers") :]
+                    results[f"{module_path}.{current_node.name}"] = current_node
                 else:
                     results[f"{module}.{current_node.name}"] = current_node
         print(f"{results}")

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -266,7 +266,7 @@ class ProjectStructureTest:
                     continue
 
                 if is_new:
-                    results[f"{'.'.join(module.split('.')[2:])}.{current_node.name}"] = current_node
+                    results[f"{module[module.find('airflow.providers'):]}.{current_node.name}"] = current_node
                 else:
                     results[f"{module}.{current_node.name}"] = current_node
         print(f"{results}")


### PR DESCRIPTION
this fixes failing tests - https://github.com/apache/airflow/pull/46436

current logic to get the import path fails for cncf providers as we have kubernetes folder inside cncf folder. This PR logic tries to find `airflow.providers` and strip everything before it.