### PR TITLE
Fix some dag card ux bugs

### DIFF
--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { Text } from "@chakra-ui/react";
-import { FiCalendar } from "react-icons/fi";
 
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { Tooltip } from "src/components/ui";
@@ -29,8 +28,6 @@ type Props = {
 export const Schedule = ({ dag }: Props) =>
   Boolean(dag.timetable_summary) && dag.timetable_description !== "Never, external triggers only" ? (
     <Tooltip content={dag.timetable_description}>
-      <Text fontSize="sm">
-        <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}
-      </Text>
+      <Text fontSize="sm">{dag.timetable_summary}</Text>
     </Tooltip>
   ) : undefined;

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -22,8 +22,8 @@ import { useState } from "react";
 import {
   UseDagRunServiceGetDagRunsKeyFn,
   useDagRunServiceTriggerDagRun,
-  UseDagServiceGetDagsKeyFn,
-  UseDagsServiceRecentDagRunsKeyFn,
+  useDagServiceGetDagsKey,
+  useDagsServiceRecentDagRunsKey,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
@@ -37,8 +37,8 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
 
   const onSuccess = async () => {
     const queryKeys = [
-      UseDagServiceGetDagsKeyFn(),
-      UseDagsServiceRecentDagRunsKeyFn(),
+      [useDagServiceGetDagsKey],
+      [useDagsServiceRecentDagRunsKey],
       UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
       UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
     ];

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -20,11 +20,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import {
-  useDagRunServiceGetDagRunsKey,
+  UseDagRunServiceGetDagRunsKeyFn,
   useDagRunServiceTriggerDagRun,
-  useDagServiceGetDagsKey,
-  useDagsServiceRecentDagRunsKey,
-  useTaskInstanceServiceGetTaskInstancesKey,
+  UseDagServiceGetDagsKeyFn,
+  UseDagsServiceRecentDagRunsKeyFn,
+  UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
@@ -37,10 +37,10 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
 
   const onSuccess = async () => {
     const queryKeys = [
-      [useDagServiceGetDagsKey],
-      [useDagsServiceRecentDagRunsKey],
-      [useDagRunServiceGetDagRunsKey, { dagId }],
-      [useTaskInstanceServiceGetTaskInstancesKey, { dagId, dagRunId: "~" }],
+      UseDagServiceGetDagsKeyFn(),
+      UseDagsServiceRecentDagRunsKeyFn(),
+      UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
+      UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
     ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -28,7 +28,6 @@ import {
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
-import { doQueryKeysMatch, type PartialQueryKey } from "src/utils";
 
 export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
@@ -37,14 +36,14 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const [dateValidationError, setDateValidationError] = useState<unknown>(undefined);
 
   const onSuccess = async () => {
-    const queryKeys: Array<PartialQueryKey> = [
-      { baseKey: useDagServiceGetDagsKey },
-      { baseKey: useDagsServiceRecentDagRunsKey },
-      { baseKey: useDagRunServiceGetDagRunsKey, options: { dagIds: [dagId] } },
-      { baseKey: useTaskInstanceServiceGetTaskInstancesKey, options: { dagId, dagRunId: "~" } },
+    const queryKeys = [
+      [useDagServiceGetDagsKey],
+      [useDagsServiceRecentDagRunsKey],
+      [useDagRunServiceGetDagRunsKey, { dagId }],
+      [useTaskInstanceServiceGetTaskInstancesKey, { dagId, dagRunId: "~" }],
     ];
 
-    await queryClient.invalidateQueries({ predicate: (query) => doQueryKeysMatch(query, queryKeys) });
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
     toaster.create({
       description: "DAG run has been successfully triggered.",

--- a/airflow/ui/src/utils/query.ts
+++ b/airflow/ui/src/utils/query.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import type { Query } from "@tanstack/react-query";
-
 import { useDagServiceGetDagDetails } from "openapi/queries";
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { useConfig } from "src/queries/useConfig";
@@ -31,26 +29,6 @@ export const isStatePending = (state?: TaskInstanceState | null) =>
   state === "queued" ||
   state === "restarting" ||
   !Boolean(state);
-
-export type PartialQueryKey = { baseKey: string; options?: Record<string, unknown> };
-
-// This allows us to specify what query key values we actually care about and ignore the rest
-// ex: match everything with this dagId and dagRunId but ignore anything related to pagination
-export const doQueryKeysMatch = (query: Query, queryKeysToMatch: Array<PartialQueryKey>) => {
-  const [baseKey, options] = query.queryKey;
-
-  const matchedKey = queryKeysToMatch.find((qk) => qk.baseKey === baseKey);
-
-  if (!matchedKey) {
-    return false;
-  }
-
-  return matchedKey.options
-    ? Object.entries(matchedKey.options).every(
-        ([key, value]) => typeof options === "object" && (options as Record<string, unknown>)[key] === value,
-      )
-    : true;
-};
 
 export const useAutoRefresh = ({ dagId, isPaused }: { dagId?: string; isPaused?: boolean }) => {
   const autoRefreshInterval = useConfig("auto_refresh_interval") as number | undefined;

--- a/airflow/ui/src/utils/query.ts
+++ b/airflow/ui/src/utils/query.ts
@@ -42,7 +42,7 @@ export const useAutoRefresh = ({ dagId, isPaused }: { dagId?: string; isPaused?:
 
   const paused = isPaused ?? dag?.is_paused;
 
-  const canRefresh = autoRefreshInterval !== undefined && (dagId === undefined ? true : !paused);
+  const canRefresh = autoRefreshInterval !== undefined && !paused;
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   return (canRefresh ? autoRefreshInterval * 1000 : false) as number | false;


### PR DESCRIPTION
Only [last commit](https://github.com/apache/airflow/commit/a8e6a50bf38695342d614848189ab1419e798fc6) is relevant

Our refetchInterval with passing a dag or is_paused was broken.

Dropped the schedule icon when displaying the timetable. It didn't look right for Asset scheduled dags

Updated TogglePause query cache invalidation to match useTrigger, since a run can start or fail immediately.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
