### PR TITLE
Add Selective Check for caplog Usage and Warn and Allow Maintainer to Approve

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -82,6 +82,7 @@ INCLUDE_SUCCESS_OUTPUTS_LABEL = "include success outputs"
 LATEST_VERSIONS_ONLY_LABEL = "latest versions only"
 LEGACY_UI_LABEL = "legacy ui"
 LEGACY_API_LABEL = "legacy api"
+LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL = "log exception"
 NON_COMMITTER_BUILD_LABEL = "non committer build"
 UPGRADE_TO_NEWER_DEPENDENCIES_LABEL = "upgrade to newer dependencies"
 USE_PUBLIC_RUNNERS_LABEL = "use public runners"
@@ -118,6 +119,7 @@ class FileGroupForCi(Enum):
     ALL_DOCS_PYTHON_FILES = "all_docs_python_files"
     TESTS_UTILS_FILES = "test_utils_files"
     ASSET_FILES = "asset_files"
+    UNIT_TEST_FILES = "unit_test_files"
 
 
 class AllProvidersSentinel:
@@ -250,6 +252,10 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^airflow/models/assets/",
             r"^task_sdk/src/airflow/sdk/definitions/asset/",
             r"^airflow/datasets/",
+        ],
+        FileGroupForCi.UNIT_TEST_FILES: [
+            r"^tests/",
+            r"^task_sdk/tests/",
         ],
     }
 )
@@ -1516,6 +1522,65 @@ class SelectiveChecks:
             sys.exit(1)
         else:
             return True
+
+    @staticmethod
+    def _check_if_log_is_mocked_in_a_file(file) -> bool:
+        """
+        Check if log is used without mock in a file
+
+        :param file: file to check
+        :return: True if log is used with mock else False
+        """
+        def_found = False
+        mock_found = False
+
+        with open(file) as f:
+            if "caplog" not in f.read():
+                return True
+
+            for line in f:
+                if "def " in line:
+                    def_found = True
+                    continue
+                elif def_found and "log" in line and "patch.object" in line:
+                    mock_found = True
+                    break
+                elif line == "\n":
+                    def_found = False
+
+        return mock_found
+
+    @cached_property
+    def is_log_mocked_in_the_tests(self) -> bool:
+        """
+        Check if log is used without mock in the tests
+        """
+        if self._is_canary_run() or self._github_event not in (
+            GithubEvents.PULL_REQUEST,
+            GithubEvents.PULL_REQUEST_TARGET,
+        ):
+            return False
+
+        # Check if changed files are unit tests
+        if self._matching_files(
+            FileGroupForCi.UNIT_TEST_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+        ):
+            # Read files and check if log is used without mock
+            for file in self._files:
+                if not self._check_if_log_is_mocked_in_a_file(file=file):
+                    get_console().print(
+                        f"[error]Please use `patch.object` to mock `log` in {file}."
+                        "Using `caplog` directly can cause side effects "
+                        "and flakiness with tests and not recommended. If you think, caplog is the only way, "
+                        "please either ask maintainer to include as an exception using "
+                        f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label or please mock it."
+                        "It is up to maintainer decision to allow this exception.",
+                    )
+                    if LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL not in self._pr_labels:
+                        sys.exit(1)
+                    else:
+                        return True
+        return True
 
     @cached_property
     def force_pip(self):

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -257,6 +257,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^tests/",
             r"^task_sdk/tests/",
             r"^providers/.*/tests/",
+            r"^dev/breeze/tests/",
         ],
     }
 )
@@ -1524,32 +1525,46 @@ class SelectiveChecks:
         else:
             return True
 
-    @staticmethod
-    def _check_if_log_is_mocked_in_a_file(file) -> bool:
+    @classmethod
+    def _find_caplog_in_def(cls, added_lines):
         """
-        Check if log is used without mock in a file
+        Find caplog in def
 
-        :param file: file to check
-        :return: True if log is used with mock else False
+        :param added_lines: lines added in the file
+        :return: True if caplog is found in def else False
         """
-        def_found = False
-        mock_found = False
-
-        with open(file) as f:
-            if "caplog" not in f.read():
+        line_counter = 0
+        while line_counter < len(added_lines):
+            if all(keyword in added_lines[line_counter] for keyword in ["def", "caplog", "(", ")"]):
                 return True
+            if "def" in added_lines[line_counter] and ")" not in added_lines[line_counter]:
+                while ")" not in added_lines[line_counter]:
+                    if "caplog" in added_lines[line_counter]:
+                        return True
+                    line_counter += 1
+            line_counter += 1
 
