### PR TITLE
Refactor deferrable mode for BeamRunPythonPipelineOperator and BeamRunJavaPipelineOperator

### DIFF
--- a/providers/apache/beam/tests/unit/apache/beam/hooks/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/hooks/test_beam.py
@@ -82,14 +82,14 @@ class TestBeamHook:
     def test_start_python_pipeline(self, mock_check_output, mock_runner):
         hook = BeamHook(runner=DEFAULT_RUNNER)
         process_line_callback = MagicMock()
-        check_job_status_callback = MagicMock()
+        is_dataflow_job_id_exist_callback = MagicMock()
 
         hook.start_python_pipeline(
             variables=copy.deepcopy(BEAM_VARIABLES_PY),
             py_file=PY_FILE,
             py_options=PY_OPTIONS,
             process_line_callback=process_line_callback,
-            check_job_status_callback=check_job_status_callback,
+            is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
         )
 
         expected_cmd = [
@@ -105,7 +105,7 @@ class TestBeamHook:
             process_line_callback=process_line_callback,
             working_directory=None,
             log=ANY,
-            check_job_status_callback=check_job_status_callback,
+            is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
         )
 
     @mock.patch("airflow.providers.apache.beam.hooks.beam.subprocess.check_output", return_value=b"2.35.0")
@@ -126,7 +126,7 @@ class TestBeamHook:
                 py_requirements=None,
                 py_system_site_packages=False,
                 process_line_callback=MagicMock(),
-                check_job_status_callback=MagicMock(),
+                is_dataflow_job_id_exist_callback=MagicMock(),
             )
 
     @pytest.mark.parametrize(
@@ -145,7 +145,7 @@ class TestBeamHook:
     ):
         hook = BeamHook(runner=DEFAULT_RUNNER)
         process_line_callback = MagicMock()
-        check_job_status_callback = MagicMock()
+        is_dataflow_job_id_exist_callback = MagicMock()
 
         hook.start_python_pipeline(
             variables=copy.deepcopy(BEAM_VARIABLES_PY),
@@ -153,7 +153,7 @@ class TestBeamHook:
             py_options=PY_OPTIONS,
             py_interpreter=py_interpreter,
             process_line_callback=process_line_callback,
-            check_job_status_callback=check_job_status_callback,
+            is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
         )
 
         expected_cmd = [
@@ -169,7 +169,7 @@ class TestBeamHook:
             process_line_callback=process_line_callback,
             working_directory=None,
             log=ANY,
-            check_job_status_callback=check_job_status_callback,
+            is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
         )
 
     @pytest.mark.parametrize(
@@ -194,7 +194,7 @@ class TestBeamHook:
         hook = BeamHook(runner=DEFAULT_RUNNER)
         mock_virtualenv.return_value = "/dummy_dir/bin/python"
         process_line_callback = MagicMock()
-        check_job_status_callback = MagicMock()
+        is_dataflow_job_id_exist_callback = MagicMock()
 
         hook.start_python_pipeline(
             variables=copy.deepcopy(BEAM_VARIABLES_PY),
@@ -203,7 +203,7 @@ class TestBeamHook:
             py_requirements=current_py_requirements,
             py_system_site_packages=current_py_system_site_packages,
             process_line_callback=process_line_callback,
-            check_job_status_callback=check_job_status_callback,
+            is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
         )
 
         expected_cmd = [
@@ -217,7 +217,7 @@ class TestBeamHook:
         mock_runner.assert_called_once_with(
             cmd=expected_cmd,
             process_line_callback=process_line_callback,
-            check_job_status_callback=check_job_status_callback,
+            is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
             working_directory=None,
             log=ANY,
         )
@@ -236,7 +236,7 @@ class TestBeamHook:
         hook = BeamHook(runner=DEFAULT_RUNNER)
         wait_for_done = mock_runner.return_value.wait_for_done
         process_line_callback = MagicMock()
-        check_job_status_callback = MagicMock()
+        is_dataflow_job_id_exist_callback = MagicMock()
 
         with pytest.raises(AirflowException, match=r"Invalid method invocation\."):
             hook.start_python_pipeline(
@@ -245,7 +245,7 @@ class TestBeamHook:
                 py_options=PY_OPTIONS,
                 py_requirements=[],
                 process_line_callback=process_line_callback,
-                check_job_status_callback=check_job_status_callback,
+                is_dataflow_job_id_exist_callback=is_dataflow_job_id_exist_callback,
             )
 
         mock_runner.assert_not_called()
@@ -275,7 +275,7 @@ class TestBeamHook:
             process_line_callback=process_line_callback,
             working_directory=None,
             log=ANY,
-            check_job_status_callback=None,
+            is_dataflow_job_id_exist_callback=None,
         )
 
     @mock.patch(BEAM_STRING.format("run_beam_command"))
@@ -304,7 +304,7 @@ class TestBeamHook:
             process_line_callback=process_line_callback,
             working_directory=None,
             log=ANY,
-            check_job_status_callback=None,
+            is_dataflow_job_id_exist_callback=None,
         )
 
     @mock.patch(BEAM_STRING.format("shutil.which"))
