### PR TITLE
AIP-84 Add login endpoint to the public url

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -133,6 +133,7 @@ def init_auth_manager(app: FastAPI | None = None) -> BaseAuthManager:
 
     if app and (auth_manager_fastapi_app := am.get_fastapi_app()):
         app.mount("/auth", auth_manager_fastapi_app)
+        app.state.auth_manager = am
 
     return am
 

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -6683,18 +6683,33 @@ paths:
       summary: Login
       description: Redirect to the login URL depending on the AuthManager configured.
       operationId: login
+      parameters:
+      - name: next
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema: {}
-        '308':
-          description: Permanent Redirect
+        '307':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Temporary Redirect
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     AppBuilderMenuItemResponse:

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -6676,6 +6676,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionInfo'
+  /public/login:
+    get:
+      tags:
+      - Login
+      summary: Login
+      description: Redirect to the login URL depending on the AuthManager configured.
+      operationId: login
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '308':
+          description: Permanent Redirect
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
 components:
   schemas:
     AppBuilderMenuItemResponse:

--- a/airflow/api_fastapi/core_api/routes/public/__init__.py
+++ b/airflow/api_fastapi/core_api/routes/public/__init__.py
@@ -38,6 +38,7 @@ from airflow.api_fastapi.core_api.routes.public.extra_links import extra_links_r
 from airflow.api_fastapi.core_api.routes.public.import_error import import_error_router
 from airflow.api_fastapi.core_api.routes.public.job import job_router
 from airflow.api_fastapi.core_api.routes.public.log import task_instances_log_router
+from airflow.api_fastapi.core_api.routes.public.login import login_router
 from airflow.api_fastapi.core_api.routes.public.monitor import monitor_router
 from airflow.api_fastapi.core_api.routes.public.plugins import plugins_router
 from airflow.api_fastapi.core_api.routes.public.pools import pools_router
@@ -87,3 +88,4 @@ public_router.include_router(authenticated_router)
 # Following routers are not included in common router, for now we don't expect it to have authentication
 public_router.include_router(monitor_router)
 public_router.include_router(version_router)
+public_router.include_router(login_router)

--- a/airflow/api_fastapi/core_api/routes/public/login.py
+++ b/airflow/api_fastapi/core_api/routes/public/login.py
@@ -27,10 +27,12 @@ login_router = AirflowRouter(tags=["Login"], prefix="/login")
 
 @login_router.get(
     "",
-    responses=create_openapi_http_exception_doc([status.HTTP_308_PERMANENT_REDIRECT]),
+    responses=create_openapi_http_exception_doc([status.HTTP_307_TEMPORARY_REDIRECT]),
 )
-def login(
-    request: Request,
-) -> RedirectResponse:
+def login(request: Request, next: None | str = None) -> RedirectResponse:
     """Redirect to the login URL depending on the AuthManager configured."""
-    return RedirectResponse(request.app.state.auth_manager.get_url_login(), status_code=308)
+    login_url = request.app.state.auth_manager.get_url_login()
+
+    if next:
+        login_url += f"?next={next}"
+    return RedirectResponse(login_url)

--- a/airflow/api_fastapi/core_api/routes/public/login.py
+++ b/airflow/api_fastapi/core_api/routes/public/login.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import Request, status
+from fastapi.responses import RedirectResponse
+
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+
+login_router = AirflowRouter(tags=["Login"], prefix="/login")
+
+
+@login_router.get(
+    "",
+    responses=create_openapi_http_exception_doc([status.HTTP_308_PERMANENT_REDIRECT]),
+)
+def login(
+    request: Request,
+) -> RedirectResponse:
+    """Redirect to the login URL depending on the AuthManager configured."""
+    return RedirectResponse(request.app.state.auth_manager.get_url_login(), status_code=308)

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -1649,10 +1649,14 @@ export type LoginServiceLoginQueryResult<
   TError = unknown,
 > = UseQueryResult<TData, TError>;
 export const useLoginServiceLoginKey = "LoginServiceLogin";
