### PR TITLE
Adding `run_after` field in task SDK datamodels

### DIFF
--- a/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -283,6 +283,7 @@ class DagRun(BaseModel):
     logical_date: Annotated[datetime, Field(title="Logical Date")]
     data_interval_start: Annotated[datetime | None, Field(title="Data Interval Start")] = None
     data_interval_end: Annotated[datetime | None, Field(title="Data Interval End")] = None
+    run_after: Annotated[datetime, Field(title="Run After")]
     start_date: Annotated[datetime, Field(title="Start Date")]
     end_date: Annotated[datetime | None, Field(title="End Date")] = None
     run_type: DagRunType

--- a/task_sdk/tests/conftest.py
+++ b/task_sdk/tests/conftest.py
@@ -154,7 +154,9 @@ class MakeTIContextCallable(Protocol):
         data_interval_start: str | datetime = ...,
         data_interval_end: str | datetime = ...,
         start_date: str | datetime = ...,
+        run_after: str | datetime = ...,
         run_type: str = ...,
+        conf=None,
     ) -> TIRunContext: ...
 
 
@@ -167,7 +169,9 @@ class MakeTIContextDictCallable(Protocol):
         data_interval_start: str | datetime = ...,
         data_interval_end: str | datetime = ...,
         start_date: str | datetime = ...,
+        run_after: str | datetime = ...,
         run_type: str = ...,
+        conf=None,
     ) -> dict[str, Any]: ...
 
 
@@ -183,6 +187,7 @@ def make_ti_context() -> MakeTIContextCallable:
         data_interval_start: str | datetime = "2024-12-01T00:00:00Z",
         data_interval_end: str | datetime = "2024-12-01T01:00:00Z",
         start_date: str | datetime = "2024-12-01T01:00:00Z",
+        run_after: str | datetime = "2024-12-01T01:00:00Z",
         run_type: str = "manual",
         conf=None,
     ) -> TIRunContext:
@@ -195,6 +200,7 @@ def make_ti_context() -> MakeTIContextCallable:
                 data_interval_end=data_interval_end,  # type: ignore
                 start_date=start_date,  # type: ignore
                 run_type=run_type,  # type: ignore
+                run_after=run_after,  # type: ignore
                 conf=conf,
             ),
             max_tries=0,
@@ -214,7 +220,9 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
         data_interval_start: str | datetime = "2024-12-01T00:00:00Z",
         data_interval_end: str | datetime = "2024-12-01T01:00:00Z",
         start_date: str | datetime = "2024-12-01T00:00:00Z",
+        run_after: str | datetime = "2024-12-01T00:00:00Z",
         run_type: str = "manual",
+        conf=None,
     ) -> dict[str, Any]:
         context = make_ti_context(
             dag_id=dag_id,
@@ -223,7 +231,9 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
             data_interval_start=data_interval_start,
             data_interval_end=data_interval_end,
             start_date=start_date,
+            run_after=run_after,
             run_type=run_type,
+            conf=conf,
         )
         return context.model_dump(exclude_unset=True, mode="json")
 

--- a/task_sdk/tests/execution_time/conftest.py
+++ b/task_sdk/tests/execution_time/conftest.py
@@ -132,6 +132,7 @@ def create_runtime_ti(mocked_parse, make_ti_context):
         data_interval_start: str | datetime = "2024-12-01T00:00:00Z",
         data_interval_end: str | datetime = "2024-12-01T01:00:00Z",
         start_date: str | datetime = "2024-12-01T01:00:00Z",
+        run_after: str | datetime = "2024-12-01T01:00:00Z",
         run_type: str = "manual",
         try_number: int = 1,
         conf=None,
@@ -148,6 +149,7 @@ def create_runtime_ti(mocked_parse, make_ti_context):
             data_interval_end=data_interval_end,
             start_date=start_date,
             run_type=run_type,
+            run_after=run_after,
             conf=conf,
         )
 

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -238,7 +238,7 @@ class TestWatchedSubprocess:
         assert "Last chance exception handler" in captured.err
         assert "RuntimeError: Fake syntax error" in captured.err
 
-    def test_regular_heartbeat(self, spy_agency: kgb.SpyAgency, monkeypatch):
+    def test_regular_heartbeat(self, spy_agency: kgb.SpyAgency, monkeypatch, mocker, make_ti_context):
         """Test that the WatchedSubprocess class regularly sends heartbeat requests, up to a certain frequency"""
         import airflow.sdk.execution_time.supervisor
 
@@ -252,6 +252,8 @@ class TestWatchedSubprocess:
                 sleep(0.05)
 
         ti_id = uuid7()
+        _ = mocker.patch.object(sdk_client.TaskInstanceOperations, "start", return_value=make_ti_context())
+
         spy = spy_agency.spy_on(sdk_client.TaskInstanceOperations.heartbeat)
         proc = ActivitySubprocess.start(
             dag_rel_path=os.devnull,
@@ -271,7 +273,7 @@ class TestWatchedSubprocess:
         # The exact number we get will depend on timing behaviour, so be a little lenient
         assert 1 <= len(spy.calls) <= 4
 
-    def test_run_simple_dag(self, test_dags_dir, captured_logs, time_machine):
+    def test_run_simple_dag(self, test_dags_dir, captured_logs, time_machine, mocker, make_ti_context):
         """Test running a simple DAG in a subprocess and capturing the output."""
 
         instant = tz.datetime(2024, 11, 7, 12, 34, 56, 78901)
@@ -285,6 +287,12 @@ class TestWatchedSubprocess:
             run_id="c",
             try_number=1,
         )
