### PR TITLE
Add a note `airflow users` command is available when FAB auth-manager is enabled

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -463,7 +463,7 @@ see in CI in your local environment.
                 --email admin@example.org
 
 .. note::
-    ``airflow users`` command is only available when the FAB auth manager is enabled.
+    ``airflow users`` command is only available when FAB auth manager is enabled.
 
 7. Exiting the Breeze environment. After successfully finishing above command will leave you in container,
    type ``exit`` to exit the container. The database created before will remain and servers will be

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -462,6 +462,8 @@ see in CI in your local environment.
                 --role Admin \
                 --email admin@example.org
 
+.. note::
+    ``airflow users`` command is only available when the FAB auth manager is enabled.
 
 7. Exiting the Breeze environment. After successfully finishing above command will leave you in container,
    type ``exit`` to exit the container. The database created before will remain and servers will be

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -463,7 +463,7 @@ see in CI in your local environment.
                 --email admin@example.org
 
 .. note::
-    ``airflow users`` command is only available when FAB auth manager is enabled.
+    ``airflow users`` command is only available when `FAB auth manager <https://airflow.apache.org/docs/apache-airflow-providers-fab/stable/auth-manager/index.html>`_ is enabled.
 
 7. Exiting the Breeze environment. After successfully finishing above command will leave you in container,
    type ``exit`` to exit the container. The database created before will remain and servers will be

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -94,6 +94,9 @@ Before running the webserver, you need to initialize the database:
          --firstname foo \
          --lastname bar
 
+.. note::
+    ``airflow users`` command is only available when the FAB auth manager is enabled.
+
 Starting Airflow
 --------------
 

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -95,7 +95,7 @@ Before running the webserver, you need to initialize the database:
          --lastname bar
 
 .. note::
-    ``airflow users`` command is only available when the FAB auth manager is enabled.
+    ``airflow users`` command is only available when FAB auth manager is enabled.
 
 Starting Airflow
 --------------

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -95,7 +95,7 @@ Before running the webserver, you need to initialize the database:
          --lastname bar
 
 .. note::
-    ``airflow users`` command is only available when FAB auth manager is enabled.
+    ``airflow users`` command is only available when `FAB auth manager <https://airflow.apache.org/docs/apache-airflow-providers-fab/stable/auth-manager/index.html>`_ is enabled.
 
 Starting Airflow
 --------------

--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -150,7 +150,7 @@ the all-in-one ``standalone`` command, you can instead run:
     airflow triggerer
 
 .. note::
-    ``airflow users`` command is only available when the FAB auth manager is enabled.
+    ``airflow users`` command is only available when FAB auth manager is enabled.
 
 What's Next?
 ''''''''''''

--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -149,6 +149,9 @@ the all-in-one ``standalone`` command, you can instead run:
 
     airflow triggerer
 
+.. note::
+    ``airflow users`` command is only available when the FAB auth manager is enabled.
+
 What's Next?
 ''''''''''''
 From this point, you can head to the :doc:`/tutorial/index` section for further examples or the :doc:`/howto/index` section if you're ready to get your hands dirty.

--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -150,7 +150,7 @@ the all-in-one ``standalone`` command, you can instead run:
     airflow triggerer
 
 .. note::
-    ``airflow users`` command is only available when `FAB auth manager <https://airflow.apache.org/docs/apache-airflow-providers-fab/stable/auth-manager/index.html>`_ is enabled.
+    ``airflow users`` command is only available when :doc:`apache-airflow-providers-fab:auth-manager/index` is enabled.
 
 What's Next?
 ''''''''''''

--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -150,7 +150,7 @@ the all-in-one ``standalone`` command, you can instead run:
     airflow triggerer
 
 .. note::
-    ``airflow users`` command is only available when FAB auth manager is enabled.
+    ``airflow users`` command is only available when `FAB auth manager <https://airflow.apache.org/docs/apache-airflow-providers-fab/stable/auth-manager/index.html>`_ is enabled.
 
 What's Next?
 ''''''''''''


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #45936 

Added a note to documentation (docs/contributing-docs) mentioning `airflow users`.