### PR TITLE
Fix Legacy configuration not removed or updated

### DIFF
--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -482,7 +482,9 @@ def lint_config(args) -> None:
         if configuration.config.section in ignore_sections or configuration.config.option in ignore_options:
             continue
 
-        if conf.has_option(configuration.config.section, configuration.config.option):
+        if conf.has_option(
+            configuration.config.section, configuration.config.option, lookup_from_deprecated_options=False
+        ):
             lint_issues.append(configuration.message)
 
     if lint_issues:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1854,15 +1854,6 @@ webserver:
       type: string
       example: ~
       default: "False"
-    cookie_samesite:
-      description: |
-        Set samesite policy on session cookies.
-        As `recommended <https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOKIE_SAMESITE>`_
-        by Flask, the default is set to ``Lax`` and not a empty string.
-      version_added: 1.10.3
-      type: string
-      example: ~
-      default: "Lax"
     default_wrap:
       description: |
         Default setting for wrap toggle on DAG code and TI log views.

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -891,58 +891,60 @@ class AirflowConfigParser(ConfigParser):
         section: str,
         key: str,
         suppress_warnings: bool = False,
+        lookup_from_deprecated_options: bool = True,
         _extra_stacklevel: int = 0,
         **kwargs,
     ) -> str | None:
         section = section.lower()
         key = key.lower()
         warning_emitted = False
-        deprecated_section: str | None
-        deprecated_key: str | None
+        deprecated_section: str | None = None
+        deprecated_key: str | None = None
 
-        option_description = self.configuration_description.get(section, {}).get(key, {})
-        if option_description.get("deprecated"):
-            deprecation_reason = option_description.get("deprecation_reason", "")
-            warnings.warn(
-                f"The '{key}' option in section {section} is deprecated. {deprecation_reason}",
-                DeprecationWarning,
-                stacklevel=2 + _extra_stacklevel,
-            )
-        # For when we rename whole sections
-        if section in self.inversed_deprecated_sections:
-            deprecated_section, deprecated_key = (section, key)
-            section = self.inversed_deprecated_sections[section]
-            if not self._suppress_future_warnings:
+        if lookup_from_deprecated_options:
+            option_description = self.configuration_description.get(section, {}).get(key, {})
+            if option_description.get("deprecated"):
+                deprecation_reason = option_description.get("deprecation_reason", "")
                 warnings.warn(
-                    f"The config section [{deprecated_section}] has been renamed to "
-                    f"[{section}]. Please update your `conf.get*` call to use the new name",
-                    FutureWarning,
+                    f"The '{key}' option in section {section} is deprecated. {deprecation_reason}",
+                    DeprecationWarning,
                     stacklevel=2 + _extra_stacklevel,
                 )
-            # Don't warn about individual rename if the whole section is renamed
-            warning_emitted = True
-        elif (section, key) in self.inversed_deprecated_options:
-            # Handle using deprecated section/key instead of the new section/key
-            new_section, new_key = self.inversed_deprecated_options[(section, key)]
-            if not self._suppress_future_warnings and not warning_emitted:
-                warnings.warn(
-                    f"section/key [{section}/{key}] has been deprecated, you should use"
-                    f"[{new_section}/{new_key}] instead. Please update your `conf.get*` call to use the "
-                    "new name",
-                    FutureWarning,
-                    stacklevel=2 + _extra_stacklevel,
-                )
+            # For when we rename whole sections
+            if section in self.inversed_deprecated_sections:
+                deprecated_section, deprecated_key = (section, key)
+                section = self.inversed_deprecated_sections[section]
+                if not self._suppress_future_warnings:
+                    warnings.warn(
+                        f"The config section [{deprecated_section}] has been renamed to "
+                        f"[{section}]. Please update your `conf.get*` call to use the new name",
+                        FutureWarning,
+                        stacklevel=2 + _extra_stacklevel,
+                    )
+                # Don't warn about individual rename if the whole section is renamed
                 warning_emitted = True
