### PR TITLE
Add Trino Connection UI Fields Placeholders

### DIFF
--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -95,7 +95,6 @@ class TrinoHook(DbApiHook):
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
         """Return custom field behaviour."""
-        import json
 
         return {
             "hidden_fields": [],

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -92,6 +92,42 @@ class TrinoHook(DbApiHook):
     query_id = ""
     _test_connection_sql = "select 1"
 
+    @classmethod
+    def get_ui_field_behaviour(cls) -> dict[str, Any]:
+        """Return custom field behaviour."""
+        import json
+
+        return {
+            "hidden_fields": [],
+            "relabeling": {},
+            "placeholders": {
+                "extra": json.dumps(
+                    {
+                        "auth": "authentication type",
+                        "impersonate_as_owner": "allow impersonate as owner",
+                        "jwt__token": "JWT token",
+                        "jwt__file": "JWT file path",
+                        "certs__client_cert_path": "Client certificate path",
+                        "certs__client_key_path": "Client key path",
+                        "kerberos__config": "Kerberos config",
+                        "kerberos__service_name": "Kerberos service name",
+                        "kerberos__mutual_authentication": "Kerberos mutual authentication",
+                        "kerberos__force_preemptive": "Kerberos force preemptive",
+                        "kerberos__hostname_override": "Kerberos hostname override",
+                        "kerberos__sanitize_mutual_error_response": "Kerberos sanitize mutual error response",
+                        "kerberos__principal": "Kerberos principal",
+                        "kerberos__delegate": "Kerberos delegate",
+                        "kerberos__ca_bundle": "Kerberos CA bundle",
+                        "session_properties": "session properties",
+                        "client_tags": "Trino client tags. Example ['sales','cluster1']",
+                        "timezone": "Trino timezone",
+                    },
+                    indent=1,
+                ),
+                "login": "Effective user for connection",
+            },
+        }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._placeholder: str = "?"

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -95,7 +95,6 @@ class TrinoHook(DbApiHook):
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
         """Return custom field behaviour."""
-
         return {
             "hidden_fields": [],
             "relabeling": {},


### PR DESCRIPTION
closes: #45841
- [x] Implementation
- [x] E2E Test

## What
- I added description text for the fields on the Trino connection creation page to make it easier for users to operate client tags and other connection-related settings.

## How
- `providers/trino/src/airflow/providers/trino/hooks/trino.py`
    - Implement `get_ui_field_behaviour()` to display tooltip text on the fields in the webserver UI.

## Test
- I followed the instructions on the page to operate the client tag feature in my local environment and successfully added client tags information to the Trino query.
    - ![截圖 2025-02-24 上午12 09 11](https://github.com/user-attachments/assets/2a15bafc-4331-4865-9d25-98bb6060db7e)
    - ![截圖 2025-02-23 下午11 49 00](https://github.com/user-attachments/assets/b43c6651-e5fd-4fa2-8f80-e27f5f71a041)
    - ![截圖 2025-02-23 下午11 50 23](https://github.com/user-attachments/assets/67022c83-6413-4190-82d2-fe0ff1606477)




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
