### PR TITLE
AIP-38 Allow specifiying injectable server url

### DIFF
--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -31,6 +31,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from airflow.api_fastapi.core_api.middleware import FlaskExceptionsMiddleware
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.settings import AIRFLOW_PATH
 from airflow.www.extensions.init_dagbag import get_dag_bag
@@ -76,7 +77,11 @@ def init_views(app: FastAPI) -> None:
 
     @app.get("/webapp/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def webapp(request: Request, rest_of_path: str):
-        return templates.TemplateResponse("/index.html", {"request": request}, media_type="text/html")
+        return templates.TemplateResponse(
+            "/index.html",
+            {"request": request, "backend_server_base_url": conf.get("fastapi", "base_url")},
+            media_type="text/html",
+        )
 
 
 def init_plugins(app: FastAPI) -> None:

--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -3,7 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
-    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="http://localhost:5173/public/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">

--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -3,6 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
     <link rel="icon" type="image/png" href="http://localhost:5173/public/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
     <title>Airflow 3.0</title>
   </head>
   <body style="height: 100%">

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
     <title>Airflow 3.0</title>
   </head>
   <body style="height: 100%">

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,7 +23,6 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
-import { OpenAPI } from "openapi/requests/core/OpenAPI";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
@@ -58,9 +57,6 @@ axios.interceptors.request.use((config) => {
 
   return config;
 });
-
-// Dynamically set the base URL for XHR requests based on the meta tag.
-OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,6 +23,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
@@ -57,6 +58,9 @@ axios.interceptors.request.use((config) => {
 
   return config;
 });
+
+// Dynamically set the base URL for XHR requests based on the meta tag.
+OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>

--- a/airflow/ui/src/queryClient.ts
+++ b/airflow/ui/src/queryClient.ts
@@ -18,6 +18,11 @@
  */
 import { QueryClient } from "@tanstack/react-query";
 
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
+
+// Dynamically set the base URL for XHR requests based on the meta tag.
+OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     mutations: {


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/46550

### How to test
- Start the front-end with breeze with or without the `dev-mode` on.
- In the airflow config set the `fastapi.base_url` to your fastapi server (localhost:9091)
- Set the appropriate CORS rules for your server to allow vite to perform xhr requests: `export AIRFLOW__API__ACCESS_CONTROL_ALLOW_ORIGINS="http://localhost:29090"`
- Start the fastapi server on the specified port (by default 9091) `airflow fastapi-api` with the (CORS env variable set in the previous step)
- Go to the UI in breeze `http://localhost:29091/webapp/` requests should go to your standalone fastapi server instead of the breeze one (9091 instead of 29091)

![Screenshot 2025-02-19 at 16 52 14](https://github.com/user-attachments/assets/15f1b9f7-d34e-438d-8c55-0adc5702fa72)


> Note: Follow up is https://github.com/apache/airflow/issues/46548 and then documentation update on how to deploy the api server and the front-end separately without rebuilding artifacts.