### PR TITLE
Link state icons in dashboard to list page with instances filtered by the state for the given duration.

### DIFF
--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -33,6 +33,7 @@ type Props = {
   readonly defaultValue: string;
   readonly groupProps?: InputGroupProps;
   readonly hideAdvanced?: boolean;
+  readonly hotkeyDisabled?: boolean;
   readonly onChange: (value: string) => void;
   readonly placeHolder: string;
 };
@@ -42,6 +43,7 @@ export const SearchBar = ({
   defaultValue,
   groupProps,
   hideAdvanced = false,
+  hotkeyDisabled = false,
   onChange,
   placeHolder,
 }: Props) => {
@@ -60,7 +62,7 @@ export const SearchBar = ({
     () => {
       searchRef.current?.focus();
     },
-    { preventDefault: true },
+    { enabled: !hotkeyDisabled, preventDefault: true },
   );
 
   return (
@@ -86,7 +88,7 @@ export const SearchBar = ({
               Advanced Search
             </Button>
           )}
-          <Kbd size="sm">{metaKey}+K</Kbd>
+          {!hotkeyDisabled && <Kbd size="sm">{metaKey}+K</Kbd>}
         </>
       }
       startElement={<FiSearch />}

--- a/airflow/ui/src/constants/searchParams.ts
+++ b/airflow/ui/src/constants/searchParams.ts
@@ -17,12 +17,15 @@
  * under the License.
  */
 export enum SearchParamsKeys {
+  END_DATE = "end_date",
   LAST_DAG_RUN_STATE = "last_dag_run_state",
   LIMIT = "limit",
   NAME_PATTERN = "name_pattern",
   OFFSET = "offset",
   PAUSED = "paused",
   SORT = "sort",
+  START_DATE = "start_date",
+  STATE = "state",
   TAGS = "tags",
   VERSION_NUMBER = "version_number",
 }

--- a/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow/ui/src/pages/DagRuns.tsx
@@ -32,6 +32,7 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { dagRunStateOptions as stateOptions } from "src/constants/stateOptions";
 import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 
@@ -108,8 +109,6 @@ const runColumns = (dagId?: string): Array<ColumnDef<DAGRunResponse>> => [
   },
 ];
 
-const STATE_PARAM = "state";
-
 export const DagRuns = () => {
   const { dagId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -118,17 +117,26 @@ export const DagRuns = () => {
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-run_after";
+  const {
+    END_DATE: END_DATE_PARAM,
+    START_DATE: START_DATE_PARAM,
+    STATE: STATE_PARAM,
+  }: SearchParamsKeysType = SearchParamsKeys;
 
   const filteredState = searchParams.get(STATE_PARAM);
+  const startDate = searchParams.get(START_DATE_PARAM);
+  const endDate = searchParams.get(END_DATE_PARAM);
 
   const refetchInterval = useAutoRefresh({});
 
   const { data, error, isLoading } = useDagRunServiceGetDagRuns(
     {
       dagId: dagId ?? "~",
+      endDateLte: endDate ?? undefined,
       limit: pagination.pageSize,
       offset: pagination.pageIndex * pagination.pageSize,
       orderBy,
+      startDateGte: startDate ?? undefined,
       state: filteredState === null ? undefined : [filteredState],
     },
     undefined,
@@ -154,7 +162,7 @@ export const DagRuns = () => {
       });
       setSearchParams(searchParams);
     },
-    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting, STATE_PARAM],
   );
 
   return (

--- a/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow/ui/src/pages/DagRuns.tsx
@@ -37,6 +37,11 @@ import { dagRunStateOptions as stateOptions } from "src/constants/stateOptions";
 import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 
 type DagRunRow = { row: { original: DAGRunResponse } };
+const {
+  END_DATE: END_DATE_PARAM,
+  START_DATE: START_DATE_PARAM,
+  STATE: STATE_PARAM,
+}: SearchParamsKeysType = SearchParamsKeys;
 
 const runColumns = (dagId?: string): Array<ColumnDef<DAGRunResponse>> => [
   ...(Boolean(dagId)
@@ -117,11 +122,6 @@ export const DagRuns = () => {
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-run_after";
-  const {
-    END_DATE: END_DATE_PARAM,
-    START_DATE: START_DATE_PARAM,
-    STATE: STATE_PARAM,
-  }: SearchParamsKeysType = SearchParamsKeys;
 
   const filteredState = searchParams.get(STATE_PARAM);
   const startDate = searchParams.get(START_DATE_PARAM);
@@ -162,7 +162,7 @@ export const DagRuns = () => {
       });
       setSearchParams(searchParams);
     },
-    [pagination, searchParams, setSearchParams, setTableURLState, sorting, STATE_PARAM],
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );
 
   return (

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -26,14 +26,14 @@ import { MetricSection } from "./MetricSection";
 
 type DagRunMetricsProps = {
   readonly dagRunStates: DAGRunStates;
-  readonly total: number;
-  readonly startDate: string;
   readonly endDate: string;
+  readonly startDate: string;
+  readonly total: number;
 };
 
 const DAGRUN_STATES: Array<keyof DAGRunStates> = ["queued", "running", "success", "failed"];
 
-export const DagRunMetrics = ({ dagRunStates, total, startDate, endDate }: DagRunMetricsProps) => (
+export const DagRunMetrics = ({ dagRunStates, endDate, startDate, total }: DagRunMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} p={2}>
     <HStack mb={4}>
       <StateBadge colorPalette="blue" fontSize="md" variant="solid">
@@ -44,13 +44,13 @@ export const DagRunMetrics = ({ dagRunStates, total, startDate, endDate }: DagRu
     </HStack>
     {DAGRUN_STATES.map((state) => (
       <MetricSection
+        endDate={endDate}
         key={state}
+        kind="dag_runs"
         runs={dagRunStates[state]}
+        startDate={startDate}
         state={state}
         total={total}
-        startDate={startDate}
-        endDate={endDate}
-        kind={"dag_runs"}
       />
     ))}
   </Box>

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -27,11 +27,13 @@ import { MetricSection } from "./MetricSection";
 type DagRunMetricsProps = {
   readonly dagRunStates: DAGRunStates;
   readonly total: number;
+  readonly startDate: string;
+  readonly endDate: string;
 };
 
 const DAGRUN_STATES: Array<keyof DAGRunStates> = ["queued", "running", "success", "failed"];
 
-export const DagRunMetrics = ({ dagRunStates, total }: DagRunMetricsProps) => (
+export const DagRunMetrics = ({ dagRunStates, total, startDate, endDate }: DagRunMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} p={2}>
     <HStack mb={4}>
       <StateBadge colorPalette="blue" fontSize="md" variant="solid">
@@ -41,7 +43,15 @@ export const DagRunMetrics = ({ dagRunStates, total }: DagRunMetricsProps) => (
       <Heading size="md">Dag Runs</Heading>
     </HStack>
     {DAGRUN_STATES.map((state) => (
-      <MetricSection key={state} runs={dagRunStates[state]} state={state} total={total} />
+      <MetricSection
+        key={state}
+        runs={dagRunStates[state]}
+        state={state}
+        total={total}
+        startDate={startDate}
+        endDate={endDate}
+        kind={"dag_runs"}
+      />
     ))}
   </Box>
 );

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -73,8 +73,18 @@ export const HistoricalMetrics = () => {
             {isLoading ? <MetricSectionSkeleton /> : undefined}
             {!isLoading && data !== undefined && (
               <Box>
-                <DagRunMetrics dagRunStates={data.dag_run_states} total={dagRunTotal} />
-                <TaskInstanceMetrics taskInstanceStates={data.task_instance_states} total={taskRunTotal} />
+                <DagRunMetrics
+                  dagRunStates={data.dag_run_states}
+                  total={dagRunTotal}
+                  startDate={startDate}
+                  endDate={endDate}
+                />
+                <TaskInstanceMetrics
+                  taskInstanceStates={data.task_instance_states}
+                  total={taskRunTotal}
+                  startDate={startDate}
+                  endDate={endDate}
+                />
               </Box>
             )}
           </GridItem>

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -75,15 +75,15 @@ export const HistoricalMetrics = () => {
               <Box>
                 <DagRunMetrics
                   dagRunStates={data.dag_run_states}
-                  total={dagRunTotal}
-                  startDate={startDate}
                   endDate={endDate}
+                  startDate={startDate}
+                  total={dagRunTotal}
                 />
                 <TaskInstanceMetrics
+                  endDate={endDate}
+                  startDate={startDate}
                   taskInstanceStates={data.task_instance_states}
                   total={taskRunTotal}
-                  startDate={startDate}
-                  endDate={endDate}
                 />
               </Box>
             )}

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, VStack, Text } from "@chakra-ui/react";
+import { Box, Flex, HStack, VStack, Text, Link } from "@chakra-ui/react";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
@@ -29,9 +29,12 @@ type MetricSectionProps = {
   readonly runs: number;
   readonly state: TaskInstanceState;
   readonly total: number;
+  readonly kind: number;
+  readonly startDate: string;
+  readonly endDate: string;
 };
 
-export const MetricSection = ({ runs, state, total }: MetricSectionProps) => {
+export const MetricSection = ({ runs, state, total, kind, startDate, endDate }: MetricSectionProps) => {
   // Calculate the given state as a percentage of total and draw a bar
   // in state's color with width as state's percentage and remaining width filed as gray
   const statePercent = total === 0 ? 0 : ((runs / total) * 100).toFixed(2);
@@ -42,9 +45,11 @@ export const MetricSection = ({ runs, state, total }: MetricSectionProps) => {
     <VStack align="left" gap={1} mb={4} ml={0} pl={0}>
       <Flex justify="space-between">
         <HStack>
-          <StateBadge fontSize="md" state={state}>
-            {runs}
-          </StateBadge>
+          <Link href={`/webapp/${kind}?state=${state}&start_date=${startDate}&end_date=${endDate}`}>
+            <StateBadge fontSize="md" state={state}>
+              {runs}
+            </StateBadge>
+          </Link>
           <Text>
             {state
               .split("_")

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -26,15 +26,15 @@ const BAR_WIDTH = 100;
 const BAR_HEIGHT = 5;
 
 type MetricSectionProps = {
+  readonly endDate: string;
+  readonly kind: string;
   readonly runs: number;
+  readonly startDate: string;
   readonly state: TaskInstanceState;
   readonly total: number;
-  readonly kind: number;
-  readonly startDate: string;
-  readonly endDate: string;
 };
 
-export const MetricSection = ({ runs, state, total, kind, startDate, endDate }: MetricSectionProps) => {
+export const MetricSection = ({ endDate, kind, runs, startDate, state, total }: MetricSectionProps) => {
   // Calculate the given state as a percentage of total and draw a bar
   // in state's color with width as state's percentage and remaining width filed as gray
   const statePercent = total === 0 ? 0 : ((runs / total) * 100).toFixed(2);

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, VStack, Text, Link } from "@chakra-ui/react";
+import { Box, Flex, HStack, VStack, Text } from "@chakra-ui/react";
+import { Link as RouterLink } from "react-router-dom";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
@@ -45,11 +46,11 @@ export const MetricSection = ({ endDate, kind, runs, startDate, state, total }: 
     <VStack align="left" gap={1} mb={4} ml={0} pl={0}>
       <Flex justify="space-between">
         <HStack>
-          <Link href={`/webapp/${kind}?state=${state}&start_date=${startDate}&end_date=${endDate}`}>
+          <RouterLink to={`/${kind}?state=${state}&start_date=${startDate}&end_date=${endDate}`}>
             <StateBadge fontSize="md" state={state}>
               {runs}
             </StateBadge>
-          </Link>
+          </RouterLink>
           <Text>
             {state
               .split("_")

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -25,10 +25,10 @@ import { StateBadge } from "src/components/StateBadge";
 import { MetricSection } from "./MetricSection";
 
 type TaskInstanceMetricsProps = {
+  readonly endDate: string;
+  readonly startDate: string;
   readonly taskInstanceStates: TaskInstanceStateCount;
   readonly total: number;
-  readonly startDate: string;
-  readonly endDate: string;
 };
 
 const TASK_STATES: Array<keyof TaskInstanceStateCount> = [
@@ -47,10 +47,10 @@ const TASK_STATES: Array<keyof TaskInstanceStateCount> = [
 ];
 
 export const TaskInstanceMetrics = ({
+  endDate,
+  startDate,
   taskInstanceStates,
   total,
-  startDate,
-  endDate,
 }: TaskInstanceMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} mt={2} p={2}>
     <HStack mb={4}>
@@ -65,13 +65,13 @@ export const TaskInstanceMetrics = ({
     ).map((state) =>
       taskInstanceStates[state] > 0 ? (
         <MetricSection
+          endDate={endDate}
           key={state}
+          kind="task_instances"
           runs={taskInstanceStates[state]}
+          startDate={startDate}
           state={state as TaskInstanceState}
           total={total}
-          startDate={startDate}
-          endDate={endDate}
-          kind={"task_instances"}
         />
       ) : undefined,
     )}

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -27,6 +27,8 @@ import { MetricSection } from "./MetricSection";
 type TaskInstanceMetricsProps = {
   readonly taskInstanceStates: TaskInstanceStateCount;
   readonly total: number;
+  readonly startDate: string;
+  readonly endDate: string;
 };
 
 const TASK_STATES: Array<keyof TaskInstanceStateCount> = [
@@ -44,7 +46,12 @@ const TASK_STATES: Array<keyof TaskInstanceStateCount> = [
   "deferred",
 ];
 
-export const TaskInstanceMetrics = ({ taskInstanceStates, total }: TaskInstanceMetricsProps) => (
+export const TaskInstanceMetrics = ({
+  taskInstanceStates,
+  total,
+  startDate,
+  endDate,
+}: TaskInstanceMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} mt={2} p={2}>
     <HStack mb={4}>
       <StateBadge colorPalette="blue" fontSize="md" variant="solid">
@@ -62,6 +69,9 @@ export const TaskInstanceMetrics = ({ taskInstanceStates, total }: TaskInstanceM
           runs={taskInstanceStates[state]}
           state={state as TaskInstanceState}
           total={total}
+          startDate={startDate}
+          endDate={endDate}
+          kind={"task_instances"}
         />
       ) : undefined,
     )}

--- a/airflow/ui/src/pages/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances.tsx
@@ -41,6 +41,12 @@ import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/uti
 import { getTaskInstanceLink } from "src/utils/links";
 
 type TaskInstanceRow = { row: { original: TaskInstanceResponse } };
+const {
+  END_DATE: END_DATE_PARAM,
+  NAME_PATTERN: NAME_PATTERN_PARAM,
+  START_DATE: START_DATE_PARAM,
+  STATE: STATE_PARAM,
+}: SearchParamsKeysType = SearchParamsKeys;
 
 const taskInstanceColumns = (
   dagId?: string,
@@ -161,12 +167,6 @@ export const TaskInstances = () => {
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
-  const {
-    END_DATE: END_DATE_PARAM,
-    NAME_PATTERN: NAME_PATTERN_PARAM,
-    START_DATE: START_DATE_PARAM,
-    STATE: STATE_PARAM,
-  }: SearchParamsKeysType = SearchParamsKeys;
 
   const filteredState = searchParams.getAll(STATE_PARAM);
   const startDate = searchParams.get(START_DATE_PARAM);
@@ -193,7 +193,7 @@ export const TaskInstances = () => {
       });
       setSearchParams(searchParams);
     },
-    [pagination, searchParams, setSearchParams, setTableURLState, sorting, STATE_PARAM],
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );
 
   const handleSearchChange = (value: string) => {

--- a/airflow/ui/src/pages/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances.tsx
@@ -154,10 +154,6 @@ const taskInstanceColumns = (
   },
 ];
 
-const STATE_PARAM = "state";
-const START_DATE_PARAM = "start_date";
-const END_DATE_PARAM = "end_date";
-
 export const TaskInstances = () => {
   const { dagId, runId, taskId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -165,11 +161,17 @@ export const TaskInstances = () => {
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
+  const {
+    END_DATE: END_DATE_PARAM,
+    NAME_PATTERN: NAME_PATTERN_PARAM,
+    START_DATE: START_DATE_PARAM,
+    STATE: STATE_PARAM,
+  }: SearchParamsKeysType = SearchParamsKeys;
+
   const filteredState = searchParams.getAll(STATE_PARAM);
   const startDate = searchParams.get(START_DATE_PARAM);
   const endDate = searchParams.get(END_DATE_PARAM);
   const hasFilteredState = filteredState.length > 0;
-  const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType = SearchParamsKeys;
 
   const [taskDisplayNamePattern, setTaskDisplayNamePattern] = useState(
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
@@ -191,7 +193,7 @@ export const TaskInstances = () => {
       });
       setSearchParams(searchParams);
     },
-    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting, STATE_PARAM],
   );
 
   const handleSearchChange = (value: string) => {
@@ -214,14 +216,14 @@ export const TaskInstances = () => {
     {
       dagId: dagId ?? "~",
       dagRunId: runId ?? "~",
+      endDateLte: endDate ?? undefined,
       limit: pagination.pageSize,
       offset: pagination.pageIndex * pagination.pageSize,
       orderBy,
+      startDateGte: startDate ?? undefined,
       state: hasFilteredState ? filteredState : undefined,
       taskDisplayNamePattern: Boolean(taskDisplayNamePattern) ? taskDisplayNamePattern : undefined,
       taskId: taskId ?? undefined,
-      startDateGte: startDate ?? undefined,
-      endDateLte: endDate ?? undefined,
     },
     undefined,
     {

--- a/airflow/ui/src/pages/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances.tsx
@@ -155,6 +155,8 @@ const taskInstanceColumns = (
 ];
 
 const STATE_PARAM = "state";
+const START_DATE_PARAM = "start_date";
+const END_DATE_PARAM = "end_date";
 
 export const TaskInstances = () => {
   const { dagId, runId, taskId } = useParams();
@@ -164,6 +166,8 @@ export const TaskInstances = () => {
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
   const filteredState = searchParams.getAll(STATE_PARAM);
+  const startDate = searchParams.get(START_DATE_PARAM);
+  const endDate = searchParams.get(END_DATE_PARAM);
   const hasFilteredState = filteredState.length > 0;
   const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType = SearchParamsKeys;
 
@@ -216,6 +220,8 @@ export const TaskInstances = () => {
       state: hasFilteredState ? filteredState : undefined,
       taskDisplayNamePattern: Boolean(taskDisplayNamePattern) ? taskDisplayNamePattern : undefined,
       taskId: taskId ?? undefined,
+      startDateGte: startDate ?? undefined,
+      endDateLte: endDate ?? undefined,
     },
     undefined,
     {

--- a/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,27 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, Link, HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
+import { Flex, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
-import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
-import { SearchBar } from "src/components/SearchBar";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
-import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
-import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
+import { getDuration, useAutoRefresh, isStatePending } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
+
+import { TaskInstancesFilter } from "./TaskInstancesFilter";
 
 type TaskInstanceRow = { row: { original: TaskInstanceResponse } };
 const {
@@ -162,7 +159,7 @@ const taskInstanceColumns = (
 
 export const TaskInstances = () => {
   const { dagId, runId, taskId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
@@ -176,39 +173,6 @@ export const TaskInstances = () => {
   const [taskDisplayNamePattern, setTaskDisplayNamePattern] = useState(
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
   );
-
-  const handleStateChange = useCallback(
-    ({ value }: SelectValueChangeDetails<string>) => {
-      const [val, ...rest] = value;
-
-      if ((val === undefined || val === "all") && rest.length === 0) {
-        searchParams.delete(STATE_PARAM);
-      } else {
-        searchParams.delete(STATE_PARAM);
-        value.filter((state) => state !== "all").map((state) => searchParams.append(STATE_PARAM, state));
-      }
-      setTableURLState({
-        pagination: { ...pagination, pageIndex: 0 },
-        sorting,
-      });
-      setSearchParams(searchParams);
-    },
-    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
-  );
-
-  const handleSearchChange = (value: string) => {
-    if (value) {
-      searchParams.set(NAME_PATTERN_PARAM, value);
-    } else {
-      searchParams.delete(NAME_PATTERN_PARAM);
-    }
-    setTableURLState({
-      pagination: { ...pagination, pageIndex: 0 },
-      sorting,
-    });
-    setTaskDisplayNamePattern(value);
-    setSearchParams(searchParams);
-  };
 
   const refetchInterval = useAutoRefresh({});
 
@@ -235,55 +199,10 @@ export const TaskInstances = () => {
 
   return (
     <>
-      <HStack>
-        <Select.Root
-          collection={stateOptions}
-          maxW="250px"
-          multiple
-          onValueChange={handleStateChange}
-          value={hasFilteredState ? filteredState : ["all"]}
-        >
-          <Select.Trigger
-            {...(hasFilteredState ? { clearable: true } : {})}
-            colorPalette="blue"
-            isActive={Boolean(filteredState)}
-          >
-            <Select.ValueText>
-              {() =>
-                hasFilteredState ? (
-                  <HStack gap="10px">
-                    {filteredState.map((state) => (
-                      <StateBadge key={state} state={state as TaskInstanceState}>
-                        {state === "none" ? "No Status" : capitalize(state)}
-                      </StateBadge>
-                    ))}
-                  </HStack>
-                ) : (
-                  "All States"
-                )
-              }
-            </Select.ValueText>
-          </Select.Trigger>
-          <Select.Content>
-            {stateOptions.items.map((option) => (
-              <Select.Item item={option} key={option.label}>
-                {option.value === "all" ? (
-                  option.label
-                ) : (
-                  <StateBadge state={option.value as TaskInstanceState}>{option.label}</StateBadge>
-                )}
-              </Select.Item>
-            ))}
-          </Select.Content>
-        </Select.Root>
-        <SearchBar
-          buttonProps={{ disabled: true }}
-          defaultValue={taskDisplayNamePattern ?? ""}
-          hideAdvanced
-          onChange={handleSearchChange}
-          placeHolder="Search Tasks"
-        />
-      </HStack>
+      <TaskInstancesFilter
+        setTaskDisplayNamePattern={setTaskDisplayNamePattern}
+        taskDisplayNamePattern={taskDisplayNamePattern}
+      />
       <DataTable
         columns={taskInstanceColumns(dagId, runId, taskId)}
         data={data?.task_instances ?? []}

--- a/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
+++ b/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
@@ -1,0 +1,132 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import type { TaskInstanceState } from "openapi/requests/types.gen";
+import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { SearchBar } from "src/components/SearchBar";
+import { StateBadge } from "src/components/StateBadge";
+import { Select } from "src/components/ui";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
+import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
+import { capitalize } from "src/utils";
+
+const { NAME_PATTERN: NAME_PATTERN_PARAM, STATE: STATE_PARAM }: SearchParamsKeysType = SearchParamsKeys;
+
+export const TaskInstancesFilter = ({
+  setTaskDisplayNamePattern,
+  taskDisplayNamePattern,
+}: {
+  readonly setTaskDisplayNamePattern: React.Dispatch<React.SetStateAction<string | undefined>>;
+  readonly taskDisplayNamePattern: string | undefined;
+}) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setTableURLState, tableURLState } = useTableURLState();
+  const { pagination, sorting } = tableURLState;
+
+  const filteredState = searchParams.getAll(STATE_PARAM);
+  const hasFilteredState = filteredState.length > 0;
+
+  const handleStateChange = useCallback(
+    ({ value }: SelectValueChangeDetails<string>) => {
+      const [val, ...rest] = value;
+
+      if ((val === undefined || val === "all") && rest.length === 0) {
+        searchParams.delete(STATE_PARAM);
+      } else {
+        searchParams.delete(STATE_PARAM);
+        value.filter((state) => state !== "all").map((state) => searchParams.append(STATE_PARAM, state));
+      }
+      setTableURLState({
+        pagination: { ...pagination, pageIndex: 0 },
+        sorting,
+      });
+      setSearchParams(searchParams);
+    },
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
+  );
+
+  const handleSearchChange = (value: string) => {
+    if (value) {
+      searchParams.set(NAME_PATTERN_PARAM, value);
+    } else {
+      searchParams.delete(NAME_PATTERN_PARAM);
+    }
+    setTableURLState({
+      pagination: { ...pagination, pageIndex: 0 },
+      sorting,
+    });
+    setTaskDisplayNamePattern(value);
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <HStack>
+      <Select.Root
+        collection={stateOptions}
+        maxW="250px"
+        multiple
+        onValueChange={handleStateChange}
+        value={hasFilteredState ? filteredState : ["all"]}
+      >
+        <Select.Trigger
+          {...(hasFilteredState ? { clearable: true } : {})}
+          colorPalette="blue"
+          isActive={Boolean(filteredState)}
+        >
+          <Select.ValueText>
+            {() =>
+              hasFilteredState ? (
+                <HStack gap="10px">
+                  {filteredState.map((state) => (
+                    <StateBadge key={state} state={state as TaskInstanceState}>
+                      {state === "none" ? "No Status" : capitalize(state)}
+                    </StateBadge>
+                  ))}
+                </HStack>
+              ) : (
+                "All States"
+              )
+            }
+          </Select.ValueText>
+        </Select.Trigger>
+        <Select.Content>
+          {stateOptions.items.map((option) => (
+            <Select.Item item={option} key={option.label}>
+              {option.value === "all" ? (
+                option.label
+              ) : (
+                <StateBadge state={option.value as TaskInstanceState}>{option.label}</StateBadge>
+              )}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+      <SearchBar
+        buttonProps={{ disabled: true }}
+        defaultValue={taskDisplayNamePattern ?? ""}
+        hideAdvanced
+        onChange={handleSearchChange}
+        placeHolder="Search Tasks"
+      />
+    </HStack>
+  );
+};

--- a/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
+++ b/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
@@ -18,7 +18,7 @@
  */
 import { HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
 import { useCallback } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useParams } from "react-router-dom";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
@@ -38,6 +38,7 @@ export const TaskInstancesFilter = ({
   readonly setTaskDisplayNamePattern: React.Dispatch<React.SetStateAction<string | undefined>>;
   readonly taskDisplayNamePattern: string | undefined;
 }) => {
+  const { runId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
@@ -124,6 +125,7 @@ export const TaskInstancesFilter = ({
         buttonProps={{ disabled: true }}
         defaultValue={taskDisplayNamePattern ?? ""}
         hideAdvanced
+        hotkeyDisabled={Boolean(runId)}
         onChange={handleSearchChange}
         placeHolder="Search Tasks"
       />

--- a/airflow/ui/src/pages/TaskInstances/index.ts
+++ b/airflow/ui/src/pages/TaskInstances/index.ts
@@ -1,0 +1,19 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export { TaskInstances } from "./TaskInstances";


### PR DESCRIPTION
On visiting the dashboard home page user could see many failed task instances in the last 24 hours. Quickly identifying the task instances involves user going to the dags page, task instances tab and then selecting failed state to sort by start_date/end_date to get recent failures. With this PR by clicking on the state icon in metrics section the respective list page in this case task instance is rendered and the state is filtered by "failed" and start_date/end_date passed as query parameters to get the task instances failed in last 24 hours.

It seems `airflow/ui/src/pages/TaskInstances.tsx` has become longer than 250 lines. I tried refactoring by moving some query parameter fields to constants but it's still at 253. I have disabled the eslint rule for now to this page. Any suggestions welcome.