### PR TITLE
Fix HttpSensor to enable returning xcom value

### DIFF
--- a/providers/http/src/airflow/providers/http/sensors/http.py
+++ b/providers/http/src/airflow/providers/http/sensors/http.py
@@ -30,6 +30,7 @@ from airflow.sensors.base import BaseSensorOperator
 if TYPE_CHECKING:
     try:
         from airflow.sdk.definitions.context import Context
+        from airflow.sensors.base import PokeReturnValue
     except ImportError:
         # TODO: Remove once provider drops support for Airflow 2
         from airflow.utils.context import Context
@@ -102,7 +103,7 @@ class HttpSensor(BaseSensorOperator):
         request_kwargs: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
         response_error_codes_allowlist: list[str] | None = None,
-        response_check: Callable[..., bool] | None = None,
+        response_check: Callable[..., bool | PokeReturnValue] | None = None,
         extra_options: dict[str, Any] | None = None,
         tcp_keep_alive: bool = True,
         tcp_keep_alive_idle: int = 120,
@@ -129,7 +130,7 @@ class HttpSensor(BaseSensorOperator):
         self.deferrable = deferrable
         self.request_kwargs = request_kwargs or {}
 
-    def poke(self, context: Context) -> bool:
+    def poke(self, context: Context) -> bool | PokeReturnValue:
         from airflow.utils.operator_helpers import determine_kwargs
 
         hook = HttpHook(
@@ -163,9 +164,9 @@ class HttpSensor(BaseSensorOperator):
 
         return True
 
-    def execute(self, context: Context) -> None:
+    def execute(self, context: Context) -> Any:
         if not self.deferrable or self.response_check:
-            super().execute(context=context)
+            return super().execute(context=context)
         elif not self.poke(context):
             self.defer(
                 timeout=timedelta(seconds=self.timeout),

--- a/providers/http/tests/unit/http/sensors/test_http.py
+++ b/providers/http/tests/unit/http/sensors/test_http.py
@@ -28,6 +28,7 @@ from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 from airflow.providers.http.triggers.http import HttpSensorTrigger
+from airflow.sensors.base import PokeReturnValue
 from airflow.utils.timezone import datetime
 
 pytestmark = pytest.mark.db_test
@@ -64,6 +65,33 @@ class TestHttpSensor:
         )
         with pytest.raises(AirflowException, match="AirflowException raised here!"):
             task.execute(context={})
+
+    @patch("airflow.providers.http.hooks.http.Session.send")
+    def test_poke_xcom_value(self, mock_session_send, create_task_of_operator):
+        """
+        XCom value can be generated via response_check
+        """
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b'{"data": "somedata"}'
+        response.headers["Content-Type"] = "application/json"
+        mock_session_send.return_value = response
+
+        def resp_check(rsp):
+            return PokeReturnValue(is_done=True, xcom_value=rsp.json()["data"])
+
+        task = create_task_of_operator(
+            HttpSensor,
+            dag_id="http_sensor_poke_exception",
+            task_id="http_sensor_poke_exception",
+            http_conn_id="http_default",
+            endpoint="",
+            request_params={},
+            response_check=resp_check,
+            timeout=5,
+            poke_interval=1,
+        )
+        assert task.execute(context={}) == "somedata"
 
     @patch("airflow.providers.http.hooks.http.Session.send")
     def test_poke_continues_for_http_500_with_extra_options_check_response_false(


### PR DESCRIPTION
Ensure that execute method returns xcom value when appropriate and update type hints accordingly.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
