### PR TITLE
feat(context): remove context key logicate_date for asset triggerable dags

### DIFF
--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -230,6 +230,7 @@ class DagRun(StrictBaseModel):
     run_type: DagRunType
     conf: Annotated[dict[str, Any], Field(default_factory=dict)]
     external_trigger: bool = False
+    triggered_by: str
 
 
 class TIRunContext(BaseModel):

--- a/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -151,6 +151,7 @@ def ti_run(
                 DR.conf,
                 DR.logical_date,
                 DR.external_trigger,
+                DR.triggered_by,
             ).filter_by(dag_id=dag_id, run_id=run_id)
         ).one_or_none()
 

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -272,6 +272,7 @@ class DagRunAlreadyExists(AirflowBadRequest):
             run_id=self.dag_run.run_id,
             external_trigger=self.dag_run.external_trigger,
             run_type=self.dag_run.run_type,
+            triggered_by=self.dag_run.triggered_by,
         )
         dag_run.id = self.dag_run.id
         return (

--- a/providers/tests/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/tests/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -35,6 +35,7 @@ from airflow.providers.amazon.aws.utils import datetime_to_epoch_utc_ms
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunTriggeredByType
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -74,7 +75,13 @@ class TestCloudwatchTaskHandler:
         self.dag = DAG(dag_id=dag_id, schedule=None, start_date=date)
         task = EmptyOperator(task_id=task_id, dag=self.dag)
         if AIRFLOW_V_3_0_PLUS:
-            dag_run = DagRun(dag_id=self.dag.dag_id, logical_date=date, run_id="test", run_type="scheduled")
+            dag_run = DagRun(
+                dag_id=self.dag.dag_id,
+                logical_date=date,
+                run_id="test",
+                run_type="scheduled",
+                triggered_by=DagRunTriggeredByType.TEST,
+            )
         else:
             dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=date, run_id="test", run_type="scheduled")
         session.add(dag_run)
@@ -124,8 +131,8 @@ class TestCloudwatchTaskHandler:
         ]
         assert [handler._event_to_str(event) for event in events] == (
             [
-                f"[{get_time_str(current_time-2000)}] First",
-                f"[{get_time_str(current_time-1000)}] Second",
+                f"[{get_time_str(current_time - 2000)}] First",
+                f"[{get_time_str(current_time - 1000)}] Second",
                 f"[{get_time_str(current_time)}] Third",
             ]
         )
@@ -150,8 +157,8 @@ class TestCloudwatchTaskHandler:
         msg_template = "*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n"
         events = "\n".join(
             [
-                f"[{get_time_str(current_time-2000)}] First",
-                f"[{get_time_str(current_time-1000)}] Second",
+                f"[{get_time_str(current_time - 2000)}] First",
+                f"[{get_time_str(current_time - 1000)}] Second",
                 f"[{get_time_str(current_time)}] Third",
             ]
         )

--- a/providers/tests/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/tests/amazon/aws/log/test_s3_task_handler.py
@@ -33,6 +33,7 @@ from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunTriggeredByType
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -62,7 +63,13 @@ class TestS3TaskHandler:
         self.dag = DAG("dag_for_testing_s3_task_handler", schedule=None, start_date=date)
         task = EmptyOperator(task_id="task_for_testing_s3_log_handler", dag=self.dag)
         if AIRFLOW_V_3_0_PLUS:
-            dag_run = DagRun(dag_id=self.dag.dag_id, logical_date=date, run_id="test", run_type="manual")
+            dag_run = DagRun(
+                dag_id=self.dag.dag_id,
+                logical_date=date,
+                run_id="test",
+                run_type="manual",
+                triggered_by=DagRunTriggeredByType.TEST,
+            )
         else:
             dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=date, run_id="test", run_type="manual")
         session.add(dag_run)

