### PR TITLE
More meaningful `@task.kubernetes` pod naming

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -588,7 +588,7 @@ class TaskDecoratorCollection:
         :param name: Name of the pod to run. This will be used (plus a random
             suffix if *random_name_suffix* is *True*) to generate a pod ID
             (DNS-1123 subdomain, containing only ``[a-z0-9.-]``). Defaults to
-            ``k8s_airflow_pod_{RANDOM_UUID}``.
+            ``k8s-airflow-pod-{python_callable.__name__}``.
         :param random_name_suffix: If *True*, will generate a random suffix.
         :param arguments: arguments of the entrypoint. (templated)
             The docker image's CMD is used if this is not provided.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import base64
 import os
 import pickle
-import uuid
 from collections.abc import Sequence
 from shlex import quote
 from tempfile import TemporaryDirectory
@@ -68,9 +67,15 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
 
     def __init__(self, namespace: str | None = None, use_dill: bool = False, **kwargs) -> None:
         self.use_dill = use_dill
+
+        # If the name was not provided, we generate operator name from the python_callable
+        # we also instruct operator to add a random suffix to avoid collisions by default
+        op_name = kwargs.pop("name", f"k8s-airflow-pod-{kwargs['python_callable'].__name__}")
+        random_name_suffix = kwargs.pop("random_name_suffix", True)
         super().__init__(
             namespace=namespace,
-            name=kwargs.pop("name", f"k8s_airflow_pod_{uuid.uuid4().hex}"),
+            name=op_name,
+            random_name_suffix=random_name_suffix,
             cmds=["placeholder-command"],
             **kwargs,
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Use name based on decorated python callable in `@task.kubernetes` pod name generation 

- generate attribute and metadata pod name based on decorated python callable
- drop uuid usage as a random suffix in favor of `random_name_suffix` argument 
- add specific pod naming tests for decorator flow because the decorator distinguishes between `name=None` and no `name` argument provided

Re-implementation of the previous PR messed up by new providers structure rebasing
https://github.com/apache/airflow/pull/46462 

closes: #46464


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
