### PR TITLE
doc: Add GCSListObjectsOperator to operators listed in documentation in Google Provider for GCS  #39290

### DIFF
--- a/providers/google/docs/operators/cloud/gcs.rst
+++ b/providers/google/docs/operators/cloud/gcs.rst
@@ -122,6 +122,37 @@ See Google Cloud Storage insert documentation to `create a ACL entry for ObjectA
 <https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls/insert>`_.
 
 
+.. _howto/operator:GCSListObjectsOperator:
+
+GCSListObjectsOperator
+----------------------
+
+Use the
+:class:`~airflow.providers.google.cloud.operators.gcs.GCSListObjectsOperator`
+to list objects in a Google Cloud Storage bucket. Optionally specify a prefix to list only objects whose 
+names begin with that prefix, and a delimiter to emulate directory-like organization.
+
+.. exampleinclude:: /../../providers/google/tests/system/google/cloud/gcs/example_gcs_copy_delete.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcs_list_bucket]
+    :end-before: [END howto_operator_gcs_list_bucket]
+
+.. _howto/operator:GCSDeleteObjectsOperator:
+
+GCSDeleteObjectsOperator
+------------------------
+
+Use the
+:class:`~airflow.providers.google.cloud.operators.gcs.GCSDeleteObjectsOperator`
+to delete one or more objects from a Google Cloud Storage bucket.
+
+.. exampleinclude:: /../../providers/google/tests/system/google/cloud/gcs/example_gcs_copy_delete.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcs_delete_object]
+    :end-before: [END howto_operator_gcs_delete_object]
+
 .. _howto/operator:GCSDeleteBucketOperator:
 
 Deleting Bucket

--- a/providers/google/docs/operators/cloud/gcs.rst
+++ b/providers/google/docs/operators/cloud/gcs.rst
@@ -129,7 +129,7 @@ GCSListObjectsOperator
 
 Use the
 :class:`~airflow.providers.google.cloud.operators.gcs.GCSListObjectsOperator`
-to list objects in a Google Cloud Storage bucket. Optionally specify a prefix to list only objects whose 
+to list objects in a Google Cloud Storage bucket. Optionally specify a prefix to list only objects whose
 names begin with that prefix, and a delimiter to emulate directory-like organization.
 
 .. exampleinclude:: /../../providers/google/tests/system/google/cloud/gcs/example_gcs_copy_delete.py


### PR DESCRIPTION
doc: Add GCSListObjectsOperator to operators listed in documentation in Google Provider for GCS  #39290

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
closes: #39290 
related: #39290