-export const UseLoginServiceLoginKeyFn = (queryKey?: Array<unknown>) => [
-  useLoginServiceLoginKey,
-  ...(queryKey ?? []),
-];
+export const UseLoginServiceLoginKeyFn = (
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
+  queryKey?: Array<unknown>,
+) => [useLoginServiceLoginKey, ...(queryKey ?? [{ next }])];
 export type AssetServiceCreateAssetEventMutationResult = Awaited<
   ReturnType<typeof AssetService.createAssetEvent>
 >;

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -20,6 +20,7 @@ import {
   GridService,
   ImportErrorService,
   JobService,
+  LoginService,
   MonitorService,
   PluginService,
   PoolService,
@@ -1640,6 +1641,16 @@ export type VersionServiceGetVersionQueryResult<
 export const useVersionServiceGetVersionKey = "VersionServiceGetVersion";
 export const UseVersionServiceGetVersionKeyFn = (queryKey?: Array<unknown>) => [
   useVersionServiceGetVersionKey,
+  ...(queryKey ?? []),
+];
+export type LoginServiceLoginDefaultResponse = Awaited<ReturnType<typeof LoginService.login>>;
+export type LoginServiceLoginQueryResult<
+  TData = LoginServiceLoginDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useLoginServiceLoginKey = "LoginServiceLogin";
+export const UseLoginServiceLoginKeyFn = (queryKey?: Array<unknown>) => [
+  useLoginServiceLoginKey,
   ...(queryKey ?? []),
 ];
 export type AssetServiceCreateAssetEventMutationResult = Awaited<

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -19,6 +19,7 @@ import {
   GridService,
   ImportErrorService,
   JobService,
+  LoginService,
   MonitorService,
   PluginService,
   PoolService,
@@ -2297,4 +2298,15 @@ export const prefetchUseVersionServiceGetVersion = (queryClient: QueryClient) =>
   queryClient.prefetchQuery({
     queryKey: Common.UseVersionServiceGetVersionKeyFn(),
     queryFn: () => VersionService.getVersion(),
+  });
+/**
+ * Login
+ * Redirect to the login URL depending on the AuthManager configured.
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseLoginServiceLogin = (queryClient: QueryClient) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseLoginServiceLoginKeyFn(),
+    queryFn: () => LoginService.login(),
   });

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -2302,11 +2302,20 @@ export const prefetchUseVersionServiceGetVersion = (queryClient: QueryClient) =>
 /**
  * Login
  * Redirect to the login URL depending on the AuthManager configured.
+ * @param data The data for the request.
+ * @param data.next
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const prefetchUseLoginServiceLogin = (queryClient: QueryClient) =>
+export const prefetchUseLoginServiceLogin = (
+  queryClient: QueryClient,
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
+) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseLoginServiceLoginKeyFn(),
-    queryFn: () => LoginService.login(),
+    queryKey: Common.UseLoginServiceLoginKeyFn({ next }),
+    queryFn: () => LoginService.login({ next }),
   });

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -20,6 +20,7 @@ import {
   GridService,
   ImportErrorService,
   JobService,
+  LoginService,
   MonitorService,
   PluginService,
   PoolService,
@@ -2725,6 +2726,25 @@ export const useVersionServiceGetVersion = <
   useQuery<TData, TError>({
     queryKey: Common.UseVersionServiceGetVersionKeyFn(queryKey),
     queryFn: () => VersionService.getVersion() as TData,
+    ...options,
+  });
+/**
+ * Login
+ * Redirect to the login URL depending on the AuthManager configured.
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const useLoginServiceLogin = <
+  TData = Common.LoginServiceLoginDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseLoginServiceLoginKeyFn(queryKey),
+    queryFn: () => LoginService.login() as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -2731,6 +2731,8 @@ export const useVersionServiceGetVersion = <
 /**
  * Login
  * Redirect to the login URL depending on the AuthManager configured.
+ * @param data The data for the request.
+ * @param data.next
  * @returns unknown Successful Response
  * @throws ApiError
  */
@@ -2739,12 +2741,17 @@ export const useLoginServiceLogin = <
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseLoginServiceLoginKeyFn(queryKey),
-    queryFn: () => LoginService.login() as TData,
+    queryKey: Common.UseLoginServiceLoginKeyFn({ next }, queryKey),
+    queryFn: () => LoginService.login({ next }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -19,6 +19,7 @@ import {
   GridService,
   ImportErrorService,
   JobService,
+  LoginService,
   MonitorService,
   PluginService,
   PoolService,
@@ -2702,5 +2703,24 @@ export const useVersionServiceGetVersionSuspense = <
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseVersionServiceGetVersionKeyFn(queryKey),
     queryFn: () => VersionService.getVersion() as TData,
+    ...options,
+  });
+/**
+ * Login
+ * Redirect to the login URL depending on the AuthManager configured.
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const useLoginServiceLoginSuspense = <
+  TData = Common.LoginServiceLoginDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseLoginServiceLoginKeyFn(queryKey),
+    queryFn: () => LoginService.login() as TData,
     ...options,
   });

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -2708,6 +2708,8 @@ export const useVersionServiceGetVersionSuspense = <
 /**
  * Login
  * Redirect to the login URL depending on the AuthManager configured.
+ * @param data The data for the request.
+ * @param data.next
  * @returns unknown Successful Response
  * @throws ApiError
  */
@@ -2716,11 +2718,16 @@ export const useLoginServiceLoginSuspense = <
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseLoginServiceLoginKeyFn(queryKey),
-    queryFn: () => LoginService.login() as TData,
+    queryKey: Common.UseLoginServiceLoginKeyFn({ next }, queryKey),
+    queryFn: () => LoginService.login({ next }) as TData,
     ...options,
   });

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -201,6 +201,7 @@ import type {
   ReparseDagFileResponse,
   GetHealthResponse,
   GetVersionResponse,
+  LoginResponse,
 } from "./types.gen";
 
 export class AssetService {
@@ -3356,6 +3357,24 @@ export class VersionService {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/version",
+    });
+  }
+}
+
+export class LoginService {
+  /**
+   * Login
+   * Redirect to the login URL depending on the AuthManager configured.
+   * @returns unknown Successful Response
+   * @throws ApiError
+   */
+  public static login(): CancelablePromise<LoginResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/login",
+      errors: {
+        308: "Permanent Redirect",
+      },
     });
   }
 }

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -201,6 +201,7 @@ import type {
   ReparseDagFileResponse,
   GetHealthResponse,
   GetVersionResponse,
+  LoginData,
   LoginResponse,
 } from "./types.gen";
 
