### PR TITLE
Double check that a dag is unpaused for autorefresh in dags list

### DIFF
--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -56,7 +56,9 @@ export const useDags = (
     undefined,
     {
       refetchInterval: (query) =>
-        query.state.data?.dags.some((dag) => dag.latest_dag_runs.some((dr) => isStatePending(dr.state)))
+        query.state.data?.dags.some(
+          (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
+        )
           ? refetchInterval
           : false,
     },


### PR DESCRIPTION
Missed a dag.is_paused check for the dags list autorefresh.

The list was still autorefreshing if there was a pending run even if that dag was paused.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
