### PR TITLE
Add recent runs duration chart.

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -31,6 +31,7 @@
     "axios": "^1.7.7",
     "chakra-react-select": "6.0.0-next.2",
     "chart.js": "^4.4.6",
+    "chartjs-plugin-annotation": "^3.1.0",
     "dayjs": "^1.11.13",
     "debounce-promise": "^3.1.2",
     "elkjs": "^0.9.3",

--- a/airflow/ui/pnpm-lock.yaml
+++ b/airflow/ui/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       chart.js:
         specifier: ^4.4.6
         version: 4.4.6
+      chartjs-plugin-annotation:
+        specifier: ^3.1.0
+        version: 3.1.0(chart.js@4.4.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -1845,6 +1848,11 @@ packages:
   chart.js@4.4.6:
     resolution: {integrity: sha512-8Y406zevUPbbIBA/HRk33khEmQPk5+cxeflWE/2rx1NJsjVWMPw/9mSP9rxHP5eqi6LNoPBVMfZHxbwLSgldYA==}
     engines: {pnpm: '>=8'}
+
+  chartjs-plugin-annotation@3.1.0:
+    resolution: {integrity: sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==}
+    peerDependencies:
+      chart.js: '>=4.0.0'
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -6544,6 +6552,10 @@ snapshots:
   chart.js@4.4.6:
     dependencies:
       '@kurkle/color': 0.3.2
+
+  chartjs-plugin-annotation@3.1.0(chart.js@4.4.6):
+    dependencies:
+      chart.js: 4.4.6
 
   check-error@2.1.1: {}
 

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Skeleton } from "@chakra-ui/react";
+import { Box, HStack, Skeleton, SimpleGrid } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -100,13 +100,15 @@ export const Overview = () => {
           startDate={startDate}
         />
       </HStack>
-      <Box h="1/3" my={5} w="1/3">
-        {isLoadingRuns ? (
-          <Skeleton height="200px" w="full" />
-        ) : (
-          <RunDuration runs={runs?.dag_runs.slice().reverse()} />
-        )}
-      </Box>
+      <SimpleGrid columns={3} gap={5} my={5}>
+        <Box borderRadius={4} borderStyle="solid" borderWidth={1} p={2}>
+          {isLoadingRuns ? (
+            <Skeleton height="200px" w="full" />
+          ) : (
+            <RunDuration runs={runs?.dag_runs} totalEntries={runs?.total_entries ?? 0} />
+          )}
+        </Box>
+      </SimpleGrid>
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -54,6 +54,7 @@ export const Overview = () => {
   const { data: runs, isLoading: isLoadingRuns } = useDagRunServiceGetDagRuns({
     dagId: dagId ?? "",
     limit: 14,
+    orderBy: "-start_date",
   });
 
   return (
@@ -100,7 +101,11 @@ export const Overview = () => {
         />
       </HStack>
       <Box h="1/3" my={5} w="1/3">
-        {isLoadingRuns ? <Skeleton height="200px" w="full" /> : <RunDuration runs={runs?.dag_runs} />}
+        {isLoadingRuns ? (
+          <Skeleton height="200px" w="full" />
+        ) : (
+          <RunDuration runs={runs?.dag_runs.slice().reverse()} />
+        )}
       </Box>
     </Box>
   );

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack } from "@chakra-ui/react";
+import { Box, HStack, Skeleton } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -24,6 +24,8 @@ import { useParams } from "react-router-dom";
 import { useDagRunServiceGetDagRuns, useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
+
+import { RunDuration } from "./RunDuration";
 
 const defaultHour = "168";
 
@@ -42,14 +44,18 @@ export const Overview = () => {
     state: ["failed"],
   });
 
-  const { data: failedRuns, isLoading: isLoadingRuns } = useDagRunServiceGetDagRuns({
+  const { data: failedRuns, isLoading: isLoadingFailedRuns } = useDagRunServiceGetDagRuns({
     dagId: dagId ?? "",
     logicalDateGte: startDate,
     logicalDateLte: endDate,
     state: ["failed"],
   });
 
-  // TODO actually link to task instances list
+  const { data: runs, isLoading: isLoadingRuns } = useDagRunServiceGetDagRuns({
+    dagId: dagId ?? "",
+    limit: 14,
+  });
+
   return (
     <Box m={4}>
       <Box my={2}>
@@ -84,7 +90,7 @@ export const Overview = () => {
           events={(failedRuns?.dag_runs ?? []).map((dr) => ({
             timestamp: dr.start_date ?? dr.logical_date ?? "",
           }))}
-          isLoading={isLoadingRuns}
+          isLoading={isLoadingFailedRuns}
           label="Failed Run"
           route={{
             pathname: "runs",
@@ -93,6 +99,9 @@ export const Overview = () => {
           startDate={startDate}
         />
       </HStack>
+      <Box h="1/3" my={5} w="1/3">
+        {isLoadingRuns ? <Skeleton height="200px" w="full" /> : <RunDuration runs={runs?.dag_runs} />}
+      </Box>
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dag/Overview/RunDuration.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/RunDuration.tsx
@@ -97,7 +97,7 @@ export const RunDuration = ({
         data={{
           datasets: [
             {
-              backgroundColor: "grey",
+              backgroundColor: system.tokens.categoryMap.get("colors")?.get("queued.600")?.value as string,
               data: runs.map((run: DAGRunResponse) => Number(getDuration(run.queued_at, run.start_date))),
               label: "Queued duration",
             },

--- a/airflow/ui/src/pages/Dag/Overview/RunDuration.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/RunDuration.tsx
@@ -1,0 +1,133 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Heading } from "@chakra-ui/react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Filler,
+  Tooltip,
+} from "chart.js";
+import type { PartialEventContext } from "chartjs-plugin-annotation";
+import annotationPlugin from "chartjs-plugin-annotation";
+import dayjs from "dayjs";
+import { Bar } from "react-chartjs-2";
+
+import type { DAGRunResponse } from "openapi/requests/types.gen";
+import { getDuration } from "src/utils/datetime_utils";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  BarElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  annotationPlugin,
+);
+
+const average = (ctx: PartialEventContext, index: number) => {
+  const values: Array<number> | undefined = ctx.chart.data.datasets[index]?.data as Array<number> | undefined;
+
+  return values === undefined ? 0 : values.reduce((initial, next) => initial + next, 0) / values.length;
+};
+
+export const RunDuration = ({ runs }: { readonly runs: Array<DAGRunResponse> | undefined }) => {
+  if (!runs) {
+    return undefined;
+  }
+
+  const runAnnotation = {
+    borderColor: "green",
+    borderWidth: 1,
+    label: {
+      content: (ctx: PartialEventContext) => average(ctx, 1).toFixed(2),
+      display: true,
+      position: "end",
+    },
+    scaleID: "y",
+    value: (ctx: PartialEventContext) => average(ctx, 1),
+  };
+
+  const queuedAnnotation = {
+    borderColor: "grey",
+    borderWidth: 1,
+    label: {
+      content: (ctx: PartialEventContext) => average(ctx, 0).toFixed(2),
+      display: true,
+      position: "end",
+    },
+    scaleID: "y",
+    value: (ctx: PartialEventContext) => average(ctx, 0),
+  };
+
+  return (
+    <Box>
+      <Heading pb={2} size="sm" textAlign="center">
+        Last 14 runs
+      </Heading>
+      <Bar
+        data={{
+          datasets: [
+            {
+              backgroundColor: "grey",
+              data: runs.map((run: DAGRunResponse) => Number(getDuration(run.queued_at, run.start_date))),
+              label: "Queued duration",
+            },
+            {
+              backgroundColor: runs.map((run: DAGRunResponse) => (run.state === "failed" ? "red" : "green")),
+              data: runs.map((run: DAGRunResponse) => Number(getDuration(run.start_date, run.end_date))),
+              label: "Run duration",
+            },
+          ],
+          labels: runs.map((run) => dayjs(run.logical_date).format("YYYY-MM-DD, hh:mm:ss")),
+        }}
+        datasetIdKey="id"
+        options={{
+          plugins: {
+            annotation: {
+              annotations: {
+                queuedAnnotation,
+                runAnnotation,
+              },
+            },
+          },
+          responsive: true,
+          scales: {
+            x: {
+              stacked: true,
+              ticks: {
+                maxTicksLimit: 3,
+              },
+              title: { align: "end", display: true, text: "Logical Date" },
+            },
+
+            y: {
+              title: { align: "end", display: true, text: "Duration (seconds)" },
+            },
+          },
+        }}
+      />
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Dag/Overview/RunDuration.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/RunDuration.tsx
@@ -33,6 +33,7 @@ import dayjs from "dayjs";
 import { Bar } from "react-chartjs-2";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
+import { system } from "src/theme";
 import { getDuration } from "src/utils/datetime_utils";
 
 ChartJS.register(
@@ -52,7 +53,13 @@ const average = (ctx: PartialEventContext, index: number) => {
   return values === undefined ? 0 : values.reduce((initial, next) => initial + next, 0) / values.length;
 };
 
-export const RunDuration = ({ runs }: { readonly runs: Array<DAGRunResponse> | undefined }) => {
+export const RunDuration = ({
+  runs,
+  totalEntries,
+}: {
+  readonly runs: Array<DAGRunResponse> | undefined;
+  readonly totalEntries: number;
+}) => {
   if (!runs) {
     return undefined;
   }
@@ -84,7 +91,7 @@ export const RunDuration = ({ runs }: { readonly runs: Array<DAGRunResponse> | u
   return (
     <Box>
       <Heading pb={2} size="sm" textAlign="center">
-        Last 14 runs
+        Last {totalEntries} runs
       </Heading>
       <Bar
         data={{
@@ -95,7 +102,10 @@ export const RunDuration = ({ runs }: { readonly runs: Array<DAGRunResponse> | u
               label: "Queued duration",
             },
             {
-              backgroundColor: runs.map((run: DAGRunResponse) => (run.state === "failed" ? "red" : "green")),
+              backgroundColor: runs.map(
+                (run: DAGRunResponse) =>
+                  system.tokens.categoryMap.get("colors")?.get(`${run.state}.600`)?.value as string,
+              ),
               data: runs.map((run: DAGRunResponse) => Number(getDuration(run.start_date, run.end_date))),
               label: "Run duration",
             },


### PR DESCRIPTION
This uses the API to get recent 14 dag runs to plot the chart along with average of the run and queued duration as annotations. The size is 1/3 since there will be 2 more for success/failed rate and grouped durations as per design. This is for initial implementation and might not completely cover all use cases like Airflow 2 but can be taken up in subsequent PRs or separate issues for them as below. If approved a similar overview page can be created for task page as well in another PR for task duration.

Notes to self and review 

1. It seems `stateColor.ts` was removed. What is the recommended way to show color based on state for a given theme?
2. Legend is not implemented now where in Airflow 2 it can be selected to show only those values.
3. Duration is now in seconds and conversion to other units is yet to be implemented.
4. x axis value is set to 3 since high number causes values to render vertically amidst smaller space.
5. landing times based toggle is not implemented yet.
6. Clicking on dagrun to take to the run page is not implemented yet.
7. Autorefresh is not yet implemented.
8. It seems even with limit of 14 passed more dagruns are returned. Changing it manually reflects correct value. Need to see if there is some cache issue.

![image](https://github.com/user-attachments/assets/762a97ba-e168-4adb-9159-a164ca99876e)

![image](https://github.com/user-attachments/assets/08ee9784-a120-4954-812c-5616c2b38102)
