### PR TITLE
Adding uuid6 as a dependency for openlineage

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -974,7 +974,8 @@
       "apache-airflow>=2.9.0",
       "attrs>=22.2",
       "openlineage-integration-common>=1.24.2",
-      "openlineage-python>=1.24.2"
+      "openlineage-python>=1.24.2",
+      "uuid6>=2024.7.10"
     ],
     "devel-deps": [],
     "plugins": [

--- a/providers/openlineage/README.rst
+++ b/providers/openlineage/README.rst
@@ -60,6 +60,7 @@ PIP package                                 Version required
 ``attrs``                                   ``>=22.2``
 ``openlineage-integration-common``          ``>=1.24.2``
 ``openlineage-python``                      ``>=1.24.2``
+``uuid6``                                   ``>=2024.7.10``
 ==========================================  ==================
 
 Cross provider package dependencies

--- a/providers/openlineage/pyproject.toml
+++ b/providers/openlineage/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "attrs>=22.2",
     "openlineage-integration-common>=1.24.2",
     "openlineage-python>=1.24.2",
+    "uuid6>=2024.7.10",
 ]
 
 [project.urls]

--- a/providers/openlineage/src/airflow/providers/openlineage/get_provider_info.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/get_provider_info.py
@@ -188,5 +188,6 @@ def get_provider_info():
             "attrs>=22.2",
             "openlineage-integration-common>=1.24.2",
             "openlineage-python>=1.24.2",
+            "uuid6>=2024.7.10",
         ],
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

#45294 seemed to add uuid6 in openlineage. This caused failures in tests.
I am not sure if this fix will fix the issue, but trying still.



Example failure https://github.com/apache/airflow/actions/runs/13264109343/job/37028275493


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