--- a/providers/tests/amazon/aws/operators/test_athena.py
+++ b/providers/tests/amazon/aws/operators/test_athena.py
@@ -40,7 +40,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
 from airflow.utils.timezone import datetime
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -241,6 +241,7 @@ class TestAthenaOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/operators/test_datasync.py
+++ b/providers/tests/amazon/aws/operators/test_datasync.py
@@ -30,7 +30,7 @@ from airflow.providers.amazon.aws.operators.datasync import DataSyncOperator
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
 from airflow.utils.timezone import datetime
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -361,6 +361,7 @@ class TestDataSyncOperatorCreate(DataSyncTestCaseBase):
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -575,6 +576,7 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -691,6 +693,7 @@ class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -900,6 +903,7 @@ class TestDataSyncOperator(DataSyncTestCaseBase):
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -1012,6 +1016,7 @@ class TestDataSyncOperatorDelete(DataSyncTestCaseBase):
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/operators/test_dms.py
+++ b/providers/tests/amazon/aws/operators/test_dms.py
@@ -46,7 +46,7 @@ from airflow.providers.amazon.aws.triggers.dms import (
 )
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -300,6 +300,7 @@ class TestDmsDescribeTasksOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -497,6 +498,7 @@ class TestDmsDescribeReplicationConfigsOperator:
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
                 logical_date=logical_date,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/operators/test_emr_add_steps.py
+++ b/providers/tests/amazon/aws/operators/test_emr_add_steps.py
@@ -31,7 +31,7 @@ from airflow.providers.amazon.aws.operators.emr import EmrAddStepsOperator
 from airflow.providers.amazon.aws.triggers.emr import EmrAddStepsTrigger
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -107,6 +107,7 @@ class TestEmrAddStepsOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -174,6 +175,7 @@ class TestEmrAddStepsOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/providers/tests/amazon/aws/operators/test_emr_create_job_flow.py
@@ -231,9 +231,9 @@ class TestEmrCreateJobFlowOperator:
         with pytest.raises(TaskDeferred) as exc:
             self.operator.execute(self.mock_context)
 
-        assert isinstance(exc.value.trigger, EmrCreateJobFlowTrigger), (
-            "Trigger is not a EmrCreateJobFlowTrigger"
-        )
+        assert isinstance(
+            exc.value.trigger, EmrCreateJobFlowTrigger
+        ), "Trigger is not a EmrCreateJobFlowTrigger"
 
     def test_template_fields(self):
         validate_template_fields(self.operator)

--- a/providers/tests/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/providers/tests/amazon/aws/operators/test_emr_create_job_flow.py
@@ -33,7 +33,7 @@ from airflow.providers.amazon.aws.triggers.emr import EmrCreateJobFlowTrigger
 from airflow.providers.amazon.aws.utils.waiter import WAITER_POLICY_NAME_MAPPING, WaitPolicy
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 from providers.tests.amazon.aws.utils.test_waiter import assert_expected_waiter_type
@@ -106,6 +106,7 @@ class TestEmrCreateJobFlowOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -154,6 +155,7 @@ class TestEmrCreateJobFlowOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -229,9 +231,9 @@ class TestEmrCreateJobFlowOperator:
         with pytest.raises(TaskDeferred) as exc:
             self.operator.execute(self.mock_context)
 
-        assert isinstance(
-            exc.value.trigger, EmrCreateJobFlowTrigger
-        ), "Trigger is not a EmrCreateJobFlowTrigger"
+        assert isinstance(exc.value.trigger, EmrCreateJobFlowTrigger), (
+            "Trigger is not a EmrCreateJobFlowTrigger"
+        )
 
     def test_template_fields(self):
         validate_template_fields(self.operator)

