### PR TITLE
AIP-84 Add asset_dependencies endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/common.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/common.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Generic, Literal, TypeVar
+
+from airflow.api_fastapi.core_api.base import BaseModel
+
+
+class BaseEdgeResponse(BaseModel):
+    """Base Edge serializer for responses."""
+
+    source_id: str
+    target_id: str
+
+
+class BaseNodeResponse(BaseModel):
+    """Base Node serializer for responses."""
+
+    id: str
+    label: str
+    type: Literal["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"]
+
+
+E = TypeVar("E", bound=BaseEdgeResponse)
+N = TypeVar("N", bound=BaseNodeResponse)
+
+
+class BaseGraphResponse(BaseModel, Generic[E, N]):
+    """Base Graph serializer for responses."""
+
+    edges: list[E]
+    nodes: list[N]

--- a/airflow/api_fastapi/core_api/datamodels/ui/structure.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/structure.py
@@ -18,36 +18,33 @@ from __future__ import annotations
 
 from typing import Literal
 
-from airflow.api_fastapi.core_api.base import BaseModel
+from airflow.api_fastapi.core_api.datamodels.ui.common import (
+    BaseEdgeResponse,
+    BaseGraphResponse,
+    BaseNodeResponse,
+)
 
 
-class EdgeResponse(BaseModel):
+class EdgeResponse(BaseEdgeResponse):
     """Edge serializer for responses."""
 
     is_setup_teardown: bool | None = None
     label: str | None = None
-    source_id: str
-    target_id: str
     is_source_asset: bool | None = None
 
 
-class NodeResponse(BaseModel):
+class NodeResponse(BaseNodeResponse):
     """Node serializer for responses."""
 
     children: list[NodeResponse] | None = None
-    id: str
     is_mapped: bool | None = None
-    label: str
     tooltip: str | None = None
     setup_teardown_type: Literal["setup", "teardown"] | None = None
-    type: Literal["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"]
     operator: str | None = None
     asset_condition_type: Literal["or-gate", "and-gate"] | None = None
 
 
-class StructureDataResponse(BaseModel):
+class StructureDataResponse(BaseGraphResponse[EdgeResponse, NodeResponse]):
     """Structure Data serializer for responses."""
 
-    edges: list[EdgeResponse]
-    nodes: list[NodeResponse]
     arrange: Literal["BT", "LR", "RL", "TB"]

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -34,6 +34,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /ui/asset_dependencies:
+    get:
+      tags:
+      - Asset
+      summary: Asset Dependencies
+      description: Asset dependencies graph.
+      operationId: asset_dependencies
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseGraphResponse'
   /ui/config:
     get:
       tags:
@@ -7144,6 +7158,38 @@ components:
       - updated_at
       title: BackfillResponse
       description: Base serializer for Backfill.
+    BaseEdgeResponse:
+      properties:
+        source_id:
+          type: string
+          title: Source Id
+        target_id:
+          type: string
+          title: Target Id
+      type: object
+      required:
+      - source_id
+      - target_id
+      title: BaseEdgeResponse
+      description: Base Edge serializer for responses.
+    BaseGraphResponse:
+      properties:
+        edges:
+          items:
+            $ref: '#/components/schemas/BaseEdgeResponse'
+          type: array
+          title: Edges
+        nodes:
+          items:
+            $ref: '#/components/schemas/BaseNodeResponse'
+          type: array
+          title: Nodes
+      type: object
+      required:
+      - edges
+      - nodes
+      title: BaseGraphResponse
+      description: Base Graph serializer for responses.
     BaseInfoResponse:
       properties:
         status:
@@ -7156,6 +7202,33 @@ components:
       - status
       title: BaseInfoResponse
       description: Base info serializer for responses.
+    BaseNodeResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        label:
+          type: string
+          title: Label
+        type:
+          type: string
+          enum:
+          - join
+          - task
+          - asset-condition
+          - asset
+          - asset-alias
+          - dag
+          - sensor
+          - trigger
+          title: Type
+      type: object
+      required:
+      - id
+      - label
+      - type
+      title: BaseNodeResponse
+      description: Base Node serializer for responses.
     BulkAction:
       type: string
       enum:
