### PR TITLE
Fix system test `test_aws_auth_manager`

### DIFF
--- a/providers/tests/system/amazon/aws/tests/test_aws_auth_manager.py
+++ b/providers/tests/system/amazon/aws/tests/test_aws_auth_manager.py
@@ -192,11 +192,8 @@ class TestAwsAuthManager:
         for policy_store_id in policy_store_ids:
             client.delete_policy_store(policyStoreId=policy_store_id)
 
-    @pytest.mark.skip("Authorization is not yet implemented in AF3 new ui")
-    def test_login_no_permissions(self, client_no_permissions):
-        response = client_no_permissions.post("/auth/login_callback")
-        assert response.status_code == 403
-
     def test_login_admin(self, client_admin_permissions):
-        response = client_admin_permissions.post("/auth/login_callback")
-        assert response.status_code == 200
+        response = client_admin_permissions.post("/auth/login_callback", follow_redirects=False)
+        assert response.status_code == 303
+        assert "location" in response.headers
+        assert "webapp?token=" in response.headers["location"]


### PR DESCRIPTION
The system test succeeds when I run it with breeze locally but it fails in AWS CI because the Airflow UI assets are not generated in AWS CI (they are locally). Let's make it simpler and test the redirection works as expected, no need to follow the redirection.

```
FAILED providers/tests/system/amazon/aws/tests/test_aws_auth_manager.py::TestAwsAuthManager::test_login_admin - jinja2.exceptions.TemplateNotFound: '/index.html' not found in search path: '/opt/airflow/airflow/ui/dist'
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
