### PR TITLE
AIP-84 Asset dependencies graph node filtering

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -181,6 +181,15 @@ paths:
       summary: Get Dependencies
       description: Dependencies graph.
       operationId: get_dependencies
+      parameters:
+      - name: node_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Node Id
       responses:
         '200':
           description: Successful Response
@@ -188,6 +197,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseGraphResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /ui/dashboard/historical_metrics_data:
     get:
       tags:

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -197,6 +197,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseGraphResponse'
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
         '422':
           description: Validation Error
           content:

--- a/airflow/api_fastapi/core_api/routes/ui/dependencies.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dependencies.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.common import BaseGraphResponse
+from airflow.api_fastapi.core_api.services.ui.dependencies import extract_connected_component_sub_graph
 from airflow.models.serialized_dag import SerializedDagModel
 
 dependencies_router = AirflowRouter(tags=["Dependencies"])
@@ -28,9 +29,7 @@ dependencies_router = AirflowRouter(tags=["Dependencies"])
 @dependencies_router.get(
     "/dependencies",
 )
-def get_dependencies(
-    session: SessionDep,
-) -> BaseGraphResponse:
+def get_dependencies(session: SessionDep, node_id: str | None = None) -> BaseGraphResponse:
     """Dependencies graph."""
     nodes_dict: dict[str, dict] = {}
     edge_tuples: set[tuple[str, str]] = set()
@@ -68,5 +67,8 @@ def get_dependencies(
         "nodes": nodes,
         "edges": edges,
     }
+
+    if node_id is not None:
+        data = extract_connected_component_sub_graph(node_id, data["nodes"], data["edges"])
 
     return BaseGraphResponse(**data)

--- a/airflow/api_fastapi/core_api/routes/ui/dependencies.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dependencies.py
@@ -17,10 +17,14 @@
 
 from __future__ import annotations
 
+from fastapi import status
+from fastapi.exceptions import HTTPException
+
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.common import BaseGraphResponse
-from airflow.api_fastapi.core_api.services.ui.dependencies import extract_connected_component_sub_graph
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.services.ui.dependencies import extract_single_connected_component
 from airflow.models.serialized_dag import SerializedDagModel
 
 dependencies_router = AirflowRouter(tags=["Dependencies"])
@@ -28,6 +32,11 @@ dependencies_router = AirflowRouter(tags=["Dependencies"])
 
 @dependencies_router.get(
     "/dependencies",
+    responses=create_openapi_http_exception_doc(
+        [
+            status.HTTP_404_NOT_FOUND,
+        ]
+    ),
 )
 def get_dependencies(session: SessionDep, node_id: str | None = None) -> BaseGraphResponse:
     """Dependencies graph."""
@@ -69,6 +78,9 @@ def get_dependencies(session: SessionDep, node_id: str | None = None) -> BaseGra
     }
 
     if node_id is not None:
-        data = extract_connected_component_sub_graph(node_id, data["nodes"], data["edges"])
+        try:
+            data = extract_single_connected_component(node_id, data["nodes"], data["edges"])
+        except ValueError as e:
+            raise HTTPException(404, str(e))
 
     return BaseGraphResponse(**data)

