### PR TITLE
Allow passing more then one `--bundle-name` to reserialize command

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -171,8 +171,9 @@ ARG_BUNDLE_NAME = Arg(
         "-B",
         "--bundle-name",
     ),
-    help=("The name of the DAG bundle to use."),
+    help=("The name of the DAG bundle to use; may be provided more than once"),
     default=None,
+    action="append",
 )
 ARG_START_DATE = Arg(("-s", "--start-date"), help="Override start_date YYYY-MM-DD", type=parsedate)
 ARG_END_DATE = Arg(("-e", "--end-date"), help="Override end_date YYYY-MM-DD", type=parsedate)

--- a/airflow/cli/commands/remote_commands/dag_command.py
+++ b/airflow/cli/commands/remote_commands/dag_command.py
@@ -548,14 +548,14 @@ def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     manager.sync_bundles_to_db(session=session)
     session.commit()
 
-    bundles = list(manager.get_all_dag_bundles())
+    all_bundles = list(manager.get_all_dag_bundles())
     if args.bundle_name:
         validate_dag_bundle_arg(args.bundle_name)
         bundles_to_reserialize = set(args.bundle_name)
     else:
-        bundles_to_reserialize = {b.name for b in bundles}
+        bundles_to_reserialize = {b.name for b in all_bundles}
 
-    for bundle in bundles:
+    for bundle in all_bundles:
         if bundle.name not in bundles_to_reserialize:
             continue
         bundle.initialize()

--- a/airflow/cli/commands/remote_commands/dag_command.py
+++ b/airflow/cli/commands/remote_commands/dag_command.py
@@ -34,13 +34,14 @@ from airflow.api.client import get_current_api_client
 from airflow.api_connexion.schemas.dag_schema import dag_schema
 from airflow.cli.simple_table import AirflowConsole
 from airflow.cli.utils import fetch_dag_run_from_run_id_or_logical_date_string
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowException
 from airflow.jobs.job import Job
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils import cli as cli_utils, timezone
-from airflow.utils.cli import get_dag, process_subdir, suppress_logs_and_warning
+from airflow.utils.cli import get_dag, process_subdir, suppress_logs_and_warning, validate_dag_bundle_arg
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.helpers import ask_yesno
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
@@ -543,21 +544,20 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
 @provide_session
 def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
-    from airflow.dag_processing.bundles.manager import DagBundlesManager
-
     manager = DagBundlesManager()
     manager.sync_bundles_to_db(session=session)
     session.commit()
+
+    bundles = list(manager.get_all_dag_bundles())
     if args.bundle_name:
-        bundle = manager.get_bundle(args.bundle_name)
-        if not bundle:
-            raise SystemExit(f"Bundle {args.bundle_name} not found")
+        validate_dag_bundle_arg(args.bundle_name)
+        bundles_to_reserialize = set(args.bundle_name)
+    else:
+        bundles_to_reserialize = {b.name for b in bundles}
+
+    for bundle in bundles:
+        if bundle.name not in bundles_to_reserialize:
+            continue
         bundle.initialize()
         dag_bag = DagBag(bundle.path, include_examples=False)
         dag_bag.sync_to_db(bundle.name, bundle_version=bundle.get_current_version(), session=session)
-    else:
-        bundles = manager.get_all_dag_bundles()
-        for bundle in bundles:
-            bundle.initialize()
-            dag_bag = DagBag(bundle.path, include_examples=False)
-            dag_bag.sync_to_db(bundle.name, bundle_version=bundle.get_current_version(), session=session)

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -374,6 +374,6 @@ def validate_dag_bundle_arg(bundle_names: list[str]) -> None:
     """Make sure only known bundles are passed as arguments."""
     known_bundles = {b.name for b in DagBundlesManager().get_all_dag_bundles()}
 
-    non_existant_bundles: set[str] = set(bundle_names) - known_bundles
-    if non_existant_bundles:
-        raise SystemExit(f"Bundles not found: {', '.join(non_existant_bundles)}")
+    unknown_bundles: set[str] = set(bundle_names) - known_bundles
+    if unknown_bundles:
+        raise SystemExit(f"Bundles not found: {', '.join(unknown_bundles)}")

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Callable, TypeVar, cast
 import re2
 
 from airflow import settings
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowException
 from airflow.sdk.execution_time.secrets_masker import should_hide_value_for_key
 from airflow.utils import cli_action_loggers, timezone
@@ -189,6 +190,7 @@ def process_subdir(subdir: str | None):
 
 def get_dag_by_file_location(dag_id: str):
     """Return DAG of a given dag_id by looking up file location."""
+    # TODO: AIP-66 - investigate more, can we use serdag?
     from airflow.models import DagBag, DagModel
 
     # Benefit is that logging from other dags in dagbag will not appear
@@ -366,3 +368,12 @@ def suppress_logs_and_warning(f: T) -> T:
                     logging.disable(logging.NOTSET)
 
     return cast(T, _wrapper)
+
+
+def validate_dag_bundle_arg(bundle_names: list[str]) -> None:
+    """Make sure only known bundles are passed as arguments."""
+    known_bundles = {b.name for b in DagBundlesManager().get_all_dag_bundles()}
+
+    non_existant_bundles: set[str] = set(bundle_names) - known_bundles
+    if non_existant_bundles:
+        raise SystemExit(f"Bundles not found: {', '.join(non_existant_bundles)}")

--- a/tests/cli/commands/remote_commands/test_dag_command.py
+++ b/tests/cli/commands/remote_commands/test_dag_command.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock
 import pendulum
 import pytest
 import time_machine
