### PR TITLE
Taking out experimental tag from ObjectStorage

### DIFF
--- a/docs/apache-airflow/core-concepts/objectstorage.rst
+++ b/docs/apache-airflow/core-concepts/objectstorage.rst
@@ -23,7 +23,6 @@ Object Storage
 
 .. versionadded:: 2.8.0
 
-|experimental|
 
 All major cloud providers offer persistent data storage in object stores. These are not classic
 "POSIX" file systems. In order to store hundreds of petabytes of data without any single points


### PR DESCRIPTION
Updated the ObjectStorage core concept doc to take out the experimental tag

This is following up on the discussion in Airflow slack about the same topic. 