### PR TITLE
Fix `TypeError` when deserializing task with `execution_timeout` set to `None`

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1392,7 +1392,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             elif k == "downstream_task_ids":
                 v = set(v)
             elif k in {"retry_delay", "execution_timeout", "max_retry_delay"}:
-                v = cls._deserialize_timedelta(v)
+                # If operator's execution_timeout is None and core.default_task_execution_timeout is not None,
+                # v will be None so do not deserialize into timedelta
+                if v is not None:
+                    v = cls._deserialize_timedelta(v)
             elif k in encoded_op["template_fields"]:
                 pass
             elif k == "resources":

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2665,6 +2665,38 @@ def test_task_resources_serde():
     }
 
 
+@pytest.fixture(scope="function", params=[None, timedelta(hours=1)])
+def default_task_execution_timeout(request):
+    """
+    Mock setting core.default_task_execution_timeout in airflow.cfg.
+    """
+    from airflow.serialization.serialized_objects import SerializedBaseOperator
+
+    DEFAULT_TASK_EXECUTION_TIMEOUT = request.param
+    with mock.patch.dict(
+        SerializedBaseOperator._CONSTRUCTOR_PARAMS, {"execution_timeout": DEFAULT_TASK_EXECUTION_TIMEOUT}
+    ):
+        yield DEFAULT_TASK_EXECUTION_TIMEOUT
+
+
+@pytest.mark.parametrize("execution_timeout", [None, timedelta(hours=1)])
+def test_task_execution_timeout_serde(execution_timeout, default_task_execution_timeout):
+    """
+    Test task execution_timeout serialization/deserialization.
+    """
+    from airflow.providers.standard.operators.empty import EmptyOperator
+
+    with DAG("test_task_execution_timeout", schedule=None, start_date=datetime(2020, 1, 1)) as _:
+        task = EmptyOperator(task_id="task1", execution_timeout=execution_timeout)
+
+    serialized = BaseSerialization.serialize(task)
+    if execution_timeout != default_task_execution_timeout:
+        assert "execution_timeout" in serialized["__var"]
+
+    deserialized = BaseSerialization.deserialize(serialized)
+    assert deserialized.execution_timeout == task.execution_timeout
+
+
 def test_taskflow_expand_serde():
     from airflow.decorators import task
     from airflow.models.xcom_arg import XComArg

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2665,7 +2665,7 @@ def test_task_resources_serde():
     }
 
 
-@pytest.fixture(scope="function", params=[None, timedelta(hours=1)])
+@pytest.fixture(params=[None, timedelta(hours=1)])
 def default_task_execution_timeout(request):
     """
     Mock setting core.default_task_execution_timeout in airflow.cfg.


### PR DESCRIPTION
This fixes a bug where task deserialisation fails with `TypeError` when task `execution_timeout` is set to `None`, but [core.default-task-execution-timeout](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#default-task-execution-timeout) is **not** set to `None` in `airflow.cfg`.

In order to reproduce:

- set [core.default-task-execution-timeout](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#default-task-execution-timeout) in `airflow.cfg` to any integer value
- set `execution_timeout=None` on any operator inside a DAG
- open DAG in Airflow UI
- you will see `Internal Server Error` in the browser, and the following in `webserver` logs:

```
...
airflow/serialization/serialized_objects.py:1488: in deserialize_operator
    cls.populate_operator(op, encoded_op)
airflow/serialization/serialized_objects.py:1345: in populate_operator
    v = cls._deserialize_timedelta(v)
airflow/serialization/serialized_objects.py:941: in _deserialize_timedelta
    return datetime.timedelta(seconds=seconds)
E   TypeError: unsupported type for timedelta seconds component: NoneType
```

If you are running with [scheduler.standalone-dag-processor](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#standalone-dag-processor) set to `True`, this is more catastrophic as you will see the same deserialization error in `scheduler` and you will not be able to schedule any new tasks.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
