### PR TITLE
Add state filter to task page.

### DIFF
--- a/airflow/ui/src/constants/stateOptions.ts
+++ b/airflow/ui/src/constants/stateOptions.ts
@@ -1,0 +1,53 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { createListCollection } from "@chakra-ui/react";
+
+import type { TaskInstanceState } from "openapi/requests/types.gen";
+
+export const taskInstanceStateOptions = createListCollection<{
+  label: string;
+  value: TaskInstanceState | "all" | "none";
+}>({
+  items: [
+    { label: "All States", value: "all" },
+    { label: "Scheduled", value: "scheduled" },
+    { label: "Queued", value: "queued" },
+    { label: "Running", value: "running" },
+    { label: "Success", value: "success" },
+    { label: "Restarting", value: "restarting" },
+    { label: "Failed", value: "failed" },
+    { label: "Up For Retry", value: "up_for_retry" },
+    { label: "Up For Reschedule", value: "up_for_reschedule" },
+    { label: "Upstream failed", value: "upstream_failed" },
+    { label: "Skipped", value: "skipped" },
+    { label: "Deferred", value: "deferred" },
+    { label: "Removed", value: "removed" },
+    { label: "No Status", value: "none" },
+  ],
+});
+
+export const dagRunStateOptions = createListCollection({
+  items: [
+    { label: "All States", value: "all" },
+    { label: "Queued", value: "queued" },
+    { label: "Running", value: "running" },
+    { label: "Failed", value: "failed" },
+    { label: "Success", value: "success" },
+  ],
+});

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -16,15 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Box,
-  createListCollection,
-  Flex,
-  HStack,
-  Link,
-  type SelectValueChangeDetails,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, Link, type SelectValueChangeDetails, Text } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback } from "react";
 import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom";
@@ -40,6 +32,7 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
+import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
 import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 
 const columns: Array<ColumnDef<DAGRunResponse>> = [
@@ -104,16 +97,6 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
     },
   },
 ];
-
-const stateOptions = createListCollection({
-  items: [
-    { label: "All States", value: "all" },
-    { label: "Queued", value: "queued" },
-    { label: "Running", value: "running" },
-    { label: "Failed", value: "failed" },
-    { label: "Success", value: "success" },
-  ],
-});
 
 const STATE_PARAM = "state";
 

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -16,14 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Box,
-  Flex,
-  Link,
-  createListCollection,
-  HStack,
-  type SelectValueChangeDetails,
-} from "@chakra-ui/react";
+import { Box, Flex, Link, HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
@@ -40,6 +33,7 @@ import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
+import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
 import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
@@ -108,25 +102,6 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     },
   },
 ];
-
-const stateOptions = createListCollection<{ label: string; value: TaskInstanceState | "all" | "none" }>({
-  items: [
-    { label: "All States", value: "all" },
-    { label: "Scheduled", value: "scheduled" },
-    { label: "Queued", value: "queued" },
-    { label: "Running", value: "running" },
-    { label: "Success", value: "success" },
-    { label: "Restarting", value: "restarting" },
-    { label: "Failed", value: "failed" },
-    { label: "Up For Retry", value: "up_for_retry" },
-    { label: "Up For Reschedule", value: "up_for_reschedule" },
-    { label: "Upstream failed", value: "upstream_failed" },
-    { label: "Skipped", value: "skipped" },
-    { label: "Deferred", value: "deferred" },
-    { label: "Removed", value: "removed" },
-    { label: "No Status", value: "none" },
-  ],
-});
 
 const STATE_PARAM = "state";
 

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -16,14 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Box,
-  createListCollection,
-  Flex,
-  HStack,
-  Link,
-  type SelectValueChangeDetails,
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, Link, type SelectValueChangeDetails } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback } from "react";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
@@ -36,6 +29,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
+import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
 import { capitalize, getDuration } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
@@ -87,25 +81,6 @@ const columns = (isMapped?: boolean): Array<ColumnDef<TaskInstanceResponse>> => 
     header: "Duration",
   },
 ];