-            for line in f:
-                if "def " in line:
-                    def_found = True
-                    continue
-                elif def_found and "log" in line and "patch.object" in line:
-                    mock_found = True
-                    break
-                elif line == "\n":
-                    def_found = False
+    def _caplog_exists_in_added_lines(self) -> bool:
+        """
+        Check if caplog is used in added lines
 
-        return mock_found
+        :return: True if caplog is used in added lines else False
+        """
+        lines = run_command(
+            ["git", "diff", f"{self._commit_ref}"],
+            capture_output=True,
+            text=True,
+            cwd=AIRFLOW_SOURCES_ROOT,
+            check=False,
+        )
+
+        if "caplog" not in lines.stdout or lines.stdout == "":
+            return False
+
+        added_caplog_lines = [
+            line.lstrip().lstrip("+ ") for line in lines.stdout.split("\n") if line.lstrip().startswith("+ ")
+        ]
+        return self._find_caplog_in_def(added_lines=added_caplog_lines)
 
     @cached_property
     def is_log_mocked_in_the_tests(self) -> bool:
@@ -1561,26 +1576,28 @@ class SelectiveChecks:
             GithubEvents.PULL_REQUEST_TARGET,
         ):
             return False
-
         # Check if changed files are unit tests
-        if self._matching_files(
-            FileGroupForCi.UNIT_TEST_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+        if (
+            self._matching_files(
+                FileGroupForCi.UNIT_TEST_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+            )
+            and LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL not in self._pr_labels
         ):
-            # Read files and check if log is used without mock
-            for file in self._files:
-                if not self._check_if_log_is_mocked_in_a_file(file=file):
-                    get_console().print(
-                        f"[error]Please use `patch.object` to mock `log` in {file}."
-                        "Using `caplog` directly can cause side effects "
-                        "and flakiness with tests and not recommended. If you think, caplog is the only way, "
-                        "please either ask maintainer to include as an exception using "
-                        f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label or please mock it."
-                        "It is up to maintainer decision to allow this exception.",
-                    )
-                    if LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL not in self._pr_labels:
-                        sys.exit(1)
-                    else:
-                        return True
+            if self._caplog_exists_in_added_lines():
+                get_console().print(
+                    f"[error]Caplog is used in the test. "
+                    f"Please be sure you are mocking the log. "
+                    "For example, use `patch.object` to mock `log`."
+                    "Using `caplog` directly in your test files can cause side effects "
+                    "and not recommended. If you think, `caplog` is the only way to test "
+                    "the functionality or there is and exceptional case, "
+                    "please ask maintainer to include as an exception using "
+                    f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label. "
+                    "It is up to maintainer decision to allow this exception.",
+                )
+                sys.exit(1)
+            else:
+                return True
         return True
 
     @cached_property

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -256,6 +256,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
         FileGroupForCi.UNIT_TEST_FILES: [
             r"^tests/",
             r"^task_sdk/tests/",
+            r"^providers/.*/tests/",
         ],
     }
 )

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import re
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from rich.console import Console
@@ -53,6 +54,9 @@ NEUTRAL_COMMIT = "938f0c1f3cc4cbe867123ee8aa9f290f9f18100a"
 # for is_legacy_ui_api_labeled tests
 LEGACY_UI_LABEL = "legacy ui"
 LEGACY_API_LABEL = "legacy api"
+
+# Use me if you are adding test for the changed files that includes caplog
+LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL = "log exception"
 
 
 def escape_ansi_colors(line):
