### PR TITLE
Update FAB auth manager `get_url_login` method to handle `Flask` and `Fastapi`

### DIFF
--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -212,6 +212,10 @@ class AirflowAppBuilder:
         auth_manager = create_auth_manager()
         auth_manager.appbuilder = self
         auth_manager.init()
+        # FAB auth manager is used in both the old FAB UI and the new React UI backend by Fastapi.
+        # It can behave differently depending on the application. Setting this flag so that it knows this
+        # instance is run in FAB.
+        auth_manager.is_in_fab = True
         if hasattr(auth_manager, "security_manager"):
             self.sm = auth_manager.security_manager
         else:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -146,10 +146,20 @@ class FabAuthManager(BaseAuthManager[User]):
 
     appbuilder: AirflowAppBuilder | None = None
 
+    is_in_fab: bool = False
+    """
+    Whether the instance is run in FAB or Fastapi.
+    Can be deleted once the Airflow 2 legacy UI is removed.
+    """
+
     def init(self) -> None:
         """Run operations when Airflow is initializing."""
         if self.appbuilder:
             self._sync_appbuilder_roles()
+
+    @cached_property
+    def fastapi_endpoint(self) -> str:
+        return conf.get("fastapi", "base_url")
 
     @staticmethod
     def get_cli_commands() -> list[CLICommand]:
@@ -443,12 +453,15 @@ class FabAuthManager(BaseAuthManager[User]):
 
     def get_url_login(self, **kwargs) -> str:
         """Return the login page url."""
-        if not self.security_manager.auth_view:
-            raise AirflowException("`auth_view` not defined in the security manager.")
-        if next_url := kwargs.get("next_url"):
-            return url_for(f"{self.security_manager.auth_view.endpoint}.login", next=next_url)
+        if self.is_in_fab:
+            if not self.security_manager.auth_view:
+                raise AirflowException("`auth_view` not defined in the security manager.")
+            if next_url := kwargs.get("next_url"):
+                return url_for(f"{self.security_manager.auth_view.endpoint}.login", next=next_url)
+            else:
+                return url_for(f"{self.security_manager.auth_view.endpoint}.login")
         else:
-            return url_for(f"{self.security_manager.auth_view.endpoint}.login")
+            return f"{self.fastapi_endpoint}/auth/login"
 
     def get_url_logout(self):
         """Return the logout page url."""

--- a/providers/fab/tests/provider_tests/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/provider_tests/fab/auth_manager/test_fab_auth_manager.py
@@ -574,26 +574,9 @@ class TestFabAuthManager:
         ):
             auth_manager_with_appbuilder.security_manager
 
-    @pytest.mark.db_test
-    def test_get_url_login_when_auth_view_not_defined(self, auth_manager_with_appbuilder):
-        with pytest.raises(AirflowException, match="`auth_view` not defined in the security manager."):
-            auth_manager_with_appbuilder.get_url_login()
-
-    @pytest.mark.db_test
-    @mock.patch("airflow.providers.fab.auth_manager.fab_auth_manager.url_for")
-    def test_get_url_login(self, mock_url_for, auth_manager_with_appbuilder):
-        auth_manager_with_appbuilder.security_manager.auth_view = Mock()
-        auth_manager_with_appbuilder.security_manager.auth_view.endpoint = "test_endpoint"
-        auth_manager_with_appbuilder.get_url_login()
-        mock_url_for.assert_called_once_with("test_endpoint.login")
-
-    @pytest.mark.db_test
-    @mock.patch("airflow.providers.fab.auth_manager.fab_auth_manager.url_for")
-    def test_get_url_login_with_next(self, mock_url_for, auth_manager_with_appbuilder):
-        auth_manager_with_appbuilder.security_manager.auth_view = Mock()
-        auth_manager_with_appbuilder.security_manager.auth_view.endpoint = "test_endpoint"
-        auth_manager_with_appbuilder.get_url_login(next_url="next_url")
-        mock_url_for.assert_called_once_with("test_endpoint.login", next="next_url")
+    def test_get_url_login(self, auth_manager):
+        result = auth_manager.get_url_login()
+        assert result == "http://localhost:29091/auth/login"
 
     @pytest.mark.db_test
     def test_get_url_logout_when_auth_view_not_defined(self, auth_manager_with_appbuilder):


### PR DESCRIPTION
FAB auth manager is currently used in AF2 web application (Flask) and AF3 web application (fastapi). One of the responsibility of the auth manager is to provide the url of the login page. This URL differs whether we are in the context of AF2 or AF3. To address both use cases, I introduce an ugly flag to specify whether the auth manager is run in AF2 or AF3. This is temporary and will be removed when the AF2 Flask application is removed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
