### PR TITLE
OTEL metric export: Switch ObservableGauge to sync Gauge metric export

### DIFF
--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import logging
 import time
 from unittest import mock
-from unittest.mock import ANY
 
 import pytest
 from opentelemetry.metrics import MeterProvider
@@ -181,9 +180,7 @@ class TestOtelMetrics:
     def test_gauge_new_metric(self, name):
         self.stats.gauge(name, value=1)
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         assert self.map[full_name(name)].value == 1
 
     def test_gauge_new_metric_with_tags(self, name):
@@ -192,27 +189,21 @@ class TestOtelMetrics:
 
         self.stats.gauge(name, value=1, tags=tags)
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         self.map[key].attributes == tags
 
     def test_gauge_existing_metric(self, name):
         self.stats.gauge(name, value=1)
         self.stats.gauge(name, value=2)
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         assert self.map[full_name(name)].value == 2
 
     def test_gauge_existing_metric_with_delta(self, name):
         self.stats.gauge(name, value=1)
         self.stats.gauge(name, value=2, delta=True)
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         assert self.map[full_name(name)].value == 3
 
     @mock.patch("random.random", side_effect=[0.1, 0.9])
@@ -239,9 +230,7 @@ class TestOtelMetrics:
 
         self.stats.timing(name, dt=datetime.timedelta(seconds=123))
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         expected_value = 123000.0
         assert self.map[full_name(name)].value == expected_value
 
@@ -251,18 +240,14 @@ class TestOtelMetrics:
 
         self.stats.timing(name, dt=1, tags=tags)
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         self.map[key].attributes == tags
 
     def test_timing_existing_metric(self, name):
         self.stats.timing(name, dt=1)
         self.stats.timing(name, dt=2)
 
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
         assert self.map[full_name(name)].value == 2
 
     # For the four test_timer_foo tests below:
@@ -278,9 +263,7 @@ class TestOtelMetrics:
         expected_duration = 3140.0
         assert timer.duration == expected_duration
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
 
     @mock.patch.object(time, "perf_counter", side_effect=[0.0, 3.14])
     def test_timer_no_name_returns_float_but_does_not_store_value(self, mock_time, name):
@@ -291,7 +274,7 @@ class TestOtelMetrics:
         expected_duration = 3140.0
         assert timer.duration == expected_duration
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_observable_gauge.assert_not_called()
+        self.meter.get_meter().create_gauge.assert_not_called()
 
     @mock.patch.object(time, "perf_counter", side_effect=[0.0, 3.14])
     def test_timer_start_and_stop_manually_send_false(self, mock_time, name):
@@ -304,7 +287,7 @@ class TestOtelMetrics:
         expected_value = 3140.0
         assert timer.duration == expected_value
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_observable_gauge.assert_not_called()
+        self.meter.get_meter().create_gauge.assert_not_called()
 
     @mock.patch.object(time, "perf_counter", side_effect=[0.0, 3.14])
     def test_timer_start_and_stop_manually_send_true(self, mock_time, name):
@@ -317,6 +300,4 @@ class TestOtelMetrics:
         expected_value = 3140.0
         assert timer.duration == expected_value
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_observable_gauge.assert_called_once_with(
-            name=full_name(name), callbacks=ANY
-        )
+        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))


### PR DESCRIPTION
# Overview
Hi Airflow community,

I´m currently trying to get Airflow metrics exported via OTEL -> Prometheus into Grafana Dashboards. I wanted to use the label advantage of OTEL to create nice Dashboards. 

During the implementation I found an issue and will use metric airflow_dag_processing_last_duration to explain the details:

This metric is exported in 2 different ways in the Airflow code, to support statsd way and otel way with labels.
Stats.timing(f"dag_processing.last_duration.{file_name}", stat.last_duration)
Stats.timing("dag_processing.last_duration", stat.last_duration, tags={"file_name": file_name})

The following prometheus example contains metric export for 2 dags (dag1, dag2). But the metric with the label (Otel) does only export the metric for 1 dag. Metric export with file_name in the metric name is exported for 2 dags.

| # HELP airflow_dag_processing_last_duration
| # TYPE airflow_dag_processing_last_duration gauge
| airflow_dag_processing_last_duration{file_name="dag1",job="Airflow"} 0.293856

| # HELP airflow_dag_processing_last_duration_dag1
| # TYPE airflow_dag_processing_last_duration_dag1  gauge
| airflow_dag_processing_last_duration_dag1 {job="Airflow"} 0.293856
| # HELP airflow_dag_processing_last_duration_blabla2
| # TYPE airflow_dag_processing_last_duration_blabla2 gauge
| airflow_dag_processing_last_duration_dag2{job="Airflow"} 0.343803

would expect that the metric is also exported like this:
| airflow_dag_processing_last_duration{file_name="dag2",job="Airflow"} 0.343803


So I debugged some time and found out that this issue is only related to the gauge export. If the metric is a counter the label export works fine.

The issue is that the gauge value is created as an ObserveableGauge and with that OTEL uses a callback to collect the metric. For this OTEL python lib creates intruments to handle the metric. The down side of this is that if a second Observable instrument with the same metric name is created, OTEL will only create one instrument because it checks for the metric name. 
This results in the issue that only the callback for the first registered metric will be executed and all other metrics with different label but same name will be ignored.
My idea is now to switch to an syncronos gauge export of the metric like it is used for the counter export. 

I´m not sure why the ObserveableGauge was used but I did not found a solution to fix the issue without switching to sync gauge export.
Also not sure about any down side of using sync gauge, like maybe runtime, but for the counter metric export sync was also used. Anyone has more know how in that area and give feedback for this?

# Details of changes:
* Use of normal sync Gauge instead of ObservedGauge.
* Moved logic to handle gauge into InternalGauge class.

Looking forward to fix this issue and the feedback from your side!