### PR TITLE
Chart - Introduce worker.extraPorts to expose additional ports to worker container

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -260,6 +260,9 @@ spec:
                 {{- end }}
           {{- end }}
           ports:
+            {{- if .Values.workers.extraPorts }}
+              {{- toYaml .Values.workers.extraPorts | nindent 12 }}
+            {{- end }}
             - name: worker-logs
               containerPort: {{ .Values.ports.workerLogs }}
           volumeMounts:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2069,11 +2069,19 @@
                 },
                 "extraInitContainers": {
                     "description": "Add additional init containers into workers (templated).",
+                    "type": "array",
+                    "default": [],
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.Container"
-                    },
+                    }
+                },
+                "extraPorts": {
+                    "description": "Expose additional ports on the worker container.",
                     "type": "array",
-                    "default": []
+                    "default": [],
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+                    }
                 },
                 "extraVolumes": {
                     "description": "Mount additional volumes into workers.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -777,6 +777,9 @@ workers:
   extraVolumes: []
   extraVolumeMounts: []
 
+  # Expose additional ports. These can be used for additional metric collection.
+  extraPorts: []
+
   # Select certain nodes for airflow worker pods.
   nodeSelector: {}
   runtimeClassName: ~


### PR DESCRIPTION
# Problem statement 
The celery worker runs many different workloads. Depending on the size of your Celery worker, you could run anywhere from 1 to 100's of concurrent tasks. There is no resource isolation within a Celery worker and a single job could in theory (and in practice) consume most of the available CPU & Memory. There is AFAIK no monitoring in place which monitors existing processes and tracks this down to specific DAGs and Tasks.

# Improving the visibility
We are trying a POC where we run a background process which continuously monitors the processes in the container, and based on the command of each process figures out what dag & task it belongs to. These metrics will be exposed as a prometheus endpoint, which needs an additional port.

# Proposed change
- Introduce `.Values.workers.extraPorts` to have the ability to expose an extra port on the Airflow worker container.
