### PR TITLE
AIP-38 Add logical date to trigger DagRun form and remove dataInterval

### DIFF
--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -42,8 +42,6 @@ type TriggerDAGFormProps = {
 export type DagRunTriggerParams = {
   conf: string;
   dagRunId: string;
-  dataIntervalEnd: string;
-  dataIntervalStart: string;
   logicalDate: string;
   note: string;
 };
@@ -51,20 +49,13 @@ export type DagRunTriggerParams = {
 const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const initialParamsDict = useDagParams(dagId, open);
-  const {
-    dateValidationError,
-    error: errorTrigger,
-    isPending,
-    triggerDagRun,
-  } = useTrigger({ dagId, onSuccessConfirm: onClose });
+  const { error: errorTrigger, isPending, triggerDagRun } = useTrigger({ dagId, onSuccessConfirm: onClose });
   const { conf, setConf } = useParamStore();
 
-  const { control, formState, handleSubmit, reset, setValue, watch } = useForm<DagRunTriggerParams>({
+  const { control, handleSubmit, reset } = useForm<DagRunTriggerParams>({
     defaultValues: {
       conf,
       dagRunId: "",
-      dataIntervalEnd: "",
-      dataIntervalStart: "",
       logicalDate: "",
       note: "",
     },
@@ -76,38 +67,6 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
       reset({ conf });
     }
   }, [conf, reset]);
-
-  useEffect(() => {
-    if (Boolean(dateValidationError)) {
-      setErrors((prev) => ({ ...prev, date: dateValidationError }));
-    }
-  }, [dateValidationError]);
-
-  const dataIntervalStart = watch("dataIntervalStart");
-  const dataIntervalEnd = watch("dataIntervalEnd");
-  const logicalDate = watch("logicalDate");
-
-  // Help filling dates
-  useEffect(() => {
-    // If logicalDate was not manually set by the user, set it to dataIntervalEnd if defined
-    // or dataIntervalStart if defined.
-    if (!formState.dirtyFields.logicalDate) {
-      if (dataIntervalEnd) {
-        setValue("logicalDate", dataIntervalEnd);
-      } else if (dataIntervalStart) {
-        setValue("logicalDate", dataIntervalStart);
-      }
-    }
-
-    // If dataIntervalStart or dataIntervalEnd was not manually set by the user, set it to logicalDate
-    // if defined.
-    if (!formState.dirtyFields.dataIntervalStart && logicalDate) {
-      setValue("dataIntervalStart", logicalDate);
-    }
-    if (!formState.dirtyFields.dataIntervalEnd && logicalDate) {
-      setValue("dataIntervalEnd", logicalDate);
-    }
-  }, [setValue, formState, dataIntervalEnd, dataIntervalStart, logicalDate]);
 
   const onSubmit = (data: DagRunTriggerParams) => {
     triggerDagRun(data);
@@ -161,45 +120,9 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
             <Box p={5}>
               <Controller
                 control={control}
-                name="dataIntervalStart"
-                render={({ field }) => (
-                  <Field.Root invalid={Boolean(errors.date)}>
-                    <Field.Label fontSize="md">Data Interval Start Date</Field.Label>
-                    <Input
-                      {...field}
-                      max={dataIntervalEnd || undefined}
-                      onBlur={resetDateError}
-                      placeholder="yyyy-mm-ddThh:mm"
-                      size="sm"
-                      type="datetime-local"
-                    />
-                  </Field.Root>
-                )}
-              />
-
-              <Controller
-                control={control}
-                name="dataIntervalEnd"
-                render={({ field }) => (
-                  <Field.Root invalid={Boolean(errors.date)} mt={6}>
-                    <Field.Label fontSize="md">Data Interval End Date</Field.Label>
-                    <Input
-                      {...field}
-                      min={dataIntervalStart || undefined}
-                      onBlur={resetDateError}
-                      placeholder="yyyy-mm-ddThh:mm"
-                      size="sm"
-                      type="datetime-local"
-                    />
-                  </Field.Root>
-                )}
-              />
-
-              <Controller
-                control={control}
                 name="logicalDate"
                 render={({ field }) => (
-                  <Field.Root invalid={Boolean(errors.date)} mt={6}>
+                  <Field.Root invalid={Boolean(errors.date)}>
                     <Field.Label fontSize="md">Logical Date</Field.Label>
                     <Input
                       {...field}

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -44,6 +44,7 @@ export type DagRunTriggerParams = {
   dagRunId: string;
   dataIntervalEnd: string;
   dataIntervalStart: string;
+  logicalDate: string;
   note: string;
 };
 
@@ -64,6 +65,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
       dagRunId: "",
       dataIntervalEnd: "",
       dataIntervalStart: "",
+      logicalDate: "",
       note: "",
     },
   });
@@ -161,6 +163,23 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
                     <Input
                       {...field}
                       min={dataIntervalStart || undefined}
+                      onBlur={resetDateError}
+                      placeholder="yyyy-mm-ddThh:mm"
+                      size="sm"
+                      type="datetime-local"
+                    />
+                  </Field.Root>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="logicalDate"
+                render={({ field }) => (
+                  <Field.Root invalid={Boolean(errors.date)} mt={6}>
+                    <Field.Label fontSize="md">Logical Date</Field.Label>
+                    <Input
+                      {...field}
                       onBlur={resetDateError}
                       placeholder="yyyy-mm-ddThh:mm"
                       size="sm"

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -59,7 +59,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
   } = useTrigger({ dagId, onSuccessConfirm: onClose });
   const { conf, setConf } = useParamStore();
 
-  const { control, handleSubmit, reset, watch } = useForm<DagRunTriggerParams>({
+  const { control, formState, handleSubmit, reset, setValue, watch } = useForm<DagRunTriggerParams>({
     defaultValues: {
       conf,
       dagRunId: "",
@@ -85,6 +85,29 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
 
   const dataIntervalStart = watch("dataIntervalStart");
   const dataIntervalEnd = watch("dataIntervalEnd");
+  const logicalDate = watch("logicalDate");
+
+  // Help filling dates
+  useEffect(() => {
+    // If logicalDate was not manually set by the user, set it to dataIntervalEnd if defined
+    // or dataIntervalStart if defined.
+    if (!formState.dirtyFields.logicalDate) {
+      if (dataIntervalEnd) {
+        setValue("logicalDate", dataIntervalEnd);
+      } else if (dataIntervalStart) {
+        setValue("logicalDate", dataIntervalStart);
+      }
+    }
+
+    // If dataIntervalStart or dataIntervalEnd was not manually set by the user, set it to logicalDate
+    // if defined.
+    if (!formState.dirtyFields.dataIntervalStart && logicalDate) {
+      setValue("dataIntervalStart", logicalDate);
+    }
+    if (!formState.dirtyFields.dataIntervalEnd && logicalDate) {
+      setValue("dataIntervalEnd", logicalDate);
+    }
+  }, [setValue, formState, dataIntervalEnd, dataIntervalStart, logicalDate]);
 
   const onSubmit = (data: DagRunTriggerParams) => {
     triggerDagRun(data);

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -65,14 +65,16 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const triggerDagRun = (dagRunRequestBody: DagRunTriggerParams) => {
     const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<string, unknown>;
 
-    const DataIntervalStart = dagRunRequestBody.dataIntervalStart
+    const dataIntervalStart = dagRunRequestBody.dataIntervalStart
       ? new Date(dagRunRequestBody.dataIntervalStart)
       : undefined;
-    const DataIntervalEnd = dagRunRequestBody.dataIntervalEnd
+    const dataIntervalEnd = dagRunRequestBody.dataIntervalEnd
       ? new Date(dagRunRequestBody.dataIntervalEnd)
       : undefined;
 
-    if (Boolean(DataIntervalStart) !== Boolean(DataIntervalEnd)) {
+    const logicalDate = dagRunRequestBody.logicalDate ? new Date(dagRunRequestBody.logicalDate) : undefined;
+
+    if (Boolean(dataIntervalStart) !== Boolean(dataIntervalEnd)) {
       setDateValidationError({
         body: {
           detail:
@@ -83,8 +85,8 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
       return;
     }
 
-    if (DataIntervalStart && DataIntervalEnd) {
-      if (DataIntervalStart > DataIntervalEnd) {
+    if (dataIntervalStart && dataIntervalEnd) {
+      if (dataIntervalStart > dataIntervalEnd) {
         setDateValidationError({
           body: {
             detail: "Data Interval Start Date must be less than or equal to Data Interval End Date.",
@@ -95,8 +97,10 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
       }
     }
 
-    const formattedDataIntervalStart = DataIntervalStart?.toISOString() ?? undefined;
-    const formattedDataIntervalEnd = DataIntervalEnd?.toISOString() ?? undefined;
+    const formattedDataIntervalStart = dataIntervalStart?.toISOString() ?? undefined;
+    const formattedDataIntervalEnd = dataIntervalEnd?.toISOString() ?? undefined;
+    // eslint-disable-next-line unicorn/no-null
+    const formattedLogicalDate = logicalDate?.toISOString() ?? null;
 
     const checkDagRunId = dagRunRequestBody.dagRunId === "" ? undefined : dagRunRequestBody.dagRunId;
     const checkNote = dagRunRequestBody.note === "" ? undefined : dagRunRequestBody.note;
@@ -108,7 +112,7 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
         dag_run_id: checkDagRunId,
         data_interval_end: formattedDataIntervalEnd,
         data_interval_start: formattedDataIntervalStart,
-        logical_date: null,
+        logical_date: formattedLogicalDate,
         note: checkNote,
       },
     });

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -33,8 +33,6 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const queryClient = useQueryClient();
   const [error, setError] = useState<unknown>(undefined);
 
-  const [dateValidationError, setDateValidationError] = useState<unknown>(undefined);
-
   const onSuccess = async () => {
     const queryKeys = [
       [useDagServiceGetDagsKey],
@@ -65,40 +63,8 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const triggerDagRun = (dagRunRequestBody: DagRunTriggerParams) => {
     const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<string, unknown>;
 
-    const dataIntervalStart = dagRunRequestBody.dataIntervalStart
-      ? new Date(dagRunRequestBody.dataIntervalStart)
-      : undefined;
-    const dataIntervalEnd = dagRunRequestBody.dataIntervalEnd
-      ? new Date(dagRunRequestBody.dataIntervalEnd)
-      : undefined;
-
     const logicalDate = dagRunRequestBody.logicalDate ? new Date(dagRunRequestBody.logicalDate) : undefined;
 
-    if (Boolean(dataIntervalStart) !== Boolean(dataIntervalEnd)) {
-      setDateValidationError({
-        body: {
-          detail:
-            "Either both Data Interval Start Date and End Date must be provided, or both must be empty.",
-        },
-      });
-
-      return;
-    }
-
-    if (dataIntervalStart && dataIntervalEnd) {
-      if (dataIntervalStart > dataIntervalEnd) {
-        setDateValidationError({
-          body: {
-            detail: "Data Interval Start Date must be less than or equal to Data Interval End Date.",
-          },
-        });
-
-        return;
-      }
-    }
-
-    const formattedDataIntervalStart = dataIntervalStart?.toISOString() ?? undefined;
-    const formattedDataIntervalEnd = dataIntervalEnd?.toISOString() ?? undefined;
     // eslint-disable-next-line unicorn/no-null
     const formattedLogicalDate = logicalDate?.toISOString() ?? null;
 
@@ -110,13 +76,11 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
       requestBody: {
         conf: parsedConfig,
         dag_run_id: checkDagRunId,
-        data_interval_end: formattedDataIntervalEnd,
-        data_interval_start: formattedDataIntervalStart,
         logical_date: formattedLogicalDate,
         note: checkNote,
       },
     });
   };
 
-  return { dateValidationError, error, isPending, triggerDagRun };
+  return { error, isPending, triggerDagRun };
 };


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/46189

Needs https://github.com/apache/airflow/pull/46390 (to fix linting issue + make the feature functional)


Logical date is optional in the form and will send `null` to the API. It can be specified to any arbitrary date otherwise:

## Example Logical Date not specified
![Screenshot 2025-02-11 at 17 36 04](https://github.com/user-attachments/assets/bd5ffe99-6c47-47f2-bf92-a829d579f15f)
![Screenshot 2025-02-11 at 17 32 07](https://github.com/user-attachments/assets/42e0a9dc-6f5b-44b9-acdf-e8540f2a5c3c)



## Example Logical Date specified
![Screenshot 2025-02-11 at 17 36 44](https://github.com/user-attachments/assets/e05a1ee6-e593-4bed-90a7-60d912534012)
![Screenshot 2025-02-11 at 17 31 44](https://github.com/user-attachments/assets/05021f74-abdf-4343-a8a1-7cb23edd716c)
