### PR TITLE
Fix some warnings in React components

### DIFF
--- a/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow/ui/src/components/RenderedJsonField.tsx
@@ -28,7 +28,7 @@ type Props = {
 } & FlexProps;
 
 const RenderedJsonField = ({ content, jsonProps, ...rest }: Props) => {
-  const contentFormatted = JSON.stringify(content, null, 4);
+  const contentFormatted = JSON.stringify(content, undefined, 4);
   const { theme } = useTheme();
 
   return (

--- a/airflow/ui/src/components/SearchDags/SearchDags.tsx
+++ b/airflow/ui/src/components/SearchDags/SearchDags.tsx
@@ -89,6 +89,7 @@ export const SearchDags = ({
         menuIsOpen
         onChange={onSelect}
         placeholder="Search Dags"
+        // eslint-disable-next-line unicorn/no-null
         value={null} // null is required https://github.com/JedWatson/react-select/issues/3066
       />
     </Field.Root>

--- a/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -138,7 +138,9 @@ export const Code = () => {
               loadOptions={loadVersions}
               onChange={handleStateChange}
               placeholder="Dag Version"
-              value={selectedVersion === null ? null : { label: selectedVersion, value: selectedVersion }} // null is required https://github.com/JedWatson/react-select/issues/3066
+              // null is required https://github.com/JedWatson/react-select/issues/3066
+              // eslint-disable-next-line unicorn/no-null
+              value={selectedVersion === null ? null : { label: selectedVersion, value: selectedVersion }}
             />
           </Field.Root>
 

--- a/airflow/ui/src/pages/Providers.tsx
+++ b/airflow/ui/src/pages/Providers.tsx
@@ -50,7 +50,7 @@ const columns: Array<ColumnDef<ProviderResponse>> = [
   {
     accessorKey: "description",
     cell: ({ row: { original } }) => {
-      const urlRegex = /http(s)?:\/\/[\w.-]+(\.?:[\w.-]+)*([#/?][\w!#$%&'()*+,./:;=?@[\]~-]*)?/gu;
+      const urlRegex = /https?:\/\/[\w.-]+(?:\.?:[\w.-]+)*(?:[#/?][\w!#$%&'()*+,./:;=?@[\]~-]*)?/gu;
       const urls = original.description.match(urlRegex);
       const cleanText = original.description.replaceAll(/\n(?:and)?/gu, " ").split(" ");
 

--- a/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -136,7 +136,11 @@ export const Details = () => {
           <Table.Row>
             <Table.Cell>Duration</Table.Cell>
             <Table.Cell>
-              {getDuration(tryInstance?.start_date ?? null, tryInstance?.end_date ?? null)}s
+              {
+                // eslint-disable-next-line unicorn/no-null
+                getDuration(tryInstance?.start_date ?? null, tryInstance?.end_date ?? null)
+              }
+              s
             </Table.Cell>
           </Table.Row>
           <Table.Row>


### PR DESCRIPTION
Warning: I am not really sure what I’m doing.

Still a couple of warnings left but they need more work to fix and a bit out of my league

```
/Users/uranusjr/Documents/programming/airflow/airflow/ui/src/components/ui/Menu.tsx
  27:7  warning  Fast refresh only works when a file only exports components. Move your component(s) to a separate file  react-refresh/only-export-components

/Users/uranusjr/Documents/programming/airflow/airflow/ui/src/components/ui/Toaster.tsx
  21:14  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
```