-
-const stateOptions = createListCollection<{ label: string; value: TaskInstanceState | "all" | "none" }>({
-  items: [
-    { label: "All States", value: "all" },
-    { label: "Scheduled", value: "scheduled" },
-    { label: "Queued", value: "queued" },
-    { label: "Running", value: "running" },
-    { label: "Success", value: "success" },
-    { label: "Restarting", value: "restarting" },
-    { label: "Failed", value: "failed" },
-    { label: "Up For Retry", value: "up_for_retry" },
-    { label: "Up For Reschedule", value: "up_for_reschedule" },
-    { label: "Upstream failed", value: "upstream_failed" },
-    { label: "Skipped", value: "skipped" },
-    { label: "Deferred", value: "deferred" },
-    { label: "Removed", value: "removed" },
-    { label: "No Status", value: "none" },
-  ],
-});
 
 const STATE_PARAM = "state";
 

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -16,18 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Link } from "@chakra-ui/react";
+import {
+  Box,
+  createListCollection,
+  Flex,
+  HStack,
+  Link,
+  type SelectValueChangeDetails,
+} from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Link as RouterLink, useParams } from "react-router-dom";
+import { useCallback } from "react";
+import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances, useTaskServiceGetTask } from "openapi/queries";
-import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
-import { getDuration } from "src/utils";
+import { Select } from "src/components/ui";
+import { capitalize, getDuration } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
 const columns = (isMapped?: boolean): Array<ColumnDef<TaskInstanceResponse>> => [
@@ -79,14 +88,57 @@ const columns = (isMapped?: boolean): Array<ColumnDef<TaskInstanceResponse>> => 
   },
 ];
 
+const stateOptions = createListCollection<{ label: string; value: TaskInstanceState | "all" | "none" }>({
+  items: [
+    { label: "All States", value: "all" },
+    { label: "Scheduled", value: "scheduled" },
+    { label: "Queued", value: "queued" },
+    { label: "Running", value: "running" },
+    { label: "Success", value: "success" },
+    { label: "Restarting", value: "restarting" },
+    { label: "Failed", value: "failed" },
+    { label: "Up For Retry", value: "up_for_retry" },
+    { label: "Up For Reschedule", value: "up_for_reschedule" },
+    { label: "Upstream failed", value: "upstream_failed" },
+    { label: "Skipped", value: "skipped" },
+    { label: "Deferred", value: "deferred" },
+    { label: "Removed", value: "removed" },
+    { label: "No Status", value: "none" },
+  ],
+});
+
+const STATE_PARAM = "state";
+
 export const Instances = () => {
   const { dagId = "", taskId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
+  const filteredState = searchParams.getAll(STATE_PARAM);
+  const hasFilteredState = filteredState.length > 0;
 
   const { data: task, error: taskError, isLoading: isTaskLoading } = useTaskServiceGetTask({ dagId, taskId });
+
+  const handleStateChange = useCallback(
+    ({ value }: SelectValueChangeDetails<string>) => {
+      const [val, ...rest] = value;
+
+      if ((val === undefined || val === "all") && rest.length === 0) {
+        searchParams.delete(STATE_PARAM);
+      } else {
+        searchParams.delete(STATE_PARAM);
+        value.filter((state) => state !== "all").map((state) => searchParams.append(STATE_PARAM, state));
+      }
+      setTableURLState({
+        pagination: { ...pagination, pageIndex: 0 },
+        sorting,
+      });
+      setSearchParams(searchParams);
+    },
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
+  );
 
   const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances({
     dagId,
@@ -94,11 +146,55 @@ export const Instances = () => {
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
     orderBy,
+    state: hasFilteredState ? filteredState : undefined,
     taskId,
   });
 
   return (
-    <Box>
+    <Box pt={4}>
+      <Flex>
+        <Select.Root
+          collection={stateOptions}
+          maxW="250px"
+          multiple
+          onValueChange={handleStateChange}
+          value={hasFilteredState ? filteredState : ["all"]}
+        >
+          <Select.Trigger
+            {...(hasFilteredState ? { clearable: true } : {})}
+            colorPalette="blue"
+            isActive={Boolean(filteredState)}
+          >
+            <Select.ValueText>
+              {() =>
+                hasFilteredState ? (
+                  <HStack gap="10px">
+                    {filteredState.map((state) => (
+                      <StateBadge key={state} state={state as TaskInstanceState}>
+                        {state === "none" ? "No Status" : capitalize(state)}
+                      </StateBadge>
+                    ))}
+                  </HStack>
+                ) : (
+                  "All States"
+                )
+              }
+            </Select.ValueText>
+          </Select.Trigger>
+          <Select.Content>
+            {stateOptions.items.map((option) => (
+              <Select.Item item={option} key={option.label}>
+                {option.value === "all" ? (
+                  option.label
+                ) : (
+                  <StateBadge state={option.value as TaskInstanceState}>{option.label}</StateBadge>
+                )}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      </Flex>
+
       <DataTable
         columns={columns(Boolean(task?.is_mapped))}
         data={data?.task_instances ?? []}


### PR DESCRIPTION
For a given task it will be helpful to have a filter similar to dag runs list and tasks page to filter task instances for a task by given state like all failed states for a task. This is very similar to how it's done in dag run page's task instance tab. 

Notes for self and review : 

`stateOptions` can perhaps be moved to a common constant inside `src/constants` to reuse between the pages.

![image](https://github.com/user-attachments/assets/fbd55384-b973-486d-adef-a490a0b04a09)
