### PR TITLE
Increase retries in `EmrContainerHook.create_emr_on_eks_cluster`

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/hooks/emr.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/emr.py
@@ -362,11 +362,11 @@ class EmrContainerHook(AwsBaseHook):
     # Retry this method when the ``create_virtual_cluster`` raises
     # "Cluster XXX is not reachable as its connection is currently being updated".
     # Even though the EKS cluster status is ``ACTIVE``, ``create_virtual_cluster`` can raise this error.
-    # Retrying is the only option.
+    # Retrying is the only option. Retry up to 3 minutes
     @tenacity.retry(
         retry=retry_if_exception(is_connection_being_updated_exception),
-        stop=stop_after_attempt(5),
-        wait=wait_fixed(10),
+        stop=stop_after_attempt(12),
+        wait=wait_fixed(15),
     )
     def create_emr_on_eks_cluster(
         self,


### PR DESCRIPTION
Follow-up of #46441.

#46441 solves the issue but only partially, the system test is succeeding and failing intermittently. When it fails, it fails due to the same error:

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the CreateVirtualCluster operation: Cluster env40beb96b-cluster is not reachable as its connection is currently being updated
```

The only thing we can do is wait longer ...

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
