### PR TITLE
Improve codeblock formatting in newsfragment

### DIFF
--- a/newsfragments/46613.significant.rst
+++ b/newsfragments/46613.significant.rst
@@ -6,27 +6,28 @@ links to XCom backend and the link is fetched from the XCom backend when viewing
 task details, for example from grid view.
 
 Example for users with custom links class:
-```
-@attr.s(auto_attribs=True)
-class CustomBaseIndexOpLink(BaseOperatorLink):
-    """Custom Operator Link for Google BigQuery Console."""
 
-    index: int = attr.ib()
+.. code-block:: python
 
-    @property
-    def name(self) -> str:
-        return f"BigQuery Console #{self.index + 1}"
+  @attr.s(auto_attribs=True)
+  class CustomBaseIndexOpLink(BaseOperatorLink):
+      """Custom Operator Link for Google BigQuery Console."""
 
-    @property
-    def xcom_key(self) -> str:
-        return f"bigquery_{self.index + 1}"
+      index: int = attr.ib()
 
-    def get_link(self, operator, *, ti_key):
-        search_queries = XCom.get_one(
-            task_id=ti_key.task_id, dag_id=ti_key.dag_id, run_id=ti_key.run_id, key="search_query"
-        )
-        return f"https://console.cloud.google.com/bigquery?j={search_query}"
-```
+      @property
+      def name(self) -> str:
+          return f"BigQuery Console #{self.index + 1}"
+
+      @property
+      def xcom_key(self) -> str:
+          return f"bigquery_{self.index + 1}"
+
+      def get_link(self, operator, *, ti_key):
+          search_queries = XCom.get_one(
+              task_id=ti_key.task_id, dag_id=ti_key.dag_id, run_id=ti_key.run_id, key="search_query"
+          )
+          return f"https://console.cloud.google.com/bigquery?j={search_query}"
 
 The link has an xcom_key defined, which is how it will be stored in the XCOM backend, with key as xcom_key and
 value as the entire link, this case: https://console.cloud.google.com/bigquery?j=search


### PR DESCRIPTION
This PR cleans up a code block within the newsfragment introduced in #46745. We used markdown earlier here which messes up the format a bit, so instead used code block with rst format which improves the formatting 

Before
<img width="1144" alt="Screenshot 2025-02-18 at 7 05 28 PM" src="https://github.com/user-attachments/assets/b5ea49f7-e257-4269-b800-85bddad1d185" />


After
<img width="1139" alt="Screenshot 2025-02-18 at 7 07 04 PM" src="https://github.com/user-attachments/assets/d72b965a-072d-4dcd-b123-f089c327b2f1" />

Related:#46745
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
