### PR TITLE
Fix Trigger Form with Empty Object Default

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -120,7 +120,7 @@
     {% elif form_details.schema and "object" in form_details.schema.type %}
       <textarea class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" valuetype="object" rows="6"
         {%- if not "null" in form_details.schema.type %} required=""{% endif -%}>
-        {%- if form_details.value %}
+        {%- if form_details.value != None %}
           {{- form_details.value | tojson() -}}
         {% endif -%}
       </textarea>


### PR DESCRIPTION
The last changes in trigger form created a regression that JSON/object entry fields with empty defaults are rendered empty. This causes errors if the object default is an empty dict (`{}`) as this is not explicitly checked.

A residual problem exists that if the object field is declared "required" and the field is empty == interpreted as `null` then the required field highlighting fails in JavaScript as the hidden data field behind CodeMirror can not be focussed. This would be major rework and will only be fixed in Airflow 3 with the new trigger form.

closes: #46858