### PR TITLE
Revert "Add support for serverless job in Databricks operators (#45188)"

### DIFF
--- a/providers/databricks/docs/operators/jobs_create.rst
+++ b/providers/databricks/docs/operators/jobs_create.rst
@@ -56,7 +56,6 @@ Currently the named parameters that ``DatabricksCreateJobsOperator`` supports ar
   - ``max_concurrent_runs``
   - ``git_source``
   - ``access_control_list``
-  - ``environments``
 
 
 Examples

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -80,7 +80,6 @@ Currently the named parameters that ``DatabricksSubmitRunOperator`` supports are
     - ``libraries``
     - ``run_name``
     - ``timeout_seconds``
-    - ``environments``
 
 .. code-block:: python
 

--- a/providers/databricks/docs/operators/task.rst
+++ b/providers/databricks/docs/operators/task.rst
@@ -44,10 +44,3 @@ Running a SQL query in Databricks using DatabricksTaskOperator
     :language: python
     :start-after: [START howto_operator_databricks_task_sql]
     :end-before: [END howto_operator_databricks_task_sql]
-
-Running a python file in Databricks in using DatabricksTaskOperator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. exampleinclude:: /../../providers/databricks/tests/system/databricks/example_databricks.py
-    :language: python
-    :start-after: [START howto_operator_databricks_task_python]
-    :end-before: [END howto_operator_databricks_task_python]

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -293,8 +293,6 @@ class DatabricksCreateJobsOperator(BaseOperator):
     :param databricks_retry_delay: Number of seconds to wait between retries (it
             might be a floating point number).
     :param databricks_retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
-    :param environments: An optional list of task execution environment specifications
-        that can be referenced by serverless tasks of this job.
 
     """
 
@@ -326,7 +324,6 @@ class DatabricksCreateJobsOperator(BaseOperator):
         databricks_retry_limit: int = 3,
         databricks_retry_delay: int = 1,
         databricks_retry_args: dict[Any, Any] | None = None,
-        environments: list[dict] | None = None,
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksCreateJobsOperator``."""
@@ -363,8 +360,6 @@ class DatabricksCreateJobsOperator(BaseOperator):
             self.json["git_source"] = git_source
         if access_control_list is not None:
             self.json["access_control_list"] = access_control_list
-        if environments is not None:
-            self.json["environments"] = environments
         if self.json:
             self.json = normalise_json_content(self.json)
 
@@ -508,8 +503,6 @@ class DatabricksSubmitRunOperator(BaseOperator):
     :param git_source: Optional specification of a remote git repository from which
         supported task types are retrieved.
     :param deferrable: Run operator in the deferrable mode.
-    :param environments: An optional list of task execution environment specifications
-        that can be referenced by serverless tasks of this job.
 
         .. seealso::
             https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsSubmit
@@ -550,7 +543,6 @@ class DatabricksSubmitRunOperator(BaseOperator):
         wait_for_termination: bool = True,
         git_source: dict[str, str] | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
-        environments: list[dict] | None = None,
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksSubmitRunOperator``."""
@@ -595,8 +587,6 @@ class DatabricksSubmitRunOperator(BaseOperator):
             self.json["access_control_list"] = access_control_list
         if git_source is not None:
             self.json["git_source"] = git_source
-        if environments is not None:
-            self.json["environments"] = environments
 
         if "dbt_task" in self.json and "git_source" not in self.json:
             raise AirflowException("git_source is required for dbt_task")
@@ -993,8 +983,6 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
     :param wait_for_termination: if we should wait for termination of the job run. ``True`` by default.
     :param workflow_run_metadata: Metadata for the workflow run. This is used when the operator is used within
         a workflow. It is expected to be a dictionary containing the run_id and conn_id for the workflow.
-    :param environments: An optional list of task execution environment specifications
-        that can be referenced by serverless tasks of this job.
     """
 
     def __init__(
@@ -1012,7 +1000,6 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
         polling_period_seconds: int = 5,
         wait_for_termination: bool = True,
         workflow_run_metadata: dict[str, Any] | None = None,
-        environments: list[dict] | None = None,
         **kwargs: Any,
     ):
         self.caller = caller
