### PR TITLE
Remove validation on git dag bundle repo_url

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -172,16 +172,7 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
     def initialize(self) -> None:
         if not self.repo_url:
             raise AirflowException(f"Connection {self.git_conn_id} doesn't have a host url")
-        if isinstance(self.repo_url, os.PathLike):
-            self._initialize()
-        elif not (
-            self.repo_url.startswith("git@") or self.repo_url.startswith("https")
-        ) or not self.repo_url.endswith(".git"):
-            raise AirflowException(
-                f"Invalid git URL: {self.repo_url}. URL must start with git@ or https and end with .git"
-            )
-        else:
-            self._initialize()
+        self._initialize()
         super().initialize()
 
     def _clone_repo_if_required(self) -> None:


### PR DESCRIPTION
We should be flexible with what repo_urls we accept. Git will tell us if it isn't able to get to the repo after all.

This does have an impact on `view_url`, but that was already correct for the common cases, so I've simply expanded test coverage a bit.