### PR TITLE
Remove backcompat re _task_event_logs from scheduler

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1059,10 +1059,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
                 for executor in self.job.executors:
                     try:
-                        # this is backcompat check if executor does not inherit from BaseExecutor
-                        # todo: remove in airflow 3.0
-                        if not hasattr(executor, "_task_event_logs"):
-                            continue
                         with create_session() as session:
                             self._process_task_event_logs(executor._task_event_logs, session)
                     except Exception:


### PR DESCRIPTION
This was added when we removed TaskContextLogger and replaced it with just adding events to the log table.  Because pre-Airflow-3.0, executors did not have to inherit from BaseExecutor, we had to add this check.  In 3.0, all executors should inherit from BaseExecutor so it should not be a problem.
