### PR TITLE
Slow down DAG processor refreshing bundles

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2659,6 +2659,16 @@ dag_processor:
       type: integer
       example: ~
       default: "30"
+    bundle_refresh_check_interval:
+      description: |
+        How often the DAG processor should check if any DAG bundles are ready for a refresh, either by hitting
+        the bundles refresh_interval or because another DAG processor has seen a newer version of the bundle.
+        A low value means we check more frequently, and have a smaller window of time where DAG processors are
+        out of sync with each other, parsing different versions of the same bundle.
+      version_added: ~
+      type: integer
+      example: ~
+      default: "5"
 fastapi:
   description: Configuration for the Fastapi webserver.
   options:

--- a/airflow/config_templates/unit_tests.cfg
+++ b/airflow/config_templates/unit_tests.cfg
@@ -90,6 +90,7 @@ scheduler_heartbeat_sec = 5
 
 [dag_processor]
 parsing_processes = 2
+bundle_refresh_check_interval = 0
 
 [triggerer]
 # Those values are set so that during unit tests things run faster than usual.

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -455,16 +455,16 @@ class DagFileProcessorManager(LoggingMixin):
 
         # we don't need to check if it's time to refresh every loop - that is way too often
         next_check = self._bundles_last_refreshed + self.bundle_refresh_check_interval
-        now_ss = time.monotonic()
-        if now_ss < next_check:
+        now_seconds = time.monotonic()
+        if now_seconds < next_check:
             self.log.debug(
                 "Not time to check if DAG Bundles need refreshed yet - skipping. "
                 "Next check in %.2f seconds",
-                next_check - now_ss,
+                next_check - now_seconds,
             )
             return
 
-        self._bundles_last_refreshed = now_ss
+        self._bundles_last_refreshed = now_seconds
 
         for bundle in self._dag_bundles:
             # TODO: AIP-66 handle errors in the case of incomplete cloning? And test this.

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -454,15 +454,17 @@ class DagFileProcessorManager(LoggingMixin):
         now = timezone.utcnow()
 
         # we don't need to check if it's time to refresh every loop - that is way too often
-        last_checked_ago = time.monotonic() - self._bundles_last_refreshed
-        if last_checked_ago < self.bundle_refresh_check_interval:
+        next_check = self._bundles_last_refreshed + self.bundle_refresh_check_interval
+        now_ss = time.monotonic()
+        if now_ss < next_check:
             self.log.debug(
-                "Not time to check if DAG Bundles need refreshed yet - skipping. Next check in %.2f seconds",
-                self.bundle_refresh_check_interval - last_checked_ago,
+                "Not time to check if DAG Bundles need refreshed yet - skipping. "
+                "Next check in %.2f seconds",
+                next_check - now_ss,
             )
             return
 
-        self._bundles_last_refreshed = time.monotonic()
+        self._bundles_last_refreshed = now_ss
 
         for bundle in self._dag_bundles:
             # TODO: AIP-66 handle errors in the case of incomplete cloning? And test this.

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -201,6 +201,12 @@ class DagFileProcessorManager(LoggingMixin):
     base_log_dir: str = attrs.field(factory=_config_get_factory("scheduler", "CHILD_PROCESS_LOG_DIRECTORY"))
     _latest_log_symlink_date: datetime = attrs.field(factory=datetime.today, init=False)
 
+    bundle_refresh_check_interval: int = attrs.field(
+        factory=_config_int_factory("dag_processor", "bundle_refresh_check_interval")
+    )
+    _bundles_last_refreshed: float = attrs.field(default=0, init=False)
+    """Last time we checked if any bundles are ready to be refreshed"""
+
     def register_exit_signals(self):
         """Register signals that stop child processes."""
         signal.signal(signal.SIGINT, self._exit_gracefully)
@@ -446,6 +452,17 @@ class DagFileProcessorManager(LoggingMixin):
     def _refresh_dag_bundles(self, known_files: dict[str, set[DagFileInfo]]):
         """Refresh DAG bundles, if required."""
         now = timezone.utcnow()
+
+        # we don't need to check if it's time to refresh every loop - that is way too often
+        last_checked_ago = time.monotonic() - self._bundles_last_refreshed
+        if last_checked_ago < self.bundle_refresh_check_interval:
+            self.log.debug(
+                "Not time to check if DAG Bundles need refreshed yet - skipping. Next check in %.2f seconds",
+                self.bundle_refresh_check_interval - last_checked_ago,
+            )
+            return
+
+        self._bundles_last_refreshed = time.monotonic()
 
         for bundle in self._dag_bundles:
             # TODO: AIP-66 handle errors in the case of incomplete cloning? And test this.


### PR DESCRIPTION
Right now we check if any bundles need to be refreshed every loop, which can be very frequent (e.g. 10 times per second or more). This introduces a new config, [dag_processor] bundle_refresh_check_interval, that allows for slowing down how often we do it. Since we send queries to the db, having some control here is helpful.