### PR TITLE
Feat: support docker operator arg `labels`

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -404,6 +404,7 @@ class TaskDecoratorCollection:
         skip_on_exit_code: int | Container[int] | None = None,
         port_bindings: dict | None = None,
         ulimits: list[dict] | None = None,
+        labels: dict[str, str] | list[str] | None = None,
         **kwargs,
     ) -> TaskDecorator:
         """Create a decorator to convert the decorated callable to a Docker task.
@@ -508,6 +509,8 @@ class TaskDecoratorCollection:
             Incompatible with ``"host"`` in ``network_mode``.
         :param ulimits: List of ulimit options to set for the container. Each item should
             be a :py:class:`docker.types.Ulimit` instance.
+        :param labels: A dictionary of name-value labels (e.g. ``{"label1": "value1", "label2": "value2"}``)
+            or a list of names of labels to set with empty values (e.g. ``["label1", "label2"]``)
         """
         # [END decorator_signature]
     def kubernetes(

--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -192,6 +192,8 @@ class DockerOperator(BaseOperator):
         Incompatible with ``"host"`` in ``network_mode``.
     :param ulimits: List of ulimit options to set for the container. Each item should
         be a :py:class:`docker.types.Ulimit` instance.
+    :param labels: A dictionary of name-value labels (e.g. ``{"label1": "value1", "label2": "value2"}``)
+        or a list of names of labels to set with empty values (e.g. ``["label1", "label2"]``)
     """
 
     # !!! Changes in DockerOperator's arguments should be also reflected in !!!
@@ -255,6 +257,7 @@ class DockerOperator(BaseOperator):
         skip_on_exit_code: int | Container[int] | None = None,
         port_bindings: dict | None = None,
         ulimits: list[Ulimit] | None = None,
+        labels: dict[str, str] | list[str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -301,6 +304,7 @@ class DockerOperator(BaseOperator):
         self.cap_add = cap_add
         self.extra_hosts = extra_hosts
         self.ulimits = ulimits or []
+        self.labels = labels
 
         self.container: dict = None  # type: ignore[assignment]
         self.retrieve_output = retrieve_output
@@ -407,6 +411,7 @@ class DockerOperator(BaseOperator):
             working_dir=self.working_dir,
             tty=self.tty,
             hostname=self.hostname,
+            labels=self.labels,
         )
         log_stream = self.cli.attach(container=self.container["Id"], stdout=True, stderr=True, stream=True)
         try:

--- a/providers/docker/tests/provider_tests/docker/operators/test_docker.py
+++ b/providers/docker/tests/provider_tests/docker/operators/test_docker.py
@@ -321,7 +321,6 @@ class TestDockerOperator:
             ipc_mode=None,
             port_bindings={},
             ulimits=[],
-            labels=None,
         )
         self.tempdir_mock.assert_not_called()
         self.client_mock.images.assert_called_once_with(name=TEST_IMAGE)
@@ -435,7 +434,6 @@ class TestDockerOperator:
                     ipc_mode=None,
                     port_bindings={},
                     ulimits=[],
-                    labels=None,
                 ),
                 call(
                     mounts=[
@@ -456,7 +454,6 @@ class TestDockerOperator:
                     ipc_mode=None,
                     port_bindings={},
                     ulimits=[],
-                    labels=None,
                 ),
             ]
         )

--- a/providers/docker/tests/provider_tests/docker/operators/test_docker.py
+++ b/providers/docker/tests/provider_tests/docker/operators/test_docker.py
@@ -226,6 +226,7 @@ class TestDockerOperator:
             tty=True,
             hostname=TEST_CONTAINER_HOSTNAME,
             ports=[],
+            labels=None,
         )
         self.client_mock.create_host_config.assert_called_once_with(
             mounts=[
@@ -319,6 +320,7 @@ class TestDockerOperator:
             ipc_mode=None,
             port_bindings={},
             ulimits=[],
+            labels=None,
         )
         self.tempdir_mock.assert_not_called()
         self.client_mock.images.assert_called_once_with(name=TEST_IMAGE)
@@ -392,6 +394,7 @@ class TestDockerOperator:
                     tty=True,
                     hostname=None,
                     ports=[],
+                    labels=None,
                 ),
                 call(
                     command="env",
@@ -430,6 +433,7 @@ class TestDockerOperator:
                     ipc_mode=None,
                     port_bindings={},
                     ulimits=[],
+                    labels=None,
                 ),
                 call(
                     mounts=[
@@ -450,6 +454,7 @@ class TestDockerOperator:
                     ipc_mode=None,
                     port_bindings={},
                     ulimits=[],
+                    labels=None,
                 ),
             ]
         )
@@ -508,6 +513,7 @@ class TestDockerOperator:
             tty=True,
             hostname=None,
             ports=[],
+            labels=None,
         )
         stringio_mock.assert_called_once_with("UNIT=FILE\nPRIVATE=FILE\nVAR=VALUE")
         self.dotenv_mock.assert_called_once_with(stream="UNIT=FILE\nPRIVATE=FILE\nVAR=VALUE")

--- a/providers/docker/tests/provider_tests/docker/operators/test_docker.py
+++ b/providers/docker/tests/provider_tests/docker/operators/test_docker.py
@@ -781,3 +781,11 @@ class TestDockerOperator:
     def test_fetch_logs(self, logger_mock, log_lines, expected_lines):
         fetch_logs(log_lines, logger_mock)
         assert logger_mock.info.call_args_list == [call("%s", line) for line in expected_lines]
+
+    @pytest.mark.parametrize("labels", ({"key": "value"}, ["key=value"]))
+    def test_labels(self, labels: dict[str, str] | list[str]):
+        operator = DockerOperator(task_id="test", image="test", labels=labels)
+        operator.execute(None)
+        self.client_mock.create_container.assert_called_once()
+        assert "labels" in self.client_mock.create_container.call_args.kwargs
+        assert labels == self.client_mock.create_container.call_args.kwargs["labels"]

--- a/providers/docker/tests/provider_tests/docker/operators/test_docker.py
+++ b/providers/docker/tests/provider_tests/docker/operators/test_docker.py
@@ -300,6 +300,7 @@ class TestDockerOperator:
             tty=True,
             hostname=TEST_CONTAINER_HOSTNAME,
             ports=[],
+            labels=None,
         )
         self.client_mock.create_host_config.assert_called_once_with(
             mounts=[
@@ -408,6 +409,7 @@ class TestDockerOperator:
                     tty=True,
                     hostname=None,
                     ports=[],
+                    labels=None,
                 ),
             ]
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The docker cli client supports the labels variable. Adding this is simple, and will be useful.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
