### PR TITLE
Fix pinecone client package rename after 6.0.0

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1073,7 +1073,7 @@
   "pinecone": {
     "deps": [
       "apache-airflow>=2.9.0",
-      "pinecone-client>=3.1.0"
+      "pinecone>=3.1.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/pinecone/README.rst
+++ b/providers/pinecone/README.rst
@@ -51,12 +51,12 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-===================  ==================
-PIP package          Version required
-===================  ==================
-``apache-airflow``   ``>=2.9.0``
-``pinecone-client``  ``>=3.1.0``
-===================  ==================
+==================  ==================
+PIP package         Version required
+==================  ==================
+``apache-airflow``  ``>=2.9.0``
+``pinecone``        ``>=3.1.0``
+==================  ==================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-pinecone/2.2.1/changelog.html>`_.

--- a/providers/pinecone/pyproject.toml
+++ b/providers/pinecone/pyproject.toml
@@ -56,7 +56,7 @@ requires-python = "~=3.9"
 # Any change in the dependencies is preserved when the file is regenerated
 dependencies = [
     "apache-airflow>=2.9.0",
-    "pinecone-client>=3.1.0",
+    "pinecone>=3.1.0",
 ]
 
 [project.urls]

--- a/providers/pinecone/src/airflow/providers/pinecone/get_provider_info.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/get_provider_info.py
@@ -63,5 +63,5 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.pinecone.operators.pinecone"],
             }
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "pinecone-client>=3.1.0"],
+        "dependencies": ["apache-airflow>=2.9.0", "pinecone>=3.1.0"],
     }


### PR DESCRIPTION
Main broke in https://github.com/apache/airflow/actions/runs/13463851687/job/37626317768

Seems to be related to pinecone-client 6.0.0 released:

< pinecone-client==5.0.1
---
> pinecone-client==6.0.0

Error in Pytests by this: Exception: The official Pinecone python package has been renamed from `pinecone-client` to `pinecone`. Please remove `pinecone-client` from your project dependencies and add `pinecone` instead. See the README at https://github.com/pinecone-io/pinecone-python-client for more information on using the python SDK.