### PR TITLE
Notify user on unhealthy backend container to run `beeze down`

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -81,6 +81,7 @@ from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.custom_param_types import BetterChoice, NotVerifiedBetterChoice
 from airflow_breeze.utils.docker_command_utils import (
     fix_ownership_using_docker,
+    notify_on_unhealthy_backend_container,
     perform_environment_checks,
     remove_docker_networks,
 )
@@ -224,6 +225,10 @@ def _run_test(
             output_outside_the_group=output_outside_the_group,
             env=env,
         )
+        if result.returncode != 0:
+            notify_on_unhealthy_backend_container(
+                project_name=project_name, backend=shell_params.backend, output=output
+            )
         if os.environ.get("CI") == "true" and result.returncode != 0:
             ps_result = run_command(
                 ["docker", "ps", "--all", "--format", "{{.Names}}"],

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -843,7 +843,51 @@ def enter_shell(shell_params: ShellParams, output: Output | None = None) -> RunC
         get_console().print(f"[red]Error {command_result.returncode} returned[/]")
         if get_verbose():
             get_console().print(command_result.stderr)
+        notify_on_unhealthy_backend_container(shell_params.project_name, shell_params.backend, output)
         return command_result
+
+
+def notify_on_unhealthy_backend_container(project_name: str, backend: str, output: Output | None = None):
+    """Put emphasis on unhealthy backend container and `breeze down` command for user."""
+    if backend not in ["postgres", "mysql"] or os.environ.get("CI") == "true":
+        return
+
+    if _is_backend_container_unhealthy(project_name, backend):
+        get_console(output=output).print(
+            "[warning]The backend container is unhealthy. You might need to run `down` "
+            "command to clean up:\n\n"
+            "\tbreeze down[/]\n"
+        )
+
+
+def _is_backend_container_unhealthy(project_name: str, backend: str) -> bool:
+    try:
+        filter = f"name={project_name}-{backend}"
+        search_response = run_command(
+            ["docker", "ps", "--filter", filter, "--format={{.Names}}"],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        container_name = search_response.stdout.strip()
+
+        # Skip the check if not found or multiple containers found
+        if len(container_name.strip().splitlines()) != 1:
+            return False
+
+        inspect_response = run_command(
+            ["docker", "inspect", "--format={{.State.Health.Status}}", container_name],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if inspect_response.returncode == 0:
+            return inspect_response.stdout.strip() == "unhealthy"
+    # We don't want to misguide the user, so in case of any error we skip the check
+    except Exception:
+        pass
+
+    return False
 
 
 def is_docker_rootless() -> bool:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR intends to inform the user that they can resolve the backend container stuck in an `unhealthy` state by running the `breeze down` command.

- Add unhealthy check for backend container with console notification message via `docker inspect`;
- Do not run a check on not `postgres` / `mysql` backends or in CI;
- Default to not show the notification in case of doubt or any error;
- Use the check for `_run_test` and `enter_shell` routines;

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