@@ -8968,6 +9041,12 @@ components:
       description: Backfill serializer for responses in dry-run mode.
     EdgeResponse:
       properties:
+        source_id:
+          type: string
+          title: Source Id
+        target_id:
+          type: string
+          title: Target Id
         is_setup_teardown:
           anyOf:
           - type: boolean
@@ -8978,12 +9057,6 @@ components:
           - type: string
           - type: 'null'
           title: Label
-        source_id:
-          type: string
-          title: Source Id
-        target_id:
-          type: string
-          title: Target Id
         is_source_asset:
           anyOf:
           - type: boolean
@@ -9429,6 +9502,24 @@ components:
       description: Job serializer for responses.
     NodeResponse:
       properties:
+        id:
+          type: string
+          title: Id
+        label:
+          type: string
+          title: Label
+        type:
+          type: string
+          enum:
+          - join
+          - task
+          - asset-condition
+          - asset
+          - asset-alias
+          - dag
+          - sensor
+          - trigger
+          title: Type
         children:
           anyOf:
           - items:
@@ -9436,17 +9527,11 @@ components:
             type: array
           - type: 'null'
           title: Children
-        id:
-          type: string
-          title: Id
         is_mapped:
           anyOf:
           - type: boolean
           - type: 'null'
           title: Is Mapped
-        label:
-          type: string
-          title: Label
         tooltip:
           anyOf:
           - type: string
@@ -9460,18 +9545,6 @@ components:
             - teardown
           - type: 'null'
           title: Setup Teardown Type
-        type:
-          type: string
-          enum:
-          - join
-          - task
-          - asset-condition
-          - asset
-          - asset-alias
-          - dag
-          - sensor
-          - trigger
-          title: Type
         operator:
           anyOf:
           - type: string

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -34,20 +34,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ui/asset_dependencies:
-    get:
-      tags:
-      - Asset
-      summary: Asset Dependencies
-      description: Asset dependencies graph.
-      operationId: asset_dependencies
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseGraphResponse'
   /ui/config:
     get:
       tags:
@@ -188,6 +174,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /ui/dependencies:
+    get:
+      tags:
+      - Dependencies
+      summary: Get Dependencies
+      description: Dependencies graph.
+      operationId: get_dependencies
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseGraphResponse'
   /ui/dashboard/historical_metrics_data:
     get:
       tags:

--- a/airflow/api_fastapi/core_api/routes/ui/__init__.py
+++ b/airflow/api_fastapi/core_api/routes/ui/__init__.py
@@ -22,6 +22,7 @@ from airflow.api_fastapi.core_api.routes.ui.backfills import backfills_router
 from airflow.api_fastapi.core_api.routes.ui.config import config_router
 from airflow.api_fastapi.core_api.routes.ui.dags import dags_router
 from airflow.api_fastapi.core_api.routes.ui.dashboard import dashboard_router
+from airflow.api_fastapi.core_api.routes.ui.dependencies import dependencies_router
 from airflow.api_fastapi.core_api.routes.ui.grid import grid_router
 from airflow.api_fastapi.core_api.routes.ui.structure import structure_router
 
@@ -30,6 +31,7 @@ ui_router = AirflowRouter(prefix="/ui", include_in_schema=False)
 ui_router.include_router(assets_router)
 ui_router.include_router(config_router)
 ui_router.include_router(dags_router)
+ui_router.include_router(dependencies_router)
 ui_router.include_router(dashboard_router)
 ui_router.include_router(structure_router)
 ui_router.include_router(backfills_router)

--- a/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -22,8 +22,10 @@ from sqlalchemy import and_, func, select
 
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.datamodels.ui.common import BaseGraphResponse
 from airflow.models import DagModel
 from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel, DagScheduleAssetReference
+from airflow.models.serialized_dag import SerializedDagModel
 
 assets_router = AirflowRouter(tags=["Asset"])
 
@@ -82,3 +84,51 @@ def next_run_assets(
     ]
     data = {"asset_expression": dag_model.asset_expression, "events": events}
     return data