--- a/airflow/api_fastapi/core_api/services/ui/dependencies.py
+++ b/airflow/api_fastapi/core_api/services/ui/dependencies.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 
-def dfs_connected_components(
+def _dfs_connected_components(
     temp: list[str], node_id: str, visited: dict[str, bool], adjacency_matrix: dict[str, list[str]]
 ) -> list[str]:
     visited[node_id] = True
@@ -29,12 +29,13 @@ def dfs_connected_components(
 
     for adj_node_id in adjacency_matrix[node_id]:
         if not visited[adj_node_id]:
-            temp = dfs_connected_components(temp, adj_node_id, visited, adjacency_matrix)
+            temp = _dfs_connected_components(temp, adj_node_id, visited, adjacency_matrix)
 
     return temp
 
 
 def extract_connected_components(adjacency_matrix: dict[str, list[str]]) -> list[list[str]]:
+    """Extract all connected components of a graph."""
     visited: dict[str, bool] = {node_id: False for node_id in adjacency_matrix}
 
     connected_components: list[list[str]] = []
@@ -42,11 +43,14 @@ def extract_connected_components(adjacency_matrix: dict[str, list[str]]) -> list
     for node_id in adjacency_matrix:
         if visited[node_id] is False:
             temp: list[str] = []
-            connected_components.append(dfs_connected_components(temp, node_id, visited, adjacency_matrix))
+            connected_components.append(_dfs_connected_components(temp, node_id, visited, adjacency_matrix))
     return connected_components
 
 
-def extract_connected_component_sub_graph(node_id: str, nodes: list[dict], edges: list[dict]) -> dict:
+def extract_single_connected_component(
+    node_id: str, nodes: list[dict], edges: list[dict]
+) -> dict[str, list[dict]]:
+    """Find the connected component that contains the node with the id ``node_id``."""
     adjacency_matrix: dict[str, list[str]] = defaultdict(list)
 
     for edge in edges:
@@ -59,7 +63,7 @@ def extract_connected_component_sub_graph(node_id: str, nodes: list[dict], edges
 
     if len(filtered_connected_components) != 1:
         raise ValueError(
-            f"Something unexpected happened, found {filtered_connected_components} for connected components of node {node_id}, expected 1 connected component."
+            f"Unique connected component not found, got {filtered_connected_components} for connected components of node {node_id}, expected only 1 connected component."
         )
 
     connected_component = filtered_connected_components[0]

--- a/airflow/api_fastapi/core_api/services/ui/dependencies.py
+++ b/airflow/api_fastapi/core_api/services/ui/dependencies.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def dfs_connected_components(
+    temp: list[str], node_id: str, visited: dict[str, bool], adjacency_matrix: dict[str, list[str]]
+) -> list[str]:
+    visited[node_id] = True
+
+    temp.append(node_id)
+
+    for adj_node_id in adjacency_matrix[node_id]:
+        if not visited[adj_node_id]:
+            temp = dfs_connected_components(temp, adj_node_id, visited, adjacency_matrix)
+
+    return temp
+
+
+def extract_connected_components(adjacency_matrix: dict[str, list[str]]) -> list[list[str]]:
+    visited: dict[str, bool] = {node_id: False for node_id in adjacency_matrix}
+
+    connected_components: list[list[str]] = []
+
+    for node_id in adjacency_matrix:
+        if visited[node_id] is False:
+            temp: list[str] = []
+            connected_components.append(dfs_connected_components(temp, node_id, visited, adjacency_matrix))
+    return connected_components
+
+
+def extract_connected_component_sub_graph(node_id: str, nodes: list[dict], edges: list[dict]) -> dict:
+    adjacency_matrix: dict[str, list[str]] = defaultdict(list)
+
+    for edge in edges:
+        adjacency_matrix[edge["source_id"]].append(edge["target_id"])
+        adjacency_matrix[edge["target_id"]].append(edge["source_id"])
+
+    connected_components = extract_connected_components(adjacency_matrix)
+
+    filtered_connected_components = [cc for cc in connected_components if node_id in cc]
+
+    if len(filtered_connected_components) != 1:
+        raise ValueError(
+            f"Something unexpected happened, found {filtered_connected_components} for connected components of node {node_id}, expected 1 connected component."
+        )
+
+    connected_component = filtered_connected_components[0]
+
+    nodes = [node for node in nodes if node["id"] in connected_component]
+    edges = [
+        edge
+        for edge in edges
+        if (edge["source_id"] in connected_component and edge["target_id"] in connected_component)
+    ]
+
+    return {"nodes": nodes, "edges": edges}

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -341,10 +341,14 @@ export type DependenciesServiceGetDependenciesQueryResult<
   TError = unknown,
 > = UseQueryResult<TData, TError>;
 export const useDependenciesServiceGetDependenciesKey = "DependenciesServiceGetDependencies";
-export const UseDependenciesServiceGetDependenciesKeyFn = (queryKey?: Array<unknown>) => [
-  useDependenciesServiceGetDependenciesKey,
-  ...(queryKey ?? []),
-];
+export const UseDependenciesServiceGetDependenciesKeyFn = (
+  {
+    nodeId,
+  }: {
+    nodeId?: string;
+  } = {},
+  queryKey?: Array<unknown>,
+) => [useDependenciesServiceGetDependenciesKey, ...(queryKey ?? [{ nodeId }])];
 export type DashboardServiceHistoricalMetricsDefaultResponse = Awaited<
   ReturnType<typeof DashboardService.historicalMetrics>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -449,13 +449,22 @@ export const prefetchUseDagsServiceRecentDagRuns = (
 /**
  * Get Dependencies
  * Dependencies graph.
+ * @param data The data for the request.
+ * @param data.nodeId
  * @returns BaseGraphResponse Successful Response
  * @throws ApiError
  */
-export const prefetchUseDependenciesServiceGetDependencies = (queryClient: QueryClient) =>
+export const prefetchUseDependenciesServiceGetDependencies = (
+  queryClient: QueryClient,
+  {
+    nodeId,
+  }: {
+    nodeId?: string;
+  } = {},
+) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn(),
-    queryFn: () => DependenciesService.getDependencies(),
+    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn({ nodeId }),
+    queryFn: () => DependenciesService.getDependencies({ nodeId }),
   });
 /**
  * Historical Metrics

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -555,6 +555,8 @@ export const useDagsServiceRecentDagRuns = <
 /**
  * Get Dependencies
  * Dependencies graph.
+ * @param data The data for the request.
+ * @param data.nodeId
  * @returns BaseGraphResponse Successful Response
  * @throws ApiError
  */
@@ -563,12 +565,17 @@ export const useDependenciesServiceGetDependencies = <
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
+  {
+    nodeId,
+  }: {
+    nodeId?: string;
+  } = {},
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn(queryKey),
-    queryFn: () => DependenciesService.getDependencies() as TData,
+    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn({ nodeId }, queryKey),
+    queryFn: () => DependenciesService.getDependencies({ nodeId }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -532,6 +532,8 @@ export const useDagsServiceRecentDagRunsSuspense = <
 /**
  * Get Dependencies
  * Dependencies graph.
+ * @param data The data for the request.
+ * @param data.nodeId
  * @returns BaseGraphResponse Successful Response
  * @throws ApiError
  */
@@ -540,12 +542,17 @@ export const useDependenciesServiceGetDependenciesSuspense = <
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
+  {
+    nodeId,
+  }: {
+    nodeId?: string;
+  } = {},
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn(queryKey),
-    queryFn: () => DependenciesService.getDependencies() as TData,
+    queryKey: Common.UseDependenciesServiceGetDependenciesKeyFn({ nodeId }, queryKey),
+    queryFn: () => DependenciesService.getDependencies({ nodeId }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -758,6 +758,7 @@ export class DependenciesService {
         node_id: data.nodeId,
       },
       errors: {
+        404: "Not Found",
         422: "Validation Error",
       },
     });

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -38,6 +38,7 @@ import type {
   GetConfigValueResponse,
   RecentDagRunsData,
   RecentDagRunsResponse,
+  GetDependenciesData,
   GetDependenciesResponse,
   HistoricalMetricsData,
   HistoricalMetricsResponse,
@@ -744,13 +745,21 @@ export class DependenciesService {
   /**
    * Get Dependencies
    * Dependencies graph.
+   * @param data The data for the request.
+   * @param data.nodeId
    * @returns BaseGraphResponse Successful Response
    * @throws ApiError
    */
-  public static getDependencies(): CancelablePromise<GetDependenciesResponse> {
+  public static getDependencies(data: GetDependenciesData = {}): CancelablePromise<GetDependenciesResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/dependencies",
+      query: {
+        node_id: data.nodeId,
+      },
+      errors: {
+        422: "Validation Error",
+      },
     });
   }
 }

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2979,6 +2979,10 @@ export type $OpenApiTs = {
          */
         200: BaseGraphResponse;
         /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
          * Validation Error
          */
         422: HTTPValidationError;

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1739,6 +1739,10 @@ export type RecentDagRunsData = {
 
 export type RecentDagRunsResponse = DAGWithLatestDagRunsCollectionResponse;
 
+export type GetDependenciesData = {
+  nodeId?: string | null;
+};
+
 export type GetDependenciesResponse = BaseGraphResponse;
 
 export type HistoricalMetricsData = {
@@ -2968,11 +2972,16 @@ export type $OpenApiTs = {
   };
   "/ui/dependencies": {
     get: {
+      req: GetDependenciesData;
       res: {
         /**
          * Successful Response
          */
         200: BaseGraphResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
       };
     };
   };


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/42368

Add the ability to provide a `node_id` to only extract the connected component containing this node. (subgraph for that particular node).