### PR TITLE
Add run after to task instances endpoints

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -47,6 +47,7 @@ class TaskInstanceResponse(BaseModel):
     run_id: str = Field(alias="dag_run_id")
     map_index: int
     logical_date: datetime | None
+    run_after: datetime
     start_date: datetime | None
     end_date: datetime | None
     duration: float | None
@@ -104,6 +105,8 @@ class TaskInstancesBatchBody(StrictBaseModel):
     dag_run_ids: list[str] | None = None
     task_ids: list[str] | None = None
     state: list[TaskInstanceState | None] | None = None
+    run_after_gte: AwareDatetime | None = None
+    run_after_lte: AwareDatetime | None = None
     logical_date_gte: AwareDatetime | None = None
     logical_date_lte: AwareDatetime | None = None
     start_date_gte: AwareDatetime | None = None

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -4834,6 +4834,24 @@ paths:
         schema:
           type: string
           title: Task Id
+      - name: run_after_gte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Run After Gte
+      - name: run_after_lte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Run After Lte
       - name: logical_date_gte
         in: query
         required: false
@@ -5456,6 +5474,24 @@ paths:
           - type: string
           - type: 'null'
           title: Task Id
+      - name: run_after_gte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Run After Gte
+      - name: run_after_lte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Run After Lte
       - name: logical_date_gte
         in: query
         required: false
@@ -10139,6 +10175,10 @@ components:
             format: date-time
           - type: 'null'
           title: Logical Date
+        run_after:
+          type: string
+          format: date-time
+          title: Run After
         start_date:
           anyOf:
           - type: string
@@ -10259,6 +10299,7 @@ components:
       - dag_run_id
       - map_index
       - logical_date
+      - run_after
       - start_date
       - end_date
       - duration
@@ -10395,6 +10436,18 @@ components:
             type: array
           - type: 'null'
           title: State
+        run_after_gte:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Run After Gte
+        run_after_lte:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Run After Lte
         logical_date_gte:
           anyOf:
           - type: string

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1734,6 +1734,7 @@ class TaskInstance(Base, LoggingMixin):
     triggerer_job = association_proxy("trigger", "triggerer_job")
     dag_run = relationship("DagRun", back_populates="task_instances", lazy="joined", innerjoin=True)
     rendered_task_instance_fields = relationship("RenderedTaskInstanceFields", lazy="noload", uselist=False)
