### PR TITLE
Add rendered templates tab.

### DIFF
--- a/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
+++ b/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Table } from "@chakra-ui/react";
+import { Box, HStack, Table, Code } from "@chakra-ui/react";
 import { useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
@@ -49,7 +49,7 @@ export const RenderedTemplates = () => {
                   <Table.Cell>{key}</Table.Cell>
                   <Table.Cell>
                     <HStack>
-                      {renderedValue}
+                      <Code>{renderedValue}</Code>
                       <ClipboardRoot value={renderedValue}>
                         <ClipboardIconButton />
                       </ClipboardRoot>

--- a/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
+++ b/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
@@ -1,0 +1,68 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, HStack, Table } from "@chakra-ui/react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+import { useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
+import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+
+export const RenderedTemplates = () => {
+  const { dagId = "", runId = "", taskId = "" } = useParams();
+  const [searchParams] = useSearchParams();
+
+  const mapIndexParam = searchParams.get("map_index");
+  const mapIndex = parseInt(mapIndexParam ?? "-1", 10);
+
+  const { data: taskInstance } = useTaskInstanceServiceGetMappedTaskInstance({
+    dagId,
+    dagRunId: runId,
+    mapIndex,
+    taskId,
+  });
+
+  return (
+    <Box p={2}>
+      <Table.Root striped>
+        <Table.Body>
+          {Object.entries(taskInstance?.rendered_fields ?? {}).map(([key, value]) => {
+            if (value !== null && value !== undefined) {
+              const renderedValue: string = typeof value === "object" ? JSON.stringify(value) : String(value);
+
+              return (
+                <Table.Row key={key}>
+                  <Table.Cell>{key}</Table.Cell>
+                  <Table.Cell>
+                    <HStack>
+                      {renderedValue}
+                      <ClipboardRoot value={renderedValue}>
+                        <ClipboardIconButton />
+                      </ClipboardRoot>
+                    </HStack>
+                  </Table.Cell>
+                </Table.Row>
+              );
+            }
+
+            return undefined;
+          })}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -32,6 +32,7 @@ const tabs = [
   { label: "XCom", value: "xcom" },
   { label: "Code", value: "code" },
   { label: "Details", value: "details" },
+  { label: "Rendered Templates", value: "rendered_templates" },
 ];
 
 export const TaskInstance = () => {

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -41,6 +41,7 @@ import { Task } from "src/pages/Task";
 import { Overview as TaskOverview } from "src/pages/Task/Overview";
 import { TaskInstance, Logs } from "src/pages/TaskInstance";
 import { Details } from "src/pages/TaskInstance/Details";
+import { RenderedTemplates } from "src/pages/TaskInstance/RenderedTemplates";
 import { TaskInstances } from "src/pages/TaskInstances";
 import { Variables } from "src/pages/Variables";
 import { XCom } from "src/pages/XCom";
@@ -126,6 +127,7 @@ export const routerConfig = [
           { element: <XCom />, path: "xcom" },
           { element: <Code />, path: "code" },
           { element: <Details />, path: "details" },
+          { element: <RenderedTemplates />, path: "rendered_templates" },
         ],
         element: <TaskInstance />,
         path: "dags/:dagId/runs/:runId/tasks/:taskId",


### PR DESCRIPTION
Rendered templates are useful for debugging. This PR doesn't address syntax highlighting as per the template field extension which needs API change and other changes requested in #39527 that can be part of future enhancements once API change is available. This adds a basic table with copy button and stringified value as initial work. This doesn't need auto-refresh as it doesn't change after initial task instance rendering. 

In the screenshot empty tuple is rendered because "()" string value is returned in the API.

![image](https://github.com/user-attachments/assets/72b4cfed-f9b2-4006-b7ac-d747a5199863)
