### PR TITLE
AIP-38 JWT Flow in the UI

### DIFF
--- a/airflow/ui/src/layouts/BaseLayout.test.tsx
+++ b/airflow/ui/src/layouts/BaseLayout.test.tsx
@@ -1,0 +1,60 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from "@testing-library/react";
+import { URLSearchParams } from "node:url";
+import * as reactRouterDom from "react-router-dom";
+import { afterEach, describe, it, vi, expect } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { BaseLayout, TOKEN_QUERY_PARAM_NAME, TOKEN_STORAGE_KEY } from "./BaseLayout";
+
+describe.each([
+  { searchParams: new URLSearchParams({ token: "something" }) },
+  { searchParams: new URLSearchParams({ param2: "someParam2", token: "else" }) },
+  { searchParams: new URLSearchParams({}) },
+])("BaseLayout", ({ searchParams }) => {
+  it("Should read from the SearchParams, persist to the localStorage and remove from the SearchParams", () => {
+    const useSearchParamMock = vi.spyOn(reactRouterDom, "useSearchParams");
+
+    const setSearchParamsMock = vi.fn();
+
+    const token = searchParams.get(TOKEN_QUERY_PARAM_NAME);
+
+    useSearchParamMock.mockImplementation(() => [searchParams, setSearchParamsMock]);
+
+    const setItemMock = vi.spyOn(localStorage, "setItem");
+
+    render(<BaseLayout />, { wrapper: Wrapper });
+
+    expect(useSearchParamMock).toHaveBeenCalled();
+
+    if (token === null) {
+      expect(setItemMock).toHaveBeenCalledTimes(0);
+    } else {
+      expect(setItemMock).toHaveBeenCalledOnce();
+      expect(setItemMock).toHaveBeenCalledWith(TOKEN_STORAGE_KEY, JSON.stringify(token));
+      expect(searchParams).not.to.contains.keys(TOKEN_QUERY_PARAM_NAME);
+    }
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow/ui/src/layouts/BaseLayout.tsx
@@ -17,12 +17,15 @@
  * under the License.
  */
 import { Flex } from "@chakra-ui/react";
-import type { PropsWithChildren } from "react";
-import { Outlet } from "react-router-dom";
+import { useEffect, type PropsWithChildren } from "react";
+import { Outlet, useSearchParams } from "react-router-dom";
+import { useLocalStorage } from "usehooks-ts";
 
 import { useConfig } from "src/queries/useConfig";
 
 import { Nav } from "./Nav";
+
+export const TOKEN_STORAGE_KEY = "token";
 
 export const BaseLayout = ({ children }: PropsWithChildren) => {
   const instanceName = useConfig("instance_name");
@@ -34,6 +37,19 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   if (typeof instanceName === "string") {
     document.title = instanceName;
   }
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const paramToken = searchParams.get("token");
+
+  const [, setToken] = useLocalStorage<string | null>(TOKEN_STORAGE_KEY, paramToken);
+
+  useEffect(() => {
+    if (paramToken !== null) {
+      setToken(paramToken);
+      searchParams.delete("token");
+      setSearchParams(searchParams);
+    }
+  }, [paramToken, searchParams, setSearchParams, setToken]);
 
   return (
     <>

--- a/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow/ui/src/layouts/BaseLayout.tsx
@@ -27,6 +27,8 @@ import { Nav } from "./Nav";
 
 export const TOKEN_STORAGE_KEY = "token";
 
+export const TOKEN_QUERY_PARAM_NAME = "token";
+
 export const BaseLayout = ({ children }: PropsWithChildren) => {
   const instanceName = useConfig("instance_name");
   // const instanceNameHasMarkup =
@@ -39,14 +41,14 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   }
 
   const [searchParams, setSearchParams] = useSearchParams();
-  const paramToken = searchParams.get("token");
+  const paramToken = searchParams.get(TOKEN_QUERY_PARAM_NAME);
 
   const [, setToken] = useLocalStorage<string | null>(TOKEN_STORAGE_KEY, paramToken);
 
   useEffect(() => {
     if (paramToken !== null) {
       setToken(paramToken);
-      searchParams.delete("token");
+      searchParams.delete(TOKEN_QUERY_PARAM_NAME);
       setSearchParams(searchParams);
     }
   }, [paramToken, searchParams, setSearchParams, setToken]);

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -27,6 +27,7 @@ import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
 
+import { TOKEN_STORAGE_KEY } from "./layouts/BaseLayout";
 import { queryClient } from "./queryClient";
 import { system } from "./theme";
 
@@ -44,6 +45,18 @@ axios.interceptors.response.use(
     return Promise.reject(error);
   },
 );
+
+axios.interceptors.request.use((config) => {
+  const token: string | null = localStorage.getItem(TOKEN_STORAGE_KEY);
+
+  if (token !== null) {
+    // usehooks-ts stores a JSON.stringified version of values, we cannot use usehooks-ts here because we are outside of
+    // a react component. Therefore using bare localStorage.getItem and manually parsing the value.
+    config.headers.Authorization = `Bearer ${JSON.parse(token)}`;
+  }
+
+  return config;
+});
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>


### PR DESCRIPTION
Part of: https://github.com/apache/airflow/issues/44884

Implements a basic jwt flow that will retrieve the token in any of the urls save it to the localstorage, clear the URL and then attach this token to every requests in the header.

I'll follow up with another PR implenting a `/login` in the backend that will redirect to the auth manager login page.