+    run_after = association_proxy("dag_run", "run_after")
     logical_date = association_proxy("dag_run", "logical_date")
     task_instance_note = relationship(
         "TaskInstanceNote",

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -990,6 +990,8 @@ export const UseTaskInstanceServiceGetMappedTaskInstancesKeyFn = (
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1012,6 +1014,8 @@ export const UseTaskInstanceServiceGetMappedTaskInstancesKeyFn = (
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1039,6 +1043,8 @@ export const UseTaskInstanceServiceGetMappedTaskInstancesKeyFn = (
       orderBy,
       pool,
       queue,
+      runAfterGte,
+      runAfterLte,
       startDateGte,
       startDateLte,
       state,
@@ -1201,6 +1207,8 @@ export const UseTaskInstanceServiceGetTaskInstancesKeyFn = (
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1224,6 +1232,8 @@ export const UseTaskInstanceServiceGetTaskInstancesKeyFn = (
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1252,6 +1262,8 @@ export const UseTaskInstanceServiceGetTaskInstancesKeyFn = (
       orderBy,
       pool,
       queue,
+      runAfterGte,
+      runAfterLte,
       startDateGte,
       startDateLte,
       state,

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -1336,6 +1336,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstance = (
  * @param data.dagId
  * @param data.dagRunId
  * @param data.taskId
+ * @param data.runAfterGte
+ * @param data.runAfterLte
  * @param data.logicalDateGte
  * @param data.logicalDateLte
  * @param data.startDateGte
@@ -1374,6 +1376,8 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstances = (
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1396,6 +1400,8 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstances = (
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1421,6 +1427,8 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstances = (
       orderBy,
       pool,
       queue,
+      runAfterGte,
+      runAfterLte,
       startDateGte,
       startDateLte,
       state,
@@ -1445,6 +1453,8 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstances = (
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -1623,6 +1633,8 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstance = (
  * @param data.dagId
  * @param data.dagRunId
  * @param data.taskId
+ * @param data.runAfterGte
+ * @param data.runAfterLte
  * @param data.logicalDateGte
  * @param data.logicalDateLte
  * @param data.startDateGte
@@ -1662,6 +1674,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstances = (
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1685,6 +1699,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstances = (
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1711,6 +1727,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstances = (
       orderBy,
       pool,
       queue,
+      runAfterGte,
+      runAfterLte,
       startDateGte,
       startDateLte,
       state,
@@ -1736,6 +1754,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstances = (
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -1603,6 +1603,8 @@ export const useTaskInstanceServiceGetTaskInstance = <
  * @param data.dagId
  * @param data.dagRunId
  * @param data.taskId
+ * @param data.runAfterGte
+ * @param data.runAfterLte
  * @param data.logicalDateGte
  * @param data.logicalDateLte
  * @param data.startDateGte
@@ -1644,6 +1646,8 @@ export const useTaskInstanceServiceGetMappedTaskInstances = <
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1666,6 +1670,8 @@ export const useTaskInstanceServiceGetMappedTaskInstances = <
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1694,6 +1700,8 @@ export const useTaskInstanceServiceGetMappedTaskInstances = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -1720,6 +1728,8 @@ export const useTaskInstanceServiceGetMappedTaskInstances = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -1932,6 +1942,8 @@ export const useTaskInstanceServiceGetMappedTaskInstance = <
  * @param data.dagId
  * @param data.dagRunId
  * @param data.taskId
+ * @param data.runAfterGte
+ * @param data.runAfterLte
  * @param data.logicalDateGte
  * @param data.logicalDateLte
  * @param data.startDateGte
@@ -1974,6 +1986,8 @@ export const useTaskInstanceServiceGetTaskInstances = <
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1997,6 +2011,8 @@ export const useTaskInstanceServiceGetTaskInstances = <
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -2026,6 +2042,8 @@ export const useTaskInstanceServiceGetTaskInstances = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -2053,6 +2071,8 @@ export const useTaskInstanceServiceGetTaskInstances = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1580,6 +1580,8 @@ export const useTaskInstanceServiceGetTaskInstanceSuspense = <
  * @param data.dagId
  * @param data.dagRunId
  * @param data.taskId
+ * @param data.runAfterGte
+ * @param data.runAfterLte
  * @param data.logicalDateGte
  * @param data.logicalDateLte
  * @param data.startDateGte
@@ -1621,6 +1623,8 @@ export const useTaskInstanceServiceGetMappedTaskInstancesSuspense = <
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1643,6 +1647,8 @@ export const useTaskInstanceServiceGetMappedTaskInstancesSuspense = <
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1671,6 +1677,8 @@ export const useTaskInstanceServiceGetMappedTaskInstancesSuspense = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -1697,6 +1705,8 @@ export const useTaskInstanceServiceGetMappedTaskInstancesSuspense = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -1909,6 +1919,8 @@ export const useTaskInstanceServiceGetMappedTaskInstanceSuspense = <
  * @param data.dagId
  * @param data.dagRunId
  * @param data.taskId
+ * @param data.runAfterGte
+ * @param data.runAfterLte
  * @param data.logicalDateGte
  * @param data.logicalDateLte
  * @param data.startDateGte
@@ -1951,6 +1963,8 @@ export const useTaskInstanceServiceGetTaskInstancesSuspense = <
     orderBy,
     pool,
     queue,
+    runAfterGte,
+    runAfterLte,
     startDateGte,
     startDateLte,
     state,
@@ -1974,6 +1988,8 @@ export const useTaskInstanceServiceGetTaskInstancesSuspense = <
     orderBy?: string;
     pool?: string[];
     queue?: string[];
+    runAfterGte?: string;
+    runAfterLte?: string;
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -2003,6 +2019,8 @@ export const useTaskInstanceServiceGetTaskInstancesSuspense = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,
@@ -2030,6 +2048,8 @@ export const useTaskInstanceServiceGetTaskInstancesSuspense = <
         orderBy,
         pool,
         queue,
+        runAfterGte,
+        runAfterLte,
         startDateGte,
         startDateLte,
         state,

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4903,6 +4903,11 @@ export const $TaskInstanceResponse = {
       ],
       title: "Logical Date",
     },
+    run_after: {
+      type: "string",
+      format: "date-time",
+      title: "Run After",
+    },
     start_date: {
       anyOf: [
         {
@@ -5139,6 +5144,7 @@ export const $TaskInstanceResponse = {
     "dag_run_id",
     "map_index",
     "logical_date",
+    "run_after",
     "start_date",
     "end_date",
     "duration",
@@ -5329,6 +5335,30 @@ export const $TaskInstancesBatchBody = {
         },
       ],
       title: "State",
+    },
+    run_after_gte: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Run After Gte",
+    },
+    run_after_lte: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Run After Lte",
     },
     logical_date_gte: {
       anyOf: [

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -2055,6 +2055,8 @@ export class TaskInstanceService {
    * @param data.dagId
    * @param data.dagRunId
    * @param data.taskId
+   * @param data.runAfterGte
+   * @param data.runAfterLte
    * @param data.logicalDateGte
    * @param data.logicalDateLte
    * @param data.startDateGte
@@ -2088,6 +2090,8 @@ export class TaskInstanceService {
         task_id: data.taskId,
       },
       query: {
+        run_after_gte: data.runAfterGte,
+        run_after_lte: data.runAfterLte,
         logical_date_gte: data.logicalDateGte,
         logical_date_lte: data.logicalDateLte,
         start_date_gte: data.startDateGte,
@@ -2330,6 +2334,8 @@ export class TaskInstanceService {
    * @param data.dagId
    * @param data.dagRunId
    * @param data.taskId
+   * @param data.runAfterGte
+   * @param data.runAfterLte
    * @param data.logicalDateGte
    * @param data.logicalDateLte
    * @param data.startDateGte
@@ -2362,6 +2368,8 @@ export class TaskInstanceService {
       },
       query: {
         task_id: data.taskId,
+        run_after_gte: data.runAfterGte,
+        run_after_lte: data.runAfterLte,
         logical_date_gte: data.logicalDateGte,
         logical_date_lte: data.logicalDateLte,
         start_date_gte: data.startDateGte,

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1266,6 +1266,7 @@ export type TaskInstanceResponse = {
   dag_run_id: string;
   map_index: number;
   logical_date: string | null;
+  run_after: string;
   start_date: string | null;
   end_date: string | null;
   duration: number | null;
@@ -1341,6 +1342,8 @@ export type TaskInstancesBatchBody = {
   dag_run_ids?: Array<string> | null;
   task_ids?: Array<string> | null;
   state?: Array<TaskInstanceState | null> | null;
+  run_after_gte?: string | null;
+  run_after_lte?: string | null;
   logical_date_gte?: string | null;
   logical_date_lte?: string | null;
   start_date_gte?: string | null;
@@ -2086,6 +2089,8 @@ export type GetMappedTaskInstancesData = {
   orderBy?: string;
   pool?: Array<string>;
   queue?: Array<string>;
+  runAfterGte?: string | null;
+  runAfterLte?: string | null;
   startDateGte?: string | null;
   startDateLte?: string | null;
   state?: Array<string>;
@@ -2168,6 +2173,8 @@ export type GetTaskInstancesData = {
   orderBy?: string;
   pool?: Array<string>;
   queue?: Array<string>;
+  runAfterGte?: string | null;
+  runAfterLte?: string | null;
   startDateGte?: string | null;
   startDateLte?: string | null;
   state?: Array<string>;

--- a/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow/ui/src/components/DurationChart.tsx
@@ -136,9 +136,7 @@ export const DurationChart = ({
               label: "Run duration",
             },
           ],
-          labels: entries.map((entry: RunResponse) =>
-            dayjs(entry.logical_date).format("YYYY-MM-DD, hh:mm:ss"),
-          ),
+          labels: entries.map((entry: RunResponse) => dayjs(entry.run_after).format("YYYY-MM-DD, hh:mm:ss")),
         }}
         datasetIdKey="id"
         options={{
@@ -157,7 +155,7 @@ export const DurationChart = ({
               ticks: {
                 maxTicksLimit: 3,
               },
-              title: { align: "end", display: true, text: "Logical Date" },
+              title: { align: "end", display: true, text: "Run After" },
             },
 
             y: {

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -38,8 +38,8 @@ export const Overview = () => {
   const { data: failedTasks, isLoading } = useTaskInstanceServiceGetTaskInstances({
     dagId: dagId ?? "",
     dagRunId: "~",
-    logicalDateGte: startDate,
-    logicalDateLte: endDate,
+    runAfterGte: startDate,
+    runAfterLte: endDate,
     state: ["failed"],
   });
 

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -42,7 +42,7 @@ export const TaskCard = ({ dagId, task }: Props) => {
       dagId,
       dagRunId: "~",
       limit: 14,
-      orderBy: "-logical_date",
+      orderBy: "-run_after",
       taskId: task.task_id ?? "",
     },
     undefined,

--- a/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -40,8 +40,8 @@ export const Overview = () => {
       dagId,
       dagRunId: "~",
       limit: 14,
-      logicalDateGte: startDate,
-      logicalDateLte: endDate,
+      runAfterGte: startDate,
+      runAfterLte: endDate,
       state: ["failed"],
       taskId,
     });
@@ -50,7 +50,7 @@ export const Overview = () => {
     dagId,
     dagRunId: "~",
     limit: 14,
-    orderBy: "-logical_date",
+    orderBy: "-run_after",
     taskId,
   });
 

--- a/airflow/ui/src/pages/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances.tsx
@@ -62,16 +62,15 @@ const taskInstanceColumns = (
     ? []
     : [
         {
-          accessorKey: "run_id",
+          accessorKey: "run_after",
           cell: ({ row: { original } }: TaskInstanceRow) => (
             <Link asChild color="fg.info" fontWeight="bold">
               <RouterLink to={`/dags/${original.dag_id}/runs/${original.dag_run_id}`}>
-                {original.dag_run_id}
+                <Time datetime={original.run_after} />
               </RouterLink>
             </Link>
           ),
-          enableSorting: false,
-          header: "Run ID",
+          header: "Dag Run",
         },
       ]),
   ...(Boolean(taskId)

--- a/scripts/ci/pre_commit/check_ti_vs_tis_attributes.py
+++ b/scripts/ci/pre_commit/check_ti_vs_tis_attributes.py
@@ -43,6 +43,7 @@ def compare_attributes(path1, path2):
         get_class_attributes(path2, "TaskInstanceHistory")
     )
     diff = diff - {
+        "run_after",
         "_logger_name",
         "_task_display_property_value",
         "task_instance_note",

--- a/tests/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/tests/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -201,6 +201,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "dag_run_id": "TEST_DAG_RUN_ID",
             "rendered_fields": {},
             "rendered_map_index": None,
+            "run_after": "2020-01-01T00:00:00Z",
             "trigger": None,
             "triggerer_job": None,
         }
@@ -249,6 +250,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "note": None,
             "rendered_map_index": None,
             "rendered_fields": {},
+            "run_after": mock.ANY,
             "trigger": None,
             "triggerer_job": None,
             "dag_version": {
@@ -316,6 +318,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "try_number": 0,
             "unixname": getuser(),
             "dag_run_id": "TEST_DAG_RUN_ID",
+            "run_after": "2020-01-01T00:00:00Z",
             "rendered_fields": {},
             "rendered_map_index": None,
             "trigger": {
@@ -367,6 +370,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "dag_run_id": "TEST_DAG_RUN_ID",
             "rendered_fields": {},
             "rendered_map_index": None,
+            "run_after": "2020-01-01T00:00:00Z",
             "trigger": None,
             "triggerer_job": None,
         }
@@ -412,6 +416,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "dag_run_id": "TEST_DAG_RUN_ID",
             "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
             "rendered_map_index": None,
+            "run_after": "2020-01-01T00:00:00Z",
             "trigger": None,
             "triggerer_job": None,
         }
@@ -514,6 +519,7 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
                 "dag_run_id": "TEST_DAG_RUN_ID",
                 "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
                 "rendered_map_index": None,
+                "run_after": "2020-01-01T00:00:00Z",
                 "trigger": None,
                 "triggerer_job": None,
             }
@@ -2304,6 +2310,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
                 "scheduled_when": None,
                 "rendered_fields": {},
                 "rendered_map_index": None,
+                "run_after": "2020-01-01T00:00:00Z",
                 "start_date": "2020-01-02T00:00:00Z",
                 "state": "restarting",
                 "task_display_name": "print_the_context",
@@ -2943,6 +2950,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             "unixname": getuser(),
             "rendered_fields": {},
             "rendered_map_index": None,
+            "run_after": "2020-01-01T00:00:00Z",
             "trigger": None,
             "triggerer_job": None,
         }
@@ -3139,6 +3147,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                     "unixname": getuser(),
                     "rendered_fields": {},
                     "rendered_map_index": None,
+                    "run_after": "2020-01-01T00:00:00Z",
                     "trigger": None,
                     "triggerer_job": None,
                 },
@@ -3240,6 +3249,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             "dag_run_id": self.RUN_ID,
             "rendered_fields": {},
             "rendered_map_index": None,
+            "run_after": "2020-01-01T00:00:00Z",
             "trigger": None,
             "triggerer_job": None,
         }
@@ -3282,6 +3292,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             "dag_run_id": self.RUN_ID,
             "rendered_fields": {},
             "rendered_map_index": None,
+            "run_after": "2020-01-01T00:00:00Z",
             "trigger": None,
             "triggerer_job": None,
         }
@@ -3338,6 +3349,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 "dag_run_id": self.RUN_ID,
                 "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
                 "rendered_map_index": None,
+                "run_after": "2020-01-01T00:00:00Z",
                 "trigger": None,
                 "triggerer_job": None,
             }
@@ -3437,6 +3449,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                     "unixname": getuser(),
                     "rendered_fields": {},
                     "rendered_map_index": None,
+                    "run_after": "2020-01-01T00:00:00Z",
                     "trigger": None,
                     "triggerer_job": None,
                 }
@@ -3660,6 +3673,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                             "unixname": getuser(),
                             "rendered_fields": {},
                             "rendered_map_index": None,
+                            "run_after": "2020-01-01T00:00:00Z",
                             "trigger": None,
                             "triggerer_job": None,
                         }


### PR DESCRIPTION
Fourth PR in a series to make sure we use `run_after` where appropriate in the UI now that logical_date is nullable.

Closes #46735

```
Check that TI and TIS have the same attributes..............................Failed
- hook id: check-taskinstance-tis-attrs
- exit code: 1

Attributes in TaskInstance but not in TaskInstanceHistory: 

 {'run_after'}

 Please make sure that the attributes are consistent across the classes.
 ```

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
