### PR TITLE
Support tracking a tag and force pushes in the git bundle

### DIFF
--- a/tests/dag_processing/bundles/test_git.py
+++ b/tests/dag_processing/bundles/test_git.py
@@ -295,7 +295,6 @@ class TestGitDagBundle:
 
         # add tag
         repo.create_tag("test")
-        print(repo.tags)
 
         # Add new file to the repo
         file_path = repo_path / "new_test.py"
@@ -335,11 +334,23 @@ class TestGitDagBundle:
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py", "new_test.py"} == files_in_repo
 
+    @pytest.mark.parametrize(
+        "amend",
+        [
+            True,
+            False,
+        ],
+    )
     @mock.patch("airflow.dag_processing.bundles.git.GitHook")
-    def test_refresh(self, mock_githook, git_repo):
+    def test_refresh(self, mock_githook, git_repo, amend):
+        """Ensure that the bundle refresh works when tracking a branch, with a new commit and amending the commit"""
         repo_path, repo = git_repo
         mock_githook.return_value.repo_url = repo_path
         starting_commit = repo.head.commit
+
+        with repo.config_writer() as writer:
+            writer.set_value("user", "name", "Test User")
+            writer.set_value("user", "email", "test@example.com")
 
         bundle = GitDagBundle(name="test", tracking_ref=GIT_DEFAULT_BRANCH)
         bundle.initialize()
@@ -353,7 +364,38 @@ class TestGitDagBundle:
         with open(file_path, "w") as f:
             f.write("hello world")
         repo.index.add([file_path])
+        commit = repo.git.commit(amend=amend, message="Another commit")
+
+        bundle.refresh()
+
+        assert bundle.get_current_version()[:6] in commit
+
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py", "new_test.py"} == files_in_repo
+
+    @mock.patch("airflow.dag_processing.bundles.git.GitHook")
+    def test_refresh_tag(self, mock_githook, git_repo):
+        """Ensure that the bundle refresh works when tracking a tag"""
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        starting_commit = repo.head.commit
+
+        # add tag
+        repo.create_tag("test123")
+
+        bundle = GitDagBundle(name="test", tracking_ref="test123")
+        bundle.initialize()
+        assert bundle.get_current_version() == starting_commit.hexsha
+
+        # Add new file to the repo
+        file_path = repo_path / "new_test.py"
+        with open(file_path, "w") as f:
+            f.write("hello world")
+        repo.index.add([file_path])
         commit = repo.index.commit("Another commit")
+
+        # update tag
+        repo.create_tag("test123", force=True)
 
         bundle.refresh()
 
@@ -440,8 +482,9 @@ class TestGitDagBundle:
             tracking_ref=GIT_DEFAULT_BRANCH,
         )
         bundle.initialize()
+        assert mock_gitRepo.return_value.remotes.origin.fetch.call_count == 2  # 1 in bare, 1 in main repo
+        mock_gitRepo.return_value.remotes.origin.fetch.reset_mock()
         bundle.refresh()
-        # check remotes called twice. one at initialize and one at refresh above
         assert mock_gitRepo.return_value.remotes.origin.fetch.call_count == 2
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- Tracking tags, while intended to be supported, weren't.
- For branches, we were doing a naive pull, but this breaks if the repo had a force push. We instead do an explicit fetch and hard reset now.
