### PR TITLE
Add log grouping using summary and details tag.

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -42,6 +42,7 @@
     "react-hook-form": "^7.20.0",
     "react-hotkeys-hook": "^4.6.1",
     "react-icons": "^5.4.0",
+    "react-innertext": "^1.1.5",
     "react-json-view": "^1.21.3",
     "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.7",

--- a/airflow/ui/pnpm-lock.yaml
+++ b/airflow/ui/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-icons:
         specifier: ^5.4.0
         version: 5.4.0(react@18.3.1)
+      react-innertext:
+        specifier: ^1.1.5
+        version: 1.1.5(@types/react@18.3.5)(react@18.3.1)
       react-json-view:
         specifier: ^1.21.3
         version: 1.21.3(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3480,6 +3483,12 @@ packages:
     resolution: {integrity: sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==}
     peerDependencies:
       react: '*'
+
+  react-innertext@1.1.5:
+    resolution: {integrity: sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==}
+    peerDependencies:
+      '@types/react': '>=0.0.0 <=99'
+      react: '>=0.0.0 <=99'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8513,6 +8522,11 @@ snapshots:
 
   react-icons@5.4.0(react@18.3.1):
     dependencies:
+      react: 18.3.1
+
+  react-innertext@1.1.5(@types/react@18.3.5)(react@18.3.1):
+    dependencies:
+      '@types/react': 18.3.5
       react: 18.3.1
 
   react-is@16.13.1: {}

--- a/airflow/ui/src/mocks/handlers/index.ts
+++ b/airflow/ui/src/mocks/handlers/index.ts
@@ -19,5 +19,6 @@
 import { handlers as configHandlers } from "./config";
 import { handlers as dagHandlers } from "./dag";
 import { handlers as dagsHandlers } from "./dags";
+import { handlers as logHandlers } from "./log";
 
-export const handlers = [...configHandlers, ...dagHandlers, ...dagsHandlers];
+export const handlers = [...configHandlers, ...dagHandlers, ...dagsHandlers, ...logHandlers];

--- a/airflow/ui/src/mocks/handlers/log.ts
+++ b/airflow/ui/src/mocks/handlers/log.ts
@@ -1,0 +1,75 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable unicorn/no-null */
+import { http, HttpResponse, type HttpHandler } from "msw";
+
+export const handlers: Array<HttpHandler> = [
+  http.get("/public/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/generate/-1", () =>
+    HttpResponse.json({
+      dag_id: "log_grouping",
+      dag_run_id: "manual__2025-02-18T12:19",
+      dag_version: {
+        bundle_name: "dags-folder",
+        bundle_url: null,
+        bundle_version: null,
+        created_at: "2025-02-18T12:06:45.723238Z",
+        dag_id: "log_grouping",
+        id: "019518f4-1adb-7223-a917-45fe08b78947",
+        version_number: 1,
+      },
+      duration: 0.203_977,
+      end_date: "2025-02-18T12:19:56.467235Z",
+      executor: null,
+      executor_config: "{}",
+      hostname: "laptop",
+      id: "01951900-16f6-7c1c-ae66-91bdfe9e0cfd",
+      logical_date: null,
+      map_index: -1,
+      max_tries: 0,
+      note: null,
+      operator: "_PythonDecoratedOperator",
+      pid: 20_703,
+      pool: "default_pool",
+      pool_slots: 1,
+      priority_weight: 1,
+      queue: "default",
+      queued_when: "2025-02-18T12:19:52.311873Z",
+      rendered_fields: { op_args: "()", op_kwargs: {}, templates_dict: null },
+      rendered_map_index: null,
+      run_after: "2025-02-18T12:19:51.120210Z",
+      scheduled_when: "2025-02-18T12:19:52.289327Z",
+      start_date: "2025-02-18T12:19:56.263258Z",
+      state: "success",
+      task_display_name: "generate",
+      task_id: "generate",
+      trigger: null,
+      triggerer_job: null,
+      try_number: 1,
+      unixname: "karthikeyan",
+    }),
+  ),
+  http.get("/public/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/generate/logs/1", () =>
+    HttpResponse.json({
+      content:
+        "[2025-02-18T17:49:56.462+0530] {logging_mixin.py:212} INFO - ::group::group name\\n[2025-02-18T17:49:56.462+0530] {logging_mixin.py:212} INFO - ::group::inner group name 0\\n[2025-02-18T17:49:56.462+0530] {logging_mixin.py:212} INFO - c3dacfc301094ebbaf02172dd4808e82\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - a6d1fa3bd57c4d14a3767afa8a0a448c\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - ::endgroup::\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - ::group::inner group name 1\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - 8cd74c3beba14447a3f7cfb929b18df5\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - f5ff1c82aad048c2b9c64a349b274305\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - ::endgroup::",
+      continuation_token: "eyJlbmRfb2ZfbG9nIjp0cnVlLCJsb2dfcG9zIjozODM3fQ.8qgLbxyEzr1Z4ruegn2QGTUFJRA",
+    }),
+  ),
+];

--- a/airflow/ui/src/mocks/handlers/log.ts
+++ b/airflow/ui/src/mocks/handlers/log.ts
@@ -62,14 +62,133 @@ export const handlers: Array<HttpHandler> = [
       trigger: null,
       triggerer_job: null,
       try_number: 1,
-      unixname: "karthikeyan",
+      unixname: "testname",
     }),
   ),
   http.get("/public/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/generate/logs/1", () =>
     HttpResponse.json({
-      content:
-        "[2025-02-18T17:49:56.462+0530] {logging_mixin.py:212} INFO - ::group::group name\\n[2025-02-18T17:49:56.462+0530] {logging_mixin.py:212} INFO - ::group::inner group name 0\\n[2025-02-18T17:49:56.462+0530] {logging_mixin.py:212} INFO - c3dacfc301094ebbaf02172dd4808e82\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - a6d1fa3bd57c4d14a3767afa8a0a448c\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - ::endgroup::\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - ::group::inner group name 1\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - 8cd74c3beba14447a3f7cfb929b18df5\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - f5ff1c82aad048c2b9c64a349b274305\\n[2025-02-18T17:49:56.463+0530] {logging_mixin.py:212} INFO - ::endgroup::",
-      continuation_token: "eyJlbmRfb2ZfbG9nIjp0cnVlLCJsb2dfcG9zIjozODM3fQ.8qgLbxyEzr1Z4ruegn2QGTUFJRA",
+      content: [
+        {
+          event: "::group::Log message source details",
+          sources: [
+            "/home/airflow/logs/dag_id=tutorial_dag/run_id=manual__2025-02-28T05:18:54.249762+00:00/task_id=load/attempt=1.log",
+          ],
+        },
+        { event: "::endgroup::" },
+        {
+          event:
+            "[2025-02-28T10:49:09.535+0530] {local_task_job_runner.py:120} INFO - ::group::Pre task execution logs",
+          timestamp: "2025-02-28T10:49:09.535000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.674+0530] {taskinstance.py:2348} INFO - Dependencies all met for dep_context=non-requeueable deps ti=<TaskInstance: tutorial_dag.load manual__2025-02-28T05:18:54.249762+00:00 [queued]>",
+          timestamp: "2025-02-28T10:49:09.674000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.678+0530] {taskinstance.py:2348} INFO - Dependencies all met for dep_context=requeueable deps ti=<TaskInstance: tutorial_dag.load manual__2025-02-28T05:18:54.249762+00:00 [queued]>",
+          timestamp: "2025-02-28T10:49:09.678000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.679+0530] {taskinstance.py:2589} INFO - Starting attempt 1 of 3",
+          timestamp: "2025-02-28T10:49:09.679000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.697+0530] {taskinstance.py:2612} INFO - Executing <Task(PythonOperator): load> on 2025-02-25 06:42:00+00:00",
+          timestamp: "2025-02-28T10:49:09.697000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.704+0530] {standard_task_runner.py:131} INFO - Started process 24882 to run task",
+          timestamp: "2025-02-28T10:49:09.704000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.706+0530] {standard_task_runner.py:147} INFO - Running: ['airflow', 'tasks', 'run', 'tutorial_dag', 'load', 'manual__2025-02-28T05:18:54.249762+00:00', '--raw', '--subdir', '/home/airflow/airflow/example_dags/tutorial_dag.py', '--cfg-path', '/tmp/tmpglv7rpjo']",
+          timestamp: "2025-02-28T10:49:09.706000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.707+0530] {standard_task_runner.py:148} INFO - Subtask load",
+          timestamp: "2025-02-28T10:49:09.707000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.740+0530] {task_command.py:442} INFO - Running <TaskInstance: tutorial_dag.load manual__2025-02-28T05:18:54.249762+00:00 [running]> on host laptop",
+          timestamp: "2025-02-28T10:49:09.740000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.841+0530] {taskinstance.py:2897} INFO - Exporting env vars: AIRFLOW_CTX_DAG_OWNER='airflow' AIRFLOW_CTX_DAG_ID='tutorial_dag' AIRFLOW_CTX_TASK_ID='load' AIRFLOW_CTX_LOGICAL_DATE='2025-02-25T06:42:00+00:00' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2025-02-28T05:18:54.249762+00:00'",
+          timestamp: "2025-02-28T10:49:09.841000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.842+0530] {logging_mixin.py:212} INFO - Task instance is in running state",
+          timestamp: "2025-02-28T10:49:09.842000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.842+0530] {logging_mixin.py:212} INFO -  Previous state of the Task instance: queued",
+          timestamp: "2025-02-28T10:49:09.842000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.848+0530] {logging_mixin.py:212} INFO - Current task name:load",
+          timestamp: "2025-02-28T10:49:09.848000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.848+0530] {logging_mixin.py:212} INFO - Dag name:tutorial_dag",
+          timestamp: "2025-02-28T10:49:09.848000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.848+0530] {taskinstance.py:689} INFO - ::endgroup::",
+          timestamp: "2025-02-28T10:49:09.848000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.852+0530] {logging_mixin.py:212} INFO - {'total_order_value': 1236.7}",
+          timestamp: "2025-02-28T10:49:09.852000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.852+0530] {python.py:198} INFO - Done. Returned value was: None",
+          timestamp: "2025-02-28T10:49:09.852000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.856+0530] {taskinstance.py:335} INFO - ::group::Post task execution logs",
+          timestamp: "2025-02-28T10:49:09.856000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.856+0530] {taskinstance.py:347} INFO - Marking task as SUCCESS. dag_id=tutorial_dag, task_id=load, run_id=manual__2025-02-28T05:18:54.249762+00:00, logical_date=20250225T064200, start_date=20250228T051909, end_date=20250228T051909",
+          timestamp: "2025-02-28T10:49:09.856000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.871+0530] {logging_mixin.py:212} INFO - Task instance in success state",
+          timestamp: "2025-02-28T10:49:09.871000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.872+0530] {logging_mixin.py:212} INFO -  Previous state of the Task instance: running",
+          timestamp: "2025-02-28T10:49:09.872000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.875+0530] {logging_mixin.py:212} INFO - Task operator:<Task(PythonOperator): load>",
+          timestamp: "2025-02-28T10:49:09.875000+05:30",
+        },
+        {
+          event:
+            "[2025-02-28T10:49:09.920+0530] {local_task_job_runner.py:262} INFO - Task exited with return code 0",
+          timestamp: "2025-02-28T10:49:09.920000+05:30",
+        },
+        {
+          event: "[2025-02-28T10:49:09.920+0530] {local_task_job_runner.py:241} INFO - ::endgroup::",
+          timestamp: "2025-02-28T10:49:09.920000+05:30",
+        },
+      ],
+      continuation_token: null,
     }),
   ),
 ];

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -1,0 +1,51 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { setupServer, type SetupServerApi } from "msw/node";
+import { afterEach, describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { handlers } from "src/mocks/handlers";
+import { AppWrapper } from "src/utils/AppWrapper";
+
+let server: SetupServerApi;
+
+beforeAll(() => {
+  server = setupServer(...handlers);
+  server.listen({ onUnhandledRequest: "bypass" });
+});
+
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("Task log grouping", () => {
+  it("Display task log content on click", async () => {
+    render(
+      <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("summary-group name")).toBeVisible());
+
+    await waitFor(() => expect(screen.queryByText(/inner group name 0/iu)).not.toBeVisible());
+    await waitFor(() => expect(screen.queryByTestId("summary-inner group name 0")).not.toBeInTheDocument());
+
+    await waitFor(() => screen.getByTestId("summary-group name").click());
+    await waitFor(() => expect(screen.queryByText(/inner group name 0/iu)).toBeVisible());
+  });
+});

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -40,7 +40,9 @@ describe("Task log grouping", () => {
       <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
     );
 
-    await waitFor(() => expect(screen.queryByTestId("summary-Pre task execution logs")).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByTestId("summary-Pre task execution logs")).toBeInTheDocument(), {
+      timeout: 10_000,
+    });
     await waitFor(() => expect(screen.getByTestId("summary-Pre task execution logs")).toBeVisible());
     await waitFor(() => expect(screen.queryByText(/Task instance is in running state/iu)).not.toBeVisible());
 

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -40,12 +40,11 @@ describe("Task log grouping", () => {
       <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
     );
 
-    await waitFor(() => expect(screen.getByTestId("summary-group name")).toBeVisible());
+    await waitFor(() => expect(screen.queryByTestId("summary-Pre task execution logs")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId("summary-Pre task execution logs")).toBeVisible());
+    await waitFor(() => expect(screen.queryByText(/Task instance is in running state/iu)).not.toBeVisible());
 
-    await waitFor(() => expect(screen.queryByText(/inner group name 0/iu)).not.toBeVisible());
-    await waitFor(() => expect(screen.queryByTestId("summary-inner group name 0")).not.toBeInTheDocument());
-
-    await waitFor(() => screen.getByTestId("summary-group name").click());
-    await waitFor(() => expect(screen.queryByText(/inner group name 0/iu)).toBeVisible());
+    await waitFor(() => screen.getByTestId("summary-Pre task execution logs").click());
+    await waitFor(() => expect(screen.queryByText(/Task instance is in running state/iu)).toBeVisible());
   });
 });

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -122,17 +122,18 @@ const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
   let groupLines: Array<string> = [];
   let groupName = "";
 
