### PR TITLE
Fix `lookup_from_deprecated_options` in AirflowConfigParser

### DIFF
--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -522,7 +522,7 @@ def lint_config(args) -> None:
             continue
 
         if conf.has_option(
-            configuration.config.section, configuration.config.option, lookup_from_deprecated_options=False
+            configuration.config.section, configuration.config.option, lookup_from_deprecated=False
         ):
             lint_issues.append(configuration.message)
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1267,6 +1267,7 @@ class AirflowConfigParser(ConfigParser):
 
         :param section: section to get option from
         :param option: option to get
+        :param lookup_from_deprecated: If True, check if the option is defined in deprecated sections
         :return:
         """
         try:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -909,7 +909,9 @@ class AirflowConfigParser(ConfigParser):
         deprecated_key: str | None = None
 
         if lookup_from_deprecated_options:
-            option_description = self.configuration_description.get(section, {}).get(key, {})
+            option_description = (
+                self.configuration_description.get(section, {}).get("options", {}).get(key, {})
+            )
             if option_description.get("deprecated"):
                 deprecation_reason = option_description.get("deprecation_reason", "")
                 warnings.warn(

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -898,7 +898,7 @@ class AirflowConfigParser(ConfigParser):
         section: str,
         key: str,
         suppress_warnings: bool = False,
-        lookup_from_deprecated_options: bool = True,
+        lookup_from_deprecated: bool = True,
         _extra_stacklevel: int = 0,
         **kwargs,
     ) -> str | None:
@@ -908,7 +908,7 @@ class AirflowConfigParser(ConfigParser):
         deprecated_section: str | None = None
         deprecated_key: str | None = None
 
-        if lookup_from_deprecated_options:
+        if lookup_from_deprecated:
             option_description = (
                 self.configuration_description.get(section, {}).get("options", {}).get(key, {})
             )
@@ -1258,7 +1258,7 @@ class AirflowConfigParser(ConfigParser):
         """
         super().read_dict(dictionary=dictionary, source=source)
 
-    def has_option(self, section: str, option: str, lookup_from_deprecated_options: bool = True) -> bool:
+    def has_option(self, section: str, option: str, lookup_from_deprecated: bool = True) -> bool:
         """
         Check if option is defined.
 
@@ -1276,7 +1276,7 @@ class AirflowConfigParser(ConfigParser):
                 fallback=None,
                 _extra_stacklevel=1,
                 suppress_warnings=True,
-                lookup_from_deprecated_options=lookup_from_deprecated_options,
+                lookup_from_deprecated=lookup_from_deprecated,
             )
             if value is None:
                 return False

--- a/tests/cli/commands/remote_commands/test_config_command.py
+++ b/tests/cli/commands/remote_commands/test_config_command.py
@@ -324,7 +324,7 @@ class TestConfigLint:
     def test_lint_detects_multiple_issues(self):
         with mock.patch(
             "airflow.configuration.conf.has_option",
-            side_effect=lambda section, option, lookup_from_deprecated_options: option
+            side_effect=lambda section, option, lookup_from_deprecated: option
             in ["check_slas", "strict_dataset_uri_validation"],
         ):
             with contextlib.redirect_stdout(StringIO()) as temp_stdout:

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -939,7 +939,7 @@ class TestDeprecatedConf:
                 assert conf.getint("celery", "worker_concurrency") == 99
 
     @pytest.mark.parametrize(
-        "deprecated_options_dict, kargs, new_section_expected, old_section_expected",
+        "deprecated_options_dict, kwargs, new_section_expected_value, old_section_expected_value",
         [
             pytest.param(
                 {("old_section", "old_key"): ("new_section", "new_key", "2.0.0")},
@@ -972,13 +972,13 @@ class TestDeprecatedConf:
         ],
     )
     def test_deprecated_options_with_lookup_from_deprecated(
-        self, deprecated_options_dict, kargs, new_section_expected, old_section_expected
+        self, deprecated_options_dict, kwargs, new_section_expected_value, old_section_expected_value
     ):
         with conf_vars({("new_section", "new_key"): "value"}):
             with set_deprecated_options(deprecated_options=deprecated_options_dict):
-                assert conf.get("new_section", "old_key", **kargs) == new_section_expected
+                assert conf.get("new_section", "old_key", **kwargs) == new_section_expected_value
 
-                assert conf.get("old_section", "old_key", **kargs) == old_section_expected
+                assert conf.get("old_section", "old_key", **kwargs) == old_section_expected_value
 
     @conf_vars(
         {

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -938,6 +938,12 @@ class TestDeprecatedConf:
             with pytest.warns(DeprecationWarning), conf_vars({("celery", "celeryd_concurrency"): "99"}):
                 assert conf.getint("celery", "worker_concurrency") == 99
 
+            # should get None when set lookup_from_deprecated_options keyword to False
+            assert (
+                conf.get("celery", "worker_concurrency", fallback=None, lookup_from_deprecated_options=False)
+                is None
+            )
+
     @conf_vars(
         {
             ("celery", "result_backend"): None,


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/46544/files/b6ac7467b0bfc36831185219112354ea22da29f4#r1966113213

## Why

`option_description` should be `self.configuration_description.get(section, {}).get("options", {}).get(key, {})` instead of `self.configuration_description.get(section, {}).get(key, {})` and the corresponding test is missing.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
