### PR TITLE
Render structured logs in the new UI rather than showing raw JSON

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2145,8 +2145,11 @@ paths:
                 properties:
                   continuation_token:
                     type: string
+                    nullable: true
                   content:
-                    type: string
+                    type: array
+                    items:
+                      type: string
             text/plain:
               schema:
                 type: string

--- a/airflow/api_connexion/schemas/log_schema.py
+++ b/airflow/api_connexion/schemas/log_schema.py
@@ -24,14 +24,14 @@ from marshmallow import Schema, fields
 class LogsSchema(Schema):
     """Schema for logs."""
 
-    content = fields.Str(dump_only=True)
-    continuation_token = fields.Str(dump_only=True)
+    content = fields.List(fields.Str(dump_only=True))
+    continuation_token = fields.Str(dump_only=True, allow_none=True)
 
 
 class LogResponseObject(NamedTuple):
     """Log Response Object."""
 
-    content: str
+    content: list[str]
     continuation_token: str | None
 
 

--- a/airflow/api_fastapi/core_api/datamodels/log.py
+++ b/airflow/api_fastapi/core_api/datamodels/log.py
@@ -16,11 +16,29 @@
 # under the License.
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, WithJsonSchema
+
+
+class StructuredLogMessage(BaseModel):
+    """An individual log message."""
+
+    # Not every message has a timestamp.
+    timestamp: Annotated[
+        datetime | None,
+        # Schema level, say this is always a datetime if it exists
+        WithJsonSchema({"type": "string", "format": "date-time"}),
+    ] = None
+    event: str
+
+    model_config = ConfigDict(extra="allow")
 
 
 class TaskInstancesLogResponse(BaseModel):
     """Log serializer for responses."""
 
-    content: str
+    content: list[StructuredLogMessage] | list[str]
+    """Either a list of parsed events, or a list of lines on parse error"""
     continuation_token: str | None

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -10106,6 +10106,21 @@ components:
       - arrange
       title: StructureDataResponse
       description: Structure Data serializer for responses.
+    StructuredLogMessage:
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+        event:
+          type: string
+          title: Event
+      additionalProperties: true
+      type: object
+      required:
+      - event
+      title: StructuredLogMessage
+      description: An individual log message.
     TaskCollectionResponse:
       properties:
         tasks:
@@ -10697,7 +10712,13 @@ components:
     TaskInstancesLogResponse:
       properties:
         content:
-          type: string
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/StructuredLogMessage'
+            type: array
+          - items:
+              type: string
+            type: array
           title: Content
         continuation_token:
           anyOf:

