### PR TITLE
Using env for file path in find command

### DIFF
--- a/providers/docker/tests/system/docker/example_docker_copy_data.py
+++ b/providers/docker/tests/system/docker/example_docker_copy_data.py
@@ -27,7 +27,6 @@ your environment & enable the code.
 from __future__ import annotations
 
 import os
-import shlex
 from datetime import datetime
 
 from docker.types import Mount
@@ -49,7 +48,7 @@ with models.DAG(
 ) as dag:
     locate_file_cmd = f"""
         sleep 10
-        find {shlex.quote("{{ params.source_location }}")} -type f -printf "%f\\n" | head -1
+        find $LOCATION -type f -printf "%f\\n" | head -1
     """
 
     t_view = BashOperator(
@@ -57,6 +56,7 @@ with models.DAG(
         bash_command=locate_file_cmd,
         do_xcom_push=True,
         params={"source_location": "/your/input_dir/path"},
+        env={"LOCATION": "{{ params.source_location }}"},
         dag=dag,
     )
 


### PR DESCRIPTION
The original patch can still be bypassed by passing payloads such as:

```json
{
    "source_location": "'; id>/tmp/pwned; '"
}
```

The issue persists because `shlex.quote` is applied before the template engine processes the input.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
