### PR TITLE
Fix bug in query invalidation and remove custom predicate logic

### DIFF
--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -22,8 +22,8 @@ import { useState } from "react";
 import {
   UseDagRunServiceGetDagRunsKeyFn,
   useDagRunServiceTriggerDagRun,
-  UseDagServiceGetDagsKeyFn,
-  UseDagsServiceRecentDagRunsKeyFn,
+  useDagServiceGetDagsKey,
+  useDagsServiceRecentDagRunsKey,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
@@ -37,8 +37,8 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
 
   const onSuccess = async () => {
     const queryKeys = [
-      UseDagServiceGetDagsKeyFn(),
-      UseDagsServiceRecentDagRunsKeyFn(),
+      [useDagServiceGetDagsKey],
+      [useDagsServiceRecentDagRunsKey],
       UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
       UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
     ];

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -20,11 +20,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import {
-  useDagRunServiceGetDagRunsKey,
+  UseDagRunServiceGetDagRunsKeyFn,
   useDagRunServiceTriggerDagRun,
-  useDagServiceGetDagsKey,
-  useDagsServiceRecentDagRunsKey,
-  useTaskInstanceServiceGetTaskInstancesKey,
+  UseDagServiceGetDagsKeyFn,
+  UseDagsServiceRecentDagRunsKeyFn,
+  UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
@@ -37,10 +37,10 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
 
   const onSuccess = async () => {
     const queryKeys = [
-      [useDagServiceGetDagsKey],
-      [useDagsServiceRecentDagRunsKey],
-      [useDagRunServiceGetDagRunsKey, { dagId }],
-      [useTaskInstanceServiceGetTaskInstancesKey, { dagId, dagRunId: "~" }],
+      UseDagServiceGetDagsKeyFn(),
+      UseDagsServiceRecentDagRunsKeyFn(),
+      UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
+      UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
     ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -28,7 +28,6 @@ import {
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
-import { doQueryKeysMatch, type PartialQueryKey } from "src/utils";
 
 export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
@@ -37,14 +36,14 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const [dateValidationError, setDateValidationError] = useState<unknown>(undefined);
 
   const onSuccess = async () => {
-    const queryKeys: Array<PartialQueryKey> = [
-      { baseKey: useDagServiceGetDagsKey },
-      { baseKey: useDagsServiceRecentDagRunsKey },
-      { baseKey: useDagRunServiceGetDagRunsKey, options: { dagIds: [dagId] } },
-      { baseKey: useTaskInstanceServiceGetTaskInstancesKey, options: { dagId, dagRunId: "~" } },
+    const queryKeys = [
+      [useDagServiceGetDagsKey],
+      [useDagsServiceRecentDagRunsKey],
+      [useDagRunServiceGetDagRunsKey, { dagId }],
+      [useTaskInstanceServiceGetTaskInstancesKey, { dagId, dagRunId: "~" }],
     ];
 
-    await queryClient.invalidateQueries({ predicate: (query) => doQueryKeysMatch(query, queryKeys) });
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
     toaster.create({
       description: "DAG run has been successfully triggered.",

--- a/airflow/ui/src/utils/query.ts
+++ b/airflow/ui/src/utils/query.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import type { Query } from "@tanstack/react-query";
-
 import { useDagServiceGetDagDetails } from "openapi/queries";
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { useConfig } from "src/queries/useConfig";
@@ -31,26 +29,6 @@ export const isStatePending = (state?: TaskInstanceState | null) =>
   state === "queued" ||
   state === "restarting" ||
   !Boolean(state);
-
-export type PartialQueryKey = { baseKey: string; options?: Record<string, unknown> };
-
-// This allows us to specify what query key values we actually care about and ignore the rest
-// ex: match everything with this dagId and dagRunId but ignore anything related to pagination
-export const doQueryKeysMatch = (query: Query, queryKeysToMatch: Array<PartialQueryKey>) => {
-  const [baseKey, options] = query.queryKey;
-
-  const matchedKey = queryKeysToMatch.find((qk) => qk.baseKey === baseKey);
-
-  if (!matchedKey) {
-    return false;
-  }
-
-  return matchedKey.options
-    ? Object.entries(matchedKey.options).every(
-        ([key, value]) => typeof options === "object" && (options as Record<string, unknown>)[key] === value,
-      )
-    : true;
-};
 
 export const useAutoRefresh = ({ dagId, isPaused }: { dagId?: string; isPaused?: boolean }) => {
   const autoRefreshInterval = useConfig("auto_refresh_interval") as number | undefined;


### PR DESCRIPTION


I was passing `{ dagIds: [dagId] }` instead of `{dagId}` to `useDagRunServiceGetDagRunsKey` and that is why the query wasn't invalidating correct.y We actually didn't need all the custom query matching logic

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
