### PR TITLE
AIP-38 Reword Trigger Section for Runs

### DIFF
--- a/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow/ui/src/pages/Run/Details.tsx
@@ -118,7 +118,7 @@ export const Details = () => {
             </Table.Row>
             {dagRun.external_trigger ? (
               <Table.Row>
-                <Table.Cell>External Trigger Source</Table.Cell>
+                <Table.Cell>Trigger Source</Table.Cell>
                 <Table.Cell>{dagRun.triggered_by}</Table.Cell>
               </Table.Row>
             ) : undefined}


### PR DESCRIPTION
Context: https://github.com/apache/airflow/pull/46074#discussion_r1943252920

Ideally we would want the datamodel to also reflect that change and drop the `external` part. This is a small change to not mention it in the UI anymore.