### PR TITLE
Handle None in DagRunAssetReference

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -89,12 +89,12 @@ class DagRunAssetReference(StrictBaseModel):
 
     run_id: str
     dag_id: str
-    execution_date: datetime = Field(alias="logical_date")
+    logical_date: datetime | None
     start_date: datetime
     end_date: datetime | None
     state: str
-    data_interval_start: datetime
-    data_interval_end: datetime
+    data_interval_start: datetime | None
+    data_interval_end: datetime | None
 
 
 class AssetEventResponse(BaseModel):

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -8941,8 +8941,10 @@ components:
           type: string
           title: Dag Id
         logical_date:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Logical Date
         start_date:
           type: string
@@ -8958,12 +8960,16 @@ components:
           type: string
           title: State
         data_interval_start:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Data Interval Start
         data_interval_end:
-          type: string
-          format: date-time
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Data Interval End
       additionalProperties: false
       type: object

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2989,8 +2989,15 @@ export const $DagRunAssetReference = {
       title: "Dag Id",
     },
     logical_date: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Logical Date",
     },
     start_date: {
@@ -3015,13 +3022,27 @@ export const $DagRunAssetReference = {
       title: "State",
     },
     data_interval_start: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Data Interval Start",
     },
     data_interval_end: {
-      type: "string",
-      format: "date-time",
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Data Interval End",
     },
   },

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -771,12 +771,12 @@ export type DagProcessorInfoResponse = {
 export type DagRunAssetReference = {
   run_id: string;
   dag_id: string;
-  logical_date: string;
+  logical_date: string | null;
   start_date: string;
   end_date: string | null;
   state: string;
-  data_interval_start: string;
-  data_interval_end: string;
+  data_interval_start: string | null;
+  data_interval_end: string | null;
 };
 
 /**


### PR DESCRIPTION
Three fields can be None: logical_date, data_interval_start, and data_interval_end.

I also changed the logical_date to use the logical_date attribute instead. We’ve renamed this as a part of AIP-83, and the aliasing is no longer needed.

Fix #46765