### PR TITLE
Remove assert in example DAG

### DIFF
--- a/providers/edge/src/airflow/providers/edge/example_dags/integration_test.py
+++ b/providers/edge/src/airflow/providers/edge/example_dags/integration_test.py
@@ -99,7 +99,8 @@ with DAG(
     @task
     def variable():
         Variable.set("integration_test_key", "value")
-        assert Variable.get("integration_test_key") == "value"
+        if Variable.get("integration_test_key") != "value":
+            raise ValueError("Variable not set as expected.")
         Variable.delete("integration_test_key")
 
     @task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,8 +374,6 @@ testing = ["dev", "providers.tests", "task_sdk.tests", "tests_common", "tests"]
 "kubernetes_tests/*" = ["D", "TID253", "S101", "TRY002"]
 "helm_tests/*" = ["D", "TID253", "S101", "TRY002"]
 "providers/**/tests/*" = ["D", "TID253", "S101", "TRY002"]
-# exclude assert in edge provider
-"providers/edge/src/airflow/providers/edge/example_dags/integration_test.py" = ["S101"]
 
 # All of the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level


### PR DESCRIPTION
As I reviewed #46608 I noticed that there is a S101 exception noted for the example DAG.

This PR cleans this up.