### PR TITLE
Make sure the SSHClient is also closed when using connection in context manager from SFTPHook

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -113,7 +113,7 @@ class SFTPHook(SSHHook):
     @contextmanager
     def get_conn(self) -> Generator[SFTPClient, None, None]:
         """Context manager that closes the connection after use."""
-        with closing(super(SFTPHook, self).get_conn()) as conn:
+        with closing(super().get_conn()) as conn:
             with closing(conn.open_sftp()) as sftp:
                 yield sftp
 

--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -205,18 +205,18 @@ class SFTPHook(SSHHook):
         :param path: full path to the remote directory to create
         :param mode: int permissions of octal mode for directory
         """
-        with self.get_conn() as conn:
-            if self.isdir(path):
-                self.log.info("%s already exists", path)
-                return
-            elif self.isfile(path):
-                raise AirflowException(f"{path} already exists and is a file")
-            else:
-                dirname, basename = os.path.split(path)
-                if dirname and not self.isdir(dirname):
-                    self.create_directory(dirname, mode)
-                if basename:
-                    self.log.info("Creating %s", path)
+        if self.isdir(path):
+            self.log.info("%s already exists", path)
+            return
+        elif self.isfile(path):
+            raise AirflowException(f"{path} already exists and is a file")
+        else:
+            dirname, basename = os.path.split(path)
+            if dirname and not self.isdir(dirname):
+                self.create_directory(dirname, mode)
+            if basename:
+                self.log.info("Creating %s", path)
+                with self.get_conn() as conn:
                     conn.mkdir(path, mode=mode)
 
     def delete_directory(self, path: str, include_files: bool = False) -> None:
@@ -225,14 +225,17 @@ class SFTPHook(SSHHook):
 
         :param path: full path to the remote directory to delete
         """
+        files, dirs = [], []
+
+        if include_files is True:
+            files, dirs, _ = self.get_tree_map(path)
+            dirs = dirs[::-1]  # reverse the order for deleting deepest directories first
+
         with self.get_conn() as conn:
-            if include_files is True:
-                files, dirs, _ = self.get_tree_map(path)
-                dirs = dirs[::-1]  # reverse the order for deleting deepest directories first
-                for file_path in files:
-                    conn.remove(file_path)
-                for dir_path in dirs:
-                    conn.rmdir(dir_path)
+            for file_path in files:
+                conn.remove(file_path)
+            for dir_path in dirs:
+                conn.rmdir(dir_path)
             conn.rmdir(path)
 
     def retrieve_file(self, remote_full_path: str, local_full_path: str, prefetch: bool = True) -> None:

--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -113,8 +113,9 @@ class SFTPHook(SSHHook):
     @contextmanager
     def get_conn(self) -> Generator[SFTPClient, None, None]:
         """Context manager that closes the connection after use."""
-        with closing(super().get_conn().open_sftp()) as conn:
-            yield conn
+        with closing(super(SFTPHook, self).get_conn()) as conn:
+            with closing(conn.open_sftp()) as sftp:
+                yield sftp
 
     def describe_directory(self, path: str) -> dict[str, dict[str, str | int | None]]:
         """

--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -225,7 +225,8 @@ class SFTPHook(SSHHook):
 
         :param path: full path to the remote directory to delete
         """
-        files, dirs = [], []
+        files: list[str] = []
+        dirs: list[str] = []
 
         if include_files is True:
             files, dirs, _ = self.get_tree_map(path)

--- a/providers/sftp/tests/provider_tests/sftp/hooks/test_sftp.py
+++ b/providers/sftp/tests/provider_tests/sftp/hooks/test_sftp.py
@@ -117,6 +117,7 @@ class TestSFTPHook:
             assert conn == mock_sftp_client
 
         mock_sftp_client.close.assert_called_once()
+        mock_ssh_client.close.assert_called_once()
 
     def test_describe_directory(self):
         output = self.hook.describe_directory(self.temp_dir)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: [#44247](https://github.com/apache/airflow/pull/44247/)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


This pull request fixes a connection leak issue when using the SFTPHook get_conn method which yields a closable sftp connection.

The issue is the connection from the SFTPClient get closed automatically but not the one from the SSHClient, leaving the connection open until the SFTPHook isn't used anymore, this PR make sure the SSHClient also get automatically closed once the SFTP connection isn't needed anymore.

Added an assertion in test_get_close_conn of TestSFTPHook to test this behaviour.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
