### PR TITLE
Add `lock` to `BaseDagBundle` and use it in `GitDagBundle`

### DIFF
--- a/airflow/dag_processing/bundles/base.py
+++ b/airflow/dag_processing/bundles/base.py
@@ -17,8 +17,10 @@
 
 from __future__ import annotations
 
+import fcntl
 import tempfile
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from pathlib import Path
 
 from airflow.configuration import conf
@@ -46,6 +48,7 @@ class BaseDagBundle(ABC):
     """
 
     supports_versioning: bool = False
+    _locked: bool = False
 
     def __init__(
         self,
@@ -67,6 +70,10 @@ class BaseDagBundle(ABC):
         and allows for deferring expensive operations until that point in time. This will
         only be called when Airflow needs the bundle files on disk - some uses only need
         to call the `view_url` method, which can run without initializing the bundle.
+
+        This method must be safe to call concurrently from different threads or processes.
+        If the underlying implementation is not safe, the `lock` context manager can be used to
+        ensure that only one thread or process is initializing the bundle at a time.
         """
         self.is_initialized = True
 
@@ -101,7 +108,13 @@ class BaseDagBundle(ABC):
 
     @abstractmethod
     def refresh(self) -> None:
-        """Retrieve the latest version of the files in the bundle."""
+        """
+        Retrieve the latest version of the files in the bundle.
+
+        This method must be safe to call concurrently from different threads or processes.
+        If the underlying implementation is not safe, the `lock` context manager can be used to
+        ensure that only one thread or process is initializing the bundle at a time.
+        """
 
     def view_url(self, version: str | None = None) -> str | None:
         """
@@ -112,3 +125,22 @@ class BaseDagBundle(ABC):
         :param version: Version to view
         :return: URL to view the bundle
         """
+
+    @contextmanager
+    def lock(self):
+        if self._locked:
+            yield
+            return
+
+        lock_dir_path = self._dag_bundle_root_storage_path / "locks"
+        lock_dir_path.mkdir(parents=True, exist_ok=True)
+        lock_file_path = lock_dir_path / f"{self.name}.lock"
+        with open(lock_file_path, "w") as lock_file:
+            # Exclusive lock - blocks until it is available
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                self._locked = True
+                yield
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+                self._locked = False

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import os
 import re
 import tempfile
@@ -52,20 +53,80 @@ def test_default_dag_storage_path():
         assert bundle._dag_bundle_root_storage_path == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 
 
+class BasicBundle(BaseDagBundle):
+    def refresh(self):
+        pass
+
+    def get_current_version(self):
+        pass
+
+    def path(self):
+        pass
+
+
 def test_dag_bundle_root_storage_path():
-    class BasicBundle(BaseDagBundle):
-        def refresh(self):
-            pass
-
-        def get_current_version(self):
-            pass
-
-        def path(self):
-            pass
-
     with conf_vars({("dag_processor", "dag_bundle_storage_path"): None}):
         bundle = BasicBundle(name="test")
         assert bundle._dag_bundle_root_storage_path == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
+
+
+def test_lock_acquisition():
+    """Test that the lock context manager sets _locked and locks a lock file."""
+    bundle = BasicBundle(name="locktest")
+    lock_dir = bundle._dag_bundle_root_storage_path / "locks"
+    lock_file = lock_dir / f"{bundle.name}.lock"
+
+    assert not bundle._locked
+
+    with bundle.lock():
+        assert bundle._locked
+        assert lock_file.exists()
+
+        # Check lock file is now locked
+        with open(lock_file, "w") as f:
+            try:
+                # Try to acquire an exclusive lock in non-blocking mode.
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                locked = False
+            except OSError:
+                locked = True
+            assert locked
+
+    # After, _locked is False and file unlock has been called.
+    assert bundle._locked is False
+    with open(lock_file, "w") as f:
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            unlocked = True
+            fcntl.flock(f, fcntl.LOCK_UN)  # Release the lock immediately.
+        except OSError:
+            unlocked = False
+        assert unlocked
+
+
+def test_lock_exception_handling():
+    """Test that exceptions within the lock context manager still release the lock."""
+    bundle = BasicBundle(name="locktest")
+    lock_dir = bundle._dag_bundle_root_storage_path / "locks"
+    lock_file = lock_dir / f"{bundle.name}.lock"
+
+    try:
+        with bundle.lock():
+            assert bundle._locked
+            raise Exception("...")
+    except Exception:
+        pass
+
+    # lock file should be unlocked
+    assert not bundle._locked
+    with open(lock_file, "w") as f:
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+            fcntl.flock(f, fcntl.LOCK_UN)
+        except OSError:
+            acquired = False
+        assert acquired
 
 
 class TestLocalDagBundle:
@@ -581,3 +642,12 @@ class TestGitDagBundle:
         )
         assert bundle.repo_url == "some_repo_url"
         assert "Could not create GitHook for connection" in mock_log.warning.call_args[0][0]
+
+    @mock.patch("airflow.dag_processing.bundles.git.GitHook")
+    def test_lock_used(self, mock_githook, git_repo):
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        bundle = GitDagBundle(name="test", tracking_ref=GIT_DEFAULT_BRANCH)
+        with mock.patch("airflow.dag_processing.bundles.git.GitDagBundle.lock") as mock_lock:
+            bundle.initialize()
+            assert mock_lock.call_count == 2  # both initialize and refresh

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -73,7 +73,7 @@ def test_dag_bundle_root_storage_path():
 def test_lock_acquisition():
     """Test that the lock context manager sets _locked and locks a lock file."""
     bundle = BasicBundle(name="locktest")
-    lock_dir = bundle._dag_bundle_root_storage_path / "locks"
+    lock_dir = bundle._dag_bundle_root_storage_path / "_locks"
     lock_file = lock_dir / f"{bundle.name}.lock"
 
     assert not bundle._locked
@@ -107,7 +107,7 @@ def test_lock_acquisition():
 def test_lock_exception_handling():
     """Test that exceptions within the lock context manager still release the lock."""
     bundle = BasicBundle(name="locktest")
-    lock_dir = bundle._dag_bundle_root_storage_path / "locks"
+    lock_dir = bundle._dag_bundle_root_storage_path / "_locks"
     lock_file = lock_dir / f"{bundle.name}.lock"
 
     try:


### PR DESCRIPTION
`initialize` and `refresh` need to be safe to call from different threads/processes, so this adds a simple `lock` context manager that bundles can use if the underlying implementation doesn't allow for that.

For example, `GitDagBundle` is the first taker.

closes: #46444