### PR TITLE
Fix new UI when running outside of breeze

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2697,4 +2697,4 @@ fastapi:
       version_added: ~
       type: string
       example: ~
-      default: "http://localhost:29091"
+      default: "http://localhost:9091"

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -507,6 +507,7 @@ class ShellParams:
         _set_var(_env, "AIRFLOW_VERSION", self.airflow_version)
         _set_var(_env, "AIRFLOW__CELERY__BROKER_URL", self.airflow_celery_broker_url)
         _set_var(_env, "AIRFLOW__CORE__EXECUTOR", self.executor)
+        _set_var(_env, "AIRFLOW__FASTAPI__BASE_URL", f"http://localhost:{FASTAPI_API_HOST_PORT}")
         if self.executor == EDGE_EXECUTOR:
             _set_var(
                 _env, "AIRFLOW__CORE__EXECUTOR", "airflow.providers.edge.executors.edge_executor.EdgeExecutor"

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -666,7 +666,7 @@ class TestAwsAuthManager:
 
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()
-        assert result == "http://localhost:29091/auth/login"
+        assert result == "http://localhost:9091/auth/login"
 
     def test_get_cli_commands_return_cli_commands(self, auth_manager):
         assert len(auth_manager.get_cli_commands()) > 0

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -576,7 +576,7 @@ class TestFabAuthManager:
 
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()
-        assert result == "http://localhost:29091/auth/login"
+        assert result == "http://localhost:9091/auth/login"
 
     @pytest.mark.db_test
     def test_get_url_logout_when_auth_view_not_defined(self, auth_manager_with_appbuilder):


### PR DESCRIPTION
`[fastapi] base_url` expected that the server would be running with the breeze port, but that's not always true. Breeze should override for its specific environment instead of the other way around.