### PR TITLE
Fix missing logical_date in DagRun for DMS operator tests

### DIFF
--- a/providers/tests/amazon/aws/operators/test_dms.py
+++ b/providers/tests/amazon/aws/operators/test_dms.py
@@ -477,13 +477,13 @@ class TestDmsDescribeReplicationConfigsOperator:
     @pytest.mark.db_test
     @mock.patch.object(DmsHook, "conn")
     def test_template_fields_native(self, mock_conn, session):
-        execution_date = timezone.datetime(2020, 1, 1)
+        logical_date = timezone.datetime(2020, 1, 1)
         Variable.set("test_filter", self.filter, session=session)
 
         dag = DAG(
             "test_dms",
             schedule=None,
-            start_date=execution_date,
+            start_date=logical_date,
             render_template_as_native_obj=True,
         )
         op = DmsDescribeReplicationConfigsOperator(
@@ -495,6 +495,7 @@ class TestDmsDescribeReplicationConfigsOperator:
             run_id="test",
             run_type=DagRunType.MANUAL,
             state=DagRunState.RUNNING,
+            logical_date=logical_date,
         )
         ti = TaskInstance(task=op)
         ti.dag_run = dag_run

--- a/providers/tests/amazon/aws/operators/test_dms.py
+++ b/providers/tests/amazon/aws/operators/test_dms.py
@@ -490,13 +490,22 @@ class TestDmsDescribeReplicationConfigsOperator:
             task_id="test_task", filter="{{ var.value.test_filter }}", dag=dag
         )
 
-        dag_run = DagRun(
-            dag_id=dag.dag_id,
-            run_id="test",
-            run_type=DagRunType.MANUAL,
-            state=DagRunState.RUNNING,
-            logical_date=logical_date,
-        )
+        if AIRFLOW_V_3_0_PLUS:
+            dag_run = DagRun(
+                dag_id=dag.dag_id,
+                run_id="test",
+                run_type=DagRunType.MANUAL,
+                state=DagRunState.RUNNING,
+                logical_date=logical_date,
+            )
+        else:
+            dag_run = DagRun(
+                dag_id=dag.dag_id,
+                run_id="test",
+                run_type=DagRunType.MANUAL,
+                state=DagRunState.RUNNING,
+                execution_date=logical_date,
+            )
         ti = TaskInstance(task=op)
         ti.dag_run = dag_run
         session.add(ti)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This pull request resolves a Pydantic validation error in the `DmsDescribeReplicationConfigsOperator` tests caused by a missing `logical_date` field in the DagRun instance. The test was updated to set `logical_date` using `execution_date`, ensuring successful validation and correct construction of the template context.

Previously it was throwing following error:
```
providers/tests/amazon/aws/operators/test_dms.py:503: in test_template_fields_native
    context = ti.get_template_context(session)
airflow/models/taskinstance.py:3242: in get_template_context
    return _get_template_context(
airflow/models/taskinstance.py:960: in _get_template_context
    dag_run=DagRunSDK.model_validate(dag_run, from_attributes=True),
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for DagRun
E   logical_date
E     Input should be a valid datetime [type=datetime_type, input_value=None, input_type=NoneType]
E       For further information visit https://errors.pydantic.dev/2.10/v/datetime_type
```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
