### PR TITLE
Fix: SnowflakeSqlApiOperator(without deferable flag) incorrectly marks the task as successful even when jobs are still active

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
@@ -455,9 +455,13 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
                 method_name="execute_complete",
             )
         else:
-            statement_status = self.poll_on_queries()
-            if statement_status["error"]:
-                raise AirflowException(statement_status["error"])
+            while True:
+                statement_status = self.poll_on_queries()
+                if statement_status["error"]:
+                    raise AirflowException(statement_status["error"])
+                if not statement_status["running"]:
+                    break
+
             self._hook.check_query_output(self.query_ids)
 
     def poll_on_queries(self):
@@ -465,6 +469,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
         queries_in_progress = set(self.query_ids)
         statement_success_status = {}
         statement_error_status = {}
+        statement_running_status = {}
         for query_id in self.query_ids:
             if not len(queries_in_progress):
                 break
@@ -479,8 +484,14 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
             if statement_status.get("status") == "success":
                 statement_success_status[query_id] = statement_status
                 queries_in_progress.remove(query_id)
+            if statement_status.get("status") == "running":
+                statement_running_status[query_id] = statement_status
             time.sleep(self.poll_interval)
-        return {"success": statement_success_status, "error": statement_error_status}
+        return {
+            "success": statement_success_status,
+            "error": statement_error_status,
+            "running": statement_running_status,
+        }
 
     def execute_complete(self, context: Context, event: dict[str, str | list[str]] | None = None) -> None:
         """

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -391,3 +391,66 @@ class TestSnowflakeSqlApiOperator:
         operator.execute(create_context(operator))
 
         assert mock_defer.called
+
+    def test_snowflake_sql_api_execute_operator_polling_running(
+        self, mock_execute_query, mock_get_sql_api_query_status, mock_check_query_output
+    ):
+        """
+        Tests that the execute method correctly loops and waits until all queries complete
+        when ``deferrable=False``
+        """
+        operator = SnowflakeSqlApiOperator(
+            task_id=TASK_ID,
+            snowflake_conn_id=CONN_ID,
+            sql=SQL_MULTIPLE_STMTS,
+            statement_count=4,
+            do_xcom_push=False,
+            deferrable=False,
+        )
+
+        mock_execute_query.return_value = ["uuid1"]
+
+        mock_get_sql_api_query_status.side_effect = [
+            # Initial get_sql_api_query_status check
+            {"status": "running"},
+            # 1st poll_on_queries check (poll_interval: 5s)
+            {"status": "running"},
+            # 2nd poll_on_queries check (poll_interval: 5s)
+            {"status": "running"},
+            # 3rd poll_on_queries check (poll_interval: 5s)
+            {"status": "success"},
+        ]
+
+        with mock.patch("time.sleep") as mock_sleep:
+            operator.execute(context=None)
+            mock_check_query_output.assert_called_once_with(["uuid1"])
+            assert mock_sleep.call_count == 3
+
+    def test_snowflake_sql_api_execute_operator_polling_failed(
+        self, mock_execute_query, mock_get_sql_api_query_status, mock_check_query_output
+    ):
+        """
+        Tests that the execute method raises AirflowException if any query fails during polling
+        when ``deferrable=False``
+        """
+        operator = SnowflakeSqlApiOperator(
+            task_id=TASK_ID,
+            snowflake_conn_id=CONN_ID,
+            sql=SQL_MULTIPLE_STMTS,
+            statement_count=4,
+            do_xcom_push=False,
+            deferrable=False,
+        )
+
+        mock_execute_query.return_value = ["uuid1"]
+
+        mock_get_sql_api_query_status.side_effect = [
+            # Initial get_sql_api_query_status check
+            {"status": "running"},
+            # 1st poll_on_queries check
+            {"status": "error"},
+        ]
+
+        with pytest.raises(AirflowException):
+            operator.execute(context=None)
+        mock_check_query_output.assert_not_called()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

<!-- Please keep an empty line above the dashes. -->
---

Fix https://github.com/apache/airflow/issues/46648.

**Problem Description**
In deferable mode, Airflow uses triggers to check the job status, so every time the deferable interval is reached, it checks the status and yields an event on [this line](https://github.com/apache/airflow/blob/main/providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py#L89).

However, when not using deferable logic, the execution follows the [else statement](https://github.com/apache/airflow/blob/main/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py#L456), which does not include a while loop to continuously monitor execution. Instead, on [this line](https://github.com/apache/airflow/blob/main/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py#L457), the task iterates through active Snowflake jobs, checks their status and then sleeps for _poll_interval_.

This results in the following behavior:

✅ If a job finishes in less than 5 seconds ( _time.sleep_ using the default _poll_interval_), the logic works correctly.
❌ If a job takes longer than 5 seconds, there is no mechanism to keep monitoring it, and the task incorrectly finishes after the loop ends - even if the Snowflake job is still running.

**Suggested Fix**
I propose adding a running status check inside **poll_on_queries** and modifying the else statement with a loop to ensure Airflow waits until all queries finish, the logic is quick similar to what we use in [deferable trigger while loop](https://github.com/subbota19/airflow/blob/main/providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py#L79) 

With this change, the Airflow task would periodically call **poll_on_queries** and continue waiting until all jobs are complete.

**Tests**
Simulates a scenario where the Snowflake job is running for two checks (10 seconds apart, assuming default _poll_interval_): ffter the second check, the job is completed successfully and task is marked as successful.

Simulates a scenario where the Snowflake job failed and ensures AirflowException is raised.
