### PR TITLE
Detailed requirement on receiving `.output` property as task input in TaskFlow tutorial

### DIFF
--- a/docs/apache-airflow/howto/custom-operator.rst
+++ b/docs/apache-airflow/howto/custom-operator.rst
@@ -269,6 +269,8 @@ Currently available lexers:
 
 If you use a non-existing lexer then the value of the template field will be rendered as a pretty-printed object.
 
+.. _custom_operator/limitations:
+
 Limitations
 ^^^^^^^^^^^
 To prevent misuse, the following limitations must be observed when defining and assigning templated fields in the

--- a/docs/apache-airflow/tutorial/taskflow.rst
+++ b/docs/apache-airflow/tutorial/taskflow.rst
@@ -576,13 +576,14 @@ task to copy the same file to a date-partitioned storage location in S3 for long
 .. note::
     Using the ``.output`` property as an input to another task is supported
     only for operator parameters listed as a ``template_field`` in the
-    downstream task. For `traditional operator classes </howto/custom-operator.html>`,
+    downstream task. For :doc:`traditional operator classes </howto/custom-operator>`,
     make sure these parameters are listed in ``template_fields`` class
     variable (like ``sqs_queue`` parameter in the ``SqsPublishOperator``
     example above); for decorated tasks using ``@task``- decorator,
     function parameters are already templated and no extra work is required.
 
-    .. seealso:: `Requirements for using templated fields in operator class </howto/custom-operator.html#limitations>`
+.. seealso::
+    - See :ref:`custom_operator/limitations` to understand requirements for using templated fields in operator classes.
 
 .. _taskflow/accessing_context_variables:
 

--- a/docs/apache-airflow/tutorial/taskflow.rst
+++ b/docs/apache-airflow/tutorial/taskflow.rst
@@ -579,7 +579,7 @@ task to copy the same file to a date-partitioned storage location in S3 for long
     downstream task. For `traditional operator classes </howto/custom-operator.html>`,
     make sure these parameters are listed in ``template_fields`` class
     variable (like ``sqs_queue`` parameter in the ``SqsPublishOperator``
-    example above); for decorated task using TaskFlow and ``@task`` decorators,
+    example above); for decorated tasks using ``@task``- decorator,
     function parameters are already templated and no extra work is required.
 
     .. seealso:: `Requirements for using templated fields in operator class </howto/custom-operator.html#limitations>`

--- a/docs/apache-airflow/tutorial/taskflow.rst
+++ b/docs/apache-airflow/tutorial/taskflow.rst
@@ -495,10 +495,6 @@ To retrieve an XCom result for a key other than ``return_value``, you can use:
     # OR
     my_op_output = my_op.output.get("some_other_xcom_key")
 
-.. note::
-    Using the ``.output`` property as an input to another task is supported only for operator parameters
-    listed as a ``template_field``.
-
 In the code example below, a :class:`~airflow.providers.http.operators.http.HttpOperator` result
 is captured via :doc:`XComs </core-concepts/xcoms>`. This XCom result, which is the task output, is then passed
 to a TaskFlow function which parses the response as JSON.
@@ -576,6 +572,17 @@ task to copy the same file to a date-partitioned storage location in S3 for long
         dest_bucket_name="data_lake",
         dest_bucket_key=f"""{BASE_PATH}/{"{{ execution_date.strftime('%Y/%m/%d') }}"}/{FILE_NAME}""",
     )
+
+.. note::
+    Using the ``.output`` property as an input to another task is supported
+    only for operator parameters listed as a ``template_field`` in the
+    downstream task. For `traditional operator classes </howto/custom-operator.html>`,
+    make sure these parameters are listed in ``template_fields`` class
+    variable (like ``sqs_queue`` parameter in the ``SqsPublishOperator``
+    example above); for decorated task using TaskFlow and ``@task`` decorators,
+    function parameters are already templated and no extra work is required.
+
+    .. seealso:: `Requirements for using templated fields in operator class </howto/custom-operator.html#limitations>`
 
 .. _taskflow/accessing_context_variables:
 


### PR DESCRIPTION
## Purpose
Gives more detailed description on using `.output` property as downstream task input when using TaskFlow.

## Details
 - Move the note block right after code examples to better understand why these examples work
 - Points out the requirement applies to downstream task
 - Provides suggestion in different cases (traditional class/decorated task)
 - Provides reference link for users planning to write up their own operator class

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
