### PR TITLE
AIP-72: Moving task sdk logs to semantically correct locations

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -587,8 +587,7 @@ def run(
 
             result = _execute_task(context, ti)
 
-        log.info("Pushing xcom", ti=ti)
-        _push_xcom_if_needed(result, ti)
+        _push_xcom_if_needed(result, ti, log)
 
         task_outlets, outlet_events = _process_outlets(context, ti.task.outlets)
         msg = SucceedTask(
@@ -697,7 +696,7 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance):
     return result
 
 
-def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance):
+def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
     """Push XCom values when task has ``do_xcom_push`` set to ``True`` and the task returns a result."""
     if ti.task.do_xcom_push:
         xcom_value = result
@@ -722,6 +721,8 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance):
         if not is_mappable_value(xcom_value):
             raise UnmappableXComTypePushed(xcom_value)
         mapped_length = len(xcom_value)
+
+    log.info("Pushing xcom", ti=ti)
 
     # If the task has multiple outputs, push each output as a separate XCom.
     if ti.task.multiple_outputs:

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -744,6 +744,7 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
 
 
 def finalize(ti: RuntimeTaskInstance, state: TerminalTIState, log: Logger):
+    log.debug("Running finalizers", ti=ti)
     if state in [TerminalTIState.SUCCESS]:
         get_listener_manager().hook.on_task_instance_success(
             previous_state=TaskInstanceState.RUNNING, task_instance=ti

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -1201,7 +1201,7 @@ class TestXComAfterTaskExecution:
         runtime_ti = create_runtime_ti(task=task)
 
         spy_agency.spy_on(_xcom_push, call_original=False)
-        _push_xcom_if_needed(result=result, ti=runtime_ti)
+        _push_xcom_if_needed(result=result, ti=runtime_ti, log=mock.MagicMock())
 
         expected_calls = [
             ("key1", "value1"),
@@ -1231,7 +1231,7 @@ class TestXComAfterTaskExecution:
             TypeError,
             match=f"Returned output was type {type(result)} expected dictionary for multiple_outputs",
         ):
-            _push_xcom_if_needed(result=result, ti=runtime_ti)
+            _push_xcom_if_needed(result=result, ti=runtime_ti, log=mock.MagicMock())
 
     def test_xcom_with_multiple_outputs_and_key_is_not_string(self, create_runtime_ti, spy_agency):
         """Test that error is raised when multiple outputs are returned and key isn't string."""
@@ -1250,7 +1250,7 @@ class TestXComAfterTaskExecution:
         spy_agency.spy_on(runtime_ti.xcom_push, call_original=False)
 
         with pytest.raises(TypeError) as exc_info:
-            _push_xcom_if_needed(result=result, ti=runtime_ti)
+            _push_xcom_if_needed(result=result, ti=runtime_ti, log=mock.MagicMock())
 
         assert str(exc_info.value) == (
             f"Returned dictionary keys must be strings when using multiple_outputs, found 2 ({int}) instead"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We should move the log for pushing xcom to when we actually try and push XCOM or it could lead to a false debugging path if something goes wrong right after the log.

Example:
```
{
        "logger": "airflow.dag_processing.bundles.manager.DagBundlesManager",
        "timestamp": "2025-02-12 13:54:16.013955",
        "event": "DAG bundles loaded: my-bundle, example_dags",
        "level": "info"
    },
    {
        "logger": "airflow.models.dagbag.DagBag",
        "timestamp": "2025-02-12 13:54:16.014495",
        "event": "Filling up the DagBag from /opt/airflow/task_sdk/tests/dags",
        "level": "info"
    },
    {
        "chan": "stdout",
        "event": "Hello World hello!",
        "timestamp": "2025-02-12T13:54:16.024092Z",
        "level": "info",
        "logger": "task"
    },
    {
        "timestamp": "2025-02-12 13:54:16.024020",
        "ti": "RuntimeTaskInstance(id=UUID('0194fa70-5f34-77f9-90ac-a269f9ea491c'), task_id='hello', dag_id='super_basic_run', run_id='fd', try_number=1, map_index=-1, hostname='bde70b9eaf12', task=<Task(CustomOperator): hello>, max_tries=0, start_date=datetime.datetime(2025, 2, 12, 13, 54, 15, 996639, tzinfo=TzInfo(UTC)))",
        "logger": "task",
        "event": "Pushing xcom",
        "level": "info"
    },
    {
        "ti_id": "0194fa70-5f34-77f9-90ac-a269f9ea491c",
        "event": "Workload success overtime reached; terminating process",
        "timestamp": "2025-02-12T13:54:21.028714Z",
        "level": "warning",
        "logger": "supervisor"
    },
    {
        "pid": 104,
        "exit_code": -15,
        "signal": "SIGTERM",
        "event": "Process exited",
        "timestamp": "2025-02-12T13:54:21.035961Z",
        "level": "info",
        "logger": "supervisor"
    },
    {
        "exit_code": -15,
        "duration": 5.047243595123291,
        "final_state": "failed",
        "event": "Task finished",
        "timestamp": "2025-02-12T13:54:21.036878Z",
        "level": "info",
        "logger": "supervisor"
    }
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