+
+
+@assets_router.get(
+    "/asset_dependencies",
+)
+def asset_dependencies(
+    session: SessionDep,
+) -> BaseGraphResponse:
+    """Asset dependencies graph."""
+    nodes_dict: dict[str, dict] = {}
+    edge_tuples: set[tuple[str, str]] = set()
+
+    for dag, dependencies in sorted(SerializedDagModel.get_dag_dependencies().items()):
+        dag_node_id = f"dag:{dag}"
+        if dag_node_id not in nodes_dict:
+            for dep in dependencies:
+                if dep.dependency_type in ("dag", "asset", "asset-alias"):
+                    # Add nodes
+                    nodes_dict[dag_node_id] = {"id": dag_node_id, "label": dag, "type": "dag"}
+                    if dep.node_id not in nodes_dict:
+                        nodes_dict[dep.node_id] = {
+                            "id": dep.node_id,
+                            "label": dep.dependency_id,
+                            "type": dep.dependency_type,
+                        }
+
+                    # Add edges
+                    # start dependency
+                    if dep.source == dep.dependency_type:
+                        source = dep.node_id
+                        target = dep.target if ":" in dep.target else f"dag:{dep.target}"
+                        edge_tuples.add((source, target))
+
+                    # end dependency
+                    if dep.target == dep.dependency_type:
+                        source = dep.source if ":" in dep.source else f"dag:{dep.source}"
+                        target = dep.node_id
+                        edge_tuples.add((source, target))
+
+    nodes = list(nodes_dict.values())
+    edges = [{"source_id": source, "target_id": target} for source, target in sorted(edge_tuples)]
+
+    data = {
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    return BaseGraphResponse(**data)

--- a/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -22,10 +22,8 @@ from sqlalchemy import and_, func, select
 
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
-from airflow.api_fastapi.core_api.datamodels.ui.common import BaseGraphResponse
 from airflow.models import DagModel
 from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel, DagScheduleAssetReference
-from airflow.models.serialized_dag import SerializedDagModel
 
 assets_router = AirflowRouter(tags=["Asset"])
 
@@ -84,51 +82,3 @@ def next_run_assets(
     ]
     data = {"asset_expression": dag_model.asset_expression, "events": events}
     return data
-
-
-@assets_router.get(
-    "/asset_dependencies",
-)
-def asset_dependencies(
-    session: SessionDep,
-) -> BaseGraphResponse:
-    """Asset dependencies graph."""
-    nodes_dict: dict[str, dict] = {}
-    edge_tuples: set[tuple[str, str]] = set()
-
-    for dag, dependencies in sorted(SerializedDagModel.get_dag_dependencies().items()):
-        dag_node_id = f"dag:{dag}"
-        if dag_node_id not in nodes_dict:
-            for dep in dependencies:
-                if dep.dependency_type in ("dag", "asset", "asset-alias"):
-                    # Add nodes
-                    nodes_dict[dag_node_id] = {"id": dag_node_id, "label": dag, "type": "dag"}
-                    if dep.node_id not in nodes_dict:
-                        nodes_dict[dep.node_id] = {
-                            "id": dep.node_id,
-                            "label": dep.dependency_id,
-                            "type": dep.dependency_type,
-                        }
-
-                    # Add edges
-                    # start dependency
-                    if dep.source == dep.dependency_type:
-                        source = dep.node_id
-                        target = dep.target if ":" in dep.target else f"dag:{dep.target}"
-                        edge_tuples.add((source, target))
-
-                    # end dependency
-                    if dep.target == dep.dependency_type:
-                        source = dep.source if ":" in dep.source else f"dag:{dep.source}"
-                        target = dep.node_id
-                        edge_tuples.add((source, target))
-
-    nodes = list(nodes_dict.values())
-    edges = [{"source_id": source, "target_id": target} for source, target in sorted(edge_tuples)]
-
-    data = {
-        "nodes": nodes,
-        "edges": edges,
-    }
-
-    return BaseGraphResponse(**data)

--- a/airflow/api_fastapi/core_api/routes/ui/dependencies.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dependencies.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.datamodels.ui.common import BaseGraphResponse
+from airflow.models.serialized_dag import SerializedDagModel
+
+dependencies_router = AirflowRouter(tags=["Dependencies"])
+
+
+@dependencies_router.get(
+    "/dependencies",
+)
+def get_dependencies(
+    session: SessionDep,
+) -> BaseGraphResponse:
+    """Dependencies graph."""
+    nodes_dict: dict[str, dict] = {}
+    edge_tuples: set[tuple[str, str]] = set()
+
+    for dag, dependencies in sorted(SerializedDagModel.get_dag_dependencies().items()):
+        dag_node_id = f"dag:{dag}"
+        if dag_node_id not in nodes_dict:
+            for dep in dependencies:
+                # Add nodes
+                nodes_dict[dag_node_id] = {"id": dag_node_id, "label": dag, "type": "dag"}
+                if dep.node_id not in nodes_dict:
+                    nodes_dict[dep.node_id] = {
+                        "id": dep.node_id,
+                        "label": dep.dependency_id,
+                        "type": dep.dependency_type,
+                    }
+
+                # Add edges
+                # not start dep
+                if dep.source != dep.dependency_type:
+                    source = dep.source if ":" in dep.source else f"dag:{dep.source}"
+                    target = dep.node_id
+                    edge_tuples.add((source, target))
+
+                # not end dep
+                if dep.target != dep.dependency_type:
+                    source = dep.node_id
+                    target = dep.target if ":" in dep.target else f"dag:{dep.target}"
+                    edge_tuples.add((source, target))
+
+    nodes = list(nodes_dict.values())
+    edges = [{"source_id": source, "target_id": target} for source, target in sorted(edge_tuples)]
+
+    data = {
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    return BaseGraphResponse(**data)

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -49,6 +49,18 @@ export const UseAssetServiceNextRunAssetsKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useAssetServiceNextRunAssetsKey, ...(queryKey ?? [{ dagId }])];
+export type AssetServiceAssetDependenciesDefaultResponse = Awaited<
+  ReturnType<typeof AssetService.assetDependencies>
+>;
+export type AssetServiceAssetDependenciesQueryResult<
+  TData = AssetServiceAssetDependenciesDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useAssetServiceAssetDependenciesKey = "AssetServiceAssetDependencies";
+export const UseAssetServiceAssetDependenciesKeyFn = (queryKey?: Array<unknown>) => [
+  useAssetServiceAssetDependenciesKey,
+  ...(queryKey ?? []),
+];
 export type AssetServiceGetAssetsDefaultResponse = Awaited<ReturnType<typeof AssetService.getAssets>>;
 export type AssetServiceGetAssetsQueryResult<
   TData = AssetServiceGetAssetsDefaultResponse,

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -16,6 +16,7 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
+  DependenciesService,
   EventLogService,
   ExtraLinksService,
   GridService,
@@ -49,18 +50,6 @@ export const UseAssetServiceNextRunAssetsKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useAssetServiceNextRunAssetsKey, ...(queryKey ?? [{ dagId }])];
-export type AssetServiceAssetDependenciesDefaultResponse = Awaited<
-  ReturnType<typeof AssetService.assetDependencies>
->;
-export type AssetServiceAssetDependenciesQueryResult<
-  TData = AssetServiceAssetDependenciesDefaultResponse,
-  TError = unknown,
-> = UseQueryResult<TData, TError>;
-export const useAssetServiceAssetDependenciesKey = "AssetServiceAssetDependencies";
-export const UseAssetServiceAssetDependenciesKeyFn = (queryKey?: Array<unknown>) => [
-  useAssetServiceAssetDependenciesKey,
-  ...(queryKey ?? []),
-];
 export type AssetServiceGetAssetsDefaultResponse = Awaited<ReturnType<typeof AssetService.getAssets>>;
 export type AssetServiceGetAssetsQueryResult<
   TData = AssetServiceGetAssetsDefaultResponse,
