### PR TITLE
Set task/dag labels for Dataproc Batch

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
@@ -2721,15 +2721,21 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
             return
 
         labels_limit = 32
-        automatic_labels = {"airflow-dag": dag_id, "airflow-task": task_id}
+        new_labels = {"airflow-dag-id": dag_id, "airflow-task-id": task_id}
+
+        if self._dag:
+            dag_display_name = re.sub(r"[.\s]", "_", self._dag.dag_display_name.lower())
+            if labels_regex.match(dag_id):
+                new_labels["airflow-dag-display-name"] = dag_display_name
+
         if isinstance(self.batch, Batch):
-            if len(self.batch.labels) + 2 <= labels_limit:
-                self.batch.labels.update(automatic_labels)
+            if len(self.batch.labels) + len(new_labels) <= labels_limit:
+                self.batch.labels.update(new_labels)
         elif "labels" not in self.batch:
-            self.batch["labels"] = automatic_labels
+            self.batch["labels"] = new_labels
         elif isinstance(self.batch.get("labels"), dict):
-            if len(self.batch["labels"]) + 2 <= labels_limit:
-                self.batch["labels"].update(automatic_labels)
+            if len(self.batch["labels"]) + len(new_labels) <= labels_limit:
+                self.batch["labels"].update(new_labels)
 
 
 class DataprocDeleteBatchOperator(GoogleCloudBaseOperator):

--- a/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
@@ -2530,6 +2530,8 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
             self.log.info("Automatic injection of OpenLineage information into Spark properties is enabled.")
             self._inject_openlineage_properties_into_dataproc_batch(context)
 
+        self.__update_batch_labels()
+
         try:
             self.operation = self.hook.create_batch(
                 region=self.region,
@@ -2709,6 +2711,25 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
                 "Dataproc batch has not been modified by OpenLineage.",
                 exc_info=e,
             )
+
+    def __update_batch_labels(self):
+        dag_id = re.sub(r"[.\s]", "_", self.dag_id.lower())
+        task_id = re.sub(r"[.\s]", "_", self.task_id.lower())
+
+        labels_regex = re.compile(r"^[a-z][\w-]{0,63}$")
+        if not labels_regex.match(dag_id) or not labels_regex.match(task_id):
+            return
+
+        labels_limit = 32
+        automatic_labels = {"airflow-dag": dag_id, "airflow-task": task_id}
+        if isinstance(self.batch, Batch):
+            if len(self.batch.labels) + 2 <= labels_limit:
+                self.batch.labels.update(automatic_labels)
+        elif "labels" not in self.batch:
+            self.batch["labels"] = automatic_labels
+        elif isinstance(self.batch.get("labels"), dict):
+            if len(self.batch["labels"]) + 2 <= labels_limit:
+                self.batch["labels"].update(automatic_labels)
 
 
 class DataprocDeleteBatchOperator(GoogleCloudBaseOperator):

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -3793,8 +3793,9 @@ class TestDataprocCreateBatchOperator:
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_create_batch_asdict_labels_updated(self, mock_hook, to_dict_mock):
         expected_labels = {
-            "airflow-dag": "test_dag",
-            "airflow-task": "test-task",
+            "airflow-dag-id": "test_dag",
+            "airflow-dag-display-name": "test_dag",
+            "airflow-task-id": "test-task",
         }
 
         expected_batch = {
@@ -3815,8 +3816,9 @@ class TestDataprocCreateBatchOperator:
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_create_batch_asdict_labels_uppercase_transformed(self, mock_hook, to_dict_mock):
         expected_labels = {
-            "airflow-dag": "test_dag",
-            "airflow-task": "test-task",
+            "airflow-dag-id": "test_dag",
+            "airflow-dag-display-name": "test_dag",
+            "airflow-task-id": "test-task",
         }
 
         expected_batch = {
@@ -3865,8 +3867,9 @@ class TestDataprocCreateBatchOperator:
         dag = DAG(dag_id="test_dag")
 
         expected_labels = {
-            "airflow-dag": "test_dag",
-            "airflow-task": "test-task",
+            "airflow-dag-id": "test_dag",
+            "airflow-dag-display-name": "test_dag",
+            "airflow-task-id": "test-task",
         }
 
         expected_batch = deepcopy(batch)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

**Set task/dag id labels for Dataproc Batch**

Setting labels `airflow-dag` and `airflow-task` using sanitized dag and task id. This should help the users to keep track of historical execution of dataproc serverless batches.

User can use those labels to cluster dataproc batches by dags and tasks, perform historical analysis and navigate to the airflow source code. 

During discussion, we considered alternative of using 'dag-display-name' but there is not enforcement for it to be a unique.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
