### PR TITLE
Feature/enable comment on maintenance mode

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -24,7 +24,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.13.1pre0``
+Release: ``0.14.0pre0``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -37,7 +37,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.13.1pre0/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.14.0pre0/>`_.
 
 Installation
 ------------
@@ -60,4 +60,4 @@ PIP package         Version required
 ==================  ==================
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.13.1pre0/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.14.0pre0/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.14.0pre0
+..........
+
+Misc
+~~~~
+
+* ``Add maintenance comment field, to make maintenance reason transparent.``
+
+
 0.13.1pre0
 ..........
 

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1737371680
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.13.1pre0
+  - 0.14.0pre0
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.13.1pre0"
+version = "0.14.0pre0"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -62,8 +62,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.13.1pre0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.13.1pre0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.14.0pre0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.14.0pre0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.13.1pre0"
+__version__ = "0.14.0pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -84,7 +84,7 @@ class EdgeExecutor(BaseExecutor):
         except NoSuchTableError:
             pass
 
-        # version 0.13.1pre0 added new column maintenance_comment
+        # version 0.14.0pre0 added new column maintenance_comment
         if edge_worker_columns and "maintenance_comment" not in edge_worker_columns:
             connection = engine.connect()
             query = "ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);"

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -87,7 +87,7 @@ class EdgeExecutor(BaseExecutor):
         # version 0.13.1pre0 added new column maintenance_comment
         if edge_worker_columns and "maintenance_comment" not in edge_worker_columns:
             connection = engine.connect()
-            query = 'ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);'
+            query = "ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);"
             connection.execute(query)
 
     @provide_session

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -78,6 +78,16 @@ class EdgeExecutor(BaseExecutor):
         if edge_job_columns and "concurrency_slots" not in edge_job_columns:
             EdgeJobModel.metadata.drop_all(engine, tables=[EdgeJobModel.__table__])
 
+        edge_worker_columns = None
+        try:
+            edge_worker_columns = [column["name"] for column in inspector.get_columns("edge_worker")]
+        except NoSuchTableError:
+            pass
+
+        # version 0.13.1pre0 added new column maintenance_comment
+        if edge_worker_columns and "maintenance_comment" not in edge_worker_columns:
+            EdgeWorkerModel.metadata.drop_all(engine, tables=[EdgeWorkerModel.__table__])
+
     @provide_session
     def start(self, session: Session = NEW_SESSION):
         """If EdgeExecutor provider is loaded first time, ensure table exists."""

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -86,8 +86,9 @@ class EdgeExecutor(BaseExecutor):
 
         # version 0.13.1pre0 added new column maintenance_comment
         if edge_worker_columns and "maintenance_comment" not in edge_worker_columns:
-            EdgeWorkerModel.metadata.drop_all(engine, tables=[EdgeWorkerModel.__table__])
-
+            connection = engine.connect()
+            query = f'ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);'
+            connection.execute(query)
     @provide_session
     def start(self, session: Session = NEW_SESSION):
         """If EdgeExecutor provider is loaded first time, ensure table exists."""

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -87,9 +87,9 @@ class EdgeExecutor(BaseExecutor):
         # version 0.13.1pre0 added new column maintenance_comment
         if edge_worker_columns and "maintenance_comment" not in edge_worker_columns:
             connection = engine.connect()
-            query = f'ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);'
+            query = 'ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);'
             connection.execute(query)
-            
+
     @provide_session
     def start(self, session: Session = NEW_SESSION):
         """If EdgeExecutor provider is loaded first time, ensure table exists."""

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -87,7 +87,7 @@ class EdgeExecutor(BaseExecutor):
         # version 0.14.0pre0 added new column maintenance_comment
         if edge_worker_columns and "maintenance_comment" not in edge_worker_columns:
             connection = engine.connect()
-            query = "ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);"
+            query = "ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(1024);"
             connection.execute(query)
 
     @provide_session

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -89,6 +89,7 @@ class EdgeExecutor(BaseExecutor):
             connection = engine.connect()
             query = f'ALTER TABLE edge_worker ADD maintenance_comment VARCHAR(128);'
             connection.execute(query)
+            
     @provide_session
     def start(self, session: Session = NEW_SESSION):
         """If EdgeExecutor provider is loaded first time, ensure table exists."""

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1737371680,
-        "versions": ["0.13.1pre0"],
+        "versions": ["0.14.0pre0"],
         "plugins": [
             {
                 "name": "edge_executor",

--- a/providers/edge/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/edge/src/airflow/providers/edge/models/edge_worker.py
@@ -75,7 +75,7 @@ class EdgeWorkerModel(Base, LoggingMixin):
     __tablename__ = "edge_worker"
     worker_name = Column(String(64), primary_key=True, nullable=False)
     state = Column(String(20))
-    maintenance_comment = Column(String(128))
+    maintenance_comment = Column(String(1024))
     _queues = Column("queues", String(256))
     first_online = Column(UtcDateTime)
     last_update = Column(UtcDateTime)

--- a/providers/edge/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/edge/src/airflow/providers/edge/models/edge_worker.py
@@ -92,7 +92,7 @@ class EdgeWorkerModel(Base, LoggingMixin):
         queues: list[str] | None,
         first_online: datetime | None = None,
         last_update: datetime | None = None,
-        maintenance_comment: str | None = None,
+        maintenance_comment: str = "",
     ):
         self.worker_name = worker_name
         self.state = state

--- a/providers/edge/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/edge/src/airflow/providers/edge/models/edge_worker.py
@@ -187,7 +187,9 @@ def reset_metrics(worker_name: str) -> None:
 
 
 @provide_session
-def request_maintenance(worker_name: str, maintenance_comment: str | None, session: Session = NEW_SESSION) -> None:
+def request_maintenance(
+    worker_name: str, maintenance_comment: str | None, session: Session = NEW_SESSION
+) -> None:
     """Writes maintenance request to the db"""
     query = select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name)
     worker: EdgeWorkerModel = session.scalar(query)
@@ -209,8 +211,11 @@ def remove_worker(worker_name: str, session: Session = NEW_SESSION) -> None:
     """Remove a worker that is offline or just gone from DB"""
     session.execute(delete(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name))
 
+
 @provide_session
-def change_maintenance_comment(worker_name: str, maintenance_comment: str | None, session: Session = NEW_SESSION) -> None:
+def change_maintenance_comment(
+    worker_name: str, maintenance_comment: str | None, session: Session = NEW_SESSION
+) -> None:
     """Writes maintenance comment in the db."""
     query = select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name)
     worker: EdgeWorkerModel = session.scalar(query)

--- a/providers/edge/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/edge/src/airflow/providers/edge/models/edge_worker.py
@@ -75,6 +75,7 @@ class EdgeWorkerModel(Base, LoggingMixin):
     __tablename__ = "edge_worker"
     worker_name = Column(String(64), primary_key=True, nullable=False)
     state = Column(String(20))
+    maintenance_comment = Column(String(128))
     _queues = Column("queues", String(256))
     first_online = Column(UtcDateTime)
     last_update = Column(UtcDateTime)
@@ -91,12 +92,14 @@ class EdgeWorkerModel(Base, LoggingMixin):
         queues: list[str] | None,
         first_online: datetime | None = None,
         last_update: datetime | None = None,
+        maintenance_comment: str | None = None,
     ):
         self.worker_name = worker_name
         self.state = state
         self.queues = queues
         self.first_online = first_online or timezone.utcnow()
         self.last_update = last_update
+        self.maintenance_comment = maintenance_comment
         super().__init__()
 
     @property
@@ -184,11 +187,12 @@ def reset_metrics(worker_name: str) -> None:
 
 
 @provide_session
-def request_maintenance(worker_name: str, session: Session = NEW_SESSION) -> None:
+def request_maintenance(worker_name: str, maintenance_comment: str, session: Session = NEW_SESSION) -> None:
     """Writes maintenance request to the db"""
     query = select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name)
     worker: EdgeWorkerModel = session.scalar(query)
     worker.state = EdgeWorkerState.MAINTENANCE_REQUEST
+    worker.maintenance_comment = maintenance_comment
 
 
 @provide_session
@@ -197,6 +201,7 @@ def exit_maintenance(worker_name: str, session: Session = NEW_SESSION) -> None:
     query = select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name)
     worker: EdgeWorkerModel = session.scalar(query)
     worker.state = EdgeWorkerState.MAINTENANCE_EXIT
+    worker.maintenance_comment = ""
 
 
 @provide_session

--- a/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
+++ b/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from flask import Blueprint, redirect, url_for
+from flask import Blueprint, redirect, request, url_for
 from flask_appbuilder import BaseView, expose
 from sqlalchemy import select
 
@@ -120,7 +120,8 @@ class EdgeWorkerHosts(BaseView):
     def worker_to_maintenance(self, worker_name: str):
         from airflow.providers.edge.models.edge_worker import request_maintenance
 
-        request_maintenance(worker_name)
+        maintenance_comment = request.form.get("maintenance_comment")
+        request_maintenance(worker_name, maintenance_comment)
         return redirect(url_for("EdgeWorkerHosts.status"))
 
     @expose("/status/maintenance/<string:worker_name>/off", methods=["POST"])

--- a/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
+++ b/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
@@ -121,7 +121,7 @@ class EdgeWorkerHosts(BaseView):
         from airflow.providers.edge.models.edge_worker import request_maintenance
 
         maintenance_comment = request.form.get("maintenance_comment")
-        request_maintenance(worker_name, maintenance_comment)
+        request_maintenance(worker_name, maintenance_comment if maintenance_comment else "")
         return redirect(url_for("EdgeWorkerHosts.status"))
 
     @expose("/status/maintenance/<string:worker_name>/off", methods=["POST"])

--- a/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
+++ b/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
@@ -121,7 +121,7 @@ class EdgeWorkerHosts(BaseView):
         from airflow.providers.edge.models.edge_worker import request_maintenance
 
         maintenance_comment = request.form.get("maintenance_comment")
-        request_maintenance(worker_name, maintenance_comment if maintenance_comment else "")
+        request_maintenance(worker_name, maintenance_comment)
         return redirect(url_for("EdgeWorkerHosts.status"))
 
     @expose("/status/maintenance/<string:worker_name>/off", methods=["POST"])
@@ -138,6 +138,15 @@ class EdgeWorkerHosts(BaseView):
         from airflow.providers.edge.models.edge_worker import remove_worker
 
         remove_worker(worker_name)
+        return redirect(url_for("EdgeWorkerHosts.status"))
+
+    @expose("/status/maintenance/<string:worker_name>/change_comment", methods=["POST"])
+    @has_access_view(AccessView.JOBS)
+    def change_maintenance_comment(self, worker_name: str):
+        from airflow.providers.edge.models.edge_worker import change_maintenance_comment
+
+        maintenance_comment = request.form.get("maintenance_comment")
+        change_maintenance_comment(worker_name, maintenance_comment)
         return redirect(url_for("EdgeWorkerHosts.status"))
 
 

--- a/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -30,11 +30,19 @@
       {% else %}
 
       <script>
-        function showform(worker_name) {
+        function showForm(worker_name) {
           var button = document.getElementById("button_" + worker_name);
           var form = document.getElementById("form_" + worker_name);
           form.style.display = "block";
           button.style.display = "none";
+        }
+        function showEditComment(worker_name) {
+          var display = document.getElementById("display_" + worker_name);
+          var textarea = document.getElementById("textarea_" + worker_name);
+          var button = document.getElementById("update_" + worker_name);
+          display.style.display = "none";
+          textarea.style.display = "block";
+          button.style.display = "inline";
         }
       </script>
       <table class="table table-striped table-bordered">
@@ -110,31 +118,38 @@
             </td>
             {%- if host.state in ["idle", "running"] -%}
               <td>
-                <button id="button_{{ host.worker_name }}" onclick="showform('{{ host.worker_name }}')" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
+                <button id="button_{{ host.worker_name }}" onclick="showForm('{{ host.worker_name }}')" class="btn btn-sm btn-primary">
                     Enter Maintenance
                 </button>
                 <form id="form_{{ host.worker_name }}" style="display: none" action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/on" method="POST">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  <div style="padding-bottom: 1em;">
+                  <div>
                     <label for="maintenance_comment">Maintenance Comment:</label>
                   </div>
-                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" required></textarea>
+                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" style="width: 100%; margin-bottom: 5px;" required></textarea>
                   <br />
-                  <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
+                  <button type="submit" class="btn btn-sm btn-primary">
                       Confirm Maintenance
                   </button>
                 </td>
               </form>
             {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
               <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/off" method="POST">
-                <td style="text-align: center; vertical-align: middle;">
-                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" style="display: block; margin: 0 auto; width:100%;" required>{{ host.maintenance_comment }}</textarea>
+                <td>
+                  <div id="display_{{ host.worker_name }}">
+                    {{ host.maintenance_comment }}
+                    <a onclick="showEditComment('{{ host.worker_name }}')" class="btn btn-sm btn-default" data-toggle="tooltip" rel="tooltip" title="Edit maintenance comment">
+                      <span class="sr-only">Edit</span>
+                      <i class="fa fa-edit"></i>
+                    </a>
+                  </div>
+                  <textarea id="textarea_{{ host.worker_name }}" name="maintenance_comment" rows="3" maxlength="1024" style="display: none; width:100%;" required>{{ host.maintenance_comment }}</textarea>
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <div style="margin-top: 10px;">
-                    <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px; margin-right: 5px;">
+                    <button type="submit" class="btn btn-sm btn-primary">
                         Exit Maintenance
                     </button>
-                    <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;" formaction="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/change_comment">
+                    <button id="update_{{ host.worker_name }}" type="submit" class="btn btn-sm btn-primary" style="display: none;" formaction="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/change_comment">
                       Update comment
                     </button>
                   </div>
@@ -144,7 +159,7 @@
               <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/remove" method="POST">
                 <td>
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
+                  <button type="submit" class="btn btn-sm btn-primary">
                       Remove
                   </button>
                 </td>

--- a/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -110,7 +110,7 @@
                   </button>
                 </td>
                 <td>
-                  <textarea  name="maintenance_comment" rows="3" required>{{ host.maintenance_comment }}</textarea>
+                  <textarea  name="maintenance_comment" rows="3" maxlength="128" required>{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
@@ -122,7 +122,7 @@
                   </button>
                 </td>
                 <td>
-                  <textarea  name="maintenance_comment" rows="3" >{{ host.maintenance_comment }}</textarea>
+                  <textarea  name="maintenance_comment" rows="3" maxlength="128">{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- elif host.state in ["offline", "unknown", "offline maintenance"] -%}
@@ -134,13 +134,13 @@
                   </button>
                 </td>
                 <td>
-                  <textarea name="maintenance_comment" rows="3" >{{ host.maintenance_comment }}</textarea>
+                  <textarea name="maintenance_comment" rows="3" maxlength="128">{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- else -%}
               <td></td>
               <td>
-                <textarea name="maintenance_comment" rows="3" >{{ host.maintenance_comment }}</textarea>
+                <textarea name="maintenance_comment" rows="3" maxlength="128">{{ host.maintenance_comment }}</textarea>
               </td>
             {% endif %}
           </tr>

--- a/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -44,6 +44,7 @@
             -->
             <th>System Information</th>
             <th>Maintenance mode</th>
+            <th>Maintenance Reason</th>
         </tr>
         {% for host in hosts %}
           <tr>
@@ -100,30 +101,43 @@
                 {% endfor %}
               </ul>
             </td>
-            <td>
-              {%- if host.state in ["idle", "running"] -%}
-                <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/on" method="POST">
+            {%- if host.state in ["idle", "running"] -%}
+              <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/on" method="POST">
+                <td>
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
                       Enter
                   </button>
-                </form>
-              {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
-                <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/off" method="POST">
+                </td>
+                <td>
+                  <textarea  name="maintenance_comment" rows="3" value="{{ host.maintenance_comment }}" required></textarea>
+                </td>
+              </form>
+            {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
+              <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/off" method="POST">
+                <td>
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
                       Exit
                   </button>
-                </form>
-              {%- elif host.state in ["offline", "unknown", "offline maintenance"] -%}
-                <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/remove" method="POST">
+                </td>
+                <td>
+                  <textarea  name="maintenance_comment" rows="3" value="{{ host.maintenance_comment }}"></textarea>
+                </td>
+              </form>
+            {%- elif host.state in ["offline", "unknown", "offline maintenance"] -%}
+              <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/remove" method="POST">
+                <td>
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
                       Remove
                   </button>
-                </form>
-              {% endif %}
-            </td>
+                </td>
+                <td>
+                  <textarea  name="maintenance_comment" rows="3" value="{{ host.maintenance_comment }}"></textarea>
+                </td>
+              </form>
+            {% endif %}
           </tr>
         {% endfor %}
       </table>

--- a/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -29,6 +29,14 @@
         <p>No Edge Workers connected or known currently.</p>
       {% else %}
 
+      <script>
+        function showform(worker_name) {
+          var button = document.getElementById("button_" + worker_name);
+          var form = document.getElementById("form_" + worker_name);
+          form.style.display = "block";
+          button.style.display = "none";
+        }
+      </script>
       <table class="table table-striped table-bordered">
         <tr>
             <th>Hostname</th>
@@ -43,8 +51,7 @@
               <th>Jobs Failed</th>
             -->
             <th>System Information</th>
-            <th>Maintenance mode</th>
-            <th>Maintenance Reason</th>
+            <th>Operations</th>
         </tr>
         {% for host in hosts %}
           <tr>
@@ -102,27 +109,30 @@
               </ul>
             </td>
             {%- if host.state in ["idle", "running"] -%}
-              <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/on" method="POST">
-                <td>
+              <td>
+                <button id="button_{{ host.worker_name }}" onclick="showform('{{ host.worker_name }}')" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
+                    Enter Maintenance
+                </button>
+                <form id="form_{{ host.worker_name }}" style="display: none" action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/on" method="POST">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                  <div style="padding-bottom: 1em;">
+                    <label for="maintenance_comment">Maintenance Comment:</label>
+                  </div>
+                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" required>{{ host.maintenance_comment }}</textarea>
+                  <br />
                   <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
-                      Enter
+                      Confirm Maintenance
                   </button>
-                </td>
-                <td>
-                  <textarea  name="maintenance_comment" rows="3" maxlength="128" required>{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
               <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/off" method="POST">
                 <td>
+                  {% if host.maintenance_comment %}<div style="padding-bottom: 1em;">{{ host.maintenance_comment }}</div>{% endif %}
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
-                      Exit
+                      Exit Maintenance
                   </button>
-                </td>
-                <td>
-                  <textarea  name="maintenance_comment" rows="3" maxlength="128">{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- elif host.state in ["offline", "unknown", "offline maintenance"] -%}
@@ -133,15 +143,9 @@
                       Remove
                   </button>
                 </td>
-                <td>
-                  <textarea name="maintenance_comment" rows="3" maxlength="128">{{ host.maintenance_comment }}</textarea>
-                </td>
               </form>
             {%- else -%}
               <td></td>
-              <td>
-                <textarea name="maintenance_comment" rows="3" maxlength="128">{{ host.maintenance_comment }}</textarea>
-              </td>
             {% endif %}
           </tr>
         {% endfor %}

--- a/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -110,7 +110,7 @@
                   </button>
                 </td>
                 <td>
-                  <textarea  name="maintenance_comment" rows="3" value="{{ host.maintenance_comment }}" required></textarea>
+                  <textarea  name="maintenance_comment" rows="3" required>{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
@@ -122,7 +122,7 @@
                   </button>
                 </td>
                 <td>
-                  <textarea  name="maintenance_comment" rows="3" value="{{ host.maintenance_comment }}"></textarea>
+                  <textarea  name="maintenance_comment" rows="3" >{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
             {%- elif host.state in ["offline", "unknown", "offline maintenance"] -%}
@@ -134,9 +134,14 @@
                   </button>
                 </td>
                 <td>
-                  <textarea  name="maintenance_comment" rows="3" value="{{ host.maintenance_comment }}"></textarea>
+                  <textarea name="maintenance_comment" rows="3" >{{ host.maintenance_comment }}</textarea>
                 </td>
               </form>
+            {%- else -%}
+              <td></td>
+              <td>
+                <textarea name="maintenance_comment" rows="3" >{{ host.maintenance_comment }}</textarea>
+              </td>
             {% endif %}
           </tr>
         {% endfor %}

--- a/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/edge/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -118,7 +118,7 @@
                   <div style="padding-bottom: 1em;">
                     <label for="maintenance_comment">Maintenance Comment:</label>
                   </div>
-                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" required>{{ host.maintenance_comment }}</textarea>
+                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" required></textarea>
                   <br />
                   <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
                       Confirm Maintenance
@@ -127,12 +127,17 @@
               </form>
             {%- elif host.state in ["maintenance pending", "maintenance mode", "maintenance request"] -%}
               <form action="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/off" method="POST">
-                <td>
-                  {% if host.maintenance_comment %}<div style="padding-bottom: 1em;">{{ host.maintenance_comment }}</div>{% endif %}
+                <td style="text-align: center; vertical-align: middle;">
+                  <textarea  name="maintenance_comment" rows="3" maxlength="1024" style="display: block; margin: 0 auto; width:100%;" required>{{ host.maintenance_comment }}</textarea>
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;">
-                      Exit Maintenance
-                  </button>
+                  <div style="margin-top: 10px;">
+                    <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px; margin-right: 5px;">
+                        Exit Maintenance
+                    </button>
+                    <button type="submit" style="padding: 10px 20px; background-color: blue; color: white; border: none; border-radius: 5px;" formaction="../edgeworkerhosts/status/maintenance/{{ host.worker_name }}/change_comment">
+                      Update comment
+                    </button>
+                  </div>
                 </td>
               </form>
             {%- elif host.state in ["offline", "unknown", "offline maintenance"] -%}

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
@@ -156,7 +156,6 @@ def register(
     worker.queues = body.queues
     worker.sysinfo = json.dumps(body.sysinfo)
     worker.last_update = timezone.utcnow()
-
     session.add(worker)
     return worker.last_update
 

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
@@ -149,10 +149,14 @@ def register(
     worker: EdgeWorkerModel = session.scalar(query)
     if not worker:
         worker = EdgeWorkerModel(worker_name=worker_name, state=body.state, queues=body.queues)
+    worker.maintenance_comment = (
+        "" if worker.state != EdgeWorkerState.OFFLINE_MAINTENANCE else worker.maintenance_comment
+    )
     worker.state = redefine_state_if_maintenance(worker.state, body.state)
     worker.queues = body.queues
     worker.sysinfo = json.dumps(body.sysinfo)
     worker.last_update = timezone.utcnow()
+
     session.add(worker)
     return worker.last_update
 

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
@@ -149,9 +149,6 @@ def register(
     worker: EdgeWorkerModel = session.scalar(query)
     if not worker:
         worker = EdgeWorkerModel(worker_name=worker_name, state=body.state, queues=body.queues)
-    worker.maintenance_comment = (
-        "" if worker.state != EdgeWorkerState.OFFLINE_MAINTENANCE else worker.maintenance_comment
-    )
     worker.state = redefine_state_if_maintenance(worker.state, body.state)
     worker.queues = body.queues
     worker.sysinfo = json.dumps(body.sysinfo)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
The edge worker can be put to maintenance mode. We need to make transparent to all operators why the worker was disabled. Therefore there is a new comment field introduced for the worker. It is mandatory to be filled before entering maintenance mode, and will be cleared upon exiting.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
