### PR TITLE
ISSUE-46884: Remove sort query params when switching tabs

### DIFF
--- a/airflow/ui/src/layouts/Details/NavTabs.tsx
+++ b/airflow/ui/src/layouts/Details/NavTabs.tsx
@@ -29,6 +29,20 @@ type Props = {
 export const NavTabs = ({ keepSearch, rightButtons, tabs }: Props) => {
   const [searchParams] = useSearchParams();
 
+  const getUpdatedSearchParams = () => {
+    if (!keepSearch) {
+      return undefined;
+    }
+
+    const updatedParams = new URLSearchParams(searchParams.toString());
+
+    if (updatedParams.has("sort")) {
+      updatedParams.delete("sort"); // Remove the 'sort' parameter only if it exists
+    }
+
+    return updatedParams.toString();
+  };
+
   return (
     <Flex alignItems="center" borderBottomWidth={1} justifyContent="space-between" mb={2}>
       <Flex>
@@ -39,7 +53,7 @@ export const NavTabs = ({ keepSearch, rightButtons, tabs }: Props) => {
             to={{
               pathname: value,
               // Preserve search params when navigating
-              search: keepSearch ? searchParams.toString() : undefined,
+              search: getUpdatedSearchParams(),
             }}
           >
             {({ isActive }) => (


### PR DESCRIPTION
closes: #46884


"Our navigation tabs currently preserve query parameters (search params) when switching between tabs. This behavior causes UI issues when sorting is applied on one tab and then a user navigates to another tab where the sorted parameter is not applicable. Specifically, if a 'sort' parameter is present in the URL on Tab A and the user switches to Tab B, which doesn't utilize sorting or doesn't have the same column for sorting, the UI breaks. This results in an error because the application attempts to apply a non-existent sort configuration."




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
