### PR TITLE
fix: disable sorting for providers table columns

### DIFF
--- a/airflow/ui/src/pages/Providers.tsx
+++ b/airflow/ui/src/pages/Providers.tsx
@@ -38,11 +38,13 @@ const columns: Array<ColumnDef<ProviderResponse>> = [
         {original.package_name}
       </Link>
     ),
+    enableSorting: false,
     header: "Package Name",
   },
   {
     accessorKey: "version",
     cell: ({ row: { original } }) => original.version,
+    enableSorting: false,
     header: () => "Version",
   },
   {
@@ -62,6 +64,7 @@ const columns: Array<ColumnDef<ProviderResponse>> = [
         ),
       );
     },
+    enableSorting: false,
     header: "Description",
   },
 ];


### PR DESCRIPTION
closes: #46688 

Disabling the sorting functionality in the provider list since we don't support sorting and pagination in the Airflow 2 UI, and the `GET /public/providers` endpoint does not support an `order_by` parameter.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
