### PR TITLE
Remove AirflowContextDeprecationWarning as all context should be clean for Airflow 3

### DIFF
--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -34,7 +34,6 @@ from typing import (
 import attrs
 from sqlalchemy import and_, select
 
-from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.models.asset import (
     AssetAliasModel,
     AssetEvent,
@@ -267,10 +266,6 @@ class InletEventsAccessors(Mapping[Union[int, Asset, AssetAlias, AssetRef], Lazy
             order_by=[AssetEvent.timestamp],
             session=self._session,
         )
-
-
-class AirflowContextDeprecationWarning(RemovedInAirflow3Warning):
-    """Warn for usage of deprecated context variables in a task."""
 
 
 def context_merge(context: Context, *args: Any, **kwargs: Any) -> None:

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -43,7 +43,6 @@ By default, in the new tests selected warnings are prohibited:
 
 * ``airflow.exceptions.AirflowProviderDeprecationWarning``
 * ``airflow.exceptions.RemovedInAirflow3Warning``
-* ``airflow.utils.context.AirflowContextDeprecationWarning``
 
 That mean if one of this warning appear during test run and do not captured the test will failed.
 

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -644,7 +644,9 @@ class OpenLineageRedactor(SecretsMasker):
             class AirflowContextDeprecationWarning(UserWarning):
                 pass
         else:
-            from airflow.utils.context import AirflowContextDeprecationWarning
+            from airflow.utils.context import (  # type: ignore[attr-defined,no-redef]
+                AirflowContextDeprecationWarning,
+            )
 
         if depth > max_depth:
             return item

--- a/providers/standard/tests/provider_tests/standard/operators/test_python.py
+++ b/providers/standard/tests/provider_tests/standard/operators/test_python.py
@@ -1253,8 +1253,6 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
     # This tests might take longer than default 60 seconds as it is serializing a lot of
     # context using dill/cloudpickle (which is slow apparently).
     @pytest.mark.execution_timeout(120)
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @pytest.mark.parametrize(
         "serializer",
         [
@@ -1314,8 +1312,6 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
 
         self.run_as_operator(f, serializer=serializer, system_site_packages=True, requirements=None)
 
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @pytest.mark.parametrize(
         "serializer",
         [
@@ -1346,8 +1342,6 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
 
         self.run_as_task(f, serializer=serializer, system_site_packages=False, requirements=["pendulum"])
 
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @pytest.mark.parametrize(
         "serializer",
         [

--- a/providers/standard/tests/provider_tests/standard/operators/test_python.py
+++ b/providers/standard/tests/provider_tests/standard/operators/test_python.py
@@ -64,7 +64,6 @@ from airflow.providers.standard.operators.python import (
 )
 from airflow.providers.standard.utils.python_virtualenv import prepare_virtualenv
 from airflow.utils import timezone
-from airflow.utils.context import AirflowContextDeprecationWarning, Context
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule
@@ -75,6 +74,7 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_
 
 if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
+    from airflow.utils.context import Context
 
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 
@@ -1253,6 +1253,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
     # This tests might take longer than default 60 seconds as it is serializing a lot of
     # context using dill/cloudpickle (which is slow apparently).
     @pytest.mark.execution_timeout(120)
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @pytest.mark.parametrize(
         "serializer",
@@ -1313,6 +1314,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
 
         self.run_as_operator(f, serializer=serializer, system_site_packages=True, requirements=None)
 
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @pytest.mark.parametrize(
         "serializer",
@@ -1344,6 +1346,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
 
         self.run_as_task(f, serializer=serializer, system_site_packages=False, requirements=["pendulum"])
 
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @pytest.mark.parametrize(
         "serializer",
@@ -1769,10 +1772,12 @@ class MyContextAssertOperator(BaseOperator):
 def get_all_the_context(**context):
     current_context = get_current_context()
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", AirflowContextDeprecationWarning)
         if AIRFLOW_V_3_0_PLUS:
             assert context == current_context
         else:
+            from airflow.utils.context import AirflowContextDeprecationWarning
+
+            warnings.simplefilter("ignore", AirflowContextDeprecationWarning)
             assert current_context._context
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -528,7 +528,6 @@ filterwarnings = [
 # Instead of that, we use a separate parameter and dynamically add it into `filterwarnings` marker.
 forbidden_warnings = [
     "airflow.exceptions.RemovedInAirflow3Warning",
-    "airflow.utils.context.AirflowContextDeprecationWarning",
     "airflow.exceptions.AirflowProviderDeprecationWarning",
 ]
 python_files = [

--- a/scripts/ci/pre_commit/check_deprecations.py
+++ b/scripts/ci/pre_commit/check_deprecations.py
@@ -32,10 +32,7 @@ console = Console(color_system="standard", width=200)
 
 
 allowed_warnings: dict[str, tuple[str, ...]] = {
-    "airflow": (
-        "airflow.exceptions.RemovedInAirflow3Warning",
-        "airflow.utils.context.AirflowContextDeprecationWarning",
-    ),
+    "airflow": ("airflow.exceptions.RemovedInAirflow3Warning",),
     "providers": ("airflow.exceptions.AirflowProviderDeprecationWarning",),
 }
 compatible_decorators: frozenset[tuple[str, ...]] = frozenset(

--- a/scripts/ci/testing/summarize_captured_warnings.py
+++ b/scripts/ci/testing/summarize_captured_warnings.py
@@ -50,7 +50,6 @@ IMPORTANT_WARNING_SIGN = {
     "pytest.PytestWarning": "!!",
     "airflow.exceptions.RemovedInAirflow3Warning": "!",
     "airflow.exceptions.AirflowProviderDeprecationWarning": "!",
-    "airflow.utils.context.AirflowContextDeprecationWarning": "!",
 }
 # Always print messages for these warning categories
 ALWAYS_SHOW_WARNINGS = {

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -121,8 +121,6 @@ class TestCliTasks:
             args = self.parser.parse_args(["tasks", "list", dag_id])
             task_command.task_list(args)
 
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test(self):
         """Test the `airflow test` command"""
         args = self.parser.parse_args(
@@ -135,8 +133,6 @@ class TestCliTasks:
         # Check that prints, and log messages, are shown
         assert "'example_python_operator__print_the_context__20180101'" in stdout.getvalue()
 
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @mock.patch("airflow.utils.timezone.utcnow")
     def test_test_no_logical_date(self, mock_utcnow):
         """Test the `airflow test` command"""
@@ -247,8 +243,6 @@ class TestCliTasks:
 
         mock_fetch_dag_run_from_run_id_or_logical_date_string.assert_called_once()
 
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_with_existing_dag_run(self, caplog):
         """Test the `airflow test` command"""
         task_id = "print_the_context"
@@ -261,8 +255,6 @@ class TestCliTasks:
         )
 
     @pytest.mark.enable_redact
-    # This filter can be removed if support for Airflow 2.x is dropped
-    @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_filters_secrets(self, capsys):
         """Test ``airflow test`` does not print secrets to stdout.
 

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -121,6 +121,7 @@ class TestCliTasks:
             args = self.parser.parse_args(["tasks", "list", dag_id])
             task_command.task_list(args)
 
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test(self):
         """Test the `airflow test` command"""
@@ -134,6 +135,7 @@ class TestCliTasks:
         # Check that prints, and log messages, are shown
         assert "'example_python_operator__print_the_context__20180101'" in stdout.getvalue()
 
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     @mock.patch("airflow.utils.timezone.utcnow")
     def test_test_no_logical_date(self, mock_utcnow):
@@ -245,6 +247,7 @@ class TestCliTasks:
 
         mock_fetch_dag_run_from_run_id_or_logical_date_string.assert_called_once()
 
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_with_existing_dag_run(self, caplog):
         """Test the `airflow test` command"""
@@ -258,6 +261,7 @@ class TestCliTasks:
         )
 
     @pytest.mark.enable_redact
+    # This filter can be removed if support for Airflow 2.x is dropped
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_filters_secrets(self, capsys):
         """Test ``airflow test`` does not print secrets to stdout.


### PR DESCRIPTION
If #46600 is merged we can carve out the `AirflowContextDeprecationWarning` from core which is a step forward to remove `RemovedInAirflow3Warning`.