### PR TITLE
[DRAFT] Support trino operator

### DIFF
--- a/providers/trino/docs/operators/trino.rst
+++ b/providers/trino/docs/operators/trino.rst
@@ -17,14 +17,11 @@
 
 .. _howto/operator:TrinoOperator:
 
-Connect to Trino using SQLExecuteQueryOperator
-==============================================
+TrinoOperator
+=============
 
-Use the :class:`SQLExecuteQueryOperator <airflow.providers.common.sql.operators.sql>` to execute
+Use the :class:`TrinoOperator <airflow.providers.trino.operators.trino>` to execute
 SQL commands in a `Trino <https://trino.io/>`__ query engine.
-
-.. warning::
-   TrinoOperator is deprecated in favor of SQLExecuteQueryOperator. If you are using TrinoOperator you should migrate as soon as possible.
 
 
 Using the Operator
@@ -32,7 +29,7 @@ Using the Operator
 
 Use the ``trino_conn_id`` argument to connect to your Trino instance
 
-An example usage of the SQLExecuteQueryOperator to connect to Trino is as follows:
+An example usage of the TrinoOperator to connect to Trino is as follows:
 
 .. exampleinclude:: /../../providers/trino/tests/system/trino/example_trino.py
     :language: python

--- a/providers/trino/src/airflow/providers/trino/operators/__init__.py
+++ b/providers/trino/src/airflow/providers/trino/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/trino/src/airflow/providers/trino/operators/trino.py
+++ b/providers/trino/src/airflow/providers/trino/operators/trino.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains the Trino operator."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, ClassVar, List
+
+from airflow.providers.common.sql.hooks.sql import return_single_query_results
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator, default_output_processor
+from airflow.providers.trino.hooks.trino import TrinoHook
+
+
+class TrinoOperator(SQLExecuteQueryOperator):
+    """
+    General Trino Operator to execute queries using Trino query engine.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:TrinoOperator`
+
+    :param sql: the SQL code to be executed as a single string, or
+        a list of str (sql statements), or a reference to a template file.
+    :param trino_conn_id: id of the connection config for the target Trino environment
+    :param autocommit: What to set the connection's autocommit setting to before executing the query
+    :param handler: (optional) the function that will be applied to the cursor (default: fetch_all_handler).
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :param output_processor: (optional) the function that will be applied to the result
+        (default: default_output_processor).
+    :param split_statements: (optional) if split single SQL string into statements. (default: True).
+    :param show_return_value_in_logs: (optional) if true operator output will be printed to the task log.
+        Use with caution. It's not recommended to dump large datasets to the log. (default: False).
+
+    """
+
+    template_fields: Sequence[str] = tuple(
+        {"trino_conn_id"}
+        | set(SQLExecuteQueryOperator.template_fields)
+    )
+    template_fields_renderers: ClassVar[dict] = {"sql": "sql"}
+    conn_id_field = "trino_conn_id"
+
+    def __init__(
+        self,
+        *,
+        sql: str | List[str],
+        trino_conn_id: str = TrinoHook.default_conn_name,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(sql=sql, conn_id=trino_conn_id, **kwargs)
+        self.trino_conn_id = trino_conn_id
+
+    def get_db_hook(self) -> TrinoHook:
+        return TrinoHook(self.trino_conn_id)
+
+    def execute(self, context):
+        self.log.info("Executing: %s", self.sql)
+        hook = self.get_db_hook()
+
+        if self.split_statements is not None:
+            extra_kwargs = {"split_statements": self.split_statements}
+        else:
+            extra_kwargs = {}
+
+        output = hook.run(
+            sql=self.sql,
+            autocommit=self.autocommit,
+            parameters=self.parameters,
+            handler=self.handler,
+            return_last=self.return_last,
+            **extra_kwargs,
+        )
+        if return_single_query_results(self.sql, self.return_last, self.split_statements):
+            # For simplicity, we pass always list as input to _process_output, regardless if
+            # single query results are going to be returned, and we return the first element
+            # of the list in this case from the (always) list returned by _process_output
+            return self._process_output([output], hook.descriptions)[-1]
+        result = self._process_output(output, hook.descriptions)
+        self.log.info("result: %s", result)
+        return result

--- a/providers/trino/src/airflow/providers/trino/operators/trino.py
+++ b/providers/trino/src/airflow/providers/trino/operators/trino.py
@@ -21,7 +21,7 @@ from collections.abc import Sequence
 from typing import Any, ClassVar, List
 
 from airflow.providers.common.sql.hooks.sql import return_single_query_results
-from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator, default_output_processor
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.trino.hooks.trino import TrinoHook
 
 
@@ -47,10 +47,7 @@ class TrinoOperator(SQLExecuteQueryOperator):
 
     """
 
-    template_fields: Sequence[str] = tuple(
-        {"trino_conn_id"}
-        | set(SQLExecuteQueryOperator.template_fields)
-    )
+    template_fields: Sequence[str] = tuple({"trino_conn_id"} | set(SQLExecuteQueryOperator.template_fields))
     template_fields_renderers: ClassVar[dict] = {"sql": "sql"}
     conn_id_field = "trino_conn_id"
 

--- a/providers/trino/tests/unit/trino/operators/__init__.py
+++ b/providers/trino/tests/unit/trino/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/trino/tests/unit/trino/operators/test_trino.py
+++ b/providers/trino/tests/unit/trino/operators/test_trino.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import MagicMock, Mock
+
+from airflow.exceptions import AirflowException
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.trino.hooks.trino import TrinoHook
+from airflow.providers.trino.operators.trino import TrinoOperator
+
+
+class TestTrinoOperator:
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
+    def test_get_hook_from_conn(self, mock_get_db_hook):
+        """
+        :class:`~.TrinoOperator` should use the hook returned by :meth:`airflow.models.Connection.get_hook`
+        if one is returned.
+
+        Specifically we verify here that :meth:`~.TrinoOperator.get_hook` returns the hook returned from a
+        call of ``get_hook`` on the object returned from :meth:`~.BaseHook.get_connection`.
+        """
+        mock_hook = MagicMock()
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = TrinoOperator(task_id="test", sql="")
+        assert operator.get_db_hook() == mock_hook
+
+    @mock.patch(
+        "airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook",
+        autospec=TrinoHook,
+    )
+    def test_get_hook_default(self, mock_get_db_hook):
+        """
+        If :meth:`airflow.models.Connection.get_hook` does not return a hook (e.g. because of an invalid
+        conn type), then :class:`~.TrinoHook` should be used.
+        """
+        mock_get_db_hook.return_value.side_effect = Mock(side_effect=AirflowException())
+
+        operator = TrinoOperator(task_id="test", sql="")
+        assert operator.get_db_hook().__class__.__name__ == "TrinoHook"
+
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
+    def test_execute(self, mock_get_db_hook):
+        sql = "SELECT * FROM test_table"
+        trino_conn_id = "trino_default"
+        parameters = ["value"]
+        autocommit = False
+        context = "test_context"
+        task_id = "test_task_id"
+
+        operator = TrinoOperator(sql=sql, trino_conn_id=trino_conn_id, parameters=parameters, task_id=task_id)
+        operator.execute(context=context)
+        mock_get_db_hook.return_value.run.assert_called_once_with(
+            sql=sql,
+            autocommit=autocommit,
+            parameters=parameters,
+            handler=fetch_all_handler,
+            return_last=True,
+        )
+
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
+    def test_trino_operator_test_multi(self, mock_get_db_hook):
+        sql = [
+            "CREATE TABLE IF NOT EXISTS test_airflow (dummy varchar)",
+            "TRUNCATE TABLE test_airflow",
+            "INSERT INTO test_airflow VALUES ('X')",
+        ]
+        trino_conn_id = "trino_default"
+        parameters = ["value"]
+        autocommit = False
+        context = "test_context"
+        task_id = "test_task_id"
+
+        operator = TrinoOperator(sql=sql, trino_conn_id=trino_conn_id, parameters=parameters, task_id=task_id)
+        operator.execute(context=context)
+        mock_get_db_hook.return_value.run.assert_called_once_with(
+            sql=sql,
+            autocommit=autocommit,
+            parameters=parameters,
+            handler=fetch_all_handler,
+            return_last=True,
+        )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #46808
related: #46808

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

A dedicated TrinoOperator that directly handles Trino's client protocol.
Instead of relying on XComs as relevant for different SQL databases & engines, TrinoOperator fetches all results in default, allowing developers to decide how to use them.

Trino client protocol [https://trino.io/docs/current/client/client-protocol.html#client-protocol]

closes: #46808
related: #46808
