### PR TITLE
Fix run/task table links

### DIFF
--- a/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow/ui/src/pages/DagRuns.tsx
@@ -43,11 +43,6 @@ const runColumns = (dagId?: string): Array<ColumnDef<DAGRunResponse>> => [
     : [
         {
           accessorKey: "dag_id",
-          cell: ({ row: { original } }: DagRunRow) => (
-            <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink to={`/dags/${original.dag_id}`}>{original.dag_id}</RouterLink>
-            </Link>
-          ),
           enableSorting: false,
           header: "Dag ID",
         },

--- a/airflow/ui/src/pages/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances.tsx
@@ -49,11 +49,6 @@ const taskInstanceColumns = (
     : [
         {
           accessorKey: "dag_id",
-          cell: ({ row: { original } }: TaskInstanceRow) => (
-            <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink to={`/dags/${original.dag_id}`}>{original.dag_id}</RouterLink>
-            </Link>
-          ),
           enableSorting: false,
           header: "Dag ID",
         },
@@ -63,13 +58,17 @@ const taskInstanceColumns = (
     : [
         {
           accessorKey: "run_after",
-          cell: ({ row: { original } }: TaskInstanceRow) => (
-            <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink to={`/dags/${original.dag_id}/runs/${original.dag_run_id}`}>
-                <Time datetime={original.run_after} />
-              </RouterLink>
-            </Link>
-          ),
+          // If we don't show the taskId column, make the dag run a link to the task instance
+          cell: ({ row: { original } }: TaskInstanceRow) =>
+            Boolean(taskId) ? (
+              <Link asChild color="fg.info" fontWeight="bold">
+                <RouterLink to={getTaskInstanceLink(original)}>
+                  <Time datetime={original.run_after} />
+                </RouterLink>
+              </Link>
+            ) : (
+              <Time datetime={original.run_after} />
+            ),
           header: "Dag Run",
         },
       ]),


### PR DESCRIPTION
When adding the global dag run and task instance tables. I accidentally broke the idea that each row should only have one link to its relevant element. Since we adjust which columns to show depending on the page you're on. Sometimes we didn't even have the link to a task instance.

Now, we only ever link to the dag run or task instance. And even if the task_id column is missing, we fallback on linking to the task instance from the run id column

Before:
<img width="528" alt="Screenshot 2025-02-19 at 11 42 55 AM" src="https://github.com/user-attachments/assets/fe69097d-28c5-4019-b51a-dcd63b183f95" />

After:
<img width="981" alt="Screenshot 2025-02-19 at 11 43 10 AM" src="https://github.com/user-attachments/assets/b2ec4e7b-55c4-4bd2-b66d-afdbc180d30c" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