+
+        # Create a mock client to assert calls to the client
+        # We assume the implementation of the client is correct and only need to check the calls
+        mock_client = mocker.Mock(spec=sdk_client.Client)
+        mock_client.task_instances.start.return_value = make_ti_context()
+
         bundle_info = BundleInfo(name="my-bundle", version=None)
         with patch.dict(os.environ, local_dag_bundle_cfg(test_dags_dir, bundle_info.name)):
             exit_code = supervise(

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -301,6 +301,7 @@ class TestWatchedSubprocess:
                 token="",
                 server="",
                 dry_run=True,
+                client=mock_client,
                 bundle_info=bundle_info,
             )
             assert exit_code == 0, captured_logs

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -108,7 +108,7 @@ class TestCommsDecoder:
             b'"id": "4d828a62-a417-4936-a7a6-2b3fabacecab", "task_id": "a", "try_number": 1, "run_id": "b", "dag_id": "c" }, '
             b'"ti_context":{"dag_run":{"dag_id":"c","run_id":"b","logical_date":"2024-12-01T01:00:00Z",'
             b'"data_interval_start":"2024-12-01T00:00:00Z","data_interval_end":"2024-12-01T01:00:00Z",'
-            b'"start_date":"2024-12-01T01:00:00Z","end_date":null,"run_type":"manual","conf":null},'
+            b'"start_date":"2024-12-01T01:00:00Z","run_after":"2024-12-01T01:00:00Z","end_date":null,"run_type":"manual","conf":null},'
             b'"max_tries":0,"variables":null,"connections":null},"file": "/dev/null", "dag_rel_path": "/dev/null", "bundle_info": {"name": '
             b'"any-name", "version": "any-version"}, "requests_fd": '
             + str(w2.fileno()).encode("ascii")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


All K8s tests started failing in https://github.com/apache/airflow/actions/runs/13158509534.

When traced down, this is the error:
```
2025-02-05T14:49:01.975482931Z stdout F [2025-02-05T14:49:01.975+0000] {_trace.py:47} DEBUG - receive_response_body.started request=<Request [b'PATCH']>
2025-02-05T14:49:01.975742808Z stdout F 2025-02-05 14:49:01 [info     ] Process exited                 [supervisor] exit_code=<Negsignal.SIGKILL: -9> pid=155 signal=SIGKILL
2025-02-05T14:49:01.977567917Z stdout F [2025-02-05T14:49:01.976+0000] {local_executor.py:99} ERROR - uhoh
2025-02-05T14:49:01.977577034Z stdout F Traceback (most recent call last):
2025-02-05T14:49:01.977581732Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/executors/local_executor.py", line 95, in _run_worker
2025-02-05T14:49:01.977586171Z stdout F     _execute_work(log, workload)
2025-02-05T14:49:01.977590339Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/executors/local_executor.py", line 116, in _execute_work
2025-02-05T14:49:01.977594466Z stdout F     supervise(
2025-02-05T14:49:01.977598674Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/sdk/execution_time/supervisor.py", line 970, in supervise
2025-02-05T14:49:01.977602662Z stdout F     process = ActivitySubprocess.start(
2025-02-05T14:49:01.977606619Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/sdk/execution_time/supervisor.py", line 602, in start
2025-02-05T14:49:01.977620685Z stdout F     proc._on_child_started(ti=what, dag_rel_path=dag_rel_path, bundle_info=bundle_info)
2025-02-05T14:49:01.977625254Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/sdk/execution_time/supervisor.py", line 611, in _on_child_started
2025-02-05T14:49:01.977629722Z stdout F     ti_context = self.client.task_instances.start(ti.id, self.pid, datetime.now(tz=timezone.utc))
2025-02-05T14:49:01.97763392Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/sdk/api/client.py", line 133, in start
2025-02-05T14:49:01.977638399Z stdout F     return TIRunContext.model_validate_json(resp.read())
2025-02-05T14:49:01.977642506Z stdout F   File "/home/airflow/.local/lib/python3.9/site-packages/pydantic/main.py", line 656, in model_validate_json
2025-02-05T14:49:01.977647135Z stdout F     return cls.__pydantic_validator__.validate_json(json_data, strict=strict, context=context)
2025-02-05T14:49:01.977651122Z stdout F pydantic_core._pydantic_core.ValidationError: 1 validation error for TIRunContext
2025-02-05T14:49:01.977655821Z stdout F dag_run.run_after
2025-02-05T14:49:01.977659999Z stdout F   Extra inputs are not permitted [type=extra_forbidden, input_value='2025-02-05T00:00:00Z', input_type=str]
2025-02-05T14:49:01.977664077Z stdout F     For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
```

This makes https://github.com/apache/airflow/pull/45732 the obvious candidate but that was merged a couple days ago, we shouldve seen the failures earlier.

But, https://github.com/apache/airflow/pull/44986 was merged recently which doesn't allow extra fields in any datamodels, due to which the fields added in the previous PR started screaming.

This PR updates the fields in task sdk datamodels.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
