### PR TITLE
Fix `compile-ui-assets` to not exit after generating main UI assets

### DIFF
--- a/scripts/ci/pre_commit/compile_ui_assets.py
+++ b/scripts/ci/pre_commit/compile_ui_assets.py
@@ -61,8 +61,8 @@ def compile_assets(ui_directory: Path, hash_file: Path):
         old_hash = hash_file.read_text() if hash_file.exists() else ""
         new_hash = get_directory_hash(ui_directory, skip_path_regexp=r".*node_modules.*")
         if new_hash == old_hash:
-            print("The UI directory has not changed! Skip regeneration.")
-            sys.exit(0)
+            print(f"The UI directory '{ui_directory}' has not changed! Skip regeneration.")
+            return
     else:
         shutil.rmtree(node_modules_directory, ignore_errors=True)
         shutil.rmtree(dist_directory, ignore_errors=True)


### PR DESCRIPTION
As part of `compile-ui-assets` we are generating assets from the main UI but also assets from the simple auth manager UI, see [code](https://github.com/apache/airflow/blob/main/scripts/ci/pre_commit/compile_ui_assets.py#L97). However, in case of successful generation, we exit the script so the simple auth manager assets are never compiled.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