@@ -3365,15 +3366,21 @@ export class LoginService {
   /**
    * Login
    * Redirect to the login URL depending on the AuthManager configured.
+   * @param data The data for the request.
+   * @param data.next
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static login(): CancelablePromise<LoginResponse> {
+  public static login(data: LoginData = {}): CancelablePromise<LoginResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/login",
+      query: {
+        next: data.next,
+      },
       errors: {
-        308: "Permanent Redirect",
+        307: "Temporary Redirect",
+        422: "Validation Error",
       },
     });
   }

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2424,6 +2424,8 @@ export type GetHealthResponse = HealthInfoResponse;
 
 export type GetVersionResponse = VersionInfo;
 
+export type LoginResponse = unknown;
+
 export type $OpenApiTs = {
   "/ui/next_run_assets/{dag_id}": {
     get: {
@@ -5085,6 +5087,20 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: VersionInfo;
+      };
+    };
+  };
+  "/public/login": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: unknown;
+        /**
+         * Permanent Redirect
+         */
+        308: HTTPExceptionResponse;
       };
     };
   };

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2424,6 +2424,10 @@ export type GetHealthResponse = HealthInfoResponse;
 
 export type GetVersionResponse = VersionInfo;
 
+export type LoginData = {
+  next?: string | null;
+};
+
 export type LoginResponse = unknown;
 
 export type $OpenApiTs = {
@@ -5092,15 +5096,20 @@ export type $OpenApiTs = {
   };
   "/public/login": {
     get: {
+      req: LoginData;
       res: {
         /**
          * Successful Response
          */
         200: unknown;
         /**
-         * Permanent Redirect
+         * Temporary Redirect
          */
-        308: HTTPExceptionResponse;
+        307: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
       };
     };
   };

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -39,7 +39,7 @@ axios.interceptors.response.use(
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);
-      globalThis.location.replace(`${import.meta.env.VITE_LEGACY_API_URL}/login?${params.toString()}`);
+      globalThis.location.replace(`/public/login?${params.toString()}`);
     }
 
     return Promise.reject(error);

--- a/tests/api_fastapi/core_api/routes/public/test_login.py
+++ b/tests/api_fastapi/core_api/routes/public/test_login.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+AUTH_MANAGER_LOGIN_URL = "http://some_login_url"
+
+
+class TestLoginEndpoint:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client) -> None:
+        auth_manager_mock = MagicMock()
+        auth_manager_mock.get_url_login.return_value = AUTH_MANAGER_LOGIN_URL
+        test_client.app.state.auth_manager = auth_manager_mock
+
+
+class TestGetLogin(TestLoginEndpoint):
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"next": None},
+            {"next": "http://localhost:29091"},
+            {"next": "http://localhost:29091", "other_param": "something_else"},
+        ],
+    )
+    def test_should_respond_308(self, test_client, params):
+        response = test_client.get("/public/login", follow_redirects=False, params=params)
+
+        assert response.status_code == 307
+        assert (
+            response.headers["location"] == f"{AUTH_MANAGER_LOGIN_URL}?next={params.get('next')}"
+            if params.get("next")
+            else AUTH_MANAGER_LOGIN_URL
+        )

--- a/tests/api_fastapi/core_api/routes/public/test_login.py
+++ b/tests/api_fastapi/core_api/routes/public/test_login.py
@@ -22,6 +22,8 @@ import pytest
 
 AUTH_MANAGER_LOGIN_URL = "http://some_login_url"
 
+pytestmark = pytest.mark.db_test
+
 
 class TestLoginEndpoint:
     @pytest.fixture(autouse=True)

--- a/tests/api_fastapi/core_api/routes/test_routes.py
+++ b/tests/api_fastapi/core_api/routes/test_routes.py
@@ -20,6 +20,7 @@ from airflow.api_fastapi.core_api.routes.public import authenticated_router, pub
 
 # Set of paths that are allowed to be accessible without authentication
 NO_AUTH_PATHS = {
+    "/public/login",
     "/public/version",
     "/public/monitor/health",
 }


### PR DESCRIPTION
part 2 of: https://github.com/apache/airflow/issues/44884
closes: https://github.com/apache/airflow/issues/44884


After a 401, we call the `/login` endpoint that will retrieve the auth_manager login URL and redirect us to it.

Tested both with `SimpleAuthManager` and `FABAuthManager`

- [x] Need tests.
- [x] Need to handle `next` query param