### PR TITLE
Remove minimum height on elements in Flexible Form

### DIFF
--- a/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
+++ b/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
@@ -40,11 +40,11 @@ export const FieldRow = ({ name }: FlexibleFormElementProps) => {
   return (
     <Field.Root orientation="horizontal" required={isRequired(param)}>
       <Stack>
-        <Field.Label fontSize="md">
+        <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
           {param.schema.title ?? name} <Field.RequiredIndicator />
         </Field.Label>
       </Stack>
-      <Stack css={{ "flex-basis": "70%" }}>
+      <Stack css={{ flexBasis: "70%" }}>
         <FieldSelector name={name} />
         <Field.HelperText>
           {param.description ?? (

--- a/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
+++ b/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
@@ -46,11 +46,15 @@ export const FieldRow = ({ name }: FlexibleFormElementProps) => {
       </Stack>
       <Stack css={{ flexBasis: "70%" }}>
         <FieldSelector name={name} />
-        <Field.HelperText>
-          {param.description ?? (
-            <Markdown remarkPlugins={[remarkGfm]}>{param.schema.description_md}</Markdown>
-          )}
-        </Field.HelperText>
+        {param.description === null ? (
+          param.schema.description_md === undefined ? undefined : (
+            <Field.HelperText>
+              <Markdown remarkPlugins={[remarkGfm]}>{param.schema.description_md}</Markdown>
+            </Field.HelperText>
+          )
+        ) : (
+          <Field.HelperText>{param.description}</Field.HelperText>
+        )}
       </Stack>
     </Field.Root>
   );

--- a/airflow/ui/src/components/TriggerDag/useParamStore.ts
+++ b/airflow/ui/src/components/TriggerDag/useParamStore.ts
@@ -21,7 +21,8 @@ import { create } from "zustand";
 import type { DagParamsSpec, ParamSpec } from "src/queries/useDagParams";
 
 export const paramPlaceholder: ParamSpec = {
-  description: undefined,
+  // eslint-disable-next-line unicorn/no-null
+  description: null,
   schema: {
     const: undefined,
     description_md: undefined,
@@ -70,7 +71,8 @@ export const useParamStore = create<FormStore>((set) => ({
           return [
             key,
             {
-              description: existingParam?.description,
+              // eslint-disable-next-line unicorn/no-null
+              description: existingParam?.description ?? null,
               schema: existingParam?.schema ?? paramPlaceholder.schema,
               value: value as unknown,
             },

--- a/airflow/ui/src/queries/useDagParams.ts
+++ b/airflow/ui/src/queries/useDagParams.ts
@@ -22,7 +22,7 @@ import { toaster } from "src/components/ui";
 export type DagParamsSpec = Record<string, ParamSpec>;
 
 export type ParamSpec = {
-  description: string | undefined;
+  description: string | null;
   schema: ParamSchema;
   value: unknown;
 };


### PR DESCRIPTION
I noticed that the flexible trigger form always used minimum 80px as space per form row, even if content is less. This occupies a too much screen space for simple forms.
Root cause is that the labels are receiving a minimum height of 80px if no flex basis is defined as style. This PR fixes the layout bug.

Before:
![image](https://github.com/user-attachments/assets/b29f4d08-ca07-4082-bba2-5a152deda1fb)

After / with this PR (incl. review comment fixes):
![image](https://github.com/user-attachments/assets/688f4311-e29e-4da2-95f0-48c73e76bac6)

FYI @shubhamraj-git 