-            deprecated_section, deprecated_key = section, key
-            section, key = (new_section, new_key)
-        elif section in self.deprecated_sections:
-            # When accessing the new section name, make sure we check under the old config name
-            deprecated_key = key
-            deprecated_section = self.deprecated_sections[section][0]
-        else:
-            deprecated_section, deprecated_key, _ = self.deprecated_options.get(
-                (section, key), (None, None, None)
-            )
+            elif (section, key) in self.inversed_deprecated_options:
+                # Handle using deprecated section/key instead of the new section/key
+                new_section, new_key = self.inversed_deprecated_options[(section, key)]
+                if not self._suppress_future_warnings and not warning_emitted:
+                    warnings.warn(
+                        f"section/key [{section}/{key}] has been deprecated, you should use"
+                        f"[{new_section}/{new_key}] instead. Please update your `conf.get*` call to use the "
+                        "new name",
+                        FutureWarning,
+                        stacklevel=2 + _extra_stacklevel,
+                    )
+                    warning_emitted = True
+                deprecated_section, deprecated_key = section, key
+                section, key = (new_section, new_key)
+            elif section in self.deprecated_sections:
+                # When accessing the new section name, make sure we check under the old config name
+                deprecated_key = key
+                deprecated_section = self.deprecated_sections[section][0]
+            else:
+                deprecated_section, deprecated_key, _ = self.deprecated_options.get(
+                    (section, key), (None, None, None)
+                )
         # first check environment variables
         option = self._get_environment_variables(
             deprecated_key,
@@ -1247,7 +1249,7 @@ class AirflowConfigParser(ConfigParser):
         """
         super().read_dict(dictionary=dictionary, source=source)
 
-    def has_option(self, section: str, option: str) -> bool:
+    def has_option(self, section: str, option: str, lookup_from_deprecated_options: bool = True) -> bool:
         """
         Check if option is defined.
 
@@ -1259,7 +1261,14 @@ class AirflowConfigParser(ConfigParser):
         :return:
         """
         try:
-            value = self.get(section, option, fallback=None, _extra_stacklevel=1, suppress_warnings=True)
+            value = self.get(
+                section,
+                option,
+                fallback=None,
+                _extra_stacklevel=1,
+                suppress_warnings=True,
+                lookup_from_deprecated_options=lookup_from_deprecated_options,
+            )
             if value is None:
                 return False
             return True

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -910,7 +910,7 @@ class AirflowConfigParser(ConfigParser):
                     DeprecationWarning,
                     stacklevel=2 + _extra_stacklevel,
                 )
-            # For when we rename whole sections
+            # For the cases in which we rename whole sections
             if section in self.inversed_deprecated_sections:
                 deprecated_section, deprecated_key = (section, key)
                 section = self.inversed_deprecated_sections[section]

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -67,7 +67,7 @@ class SerializedDagModel(Base):
     * ``[core] min_serialized_dag_update_interval = 30`` (s):
       serialized DAGs are updated in DB when a file gets processed by scheduler,
       to reduce DB write rate, there is a minimal interval of updating serialized DAGs.
-    * ``[scheduler] dag_dir_list_interval = 300`` (s):
+    * ``[dag_processor] refresh_interval = 300`` (s):
       interval of deleting serialized DAGs in DB when the files are deleted, suggest
       to use a smaller interval such as 60
     * ``[core] compress_serialized_dags``:

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -109,7 +109,9 @@ def create_app(config=None, testing=False):
     flask_app.config["SESSION_COOKIE_SECURE"] = conf.getboolean("webserver", "COOKIE_SECURE")
 
     # Note: Ensure "Lax" is the default if config not specified
-    flask_app.config["SESSION_COOKIE_SAMESITE"] = conf.get("webserver", "COOKIE_SAMESITE") or "Lax"
+    flask_app.config["SESSION_COOKIE_SAMESITE"] = (
+        conf.get("webserver", "COOKIE_SAMESITE", fallback=None) or "Lax"
+    )
 
     # Above Flask 2.0.x, default value of SEND_FILE_MAX_AGE_DEFAULT changed 12 hours to None.
     # for static file caching, it needs to set value explicitly.

--- a/tests/cli/commands/remote_commands/test_config_command.py
+++ b/tests/cli/commands/remote_commands/test_config_command.py
@@ -324,7 +324,8 @@ class TestConfigLint:
     def test_lint_detects_multiple_issues(self):
         with mock.patch(
             "airflow.configuration.conf.has_option",
-            side_effect=lambda s, o: o in ["check_slas", "strict_dataset_uri_validation"],
+            side_effect=lambda s, o, lookup_from_deprecated_options: o
+            in ["check_slas", "strict_dataset_uri_validation"],
         ):
             with contextlib.redirect_stdout(StringIO()) as temp_stdout:
                 config_command.lint_config(cli_parser.get_parser().parse_args(["config", "lint"]))

--- a/tests/cli/commands/remote_commands/test_config_command.py
+++ b/tests/cli/commands/remote_commands/test_config_command.py
@@ -324,7 +324,7 @@ class TestConfigLint:
     def test_lint_detects_multiple_issues(self):
         with mock.patch(
             "airflow.configuration.conf.has_option",
-            side_effect=lambda s, o, lookup_from_deprecated_options: o
+            side_effect=lambda section, option, lookup_from_deprecated_options: option
             in ["check_slas", "strict_dataset_uri_validation"],
         ):
             with contextlib.redirect_stdout(StringIO()) as temp_stdout:


### PR DESCRIPTION

closes: #46517

The `inversed_deprecated_options` logic in `config_command.py` causes `config lint` to retrieve the new section-option pair from the old section-option pair. Adding the `lookup_from_deprecated_options` argument can resolve the error.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