@@ -1028,7 +1015,7 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
         self.polling_period_seconds = polling_period_seconds
         self.wait_for_termination = wait_for_termination
         self.workflow_run_metadata = workflow_run_metadata
-        self.environments = environments
+
         self.databricks_run_id: int | None = None
 
         super().__init__(**kwargs)
@@ -1108,10 +1095,8 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
             run_json["new_cluster"] = self.new_cluster
         elif self.existing_cluster_id:
             run_json["existing_cluster_id"] = self.existing_cluster_id
-        elif self.environments:
-            run_json["environments"] = self.environments
         else:
-            raise ValueError("Must specify either existing_cluster_id, new_cluster or environments.")
+            raise ValueError("Must specify either existing_cluster_id or new_cluster.")
         return run_json
 
     def _launch_job(self, context: Context | None = None) -> int | None:
@@ -1415,8 +1400,6 @@ class DatabricksTaskOperator(DatabricksTaskBaseOperator):
     :param new_cluster: Specs for a new cluster on which this task will be run.
     :param polling_period_seconds: Controls the rate which we poll for the result of this notebook job run.
     :param wait_for_termination: if we should wait for termination of the job run. ``True`` by default.
-    :param environments: An optional list of task execution environment specifications
-        that can be referenced by serverless tasks of this job
     """
 
     CALLER = "DatabricksTaskOperator"
@@ -1436,7 +1419,6 @@ class DatabricksTaskOperator(DatabricksTaskBaseOperator):
         polling_period_seconds: int = 5,
         wait_for_termination: bool = True,
         workflow_run_metadata: dict | None = None,
-        environments: list[dict] | None = None,
         **kwargs,
     ):
         self.task_config = task_config
@@ -1454,7 +1436,6 @@ class DatabricksTaskOperator(DatabricksTaskBaseOperator):
             polling_period_seconds=polling_period_seconds,
             wait_for_termination=wait_for_termination,
             workflow_run_metadata=workflow_run_metadata,
-            environments=environments,
             **kwargs,
         )
 

--- a/providers/databricks/tests/provider_tests/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/provider_tests/databricks/operators/test_databricks.py
@@ -265,15 +265,6 @@ ACCESS_CONTROL_LIST = [
         "permission_level": "CAN_MANAGE",
     }
 ]
-ENVIRONMENTS = [
-    {
-        "environment_key": "default_environment",
-        "spec": {
-            "client": "1",
-            "dependencies": ["library1"],
-        },
-    }
-]
 
 
 def mock_dict(d: dict):
@@ -316,7 +307,6 @@ class TestDatabricksCreateJobsOperator:
             max_concurrent_runs=MAX_CONCURRENT_RUNS,
             git_source=GIT_SOURCE,
             access_control_list=ACCESS_CONTROL_LIST,
-            environments=ENVIRONMENTS,
         )
         expected = utils.normalise_json_content(
             {
@@ -331,7 +321,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "environments": ENVIRONMENTS,
             }
         )
 
@@ -353,7 +342,6 @@ class TestDatabricksCreateJobsOperator:
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
             "git_source": GIT_SOURCE,
             "access_control_list": ACCESS_CONTROL_LIST,
-            "environments": ENVIRONMENTS,
         }
         op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
 
@@ -370,7 +358,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "environments": ENVIRONMENTS,
             }
         )
 
@@ -393,7 +380,6 @@ class TestDatabricksCreateJobsOperator:
         override_max_concurrent_runs = 0
         override_git_source = {}
         override_access_control_list = []
-        override_environments = []
         json = {
             "name": JOB_NAME,
             "tags": TAGS,
@@ -406,7 +392,6 @@ class TestDatabricksCreateJobsOperator:
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
             "git_source": GIT_SOURCE,
             "access_control_list": ACCESS_CONTROL_LIST,
-            "environments": ENVIRONMENTS,
         }
 
         op = DatabricksCreateJobsOperator(
@@ -423,7 +408,6 @@ class TestDatabricksCreateJobsOperator:
             max_concurrent_runs=override_max_concurrent_runs,
             git_source=override_git_source,
             access_control_list=override_access_control_list,
-            environments=override_environments,
         )
 
         expected = utils.normalise_json_content(
@@ -439,7 +423,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": override_max_concurrent_runs,
                 "git_source": override_git_source,
                 "access_control_list": override_access_control_list,
-                "environments": override_environments,
             }
         )
 
@@ -483,7 +466,6 @@ class TestDatabricksCreateJobsOperator:
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
             "git_source": GIT_SOURCE,
             "access_control_list": ACCESS_CONTROL_LIST,
-            "environments": ENVIRONMENTS,
         }
         op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
         db_mock = db_mock_class.return_value
@@ -508,7 +490,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "environments": ENVIRONMENTS,
             }
         )
         db_mock_class.assert_called_once_with(
@@ -541,7 +522,6 @@ class TestDatabricksCreateJobsOperator:
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
             "git_source": GIT_SOURCE,
             "access_control_list": ACCESS_CONTROL_LIST,
-            "environments": ENVIRONMENTS,
         }
         op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
         db_mock = db_mock_class.return_value
@@ -564,7 +544,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "environments": ENVIRONMENTS,
             }
         )
         db_mock_class.assert_called_once_with(
@@ -671,72 +650,6 @@ class TestDatabricksSubmitRunOperator:
         )
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "spark_python_task": SPARK_PYTHON_TASK, "run_name": TASK_ID}
-        )
-
-        assert expected == utils.normalise_json_content(op.json)
-
-    def test_init_with_serverless_spark_python_task_named_parameters(self):
-        """
-        Test the initializer with the named parameters.
-        """
-        python_tasks = [
-            {
-                "task_key": "pythong_task_1",
-                "new_cluster": {
-                    "spark_version": "7.3.x-scala2.12",
-                    "node_type_id": "i3.xlarge",
-                    "spark_conf": {
-                        "spark.speculation": True,
-                    },
-                    "aws_attributes": {
-                        "availability": "SPOT",
-                        "zone_id": "us-west-2a",
-                    },
-                    "autoscale": {
-                        "min_workers": 2,
-                        "max_workers": 16,
-                    },
-                },
-                "spark_python_task": {"python_file": "/Users/jsmith@example.com/example_file.py"},
-                "timeout_seconds": 86400,
-                "max_retries": 3,
-                "min_retry_interval_millis": 2000,
-                "retry_on_timeout": False,
-                "environment_key": "default_environment",
-            },
-        ]
-        json = {
-            "name": JOB_NAME,
-            "tags": TAGS,
-            "tasks": python_tasks,
-            "job_clusters": JOB_CLUSTERS,
-            "email_notifications": EMAIL_NOTIFICATIONS,
-            "webhook_notifications": WEBHOOK_NOTIFICATIONS,
-            "timeout_seconds": TIMEOUT_SECONDS,
-            "schedule": SCHEDULE,
-            "max_concurrent_runs": MAX_CONCURRENT_RUNS,
-            "git_source": GIT_SOURCE,
-        }
-        op = DatabricksSubmitRunOperator(
-            task_id=TASK_ID,
-            json=json,
-            environments=ENVIRONMENTS,
-        )
-        expected = utils.normalise_json_content(
-            {
-                "name": JOB_NAME,
-                "tags": TAGS,
-                "tasks": python_tasks,
-                "job_clusters": JOB_CLUSTERS,
-                "email_notifications": EMAIL_NOTIFICATIONS,
-                "webhook_notifications": WEBHOOK_NOTIFICATIONS,
-                "timeout_seconds": TIMEOUT_SECONDS,
-                "schedule": SCHEDULE,
-                "max_concurrent_runs": MAX_CONCURRENT_RUNS,
-                "git_source": GIT_SOURCE,
-                "environments": ENVIRONMENTS,
-                "run_name": TASK_ID,
-            }
         )
 
         assert expected == utils.normalise_json_content(op.json)
@@ -2217,7 +2130,7 @@ class TestDatabricksNotebookOperator:
         )
         with pytest.raises(ValueError) as exc_info:
             operator._get_run_json()
-        exception_message = "Must specify either existing_cluster_id, new_cluster or environments."
+        exception_message = "Must specify either existing_cluster_id or new_cluster."
         assert str(exc_info.value) == exception_message
 
     def test_job_runs_forever_by_default(self):
@@ -2430,16 +2343,3 @@ class TestDatabricksTaskOperator:
         expected_task_key = "test_task_key"
 
         assert expected_task_key == operator.databricks_task_key
-
-    def test_get_task_base_json_serverless(self):
-        task_config = SPARK_PYTHON_TASK
-        operator = DatabricksTaskOperator(
-            task_id="test_task",
-            databricks_conn_id="test_conn_id",
-            task_config=task_config,
-            environments=ENVIRONMENTS,
-        )
-        task_base_json = operator._get_task_base_json()
-
-        assert operator.task_config == task_config
-        assert task_base_json == task_config

--- a/providers/databricks/tests/provider_tests/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/provider_tests/databricks/operators/test_databricks_workflow.py
@@ -77,19 +77,9 @@ def test_flatten_node():
 
 def test_create_workflow_json(mock_databricks_hook, context, mock_task_group):
     """Test that _CreateDatabricksWorkflowOperator.create_workflow_json returns the expected JSON."""
-    environments = [
-        {
-            "environment_key": "default_environment",
-            "spec": {
-                "client": "1",
-                "dependencies": ["library1"],
-            },
-        }
-    ]
     operator = _CreateDatabricksWorkflowOperator(
         task_id="test_task",
         databricks_conn_id="databricks_default",
-        environments=environments,
     )
     operator.task_group = mock_task_group
 
@@ -106,7 +96,6 @@ def test_create_workflow_json(mock_databricks_hook, context, mock_task_group):
     assert workflow_json["job_clusters"] == []
     assert workflow_json["max_concurrent_runs"] == 1
     assert workflow_json["timeout_seconds"] == 0
-    assert workflow_json["environments"] == environments
 
 
 def test_create_or_reset_job_existing(mock_databricks_hook, context, mock_task_group):
@@ -227,7 +216,6 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
         task_group=task_group,
         task_id="launch",
         databricks_conn_id="databricks_conn",
-        environments=[],
         existing_clusters=[],
         extra_job_params={},
         job_clusters=[],

--- a/providers/databricks/tests/system/databricks/example_databricks.py
+++ b/providers/databricks/tests/system/databricks/example_databricks.py
@@ -238,29 +238,6 @@ with DAG(
     )
     # [END howto_operator_databricks_task_sql]
 
-    # [START howto_operator_databricks_task_python]
-    environments = [
-        {
-            "environment_key": "default_environment",
-            "spec": {
-                "client": "1",
-                "dependencies": ["library1"],
-            },
-        }
-    ]
-    task_operator_python_query = DatabricksTaskOperator(
-        task_id="python_task",
-        databricks_conn_id="databricks_conn",
-        task_config={
-            "spark_python_task": {
-                "python_file": "/Users/jsmith@example.com/example_file.py",
-            },
-            "environment_key": "default_environment",
-        },
-        environments=environments,
-    )
-    # [END howto_operator_databricks_task_python]
-
     from tests_common.test_utils.watcher import watcher
 
     # This test needs watcher in order to properly mark success/failure


### PR DESCRIPTION
This reverts commit 0631ba76e0bdc7a52e873f3ec85787cbaf0e0dec.

Related https://github.com/apache/airflow/issues/46569, https://github.com/apache/airflow/issues/45138

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