@@ -343,6 +332,18 @@ export const UseDagsServiceRecentDagRunsKeyFn = (
       tagsMatchMode,
     },
   ]),
+];
+export type DependenciesServiceGetDependenciesDefaultResponse = Awaited<
+  ReturnType<typeof DependenciesService.getDependencies>
+>;
+export type DependenciesServiceGetDependenciesQueryResult<
+  TData = DependenciesServiceGetDependenciesDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useDependenciesServiceGetDependenciesKey = "DependenciesServiceGetDependencies";
+export const UseDependenciesServiceGetDependenciesKeyFn = (queryKey?: Array<unknown>) => [
+  useDependenciesServiceGetDependenciesKey,
+  ...(queryKey ?? []),
 ];
 export type DashboardServiceHistoricalMetricsDefaultResponse = Awaited<
   ReturnType<typeof DashboardService.historicalMetrics>

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -55,6 +55,17 @@ export const prefetchUseAssetServiceNextRunAssets = (
     queryFn: () => AssetService.nextRunAssets({ dagId }),
   });
 /**
+ * Asset Dependencies
+ * Asset dependencies graph.
+ * @returns BaseGraphResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseAssetServiceAssetDependencies = (queryClient: QueryClient) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseAssetServiceAssetDependenciesKeyFn(),
+    queryFn: () => AssetService.assetDependencies(),
+  });
+/**
  * Get Assets
  * Get assets.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -15,6 +15,7 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
+  DependenciesService,
   EventLogService,
   ExtraLinksService,
   GridService,
@@ -53,17 +54,6 @@ export const prefetchUseAssetServiceNextRunAssets = (
   queryClient.prefetchQuery({
     queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }),
     queryFn: () => AssetService.nextRunAssets({ dagId }),
-  });
-/**
- * Asset Dependencies
- * Asset dependencies graph.
- * @returns BaseGraphResponse Successful Response
- * @throws ApiError
- */
-export const prefetchUseAssetServiceAssetDependencies = (queryClient: QueryClient) =>
-  queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceAssetDependenciesKeyFn(),
-    queryFn: () => AssetService.assetDependencies(),
   });
 /**
  * Get Assets
@@ -455,6 +445,17 @@ export const prefetchUseDagsServiceRecentDagRuns = (
         tags,
         tagsMatchMode,
       }),
+  });
+/**
+ * Get Dependencies
+ * Dependencies graph.
+ * @returns BaseGraphResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseDependenciesServiceGetDependencies = (queryClient: QueryClient) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn(),
+    queryFn: () => DependenciesService.getDependencies(),
   });
 /**
  * Historical Metrics

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -16,6 +16,7 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
+  DependenciesService,
   EventLogService,
   ExtraLinksService,
   GridService,
@@ -81,25 +82,6 @@ export const useAssetServiceNextRunAssets = <
   useQuery<TData, TError>({
     queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }, queryKey),
     queryFn: () => AssetService.nextRunAssets({ dagId }) as TData,
-    ...options,
-  });
-/**
- * Asset Dependencies
- * Asset dependencies graph.
- * @returns BaseGraphResponse Successful Response
- * @throws ApiError
- */
-export const useAssetServiceAssetDependencies = <
-  TData = Common.AssetServiceAssetDependenciesDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceAssetDependenciesKeyFn(queryKey),
-    queryFn: () => AssetService.assetDependencies() as TData,
     ...options,
   });
 /**
@@ -568,6 +550,25 @@ export const useDagsServiceRecentDagRuns = <
         tags,
         tagsMatchMode,
       }) as TData,
+    ...options,
+  });
+/**
+ * Get Dependencies
+ * Dependencies graph.
+ * @returns BaseGraphResponse Successful Response
+ * @throws ApiError
+ */
+export const useDependenciesServiceGetDependencies = <
+  TData = Common.DependenciesServiceGetDependenciesDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn(queryKey),
+    queryFn: () => DependenciesService.getDependencies() as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -84,6 +84,25 @@ export const useAssetServiceNextRunAssets = <
     ...options,
   });
 /**
+ * Asset Dependencies
+ * Asset dependencies graph.
+ * @returns BaseGraphResponse Successful Response
+ * @throws ApiError
+ */
+export const useAssetServiceAssetDependencies = <
+  TData = Common.AssetServiceAssetDependenciesDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseAssetServiceAssetDependenciesKeyFn(queryKey),
+    queryFn: () => AssetService.assetDependencies() as TData,
+    ...options,
+  });
+/**
  * Get Assets
  * Get assets.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -15,6 +15,7 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
+  DependenciesService,
   EventLogService,
   ExtraLinksService,
   GridService,
@@ -58,25 +59,6 @@ export const useAssetServiceNextRunAssetsSuspense = <
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }, queryKey),
     queryFn: () => AssetService.nextRunAssets({ dagId }) as TData,
-    ...options,
-  });
-/**
- * Asset Dependencies
- * Asset dependencies graph.
- * @returns BaseGraphResponse Successful Response
- * @throws ApiError
- */
-export const useAssetServiceAssetDependenciesSuspense = <
-  TData = Common.AssetServiceAssetDependenciesDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceAssetDependenciesKeyFn(queryKey),
-    queryFn: () => AssetService.assetDependencies() as TData,
     ...options,
   });
 /**
@@ -545,6 +527,25 @@ export const useDagsServiceRecentDagRunsSuspense = <
         tags,
         tagsMatchMode,
       }) as TData,
+    ...options,
+  });
+/**
+ * Get Dependencies
+ * Dependencies graph.
+ * @returns BaseGraphResponse Successful Response
+ * @throws ApiError
+ */
+export const useDependenciesServiceGetDependenciesSuspense = <
+  TData = Common.DependenciesServiceGetDependenciesDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn(queryKey),
+    queryFn: () => DependenciesService.getDependencies() as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -61,6 +61,25 @@ export const useAssetServiceNextRunAssetsSuspense = <
     ...options,
   });
 /**
+ * Asset Dependencies
+ * Asset dependencies graph.
+ * @returns BaseGraphResponse Successful Response
+ * @throws ApiError
+ */
+export const useAssetServiceAssetDependenciesSuspense = <
+  TData = Common.AssetServiceAssetDependenciesDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseAssetServiceAssetDependenciesKeyFn(queryKey),
+    queryFn: () => AssetService.assetDependencies() as TData,
+    ...options,
+  });
+/**
  * Get Assets
  * Get assets.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -496,6 +496,46 @@ export const $BackfillResponse = {
   description: "Base serializer for Backfill.",
 } as const;
 
+export const $BaseEdgeResponse = {
+  properties: {
+    source_id: {
+      type: "string",
+      title: "Source Id",
+    },
+    target_id: {
+      type: "string",
+      title: "Target Id",
+    },
+  },
+  type: "object",
+  required: ["source_id", "target_id"],
+  title: "BaseEdgeResponse",
+  description: "Base Edge serializer for responses.",
+} as const;
+
+export const $BaseGraphResponse = {
+  properties: {
+    edges: {
+      items: {
+        $ref: "#/components/schemas/BaseEdgeResponse",
+      },
+      type: "array",
+      title: "Edges",
+    },
+    nodes: {
+      items: {
+        $ref: "#/components/schemas/BaseNodeResponse",
+      },
+      type: "array",
+      title: "Nodes",
+    },
+  },
+  type: "object",
+  required: ["edges", "nodes"],
+  title: "BaseGraphResponse",
+  description: "Base Graph serializer for responses.",
+} as const;
+
 export const $BaseInfoResponse = {
   properties: {
     status: {
@@ -514,6 +554,28 @@ export const $BaseInfoResponse = {
   required: ["status"],
   title: "BaseInfoResponse",
   description: "Base info serializer for responses.",
+} as const;
+
+export const $BaseNodeResponse = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    type: {
+      type: "string",
+      enum: ["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"],
+      title: "Type",
+    },
+  },
+  type: "object",
+  required: ["id", "label", "type"],
+  title: "BaseNodeResponse",
+  description: "Base Node serializer for responses.",
 } as const;
 
 export const $BulkAction = {
@@ -3177,6 +3239,14 @@ export const $DryRunBackfillResponse = {
 
 export const $EdgeResponse = {
   properties: {
+    source_id: {
+      type: "string",
+      title: "Source Id",
+    },
+    target_id: {
+      type: "string",
+      title: "Target Id",
+    },
     is_setup_teardown: {
       anyOf: [
         {
@@ -3198,14 +3268,6 @@ export const $EdgeResponse = {
         },
       ],
       title: "Label",
-    },
-    source_id: {
-      type: "string",
-      title: "Source Id",
-    },
-    target_id: {
-      type: "string",
-      title: "Target Id",
     },
     is_source_asset: {
       anyOf: [
@@ -3923,6 +3985,19 @@ export const $JobResponse = {
 
 export const $NodeResponse = {
   properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    type: {
+      type: "string",
+      enum: ["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"],
+      title: "Type",
+    },
     children: {
       anyOf: [
         {
@@ -3937,10 +4012,6 @@ export const $NodeResponse = {
       ],
       title: "Children",
     },
-    id: {
-      type: "string",
-      title: "Id",
-    },
     is_mapped: {
       anyOf: [
         {
@@ -3951,10 +4022,6 @@ export const $NodeResponse = {
         },
       ],
       title: "Is Mapped",
-    },
-    label: {
-      type: "string",
-      title: "Label",
     },
     tooltip: {
       anyOf: [
@@ -3978,11 +4045,6 @@ export const $NodeResponse = {
         },
       ],
       title: "Setup Teardown Type",
-    },
-    type: {
-      type: "string",
-      enum: ["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"],
-      title: "Type",
     },
     operator: {
       anyOf: [

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -5,6 +5,7 @@ import { request as __request } from "./core/request";
 import type {
   NextRunAssetsData,
   NextRunAssetsResponse,
+  AssetDependenciesResponse,
   GetAssetsData,
   GetAssetsResponse,
   GetAssetAliasesData,
@@ -225,6 +226,19 @@ export class AssetService {
       errors: {
         422: "Validation Error",
       },
+    });
+  }
+
+  /**
+   * Asset Dependencies
+   * Asset dependencies graph.
+   * @returns BaseGraphResponse Successful Response
+   * @throws ApiError
+   */
+  public static assetDependencies(): CancelablePromise<AssetDependenciesResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ui/asset_dependencies",
     });
   }
 

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -5,7 +5,6 @@ import { request as __request } from "./core/request";
 import type {
   NextRunAssetsData,
   NextRunAssetsResponse,
-  AssetDependenciesResponse,
   GetAssetsData,
   GetAssetsResponse,
   GetAssetAliasesData,
@@ -37,6 +36,7 @@ import type {
   GetConfigValueResponse,
   RecentDagRunsData,
   RecentDagRunsResponse,
+  GetDependenciesResponse,
   HistoricalMetricsData,
   HistoricalMetricsResponse,
   StructureDataData,
@@ -226,19 +226,6 @@ export class AssetService {
       errors: {
         422: "Validation Error",
       },
-    });
-  }
-
-  /**
-   * Asset Dependencies
-   * Asset dependencies graph.
-   * @returns BaseGraphResponse Successful Response
-   * @throws ApiError
-   */
-  public static assetDependencies(): CancelablePromise<AssetDependenciesResponse> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/ui/asset_dependencies",
     });
   }
 
