### PR TITLE
Make logical_date nullable in API responses

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -46,7 +46,7 @@ class TaskInstanceResponse(BaseModel):
     dag_id: str
     run_id: str = Field(alias="dag_run_id")
     map_index: int
-    logical_date: datetime
+    logical_date: datetime | None
     start_date: datetime | None
     end_date: datetime | None
     duration: float | None

--- a/airflow/api_fastapi/core_api/datamodels/xcom.py
+++ b/airflow/api_fastapi/core_api/datamodels/xcom.py
@@ -29,7 +29,7 @@ class XComResponse(BaseModel):
 
     key: str
     timestamp: datetime
-    logical_date: datetime
+    logical_date: datetime | None
     map_index: int
     task_id: str
     dag_id: str

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -9952,8 +9952,10 @@ components:
           type: integer
           title: Map Index
         logical_date:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Logical Date
         start_date:
           anyOf:
@@ -10760,8 +10762,10 @@ components:
           format: date-time
           title: Timestamp
         logical_date:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Logical Date
         map_index:
           type: integer
@@ -10796,8 +10800,10 @@ components:
           format: date-time
           title: Timestamp
         logical_date:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Logical Date
         map_index:
           type: integer
@@ -10835,8 +10841,10 @@ components:
           format: date-time
           title: Timestamp
         logical_date:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Logical Date
         map_index:
           type: integer

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4811,8 +4811,15 @@ export const $TaskInstanceResponse = {
       title: "Map Index",
     },
     logical_date: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Logical Date",
     },
     start_date: {
@@ -6138,8 +6145,15 @@ export const $XComResponse = {
       title: "Timestamp",
     },
     logical_date: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Logical Date",
     },
     map_index: {
@@ -6177,8 +6191,15 @@ export const $XComResponseNative = {
       title: "Timestamp",
     },
     logical_date: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Logical Date",
     },
     map_index: {
@@ -6219,8 +6240,15 @@ export const $XComResponseString = {
       title: "Timestamp",
     },
     logical_date: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Logical Date",
     },
     map_index: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1251,7 +1251,7 @@ export type TaskInstanceResponse = {
   dag_id: string;
   dag_run_id: string;
   map_index: number;
-  logical_date: string;
+  logical_date: string | null;
   start_date: string | null;
   end_date: string | null;
   duration: number | null;
@@ -1509,7 +1509,7 @@ export type XComCreateBody = {
 export type XComResponse = {
   key: string;
   timestamp: string;
-  logical_date: string;
+  logical_date: string | null;
   map_index: number;
   task_id: string;
   dag_id: string;
@@ -1522,7 +1522,7 @@ export type XComResponse = {
 export type XComResponseNative = {
   key: string;
   timestamp: string;
-  logical_date: string;
+  logical_date: string | null;
   map_index: number;
   task_id: string;
   dag_id: string;
@@ -1536,7 +1536,7 @@ export type XComResponseNative = {
 export type XComResponseString = {
   key: string;
   timestamp: string;
-  logical_date: string;
+  logical_date: string | null;
   map_index: number;
   task_id: string;
   dag_id: string;

--- a/airflow/ui/src/components/TrendCountChart.tsx
+++ b/airflow/ui/src/components/TrendCountChart.tsx
@@ -35,7 +35,7 @@ import { useColorMode } from "src/context/colorMode";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip);
 
-export type ChartEvent = { timestamp: string };
+export type ChartEvent = { timestamp: string | null };
 
 const aggregateEventsIntoIntervals = (events: Array<ChartEvent>, startDate: string, endDate: string) => {
   const totalMinutes = dayjs(endDate).diff(startDate, "minutes");
@@ -43,6 +43,9 @@ const aggregateEventsIntoIntervals = (events: Array<ChartEvent>, startDate: stri
   const intervals = Array.from({ length: 10 }).fill(0) as Array<number>;
 
   events.forEach((event) => {
+    if (event.timestamp === null) {
+      return;
+    }
     const minutesSinceStart = dayjs(event.timestamp).diff(startDate, "minutes");
     const intervalIndex = Math.min(Math.floor(minutesSinceStart / intervalSize), 9);
 


### PR DESCRIPTION
Fix #46487.

Two things not sure:

1. Should we make the logical_date field in BackfillResponse nullable too? cc @dstandish 
2. Are additional changes needed to handle null values in ChartEvent? cc @bbovenzi or @pierrejeambrun 