### PR TITLE
Enable accessing Variables from the top level of the DAG files

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -88,7 +88,7 @@ def create_app(apps: str = "all") -> FastAPI:
         init_middlewares(app)
 
     if "execution" in apps_list or "all" in apps_list:
-        task_exec_api_app = create_task_execution_api_app(app)
+        task_exec_api_app = create_task_execution_api_app()
         init_error_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 

--- a/airflow/api_fastapi/execution_api/app.py
+++ b/airflow/api_fastapi/execution_api/app.py
@@ -18,9 +18,15 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from functools import cached_property
+from typing import TYPE_CHECKING
 
+import attrs
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
+
+if TYPE_CHECKING:
+    import httpx
 
 
 @asynccontextmanager
@@ -30,7 +36,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-def create_task_execution_api_app(app: FastAPI) -> FastAPI:
+def create_task_execution_api_app() -> FastAPI:
     """Create FastAPI app for task execution API."""
     from airflow.api_fastapi.execution_api.routes import execution_api_router
 
@@ -88,3 +94,37 @@ def get_extra_schemas() -> dict[str, dict]:
         # as that has different payload requirements
         "TerminalTIState": {"type": "string", "enum": list(TerminalTIState)},
     }
+
+
+@attrs.define()
+class InProcessExecuctionAPI:
+    """
+    A helper class to make it possible to run the ExecutionAPI "in-process".
+
+    The sync version of this makes use of a2wsgi which runs the async loop in a separate thread. This is
+    needed so that we can use the sync httpx client
+    """
+
+    _app: FastAPI | None = None
+
+    @cached_property
+    def app(self):
+        if not self._app:
+            from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
+
+            self._app = create_task_execution_api_app()
+
+        return self._app
+
+    @cached_property
+    def transport(self) -> httpx.WSGITransport:
+        import httpx
+        from a2wsgi import ASGIMiddleware
+
+        return httpx.WSGITransport(app=ASGIMiddleware(self.app))  # type: ignore[arg-type]
+
+    @cached_property
+    def atransport(self) -> httpx.ASGITransport:
+        import httpx
+
+        return httpx.ASGITransport(app=self.app)

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import Boolean, Column, Integer, String, Text, delete, select
@@ -136,6 +138,28 @@ class Variable(Base, LoggingMixin):
         :param default_var: Default value of the Variable if the Variable doesn't exist
         :param deserialize_json: Deserialize the value to a Python dict
         """
+        # TODO: This is not the best way of having compat, but it's "better than erroring" for now. This still
+        # means SQLA etc is loaded, but we can't avoid that unless/until we add import shims as a big
+        # back-compat layer
+
+        # If this is set it means are in some kind of execution context (Task, Dag Parse or Triggerer perhaps)
+        # and should use the Task SDK API server path
+        if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
+            warnings.warn(
+                "Using Variable.get from `airflow.models` is deprecated. Please use `from airflow.sdk import"
+                "Variable` instead",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            from airflow.sdk import Variable as TaskSDKVariable
+            from airflow.sdk.definitions._internal.types import NOTSET
+
+            return TaskSDKVariable.get(
+                key,
+                default=NOTSET if default_var is cls.__NO_DEFAULT_SENTINEL else default_var,
+                deserialize_json=deserialize_json,
+            )
+
         var_val = Variable.get_variable_from_secrets(key=key)
         if var_val is None:
             if default_var is not cls.__NO_DEFAULT_SENTINEL:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -342,6 +342,7 @@ BUNDLE_EXTRAS: dict[str, list[str]] = {
 }
 
 DEPENDENCIES = [
+    "a2wsgi>=1.10.8",
     # Alembic is important to handle our migrations in predictable and performant way. It is developed
     # together with SQLAlchemy. Our experience with Alembic is that it very stable in minor version
     # The 1.13.0 of alembic marked some migration code as SQLAlchemy 2+ only so we limit it to 1.13.1

--- a/task_sdk/src/airflow/sdk/__init__.py
+++ b/task_sdk/src/airflow/sdk/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "Label",
     "MappedOperator",
     "TaskGroup",
+    "Variable",
     "XComArg",
     "dag",
     "get_current_context",
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.edges import EdgeModifier, Label
     from airflow.sdk.definitions.mappedoperator import MappedOperator
     from airflow.sdk.definitions.taskgroup import TaskGroup
+    from airflow.sdk.definitions.variable import Variable
     from airflow.sdk.definitions.xcom_arg import XComArg
 
 __lazy_imports: dict[str, str] = {

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -384,8 +384,8 @@ class Client(httpx.Client):
         if dry_run:
             # If dry run is requested, install a no op handler so that simple tasks can "heartbeat" using a
             # real client, but just don't make any HTTP requests
-            kwargs["transport"] = httpx.MockTransport(noop_handler)
-            kwargs["base_url"] = "dry-run://server"
+            kwargs.setdefault("transport", httpx.MockTransport(noop_handler))
+            kwargs.setdefault("base_url", "dry-run://server")
         else:
             kwargs["base_url"] = base_url
         pyver = f"{'.'.join(map(str, sys.version_info[:3]))}"

--- a/tests/api_fastapi/test_app.py
+++ b/tests/api_fastapi/test_app.py
@@ -57,10 +57,10 @@ def test_core_api_app(
 def test_execution_api_app(
     mock_create_task_exec_api, mock_init_plugins, mock_init_views, mock_init_dag_bag, client
 ):
-    test_app = client(apps="execution").app
+    client(apps="execution")
 
     # Assert that execution-related functions were called
-    mock_create_task_exec_api.assert_called_once_with(test_app)
+    mock_create_task_exec_api.assert_called_once()
 
     # Assert that core-related functions were NOT called
     mock_init_dag_bag.assert_not_called()
@@ -91,4 +91,4 @@ def test_all_apps(mock_create_task_exec_api, mock_init_plugins, mock_init_views,
     mock_init_plugins.assert_called_once_with(test_app)
 
     # Assert that execution-related functions were also called
-    mock_create_task_exec_api.assert_called_once_with(test_app)
+    mock_create_task_exec_api.assert_called_once_with()

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -17,10 +17,12 @@
 # under the License.
 from __future__ import annotations
 
+import inspect
 import pathlib
 import sys
+import textwrap
 from socket import socketpair
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 from unittest.mock import patch
 
 import pytest
@@ -32,6 +34,7 @@ from airflow.configuration import conf
 from airflow.dag_processing.processor import (
     DagFileParseRequest,
     DagFileParsingResult,
+    DagFileProcessorProcess,
     _parse_file,
 )
 from airflow.models import DagBag, TaskInstance
@@ -51,16 +54,9 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.db_test
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-PY311 = sys.version_info >= (3, 11)
-
-# Include the words "airflow" and "dag" in the file contents,
-# tricking airflow into thinking these
-# files contain a DAG (otherwise Airflow will skip them)
-PARSEABLE_DAG_FILE_CONTENTS = '"airflow DAG"'
 
 # Filename to be used for dags that are created in an ad-hoc manner and can be removed/
 # created at runtime
-TEMP_DAG_FILENAME = "temp_dag.py"
 TEST_DAG_FOLDER = pathlib.Path(__file__).parents[1].resolve() / "dags"
 
 
@@ -133,44 +129,45 @@ class TestDagFileProcessor:
         assert resp.import_errors is not None
         assert "a.py" in resp.import_errors
 
+    # @pytest.mark.execution_timeout(10)
+    def test_top_level_variable_access(
+        self, spy_agency: SpyAgency, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Create the dag in a fn, and use inspect.getsource to write it to a file so that
+        # a) the test dag is directly viewable here in the tests
+        # b) that it shows to IDEs/mypy etc.
+        def dag_in_a_fn():
+            from airflow.sdk import DAG, Variable
 
-#     @conf_vars({("logging", "dag_processor_log_target"): "stdout"})
-#     @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
-#     @mock.patch("airflow.dag_processing.processor.redirect_stdout")
-#     def test_dag_parser_output_when_logging_to_stdout(self, mock_redirect_stdout_for_file):
-#         processor = DagFileProcessorProcess(
-#             file_path="abc.txt",
-#             dag_directory=[],
-#             callback_requests=[],
-#         )
-#         processor._run_file_processor(
-#             result_channel=MagicMock(),
-#             parent_channel=MagicMock(),
-#             file_path="fake_file_path",
-#             thread_name="fake_thread_name",
-#             callback_requests=[],
-#             dag_directory=[],
-#         )
-#         mock_redirect_stdout_for_file.assert_not_called()
-#
-#     @conf_vars({("logging", "dag_processor_log_target"): "file"})
-#     @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
-#     @mock.patch("airflow.dag_processing.processor.redirect_stdout")
-#     def test_dag_parser_output_when_logging_to_file(self, mock_redirect_stdout_for_file):
-#         processor = DagFileProcessorProcess(
-#             file_path="abc.txt",
-#             dag_directory=[],
-#             callback_requests=[],
-#         )
-#         processor._run_file_processor(
-#             result_channel=MagicMock(),
-#             parent_channel=MagicMock(),
-#             file_path="fake_file_path",
-#             thread_name="fake_thread_name",
-#             callback_requests=[],
-#             dag_directory=[],
-#         )
-#         mock_redirect_stdout_for_file.assert_called_once()
+            with DAG(f"test_{Variable.get('myvar')}"):
+                ...
+
+        path = write_dag_in_a_fn_to_file(dag_in_a_fn, tmp_path)
+
+        monkeypatch.setenv("AIRFLOW_VAR_MYVAR", "abc")
+        proc = DagFileProcessorProcess.start(
+            id=1,
+            path=path,
+            bundle_path=tmp_path,
+            callbacks=[],
+        )
+
+        while not proc.is_ready:
+            proc._service_subprocess(0.1)
+
+        result = proc.parsing_result
+        assert result is not None
+        assert result.import_errors == {}
+        assert result.serialized_dags[0].dag_id == "test_abc"
+
+
+def write_dag_in_a_fn_to_file(fn: Callable[[], None], folder: pathlib.Path) -> pathlib.Path:
+    assert folder.is_dir()
+    name = fn.__name__
+    path = folder.joinpath(name + ".py")
+    path.write_text(textwrap.dedent(inspect.getsource(fn)) + f"\n\n{name}()")
+
+    return path
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #45449


Since I want to maintain the property of being able to run a DAG processor
without the Execution API server running, and since the Dag Processor Manager
already has a database connection I have chosen to run the FastAPI execution
server in process.

To achive this I make use of two features:

- The first is the abilty to provide an httpx.Client with a Transport object
  that has an WSGI appliction to not send real requests, but to instead call
  the WSGI app directly to service the request
- The second is a2wsgi. Since we are making a call from with in a synchronus
  context we have to give httpx a WSGI (if we were making Async requests we
  could give httpx an ASGI app directly), and FastAPI at it's outer layers is
  an async framework (even if it supports running sync routes) we need to
  somehow wrap the async call to return a sync result. a2wsgi does this for us
  by using a async loop off the main thread.

I tested this with a simple DAG file initially:

```python
import time
import sys
from airflow.decorators import dag, task
from airflow.sdk import Variable

from airflow.utils.session import create_session

if Variable.get("hi", default=None):
    raise RuntimeError("Var hi was defined")

@dag(schedule=None)
def hi():
    @task()
    def hello():
        print("hello")
        time.sleep(3)
        print("goodbye")
        print("err mesg", file=sys.stderr)

    hello()

hi()
```

If the variable is defined it results in an import error. If the variable is
not defined you get the DAG defined.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
