### PR TITLE
[snowflake] Add ocsp_fail_open setting for SnowflakeHook

### DIFF
--- a/providers/snowflake/docs/connections/snowflake.rst
+++ b/providers/snowflake/docs/connections/snowflake.rst
@@ -64,6 +64,7 @@ Extra (optional)
     * ``insecure_mode``: Turn off OCSP certificate checks. For details, see: `How To: Turn Off OCSP Checking in Snowflake Client Drivers - Snowflake Community <https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers>`_.
     * ``host``: Target Snowflake hostname to connect to (e.g., for local testing with LocalStack).
     * ``port``: Target Snowflake port to connect to (e.g., for local testing with LocalStack).
+    * ``ocsp_fail_open``: Specify `ocsp_fail_open <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#label-python-ocsp-choosing-fail-open-or-fail-close-mode>`_.
 
 URI format example
 ^^^^^^^^^^^^^^^^^^

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -299,6 +299,12 @@ class SnowflakeHook(DbApiHook):
         if snowflake_port:
             conn_config["port"] = snowflake_port
 
+        # if a value for ocsp_fail_open is set, pass it along.
+        # Note the check is for `is not None` so that we can pass along `False` as a value.
+        ocsp_fail_open = extra_dict.get("ocsp_fail_open")
+        if ocsp_fail_open is not None:
+            conn_config["ocsp_fail_open"] = _try_to_boolean(ocsp_fail_open)
+
         return conn_config
 
     def get_uri(self) -> str:
@@ -320,6 +326,7 @@ class SnowflakeHook(DbApiHook):
                     "client_request_mfa_token",
                     "client_store_temporary_credential",
                     "json_result_force_utf8_decoding",
+                    "ocsp_fail_open",
                 ]
             }
         )
@@ -345,6 +352,9 @@ class SnowflakeHook(DbApiHook):
         if "json_result_force_utf8_decoding" in conn_params:
             engine_kwargs.setdefault("connect_args", {})
             engine_kwargs["connect_args"]["json_result_force_utf8_decoding"] = True
+        if "ocsp_fail_open" in conn_params:
+            engine_kwargs.setdefault("connect_args", {})
+            engine_kwargs["connect_args"]["ocsp_fail_open"] = conn_params["ocsp_fail_open"]
         for key in ["session_parameters", "private_key"]:
             if conn_params.get(key):
                 engine_kwargs.setdefault("connect_args", {})


### PR DESCRIPTION
Adds support for passing through the `ocsp_fail_open` parameter. Ref: https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#choosing-fail-open-or-fail-close-mode

The `ocsp_fail_open` parameter defaults to `True` inside of the driver when the snowflake-connector version is 1.8.0 or later. So the usual case for overriding the setting will be providing a `False` value. That is different than other flags (where we only pass through `True`), so you may notice some difference in the flag handling.

Also, for building the sqlalchemy engine, this parameter needs to be passed in as part of `connect_args`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
