### PR TITLE
Always populate mapped tasks

### DIFF
--- a/airflow/www/static/js/api/useMappedInstances.ts
+++ b/airflow/www/static/js/api/useMappedInstances.ts
@@ -48,7 +48,6 @@ export default function useMappedInstances({
       }),
     {
       keepPreviousData: true,
-      initialData: { taskInstances: [], totalEntries: 0 },
       refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
       // staleTime should be similar to the refresh interval
       staleTime: (autoRefreshInterval || 1) * 1000,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently, when `auto_refresh_interval` is set to a large number, the `Mapped Tasks` panel in the GUI will always show `No data found.` By removing the `initialData` param from the query, `Mapped Tasks` will still be populated, regardless of the value of `auto_refresh_interval`.

Tested this on our internal test environment after manually building and adding new static/dist files 👍 

I'm not a front end expert by any means, apologies for anything I'm missing!

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
