### PR TITLE
AIP-72: Port tests in TestDagDecorator to task sdk

### DIFF
--- a/task_sdk/tests/execution_time/conftest.py
+++ b/task_sdk/tests/execution_time/conftest.py
@@ -83,6 +83,8 @@ def mocked_parse(spy_agency):
             return ti
 
         dag = DAG(dag_id=dag_id, start_date=timezone.datetime(2024, 12, 3))
+        if what.ti_context.dag_run.conf:
+            dag.params = what.ti_context.dag_run.conf  # type: ignore[assignment]
         task.dag = dag
         t = dag.task_dict[task.task_id]
         ti = RuntimeTaskInstance.model_construct(

--- a/task_sdk/tests/execution_time/conftest.py
+++ b/task_sdk/tests/execution_time/conftest.py
@@ -70,7 +70,7 @@ def mocked_parse(spy_agency):
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance, parse
         from airflow.utils import timezone
 
-        if getattr(task, "dag") is not None:
+        if task.has_dag():
             if what.ti_context.dag_run.conf:
                 task.dag.params = what.ti_context.dag_run.conf  # type: ignore[assignment]
             ti = RuntimeTaskInstance.model_construct(

--- a/task_sdk/tests/execution_time/conftest.py
+++ b/task_sdk/tests/execution_time/conftest.py
@@ -70,9 +70,19 @@ def mocked_parse(spy_agency):
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance, parse
         from airflow.utils import timezone
 
+        if getattr(task, "dag") is not None:
+            if what.ti_context.dag_run.conf:
+                task.dag.params = what.ti_context.dag_run.conf  # type: ignore[assignment]
+            ti = RuntimeTaskInstance.model_construct(
+                **what.ti.model_dump(exclude_unset=True),
+                task=task,
+                _ti_context_from_server=what.ti_context,
+                max_tries=what.ti_context.max_tries,
+            )
+            spy_agency.spy_on(parse, call_fake=lambda _: ti)
+            return ti
+
         dag = DAG(dag_id=dag_id, start_date=timezone.datetime(2024, 12, 3))
-        if what.ti_context.dag_run.conf:
-            dag.params = what.ti_context.dag_run.conf  # type: ignore[assignment]
         task.dag = dag
         t = dag.task_dict[task.task_id]
         ti = RuntimeTaskInstance.model_construct(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We have already ported over dag decorator to the task sdk but not some of its tests.
This PR moves https://github.com/apache/airflow/blob/main/tests/models/test_dag.py#L2522-L2648 to the task sdk tests:

 - some are under task runner as we are checking some runtime behaviour with tasks too
- rest remain to be under `definitions/test_dag.py`


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