@@ -962,7 +966,7 @@ def test_expected_output_pull_request_main(
         files=files,
         commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
-        pr_labels=(),
+        pr_labels=(LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,),
         default_branch="main",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
@@ -1310,7 +1314,10 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
         (
             pytest.param(
                 ("INTHEWILD.md", "providers/asana/tests/asana.py"),
-                ("full tests needed",),
+                (
+                    "full tests needed",
+                    LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,
+                ),
                 "v2-7-stable",
                 {
                     "all-python-versions": "['3.9']",
@@ -1466,7 +1473,7 @@ def test_expected_output_pull_request_v2_7(
         files=files,
         commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
-        pr_labels=(),
+        pr_labels=(LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,),
         default_branch="v2-7-stable",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
@@ -1729,7 +1736,7 @@ def test_expected_output_pull_request_target(
         files=files,
         commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST_TARGET,
-        pr_labels=(),
+        pr_labels=(LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,),
         default_branch="main",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
@@ -2581,3 +2588,206 @@ def test_pr_labels(
         pr_labels=pr_labels,
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
+
+
+@pytest.mark.parametrize(
+    "files, pr_labels, github_event",
+    [
+        pytest.param(
+            ("tests/test.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the the git diff Tests",
+        ),
+        pytest.param(
+            ("providers/common/sql/tests/unit/common/sql/operators/test_sql.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff Providers",
+        ),
+        pytest.param(
+            ("task_sdk/tests/definitions/test_dag.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff TaskSDK",
+        ),
+    ],
+)
+# Patch run_command
+@patch("airflow_breeze.utils.selective_checks.run_command")
+def test_is_log_mocked_in_the_tests_fail(
+    mock_run_command,
+    files: tuple[str, ...],
+    pr_labels: tuple[str, ...],
+    github_event: GithubEvents,
+):
+    mock_run_command_result = MagicMock()
+    mock_run_command_result.stdout = """
+        + #Test Change
+        + def test_selective_checks_caplop(self, caplog)
+        +   caplog.set_level(logging.INFO)
+        +   "test log" in caplog.text
+    """
+    mock_run_command.return_value = mock_run_command_result
+    with pytest.raises(SystemExit):
+        selective_checks = SelectiveChecks(
+            files=files,
+            commit_ref=NEUTRAL_COMMIT,
+            github_event=GithubEvents.PULL_REQUEST,
+            default_branch="main",
+        )
+    assert (
+        "[error]please ask maintainer to include as an exception using "
+        f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label." in escape_ansi_colors(str(selective_checks))
+    )
+
+
+@pytest.mark.parametrize(
+    "files, pr_labels, github_event",
+    [
+        pytest.param(
+            ("tests/test.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the the git diff Tests",
+        ),
+        pytest.param(
+            ("providers/common/sql/tests/unit/common/sql/operators/test_sql.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff Providers",
+        ),
+        pytest.param(
+            ("task_sdk/tests/definitions/test_dag.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff TaskSDK",
+        ),
+    ],
+)
+# Patch run_command
+@patch("airflow_breeze.utils.selective_checks.run_command")
+def test_is_log_mocked_in_the_tests_fail_formatted(
+    mock_run_command,
+    files: tuple[str, ...],
+    pr_labels: tuple[str, ...],
+    github_event: GithubEvents,
+):
+    mock_run_command_result = MagicMock()
+    mock_run_command_result.stdout = """
+        + #Test Change
+        + def test_selective_checks(
+        +     self,
+        +     caplog
+        + )
+        +   caplog.set_level(logging.INFO)
+        +   "test log" in caplog.text
+    """
+    mock_run_command.return_value = mock_run_command_result
+    with pytest.raises(SystemExit):
+        selective_checks = SelectiveChecks(
+            files=files,
+            commit_ref=NEUTRAL_COMMIT,
+            github_event=GithubEvents.PULL_REQUEST,
+            default_branch="main",
+        )
+    assert (
+        "[error]please ask maintainer to include as an exception using "
+        f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label." in escape_ansi_colors(str(selective_checks))
+    )
+
+
+@pytest.mark.parametrize(
+    "files, pr_labels, github_event",
+    [
+        pytest.param(
+            ("tests/test.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the the git diff Tests",
+        ),
+        pytest.param(
+            ("providers/common/sql/tests/unit/common/sql/operators/test_sql.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff Providers",
+        ),
+        pytest.param(
+            ("task_sdk/tests/definitions/test_dag.py",),
+            (),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff TaskSDK",
+        ),
+    ],
+)
+# Patch run_command
+@patch("airflow_breeze.utils.selective_checks.run_command")
+def test_is_log_mocked_in_the_tests_not_fail(
+    mock_run_command,
+    files: tuple[str, ...],
+    pr_labels: tuple[str, ...],
+    github_event: GithubEvents,
+):
+    mock_run_command_result = MagicMock()
+    mock_run_command_result.stdout = """
+         + #Test Change
+         + def test_selective_checks(self)
+         +   assert "I am just a test" == "I am just a test"
+     """
+    mock_run_command.return_value = mock_run_command_result
+    selective_checks = SelectiveChecks(
+        files=files,
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+        default_branch="main",
+    )
+    assert selective_checks.is_log_mocked_in_the_tests
+
+
+@pytest.mark.parametrize(
+    "files, pr_labels, github_event",
+    [
+        pytest.param(
+            ("tests/test.py",),
+            (LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the the git diff Tests",
+        ),
+        pytest.param(
+            ("providers/common/sql/tests/unit/common/sql/operators/test_sql.py",),
+            (LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff Providers",
+        ),
+        pytest.param(
+            ("task_sdk/tests/definitions/test_dag.py",),
+            (LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL,),
+            GithubEvents.PULL_REQUEST,
+            id="Caplog is in the git diff TaskSDK",
+        ),
+    ],
+)
+# Patch run_command
+@patch("airflow_breeze.utils.selective_checks.run_command")
+def test_is_log_mocked_in_the_tests_not_fail_with_label(
+    mock_run_command,
+    files: tuple[str, ...],
+    pr_labels: tuple[str, ...],
+    github_event: GithubEvents,
+):
+    mock_run_command_result = MagicMock()
+    mock_run_command_result.stdout = """
+        + #Test Change
+        + def test_selective_checks_caplop(self, caplog)
+        +   caplog.set_level(logging.INFO)
+        +   "test log" in caplog.text
+    """
+    mock_run_command.return_value = mock_run_command_result
+    with pytest.raises(SystemExit):
+        selective_checks = SelectiveChecks(
+            files=files,
+            commit_ref=NEUTRAL_COMMIT,
+            github_event=GithubEvents.PULL_REQUEST,
+            default_branch="main",
+        )
+    assert selective_checks.is_log_mocked_in_the_tests

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -2630,16 +2630,21 @@ def test_is_log_mocked_in_the_tests_fail(
     """
     mock_run_command.return_value = mock_run_command_result
     with pytest.raises(SystemExit):
-        selective_checks = SelectiveChecks(
-            files=files,
-            commit_ref=NEUTRAL_COMMIT,
-            github_event=GithubEvents.PULL_REQUEST,
-            default_branch="main",
+        assert (
+            "[error]please ask maintainer to include as an exception using "
+            f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label."
+            in escape_ansi_colors(
+                str(
+                    SelectiveChecks(
+                        files=files,
+                        commit_ref=NEUTRAL_COMMIT,
+                        pr_labels=pr_labels,
+                        github_event=GithubEvents.PULL_REQUEST,
+                        default_branch="main",
+                    )
+                )
+            )
         )
-    assert (
-        "[error]please ask maintainer to include as an exception using "
-        f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label." in escape_ansi_colors(str(selective_checks))
-    )
 
 
 @pytest.mark.parametrize(
@@ -2685,16 +2690,21 @@ def test_is_log_mocked_in_the_tests_fail_formatted(
     """
     mock_run_command.return_value = mock_run_command_result
     with pytest.raises(SystemExit):
-        selective_checks = SelectiveChecks(
-            files=files,
-            commit_ref=NEUTRAL_COMMIT,
-            github_event=GithubEvents.PULL_REQUEST,
-            default_branch="main",
+        assert (
+            "[error]please ask maintainer to include as an exception using "
+            f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label."
+            in escape_ansi_colors(
+                str(
+                    SelectiveChecks(
+                        files=files,
+                        commit_ref=NEUTRAL_COMMIT,
+                        pr_labels=pr_labels,
+                        github_event=GithubEvents.PULL_REQUEST,
+                        default_branch="main",
+                    )
+                )
+            )
         )
-    assert (
-        "[error]please ask maintainer to include as an exception using "
-        f"'{LOG_WITHOUT_MOCK_IN_TESTS_EXCEPTION_LABEL}' label." in escape_ansi_colors(str(selective_checks))
-    )
 
 
 @pytest.mark.parametrize(
@@ -2738,6 +2748,7 @@ def test_is_log_mocked_in_the_tests_not_fail(
     selective_checks = SelectiveChecks(
         files=files,
         commit_ref=NEUTRAL_COMMIT,
+        pr_labels=pr_labels,
         github_event=GithubEvents.PULL_REQUEST,
         default_branch="main",
     )
@@ -2783,11 +2794,11 @@ def test_is_log_mocked_in_the_tests_not_fail_with_label(
         +   "test log" in caplog.text
     """
     mock_run_command.return_value = mock_run_command_result
-    with pytest.raises(SystemExit):
-        selective_checks = SelectiveChecks(
-            files=files,
-            commit_ref=NEUTRAL_COMMIT,
-            github_event=GithubEvents.PULL_REQUEST,
-            default_branch="main",
-        )
+    selective_checks = SelectiveChecks(
+        files=files,
+        commit_ref=NEUTRAL_COMMIT,
+        pr_labels=pr_labels,
+        github_event=GithubEvents.PULL_REQUEST,
+        default_branch="main",
+    )
     assert selective_checks.is_log_mocked_in_the_tests


### PR DESCRIPTION
closes: #46445 

Unit tests will be included and logic will be checked again to ensure covering all cases.

Update: added the tests and updated the logic

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
