### PR TITLE
Fix backfill behavior for existing dag runs

### DIFF
--- a/airflow/models/backfill.py
+++ b/airflow/models/backfill.py
@@ -335,8 +335,8 @@ def _create_backfill_dag_run(
         except IntegrityError:
             log.info(
                 "Skipped creating backfill dag run for dag_id=%s backfill_id=%s, logical_date=%s (already exists)",
-                dr.dag_id,
-                dr.id,
+                dag.dag_id,
+                backfill_id,
                 info.logical_date,
             )
             log.info("Doing session rollback.")

--- a/airflow/models/backfill.py
+++ b/airflow/models/backfill.py
@@ -357,7 +357,6 @@ def _create_backfill_dag_run(
                 backfill_id,
                 info.logical_date,
             )
-            log.info("rolling back")
             nested.rollback()
 
             session.add(

--- a/airflow/models/backfill.py
+++ b/airflow/models/backfill.py
@@ -47,7 +47,7 @@ from airflow.models.dag_version import DagVersion
 from airflow.settings import json
 from airflow.utils import timezone
 from airflow.utils.session import create_session
-from airflow.utils.sqlalchemy import UtcDateTime, nulls_first
+from airflow.utils.sqlalchemy import UtcDateTime, nulls_first, with_row_locks
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
@@ -166,6 +166,9 @@ class BackfillDagRun(Base):
     backfill = relationship("Backfill", back_populates="backfill_dag_run_associations")
     dag_run = relationship("DagRun")
 
+    def __repr__(self):
+        return f"BackfillDagRun(id={self.id}, backfill_id={self.backfill_id}, logical_date='{self.logical_date}')"
+
     __table_args__ = (
         UniqueConstraint("backfill_id", "dag_run_id", name="ix_bdr_backfill_id_dag_run_id"),
         ForeignKeyConstraint(
@@ -265,28 +268,6 @@ def _do_dry_run(*, dag_id, from_date, to_date, reverse, reprocess_behavior, sess
     return logical_dates
 
 
-def should_create_backfill_dag_run(
-    info, reprocess_behavior, backfill_id, backfill_sort_ordinal, session
-) -> bool:
-    """Determine if a backfill DAG run should be created and add a BackfillDagRun if required."""
-    dr = session.scalar(_get_latest_dag_run_row_query(info, session))
-    if not dr:
-        return False
-    non_create_reason = _get_dag_run_no_create_reason(dr, reprocess_behavior)
-    if non_create_reason:
-        session.add(
-            BackfillDagRun(
-                backfill_id=backfill_id,
-                dag_run_id=None,
-                logical_date=info.logical_date,
-                exception_reason=non_create_reason,
-                sort_ordinal=backfill_sort_ordinal,
-            )
-        )
-        return True
-    return False
-
-
 def _create_backfill_dag_run(
     *,
     dag: DAG,
@@ -299,12 +280,49 @@ def _create_backfill_dag_run(
 ):
     from airflow.models.dagrun import DagRun
 
-    with session.begin_nested():
-        should_skip_create_backfill = should_create_backfill_dag_run(
-            info, reprocess_behavior, backfill_id, backfill_sort_ordinal, session
-        )
-        if should_skip_create_backfill:
-            return
+    with session.begin_nested() as nested:
+        dr = session.scalar(_get_latest_dag_run_row_query(info, session))
+        if dr:
+            non_create_reason = _get_dag_run_no_create_reason(dr, reprocess_behavior)
+            if non_create_reason:
+                session.add(
+                    BackfillDagRun(
+                        backfill_id=backfill_id,
+                        dag_run_id=None,
+                        logical_date=info.logical_date,
+                        exception_reason=non_create_reason,
+                        sort_ordinal=backfill_sort_ordinal,
+                    )
+                )
+                return
+            else:
+                lock = session.execute(
+                    with_row_locks(
+                        query=select(DagRun).where(DagRun.logical_date == info.logical_date),
+                        session=session,
+                        skip_locked=True,
+                    )
+                )
+                if lock:
+                    _handle_clear_run(
+                        session=session,
+                        dag=dag,
+                        dr=dr,
+                        info=info,
+                        backfill_id=backfill_id,
+                        sort_ordinal=backfill_sort_ordinal,
+                    )
+                else:
+                    session.add(
+                        BackfillDagRun(
+                            backfill_id=backfill_id,
+                            dag_run_id=None,
+                            logical_date=info.logical_date,
+                            exception_reason=BackfillDagRunExceptionReason.IN_FLIGHT,
+                            sort_ordinal=backfill_sort_ordinal,
+                        )
+                    )
+                return
 
         dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
         try:
@@ -339,11 +357,17 @@ def _create_backfill_dag_run(
                 backfill_id,
                 info.logical_date,
             )
-            log.info("Doing session rollback.")
-            session.rollback()
+            log.info("rolling back")
+            nested.rollback()
 
-            should_create_backfill_dag_run(
-                info, reprocess_behavior, backfill_id, backfill_sort_ordinal, session
+            session.add(
+                BackfillDagRun(
+                    backfill_id=backfill_id,
+                    dag_run_id=None,
+                    logical_date=info.logical_date,
+                    exception_reason=BackfillDagRunExceptionReason.IN_FLIGHT,
+                    sort_ordinal=backfill_sort_ordinal,
+                )
             )
 
 
@@ -360,6 +384,42 @@ def _get_info_list(
     if reverse:
         dagrun_info_list = reversed(dagrun_info_list)
     return dagrun_info_list
+
+
+def _handle_clear_run(session, dag, dr, info, backfill_id, sort_ordinal):
+    """Clear the existing DAG run and update backfill metadata."""
+    from sqlalchemy.sql import update
+
+    from airflow.models import DagRun
+    from airflow.utils.state import DagRunState
+    from airflow.utils.types import DagRunType
+
+    dag.clear(
+        run_id=dr.run_id,
+        dag_run_state=DagRunState.QUEUED,
+        session=session,
+        confirm_prompt=False,
+        dry_run=False,
+    )
+
+    # Update backfill_id and run_type in DagRun table
+    session.execute(
+        update(DagRun)
+        .where(DagRun.logical_date == info.logical_date)
+        .values(
+            backfill_id=backfill_id,
+            run_type=DagRunType.BACKFILL_JOB,
+            triggered_by=DagRunTriggeredByType.BACKFILL,
+        )
+    )
+    session.add(
+        BackfillDagRun(
+            backfill_id=backfill_id,
+            dag_run_id=dr.id,
+            logical_date=info.logical_date,
+            sort_ordinal=sort_ordinal,
+        )
+    )
 
 
 def _create_backfill(

--- a/tests/models/test_backfill.py
+++ b/tests/models/test_backfill.py
@@ -152,46 +152,23 @@ def test_create_backfill_simple(reverse, existing, dag_maker, session):
     assert all(x.conf == expected_run_conf for x in dag_runs)
 
 
-# Marking test xfail as backfill reprocess behaviour impacted by restoring logical date unique constraints in #46295
-# TODO: Fix backfill reprocess behaviour as per #46295
-@pytest.mark.xfail(
-    reason="Backfill reprocess behaviour impacted by restoring logical date unique constraints."
-)
 @pytest.mark.parametrize(
-    "reprocess_behavior, run_counts",
+    "reprocess_behavior, num_in_b, exc_reasons",
     [
         (
             ReprocessBehavior.NONE,
-            {
-                "2021-01-01": 1,
-                "2021-01-09": 1,
-            },
+            4,
+            {"2021-01-05": "already exists", "2021-01-06": "already exists", "2021-01-07": "in flight"},
         ),
         (
             ReprocessBehavior.FAILED,
-            {
-                "2021-01-01": 1,
-                "2021-01-02": 1,
-                "2021-01-03": 1,
-                "2021-01-06": 1,
-                "2021-01-09": 1,
-            },
+            5,
+            {"2021-01-05": "already exists", "2021-01-07": "in flight"},
         ),
-        (
-            ReprocessBehavior.COMPLETED,
-            {
-                "2021-01-01": 1,
-                "2021-01-02": 1,
-                "2021-01-03": 1,
-                "2021-01-04": 1,
-                "2021-01-05": 1,
-                "2021-01-06": 1,
-                "2021-01-09": 1,
-            },
-        ),
+        (ReprocessBehavior.COMPLETED, 6, {"2021-01-07": "in flight"}),
     ],
 )
-def test_reprocess_behavior(reprocess_behavior, run_counts, dag_maker, session):
+def test_reprocess_behavior(reprocess_behavior, num_in_b, exc_reasons, dag_maker, session):
     """
     We have two modes whereby when there's an existing run(s) in the range
     of the backfill, we will create a new run.
@@ -202,45 +179,31 @@ def test_reprocess_behavior(reprocess_behavior, run_counts, dag_maker, session):
     with dag_maker(schedule="@daily", dag_id=dag_id) as dag:
         PythonOperator(task_id="hi", python_callable=print)
 
-    for num, (date, state) in enumerate(
-        [
-            (date, state)
-            for date, states in [
-                # order matters here
-                # whether a dag run is created for backfill depends on
-                # the last run for a logical date
-                ("2021-01-02", ["failed"]),
-                ("2021-01-03", ["success", "failed"]),  # <-- 2021-01-03 is "failed"
-                ("2021-01-04", ["failed", "success"]),  # <-- 2021-01-04 is "success"
-                ("2021-01-05", ["success", "success"]),
-                ("2021-01-06", ["failed", "failed"]),
-                ("2021-01-07", ["running", "running"]),
-                ("2021-01-08", ["failed", "running"]),
-            ]
-            for state in states
-        ]
-    ):
+    for date, state in [
+        ("2021-01-05", "success"),
+        ("2021-01-06", "failed"),
+        ("2021-01-07", "running"),
+    ]:
         dr = dag_maker.create_dagrun(
-            run_id=f"scheduled_{date}-{num}",
+            run_id=f"scheduled_{date}",
             logical_date=timezone.parse(date),
             session=session,
             state=state,
         )
-        dr.start_date = timezone.parse(date) + timedelta(seconds=num)
+        dr.start_date = timezone.parse(date)
         for ti in dr.get_task_instances(session=session):
             ti.state = state
         session.commit()
 
     b = _create_backfill(
         dag_id=dag.dag_id,
-        from_date=pendulum.parse("2021-01-01"),
+        from_date=pendulum.parse("2021-01-03"),
         to_date=pendulum.parse("2021-01-09"),
         max_active_runs=2,
         reprocess_behavior=reprocess_behavior,
         reverse=False,
         dag_run_conf=None,
     )
-    from collections import Counter
 
     session.expunge_all()
     query = (
@@ -251,35 +214,22 @@ def test_reprocess_behavior(reprocess_behavior, run_counts, dag_maker, session):
     )
     # these are all the dag runs that are part of this backfill
     dag_runs_in_b = session.scalars(query).all()
+    assert len(dag_runs_in_b) == num_in_b
+
     # verify they all have the right run type
     assert all(x.run_type == DagRunType.BACKFILL_JOB for x in dag_runs_in_b)
     # verify they all have the right triggered by type
     assert all(x.triggered_by == DagRunTriggeredByType.BACKFILL for x in dag_runs_in_b)
+    # every run associated with the backfill should have the backfill id
+    assert all(x.backfill_id == b.id for x in dag_runs_in_b)
 
-    # verify that we see the dates and counts expected
-    backfill_dates = [str(x.logical_date.date()) for x in dag_runs_in_b]
-    assert Counter(backfill_dates) == run_counts
-
-    def _get_bdr(date):
-        return session.scalar(
-            select(BackfillDagRun).where(BackfillDagRun.logical_date == timezone.parse(date))
+    reasons = session.execute(
+        select(BackfillDagRun.logical_date, BackfillDagRun.exception_reason).where(
+            BackfillDagRun.backfill_id == b.id, BackfillDagRun.exception_reason.is_not(None)
         )
-
-    # 2021-01-08 is running so we will not create a run for it
-    bdr = _get_bdr("2021-01-08")
-    assert bdr.exception_reason == BackfillDagRunExceptionReason.IN_FLIGHT
-
-    # 2021-01-04 is "failed" so it may or may not be reprocessed depending
-    # on the configuration
-    bdr = _get_bdr("2021-01-04")
-    actual_reason = bdr.exception_reason
-    if reprocess_behavior is ReprocessBehavior.FAILED:
-        assert actual_reason == BackfillDagRunExceptionReason.ALREADY_EXISTS
-    elif reprocess_behavior is ReprocessBehavior.COMPLETED:
-        assert actual_reason is None
-    elif reprocess_behavior is ReprocessBehavior.NONE:
-        assert actual_reason == BackfillDagRunExceptionReason.ALREADY_EXISTS
-
+    ).all()
+    actual = dict({str(d.date()): r for d, r in reasons})
+    assert actual == exc_reasons
     # all the runs created by the backfill should have state queued
     assert all(x.state == DagRunState.QUEUED for x in dag_runs_in_b)
 

--- a/tests/models/test_backfill.py
+++ b/tests/models/test_backfill.py
@@ -171,9 +171,7 @@ def test_create_backfill_simple(reverse, existing, dag_maker, session):
 def test_reprocess_behavior(reprocess_behavior, num_in_b, exc_reasons, dag_maker, session):
     """
     We have two modes whereby when there's an existing run(s) in the range
-    of the backfill, we will create a new run.
-    This test might need to be altered if we change the behavior re multiple
-    runs of same logical date.  But for now, it verifies the current behavior.
+    of the backfill, we will clear an existing run.
     """
     dag_id = "backfill-test-reprocess-behavior"
     with dag_maker(schedule="@daily", dag_id=dag_id) as dag:


### PR DESCRIPTION
There were some issues in the logic that needed to be resolved.

Some of them were unset variables in the exception block, but the main issue was re the need to clear a dag run when the log date is there.

Replaces https://github.com/apache/airflow/pull/46554
Closes https://github.com/apache/airflow/issues/46278

Also resolves comment thread https://github.com/apache/airflow/pull/46248/files#r1952725320.


