### PR TITLE
Handle null logical date in TI.log_url

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2034,10 +2034,9 @@ class TaskInstance(Base, LoggingMixin):
     def log_url(self) -> str:
         """Log URL for TaskInstance."""
         run_id = quote(self.run_id)
-        base_date = quote(self.logical_date.strftime("%Y-%m-%dT%H:%M:%S%z"))
         base_url = conf.get_mandatory_value("webserver", "BASE_URL")
         map_index = f"&map_index={self.map_index}" if self.map_index >= 0 else ""
-        return (
+        _log_uri = (
             f"{base_url}"
             f"/dags"
             f"/{self.dag_id}"
@@ -2045,9 +2044,12 @@ class TaskInstance(Base, LoggingMixin):
             f"?dag_run_id={run_id}"
             f"&task_id={self.task_id}"
             f"{map_index}"
-            f"&base_date={base_date}"
             "&tab=logs"
         )
+        if self.logical_date:
+            base_date = quote(self.logical_date.strftime("%Y-%m-%dT%H:%M:%S%z"))
+            _log_uri = f"{_log_uri}&base_date={base_date}"
+        return _log_uri
 
     @property
     def mark_success_url(self) -> str:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1921,8 +1921,8 @@ class TestTaskInstance:
             "/dags/my_dag/grid"
             "?dag_run_id=test"
             "&task_id=op"
-            "&base_date=2018-01-01T00%3A00%3A00%2B0000"
             "&tab=logs"
+            "&base_date=2018-01-01T00%3A00%3A00%2B0000"
         )
         assert ti.log_url == expected_url
 


### PR DESCRIPTION
This was causing issues.

```
[2025-02-12T14:26:56.727+0000] {scheduler_job_runner.py:930} ERROR - Exception when executing SchedulerJob._run_scheduler_loop
Traceback (most recent call last):
  File "/opt/airflow/airflow/jobs/scheduler_job_runner.py", line 926, in _execute
    self._run_scheduler_loop()
  File "/opt/airflow/airflow/jobs/scheduler_job_runner.py", line 1056, in _run_scheduler_loop
    num_finished_events += self._process_executor_events(
  File "/opt/airflow/airflow/jobs/scheduler_job_runner.py", line 720, in _process_executor_events
    return SchedulerJobRunner.process_executor_events(
  File "/opt/airflow/airflow/jobs/scheduler_job_runner.py", line 811, in process_executor_events
    cls._set_span_attrs__process_executor_events(span, state, ti)
  File "/opt/airflow/airflow/jobs/scheduler_job_runner.py", line 888, in _set_span_attrs__process_executor_events
    "log_url": ti.log_url,
  File "/opt/airflow/airflow/models/taskinstance.py", line 2037, in log_url
    base_date = quote(self.logical_date.strftime("%Y-%m-%dT%H:%M:%S%z"))
AttributeError: 'NoneType' object has no attribute 'strftime'
```

```
[2025-02-12T14:31:59.755+0000] {validation.py:244} ERROR - http://localhost:28080/api/v1/dags/afexception/dagRuns/manual__2025-02-12T14:31:59.025683+00:00_YVpxZLzf/taskInstances/afexception_task validation error: None is not of type 'string'

Failed validating 'type' in schema['properties']['logical_date']:
    {'type': 'string', 'format': 'datetime'}

On instance['logical_date']:
    None
[2025-02-12T14:31:59.756+0000] {_internal.py:224} INFO - 172.18.0.1 - - [12/Feb/2025 14:31:59] "GET /api/v1/dags/afexception/dagRuns/manual__2025-02-12T14:31:59.025683+00:00_YVpxZLzf/taskInstances/afexception_task HTTP/1.1" 500 -
```

Since base_date is no longer used in the new UI, we can simply not render the param when logical date is None.