### PR TITLE
Masking details while creating connections using json & uri

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import os
 import socket
@@ -156,6 +157,42 @@ def _build_metrics(func_name, namespace):
                 for sensitive_field in sensitive_fields:
                     if command.startswith(f"{sensitive_field}="):
                         full_command[idx] = f'{sensitive_field}={"*" * 8}'
+
+    # handle conn-json and conn-uri separately as it requires different handling
+    if "--conn-json" in full_command:
+        json_index = full_command.index("--conn-json") + 1
+        conn_json = json.loads(full_command[json_index])
+
+        print("conn-json is", conn_json)
+
+        for k in conn_json:
+            if k and should_hide_value_for_key(k):
+                conn_json[k] = "*" * 8
+        full_command[json_index] = json.dumps(conn_json)
+
+    if "--conn-uri" in full_command:
+        from urllib.parse import urlparse, urlunparse
+
+        uri_index = full_command.index("--conn-uri") + 1
+        conn_uri = full_command[uri_index]
+        parsed_uri = urlparse(conn_uri)
+
+        if parsed_uri.password:
+            password = "*" * 8
+            netloc = f"{parsed_uri.username}:{password}@{parsed_uri.hostname}"
+            if parsed_uri.port:
+                netloc += f":{parsed_uri.port}"
+
+        full_command[uri_index] = urlunparse(
+            (
+                parsed_uri.scheme,
+                netloc,
+                parsed_uri.path,
+                parsed_uri.params,
+                parsed_uri.query,
+                parsed_uri.fragment,
+            )
+        )
 
     metrics = {
         "sub_command": func_name,

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 
 import functools
-import json
 import logging
 import os
 import socket
@@ -160,11 +159,10 @@ def _build_metrics(func_name, namespace):
 
     # handle conn-json and conn-uri separately as it requires different handling
     if "--conn-json" in full_command:
+        import json
+
         json_index = full_command.index("--conn-json") + 1
         conn_json = json.loads(full_command[json_index])
-
-        print("conn-json is", conn_json)
-
         for k in conn_json:
             if k and should_hide_value_for_key(k):
                 conn_json[k] = "*" * 8
@@ -176,7 +174,6 @@ def _build_metrics(func_name, namespace):
         uri_index = full_command.index("--conn-uri") + 1
         conn_uri = full_command[uri_index]
         parsed_uri = urlparse(conn_uri)
-
         if parsed_uri.password:
             password = "*" * 8
             netloc = f"{parsed_uri.username}:{password}@{parsed_uri.hostname}"

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -88,46 +88,78 @@ class TestCliUtil:
             cli.get_dags(None, "foobar", True)
 
     @pytest.mark.parametrize(
-        ["given_command", "expected_masked_command"],
+        ["given_command", "expected_masked_command", "is_command_list"],
         [
             (
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin --password test",
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin --password ********",
+                False,
             ),
             (
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin -p test",
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin -p ********",
+                False,
             ),
             (
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin --password=test",
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin --password=********",
+                False,
             ),
             (
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin -p=test",
                 "airflow users create -u test2 -l doe -f jon -e jdoe@apache.org -r admin -p=********",
+                False,
             ),
             (
                 "airflow connections add dsfs --conn-login asd --conn-password test --conn-type google",
                 "airflow connections add dsfs --conn-login asd --conn-password ******** --conn-type google",
+                False,
+            ),
+            (
+                "airflow connections add my_postgres_conn --conn-uri postgresql://user:my-password@localhost:5432/mydatabase",
+                "airflow connections add my_postgres_conn --conn-uri postgresql://user:********@localhost:5432/mydatabase",
+                False,
+            ),
+            (
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "my_new_conn",
+                    "--conn-json",
+                    '{"conn_type": "my-conn-type", "login": "my-login", "password": "my-password", "host": "my-host", "port": 1234, "schema": "my-schema", "extra": {"param1": "val1", "param2": "val2"}}',
+                ],
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "my_new_conn",
+                    "--conn-json",
+                    '{"conn_type": "my-conn-type", "login": "my-login", "password": "********", '
+                    '"host": "my-host", "port": 1234, "schema": "my-schema", "extra": {"param1": '
+                    '"val1", "param2": "val2"}}',
+                ],
+                True,
             ),
             (
                 "airflow scheduler -p",
                 "airflow scheduler -p",
+                False,
             ),
             (
                 "airflow celery flower -p 8888",
                 "airflow celery flower -p 8888",
+                False,
             ),
         ],
     )
     def test_cli_create_user_supplied_password_is_masked(
-        self, given_command, expected_masked_command, session
+        self, given_command, expected_masked_command, is_command_list, session
     ):
         # '-p' value which is not password, like 'airflow scheduler -p'
         # or 'airflow celery flower -p 8888', should not be masked
-        args = given_command.split()
-
-        expected_command = expected_masked_command.split()
+        args = given_command if is_command_list else given_command.split()
+        expected_command = expected_masked_command if is_command_list else expected_masked_command.split()
 
         exec_date = timezone.utcnow()
         namespace = Namespace(dag_id="foo", task_id="bar", subcommand="test", logical_date=exec_date)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We should also mask the connection details when connections are created using conn-json or conn-extra to unify with rest of the ways.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
