### PR TITLE
Remove 2.8 version check from CeleryExecutor CLI

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -53,7 +53,7 @@ from airflow.cli.cli_config import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning, AirflowTaskTimeout
 from airflow.executors.base_executor import BaseExecutor
-from airflow.providers.celery.version_compat import AIRFLOW_V_2_8_PLUS, AIRFLOW_V_3_0_PLUS
+from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.stats import Stats
 from airflow.utils.state import TaskInstanceState
 from celery import states as celery_states
@@ -158,10 +158,7 @@ ARG_WITHOUT_GOSSIP = Arg(
     action="store_true",
 )
 
-if AIRFLOW_V_2_8_PLUS:
-    CELERY_CLI_COMMAND_PATH = "airflow.providers.celery.cli.celery_command"
-else:
-    CELERY_CLI_COMMAND_PATH = "airflow.cli.commands.celery_command"
+CELERY_CLI_COMMAND_PATH = "airflow.providers.celery.cli.celery_command"
 
 CELERY_COMMANDS = (
     ActionCommand(

--- a/providers/celery/src/airflow/providers/celery/version_compat.py
+++ b/providers/celery/src/airflow/providers/celery/version_compat.py
@@ -26,5 +26,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
     return airflow_version.major, airflow_version.minor, airflow_version.micro
 
 
-AIRFLOW_V_2_8_PLUS = get_base_airflow_version_tuple() >= (2, 8, 0)
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)


### PR DESCRIPTION
We now support only 2.9+ with providers.