### PR TITLE
Fix constraints generation for 3.9-3.11

### DIFF
--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -119,7 +119,8 @@ jobs:
           for PYTHON in $PYTHON_VERSIONS; do
             breeze release-management generate-constraints \
             --airflow-constraints-mode constraints --answer yes \
-            --chicken-egg-providers "${CHICKEN_EGG_PROVIDERS}"
+            --chicken-egg-providers "${CHICKEN_EGG_PROVIDERS}" \
+            --python "${PYTHON}"
           done
       - name: "Dependency upgrade summary"
         shell: bash


### PR DESCRIPTION
When we switched to sequential in #46223, we missed actually passing the python version. Oops.