### PR TITLE
Respect celery log level in structlog config / try to clean up a bit

### DIFF
--- a/task_sdk/src/airflow/sdk/log.py
+++ b/task_sdk/src/airflow/sdk/log.py
@@ -241,7 +241,6 @@ def configure_logging(
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         drop_positional_args,
     ]
-    enable_pretty_log = False
     if enable_pretty_log:
         formatter = "colored"
         logger_factory, pre_chain_add, processors, timestamper, console_renderer = _configure_logging_pretty(

--- a/task_sdk/src/airflow/sdk/log.py
+++ b/task_sdk/src/airflow/sdk/log.py
@@ -128,6 +128,7 @@ class StdBinaryStreamHandler(logging.StreamHandler):
 def _common_processors(timestamp_fmt):
     timestamper = structlog.processors.MaybeTimeStamper(fmt=timestamp_fmt)
     processors: list[structlog.typing.Processor] = [
+        timestamper,
         structlog.contextvars.merge_contextvars,
         structlog.processors.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),

--- a/task_sdk/src/airflow/sdk/log.py
+++ b/task_sdk/src/airflow/sdk/log.py
@@ -155,7 +155,7 @@ def _common_processors(timestamp_fmt):
 
 
 @cache
-def logging_processors_pretty():
+def _logging_processors_pretty():
     timestamper, processors, suppress = _common_processors(timestamp_fmt="%Y-%m-%d %H:%M:%S.%f")
 
     rich_exc_formatter = structlog.dev.RichTracebackFormatter(
@@ -177,7 +177,7 @@ def logging_processors_pretty():
 
 
 @cache
-def logging_processors_ugly():
+def _logging_processors_plain():
     timestamper, processors, suppress = _common_processors(timestamp_fmt="iso")
     dict_exc_formatter = structlog.tracebacks.ExceptionDictTransformer(
         use_rich=False, show_locals=False, suppress=suppress
@@ -252,7 +252,7 @@ def configure_logging(
         formatter = "plain"
         color_format_processors.append(_json_processor)
         plain_format_processors.append(_json_processor)  # why do we conditionally add json processor here?
-        logger_factory, output, pre_chain_add, processors, timestamper = _configure_logging_ugly(
+        logger_factory, output, pre_chain_add, processors, timestamper = _configure_logging_plain(
             output=output,
         )
 
@@ -327,8 +327,8 @@ def configure_logging(
     )
 
 
-def _configure_logging_ugly(*, output):
-    processors, timestamper, exc_group_processor, dict_tracebacks = logging_processors_ugly()
+def _configure_logging_plain(*, output):
+    processors, timestamper, exc_group_processor, dict_tracebacks = _logging_processors_plain()
     if output is not None and "b" not in output.mode:
         if not hasattr(output, "buffer"):
             raise ValueError(
@@ -354,7 +354,7 @@ def _configure_logging_pretty(*, output):
         logger_factory = structlog.WriteLoggerFactory(wrapper)
     else:
         logger_factory = structlog.WriteLoggerFactory(output)
-    processors, timestamper, console_renderer = logging_processors_pretty()
+    processors, timestamper, console_renderer = _logging_processors_pretty()
     pre_chain_add = []
     return logger_factory, pre_chain_add, processors, timestamper, console_renderer
 

--- a/task_sdk/src/airflow/sdk/log.py
+++ b/task_sdk/src/airflow/sdk/log.py
@@ -195,12 +195,12 @@ def _logging_processors_plain():
         # Note: this is likely an "expensive" step, but lets massage the dict order for nice
         # viewing of the raw JSON logs.
         # Maybe we don't need this once the UI renders the JSON instead of displaying the raw text
-        # msg = {
-        #     "timestamp": msg.pop("timestamp"),
-        #     "level": msg.pop("level"),
-        #     "event": msg.pop("event"),
-        #     **msg,
-        # }
+        msg = {
+            "timestamp": msg.pop("timestamp"),
+            "level": msg.pop("level"),
+            "event": msg.pop("event"),
+            **msg,
+        }
         return msgspec.json.encode(msg, enc_hook=default)
 
     json = structlog.processors.JSONRenderer(serializer=json_dumps)


### PR DESCRIPTION
This area of code is quite confusing and hard to follow.  I try to make it a *little* bit easier to follow by breaking up some of the functions into smaller ones.  In some cases this clarifies the logic a little bit. I did not intend any behavior changes in the refactor portion of this.

The one behavior change I did intend was in the celery_command file, where I pass the log level to `configure_logging` so that you don't have debug logs on by default when using structlog.

There's a lot here that I still don't really understand and which remains confusing but I accomplished my main goal here so moving on for now.
