### PR TITLE
add Karen to triage team

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -134,7 +134,7 @@ github:
     - vatsrahul1001
     - cmarteepants
     - bugraoz93
-    - briana-okyere
+    - karenbraganz
     - gyli
 
 notifications:


### PR DESCRIPTION
@karenbraganz is interested in getting more involved in OSS Airflow and would like to join the triage team. I've spoken with @Briana-Okyere, and she's ok stepping away from the triage team.