### PR TITLE
Move execution_api_server_url config to the core section

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -528,6 +528,13 @@ core:
       type: integer
       example: ~
       default: "4096"
+    execution_api_server_url:
+      description: |
+        The url of the execution api server.
+      version_added: 3.0.0
+      type: string
+      example: ~
+      default: "http://localhost:9091/execution/"
 database:
   description: ~
   options:

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -121,7 +121,7 @@ def _execute_work(log: logging.Logger, workload: workloads.ExecuteTask) -> None:
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
         token=workload.token,
-        server=conf.get("workers", "execution_api_server_url", fallback="http://localhost:9091/execution/"),
+        server=conf.get("core", "execution_api_server_url"),
         log_path=workload.log_path,
     )
 

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -38,11 +38,11 @@ metadata:
   {{- end }}
 {{- $Global := . }}
 data:
-  {{/*- Set a default for workers.execution_api_server_url pointing to the api-server service if it's not set -*/}}
+  {{/*- Set a default for core.execution_api_server_url pointing to the api-server service if it's not set -*/}}
   {{- if semverCompare ">=3.0.0" .Values.airflowVersion -}}
-    {{- $config := merge .Values.config ( dict  "workers" dict )}}
-    {{- if not (hasKey $config.workers "execution_api_server_url") -}}
-      {{- $_ := set $config.workers "execution_api_server_url" (printf "http://%s-api-server:%d/execution/" (include "airflow.fullname" .) (int .Values.ports._apiServer))  -}}
+    {{- $config := merge .Values.config ( dict  "core" dict )}}
+    {{- if not (hasKey $config.core "execution_api_server_url") -}}
+      {{- $_ := set $config.core "execution_api_server_url" (printf "http://%s-api-server:%d/execution/" (include "airflow.fullname" .) (int .Values.ports._apiServer))  -}}
     {{- end -}}
   {{- end -}}
   # These are system-specified config overrides.

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -162,7 +162,7 @@ def execute_workload(input: str) -> None:
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
         token=workload.token,
-        server=conf.get("workers", "execution_api_server_url", fallback="http://localhost:9091/execution/"),
+        server=conf.get("core", "execution_api_server_url"),
         log_path=workload.log_path,
     )
 

--- a/providers/edge/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/edge/src/airflow/providers/edge/cli/edge_command.py
@@ -277,9 +277,7 @@ class _EdgeWorkerCli:
                     dag_rel_path=workload.dag_rel_path,
                     bundle_info=workload.bundle_info,
                     token=workload.token,
-                    server=conf.get(
-                        "workers", "execution_api_server_url", fallback="http://localhost:9091/execution/"
-                    ),
+                    server=conf.get("core", "execution_api_server_url"),
                     log_path=workload.log_path,
                 )
                 return 0

--- a/task_sdk/src/airflow/sdk/execution_time/execute_workload.py
+++ b/task_sdk/src/airflow/sdk/execution_time/execute_workload.py
@@ -59,12 +59,7 @@ def execute_workload(input: str) -> None:
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
         token=workload.token,
-        # fallback to internal cluster service for api server
-        server=conf.get(
-            "workers",
-            "execution_api_server_url",
-            fallback="http://airflow-api-server.airflow.svc.cluster.local:9091/execution/",
-        ),
+        server=conf.get("core", "execution_api_server_url"),
         log_path=workload.log_path,
     )
 


### PR DESCRIPTION
This adds it to config.yml so itll be documented and moves the default into config (if we have a fallback default, we might as well show it in docs too, and every use will have the default already).
