### PR TITLE
[EDGE]Fix maintenance states during shut down

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -24,7 +24,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.18.0pre0``
+Release: ``0.18.1pre0``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -37,7 +37,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.0pre0/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.1pre0/>`_.
 
 Installation
 ------------
@@ -60,4 +60,4 @@ PIP package         Version required
 ==================  ===================
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.0pre0/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.1pre0/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.18.1pre0
+..........
+
+Fix
+~~~
+
+* ``Edge worker will not jump to maintenance request from offline maintenance during shut down.``
+
+
 0.18.0pre0
 ..........
 

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1737371680
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.18.0pre0
+  - 0.18.1pre0
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.18.0pre0"
+version = "0.18.1pre0"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -61,8 +61,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.0pre0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.0pre0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.1pre0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.18.1pre0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.18.0pre0"
+__version__ = "0.18.1pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/edge/src/airflow/providers/edge/cli/edge_command.py
@@ -236,15 +236,23 @@ class _EdgeWorkerCli:
     @staticmethod
     def _get_state() -> EdgeWorkerState:
         """State of the Edge Worker."""
-        if _EdgeWorkerCli.drain:
-            return EdgeWorkerState.TERMINATING
-        elif _EdgeWorkerCli.jobs:
-            if _EdgeWorkerCli.maintenance_mode:
+        if _EdgeWorkerCli.jobs:
+            if _EdgeWorkerCli.drain:
+                return EdgeWorkerState.TERMINATING
+            if _EdgeWorkerCli.maintenance_mode: 
                 return EdgeWorkerState.MAINTENANCE_PENDING
             return EdgeWorkerState.RUNNING
+
+        if _EdgeWorkerCli.drain:
+            if _EdgeWorkerCli.maintenance_mode:
+                return EdgeWorkerState.OFFLINE_MAINTENANCE
+            return EdgeWorkerState.OFFLINE
+            
         if _EdgeWorkerCli.maintenance_mode:
             return EdgeWorkerState.MAINTENANCE_MODE
-        return EdgeWorkerState.IDLE
+         return EdgeWorkerState.IDLE
+
+
 
     def _launch_job_af3(self, edge_job: EdgeJobFetched) -> tuple[Process, Path]:
         if TYPE_CHECKING:

--- a/providers/edge/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/edge/src/airflow/providers/edge/cli/edge_command.py
@@ -239,7 +239,7 @@ class _EdgeWorkerCli:
         if _EdgeWorkerCli.jobs:
             if _EdgeWorkerCli.drain:
                 return EdgeWorkerState.TERMINATING
-            if _EdgeWorkerCli.maintenance_mode: 
+            if _EdgeWorkerCli.maintenance_mode:
                 return EdgeWorkerState.MAINTENANCE_PENDING
             return EdgeWorkerState.RUNNING
 

--- a/providers/edge/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/edge/src/airflow/providers/edge/cli/edge_command.py
@@ -247,12 +247,10 @@ class _EdgeWorkerCli:
             if _EdgeWorkerCli.maintenance_mode:
                 return EdgeWorkerState.OFFLINE_MAINTENANCE
             return EdgeWorkerState.OFFLINE
-            
+
         if _EdgeWorkerCli.maintenance_mode:
             return EdgeWorkerState.MAINTENANCE_MODE
-         return EdgeWorkerState.IDLE
-
-
+        return EdgeWorkerState.IDLE
 
     def _launch_job_af3(self, edge_job: EdgeJobFetched) -> tuple[Process, Path]:
         if TYPE_CHECKING:

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1737371680,
-        "versions": ["0.18.0pre0"],
+        "versions": ["0.18.1pre0"],
         "plugins": [
             {
                 "name": "edge_executor",

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/worker.py
@@ -125,6 +125,7 @@ def redefine_state_if_maintenance(
             EdgeWorkerState.MAINTENANCE_MODE,
         )
         or worker_state == EdgeWorkerState.OFFLINE_MAINTENANCE
+        and body_state == EdgeWorkerState.STARTING
     ):
         return EdgeWorkerState.MAINTENANCE_REQUEST
 

--- a/providers/edge/tests/unit/edge/cli/test_edge_command.py
+++ b/providers/edge/tests/unit/edge/cli/test_edge_command.py
@@ -305,7 +305,7 @@ class TestEdgeWorkerCli:
 
     @pytest.mark.parametrize(
         "drain, maintenance_mode, jobs, expected_state",
-        [   
+        [
             pytest.param(False, False, False, EdgeWorkerState.IDLE, id="idle"),
             pytest.param(False, False, True, EdgeWorkerState.RUNNING, id="running_jobs"),
             pytest.param(False, True, False, EdgeWorkerState.MAINTENANCE_MODE, id="maintenance_no_job"),
@@ -313,8 +313,8 @@ class TestEdgeWorkerCli:
                 False, True, True, EdgeWorkerState.MAINTENANCE_PENDING, id="maintenance_running_jobs"
             ),
             pytest.param(True, False, False, EdgeWorkerState.OFFLINE, id="shut_down"),
-            pytest.param(True, False, True, EdgeWorkerState.TERMINATING, id="terminating"),           
-            pytest.param(True, True, False, EdgeWorkerState.OFFLINE_MAINTENANCE, id="offline_maintenance"),           
+            pytest.param(True, False, True, EdgeWorkerState.TERMINATING, id="terminating"),
+            pytest.param(True, True, False, EdgeWorkerState.OFFLINE_MAINTENANCE, id="offline_maintenance"),
             pytest.param(True, True, True, EdgeWorkerState.TERMINATING, id="maintenance_shut_down"),
         ],
     )

--- a/providers/edge/tests/unit/edge/cli/test_edge_command.py
+++ b/providers/edge/tests/unit/edge/cli/test_edge_command.py
@@ -305,14 +305,16 @@ class TestEdgeWorkerCli:
 
     @pytest.mark.parametrize(
         "drain, maintenance_mode, jobs, expected_state",
-        [
-            pytest.param(False, False, True, EdgeWorkerState.RUNNING, id="running_jobs"),
-            pytest.param(True, False, True, EdgeWorkerState.TERMINATING, id="shutting_down"),
+        [   
             pytest.param(False, False, False, EdgeWorkerState.IDLE, id="idle"),
+            pytest.param(False, False, True, EdgeWorkerState.RUNNING, id="running_jobs"),
+            pytest.param(False, True, False, EdgeWorkerState.MAINTENANCE_MODE, id="maintenance_no_job"),
             pytest.param(
                 False, True, True, EdgeWorkerState.MAINTENANCE_PENDING, id="maintenance_running_jobs"
             ),
-            pytest.param(False, True, False, EdgeWorkerState.MAINTENANCE_MODE, id="maintenance_no_job"),
+            pytest.param(True, False, False, EdgeWorkerState.OFFLINE, id="shut_down"),
+            pytest.param(True, False, True, EdgeWorkerState.TERMINATING, id="terminating"),           
+            pytest.param(True, True, False, EdgeWorkerState.OFFLINE_MAINTENANCE, id="offline_maintenance"),           
             pytest.param(True, True, True, EdgeWorkerState.TERMINATING, id="maintenance_shut_down"),
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
When a worker is registered, and it was in offline maintenance, we set the state to maintenance request. However, this has a side effect. During graceful shut down we set the state to offline maintenance, and if we are not lucky, the heartbeat is called again, which will set the state to maintenance request from offline maintenance during shut down.
Solution: Only modify offline maintenance to maintenance request if the worker is starting up

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
