### PR TITLE
Support `--bundle-name` on DAG processor

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1943,7 +1943,7 @@ core_commands: list[CLICommand] = [
         args=(
             ARG_PID,
             ARG_DAEMON,
-            ARG_SUBDIR,
+            ARG_BUNDLE_NAME,
             ARG_NUM_RUNS,
             ARG_STDOUT,
             ARG_STDERR,

--- a/airflow/cli/commands/local_commands/dag_processor_command.py
+++ b/airflow/cli/commands/local_commands/dag_processor_command.py
@@ -33,9 +33,14 @@ log = logging.getLogger(__name__)
 
 def _create_dag_processor_job_runner(args: Any) -> DagProcessorJobRunner:
     """Create DagFileProcessorProcess instance."""
+    if args.bundle_name:
+        cli_utils.validate_dag_bundle_arg(args.bundle_name)
     return DagProcessorJobRunner(
         job=Job(),
-        processor=DagFileProcessorManager(max_runs=args.num_runs),
+        processor=DagFileProcessorManager(
+            max_runs=args.num_runs,
+            bundle_names_to_parse=args.bundle_name,
+        ),
     )
 
 

--- a/newsfragments/aip-66.significant.rst
+++ b/newsfragments/aip-66.significant.rst
@@ -10,6 +10,14 @@ The following DAG parsing configuration options were moved into the ``dag_proces
 * ``[scheduler] stale_dag_threshold`` → ``[dag_processor] stale_dag_threshold``
 * ``[scheduler] print_stats_interval`` → ``[dag_processor] print_stats_interval``
 
+The "subdir" concept has been superseded by the "bundle" concept. Users are able to
+define separate bundles for different DAG folders, and can refer to them by the bundle name
+instead of their location on disk.
+
+The ``-subdir`` option of the following commands has been replaced with ``--bundle-name``:
+
+* ``airflow dag-processor``
+
 The ``--subdir`` option has been removed from the following commands (it was a noop):
 
 * ``airflow dags pause``

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -1035,3 +1035,21 @@ class TestDagFileProcessorManager:
                 manager.run()
                 bundleone.refresh.assert_called_once()
                 bundleone.get_current_version.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "bundle_names, expected",
+        [
+            (None, {"bundle1", "bundle2", "bundle3"}),
+            (["bundle1"], {"bundle1"}),
+            (["bundle1", "bundle2"], {"bundle1", "bundle2"}),
+        ],
+    )
+    def test_bundle_names_to_parse(self, bundle_names, expected, configure_dag_bundles):
+        config = {f"bundle{i}": os.devnull for i in range(1, 4)}
+        with configure_dag_bundles(config):
+            manager = DagFileProcessorManager(max_runs=1, bundle_names_to_parse=bundle_names)
+            manager._run_parsing_loop = MagicMock()
+            manager.run()
+
+        bundle_names_being_parsed = {b.name for b in manager._dag_bundles}
+        assert bundle_names_being_parsed == expected


### PR DESCRIPTION
This adds support for the bundle name arg on the DAG processor, which allows for a DAG processor to only parse certain bundles.

This also removes the subdir arg, as that has been superceded by separate bundles.

related: #45647 