### PR TITLE
Add RemovedInAirflow4Warning

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -483,6 +483,13 @@ class RemovedInAirflow3Warning(DeprecationWarning):
     "Indicates the airflow version that started raising this deprecation warning"
 
 
+class RemovedInAirflow4Warning(DeprecationWarning):
+    """Issued for usage of deprecated features that will be removed in Airflow4."""
+
+    deprecated_since: str | None = None
+    "Indicates the airflow version that started raising this deprecation warning"
+
+
 class AirflowProviderDeprecationWarning(DeprecationWarning):
     """Issued for usage of deprecated features of Airflow provider."""
 


### PR DESCRIPTION
This is needed for cases where we want to deprecate stuff in Airflow 3 rather than remove them (like email integration in code)