### PR TITLE
AIP-38 Injectable path for static files

### DIFF
--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -31,6 +31,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from airflow.api_fastapi.core_api.middleware import FlaskExceptionsMiddleware
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.settings import AIRFLOW_PATH
 from airflow.www.extensions.init_dagbag import get_dag_bag
@@ -76,7 +77,11 @@ def init_views(app: FastAPI) -> None:
 
     @app.get("/webapp/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def webapp(request: Request, rest_of_path: str):
-        return templates.TemplateResponse("/index.html", {"request": request}, media_type="text/html")
+        return templates.TemplateResponse(
+            "/index.html",
+            {"request": request, "backend_server_base_url": conf.get("fastapi", "base_url")},
+            media_type="text/html",
+        )
 
 
 def init_plugins(app: FastAPI) -> None:

--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -67,7 +67,7 @@ def init_views(app: FastAPI) -> None:
     templates = Jinja2Templates(directory=directory)
 
     app.mount(
-        "/static",
+        "/webapp/static",
         StaticFiles(
             directory=directory,
             html=True,

--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -3,7 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
-    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="http://localhost:5173/public/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">

--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -3,6 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
     <link rel="icon" type="image/png" href="http://localhost:5173/public/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/pin_32.png" />
+    <link rel="icon" type="image/png" href="/static/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
     <title>Airflow 3.0</title>

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
     <title>Airflow 3.0</title>
   </head>
   <body style="height: 100%">

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -2,6 +2,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
+    <base href="{{ backend_server_base_url }}/webapp/" />
     <link rel="icon" type="image/png" href="/static/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}">
     <title>Airflow 3.0</title>
   </head>
   <body style="height: 100%">

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,7 +23,6 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
-import { OpenAPI } from "openapi/requests/core/OpenAPI";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
@@ -58,9 +57,6 @@ axios.interceptors.request.use((config) => {
 
   return config;
 });
-
-// Dynamically set the base URL for XHR requests based on the meta tag.
-OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,6 +23,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
@@ -57,6 +58,9 @@ axios.interceptors.request.use((config) => {
 
   return config;
 });
+
+// Dynamically set the base URL for XHR requests based on the meta tag.
+OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>

--- a/airflow/ui/src/queryClient.ts
+++ b/airflow/ui/src/queryClient.ts
@@ -18,6 +18,11 @@
  */
 import { QueryClient } from "@tanstack/react-query";
 
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
+
+// Dynamically set the base URL for XHR requests based on the meta tag.
+OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     mutations: {

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -168,4 +168,8 @@ export const routerConfig = [
   },
 ];
 
-export const router = createBrowserRouter(routerConfig, { basename: "/webapp" });
+const locationPath = globalThis.window.location.pathname;
+const indexOf = locationPath.indexOf("webapp/");
+const basename = locationPath.slice(0, indexOf + 7);
+
+export const router = createBrowserRouter(routerConfig, { basename });

--- a/airflow/ui/vite.config.ts
+++ b/airflow/ui/vite.config.ts
@@ -22,6 +22,7 @@ import { defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "./",
   build: { chunkSizeWarningLimit: 1600, manifest: true },
   plugins: [
     react(),
@@ -29,7 +30,7 @@ export default defineConfig({
     {
       name: "transform-url-src",
       transformIndexHtml: (html) =>
-        html.replace(`src="/assets/`, `src="/static/assets/`).replace(`href="/`, `href="/webapp/`),
+        html.replace(`src="./assets/`, `src="./static/assets/`).replace(`href="/`, `href="/webapp/`),
     },
     cssInjectedByJsPlugin(),
   ],

--- a/airflow/ui/vite.config.ts
+++ b/airflow/ui/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     {
       name: "transform-url-src",
       transformIndexHtml: (html) =>
-        html.replace(`src="./assets/`, `src="./static/assets/`).replace(`href="/`, `href="/webapp/`),
+        html.replace(`src="./assets/`, `src="./static/assets/`).replace(`href="/`, `href="./`),
     },
     cssInjectedByJsPlugin(),
   ],


### PR DESCRIPTION
Solves https://github.com/apache/airflow/issues/46548

Built on top of https://github.com/apache/airflow/pull/46900, only the last commit is relevant.

First draft, you should be able to edit the `fastapi.base_url` parameter, for instance set `http://localhost:29091/d12345`, and the UI should render at: `http://localhost:29091/d12345/webapp`

![Screenshot 2025-02-20 at 18 51 17](https://github.com/user-attachments/assets/435e407f-3b64-41fd-b2d0-66bd2714e967)


I need to fix the pin.

For future request, I noticed that the tasksdk client might be not using the `base_url` param and reach the wrong endpoints when this is configured.