### PR TITLE
Add trigger as source for asset event.

### DIFF
--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/AssetEvent.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/AssetEvent.tsx
@@ -27,7 +27,13 @@ import { Tooltip } from "src/components/ui";
 
 export const AssetEvent = ({ event }: { readonly event: AssetEventResponse }) => {
   const hasDagRuns = event.created_dagruns.length > 0;
-  const source = event.extra?.from_rest_api === true ? "API" : "";
+  let source = "";
+
+  if (event.extra?.from_rest_api === true) {
+    source = "API";
+  } else if (event.extra?.from_trigger === true) {
+    source = "Trigger";
+  }
 
   return (
     <Box fontSize={13} mt={1} w="full">


### PR DESCRIPTION
Related to #45965 . `from_trigger` is set as True for asset events from trigger with which source can be displayed as `Trigger` in the UI.

![image](https://github.com/user-attachments/assets/a2c76855-44a2-4738-a0e6-e72ec74fc577)