+from sqlalchemy import select
 
 from airflow import settings
 from airflow.api_connexion.schemas.dag_schema import DAGSchema, dag_schema
@@ -39,7 +40,6 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import _run_inline_trigger
-from airflow.models.dag_version import DagVersion
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.triggers.base import TriggerEvent
@@ -78,66 +78,6 @@ class TestCliDags:
 
     def setup_method(self):
         clear_db_runs()  # clean-up all dag run before start each test
-
-    def test_reserialize(self, session):
-        # Assert that there are serialized Dags
-        serialized_dags_before_command = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_before_command)  # There are serialized DAGs to delete
-        # delete all versioning
-        session.query(DagVersion).delete()
-
-        serialized_dags_before_command = session.query(SerializedDagModel).all()
-        assert not len(serialized_dags_before_command)  # There are no more serialized dag
-        dag_version_before_command = session.query(DagVersion).all()
-        assert not len(dag_version_before_command)
-        # Serialize the dags
-        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize"]))
-        # Assert serialized Dags
-        serialized_dags_after_clear = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_after_clear)
-        dag_version_after_command = session.query(DagVersion).all()
-        assert len(dag_version_after_command)
-
-    def test_reserialize_should_support_bundle_name_argument(self, configure_testing_dag_bundle, session):
-        # Run clear of serialized dags
-        session.query(DagVersion).delete()
-
-        # Assert no serialized Dags
-        serialized_dags_after_clear = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_after_clear) == 0
-
-        path_to_parse = TEST_DAGS_FOLDER / "test_dag_with_no_tags.py"
-
-        with configure_testing_dag_bundle(path_to_parse):
-            # reserializes only the above path
-            dag_command.dag_reserialize(
-                self.parser.parse_args(["dags", "reserialize", "--bundle-name", "testing"])
-            )
-
-        # Check serialized DAG are back
-        serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_after_reserialize) == 1
-
-    def test_reserialize_should_support_more_than_one_bundle(self, configure_testing_dag_bundle, session):
-        # Run clear of serialized dags
-        session.query(DagVersion).delete()
-
-        # Assert no serialized Dags
-        serialized_dags_after_clear = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_after_clear) == 0
-
-        path_to_parse = TEST_DAGS_FOLDER / "test_dag_with_no_tags.py"
-
-        with configure_testing_dag_bundle(path_to_parse):
-            # The command will now serialize the above bundle and the example dag bundle
-            dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize"]))
-
-        # Check serialized DAG are back
-        serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_after_reserialize) > 1
-        serialized_dag_ids = [dag.dag_id for dag in serialized_dags_after_reserialize]
-        assert "test_dag_with_no_tags" in serialized_dag_ids
-        assert "example_bash_operator" in serialized_dag_ids
 
     def test_show_dag_dependencies_print(self):
         with contextlib.redirect_stdout(StringIO()) as temp_stdout:
@@ -811,3 +751,50 @@ class TestCliDags:
         # only second operator was actually executed, first one was marked as success
         assert len(mock__execute_task_with_callbacks.call_args_list) == 1
         assert mock__execute_task_with_callbacks.call_args_list[0].kwargs["self"].task_id == "dummy_operator"
+
+
+class TestCliDagsReserialize:
+    parser = cli_parser.get_parser()
+
+    test_bundles_config = {
+        "bundle1": TEST_DAGS_FOLDER / "test_example_bash_operator.py",
+        "bundle2": TEST_DAGS_FOLDER / "test_sensor.py",
+        "bundle3": TEST_DAGS_FOLDER / "test_dag_with_no_tags.py",
+    }
+
+    @classmethod
+    def setup_class(cls):
+        clear_db_dags()
+
+    def teardown_method(self):
+        clear_db_dags()
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_reserialize(self, configure_dag_bundles, session):
+        with configure_dag_bundles(self.test_bundles_config):
+            dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize"]))
+
+        serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
+        assert serialized_dag_ids == {"test_example_bash_operator", "test_dag_with_no_tags", "test_sensor"}
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_reserialize_should_support_bundle_name_argument(self, configure_dag_bundles, session):
+        with configure_dag_bundles(self.test_bundles_config):
+            dag_command.dag_reserialize(
+                self.parser.parse_args(["dags", "reserialize", "--bundle-name", "bundle1"])
+            )
+
+        serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
+        assert serialized_dag_ids == {"test_example_bash_operator"}
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_reserialize_should_support_multiple_bundle_name_arguments(self, configure_dag_bundles, session):
+        with configure_dag_bundles(self.test_bundles_config):
+            dag_command.dag_reserialize(
+                self.parser.parse_args(
+                    ["dags", "reserialize", "--bundle-name", "bundle1", "--bundle-name", "bundle2"]
+                )
+            )
+
+        serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
+        assert serialized_dag_ids == {"test_example_bash_operator", "test_sensor"}

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -248,3 +248,11 @@ def test__search_for_dags_file():
     assert _search_for_dag_file(existing_folder.as_posix()) is None
     # when multiple files found, default to the dags folder
     assert _search_for_dag_file("any/hi/__init__.py") is None
+
+
+def test_validate_dag_bundle_arg():
+    with pytest.raises(SystemExit, match="Bundles not found: (x, y)|(y, x)"):
+        cli.validate_dag_bundle_arg(["x", "y", "dags-folder"])
+
+    # doesn't raise
+    cli.validate_dag_bundle_arg(["dags-folder"])


### PR DESCRIPTION
This allows multiple bundle names to passed via the cli - the reserialize command is the only current user of it. But this will apply across a number of commands longer term, so a bit of prep was done by extracting out the validation into a helper.