### PR TITLE
Integrate the SimpleAuthManager UI in dev mode

### DIFF
--- a/airflow/auth/managers/simple/ui/dev/index.html
+++ b/airflow/auth/managers/simple/ui/dev/index.html
@@ -1,0 +1,23 @@
+<!-- Entry html file when the Vite dev server is running -->
+<!doctype html>
+<html lang="en" style="height: 100%">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="http://localhost:5174/public/pin_32.png" />
+    <script type="module" src="http://localhost:5174/@vite/client"></script>
+    <script type="module">
+      import RefreshRuntime from "http://localhost:5174/@react-refresh";
+
+      RefreshRuntime.injectIntoGlobalHook(window);
+      window.$RefreshReg$ = () => {};
+      window.$RefreshSig$ = () => (type) => type;
+      window.__vite_plugin_react_preamble_installed__ = true;
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Airflow 3.0</title>
+  </head>
+  <body style="height: 100%">
+    <div id="root" style="height: 100%"></div>
+    <script type="module" src="http://localhost:5174/src/main.tsx"></script>
+  </body>
+</html>

--- a/airflow/auth/managers/simple/ui/package.json
+++ b/airflow/auth/managers/simple/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 5174",
     "build": "vite build",
     "preview": "vite preview",
     "codegen": "openapi-rq -i \"../openapi/v1-generated.yaml\" -c axios --format prettier -o openapi-gen --operationId",

--- a/scripts/ci/pre_commit/compile_ui_assets_dev.py
+++ b/scripts/ci/pre_commit/compile_ui_assets_dev.py
@@ -34,23 +34,57 @@ if __name__ not in ("__main__", "__mp_main__"):
 
 AIRFLOW_SOURCES_PATH = Path(__file__).parents[3].resolve()
 UI_CACHE_DIR = AIRFLOW_SOURCES_PATH / ".build" / "ui"
+
+
+UI_DIRECTORY = AIRFLOW_SOURCES_PATH / "airflow" / "ui"
 UI_HASH_FILE = UI_CACHE_DIR / "hash.txt"
 UI_ASSET_OUT_FILE = UI_CACHE_DIR / "asset_compile.out"
 UI_ASSET_OUT_DEV_MODE_FILE = UI_CACHE_DIR / "asset_compile_dev_mode.out"
 
+
+SIMPLE_AUTH_MANAGER_UI_DIRECTORY = AIRFLOW_SOURCES_PATH / "airflow" / "auth" / "managers" / "simple" / "ui"
+SIMPLE_AUTH_MANAGER_UI_HASH_FILE = UI_CACHE_DIR / "simple-auth-manager-hash.txt"
+SIMPLE_AUTH_MANAGER_UI_ASSET_OUT_FILE = UI_CACHE_DIR / "simple_auth_manager_asset_compile.out"
+SIMPLE_AUTH_MANAGER_UI_ASSET_OUT_DEV_MODE_FILE = (
+    UI_CACHE_DIR / "simple_auth_manager_asset_compile_dev_mode.out"
+)
+
 if __name__ == "__main__":
-    ui_directory = AIRFLOW_SOURCES_PATH / "airflow" / "ui"
     UI_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["FORCE_COLOR"] = "true"
+
     if UI_HASH_FILE.exists():
         # cleanup hash of ui so that next compile-assets recompiles them
         UI_HASH_FILE.unlink()
-    env = os.environ.copy()
-    env["FORCE_COLOR"] = "true"
     UI_ASSET_OUT_FILE.unlink(missing_ok=True)
+
+    if SIMPLE_AUTH_MANAGER_UI_HASH_FILE.exists():
+        # cleanup hash of ui so that next compile-assets recompiles them
+        SIMPLE_AUTH_MANAGER_UI_HASH_FILE.unlink()
+    SIMPLE_AUTH_MANAGER_UI_ASSET_OUT_FILE.unlink(missing_ok=True)
+
     with open(UI_ASSET_OUT_DEV_MODE_FILE, "w") as f:
         subprocess.run(
             ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"],
-            cwd=os.fspath(ui_directory),
+            cwd=os.fspath(UI_DIRECTORY),
+            check=True,
+            stdout=f,
+            stderr=subprocess.STDOUT,
+        )
+        subprocess.Popen(
+            ["pnpm", "dev"],
+            cwd=os.fspath(UI_DIRECTORY),
+            env=env,
+            stdout=f,
+            stderr=subprocess.STDOUT,
+        )
+
+    with open(SIMPLE_AUTH_MANAGER_UI_ASSET_OUT_DEV_MODE_FILE, "w") as f:
+        subprocess.run(
+            ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"],
+            cwd=os.fspath(SIMPLE_AUTH_MANAGER_UI_DIRECTORY),
             check=True,
             stdout=f,
             stderr=subprocess.STDOUT,
@@ -58,7 +92,7 @@ if __name__ == "__main__":
         subprocess.run(
             ["pnpm", "dev"],
             check=True,
-            cwd=os.fspath(ui_directory),
+            cwd=os.fspath(SIMPLE_AUTH_MANAGER_UI_DIRECTORY),
             env=env,
             stdout=f,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
Integrate the dev mode of the SImpleAuthManager UI into breeze. (Before the UI would be just blank)


Before:
![Screenshot 2025-02-06 at 11 26 03](https://github.com/user-attachments/assets/dbbd2c00-7bab-462f-b7a6-b53bddb4521c)
![Screenshot 2025-02-06 at 11 26 19](https://github.com/user-attachments/assets/2947f286-bc04-4ebf-85d5-cb8189723249)


Now:
![Screenshot 2025-02-06 at 11 25 25](https://github.com/user-attachments/assets/56bc4251-4665-432f-bac8-1b54752dccb7)