--- a/providers/tests/amazon/aws/operators/test_s3.py
+++ b/providers/tests/amazon/aws/operators/test_s3.py
@@ -57,7 +57,7 @@ from airflow.providers.common.compat.openlineage.facet import (
 from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.utils.state import DagRunState
 from airflow.utils.timezone import datetime, utcnow
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 
@@ -660,6 +660,7 @@ class TestS3DeleteObjectsOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/operators/test_sagemaker_base.py
+++ b/providers/tests/amazon/aws/operators/test_sagemaker_base.py
@@ -32,7 +32,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import (
 )
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from providers.tests.amazon.aws.utils.test_template_fields import validate_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -215,6 +215,7 @@ class TestSageMakerExperimentOperator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/sensors/test_s3.py
+++ b/providers/tests/amazon/aws/sensors/test_s3.py
@@ -31,7 +31,7 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor, S3KeysUnchangedSensor
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -135,6 +135,7 @@ class TestS3KeySensor:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(
@@ -178,6 +179,7 @@ class TestS3KeySensor:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/amazon/aws/transfers/test_base.py
+++ b/providers/tests/amazon/aws/transfers/test_base.py
@@ -24,7 +24,7 @@ from airflow.models import DagRun, TaskInstance
 from airflow.providers.amazon.aws.transfers.base import AwsToAwsBaseOperator
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -52,6 +52,7 @@ class TestAwsToAwsBaseOperator:
                 logical_date=timezone.datetime(2020, 1, 1),
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             ti.dag_run = DagRun(

--- a/providers/tests/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/providers/tests/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -32,7 +32,7 @@ from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import (
 )
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -282,6 +282,7 @@ class TestDynamodbToS3:
                 logical_date=timezone.datetime(2020, 1, 1),
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             ti.dag_run = DagRun(

--- a/providers/tests/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/providers/tests/amazon/aws/transfers/test_mongo_to_s3.py
@@ -25,7 +25,7 @@ from airflow.models import DAG, DagRun, TaskInstance
 from airflow.providers.amazon.aws.transfers.mongo_to_s3 import MongoToS3Operator
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -90,6 +90,7 @@ class TestMongoToS3Operator:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
         else:
             dag_run = DagRun(

--- a/providers/tests/microsoft/azure/operators/test_data_factory.py
+++ b/providers/tests/microsoft/azure/operators/test_data_factory.py
@@ -299,7 +299,10 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
     def get_dag_run(self, dag_id: str = "test_dag_id", run_id: str = "test_dag_id") -> DagRun:
         if AIRFLOW_V_3_0_PLUS:
             dag_run = DagRun(
-                dag_id=dag_id, run_type="manual", logical_date=timezone.datetime(2022, 1, 1), run_id=run_id
+                dag_id=dag_id,
+                run_type="manual",
+                logical_date=timezone.datetime(2022, 1, 1),
+                run_id=run_id,
             )
         else:
             dag_run = DagRun(  # type: ignore[call-arg]
@@ -354,8 +357,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
 
     @pytest.mark.db_test
     @mock.patch(
-        "airflow.providers.microsoft.azure.operators.data_factory.AzureDataFactoryRunPipelineOperator"
-        ".defer"
+        "airflow.providers.microsoft.azure.operators.data_factory.AzureDataFactoryRunPipelineOperator.defer"
     )
     @mock.patch(
         "airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.get_pipeline_run_status",
@@ -377,8 +379,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
     @pytest.mark.db_test
     @pytest.mark.parametrize("status", sorted(AzureDataFactoryPipelineRunStatus.FAILURE_STATES))
     @mock.patch(
-        "airflow.providers.microsoft.azure.operators.data_factory.AzureDataFactoryRunPipelineOperator"
-        ".defer"
+        "airflow.providers.microsoft.azure.operators.data_factory.AzureDataFactoryRunPipelineOperator.defer"
     )
     @mock.patch(
         "airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.get_pipeline_run_status",

--- a/providers/tests/microsoft/azure/sensors/test_wasb.py
+++ b/providers/tests/microsoft/azure/sensors/test_wasb.py
@@ -32,7 +32,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.providers.microsoft.azure.sensors.wasb import WasbBlobSensor, WasbPrefixSensor
 from airflow.providers.microsoft.azure.triggers.wasb import WasbBlobSensorTrigger, WasbPrefixSensorTrigger
 from airflow.utils import timezone
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator
@@ -120,6 +120,7 @@ class TestWasbBlobAsyncSensor:
                 dag_id=dag.dag_id,
                 logical_date=logical_date,
                 run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
+                triggered_by=DagRunTriggeredByType.TEST,
             )
 
         task_instance = TaskInstance(task=task)
@@ -263,6 +264,7 @@ class TestWasbPrefixAsyncSensor:
                 dag_id=dag.dag_id,
                 logical_date=logical_date,
                 run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
+                triggered_by=DagRunTriggeredByType.TEST,
             )
 
         task_instance = TaskInstance(task=task)
@@ -301,9 +303,9 @@ class TestWasbPrefixAsyncSensor:
         mock_hook.return_value.check_for_prefix.return_value = False
         with pytest.raises(TaskDeferred) as exc:
             self.SENSOR.execute(self.create_context(self.SENSOR))
-        assert isinstance(
-            exc.value.trigger, WasbPrefixSensorTrigger
-        ), "Trigger is not a WasbPrefixSensorTrigger"
+        assert isinstance(exc.value.trigger, WasbPrefixSensorTrigger), (
+            "Trigger is not a WasbPrefixSensorTrigger"
+        )
 
     @pytest.mark.parametrize(
         "event",

--- a/providers/tests/microsoft/azure/sensors/test_wasb.py
+++ b/providers/tests/microsoft/azure/sensors/test_wasb.py
@@ -303,9 +303,9 @@ class TestWasbPrefixAsyncSensor:
         mock_hook.return_value.check_for_prefix.return_value = False
         with pytest.raises(TaskDeferred) as exc:
             self.SENSOR.execute(self.create_context(self.SENSOR))
-        assert isinstance(exc.value.trigger, WasbPrefixSensorTrigger), (
-            "Trigger is not a WasbPrefixSensorTrigger"
-        )
+        assert isinstance(
+            exc.value.trigger, WasbPrefixSensorTrigger
+        ), "Trigger is not a WasbPrefixSensorTrigger"
 
     @pytest.mark.parametrize(
         "event",

--- a/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -303,6 +303,7 @@ class DagRun(BaseModel):
     run_type: DagRunType
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     external_trigger: Annotated[bool | None, Field(title="External Trigger")] = False
+    triggered_by: str
 
 
 class HTTPValidationError(BaseModel):

--- a/task_sdk/src/airflow/sdk/definitions/_internal/templater.py
+++ b/task_sdk/src/airflow/sdk/definitions/_internal/templater.py
@@ -128,8 +128,6 @@ class Templater:
                 setattr(parent, attr_name, rendered_content)
 
     def _render(self, template, context, dag=None) -> Any:
-        if dag and dag.is_asset_triggerable:
-            context.pop("logical_date", None)
         if dag and dag.render_template_as_native_obj:
             return render_template_as_native(template, context)
         return render_template_to_string(template, context)

--- a/task_sdk/src/airflow/sdk/definitions/_internal/templater.py
+++ b/task_sdk/src/airflow/sdk/definitions/_internal/templater.py
@@ -128,6 +128,8 @@ class Templater:
                 setattr(parent, attr_name, rendered_content)
 
     def _render(self, template, context, dag=None) -> Any:
+        if dag and dag.is_asset_triggerable:
+            context.pop("logical_date", None)
         if dag and dag.render_template_as_native_obj:
             return render_template_as_native(template, context)
         return render_template_to_string(template, context)

--- a/task_sdk/src/airflow/sdk/definitions/dag.py
+++ b/task_sdk/src/airflow/sdk/definitions/dag.py
@@ -25,7 +25,7 @@ import os
 import sys
 import weakref
 from collections import abc
-from collections.abc import Collection, Iterable, MutableSet
+from collections.abc import Collection, Iterable, MutableSet, Sequence
 from datetime import datetime, timedelta
 from inspect import signature
 from re import Pattern
@@ -654,6 +654,17 @@ class DAG:
     @property
     def allow_future_exec_dates(self) -> bool:
         return settings.ALLOW_FUTURE_LOGICAL_DATES and not self.timetable.can_be_scheduled
+
+    @property
+    def is_asset_triggerable(self) -> bool:
+        if isinstance(self.schedule, (BaseAsset, AssetTriggeredTimetable)):
+            return True
+
+        if isinstance(self.schedule, Sequence) and all(
+            isinstance(asset, BaseAsset) for asset in self.schedule
+        ):
+            return True
+        return False
 
     def resolve_template_files(self):
         for t in self.tasks:

--- a/task_sdk/src/airflow/sdk/definitions/dag.py
+++ b/task_sdk/src/airflow/sdk/definitions/dag.py
@@ -25,7 +25,7 @@ import os
 import sys
 import weakref
 from collections import abc
-from collections.abc import Collection, Iterable, MutableSet, Sequence
+from collections.abc import Collection, Iterable, MutableSet
 from datetime import datetime, timedelta
 from inspect import signature
 from re import Pattern
@@ -654,17 +654,6 @@ class DAG:
     @property
     def allow_future_exec_dates(self) -> bool:
         return settings.ALLOW_FUTURE_LOGICAL_DATES and not self.timetable.can_be_scheduled
-
-    @property
-    def is_asset_triggerable(self) -> bool:
-        if isinstance(self.schedule, (BaseAsset, AssetTriggeredTimetable)):
-            return True
-
-        if isinstance(self.schedule, Sequence) and all(
-            isinstance(asset, BaseAsset) for asset in self.schedule
-        ):
-            return True
-        return False
 
     def resolve_template_files(self):
         for t in self.tasks:

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -160,7 +160,7 @@ class RuntimeTaskInstance(TaskInstance):
             }
             context.update(context_from_server)
 
-            if logical_date := dag_run.logical_date:
+            if (logical_date := dag_run.logical_date) and dag_run.triggered_by != "asset":
                 ds = logical_date.strftime("%Y-%m-%d")
                 ds_nodash = ds.replace("-", "")
                 ts = logical_date.isoformat()

--- a/task_sdk/tests/conftest.py
+++ b/task_sdk/tests/conftest.py
@@ -117,9 +117,9 @@ def captured_logs(request):
         # We need to replace remove the last processor (the one that turns JSON into text, as we want the
         # event dict for tests)
         proc = processors.pop()
-        assert isinstance(proc, (structlog.dev.ConsoleRenderer, structlog.processors.JSONRenderer)), (
-            "Pre-condition"
-        )
+        assert isinstance(
+            proc, (structlog.dev.ConsoleRenderer, structlog.processors.JSONRenderer)
+        ), "Pre-condition"
     try:
         cap = LogCapture()
         processors.append(cap)
@@ -267,9 +267,7 @@ def mocked_parse(spy_agency):
 
             mocked_parse(
                 StartupDetails(
-                    ti=TaskInstance(
-                        id=uuid7(), task_id="hello", dag_id="super_basic_run", run_id="c", try_number=1
-                    ),
+                    ti=TaskInstance(id=uuid7(), task_id="hello", dag_id="super_basic_run", run_id="c", try_number=1),
                     file="",
                     requests_fd=0,
                 ),

--- a/task_sdk/tests/conftest.py
+++ b/task_sdk/tests/conftest.py
@@ -117,9 +117,9 @@ def captured_logs(request):
         # We need to replace remove the last processor (the one that turns JSON into text, as we want the
         # event dict for tests)
         proc = processors.pop()
-        assert isinstance(
-            proc, (structlog.dev.ConsoleRenderer, structlog.processors.JSONRenderer)
-        ), "Pre-condition"
+        assert isinstance(proc, (structlog.dev.ConsoleRenderer, structlog.processors.JSONRenderer)), (
+            "Pre-condition"
+        )
     try:
         cap = LogCapture()
         processors.append(cap)
@@ -205,6 +205,7 @@ def make_ti_context() -> MakeTIContextCallable:
                 run_type=run_type,  # type: ignore
                 run_after=run_after,  # type: ignore
                 conf=conf,
+                triggered_by="ui",
             ),
             max_tries=0,
         )
@@ -266,7 +267,9 @@ def mocked_parse(spy_agency):
 
             mocked_parse(
                 StartupDetails(
-                    ti=TaskInstance(id=uuid7(), task_id="hello", dag_id="super_basic_run", run_id="c", try_number=1),
+                    ti=TaskInstance(
+                        id=uuid7(), task_id="hello", dag_id="super_basic_run", run_id="c", try_number=1
+                    ),
                     file="",
                     requests_fd=0,
                 ),

--- a/task_sdk/tests/definitions/test_baseoperator.py
+++ b/task_sdk/tests/definitions/test_baseoperator.py
@@ -27,12 +27,10 @@ from unittest import mock
 import jinja2
 import pytest
 
-from airflow.sdk.definitions.asset import Asset, AssetAlias
 from airflow.sdk.definitions.baseoperator import BaseOperator, BaseOperatorMeta
 from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.definitions.template import literal
 from airflow.task.priority_strategy import _DownstreamPriorityWeightStrategy, _UpstreamPriorityWeightStrategy
-from airflow.timetables.simple import AssetTriggeredTimetable
 
 DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
 
@@ -623,47 +621,3 @@ def test_render_template_fields_logging(
         assert expected_log in caplog.text
     if not_expected_log:
         assert not_expected_log not in caplog.text
-
-
-def test_find_mapped_dependants_in_another_group():
-    from airflow.decorators import task as task_decorator
-    from airflow.sdk import TaskGroup
-
-    @task_decorator
-    def gen(x):
-        return list(range(x))
-
-    @task_decorator
-    def add(x, y):
-        return x + y
-
-    with DAG(dag_id="test"):
-        with TaskGroup(group_id="g1"):
-            gen_result = gen(3)
-        with TaskGroup(group_id="g2"):
-            add_result = add.partial(y=1).expand(x=gen_result)
-
-    # breakpoint()
-    dependants = list(gen_result.operator.iter_mapped_dependants())
-    assert dependants == [add_result.operator]
-
-
-@pytest.mark.parametrize(
-    "schedule",
-    [
-        Asset(name="test"),
-        [Asset(name="test-1")],
-        [AssetAlias(name="alias-1")],
-        AssetTriggeredTimetable(assets=Asset(name="timetable-test")),
-    ],
-)
-def test_logical_date_not_in_asset_triggable_dag(schedule):
-    from airflow.providers.standard.operators.bash import BashOperator
-
-    with DAG(dag_id="asset_triggable_dag", schedule=schedule, catchup=False):
-        task = BashOperator(task_id="producing_task_1", bash_command="echo {{ logical_date }}")
-
-    content = "{{ logical_date }}"
-    context = {"logical_date": "test_value"}
-    with pytest.raises(jinja2.exceptions.UndefinedError):
-        task.render_template(content, context)

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -109,7 +109,7 @@ class TestCommsDecoder:
             b'"id": "4d828a62-a417-4936-a7a6-2b3fabacecab", "task_id": "a", "try_number": 1, "run_id": "b", "dag_id": "c" }, '
             b'"ti_context":{"dag_run":{"dag_id":"c","run_id":"b","logical_date":"2024-12-01T01:00:00Z",'
             b'"data_interval_start":"2024-12-01T00:00:00Z","data_interval_end":"2024-12-01T01:00:00Z",'
-            b'"start_date":"2024-12-01T01:00:00Z","run_after":"2024-12-01T01:00:00Z","end_date":null,"run_type":"manual","conf":null},'
+            b'"start_date":"2024-12-01T01:00:00Z","triggered_by":"ui","run_after":"2024-12-01T01:00:00Z","end_date":null,"run_type":"manual","conf":null},'
             b'"max_tries":0,"variables":null,"connections":null},"file": "/dev/null", "dag_rel_path": "/dev/null", "bundle_info": {"name": '
             b'"any-name", "version": "any-version"}, "requests_fd": '
             + str(w2.fileno()).encode("ascii")

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2120,6 +2120,7 @@ class TestTaskInstance:
             run_type="manual",
             state=DagRunState.RUNNING,
             logical_date=timezone.utcnow(),
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.merge(dr)
         task = dag1.get_task("producing_task_1")
@@ -2161,9 +2162,9 @@ class TestTaskInstance:
 
         # check that the asset event has an earlier timestamp than the ADRQ's
         adrq_timestamps = session.query(AssetDagRunQueue.created_at).filter_by(asset_id=event.asset.id).all()
-        assert all(
-            event.timestamp < adrq_timestamp for (adrq_timestamp,) in adrq_timestamps
-        ), f"Some items in {[str(t) for t in adrq_timestamps]} are earlier than {event.timestamp}"
+        assert all(event.timestamp < adrq_timestamp for (adrq_timestamp,) in adrq_timestamps), (
+            f"Some items in {[str(t) for t in adrq_timestamps]} are earlier than {event.timestamp}"
+        )
 
     def test_outlet_assets_failed(self, create_task_instance, testing_dag_bundle):
         """
@@ -2185,6 +2186,7 @@ class TestTaskInstance:
             run_type="manual",
             state=DagRunState.RUNNING,
             logical_date=timezone.utcnow(),
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.merge(dr)
         task = dag_with_fail_task.get_task("fail_task")
@@ -2250,6 +2252,7 @@ class TestTaskInstance:
             run_type="manual",
             state=DagRunState.RUNNING,
             logical_date=timezone.utcnow(),
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.merge(dr)
         task = dag_with_skip_task.get_task("skip_task")
@@ -3886,9 +3889,9 @@ class TestTaskInstance:
         for key, expected_value in expected_values.items():
             assert hasattr(ti, key), f"Key {key} is missing in the TaskInstance."
             if key not in hybrid_props:
-                assert (
-                    getattr(ti, key) == expected_value
-                ), f"Key: {key} had different values. Make sure it loads it in the refresh refresh_from_db()"
+                assert getattr(ti, key) == expected_value, (
+                    f"Key: {key} had different values. Make sure it loads it in the refresh refresh_from_db()"
+                )
 
     def test_operator_field_with_serialization(self, create_task_instance):
         ti = create_task_instance()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2162,9 +2162,9 @@ class TestTaskInstance:
 
         # check that the asset event has an earlier timestamp than the ADRQ's
         adrq_timestamps = session.query(AssetDagRunQueue.created_at).filter_by(asset_id=event.asset.id).all()
-        assert all(event.timestamp < adrq_timestamp for (adrq_timestamp,) in adrq_timestamps), (
-            f"Some items in {[str(t) for t in adrq_timestamps]} are earlier than {event.timestamp}"
-        )
+        assert all(
+            event.timestamp < adrq_timestamp for (adrq_timestamp,) in adrq_timestamps
+        ), f"Some items in {[str(t) for t in adrq_timestamps]} are earlier than {event.timestamp}"
 
     def test_outlet_assets_failed(self, create_task_instance, testing_dag_bundle):
         """
@@ -3889,9 +3889,9 @@ class TestTaskInstance:
         for key, expected_value in expected_values.items():
             assert hasattr(ti, key), f"Key {key} is missing in the TaskInstance."
             if key not in hybrid_props:
-                assert getattr(ti, key) == expected_value, (
-                    f"Key: {key} had different values. Make sure it loads it in the refresh refresh_from_db()"
-                )
+                assert (
+                    getattr(ti, key) == expected_value
+                ), f"Key: {key} had different values. Make sure it loads it in the refresh refresh_from_db()"
 
     def test_operator_field_with_serialization(self, create_task_instance):
         ti = create_task_instance()

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/amazon/__init__.py
+++ b/tests/providers/amazon/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/amazon/aws/__init__.py
+++ b/tests/providers/amazon/aws/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/microsoft/__init__.py
+++ b/tests/providers/microsoft/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/microsoft/azure/__init__.py
+++ b/tests/providers/microsoft/azure/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -51,7 +51,7 @@ from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.timezone import coerce_datetime, datetime
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests.models import TEST_DAGS_FOLDER
 from tests_common.test_utils.db import clear_db_runs
@@ -393,8 +393,7 @@ class TestExternalTaskSensor:
             caplog.clear()
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
             assert (
-                f"Poking for tasks ['{TEST_TASK_ID}'] "
-                f"in dag {TEST_DAG_ID} on {DEFAULT_DATE.isoformat()} ... "
+                f"Poking for tasks ['{TEST_TASK_ID}'] in dag {TEST_DAG_ID} on {DEFAULT_DATE.isoformat()} ... "
             ) in caplog.messages
 
     def test_external_task_sensor_external_task_ids_param(self, caplog):
@@ -412,8 +411,7 @@ class TestExternalTaskSensor:
             caplog.clear()
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
             assert (
-                f"Poking for tasks ['{TEST_TASK_ID}'] "
-                f"in dag {TEST_DAG_ID} on {DEFAULT_DATE.isoformat()} ... "
+                f"Poking for tasks ['{TEST_TASK_ID}'] in dag {TEST_DAG_ID} on {DEFAULT_DATE.isoformat()} ... "
             ) in caplog.messages
 
     def test_external_task_sensor_failed_states_as_success_mulitple_task_ids(self, caplog):
@@ -1434,13 +1432,13 @@ def dag_bag_cyclic():
                 dags.append(dag)
                 task_a = ExternalTaskSensor(
                     task_id=f"task_a_{n}",
-                    external_dag_id=f"dag_{n-1}",
-                    external_task_id=f"task_b_{n-1}",
+                    external_dag_id=f"dag_{n - 1}",
+                    external_task_id=f"task_b_{n - 1}",
                 )
                 task_b = ExternalTaskMarker(
                     task_id=f"task_b_{n}",
-                    external_dag_id=f"dag_{n+1}",
-                    external_task_id=f"task_a_{n+1}",
+                    external_dag_id=f"dag_{n + 1}",
+                    external_task_id=f"task_a_{n + 1}",
                     recursion_depth=3,
                 )
                 task_a >> task_b
@@ -1450,8 +1448,8 @@ def dag_bag_cyclic():
             dags.append(dag)
             task_a = ExternalTaskSensor(
                 task_id=f"task_a_{depth}",
-                external_dag_id=f"dag_{depth-1}",
-                external_task_id=f"task_b_{depth-1}",
+                external_dag_id=f"dag_{depth - 1}",
+                external_task_id=f"task_b_{depth - 1}",
             )
             task_b = ExternalTaskMarker(
                 task_id=f"task_b_{depth}",
@@ -1602,6 +1600,7 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
             logical_date=logical_date,
             run_type=DagRunType.MANUAL,
             run_id=f"test_{delta}",
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.add(dagrun)
         for task in dag.tasks:
@@ -1627,6 +1626,7 @@ def test_clear_overlapping_external_task_marker_with_end_date(dag_bag_head_tail,
             logical_date=logical_date,
             run_type=DagRunType.MANUAL,
             run_id=f"test_{delta}",
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.add(dagrun)
         for task in dag.tasks:
@@ -1707,6 +1707,7 @@ def test_clear_overlapping_external_task_marker_mapped_tasks(dag_bag_head_tail_m
             logical_date=logical_date,
             run_type=DagRunType.MANUAL,
             run_id=f"test_{delta}",
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.add(dagrun)
         for task in dag.tasks:

--- a/tests/system/providers/__init__.py
+++ b/tests/system/providers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/system/providers/pinecone/__init__.py
+++ b/tests/system/providers/pinecone/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
## Why

#46194

## What
* Add `triggered_by` to task_sdk DagRun
* Not adding `data_interval_start, data_interval_end, prev_data_interval_start_success, prev_data_interval_end_success, logical_date, ds, ds_nodash, ts, ts_nodash, ts_nodash_with_tz` keys to context if it's a triggered_by asset

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