--- a/airflow/api_fastapi/core_api/routes/public/log.py
+++ b/airflow/api_fastapi/core_api/routes/public/log.py
@@ -92,10 +92,7 @@ def get_log(
     if metadata.get("download_logs") and metadata["download_logs"]:
         full_content = True
 
-    if full_content:
-        metadata["download_logs"] = True
-    else:
-        metadata["download_logs"] = False
+    metadata["download_logs"] = full_content
 
     task_log_reader = TaskLogReader()
 

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4645,6 +4645,25 @@ export const $StructureDataResponse = {
   description: "Structure Data serializer for responses.",
 } as const;
 
+export const $StructuredLogMessage = {
+  properties: {
+    timestamp: {
+      type: "string",
+      format: "date-time",
+      title: "Timestamp",
+    },
+    event: {
+      type: "string",
+      title: "Event",
+    },
+  },
+  additionalProperties: true,
+  type: "object",
+  required: ["event"],
+  title: "StructuredLogMessage",
+  description: "An individual log message.",
+} as const;
+
 export const $TaskCollectionResponse = {
   properties: {
     tasks: {
@@ -5628,7 +5647,20 @@ export const $TaskInstancesBatchBody = {
 export const $TaskInstancesLogResponse = {
   properties: {
     content: {
-      type: "string",
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/StructuredLogMessage",
+          },
+          type: "array",
+        },
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+      ],
       title: "Content",
     },
     continuation_token: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1217,6 +1217,15 @@ export type StructureDataResponse = {
 export type arrange = "BT" | "LR" | "RL" | "TB";
 
 /**
+ * An individual log message.
+ */
+export type StructuredLogMessage = {
+  timestamp?: string;
+  event: string;
+  [key: string]: unknown | string;
+};
+
+/**
  * Task collection serializer for responses.
  */
 export type TaskCollectionResponse = {
@@ -1393,7 +1402,7 @@ export type TaskInstancesBatchBody = {
  * Log serializer for responses.
  */
 export type TaskInstancesLogResponse = {
-  content: string;
+  content: Array<StructuredLogMessage> | Array<string>;
   continuation_token: string | null;
 };
 

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -19,7 +19,11 @@
 import dayjs from "dayjs";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
-import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import type {
+  StructuredLogMessage,
+  TaskInstanceResponse,
+  TaskInstancesLogResponse,
+} from "openapi/requests/types.gen";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 type Props = {
@@ -29,32 +33,36 @@ type Props = {
 };
 
 type ParseLogsProps = {
-  data: TaskInstanceResponse["content"];
+  data: TaskInstancesLogResponse["content"];
 };
 
-const renderStructuredLog = ({ event, level = undefined, timestamp = undefined, ...structured }, index) => {
+const renderStructuredLog = (logMessage: string | StructuredLogMessage, index: number) => {
+  if (typeof logMessage === "string") {
+    return <p key={index}>{logMessage}</p>;
+  }
+
+  const { event, level = undefined, timestamp, ...structured } = logMessage;
   const elements = [];
 
   if (Boolean(timestamp)) {
-    elements.push("[", <time datetime={timestamp}>{timestamp}</time>, "] ");
+    elements.push("[", <time dateTime={timestamp}>{timestamp}</time>, "] ");
   }
 
-  if (Boolean(level)) {
+  if (typeof level === "string") {
     elements.push(<span className={`log-level ${level}`}>{level.toUpperCase()}</span>, " - ");
   }
 
   elements.push(<span className="event">{event}</span>);
 
   for (const key in structured) {
-    if (!Object.hasOwn(structured, key)) {
-      continue;
+    if (Object.hasOwn(structured, key)) {
+      elements.push(
+        " ",
+        <span className={`log-key ${key}`}>
+          {key}={JSON.stringify(structured[key])}
+        </span>,
+      );
     }
-    elements.push(
-      " ",
-      <span className={`log-key ${key}`}>
-        {key}={JSON.stringify(structured[key])}
-      </span>,
-    );
   }
 
   return <p key={index}>{elements}</p>;
@@ -62,20 +70,16 @@ const renderStructuredLog = ({ event, level = undefined, timestamp = undefined, 
 
 // TODO: add support for log groups, colors, formats, filters
 const parseLogs = ({ data }: ParseLogsProps) => {
-  if (data === undefined) {
-    return {};
-  }
-  let lines;
-
   let warning;
-
   let parsedLines;
 
   try {
-    parsedLines = data.map(renderStructuredLog);
+    parsedLines = data.map((datum, index) => renderStructuredLog(datum, index));
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "An error occurred.";
+
     // eslint-disable-next-line no-console
-    console.warn(`Error parsing logs: ${error}`);
+    console.warn(`Error parsing logs: ${errorMessage}`);
     warning = "Unable to show logs. There was an error parsing logs.";
 
     return { data, warning };
@@ -111,7 +115,7 @@ export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
   );
 
   const parsedData = parseLogs({
-    data: data?.content,
+    data: data?.content ?? [],
   });
 
   return { data: parsedData, ...rest };

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -143,7 +143,7 @@ def _parse_log_lines(lines: Iterable[str]) -> Iterable[tuple[datetime | None, in
             yield timestamp, idx, log
 
 
-def _interleave_logs(*logs) -> Iterable[StructuredLogMessage]:
+def _interleave_logs(*logs: str) -> Iterable[StructuredLogMessage]:
     min_date = pendulum.datetime(2000, 1, 1)
 
     records = itertools.chain.from_iterable(_parse_log_lines(log.splitlines()) for log in logs)
@@ -462,7 +462,10 @@ class FileTaskHandler(logging.Handler):
         )
 
     def read(
-        self, task_instance, try_number: int | None = None, metadata=None
+        self,
+        task_instance: TaskInstance,
+        try_number: int | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> tuple[list[StructuredLogMessage] | str, dict[str, Any]]:
         """
         Read logs of given task instance from local machine.

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -472,7 +472,7 @@ class FileTaskHandler(logging.Handler):
 
         :param task_instance: task instance object
         :param try_number: task instance try_number to read logs from. If None
-                           it returns all logs separated by try_number
+                            it returns the log of task_instance.try_number
         :param metadata: log metadata, can be used for steaming log reading and auto-tailing.
         :return: a list of listed tuples which order log string by host
         """

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -78,10 +78,10 @@ class TaskLogReader:
         """
         if try_number is None:
             try_number = ti.try_number
-        metadata.pop("end_of_log", None)
-        metadata.pop("max_offset", None)
-        metadata.pop("offset", None)
-        metadata.pop("log_pos", None)
+
+        for key in ("end_of_log", "max_offset", "offset", "log_pos"):
+            metadata.pop(key, None)
+
         while True:
             logs, out_metadata = self.read_log_chunks(ti, try_number, metadata)
             # Update the metadata dict in place so caller can get new values/end-of-log etc.
@@ -91,6 +91,7 @@ class TaskLogReader:
                 # Optimize this so in stream mode we can just pass logs right through, or even better add
                 # support to 307 redirect to a signed URL etc.
                 yield (log if isinstance(log, str) else log.model_dump_json()) + "\n"
+
             if not out_metadata.get("end_of_log", False) and ti.state not in (
                 TaskInstanceState.RUNNING,
                 TaskInstanceState.DEFERRED,

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -380,16 +380,15 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
                 from airflow.utils.log.file_task_handler import StructuredLogMessage
 
                 header = [
-                    StructuredLogMessage.model_construct(
+                    StructuredLogMessage(
                         event="::group::Log message source details",
                         sources=[host for host in logs_by_host.keys()],
-                    ),
-                    StructuredLogMessage.model_construct(event="::endgroup::"),
+                    ),  # type: ignore[call-arg]
+                    StructuredLogMessage(event="::endgroup::"),
                 ]  # type: ignore[misc]
 
                 message = header + [
-                    StructuredLogMessage.model_construct(event=concat_logs(hits))
-                    for hits in logs_by_host.values()
+                    StructuredLogMessage(event=concat_logs(hits)) for hits in logs_by_host.values()
                 ]  # type: ignore[misc]
             else:
                 message = [

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -30,6 +30,7 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
 @pytest.mark.db_test
@@ -67,11 +68,15 @@ class TestGCSTaskHandler:
     @mock.patch("google.cloud.storage.Client")
     @mock.patch("airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id")
     @pytest.mark.parametrize(
-        "conn_id", [pytest.param("", id="no-conn"), pytest.param("my_gcs_conn", id="with-conn")]
+        "conn_id",
+        [pytest.param("", id="no-conn"), pytest.param("my_gcs_conn", id="with-conn")],
     )
     def test_client_conn_id_behavior(self, mock_get_cred, mock_client, mock_hook, conn_id):
         """When remote log conn id configured, hook will be used"""
-        mock_hook.return_value.get_credentials_and_project_id.return_value = ("test_cred", "test_proj")
+        mock_hook.return_value.get_credentials_and_project_id.return_value = (
+            "test_cred",
+            "test_proj",
+        )
         mock_get_cred.return_value = ("test_cred", "test_proj")
         with conf_vars({("logging", "remote_log_conn_id"): conn_id}):
             return_value = self.gcs_task_handler.client
@@ -104,12 +109,20 @@ class TestGCSTaskHandler:
         session.add(ti)
         session.commit()
         logs, metadata = self.gcs_task_handler._read(ti, self.ti.try_number)
-        mock_blob.from_string.assert_called_once_with(
-            "gs://bucket/remote/log/location/1.log", mock_client.return_value
-        )
-        assert "*** Found remote logs:\n***   * gs://bucket/remote/log/location/1.log\n" in logs
-        assert logs.endswith("CONTENT")
-        assert metadata == {"end_of_log": True, "log_pos": 7}
+        expected_gs_uri = f"gs://bucket/{mock_obj.name}"
+
+        mock_blob.from_string.assert_called_once_with(expected_gs_uri, mock_client.return_value)
+
+        if AIRFLOW_V_3_0_PLUS:
+            assert logs[0].event == "::group::Log message source details"
+            assert logs[0].sources == [expected_gs_uri]
+            assert logs[1].event == "::endgroup::"
+            assert logs[2].event == "CONTENT"
+            assert metadata == {"end_of_log": True, "log_pos": 1}
+        else:
+            assert f"*** Found remote logs:\n***   * {expected_gs_uri}\n" in logs
+            assert logs.endswith("CONTENT")
+            assert metadata == {"end_of_log": True, "log_pos": 7}
 
     @mock.patch(
         "airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id",
@@ -127,18 +140,26 @@ class TestGCSTaskHandler:
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
         log, metadata = self.gcs_task_handler._read(ti, self.ti.try_number)
+        expected_gs_uri = f"gs://bucket/{mock_obj.name}"
 
-        assert (
-            "*** Found remote logs:\n"
-            "***   * gs://bucket/remote/log/location/1.log\n"
-            "*** Unable to read remote log Failed to connect\n"
-            "*** Found local files:\n"
-            f"***   * {self.gcs_task_handler.local_base}/1.log\n"
-        ) in log
-        assert metadata == {"end_of_log": True, "log_pos": 0}
-        mock_blob.from_string.assert_called_once_with(
-            "gs://bucket/remote/log/location/1.log", mock_client.return_value
-        )
+        if AIRFLOW_V_3_0_PLUS:
+            assert log[0].event == "::group::Log message source details"
+            assert log[0].sources == [
+                expected_gs_uri,
+                f"{self.gcs_task_handler.local_base}/1.log",
+            ]
+            assert log[1].event == "::endgroup::"
+            assert metadata == {"end_of_log": True, "log_pos": 0}
+        else:
+            assert (
+                "*** Found remote logs:\n"
+                "***   * gs://bucket/remote/log/location/1.log\n"
+                "*** Unable to read remote log Failed to connect\n"
+                "*** Found local files:\n"
+                f"***   * {self.gcs_task_handler.local_base}/1.log\n"
+            ) in log
+            assert metadata == {"end_of_log": True, "log_pos": 0}
+        mock_blob.from_string.assert_called_once_with(expected_gs_uri, mock_client.return_value)
 
     @mock.patch(
         "airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 from azure.core.exceptions import HttpResponseError
 
 from airflow.configuration import conf
+from airflow.providers.microsoft.azure.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -137,9 +138,13 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
 
         if blob_names:
             uris = [f"https://{self.wasb_container}.blob.core.windows.net/{b}" for b in blob_names]
-            messages.extend(["Found remote logs:", *[f"  * {x}" for x in sorted(uris)]])
+            if AIRFLOW_V_3_0_PLUS:
+                messages = uris
+            else:
+                messages.extend(["Found remote logs:", *[f"  * {x}" for x in sorted(uris)]])
         else:
-            messages.append(f"No logs found in WASB; ti=%s {ti}")
+            if not AIRFLOW_V_3_0_PLUS:
+                messages.append(f"No logs found in WASB; ti=%s {ti}")
 
         for name in sorted(blob_names):
             remote_log = ""

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/version_compat.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/version_compat.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# NOTE! THIS FILE IS COPIED MANUALLY IN OTHER PROVIDERS DELIBERATELY TO AVOID ADDING UNNECESSARY
+# DEPENDENCIES BETWEEN PROVIDERS. IF YOU WANT TO ADD CONDITIONAL CODE IN YOUR PROVIDER THAT DEPENDS
+# ON AIRFLOW VERSION, PLEASE COPY THIS FILE TO THE ROOT PACKAGE OF YOUR PROVIDER AND IMPORT
+# THOSE CONSTANTS FROM IT RATHER THAN IMPORTING THEM FROM ANOTHER PROVIDER OR TEST CODE
+#
+from __future__ import annotations
+
+
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    from packaging.version import Version
+
+    from airflow import __version__
+
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
+
+
+AIRFLOW_V_2_10_PLUS = get_base_airflow_version_tuple() >= (2, 10, 0)
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -44,6 +44,18 @@ from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
+
+
+if AIRFLOW_V_3_0_PLUS:
+    from typing import Union
+
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    OsLogMsgType = Union[list[StructuredLogMessage], str]
+else:
+    OsLogMsgType = list[tuple[str, str]]  # type: ignore[misc]
+
+
 USE_PER_RUN_LOG_ID = hasattr(DagRun, "get_log_template")
 OsLogMsgType = list[tuple[str, str]]
 LOG_LINE_DEFAULTS = {"exc_text": "", "stack_info": ""}

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -409,16 +409,15 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
                 from airflow.utils.log.file_task_handler import StructuredLogMessage
 
                 header = [
-                    StructuredLogMessage.model_construct(
+                    StructuredLogMessage(
                         event="::group::Log message source details",
                         sources=[host for host in logs_by_host.keys()],
-                    ),
-                    StructuredLogMessage.model_construct(event="::endgroup::"),
+                    ),  # type: ignore[call-arg]
+                    StructuredLogMessage(event="::endgroup::"),
                 ]
 
                 message = header + [
-                    StructuredLogMessage.model_construct(event=concat_logs(hits))
-                    for hits in logs_by_host.values()
+                    StructuredLogMessage(event=concat_logs(hits)) for hits in logs_by_host.values()
                 ]
             else:
                 message = [(host, concat_logs(hits)) for host, hits in logs_by_host.items()]  # type: ignore[misc]

--- a/providers/redis/src/airflow/providers/redis/log/redis_task_handler.py
+++ b/providers/redis/src/airflow/providers/redis/log/redis_task_handler.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.providers.redis.hooks.redis import RedisHook
+from airflow.providers.redis.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -79,6 +80,8 @@ class RedisTaskHandler(FileTaskHandler, LoggingMixin):
         log_str = b"\n".join(
             self.conn.lrange(self._render_filename(ti, try_number), start=0, end=-1)
         ).decode()
+        if AIRFLOW_V_3_0_PLUS:
+            log_str = [log_str]  # type: ignore[assignment]
         return log_str, {"end_of_log": True}
 
     def set_context(self, ti: TaskInstance, **kwargs) -> None:

--- a/providers/redis/src/airflow/providers/redis/version_compat.py
+++ b/providers/redis/src/airflow/providers/redis/version_compat.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# NOTE! THIS FILE IS COPIED MANUALLY IN OTHER PROVIDERS DELIBERATELY TO AVOID ADDING UNNECESSARY
+# DEPENDENCIES BETWEEN PROVIDERS. IF YOU WANT TO ADD CONDITIONAL CODE IN YOUR PROVIDER THAT DEPENDS
+# ON AIRFLOW VERSION, PLEASE COPY THIS FILE TO THE ROOT PACKAGE OF YOUR PROVIDER AND IMPORT
+# THOSE CONSTANTS FROM IT RATHER THAN IMPORTING THEM FROM ANOTHER PROVIDER OR TEST CODE
+#
+from __future__ import annotations
+
+
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    from packaging.version import Version
+
+    from airflow import __version__
+
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
+
+
+AIRFLOW_V_2_10_PLUS = get_base_airflow_version_tuple() >= (2, 10, 0)
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -51,7 +51,12 @@ class TestRedisTaskHandler:
                 run_type="scheduled",
             )
         else:
-            dag_run = DagRun(dag_id=dag.dag_id, execution_date=date, run_id="test", run_type="scheduled")
+            dag_run = DagRun(
+                dag_id=dag.dag_id,
+                execution_date=date,
+                run_id="test",
+                run_type="scheduled",
+            )
 
         dag_run.set_state(State.RUNNING)
         with create_session() as session:
@@ -105,5 +110,8 @@ class TestRedisTaskHandler:
             lrange.return_value = [b"Line 1", b"Line 2"]
             logs = handler.read(ti)
 
-        assert logs == ([[("", "Line 1\nLine 2")]], [{"end_of_log": True}])
+        if AIRFLOW_V_3_0_PLUS:
+            assert logs == (["Line 1\nLine 2"], {"end_of_log": True})
+        else:
+            assert logs == ([[("", "Line 1\nLine 2")]], [{"end_of_log": True}])
         lrange.assert_called_once_with(key, start=0, end=-1)

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -183,9 +183,11 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/test_version_compat.py",
             "providers/http/tests/unit/http/test_exceptions.py",
             "providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adls.py",
+            "providers/microsoft/azure/tests/unit/microsoft/azure/test_version_compat.py",
             "providers/openlineage/tests/unit/openlineage/test_version_compat.py",
             "providers/opensearch/tests/unit/opensearch/test_version_compat.py",
             "providers/presto/tests/unit/presto/test_version_compat.py",
+            "providers/redis/tests/unit/redis/test_version_compat.py",
             "providers/snowflake/tests/unit/snowflake/triggers/test_snowflake_trigger.py",
             "providers/standard/tests/unit/standard/operators/test_empty.py",
             "providers/standard/tests/unit/standard/operators/test_latest_only.py",
@@ -558,8 +560,7 @@ class TestGoogleProviderProjectStructure(ExampleCoverageTest, AssetsCoverageTest
         "GoogleCampaignManagerReportSensor",
         "airflow.providers.google.marketing_platform.sensors.display_video."
         "GoogleDisplayVideo360GetSDFDownloadOperationSensor",
-        "airflow.providers.google.marketing_platform.sensors.display_video."
-        "GoogleDisplayVideo360ReportSensor",
+        "airflow.providers.google.marketing_platform.sensors.display_video.GoogleDisplayVideo360ReportSensor",
     }
 
     @pytest.mark.xfail(reason="We did not reach full coverage yet")

--- a/tests/api_fastapi/core_api/routes/public/test_log.py
+++ b/tests/api_fastapi/core_api/routes/public/test_log.py
@@ -165,7 +165,6 @@ class TestTaskInstancesLog:
         )
         expected_filename = f"{self.log_dir}/dag_id={self.DAG_ID}/run_id={self.RUN_ID}/task_id={self.TASK_ID}/attempt={try_number}.log"
         log_content = "Log for testing." if try_number == 1 else "Log for testing 2."
-
         resp_contnt = response.json()["content"]
         assert expected_filename in resp_contnt[0]["sources"]
         assert log_content in resp_contnt[2]["event"]

--- a/tests/api_fastapi/core_api/routes/public/test_log.py
+++ b/tests/api_fastapi/core_api/routes/public/test_log.py
@@ -165,12 +165,12 @@ class TestTaskInstancesLog:
         )
         expected_filename = f"{self.log_dir}/dag_id={self.DAG_ID}/run_id={self.RUN_ID}/task_id={self.TASK_ID}/attempt={try_number}.log"
         log_content = "Log for testing." if try_number == 1 else "Log for testing 2."
-        assert "[('localhost'," in response.json()["content"]
-        assert f"*** Found local files:\\n***   * {expected_filename}\\n" in response.json()["content"]
-        assert f"{log_content}')]" in response.json()["content"]
 
-        info = serializer.loads(response.json()["continuation_token"])
-        assert info == {"end_of_log": True, "log_pos": 16 if try_number == 1 else 18}
+        resp_contnt = response.json()["content"]
+        assert expected_filename in resp_contnt[0]["sources"]
+        assert log_content in resp_contnt[2]["event"]
+
+        assert response.json()["continuation_token"] is None
         assert response.status_code == 200
 
     @pytest.mark.parametrize(
@@ -220,9 +220,10 @@ class TestTaskInstancesLog:
         assert response.status_code == 200
 
         log_content = "Log for testing." if try_number == 1 else "Log for testing 2."
-        assert "localhost\n" in response.content.decode("utf-8")
-        assert f"*** Found local files:\n***   * {expected_filename}\n" in response.content.decode("utf-8")
-        assert f"{log_content}\n" in response.content.decode("utf-8")
+        resp_content = response.content.decode("utf-8")
+
+        assert expected_filename in resp_content
+        assert log_content in resp_content
 
     @pytest.mark.parametrize(
         "request_url, expected_filename, extra_query_string, try_number",
@@ -275,9 +276,9 @@ class TestTaskInstancesLog:
         assert response.status_code == 200
 
         log_content = "Log for testing." if try_number == 1 else "Log for testing 2."
-        assert "localhost\n" in response.content.decode("utf-8")
-        assert f"*** Found local files:\n***   * {expected_filename}\n" in response.content.decode("utf-8")
-        assert f"{log_content}\n" in response.content.decode("utf-8")
+        resp_content = response.content.decode("utf-8")
+        assert expected_filename in resp_content
+        assert log_content in resp_content
 
     @pytest.mark.parametrize("try_number", [1, 2])
     def test_get_logs_response_with_ti_equal_to_none(self, try_number):
@@ -295,10 +296,10 @@ class TestTaskInstancesLog:
     @pytest.mark.parametrize("try_number", [1, 2])
     def test_get_logs_with_metadata_as_download_large_file(self, try_number):
         with mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read") as read_mock:
-            first_return = ([[("", "1st line")]], [{}])
-            second_return = ([[("", "2nd line")]], [{"end_of_log": False}])
-            third_return = ([[("", "3rd line")]], [{"end_of_log": True}])
-            fourth_return = ([[("", "should never be read")]], [{"end_of_log": True}])
+            first_return = (["", "1st line"], {})
+            second_return = (["", "2nd line"], {"end_of_log": False})
+            third_return = (["", "3rd line"], {"end_of_log": True})
+            fourth_return = (["", "should never be read"], {"end_of_log": True})
             read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
 
             response = self.client.get(

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -156,11 +156,11 @@ class TestLogView:
         stream = task_log_reader.read_log_stream(ti=ti, try_number=1, metadata={})
 
         assert list(stream) == [
-            "{"
+            '{"timestamp":null,'
             '"event":"::group::Log message source details",'
             f'"sources":["{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log"]'
             "}\n",
-            '{"event":"::endgroup::"}\n',
+            '{"timestamp":null,"event":"::endgroup::"}\n',
             '{"timestamp":null,"event":"try_number=1."}\n',
         ]
 
@@ -170,11 +170,11 @@ class TestLogView:
         stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
 
         assert list(stream) == [
-            "{"
+            '{"timestamp":null,'
             '"event":"::group::Log message source details",'
             f'"sources":["{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log"]'
             "}\n",
-            '{"event":"::endgroup::"}\n',
+            '{"timestamp":null,"event":"::endgroup::"}\n',
             '{"timestamp":null,"event":"try_number=3."}\n',
         ]
 

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -125,10 +125,9 @@ class TestLogView:
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
-        logs, metadatas = task_log_reader.read_log_chunks(ti=ti, try_number=1, metadata={})
-        assert logs[0] == [
+        logs, metadata = task_log_reader.read_log_chunks(ti=ti, try_number=1, metadata={})
+        assert logs == [
             (
-                "localhost",
                 " INFO - ::group::Log message source details\n"
                 "*** Found local files:\n"
                 f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
@@ -136,7 +135,7 @@ class TestLogView:
                 "try_number=1.",
             )
         ]
-        assert metadatas == {"end_of_log": True, "log_pos": 13}
+        assert metadata == {"end_of_log": True, "log_pos": 13}
 
     def test_test_read_log_chunks_should_read_all_files(self):
         task_log_reader = TaskLogReader()

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -669,7 +669,8 @@ def test_interleave_interleaves():
         ]
     )
 
-    tz = pendulum.tz.FixedTimezone(-28800, name="-08:00")
+    # -08:00
+    tz = pendulum.tz.fixed_timezone(-28800)
     DateTime = pendulum.DateTime
     expected = [
         {

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -481,7 +481,13 @@ class TestFileTaskLogHandler:
             logs, metadata = fth._read(ti=ti, try_number=1)
         if served_logs_checked:
             fth._read_from_logs_server.assert_called_once()
-            assert events(logs) == ["this", "log", "content"]
+            assert events(logs) == [
+                "::group::Log message source details",
+                "::endgroup::",
+                "this",
+                "log",
+                "content",
+            ]
             assert metadata == {"end_of_log": True, "log_pos": 3}
         else:
             fth._read_from_logs_server.assert_not_called()


### PR DESCRIPTION
Closes #46657

There are multiple parts to this PR

First off: the log reader interface was _a mess_ There was some odd+old code
do deal with reading from multiple hosts that made the message confusing. This
  was added for smart sensors (which went away in v2.4 or v2.5) but this mess
  remained, and reading from multiple hosts is handled differently now.

This PR keeps the current "parse+interleave" behaviour (though it's debatable
if the interleave feature is needed specifically, or if we could get away with
a simpler concat instead. Future work there if anyone wants to think about and
tackle this.) but changes the JSON resposne type from a single string (the
value of which was previoulsy a mess of double encoded JSON and repr of a
python tuple making it impossible to do anything but display at) to a list of
either strings (when it can't be parsed) or a list of
dicts/StructuredLogMessage.

I have also done some cursory rendering/displaying of these structured log
messages in the UI, but they could be greatly improved by adding colors to
various components of the log.

The current rendered HTML looks like this:

```html
<p>
    <span class="event">::group::Log message source details</span>
    <span class="log-key sources">sources=["/root/airflow/logs/dag_id=trigger_test/run_id=manual__2025-02-16T12:23:29.118614+00:00_gOTl0Qub/task_id=waiter/attempt=1.log","/root/airflow/logs/dag_id=trigger_test/run_id=manual__2025-02-16T12:23:29.118614+00:00_gOTl0Qub/task_id=waiter/attempt=1.log.trigger.14.log"]</span>
</p>
<p><span class="event">::endgroup::</span></p>
<p>[<time datetime="2025-02-16T12:23:30.033308">2025-02-16T12:23:30.033308</time>] <span class="log-level debug">DEBUG</span> - <span class="event">Hook impls: []</span> <span class="log-key logger">logger="airflow.listeners.listener"</span></p>
```

Although not used by the UI, the non-application/json content type is now
updated to a) include the continuation token as a header, and to set the
content type as application/x-ndjson

It's not the prettiest yet, I'll leave that to people more talented at that than me

<img width="1473" alt="Screenshot 2025-02-17 at 14 58 44" src="https://github.com/user-attachments/assets/64358dca-77a9-4a21-ad1b-602b3cd418fe" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
