### PR TITLE
Add `system` markers automatically when use `test_run`

### DIFF
--- a/tests_common/test_utils/system_tests.py
+++ b/tests_common/test_utils/system_tests.py
@@ -20,6 +20,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Callable
 
+import pytest
 from tabulate import tabulate
 
 from airflow.utils.state import DagRunState
@@ -58,6 +59,7 @@ def get_test_run(dag, **test_kwargs):
         else:
             return [current, new]
 
+    @pytest.mark.system
     def test_run():
         dag.on_failure_callback = add_callback(dag.on_failure_callback, callback)
         dag.on_success_callback = add_callback(dag.on_success_callback, callback)


### PR DESCRIPTION
System tests are no longer runnable because if you run them using `breeze testing providers-tests ...` you'll get `The test is skipped because it does not have the system marker. Only tests marked with pytest.mark.system are run`.

This happens because due to the providers restructure, [the code](https://github.com/apache/airflow/blob/main/tests/system/conftest.py#L42C5-L42C34) responsible of adding automatically these markers no longer work.

I propose to add them automatically when use [test_run](https://github.com/apache/airflow/blob/main/tests_common/test_utils/system_tests.py#L34). This function is the recommended way of defining and running system tests. It should only be used for system tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