@@ -722,6 +709,21 @@ export class DagsService {
       errors: {
         422: "Validation Error",
       },
+    });
+  }
+}
+
+export class DependenciesService {
+  /**
+   * Get Dependencies
+   * Dependencies graph.
+   * @returns BaseGraphResponse Successful Response
+   * @throws ApiError
+   */
+  public static getDependencies(): CancelablePromise<GetDependenciesResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ui/dependencies",
     });
   }
 }

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -135,11 +135,46 @@ export type BackfillResponse = {
 };
 
 /**
+ * Base Edge serializer for responses.
+ */
+export type BaseEdgeResponse = {
+  source_id: string;
+  target_id: string;
+};
+
+/**
+ * Base Graph serializer for responses.
+ */
+export type BaseGraphResponse = {
+  edges: Array<BaseEdgeResponse>;
+  nodes: Array<BaseNodeResponse>;
+};
+
+/**
  * Base info serializer for responses.
  */
 export type BaseInfoResponse = {
   status: string | null;
 };
+
+/**
+ * Base Node serializer for responses.
+ */
+export type BaseNodeResponse = {
+  id: string;
+  label: string;
+  type: "join" | "task" | "asset-condition" | "asset" | "asset-alias" | "dag" | "sensor" | "trigger";
+};
+
+export type type =
+  | "join"
+  | "task"
+  | "asset-condition"
+  | "asset"
+  | "asset-alias"
+  | "dag"
+  | "sensor"
+  | "trigger";
 
 /**
  * Bulk Action to be performed on the used model.
@@ -850,10 +885,10 @@ export type DryRunBackfillResponse = {
  * Edge serializer for responses.
  */
 export type EdgeResponse = {
-  is_setup_teardown?: boolean | null;
-  label?: string | null;
   source_id: string;
   target_id: string;
+  is_setup_teardown?: boolean | null;
+  label?: string | null;
   is_source_asset?: boolean | null;
 };
 
