### PR TITLE
More import aliases in airflow.sdk

### DIFF
--- a/airflow/example_dags/example_params_trigger_ui.py
+++ b/airflow/example_dags/example_params_trigger_ui.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from airflow.decorators import task
 from airflow.models.dag import DAG
-from airflow.sdk import Param, ParamsDict
+from airflow.sdk import Param
 from airflow.utils.trigger_rule import TriggerRule
 
 # [START params_trigger]
@@ -56,7 +56,7 @@ with DAG(
 
     @task(task_id="get_names", task_display_name="Get names")
     def get_names(**kwargs) -> list[str]:
-        params: ParamsDict = kwargs["params"]
+        params = kwargs["params"]
         if "names" not in params:
             print("Uuups, no names given, was no UI used to trigger?")
             return []
@@ -64,7 +64,7 @@ with DAG(
 
     @task.branch(task_id="select_languages", task_display_name="Select languages")
     def select_languages(**kwargs) -> list[str]:
-        params: ParamsDict = kwargs["params"]
+        params = kwargs["params"]
         selected_languages = []
         for lang in ["english", "german", "french"]:
             if params[lang]:

--- a/airflow/example_dags/example_params_ui_tutorial.py
+++ b/airflow/example_dags/example_params_ui_tutorial.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from airflow.decorators import task
 from airflow.models.dag import DAG
-from airflow.sdk import Param, ParamsDict
+from airflow.sdk import Param
 
 with (
     DAG(
@@ -253,7 +253,7 @@ with (
     # [START section_3]
     @task(task_display_name="Show used parameters")
     def show_params(**kwargs) -> None:
-        params: ParamsDict = kwargs["params"]
+        params = kwargs["params"]
         print(f"This DAG was triggered with the following parameters:\n\n{json.dumps(params, indent=4)}\n")
 
     show_params()

--- a/task_sdk/src/airflow/sdk/__init__.py
+++ b/task_sdk/src/airflow/sdk/__init__.py
@@ -33,7 +33,6 @@ __all__ = [
     "Label",
     "Metadata",
     "Param",
-    "ParamsDict",
     "TaskGroup",
     "Variable",
     "XComArg",
@@ -55,7 +54,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context, get_current_context, get_parsing_context
     from airflow.sdk.definitions.dag import DAG, dag
     from airflow.sdk.definitions.edges import EdgeModifier, Label
-    from airflow.sdk.definitions.param import Param, ParamsDict
+    from airflow.sdk.definitions.param import Param
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.sdk.definitions.template import literal
     from airflow.sdk.definitions.variable import Variable
@@ -75,7 +74,6 @@ __lazy_imports: dict[str, str] = {
     "Label": ".definitions.edges",
     "Metadata": ".definitions.asset.metadata",
     "Param": ".definitions.param",
-    "ParamsDict": ".definitions.param",
     "TaskGroup": ".definitions.taskgroup",
     "Variable": ".definitions.variable",
     "XComArg": ".definitions.xcom_arg",

--- a/task_sdk/src/airflow/sdk/__init__.py
+++ b/task_sdk/src/airflow/sdk/__init__.py
@@ -21,52 +21,68 @@ from typing import TYPE_CHECKING
 __all__ = [
     "__version__",
     "Asset",
+    "AssetAlias",
+    "AssetAll",
+    "AssetAny",
     "AssetWatcher",
     "BaseOperator",
     "Connection",
+    "Context",
     "DAG",
     "EdgeModifier",
     "Label",
-    "MappedOperator",
+    "Metadata",
+    "Param",
+    "ParamsDict",
     "TaskGroup",
     "Variable",
     "XComArg",
+    "asset",
     "dag",
     "get_current_context",
     "get_parsing_context",
+    "literal",
 ]
 
 __version__ = "1.0.0.alpha1"
 
 if TYPE_CHECKING:
-    from airflow.sdk.definitions.asset import Asset, AssetWatcher
+    from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher
+    from airflow.sdk.definitions.assets.decorators import asset
+    from airflow.sdk.definitions.assets.metadata import Metadata
     from airflow.sdk.definitions.baseoperator import BaseOperator
     from airflow.sdk.definitions.connection import Connection
-    from airflow.sdk.definitions.context import get_current_context, get_parsing_context
+    from airflow.sdk.definitions.context import Context, get_current_context, get_parsing_context
     from airflow.sdk.definitions.dag import DAG, dag
     from airflow.sdk.definitions.edges import EdgeModifier, Label
-    from airflow.sdk.definitions.mappedoperator import MappedOperator
+    from airflow.sdk.definitions.param import Param, ParamsDict
     from airflow.sdk.definitions.taskgroup import TaskGroup
+    from airflow.sdk.definitions.template import literal
     from airflow.sdk.definitions.variable import Variable
     from airflow.sdk.definitions.xcom_arg import XComArg
 
 __lazy_imports: dict[str, str] = {
+    "Asset": ".definitions.asset",
+    "AssetAlias": ".definitions.asset",
+    "AssetAll": ".definitions.asset",
+    "AssetAny": ".definitions.asset",
+    "AssetWatcher": ".definitions.asset",
     "BaseOperator": ".definitions.baseoperator",
     "Connection": ".definitions.connection",
-    "Param": ".definitions.param",
-    "ParamsDict": ".definitions.param",
+    "Context": ".definitions.context",
     "DAG": ".definitions.dag",
     "EdgeModifier": ".definitions.edges",
     "Label": ".definitions.edges",
-    "MappedOperator": ".definitions.mappedoperator",
+    "Metadata": ".definitions.asset.metadata",
+    "Param": ".definitions.param",
+    "ParamsDict": ".definitions.param",
     "TaskGroup": ".definitions.taskgroup",
     "Variable": ".definitions.variable",
     "XComArg": ".definitions.xcom_arg",
+    "asset": ".definitions.asset.decorators",
     "dag": ".definitions.dag",
     "get_current_context": ".definitions.context",
     "get_parsing_context": ".definitions.context",
-    "Asset": ".definitions.asset",
-    "AssetWatcher": ".definitions.asset",
 }
 
 


### PR DESCRIPTION
I also removed MappedOperator since I don't think there's any case the user wants to instantiate it directly.

I'm also not sure if we need to expose get_parsing_context and ParamsDict. When are they useful to the user?