### PR TITLE
Remove Airflow 3 Deprecation Warning dependency in OTel Provider

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -53,7 +53,6 @@ from airflow.providers.openlineage.utils.selective_enable import (
 from airflow.providers.openlineage.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 from airflow.sensors.base import BaseSensorOperator
 from airflow.serialization.serialized_objects import SerializedBaseOperator
-from airflow.utils.context import AirflowContextDeprecationWarning
 from airflow.utils.module_loading import import_string
 from airflow.utils.session import NEW_SESSION, provide_session
 from openlineage.client.utils import RedactMixin
@@ -640,6 +639,13 @@ class OpenLineageRedactor(SecretsMasker):
         return instance
 
     def _redact(self, item: Redactable, name: str | None, depth: int, max_depth: int) -> Redacted:
+        if AIRFLOW_V_3_0_PLUS:
+            # Keep compatibility for Airflow 2.x, remove when Airflow 3.0 is the minimum version
+            class AirflowContextDeprecationWarning(UserWarning):
+                pass
+        else:
+            from airflow.utils.context import AirflowContextDeprecationWarning
+
         if depth > max_depth:
             return item
         try:


### PR DESCRIPTION
As we are getting closer to Airflow 3, Deprecations warnings should not be warning for Airflow 3 anymore. 

To be able to clean this also the AirflowContextDeprecationWarning needs to be removed in core, which OTel provider still depends on. Adding a small import indirection such that we can clean the core w/o breaking provider.