### PR TITLE
Separate the case where DagFileInfo should have bundle path from the one where it doesn't have to

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -399,7 +399,7 @@ class DagFileProcessorManager(LoggingMixin):
             return
 
         bundle_info = ParseBundleInfo(
-            name=request.bundle_name, root_path=bundle.path, version=request.bundle_version
+            name=request.bundle_name, path=bundle.path, version=request.bundle_version
         )
         file_info = ParseFileInfo(
             rel_path=Path(request.filepath),
@@ -510,7 +510,7 @@ class DagFileProcessorManager(LoggingMixin):
         rel_paths = (Path(x).relative_to(bundle.path) for x in file_paths)
         bundle_info = ParseBundleInfo(
             name=bundle.name,
-            root_path=bundle.path,
+            path=bundle.path,
             version=bundle.version,
         )
         return (ParseFileInfo(rel_path=p, bundle=bundle_info) for p in rel_paths)
@@ -546,7 +546,7 @@ class DagFileProcessorManager(LoggingMixin):
                 rel_filelocs.append(str(info.rel_path))
             else:
                 for abs_sub_path in find_zipped_dags(abs_path=info.absolute_path):
-                    rel_sub_path = Path(abs_sub_path).relative_to(info.bundle.root_path)
+                    rel_sub_path = Path(abs_sub_path).relative_to(info.bundle.path)
                     rel_filelocs.append(str(rel_sub_path))
 
         DagModel.deactivate_deleted_dags(bundle_name=bundle_name, rel_filelocs=rel_filelocs)

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -50,7 +50,7 @@ import airflow.models
 from airflow.configuration import conf
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.collection import update_dag_parsing_results_in_db
-from airflow.dag_processing.parse_info import BundleInfo, DagEntrypoint, ParseFileInfo
+from airflow.dag_processing.parse_info import DagEntrypoint, ParseBundleInfo, ParseFileInfo
 from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
 from airflow.exceptions import AirflowException
 from airflow.models.dag import DagModel
@@ -398,7 +398,7 @@ class DagFileProcessorManager(LoggingMixin):
             self.log.error("Bundle %s no longer configured, skipping callback", request.bundle_name)
             return
 
-        bundle_info = BundleInfo(
+        bundle_info = ParseBundleInfo(
             name=request.bundle_name, root_path=bundle.path, version=request.bundle_version
         )
         file_info = ParseFileInfo(
@@ -508,7 +508,7 @@ class DagFileProcessorManager(LoggingMixin):
         self.log.info("Found %s files for bundle %s", len(file_paths), bundle.name)
 
         rel_paths = (Path(x).relative_to(bundle.path) for x in file_paths)
-        bundle_info = BundleInfo(
+        bundle_info = ParseBundleInfo(
             name=bundle.name,
             root_path=bundle.path,
             version=bundle.version,

--- a/airflow/dag_processing/parse_info.py
+++ b/airflow/dag_processing/parse_info.py
@@ -29,12 +29,12 @@ class ParseBundleInfo:
     In-parsing time context about bundle being processed.
 
     :param name: Bundle name.
-    :param root_path: Root path of the bundle version.
+    :param path: Path of the bundle version's root.
     :param version: Bundle version.
     """
 
     name: str
-    root_path: Path | str = field(compare=False)
+    path: Path | str = field(compare=False)
     version: str | None = None
 
 
@@ -55,7 +55,7 @@ class ParseFileInfo(_ParseFileInfo):
 
     @property
     def absolute_path(self) -> Path:
-        return Path(self.bundle.root_path) / Path(self.rel_path)
+        return Path(self.bundle.path) / Path(self.rel_path)
 
     @cached_property
     def entrypoint(self) -> DagEntrypoint:

--- a/airflow/dag_processing/parse_info.py
+++ b/airflow/dag_processing/parse_info.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import cached_property
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BundleInfo:
+    """
+    In-parsing time context about bundle being processed.
+
+    :param name: Bundle name.
+    :param root_path: Root path of the bundle version.
+    :param version: Bundle version.
+    """
+
+    name: str
+    root_path: Path | str = field(compare=False)
+    version: str | None = None
+
+
+@dataclass(frozen=True)
+class ParseFileInfo:
+    """
+    Information about a DAG file at parse time with fixed version.
+
+    :param rel_path: Relative path of a file within a bundle.
+    :param bundle: Bundle information.
+    """
+
+    rel_path: Path | str
+    bundle: BundleInfo
+
+    @property
+    def absolute_path(self) -> Path:
+        return Path(self.bundle.root_path) / Path(self.rel_path)
+
+    @cached_property
+    def entrypoint(self) -> DagEntrypoint:
+        return DagEntrypoint(rel_path=Path(self.rel_path), bundle_name=self.bundle.name)
+
+
+@dataclass(frozen=True)
+class DagEntrypoint:
+    """
+    DAG file entrypoint identifier.
+
+    Fully identifies an entrypoint for potential DAG files within an Airflow deployment and other Airflow entities related to it (import errors, warnings, etc.).
+
+    :param rel_path: Relative path of an entrypoint file within a bundle.
+    :param bundle_name: Name of the bundle.
+    """
+
+    rel_path: Path
+    bundle_name: str

--- a/airflow/dag_processing/parse_info.py
+++ b/airflow/dag_processing/parse_info.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 
 @dataclass(frozen=True)
-class BundleInfo:
+class ParseBundleInfo:
     """
     In-parsing time context about bundle being processed.
 
@@ -47,7 +47,7 @@ class ParseFileInfo:
     """
 
     rel_path: Path | str
-    bundle: BundleInfo
+    bundle: ParseBundleInfo
 
     @property
     def absolute_path(self) -> Path:

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -74,7 +74,7 @@ def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileP
     # TODO: Set known_pool names on DagBag!
     bag = DagBag(
         dag_folder=msg.parse_file_info.absolute_path,
-        bundle_path=Path(msg.parse_file_info.bundle.root_path),
+        bundle_path=Path(msg.parse_file_info.bundle.path),
         include_examples=False,
         safe_mode=True,
         load_op_links=False,

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -46,7 +46,7 @@ from airflow.dag_processing.manager import (
     DagFileProcessorManager,
     DagFileStat,
 )
-from airflow.dag_processing.parse_info import BundleInfo, ParseFileInfo
+from airflow.dag_processing.parse_info import ParseBundleInfo, ParseFileInfo
 from airflow.dag_processing.processor import DagFileProcessorProcess
 from airflow.models import DAG, DagBag, DagModel, DbCallbackRequest
 from airflow.models.asset import TaskOutletAssetReference
@@ -78,8 +78,8 @@ TEST_DAG_FOLDER = Path(__file__).parents[1].resolve() / "dags"
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 
-def _default_bundle_info() -> BundleInfo:
-    return BundleInfo(
+def _default_bundle_info() -> ParseBundleInfo:
+    return ParseBundleInfo(
         name="testing",
         root_path=TEST_DAGS_FOLDER,
     )
@@ -575,7 +575,7 @@ class TestDagFileProcessorManager:
     )
     def test_serialize_callback_requests(self, callbacks, path, expected_buffer):
         file_info = ParseFileInfo(
-            bundle=BundleInfo(name="testing", root_path="/opt/airflow/dags"), rel_path=path
+            bundle=ParseBundleInfo(name="testing", root_path="/opt/airflow/dags"), rel_path=path
         )
         processor = self.mock_processor()
         processor._on_child_started(callbacks=callbacks, parse_file_info=file_info)
@@ -697,7 +697,7 @@ class TestDagFileProcessorManager:
         with dag_maker("test_dag2") as dag2:
             dag2.relative_fileloc = "test_dag2.py"
         dag_maker.sync_dagbag_to_db()
-        maker_bundle = BundleInfo(name="dag_maker", root_path=TEST_DAGS_FOLDER)
+        maker_bundle = ParseBundleInfo(name="dag_maker", root_path=TEST_DAGS_FOLDER)
 
         active_files = [
             ParseFileInfo(bundle=maker_bundle, rel_path=Path("test_dag1.py")),
@@ -788,7 +788,7 @@ class TestDagFileProcessorManager:
                 processor_timeout=365 * 86_400,
             )
             manager._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
-            bundle_info = BundleInfo(name="testing", root_path=Path(tmp_path))
+            bundle_info = ParseBundleInfo(name="testing", root_path=Path(tmp_path))
 
             dag1_path = ParseFileInfo(bundle=bundle_info, rel_path=Path("file1.py"))
             dag1_req1 = DagCallbackRequest(

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -81,7 +81,7 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 def _default_bundle_info() -> ParseBundleInfo:
     return ParseBundleInfo(
         name="testing",
-        root_path=TEST_DAGS_FOLDER,
+        path=TEST_DAGS_FOLDER,
     )
 
 
@@ -430,7 +430,7 @@ class TestDagFileProcessorManager:
             test_dag_path.absolute_path,
             read_dags_from_db=False,
             include_examples=False,
-            bundle_path=test_dag_path.bundle.root_path,
+            bundle_path=test_dag_path.bundle.path,
         )
 
         with create_session() as session:
@@ -530,7 +530,7 @@ class TestDagFileProcessorManager:
                 b'"parse_file_info":'
                 b"{"
                 b'"rel_path":"test_dag.py",'
-                b'"bundle":{"name":"testing","root_path":"/opt/airflow/dags","version":null}'
+                b'"bundle":{"name":"testing","path":"/opt/airflow/dags","version":null}'
                 b"},"
                 b'"requests_fd":123,'
                 b'"callback_requests":[],'
@@ -553,7 +553,7 @@ class TestDagFileProcessorManager:
                 b'"parse_file_info":'
                 b"{"
                 b'"rel_path":"dag_callback_dag.py",'
-                b'"bundle":{"name":"testing","root_path":"/opt/airflow/dags","version":null}'
+                b'"bundle":{"name":"testing","path":"/opt/airflow/dags","version":null}'
                 b"},"
                 b'"requests_fd":123,"callback_requests":'
                 b"["
@@ -575,7 +575,7 @@ class TestDagFileProcessorManager:
     )
     def test_serialize_callback_requests(self, callbacks, path, expected_buffer):
         file_info = ParseFileInfo(
-            bundle=ParseBundleInfo(name="testing", root_path="/opt/airflow/dags"), rel_path=path
+            bundle=ParseBundleInfo(name="testing", path="/opt/airflow/dags"), rel_path=path
         )
         processor = self.mock_processor()
         processor._on_child_started(callbacks=callbacks, parse_file_info=file_info)
@@ -697,7 +697,7 @@ class TestDagFileProcessorManager:
         with dag_maker("test_dag2") as dag2:
             dag2.relative_fileloc = "test_dag2.py"
         dag_maker.sync_dagbag_to_db()
-        maker_bundle = ParseBundleInfo(name="dag_maker", root_path=TEST_DAGS_FOLDER)
+        maker_bundle = ParseBundleInfo(name="dag_maker", path=TEST_DAGS_FOLDER)
 
         active_files = [
             ParseFileInfo(bundle=maker_bundle, rel_path=Path("test_dag1.py")),
@@ -788,7 +788,7 @@ class TestDagFileProcessorManager:
                 processor_timeout=365 * 86_400,
             )
             manager._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
-            bundle_info = ParseBundleInfo(name="testing", root_path=Path(tmp_path))
+            bundle_info = ParseBundleInfo(name="testing", path=Path(tmp_path))
 
             dag1_path = ParseFileInfo(bundle=bundle_info, rel_path=Path("file1.py"))
             dag1_req1 = DagCallbackRequest(

--- a/tests/dag_processing/test_parse_info.py
+++ b/tests/dag_processing/test_parse_info.py
@@ -1,0 +1,106 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import airflow.dag_processing.parse_info as parse_info
+
+
+def test_parse_bundle_info_hash():
+    same_1 = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
+    same_2 = parse_info.ParseBundleInfo(name="bundle-name", root_path=Path("/root/path"))
+    different_name = parse_info.ParseBundleInfo(name="different-name", root_path="/root/path")
+    different_path = parse_info.ParseBundleInfo(name="bundle-name", root_path="/different/path")
+    different_version = parse_info.ParseBundleInfo(
+        name="bundle-name", root_path="/root/path", version="1.0.0"
+    )
+    assert hash(same_1) == hash(same_2)
+    assert hash(same_1) == hash(different_path)
+    assert hash(same_1) != hash(different_name)
+    assert hash(same_1) != hash(different_version)
+
+
+def test_parse_bundle_info_eq():
+    same_1 = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
+    same_2 = parse_info.ParseBundleInfo(name="bundle-name", root_path=Path("/root/path"))
+    different_name = parse_info.ParseBundleInfo(name="different-name", root_path="/root/path")
+    different_path = parse_info.ParseBundleInfo(name="bundle-name", root_path="/different/path")
+    different_version = parse_info.ParseBundleInfo(
+        name="bundle-name", root_path="/root/path", version="1.0.0"
+    )
+    assert same_1 == same_2
+    assert same_1 == different_path
+    assert same_1 != different_name
+    assert same_1 != different_version
+
+
+def test_parse_file_info_hash():
+    bundle = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
+    other_bundle = parse_info.ParseBundleInfo(name="other-bundle-name", root_path="/root/path")
+
+    same_1 = parse_info.ParseFileInfo(rel_path="a", bundle=bundle)
+    same_2 = parse_info.ParseFileInfo(rel_path=Path("a"), bundle=bundle)
+    different_rel_path = parse_info.ParseFileInfo(rel_path="b", bundle=bundle)
+    different_bundle = parse_info.ParseFileInfo(rel_path="a", bundle=other_bundle)
+
+    assert hash(same_1) == hash(same_2)
+    assert hash(same_1) != hash(different_rel_path)
+    assert hash(same_1) != hash(different_bundle)
+
+
+def test_parse_file_info_eq():
+    bundle = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
+    other_bundle = parse_info.ParseBundleInfo(name="other-bundle-name", root_path="/root/path")
+
+    same_1 = parse_info.ParseFileInfo(rel_path="a", bundle=bundle)
+    same_2 = parse_info.ParseFileInfo(rel_path=Path("a"), bundle=bundle)
+    different_rel_path = parse_info.ParseFileInfo(rel_path="b", bundle=bundle)
+    different_bundle = parse_info.ParseFileInfo(rel_path="a", bundle=other_bundle)
+
+    assert same_1 == same_2
+    assert same_2 == same_1
+    assert same_1 != different_rel_path
+    assert different_rel_path != same_1
+    assert same_1 != different_bundle
+    assert different_bundle != same_1
+
+
+def test_dag_entrypoint_hash():
+    same_1 = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="bundle-name")
+    same_2 = parse_info.DagEntrypoint(rel_path=Path("a/b"), bundle_name="bundle-name")
+
+    different_rel_path = parse_info.DagEntrypoint(rel_path="c/d", bundle_name="bundle-name")
+    different_bundle_name = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="other-bundle")
+
+    assert hash(same_1) == hash(same_2)
+    assert hash(same_1) != hash(different_rel_path)
+    assert hash(same_1) != hash(different_bundle_name)
+
+
+def test_dag_entrypoint_eq():
+    same_1 = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="bundle-name")
+    same_2 = parse_info.DagEntrypoint(rel_path=Path("a/b"), bundle_name="bundle-name")
+
+    different_rel_path = parse_info.DagEntrypoint(rel_path="c/d", bundle_name="bundle-name")
+    different_bundle_name = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="other-bundle")
+
+    assert same_1 == same_2
+    assert same_1 != different_rel_path
+    assert same_1 != different_bundle_name

--- a/tests/dag_processing/test_parse_info.py
+++ b/tests/dag_processing/test_parse_info.py
@@ -79,11 +79,11 @@ def test_parse_file_info_eq():
 
 
 def test_dag_entrypoint_hash():
-    same_1 = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="bundle-name")
-    same_2 = parse_info.DagEntrypoint(rel_path=Path("a/b"), bundle_name="bundle-name")
+    same_1 = parse_info.DagFile(rel_path="a/b", bundle_name="bundle-name")
+    same_2 = parse_info.DagFile(rel_path=Path("a/b"), bundle_name="bundle-name")
 
-    different_rel_path = parse_info.DagEntrypoint(rel_path="c/d", bundle_name="bundle-name")
-    different_bundle_name = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="other-bundle")
+    different_rel_path = parse_info.DagFile(rel_path="c/d", bundle_name="bundle-name")
+    different_bundle_name = parse_info.DagFile(rel_path="a/b", bundle_name="other-bundle")
 
     assert hash(same_1) == hash(same_2)
     assert hash(same_1) != hash(different_rel_path)
@@ -91,11 +91,11 @@ def test_dag_entrypoint_hash():
 
 
 def test_dag_entrypoint_eq():
-    same_1 = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="bundle-name")
-    same_2 = parse_info.DagEntrypoint(rel_path=Path("a/b"), bundle_name="bundle-name")
+    same_1 = parse_info.DagFile(rel_path="a/b", bundle_name="bundle-name")
+    same_2 = parse_info.DagFile(rel_path=Path("a/b"), bundle_name="bundle-name")
 
-    different_rel_path = parse_info.DagEntrypoint(rel_path="c/d", bundle_name="bundle-name")
-    different_bundle_name = parse_info.DagEntrypoint(rel_path="a/b", bundle_name="other-bundle")
+    different_rel_path = parse_info.DagFile(rel_path="c/d", bundle_name="bundle-name")
+    different_bundle_name = parse_info.DagFile(rel_path="a/b", bundle_name="other-bundle")
 
     assert same_1 == same_2
     assert same_1 != different_rel_path

--- a/tests/dag_processing/test_parse_info.py
+++ b/tests/dag_processing/test_parse_info.py
@@ -24,13 +24,11 @@ import airflow.dag_processing.parse_info as parse_info
 
 
 def test_parse_bundle_info_hash():
-    same_1 = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
-    same_2 = parse_info.ParseBundleInfo(name="bundle-name", root_path=Path("/root/path"))
-    different_name = parse_info.ParseBundleInfo(name="different-name", root_path="/root/path")
-    different_path = parse_info.ParseBundleInfo(name="bundle-name", root_path="/different/path")
-    different_version = parse_info.ParseBundleInfo(
-        name="bundle-name", root_path="/root/path", version="1.0.0"
-    )
+    same_1 = parse_info.ParseBundleInfo(name="bundle-name", path="/root/path")
+    same_2 = parse_info.ParseBundleInfo(name="bundle-name", path=Path("/root/path"))
+    different_name = parse_info.ParseBundleInfo(name="different-name", path="/root/path")
+    different_path = parse_info.ParseBundleInfo(name="bundle-name", path="/different/path")
+    different_version = parse_info.ParseBundleInfo(name="bundle-name", path="/root/path", version="1.0.0")
     assert hash(same_1) == hash(same_2)
     assert hash(same_1) == hash(different_path)
     assert hash(same_1) != hash(different_name)
@@ -38,13 +36,11 @@ def test_parse_bundle_info_hash():
 
 
 def test_parse_bundle_info_eq():
-    same_1 = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
-    same_2 = parse_info.ParseBundleInfo(name="bundle-name", root_path=Path("/root/path"))
-    different_name = parse_info.ParseBundleInfo(name="different-name", root_path="/root/path")
-    different_path = parse_info.ParseBundleInfo(name="bundle-name", root_path="/different/path")
-    different_version = parse_info.ParseBundleInfo(
-        name="bundle-name", root_path="/root/path", version="1.0.0"
-    )
+    same_1 = parse_info.ParseBundleInfo(name="bundle-name", path="/root/path")
+    same_2 = parse_info.ParseBundleInfo(name="bundle-name", path=Path("/root/path"))
+    different_name = parse_info.ParseBundleInfo(name="different-name", path="/root/path")
+    different_path = parse_info.ParseBundleInfo(name="bundle-name", path="/different/path")
+    different_version = parse_info.ParseBundleInfo(name="bundle-name", path="/root/path", version="1.0.0")
     assert same_1 == same_2
     assert same_1 == different_path
     assert same_1 != different_name
@@ -52,8 +48,8 @@ def test_parse_bundle_info_eq():
 
 
 def test_parse_file_info_hash():
-    bundle = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
-    other_bundle = parse_info.ParseBundleInfo(name="other-bundle-name", root_path="/root/path")
+    bundle = parse_info.ParseBundleInfo(name="bundle-name", path="/root/path")
+    other_bundle = parse_info.ParseBundleInfo(name="other-bundle-name", path="/root/path")
 
     same_1 = parse_info.ParseFileInfo(rel_path="a", bundle=bundle)
     same_2 = parse_info.ParseFileInfo(rel_path=Path("a"), bundle=bundle)
@@ -66,8 +62,8 @@ def test_parse_file_info_hash():
 
 
 def test_parse_file_info_eq():
-    bundle = parse_info.ParseBundleInfo(name="bundle-name", root_path="/root/path")
-    other_bundle = parse_info.ParseBundleInfo(name="other-bundle-name", root_path="/root/path")
+    bundle = parse_info.ParseBundleInfo(name="bundle-name", path="/root/path")
+    other_bundle = parse_info.ParseBundleInfo(name="other-bundle-name", path="/root/path")
 
     same_1 = parse_info.ParseFileInfo(rel_path="a", bundle=bundle)
     same_2 = parse_info.ParseFileInfo(rel_path=Path("a"), bundle=bundle)

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -83,7 +83,7 @@ class TestDagFileProcessor:
                     rel_path=file_path,
                     bundle=ParseBundleInfo(
                         name="testing",
-                        root_path=TEST_DAG_FOLDER,
+                        path=TEST_DAG_FOLDER,
                     ),
                 ),
                 requests_fd=1,
@@ -200,7 +200,7 @@ def test_parse_file_entrypoint_parses_dag_callbacks(spy_agency):
     w.makefile("wb").write(
         b'{"parse_file_info": '
         b'{"rel_path":"wait.py",'
-        b'"bundle":{"name":"testing","root_path":"/files/dags","version":null}'
+        b'"bundle":{"name":"testing","path":"/files/dags","version":null}'
         b'},"requests_fd":'
         + str(w2.fileno()).encode("ascii")
         + b',"callback_requests": [{"filepath": "wait.py", "bundle_name": "testing", "bundle_version": null, '
@@ -260,7 +260,7 @@ def test_parse_file_with_dag_callbacks(spy_agency):
         DagFileParseRequest(
             parse_file_info=ParseFileInfo(
                 rel_path="A",
-                bundle=ParseBundleInfo(name="no matter", root_path="no matter"),
+                bundle=ParseBundleInfo(name="no matter", path="no matter"),
             ),
             requests_fd=1,
             callback_requests=requests,

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -29,7 +29,7 @@ from pydantic import TypeAdapter
 
 from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest, TaskCallbackRequest
 from airflow.configuration import conf
-from airflow.dag_processing.parse_info import BundleInfo, ParseFileInfo
+from airflow.dag_processing.parse_info import ParseBundleInfo, ParseFileInfo
 from airflow.dag_processing.processor import (
     DagFileParseRequest,
     DagFileParsingResult,
@@ -81,7 +81,7 @@ class TestDagFileProcessor:
             DagFileParseRequest(
                 parse_file_info=ParseFileInfo(
                     rel_path=file_path,
-                    bundle=BundleInfo(
+                    bundle=ParseBundleInfo(
                         name="testing",
                         root_path=TEST_DAG_FOLDER,
                     ),
@@ -260,7 +260,7 @@ def test_parse_file_with_dag_callbacks(spy_agency):
         DagFileParseRequest(
             parse_file_info=ParseFileInfo(
                 rel_path="A",
-                bundle=BundleInfo(name="no matter", root_path="no matter"),
+                bundle=ParseBundleInfo(name="no matter", root_path="no matter"),
             ),
             requests_fd=1,
             callback_requests=requests,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #45623 (AIP-66 cleanup)

Before migrating the rest of entities in DB that rely on an absolute path of the DAG to use relative one + bundle name, this PR clearly separates the cases where DAG metadata has absolute path determined from the ones, where it is not needed. Effectively, it splits `DagFileInfo` into 2 entities:
  - `DagEntrypoint` - where DAG(s) file is referenced without a tie to any version (and path where it is actually present as a file)
  - `ParseFileInfo` - where DAG(s) file is parsed within a fixed parse context - here we guarantee that the file has some absolute path attached to it and can be read.

This separation of types delegates the pain of figuring out of "do I have an absolute path set here?" to static type checks and revealed a couple of bugs in tests.
With this implemented, the migration of DAG code and import errors becomes straight forward and removes the need to pass multiple additional parameters across multiple methods in `dag_processing/collection.py` of model. Otherwise we would have to drag bundle's name, path and version as arguments across multiple functions (or do an even more disruptive refactoring, which wouldn't align with feature-freeze goals at all).

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
