### PR TITLE
Make rendered_map_index default to map_index

### DIFF
--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -65,7 +65,7 @@ class TaskInstanceSchema(SQLAlchemySchema):
     executor = auto_field()
     executor_config = auto_field()
     note = auto_field()
-    rendered_map_index = auto_field()
+    rendered_map_index = fields.String(attribute="rendered_map_index", dump_only=True)
     rendered_fields = JsonObjectField(dump_default={})
     trigger = fields.Nested(TriggerSchema)
     triggerer_job = fields.Nested(JobSchema)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2279,7 +2279,7 @@ class DagModel(Base):
         :meta private:
         """
         return case(
-            (self._dag_display_property_value.isnot(None), self._dag_display_property_value),
+            (self._dag_display_property_value.is_not(None), self._dag_display_property_value),
             else_=self.dag_id,
         )
 

--- a/airflow/models/taskinstancehistory.py
+++ b/airflow/models/taskinstancehistory.py
@@ -92,7 +92,7 @@ class TaskInstanceHistory(Base):
     next_method = Column(String(1000))
     next_kwargs = Column(MutableDict.as_mutable(ExtendedJSON))
 
-    task_display_name = Column("task_display_name", String(2000), nullable=True)
+    task_display_name = Column(String(2000), nullable=True)
     dag_version_id = Column(UUIDType(binary=False))
 
     dag_version = relationship(

--- a/scripts/ci/pre_commit/check_ti_vs_tis_attributes.py
+++ b/scripts/ci/pre_commit/check_ti_vs_tis_attributes.py
@@ -45,6 +45,7 @@ def compare_attributes(path1, path2):
     diff = diff - {
         "run_after",
         "_logger_name",
+        "_rendered_map_index",
         "_task_display_property_value",
         "task_instance_note",
         "dag_run",

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -228,7 +228,7 @@ class TestGetMappedTaskInstance(TestMappedTaskInstanceEndpoint):
             "queued_when": None,
             "scheduled_when": None,
             "rendered_fields": {},
-            "rendered_map_index": None,
+            "rendered_map_index": "0",
             "start_date": "2020-01-01T00:00:00+00:00",
             "state": "success",
             "task_id": "task_2",

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -409,7 +409,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "unixname": getuser(),
                 "dag_run_id": "TEST_DAG_RUN_ID",
                 "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
-                "rendered_map_index": None,
+                "rendered_map_index": str(map_index),
                 "trigger": None,
                 "triggerer_job": None,
             }
@@ -2379,7 +2379,7 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
                 "unixname": getuser(),
                 "dag_run_id": "TEST_DAG_RUN_ID",
                 "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
-                "rendered_map_index": None,
+                "rendered_map_index": str(map_index),
                 "trigger": None,
                 "triggerer_job": None,
             }

--- a/tests/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/tests/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -518,7 +518,7 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
                 "unixname": getuser(),
                 "dag_run_id": "TEST_DAG_RUN_ID",
                 "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
-                "rendered_map_index": None,
+                "rendered_map_index": str(map_index),
                 "run_after": "2020-01-01T00:00:00Z",
                 "trigger": None,
                 "triggerer_job": None,
@@ -740,7 +740,7 @@ class TestGetMappedTaskInstances:
             .first()
         )
 
-        ti.rendered_map_index = "a"
+        ti._rendered_map_index = "a"
 
         session.commit()
 
@@ -3346,7 +3346,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 "unixname": getuser(),
                 "dag_run_id": self.RUN_ID,
                 "rendered_fields": {"op_args": "()", "op_kwargs": {}, "templates_dict": None},
-                "rendered_map_index": None,
+                "rendered_map_index": str(map_index),
                 "run_after": "2020-01-01T00:00:00Z",
                 "trigger": None,
                 "triggerer_job": None,

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3825,7 +3825,7 @@ class TestTaskInstance:
 
     def test_refresh_from_db(self, create_task_instance):
         run_date = timezone.utcnow()
-        hybrid_props = ["task_display_name"]
+        hybrid_props = ["rendered_map_index", "task_display_name"]
         expected_values = {
             "task_id": "test_refresh_from_db_task",
             "dag_id": "test_refresh_from_db_dag",


### PR DESCRIPTION
This uses the same implementation as dag_display_name and task_display_name; those fields are nullable in the db, but in Python they default to dag_id/task_id.

See https://github.com/apache/airflow/issues/46715#issuecomment-2668781669