### PR TITLE
Fix: invalid scheduler-deployment chart template on multiple executors

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -47,6 +47,7 @@
 {{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list . .Values.scheduler.logGroomerSidecar) }}
 {{- $containerLifecycleHooks := or .Values.scheduler.containerLifecycleHooks .Values.containerLifecycleHooks }}
 {{- $containerLifecycleHooksLogGroomerSidecar := or .Values.scheduler.logGroomerSidecar.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $executors := split "," .Values.executor }}
 apiVersion: apps/v1
 kind: {{ if $stateful }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
@@ -57,7 +58,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    executor: "{{ .Values.executor }}"
+    executor: "{{ $executors._0 }}"
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -325,6 +325,7 @@ rbac:
 # Airflow executor
 # One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
 # Specify executors in a prioritized list to leverage multiple execution environments as needed.
+# Only the first executor of the list (default executor) is used to label the scheduler objects.
 executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -833,12 +833,12 @@ class TestScheduler:
     @pytest.mark.parametrize(
         "executor, label",
         [
-            {"LocalExecutor","LocalExecutor"},
-            {"LocalKubernetesExecutor","LocalKubernetesExecutor"},
-            {"CeleryExecutor","CeleryExecutor"},
-            {"KubernetesExecutor","KubernetesExecutor"},
-            {"CeleryKubernetesExecutor","CeleryKubernetesExecutor"},
-            {"CeleryExecutor,KubernetesExecutor","CeleryExecutor"},
+            ("LocalExecutor", "LocalExecutor"),
+            ("LocalKubernetesExecutor", "LocalKubernetesExecutor"),
+            ("CeleryExecutor", "CeleryExecutor"),
+            ("KubernetesExecutor", "KubernetesExecutor"),
+            ("CeleryKubernetesExecutor", "CeleryKubernetesExecutor"),
+            ("CeleryExecutor,KubernetesExecutor", "CeleryExecutor"),
         ],
     )
     def test_scheduler_deployment_has_default_executor_label(self, executor, label):

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -831,24 +831,24 @@ class TestScheduler:
         assert jmespath.search("spec.volumeClaimTemplates[0].metadata.annotations", docs[0]) == {"foo": "bar"}
 
     @pytest.mark.parametrize(
-        "executor",
+        "executor, label",
         [
-            "LocalExecutor",
-            "LocalKubernetesExecutor",
-            "CeleryExecutor",
-            "KubernetesExecutor",
-            "CeleryKubernetesExecutor",
-            "CeleryExecutor,KubernetesExecutor",
+            {"LocalExecutor","LocalExecutor"},
+            {"LocalKubernetesExecutor","LocalKubernetesExecutor"},
+            {"CeleryExecutor","CeleryExecutor"},
+            {"KubernetesExecutor","KubernetesExecutor"},
+            {"CeleryKubernetesExecutor","CeleryKubernetesExecutor"},
+            {"CeleryExecutor,KubernetesExecutor","CeleryExecutor"},
         ],
     )
-    def test_scheduler_deployment_has_executor_label(self, executor):
+    def test_scheduler_deployment_has_default_executor_label(self, executor, label):
         docs = render_chart(
             values={"executor": executor},
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
 
         assert len(docs) == 1
-        assert executor == docs[0]["metadata"]["labels"].get("executor")
+        assert label == docs[0]["metadata"]["labels"].get("executor")
 
     def test_should_add_component_specific_annotations(self):
         docs = render_chart(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #46733

The comma is not a valid value character for a Kubernetes label ([ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set))
[Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) doesn't support partial label value check operator (contains,like,...)
Using the default executor (first in the list) to label the scheduler seems the most reasonable solution.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