@@ -1021,26 +1056,16 @@ export type JobResponse = {
  * Node serializer for responses.
  */
 export type NodeResponse = {
-  children?: Array<NodeResponse> | null;
   id: string;
-  is_mapped?: boolean | null;
   label: string;
+  type: "join" | "task" | "asset-condition" | "asset" | "asset-alias" | "dag" | "sensor" | "trigger";
+  children?: Array<NodeResponse> | null;
+  is_mapped?: boolean | null;
   tooltip?: string | null;
   setup_teardown_type?: "setup" | "teardown" | null;
-  type: "join" | "task" | "asset-condition" | "asset" | "asset-alias" | "dag" | "sensor" | "trigger";
   operator?: string | null;
   asset_condition_type?: "or-gate" | "and-gate" | null;
 };
-
-export type type =
-  | "join"
-  | "task"
-  | "asset-condition"
-  | "asset"
-  | "asset-alias"
-  | "dag"
-  | "sensor"
-  | "trigger";
 
 /**
  * Request body for Clear Task Instances endpoint.
@@ -1569,6 +1594,8 @@ export type NextRunAssetsData = {
 export type NextRunAssetsResponse = {
   [key: string]: unknown;
 };
+
+export type AssetDependenciesResponse = BaseGraphResponse;
 
 export type GetAssetsData = {
   dagIds?: Array<string>;
@@ -2469,6 +2496,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError;
+      };
+    };
+  };
+  "/ui/asset_dependencies": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: BaseGraphResponse;
       };
     };
   };

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1595,8 +1595,6 @@ export type NextRunAssetsResponse = {
   [key: string]: unknown;
 };
 
-export type AssetDependenciesResponse = BaseGraphResponse;
-
 export type GetAssetsData = {
   dagIds?: Array<string>;
   limit?: number;
@@ -1727,6 +1725,8 @@ export type RecentDagRunsData = {
 };
 
 export type RecentDagRunsResponse = DAGWithLatestDagRunsCollectionResponse;
+
+export type GetDependenciesResponse = BaseGraphResponse;
 
 export type HistoricalMetricsData = {
   endDate?: string | null;
@@ -2499,16 +2499,6 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/ui/asset_dependencies": {
-    get: {
-      res: {
-        /**
-         * Successful Response
-         */
-        200: BaseGraphResponse;
-      };
-    };
-  };
   "/public/assets": {
     get: {
       req: GetAssetsData;
@@ -2921,6 +2911,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError;
+      };
+    };
+  };
+  "/ui/dependencies": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: BaseGraphResponse;
       };
     };
   };


### PR DESCRIPTION
Part 1 of https://github.com/apache/airflow/issues/42368 This is just the migration and some code refactoring to deduplicated Graph like datamodels.

I will work on a follow up PR to introduce the `node_id` filter and logic to extract a connected component. (subgraph)