### PR TITLE
Fix TestRdsCopyDbSnapshotOperator tests

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -43,7 +43,7 @@
     "devel-deps": [
       "aiobotocore>=2.13.0",
       "aws_xray_sdk>=2.12.0",
-      "moto[cloudformation,glue]>=5.0.0,!=5.1.0",
+      "moto[cloudformation,glue]>=5.0.0",
       "mypy-boto3-appflow>=1.35.39",
       "mypy-boto3-rds>=1.34.90",
       "mypy-boto3-redshift-data>=1.34.0",

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -137,7 +137,7 @@ dependencies = [
 dev = [
     "aiobotocore>=2.13.0",
     "aws_xray_sdk>=2.12.0",
-    "moto[cloudformation,glue]>=5.0.0,!=5.1.0",
+    "moto[cloudformation,glue]>=5.0.0",
     "mypy-boto3-appflow>=1.35.39",
     "mypy-boto3-rds>=1.34.90",
     "mypy-boto3-redshift-data>=1.34.0",

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1371,7 +1371,7 @@ def get_provider_info():
         "devel-dependencies": [
             "aiobotocore>=2.13.0",
             "aws_xray_sdk>=2.12.0",
-            "moto[cloudformation,glue]>=5.0.0,!=5.1.0",
+            "moto[cloudformation,glue]>=5.0.0",
             "mypy-boto3-appflow>=1.35.39",
             "mypy-boto3-rds>=1.34.90",
             "mypy-boto3-redshift-data>=1.34.0",


### PR DESCRIPTION
Moto improved the fixtures now, so basically when copy db snapshotted it looks for kms in an account when snapshot not have already kms, as moto is mocked aws so no kms exists in account, creating kms key that should fix this.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
