### PR TITLE
Remove the `--subdir` arg from the dags pause/unpause command

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1095,7 +1095,7 @@ DAGS_COMMANDS = (
             "treating the `--dag-id` as a regex pattern."
         ),
         func=lazy_load_command("airflow.cli.commands.remote_commands.dag_command.dag_pause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_ID_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_TREAT_DAG_ID_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="unpause",
@@ -1106,7 +1106,7 @@ DAGS_COMMANDS = (
             "treating the `--dag-id` as a regex pattern."
         ),
         func=lazy_load_command("airflow.cli.commands.remote_commands.dag_command.dag_unpause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_ID_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_TREAT_DAG_ID_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="trigger",

--- a/newsfragments/aip-66.significant.rst
+++ b/newsfragments/aip-66.significant.rst
@@ -10,6 +10,11 @@ The following DAG parsing configuration options were moved into the ``dag_proces
 * ``[scheduler] stale_dag_threshold`` → ``[dag_processor] stale_dag_threshold``
 * ``[scheduler] print_stats_interval`` → ``[dag_processor] print_stats_interval``
 
+The ``--subdir`` option has been removed from the following commands (it was a noop):
+
+* ``airflow dags pause``
+* ``airflow dags unpause``
+
 .. Provide additional contextual information
 
 .. Check the type of change that applies to this change
@@ -19,7 +24,7 @@ The following DAG parsing configuration options were moved into the ``dag_proces
   * [ ] Dag changes
   * [x] Config changes
   * [ ] API changes
-  * [ ] CLI changes
+  * [x] CLI changes
   * [ ] Behaviour changes
   * [ ] Plugin changes
   * [ ] Dependency changes


### PR DESCRIPTION
The arg didn't actually do anything :)

related: #45647 