+  // TODO: Add support for nested groups
   /* eslint-disable react/no-array-index-key */
   const parsedLines = lines.map((line, index) => {
-    if (line.includes("::group::")) {
+    if (line.includes("::group::") && !startGroup) {
       startGroup = true;
       groupName = line.split("::group::")[1] as string;
     } else if (line.includes("::endgroup::")) {
       startGroup = false;
       groupLines.push(line);
       const group = (
-        <details>
-          <summary>
+        <details key={groupName}>
+          <summary data-testid={`summary-${groupName}`}>
             <Text as="span" color="fg.info" cursor="pointer">
               {groupName}
             </Text>

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Badge } from "@chakra-ui/react";
+import { Badge, Text } from "@chakra-ui/react";
 import type { UseQueryOptions } from "@tanstack/react-query";
 import dayjs from "dayjs";
 
@@ -117,6 +117,47 @@ const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
 
     return { data, warning };
   }
+
+  let startGroup = false;
+  let groupLines: Array<string> = [];
+  let groupName = "";
+
+  /* eslint-disable react/no-array-index-key */
+  const parsedLines = lines.map((line, index) => {
+    if (line.includes("::group::")) {
+      startGroup = true;
+      groupName = line.split("::group::")[1] as string;
+    } else if (line.includes("::endgroup::")) {
+      startGroup = false;
+      groupLines.push(line);
+      const group = (
+        <details>
+          <summary>
+            <Text as="span" color="fg.info" cursor="pointer">
+              {groupName}
+            </Text>
+          </summary>
+          {groupLines.map((text, groupIndex) => (
+            <Text key={groupIndex} py={1}>
+              {text}
+            </Text>
+          ))}
+        </details>
+      );
+
+      groupLines = [];
+
+      return group;
+    }
+
+    if (startGroup) {
+      groupLines.push(line);
+
+      return undefined;
+    } else {
+      return <Text key={index}>{line}</Text>;
+    }
+  });
 
   return {
     fileSources: [],

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -43,10 +43,6 @@ type ParseLogsProps = {
   logLevelFilters?: Array<string>;
 };
 
-let startGroup = false;
-let groupLines: Array<JSX.Element | ""> = [];
-let groupName = "";
-
 const renderStructuredLog = (
   logMessage: string | StructuredLogMessage,
   index: number,
@@ -118,6 +114,9 @@ const renderStructuredLog = (
 const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
   let warning;
   let parsedLines;
+  let startGroup = false;
+  let groupLines: Array<JSX.Element | ""> = [];
+  let groupName = "";
 
   try {
     parsedLines = data.map((datum, index) => renderStructuredLog(datum, index, logLevelFilters));

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -132,7 +132,7 @@ const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
   }
 
   // TODO: Add support for nested groups
-  /* eslint-disable react/no-array-index-key */
+
   parsedLines = parsedLines.map((line) => {
     const text = innerText(line);
 
@@ -148,11 +148,7 @@ const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
               {groupName}
             </Text>
           </summary>
-          {groupLines.map((groupLine, groupIndex) => (
-            <Text backgroundColor="bg.emphasized" key={groupIndex}>
-              {groupLine}
-            </Text>
-          ))}
+          {groupLines}
         </details>
       );
 

--- a/airflow/ui/testsSetup.ts
+++ b/airflow/ui/testsSetup.ts
@@ -20,7 +20,7 @@ import * as matchers from "@testing-library/jest-dom/matchers";
 import "@testing-library/jest-dom/vitest";
 import type { HttpHandler } from "msw";
 import { setupServer, type SetupServerApi } from "msw/node";
-import { afterEach, expect, beforeAll, afterAll } from "vitest";
+import { beforeEach, expect, beforeAll, afterAll } from "vitest";
 
 import { handlers } from "src/mocks/handlers";
 
@@ -34,5 +34,5 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: "bypass" });
 });
 
-afterEach(() => server.resetHandlers());
+beforeEach(() => server.resetHandlers());
 afterAll(() => server.close());


### PR DESCRIPTION
We extensively use log grouping in Airflow 2. While looking at implementation of grouping through a prism plugin to support colors I found about `<details>` and `<summary>` tag which  has good browser support supporting almost all browsers in last 5 years. 

The implementation is to keep the group name under `<details>` and to have the group's log content under `<summary>` section which can be clicked to expand like Airflow 2. The PR involves looking for "::group::" in the log line to indicate the log group start marker and collect the subsequent lines till line with "::endgroup::" is reached and wrap them up in the `<details>` tag as a section. The code logic and styling around this can be improved but I felt this is a good enough to open a PR for discussion. This also makes the implementation simpler compared to Airflow 2.

Docs : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details

Notes to reviewer and self 

1. It seems "::group::<name>" is the documented approach though code also supports "##group##<name>" . Do we need to support this? 
2. I just used split string by "::group::" and capture the part after marker as name instead of regex to extract group name for simplicity but it can be made as a regex.

![image](https://github.com/user-attachments/assets/6ff33886-bc12-4c60-b47b-d946664cac6c)
