### PR TITLE
Use dagRunStateOptions for dagrun state filters.

### DIFF
--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -32,7 +32,7 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
-import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
+import { dagRunStateOptions as stateOptions } from "src/constants/stateOptions";
 import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 
 const columns: Array<ColumnDef<DAGRunResponse>> = [


### PR DESCRIPTION
Ref : https://github.com/apache/airflow/pull/46661#issuecomment-2653315943

The import statement was incorrect causing task instance states to be present in dagrun state filter.