### PR TITLE
Import the right BaseOperator in baseoperatorlinks

### DIFF
--- a/airflow/models/baseoperatorlink.py
+++ b/airflow/models/baseoperatorlink.py
@@ -26,8 +26,8 @@ from airflow.models.xcom import BaseXCom
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.sdk.definitions.baseoperator import BaseOperator
 
 
 @attrs.define()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Ran into this issue on my PR:
```
providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py:156: error:
Argument 1 of "get_link" is incompatible with supertype "BaseOperatorLink";
supertype defines the argument type as "BaseOperator"  [override]
        def get_link(self, operator: BaseOperator, *, ti_key: TaskInstance...
                           ^~~~~~~~~~~~~~~~~~~~~~
providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py:156: note: This violates the Liskov substitution principle
providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py:156: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py:[40](https://github.com/apache/airflow/actions/runs/13411555655/job/37463344676?pr=46860#step:6:41): error:
Argument 1 of "get_link" is incompatible with supertype "BaseOperatorLink";
supertype defines the argument type as "BaseOperator"  [override]
        def get_link(self, operator: BaseOperator, *, ti_key: TaskInstance...
```

Caused due to recent change: #46415

Changing back to the correct BaseOperator from models. We will make the move when we start moving providers to use task sdk cc @ashb


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
