### PR TITLE
Speed-up check-default-configuration pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -215,12 +215,6 @@ repos:
         files: ^airflow/models/taskinstance.py$|^airflow/models/taskinstancehistory.py$
         pass_filenames: false
         require_serial: true
-      - id: check-default-configuration
-        name: Check the default configuration
-        entry: ./scripts/ci/pre_commit/check_default_configuration.py
-        language: python
-        additional_dependencies: ['rich>=12.4.4']
-        always_run: true
       - id: check-deferrable-default
         name: Check and fix default value of default_deferrable
         language: python
@@ -1462,4 +1456,12 @@ repos:
         pass_filenames: false
         files: ^airflow/migrations/versions/.*\.py$|^docs/apache-airflow/migrations-ref\.rst$
         additional_dependencies: ['rich>=12.4.4']
+      - id: check-default-configuration
+        name: Check the default configuration
+        entry: ./scripts/ci/pre_commit/check_default_configuration.py
+        language: python
+        additional_dependencies: ['rich>=12.4.4']
+        require_serial: true
+        pass_filenames: false
+        files: ^airflow/config_templates/config.yml
         ## ONLY ADD PRE-COMMITS HERE THAT REQUIRE CI IMAGE

--- a/contributing-docs/08_static_code_checks.rst
+++ b/contributing-docs/08_static_code_checks.rst
@@ -158,7 +158,7 @@ require Breeze Docker image to be built locally.
 +-----------------------------------------------------------+--------------------------------------------------------+---------+
 | check-decorated-operator-implements-custom-name           | Check @task decorator implements custom_operator_name  |         |
 +-----------------------------------------------------------+--------------------------------------------------------+---------+
-| check-default-configuration                               | Check the default configuration                        |         |
+| check-default-configuration                               | Check the default configuration                        | *       |
 +-----------------------------------------------------------+--------------------------------------------------------+---------+
 | check-deferrable-default                                  | Check and fix default value of default_deferrable      |         |
 +-----------------------------------------------------------+--------------------------------------------------------+---------+


### PR DESCRIPTION
The check-default-configuration pre-commit added in #46622 is slow and it's not necessary to be run always - only when configuration definition changes. Also it does not really take any files from changed PR as input, so it should be configured to not pass the files to it and to not run parallel instances - because when run with `--all-files` it will run as many parallel copies of it as many processors you have and they will essentially run the same check.

Also this pre-commit requires breeze image to be present so it should be addded at the end of pre-commit files, so that is not run when breeze image is not built.

All this behaviours have been fixed in this PR. After this change:

* only one copy of the check is run when this pre-commit runs
* in local pre-commit will only be run if config.yml changes
* in canary runs it will always run (with --all-files)
* it is marked as "breeze image" tests by placing it at the end of pre-commit configuration file

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
