### PR TITLE
Ensure that the the generated airflow.cfg contains a random jwt_secret and fernet_key

### DIFF
--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -27,7 +27,7 @@ from airflow.api_fastapi.app import get_auth_manager
 from airflow.auth.managers.models.base_user import BaseUser
 from airflow.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.configuration import conf
-from airflow.utils.jwt_signer import JWTSigner
+from airflow.utils.jwt_signer import JWTSigner, get_signing_key
 
 if TYPE_CHECKING:
     from airflow.auth.managers.base_auth_manager import ResourceMethod
@@ -38,7 +38,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 @cache
 def get_signer() -> JWTSigner:
     return JWTSigner(
-        secret_key=conf.get("api", "auth_jwt_secret"),
+        secret_key=get_signing_key("api", "auth_jwt_secret"),
         expiration_time_in_seconds=conf.getint("api", "auth_jwt_expiration_time"),
         audience="front-apis",
     )

--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -30,7 +30,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
 from airflow.typing_compat import Literal
-from airflow.utils.jwt_signer import JWTSigner
+from airflow.utils.jwt_signer import JWTSigner, get_signing_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -464,7 +464,7 @@ class BaseAuthManager(Generic[T], LoggingMixin):
         :meta private:
         """
         return JWTSigner(
-            secret_key=conf.get("api", "auth_jwt_secret"),
+            secret_key=get_signing_key("api", "auth_jwt_secret"),
             expiration_time_in_seconds=conf.getint("api", "auth_jwt_expiration_time"),
             audience="front-apis",
         )

--- a/airflow/auth/managers/simple/services/login.py
+++ b/airflow/auth/managers/simple/services/login.py
@@ -23,8 +23,7 @@ from airflow.api_fastapi.app import get_auth_manager
 from airflow.auth.managers.simple.datamodels.login import LoginBody, LoginResponse
 from airflow.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.auth.managers.simple.user import SimpleAuthManagerUser
-from airflow.configuration import conf
-from airflow.utils.jwt_signer import JWTSigner
+from airflow.utils.jwt_signer import JWTSigner, get_signing_key
 
 
 class SimpleAuthManagerLogin:
@@ -66,7 +65,7 @@ class SimpleAuthManagerLogin:
         )
 
         signer = JWTSigner(
-            secret_key=conf.get("api", "auth_jwt_secret"),
+            secret_key=get_signing_key("api", "auth_jwt_secret"),
             expiration_time_in_seconds=expiration_time_in_sec,
             audience="front-apis",
         )


### PR DESCRIPTION
I don't know exactly when this got broken, and unforutnaltey it wasn't tested,
but I suspect it might have been around the time we swapped the default config
from a config file to the yaml based values. I.e. a while ago!

To make sure it doesn't get broken I've gone and added some unit tests

And to make my next PR and test easier I have done the same thing with the
`auth_jwt_secret` that we do for fernet_key -- of only set it in the config
file if we're generating that file, not always in memory.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