@@ -335,7 +335,7 @@ class TestBeamHook:
             process_line_callback=process_line_callback,
             working_directory=go_workspace,
             log=ANY,
-            check_job_status_callback=None,
+            is_dataflow_job_id_exist_callback=None,
         )
 
     @mock.patch(BEAM_STRING.format("shutil.which"))
@@ -381,7 +381,7 @@ class TestBeamHook:
             process_line_callback=process_line_callback,
             working_directory=None,
             log=ANY,
-            check_job_status_callback=None,
+            is_dataflow_job_id_exist_callback=None,
         )
 
 

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_java.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_java.py
@@ -80,8 +80,8 @@ with DAG(
     )
 
     # [START howto_operator_start_java_job_local_jar]
-    start_java_job_local = BeamRunJavaPipelineOperator(
-        task_id="start_java_job_local",
+    start_java_job_direct = BeamRunJavaPipelineOperator(
+        task_id="start_java_job_direct",
         jar=LOCAL_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
@@ -95,10 +95,25 @@ with DAG(
     )
     # [END howto_operator_start_java_job_local_jar]
 
+    start_java_job_direct_deferrable = BeamRunJavaPipelineOperator(
+        task_id="start_java_job_direct_deferrable",
+        jar=LOCAL_JAR,
+        pipeline_options={
+            "output": GCS_OUTPUT,
+        },
+        job_class="org.apache.beam.examples.WordCount",
+        dataflow_config={
+            "check_if_running": CheckJobRunning.WaitForRun,
+            "location": LOCATION,
+            "poll_sleep": 10,
+        },
+        deferrable=True,
+    )
+
     # [START howto_operator_start_java_job_jar_on_gcs]
-    start_java_job = BeamRunJavaPipelineOperator(
+    start_java_job_dataflow = BeamRunJavaPipelineOperator(
         runner=BeamRunnerType.DataflowRunner,
-        task_id="start_java_job",
+        task_id="start_java_job_dataflow",
         jar=GCS_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
@@ -115,9 +130,9 @@ with DAG(
     # [END howto_operator_start_java_job_jar_on_gcs]
 
     # [START howto_operator_start_java_job_jar_on_gcs_deferrable]
-    start_java_deferrable = BeamRunJavaPipelineOperator(
+    start_java_job_dataflow_deferrable = BeamRunJavaPipelineOperator(
         runner=BeamRunnerType.DataflowRunner,
-        task_id="start_java_job_deferrable",
+        task_id="start_java_job_dataflow_deferrable",
         jar=GCS_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
@@ -143,7 +158,12 @@ with DAG(
         create_bucket
         >> download_file
         # TEST BODY
-        >> [start_java_job_local, start_java_job, start_java_deferrable]
+        >> [
+            start_java_job_direct,
+            start_java_job_direct_deferrable,
+            start_java_job_dataflow,
+            start_java_job_dataflow_deferrable,
+        ]
         # TEST TEARDOWN
         >> delete_bucket
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have refactored deferrable mode for `Dataflow` runner for `BeamRunPythonPipelineOperator` and `BeamRunJavaPipelineOperator` to be able to submit the Job using Apache Beam from a `worker`, and then use the Dataflow API to monitor the Job's status from the `triggerer`.

In the current implementation the operator, in deferrable mode, uses Apache Beam for submitting and monitoring Job from the `triggerer`, and this implementation confuses our users. Users try to use `deferrable` mode to optimize resources, but the current implementation does not optimize any it just switches Beam's running processes from `worker` to `triggerer`. 

By this PR I have changed this logic for Dataflow's runner, because for Dataflow's runner it's possible to change Job's state monitoring process from Apache Beam to Dataflow API. In my implementation the operator starts the Job using Apache Beam on the `worker` then using `is_dataflow_job_id_exist_callback` wait until the Job provides `dataflow_job_id`. After that the operator leaves the Apache Beam waiting process and then starts a Trigger on `triggerer` for monitoring Job's status using Dataflow API.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
