### PR TITLE
Fix task sdk client dry-run mode

### DIFF
--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -344,6 +344,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
                     "logical_date": "2021-01-01T00:00:00Z",
                     "start_date": "2021-01-01T00:00:00Z",
                     "run_type": DagRunType.MANUAL,
+                    "run_after": "2021-01-01T00:00:00Z",
                 },
                 "max_tries": 0,
             },

--- a/task_sdk/tests/api/test_client.py
+++ b/task_sdk/tests/api/test_client.py
@@ -37,6 +37,11 @@ def make_client(transport: httpx.MockTransport) -> Client:
     return Client(base_url="test://server", token="", transport=transport)
 
 
+def make_client_w_dry_run() -> Client:
+    """Get a client with dry_run enabled"""
+    return Client(base_url=None, dry_run=True, token="")
+
+
 def make_client_w_responses(responses: list[httpx.Response]) -> Client:
     """Helper fixture to create a mock client with custom responses."""
 
@@ -49,6 +54,34 @@ def make_client_w_responses(responses: list[httpx.Response]) -> Client:
 
 
 class TestClient:
+    @pytest.mark.parametrize(
+        ["path", "json_response"], 
+        [
+            (
+                "/task-instances/1/run", 
+                {
+                    "dag_run": {
+                        "dag_id": "test_dag",
+                        "run_id": "test_run",
+                        "logical_date": "2021-01-01T00:00:00Z",
+                        "start_date": "2021-01-01T00:00:00Z",
+                        "run_type": "manual",
+                        "run_after": "2021-01-01T00:00:00Z",
+                    },
+                    "max_tries": 0,
+                },
+            ),
+        ],
+    )
+    def test_dry_run(self, path, json_response):
+        client = make_client_w_dry_run()
+        assert client.base_url == "dry-run://server"
+
+        resp = client.get(path)
+
+        assert resp.status_code == 200
+        assert resp.json() == json_response
+
     def test_error_parsing(self):
         responses = [
             httpx.Response(422, json={"detail": [{"loc": ["#0"], "msg": "err", "type": "required"}]})

--- a/task_sdk/tests/api/test_client.py
+++ b/task_sdk/tests/api/test_client.py
@@ -55,10 +55,10 @@ def make_client_w_responses(responses: list[httpx.Response]) -> Client:
 
 class TestClient:
     @pytest.mark.parametrize(
-        ["path", "json_response"], 
+        ["path", "json_response"],
         [
             (
-                "/task-instances/1/run", 
+                "/task-instances/1/run",
                 {
                     "dag_run": {
                         "dag_id": "test_dag",


### PR DESCRIPTION
The `run_after` field was missing in the fake dag run response, resulting in the following error upon calling the `supervise` function:
```
ValidationError: 1 validation error for TIRunContext
dag_run.run_after
  Field required [type=missing, input_value={'dag_id': 'test_dag', 'r...', 'run_type': 'manual'}, 
input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```

related to: https://github.com/apache/airflow/pull/45732, https://github.com/apache/airflow/pull/46492

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
