### PR TITLE
AIP-81 | AIP-84 | Include Token Generation Endpoints in FAB

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
           - --fuzzy-match-generates-todo
       - id: insert-license
         name: Add license for all YAML files except Helm templates
-        exclude: ^\.github/.*$|^chart/templates/.*|.*/reproducible_build.yaml$|^airflow/api_fastapi/core_api/openapi/v1-generated.yaml$|^airflow/auth/managers/simple/openapi/v1-generated.yaml$|^.*/pnpm-lock.yaml$
+        exclude: ^\.github/.*$|^chart/templates/.*|.*/reproducible_build.yaml$|^airflow/api_fastapi/core_api/openapi/v1-generated.yaml$|^providersv1-generated.yaml$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml$|^.*/pnpm-lock.yaml$
         types: [yaml]
         files: \.ya?ml$
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
           - --fuzzy-match-generates-todo
       - id: insert-license
         name: Add license for all YAML files except Helm templates
-        exclude: ^\.github/.*$|^chart/templates/.*|.*/reproducible_build.yaml$|^airflow/api_fastapi/core_api/openapi/v1-generated.yaml$|^airflow/auth/managers/simple/openapi/v1-generated.yaml$|^airflow/auth/managers/simple/openapi/v1-generated.yaml$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml$|^.*/pnpm-lock.yaml$
+        exclude: ^\.github/.*$|^chart/templates/.*|.*/reproducible_build.yaml$|^airflow/api_fastapi/core_api/openapi/v1-generated.yaml$|^airflow/auth/managers/simple/openapi/v1-generated.yaml$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml$|^.*/pnpm-lock.yaml$
         types: [yaml]
         files: \.ya?ml$
         args:
@@ -1383,7 +1383,7 @@ repos:
         language: python
         entry: ./scripts/ci/pre_commit/update_fastapi_api_spec.py
         pass_filenames: false
-        files: ^airflow/api_fastapi/.*\.py$
+        files: ^airflow/api_fastapi/.*\.py$|^airflow/auth/managers/simple/.*\.py$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
         exclude: ^airflow/api_fastapi/execution_api/.*
         additional_dependencies: ['rich>=12.4.4']
       - id: generate-tasksdk-datamodels

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
           - --fuzzy-match-generates-todo
       - id: insert-license
         name: Add license for all YAML files except Helm templates
-        exclude: ^\.github/.*$|^chart/templates/.*|.*/reproducible_build.yaml$|^airflow/api_fastapi/core_api/openapi/v1-generated.yaml$|^providersv1-generated.yaml$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml$|^.*/pnpm-lock.yaml$
+        exclude: ^\.github/.*$|^chart/templates/.*|.*/reproducible_build.yaml$|^airflow/api_fastapi/core_api/openapi/v1-generated.yaml$|^airflow/auth/managers/simple/openapi/v1-generated.yaml$|^airflow/auth/managers/simple/openapi/v1-generated.yaml$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml$|^.*/pnpm-lock.yaml$
         types: [yaml]
         files: \.ya?ml$
         args:

--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -114,7 +114,9 @@ class BaseAuthManager(Generic[T], LoggingMixin):
             log.error("JWT token is not valid")
             raise e
 
-    def get_jwt_token(self, user: T, expiration_time_in_seconds: int = 0) -> str:
+    def get_jwt_token(
+        self, user: T, expiration_time_in_seconds: int = conf.getint("api", "auth_jwt_expiration_time")
+    ) -> str:
         """Return the JWT token from a user object."""
         return self._get_token_signer(
             expiration_time_in_seconds=expiration_time_in_seconds
@@ -459,15 +461,16 @@ class BaseAuthManager(Generic[T], LoggingMixin):
         """Register views specific to the auth manager."""
 
     @staticmethod
-    def _get_token_signer(expiration_time_in_seconds: int = 0) -> JWTSigner:
+    def _get_token_signer(
+        expiration_time_in_seconds: int = conf.getint("api", "auth_jwt_expiration_time"),
+    ) -> JWTSigner:
         """
         Return the signer used to sign JWT token.
 
         :meta private:
-        """
-        if expiration_time_in_seconds == 0:
-            expiration_time_in_seconds = conf.getint("api", "auth_jwt_expiration_time")
 
+        :param expiration_time_in_seconds: expiration time in seconds of the token
+        """
         return JWTSigner(
             secret_key=get_signing_key("api", "auth_jwt_secret"),
             expiration_time_in_seconds=expiration_time_in_seconds,

--- a/airflow/auth/managers/simple/routes/login.py
+++ b/airflow/auth/managers/simple/routes/login.py
@@ -37,7 +37,9 @@ def create_token(
     body: LoginBody,
 ) -> LoginResponse:
     """Authenticate the user."""
-    return SimpleAuthManagerLogin.create_token(body, conf.getint("api", "auth_jwt_expiration_time"))
+    return SimpleAuthManagerLogin.create_token(
+        body=body, expiration_time_in_sec=conf.getint("api", "auth_jwt_expiration_time")
+    )
 
 
 @login_router.post(
@@ -49,4 +51,6 @@ def create_token_cli(
     body: LoginBody,
 ) -> LoginResponse:
     """Authenticate the user for the CLI."""
-    return SimpleAuthManagerLogin.create_token(body, conf.getint("api", "auth_jwt_cli_expiration_time"))
+    return SimpleAuthManagerLogin.create_token(
+        body=body, expiration_time_in_sec=conf.getint("api", "auth_jwt_cli_expiration_time")
+    )

--- a/airflow/auth/managers/simple/routes/login.py
+++ b/airflow/auth/managers/simple/routes/login.py
@@ -37,9 +37,7 @@ def create_token(
     body: LoginBody,
 ) -> LoginResponse:
     """Authenticate the user."""
-    return SimpleAuthManagerLogin.create_token(
-        body=body, expiration_time_in_sec=conf.getint("api", "auth_jwt_expiration_time")
-    )
+    return SimpleAuthManagerLogin.create_token(body=body)
 
 
 @login_router.post(

--- a/airflow/auth/managers/simple/services/login.py
+++ b/airflow/auth/managers/simple/services/login.py
@@ -23,13 +23,16 @@ from airflow.api_fastapi.app import get_auth_manager
 from airflow.auth.managers.simple.datamodels.login import LoginBody, LoginResponse
 from airflow.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.auth.managers.simple.user import SimpleAuthManagerUser
+from airflow.configuration import conf
 
 
 class SimpleAuthManagerLogin:
     """Service for login."""
 
     @classmethod
-    def create_token(cls, body: LoginBody, expiration_time_in_sec: int) -> LoginResponse:
+    def create_token(
+        cls, body: LoginBody, expiration_time_in_sec: int = conf.getint("api", "auth_jwt_expiration_time")
+    ) -> LoginResponse:
         """
         Authenticate user with given configuration.
 

--- a/airflow/auth/managers/simple/services/login.py
+++ b/airflow/auth/managers/simple/services/login.py
@@ -23,7 +23,6 @@ from airflow.api_fastapi.app import get_auth_manager
 from airflow.auth.managers.simple.datamodels.login import LoginBody, LoginResponse
 from airflow.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.auth.managers.simple.user import SimpleAuthManagerUser
-from airflow.utils.jwt_signer import JWTSigner, get_signing_key
 
 
 class SimpleAuthManagerLogin:
@@ -64,10 +63,8 @@ class SimpleAuthManagerLogin:
             role=found_users[0]["role"],
         )
 
-        signer = JWTSigner(
-            secret_key=get_signing_key("api", "auth_jwt_secret"),
-            expiration_time_in_seconds=expiration_time_in_sec,
-            audience="front-apis",
+        return LoginResponse(
+            jwt_token=get_auth_manager().get_jwt_token(
+                user=user, expiration_time_in_seconds=expiration_time_in_sec
+            )
         )
-        token = signer.generate_signed_token(get_auth_manager().serialize_user(user))
-        return LoginResponse(jwt_token=token)

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -21,8 +21,14 @@ API
 API Authentication
 ------------------
 
-The API authentication is handled by the auth manager. For more information about API authentication, please refer to the auth manager documentation used by your environment.
-By default Airflow uses the FAB auth manager, if you did not specify any other auth manager, please look at :doc:`apache-airflow-providers-fab:auth-manager/api-authentication`.
+The API authentication is handled by the auth manager.
+For more information about API authentication, please refer to the auth manager documentation used by your environment.
+By default Airflow uses the ``Simple Auth Manager``, if you did not specify any other auth manager.
+``Simple Auth Manager`` is a basic auth manager that persisted under Airflow core.
+It is not recommended to use it in production and currently aiming for development purposes.
+
+Please install ``apache-airflow-providers-fab`` to use the auth manager that is aimed for production.
+For that, please look at :doc:`apache-airflow-providers-fab:auth-manager/api-authentication`.
 
 Enabling CORS
 -------------

--- a/newsfragments/46916.significant.rst
+++ b/newsfragments/46916.significant.rst
@@ -1,0 +1,19 @@
+API authentication is migrated to token based authentication for default and FAB provider.
+
+The default setting is using API to create a token (JWT) to authenticate the requests to access the API.
+The endpoints are populated under ``/auth`` path.
+If none of the providers are installed such as FAB, the API will use the default use Simple Auth Manager in the core.
+
+To integrate the same functioning into API requests as in >3.0.0, please install ``apache-airflow-providers-fab``.
+For more information, please look at :doc:`apache-airflow-providers-fab:auth-manager/api-authentication`.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [x] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/newsfragments/46916.significant.rst
+++ b/newsfragments/46916.significant.rst
@@ -1,10 +1,10 @@
-API authentication is migrated to token based authentication for default and FAB provider.
+Public API authentication is migrated to JWT token based authentication for default (Simple Auth Manager) and FAB provider.
 
 The default setting is using API to create a token (JWT) to authenticate the requests to access the API.
 The endpoints are populated under ``/auth`` path.
 If none of the providers are installed such as FAB, the API will use the default use Simple Auth Manager in the core.
 
-To integrate the same functioning into API requests as in >3.0.0, please install ``apache-airflow-providers-fab``.
+To integrate the same functioning into API requests using FAB provider. Please install ``apache-airflow-providers-fab``.
 For more information, please look at :doc:`apache-airflow-providers-fab:auth-manager/api-authentication`.
 
 * Types of change

--- a/providers/fab/docs/auth-manager/api-authentication.rst
+++ b/providers/fab/docs/auth-manager/api-authentication.rst
@@ -53,7 +53,7 @@ command as in the example below.
 
 
 Token based authentication
-'''''''''''''''''''''''
+''''''''''''''''''''''''''
 The token based authentication is the default setting for the API.
 To be able to use the API, you need to create a token first and use this token in the requests to access the API.
 
@@ -71,7 +71,7 @@ Example of creating a token:
       -d '{
       "username": "username",
       "password": "password"
-    }'
+      }'
 
 This process will return a token that you can use in the requests to access the API.
 

--- a/providers/fab/docs/auth-manager/api-authentication.rst
+++ b/providers/fab/docs/auth-manager/api-authentication.rst
@@ -45,6 +45,36 @@ command as in the example below.
     $ airflow config get-value api auth_backends
     airflow.providers.fab.auth_manager.api.auth.backend.basic_auth
 
+.. versionchanged:: 3.0.0
+
+    In Airflow <3.0.0, the default setting is using token based authentication.
+    This approach is independent from which ``auth_backend`` is used.
+    The default setting is using API to create a token (JWT) first and use this token in the requests to access the API.
+
+
+Token based authentication
+'''''''''''''''''''''''
+The token based authentication is the default setting for the API.
+To be able to use the API, you need to create a token first and use this token in the requests to access the API.
+
+Endpoints are populated under ``/auth`` path. These endpoints are mounted to the Airflow API.
+You should use your username and password, as seen in the example below.
+The token is valid for seconds in ``auth_jwt_expiration_time`` which can be set from ``airflow.cfg``.
+
+Example of creating a token:
+.. code-block:: bash
+
+    curl -X 'POST' \
+      'http://localhost:32784/auth/token' \
+      -H 'accept: application/json' \
+      -H 'Content-Type: application/json' \
+      -d '{
+      "username": "username",
+      "password": "password"
+    }'
+
+This process will return a token that you can use in the requests to access the API.
+
 Kerberos authentication
 '''''''''''''''''''''''
 

--- a/providers/fab/docs/auth-manager/api-authentication.rst
+++ b/providers/fab/docs/auth-manager/api-authentication.rst
@@ -47,19 +47,19 @@ command as in the example below.
 
 .. versionchanged:: 3.0.0
 
-    In Airflow <3.0.0, the default setting is using token based authentication.
+    In Airflow, the default setting is using token based authentication.
     This approach is independent from which ``auth_backend`` is used.
-    The default setting is using API to create a token (JWT) first and use this token in the requests to access the API.
+    The default setting is using Airflow public API to create a token (JWT) first and use this token in the requests to access the API.
 
 
-Token based authentication
-''''''''''''''''''''''''''
-The token based authentication is the default setting for the API.
-To be able to use the API, you need to create a token first and use this token in the requests to access the API.
+JWT Token based authentication
+''''''''''''''''''''''''''''''
+The JWT token based authentication is the default setting for the API.
+To be able to use the Airflow Public API, you need to create a token first and use this token in the requests to access the API.
 
 Endpoints are populated under ``/auth`` path. These endpoints are mounted to the Airflow API.
 You should use your username and password, as seen in the example below.
-The token is valid for seconds in ``auth_jwt_expiration_time`` which can be set from ``airflow.cfg``.
+The token is valid for seconds defined in ``auth_jwt_expiration_time`` which can be set from ``airflow.cfg``.
 
 Example of creating a token:
 .. code-block:: bash

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_endpoints/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_endpoints/login.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import cast
+
+from starlette import status
+
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.configuration import conf
+from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+from airflow.providers.fab.auth_manager.models.login import CLIAPITokenResponse
+
+login_router = AirflowRouter(tags=["FabAuthManager"])
+
+
+@login_router.post(
+    "/token/cli",
+    response_model=CLIAPITokenResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED]),
+)
+def create_token_cli() -> CLIAPITokenResponse:
+    """Generate a new CLI API token."""
+    auth_manager = cast(FabAuthManager, get_auth_manager())
+
+    # There is no user base expiration in FAB, so we can't use this.
+    # We can only set this globally but this would impact global expiration time for all tokens.
+    auth_manager.appbuilder.app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(
+        seconds=conf.getint("api", "auth_jwt_cli_expiration_time")
+    )
+
+    # Get token for implementing custom expiration time for JWT token
+    # token = auth_manager.get_jwt_token(user=auth_manager.get_user())
+
+    # Refresh the token with the new expiration time
+    return CLIAPITokenResponse(
+        jwt_cli_token=auth_manager.security_manager.refresh_jwt_token(user=auth_manager.get_user())
+    )

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/login.py
@@ -23,3 +23,10 @@ class LoginResponse(BaseModel):
     """API Token serializer for responses."""
 
     jwt_token: str
+
+
+class LoginBody(BaseModel):
+    """API Token serializer for requests."""
+
+    username: str
+    password: str

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/login.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.api_fastapi.core_api.base import BaseModel
+
+
+class LoginResponse(BaseModel):
+    """API Token serializer for responses."""
+
+    jwt_token: str

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
@@ -10,16 +10,22 @@ paths:
     post:
       tags:
       - FabAuthManager
-      summary: Create Token Cli
+      summary: Create Token
       description: Generate a new CLI API token.
-      operationId: create_token_cli
+      operationId: create_token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginBody'
+        required: true
       responses:
         '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenResponse'
+                $ref: '#/components/schemas/LoginResponse'
         '400':
           description: Bad Request
           content:
@@ -32,6 +38,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /token/cli:
     post:
       tags:
@@ -39,13 +51,19 @@ paths:
       summary: Create Token Cli
       description: Generate a new CLI API token.
       operationId: create_token_cli
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginBody'
+        required: true
       responses:
         '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenResponse'
+                $ref: '#/components/schemas/LoginResponse'
         '400':
           description: Bad Request
           content:
@@ -58,6 +76,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     HTTPExceptionResponse:
@@ -72,13 +96,57 @@ components:
       - detail
       title: HTTPExceptionResponse
       description: HTTPException Model used for error response.
-    TokenResponse:
+    HTTPValidationError:
       properties:
-        jwt_cli_token:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    LoginBody:
+      properties:
+        username:
           type: string
-          title: Jwt Cli Token
+          title: Username
+        password:
+          type: string
+          title: Password
       type: object
       required:
-      - jwt_cli_token
-      title: TokenResponse
+      - username
+      - password
+      title: LoginBody
+      description: API Token serializer for requests.
+    LoginResponse:
+      properties:
+        jwt_token:
+          type: string
+          title: Jwt Token
+      type: object
+      required:
+      - jwt_token
+      title: LoginResponse
       description: API Token serializer for responses.
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
@@ -11,7 +11,7 @@ paths:
       tags:
       - FabAuthManager
       summary: Create Token
-      description: Generate a new CLI API token.
+      description: Generate a new API token.
       operationId: create_token
       requestBody:
         content:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
@@ -1,0 +1,84 @@
+openapi: 3.1.0
+info:
+  title: FAB auth manager API
+  description: This is FAB auth manager API. This API is only available if the auth
+    manager used in the Airflow environment is FAB auth manager. This API provides
+    endpoints to manage users and permissions managed by the FAB auth manager.
+  version: 0.1.0
+paths:
+  /token:
+    post:
+      tags:
+      - FabAuthManager
+      summary: Create Token Cli
+      description: Generate a new CLI API token.
+      operationId: create_token_cli
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+  /token/cli:
+    post:
+      tags:
+      - FabAuthManager
+      summary: Create Token Cli
+      description: Generate a new CLI API token.
+      operationId: create_token_cli
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+components:
+  schemas:
+    HTTPExceptionResponse:
+      properties:
+        detail:
+          anyOf:
+          - type: string
+          - type: object
+          title: Detail
+      type: object
+      required:
+      - detail
+      title: HTTPExceptionResponse
+      description: HTTPException Model used for error response.
+    TokenResponse:
+      properties:
+        jwt_cli_token:
+          type: string
+          title: Jwt Cli Token
+      type: object
+      required:
+      - jwt_cli_token
+      title: TokenResponse
+      description: API Token serializer for responses.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -34,10 +34,8 @@ login_router = AirflowRouter(tags=["FabAuthManager"])
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED]),
 )
 def create_token(body: LoginBody) -> LoginResponse:
-    """Generate a new CLI API token."""
-    return FABAuthManagerLogin.create_token(
-        body=body, expiration_time_in_sec=conf.getint("api", "auth_jwt_expiration_time")
-    )
+    """Generate a new API token."""
+    return FABAuthManagerLogin.create_token(body=body)
 
 
 @login_router.post(

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -21,7 +21,7 @@ from starlette import status
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.configuration import conf
-from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginBody, LoginResponse
 from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin
 
 login_router = AirflowRouter(tags=["FabAuthManager"])
@@ -33,10 +33,10 @@ login_router = AirflowRouter(tags=["FabAuthManager"])
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED]),
 )
-def create_token() -> LoginResponse:
+def create_token(body: LoginBody) -> LoginResponse:
     """Generate a new CLI API token."""
     return FABAuthManagerLogin.create_token(
-        expiration_time_in_sec=conf.getint("api", "auth_jwt_expiration_time")
+        body=body, expiration_time_in_sec=conf.getint("api", "auth_jwt_expiration_time")
     )
 
 
@@ -46,8 +46,8 @@ def create_token() -> LoginResponse:
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED]),
 )
-def create_token_cli() -> LoginResponse:
+def create_token_cli(body: LoginBody) -> LoginResponse:
     """Generate a new CLI API token."""
     return FABAuthManagerLogin.create_token(
-        expiration_time_in_sec=conf.getint("api", "auth_jwt_cli_expiration_time")
+        body=body, expiration_time_in_sec=conf.getint("api", "auth_jwt_cli_expiration_time")
     )

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import cast
+
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+
+
+class FABAuthManagerLogin:
+    """Login Service for FABAuthManager."""
+
+    @classmethod
+    def create_token(cls, expiration_time_in_sec: int) -> LoginResponse:
+        """Create a new token with the given expiration time."""
+        auth_manager = cast(FabAuthManager, get_auth_manager())
+
+        # There is no user base expiration in FAB, so we can't use this.
+        # We can only set this globally but this would impact global expiration time for all tokens.
+        auth_manager.appbuilder.app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(
+            seconds=expiration_time_in_sec
+        )
+
+        # Refresh the token with the new expiration time
+        return LoginResponse(jwt_token=auth_manager.security_manager.refresh_jwt_token())

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -52,7 +52,6 @@ from airflow.cli.cli_config import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.models import DagModel
-from airflow.providers.fab.auth_manager.api_fastapi.routes.login import login_router
 from airflow.providers.fab.auth_manager.cli_commands.definition import (
     DB_COMMANDS,
     ROLES_COMMANDS,
@@ -186,6 +185,9 @@ class FabAuthManager(BaseAuthManager[User]):
         return commands
 
     def get_fastapi_app(self) -> FastAPI | None:
+        """Get the FastAPI app."""
+        from airflow.providers.fab.auth_manager.api_fastapi.routes.login import login_router
+
         flask_app = create_app(enable_plugins=False)
 
         app = FastAPI(

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -52,6 +52,7 @@ from airflow.cli.cli_config import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.models import DagModel
+from airflow.providers.fab.auth_manager.api_fastapi.routes.login import login_router
 from airflow.providers.fab.auth_manager.cli_commands.definition import (
     DB_COMMANDS,
     ROLES_COMMANDS,
@@ -196,6 +197,10 @@ class FabAuthManager(BaseAuthManager[User]):
                 "manager."
             ),
         )
+
+        # Add the login router to the FastAPI app
+        app.include_router(login_router)
+
         app.mount("/", WSGIMiddleware(flask_app))
 
         return app

--- a/providers/fab/src/airflow/providers/fab/auth_manager/models/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/models/login.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.api_fastapi.core_api.base import BaseModel
+
+
+class CLIAPITokenResponse(BaseModel):
+    """CLI API Token serializer for responses."""
+
+    jwt_cli_token: str
+
+
+class CLIAPIRefreshTokenResponse(BaseModel):
+    """CLI API Token serializer for responses."""
+
+    jwt_cli_token: str
+
+
+class CLIAPITokenPostBody(BaseModel):
+    """CLI API Token serializer for post bodies."""
+
+    user_id: str
+    jwt_cli_data: str
+    jwt_cli_header: str

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -63,7 +63,12 @@ from flask_appbuilder.security.views import (
 )
 from flask_appbuilder.views import expose
 from flask_babel import lazy_gettext
-from flask_jwt_extended import JWTManager, current_user as current_user_jwt
+from flask_jwt_extended import (
+    JWTManager,
+    create_access_token,
+    current_user as current_user_jwt,
+    get_jwt_identity,
+)
 from flask_login import LoginManager
 from itsdangerous import want_bytes
 from markupsafe import Markup
@@ -538,6 +543,10 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         jwt_manager.init_app(self.appbuilder.app)
         jwt_manager.user_lookup_loader(self.load_user_jwt)
 
+    def refresh_jwt_token(self, user: User) -> str:
+        """Refresh the JWT token."""
+        return create_access_token(identity=get_jwt_identity())
+
     def reset_password(self, userid: int, password: str) -> bool:
         """
         Change/Reset a user's password for auth db.
@@ -589,6 +598,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 "warning",
             )
 
+    # Check
     def load_user_jwt(self, _jwt_header, jwt_data):
         identity = jwt_data["sub"]
         user = self.load_user(identity)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -63,10 +63,7 @@ from flask_appbuilder.security.views import (
 )
 from flask_appbuilder.views import expose
 from flask_babel import lazy_gettext
-from flask_jwt_extended import (
-    JWTManager,
-    current_user as current_user_jwt,
-)
+from flask_jwt_extended import JWTManager, current_user as current_user_jwt
 from flask_login import LoginManager
 from itsdangerous import want_bytes
 from markupsafe import Markup
@@ -2106,6 +2103,20 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             else:
                 log.error(e)
                 return None
+
+    def check_password(self, username, password) -> bool:
+        """
+        Check if the password is correct for the username.
+
+        :param username: the username
+        :param password: the password
+        """
+        user = self.find_user(username=username)
+        if user is None:
+            user = self.find_user(email=username)
+        if user is None:
+            return False
+        return check_password_hash(user.password, password)
 
     def auth_user_db(self, username, password):
         """

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -543,7 +543,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         jwt_manager.init_app(self.appbuilder.app)
         jwt_manager.user_lookup_loader(self.load_user_jwt)
 
-    def refresh_jwt_token(self, user: User) -> str:
+    def refresh_jwt_token(self) -> str:
         """Refresh the JWT token."""
         return create_access_token(identity=get_jwt_identity())
 
@@ -598,7 +598,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 "warning",
             )
 
-    # Check
     def load_user_jwt(self, _jwt_header, jwt_data):
         identity = jwt_data["sub"]
         user = self.load_user(identity)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -65,9 +65,7 @@ from flask_appbuilder.views import expose
 from flask_babel import lazy_gettext
 from flask_jwt_extended import (
     JWTManager,
-    create_access_token,
     current_user as current_user_jwt,
-    get_jwt_identity,
 )
 from flask_login import LoginManager
 from itsdangerous import want_bytes
@@ -542,10 +540,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         jwt_manager = JWTManager()
         jwt_manager.init_app(self.appbuilder.app)
         jwt_manager.user_lookup_loader(self.load_user_jwt)
-
-    def refresh_jwt_token(self) -> str:
-        """Refresh the JWT token."""
-        return create_access_token(identity=get_jwt_identity())
 
     def reset_password(self, userid: int, password: str) -> bool:
         """

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/__init__.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/__init__.py
@@ -14,26 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
-from airflow.api_fastapi.core_api.base import BaseModel
-
-
-class CLIAPITokenResponse(BaseModel):
-    """CLI API Token serializer for responses."""
-
-    jwt_cli_token: str
-
-
-class CLIAPIRefreshTokenResponse(BaseModel):
-    """CLI API Token serializer for responses."""
-
-    jwt_cli_token: str
-
-
-class CLIAPITokenPostBody(BaseModel):
-    """CLI API Token serializer for post bodies."""
-
-    user_id: str
-    jwt_cli_data: str
-    jwt_cli_header: str

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
@@ -28,5 +28,5 @@ def fab_auth_manager():
 
 
 @pytest.fixture(scope="module")
-def test_client(auth_manager):
-    return TestClient(auth_manager.get_fastapi_app())
+def test_client(fab_auth_manager):
+    return TestClient(fab_auth_manager.get_fastapi_app())

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
@@ -24,7 +24,7 @@ from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 
 @pytest.fixture(scope="module")
 def fab_auth_manager():
-    return FabAuthManager()
+    return FabAuthManager(None)
 
 
 @pytest.fixture(scope="module")

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+
+
+@pytest.fixture(scope="module")
+def fab_auth_manager():
+    return FabAuthManager()
+
+
+@pytest.fixture(scope="module")
+def test_client(auth_manager):
+    return TestClient(auth_manager.get_fastapi_app())

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/__init__.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -27,17 +27,18 @@ from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import Logi
 @pytest.mark.db_test
 class TestLogin:
     dummy_login_body = LoginBody(username="dummy", password="dummy")
+    dummy_token = LoginResponse(jwt_token="DUMMY_TOKEN")
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
     def test_create_token(self, mock_fab_auth_manager_login, test_client):
-        mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
+        mock_fab_auth_manager_login.create_token.return_value = self.dummy_token
 
         response = test_client.post(
             "/token",
             json=self.dummy_login_body.model_dump(),
         )
         assert response.status_code == 201
-        assert response.json()["jwt_token"]
+        assert response.json()["jwt_token"] == self.dummy_token.jwt_token
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
     def test_create_token_cli(self, mock_fab_auth_manager_login, test_client):
@@ -48,4 +49,4 @@ class TestLogin:
             json=self.dummy_login_body.model_dump(),
         )
         assert response.status_code == 201
-        assert response.json()["jwt_token"]
+        assert response.json()["jwt_token"] == self.dummy_token.jwt_token

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginBody, LoginResponse
 
 
+@pytest.mark.db_test
 class TestLogin:
     dummy_login_body = LoginBody(username="dummy", password="dummy")
 

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -19,16 +19,19 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginBody, LoginResponse
 
 
 class TestLogin:
+    dummy_login_body = LoginBody(username="dummy", password="dummy")
+
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
     def test_create_token(self, mock_fab_auth_manager_login, test_client):
         mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
 
         response = test_client.post(
             "/token",
+            json=self.dummy_login_body.model_dump(),
         )
         assert response.status_code == 201
         assert response.json()["jwt_token"]
@@ -39,6 +42,7 @@ class TestLogin:
 
         response = test_client.post(
             "/token/cli",
+            json=self.dummy_login_body.model_dump(),
         )
         assert response.status_code == 201
         assert response.json()["jwt_token"]

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+
+TEST_USER_1 = "test1"
+TEST_USER_2 = "test2"
+
+
+class TestLogin:
+    @pytest.mark.parametrize(
+        "test_user",
+        [
+            TEST_USER_1,
+            TEST_USER_2,
+        ],
+    )
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
+    def test_create_token(self, mock_fab_auth_manager_login, test_client, auth_manager, test_user):
+        mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
+
+        response = test_client.post(
+            "/token",
+        )
+        assert response.status_code == 201
+        assert response.json()["jwt_token"]
+
+    @pytest.mark.parametrize(
+        "test_user",
+        [
+            TEST_USER_1,
+            TEST_USER_2,
+        ],
+    )
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
+    def test_create_token_cli(self, mock_fab_auth_manager_login, test_client, auth_manager, test_user):
+        mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
+
+        response = test_client.post(
+            "/token/cli",
+        )
+        assert response.status_code == 201
+        assert response.json()["jwt_token"]

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -19,24 +19,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
-
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
-
-TEST_USER_1 = "test1"
-TEST_USER_2 = "test2"
 
 
 class TestLogin:
-    @pytest.mark.parametrize(
-        "test_user",
-        [
-            TEST_USER_1,
-            TEST_USER_2,
-        ],
-    )
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
-    def test_create_token(self, mock_fab_auth_manager_login, test_client, auth_manager, test_user):
+    def test_create_token(self, mock_fab_auth_manager_login, test_client):
         mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
 
         response = test_client.post(
@@ -45,15 +33,8 @@ class TestLogin:
         assert response.status_code == 201
         assert response.json()["jwt_token"]
 
-    @pytest.mark.parametrize(
-        "test_user",
-        [
-            TEST_USER_1,
-            TEST_USER_2,
-        ],
-    )
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
-    def test_create_token_cli(self, mock_fab_auth_manager_login, test_client, auth_manager, test_user):
+    def test_create_token_cli(self, mock_fab_auth_manager_login, test_client):
         mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
 
         response = test_client.post(

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/__init__.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -20,32 +20,94 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
+from starlette.exceptions import HTTPException
+
 from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin
 
 if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+
+"""
+        dummy_security_manager = MagicMock()
+        dummy_user = MagicMock()
+        mock_fab_auth_manager_login.return_value.security_manager = dummy_security_manager
+        dummy_security_manager.find_user.return_value = dummy_user
+        dummy_user.password = "dummy"
+
+"""
 
 
 class TestLogin:
     def setup_method(
         self,
     ):
+        self.dummy_auth_manager = MagicMock()
         self.dummy_app_builder = MagicMock()
         self.dummy_app = MagicMock()
+        self.dummy_login_body = MagicMock()
+        self.dummy_user = MagicMock()
+        self.dummy_user.password = "dummy"
+        self.dummy_security_manager = MagicMock()
+        self.dummy_login_body.username = "dummy"
+        self.dummy_login_body.password = "dummy"
+        self.dummy_token = "DUMMY_TOKEN"
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
-    def test_create_token(self, get_auth_manager, fab_auth_manager):
-        get_auth_manager.return_value = fab_auth_manager
-        fab_auth_manager.init()
-
-        fab_auth_manager.appbuilder = self.dummy_app_builder
-        self.dummy_app_builder.app = self.dummy_app
-
-        security_manager = MagicMock()
-        fab_auth_manager.security_manager = security_manager
-        security_manager.refresh_jwt_token.return_value = "DUMMY_TOKEN"
+    def test_create_token(self, get_auth_manager):
+        get_auth_manager.return_value = self.dummy_auth_manager
+        self.dummy_auth_manager.security_manager = self.dummy_security_manager
+        self.dummy_security_manager.find_user.return_value = self.dummy_user
+        print(f"User in test: {self.dummy_user}")
+        self.dummy_auth_manager.get_jwt_token.return_value = self.dummy_token
 
         login_response: LoginResponse = FABAuthManagerLogin.create_token(
+            body=self.dummy_login_body,
             expiration_time_in_sec=1,
         )
-        assert login_response.jwt_token == "DUMMY_TOKEN"
+        assert login_response.jwt_token == self.dummy_token
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
+    def test_create_token_invalid_username(self, get_auth_manager):
+        get_auth_manager.return_value = self.dummy_auth_manager
+        self.dummy_auth_manager.security_manager = self.dummy_security_manager
+        self.dummy_security_manager.find_user.return_value = None
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerLogin.create_token(
+                body=self.dummy_login_body,
+                expiration_time_in_sec=1,
+            )
+        assert ex.value.status_code == 401
+        assert ex.value.detail == "Invalid username"
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
+    def test_create_token_invalid_password(self, get_auth_manager):
+        get_auth_manager.return_value = self.dummy_auth_manager
+        self.dummy_auth_manager.security_manager = self.dummy_security_manager
+        self.dummy_security_manager.find_user.return_value = self.dummy_user
+        self.dummy_user.password = "invalid_password"
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerLogin.create_token(
+                body=self.dummy_login_body,
+                expiration_time_in_sec=1,
+            )
+        assert ex.value.status_code == 401
+        assert ex.value.detail == "Invalid password"
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
+    def test_create_token_empty_user_password(self, get_auth_manager):
+        get_auth_manager.return_value = self.dummy_auth_manager
+        self.dummy_auth_manager.security_manager = self.dummy_security_manager
+        self.dummy_security_manager.find_user.return_value = self.dummy_user
+        self.dummy_login_body.username = ""
+        self.dummy_login_body.password = ""
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerLogin.create_token(
+                body=self.dummy_login_body,
+                expiration_time_in_sec=1,
+            )
+        assert ex.value.status_code == 400
+        assert ex.value.detail == "Username and password must be provided"

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
 
 
+@pytest.mark.db_test
 @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
 class TestLogin:
     def setup_method(

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin
+
+if TYPE_CHECKING:
+    from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+
+TEST_USER_1 = "test1"
+TEST_ROLE_1 = "viewer"
+TEST_USER_2 = "test2"
+TEST_ROLE_2 = "admin"
+
+
+class TestLogin:
+    def setup_method(
+        self,
+    ):
+        self.dummy_app_builder = MagicMock()
+        self.dummy_app = MagicMock()
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
+    def test_create_token(self, get_auth_manager, fab_auth_manager):
+        get_auth_manager.return_value = fab_auth_manager
+        fab_auth_manager.init()
+
+        fab_auth_manager.appbuilder = self.dummy_app_builder
+        self.dummy_app_builder.app = self.dummy_app
+
+        security_manager = MagicMock()
+        fab_auth_manager.security_manager = security_manager
+        security_manager.refresh_jwt_token.return_value = "DUMMY_TOKEN"
+
+        login_response: LoginResponse = FABAuthManagerLogin.create_token(
+            expiration_time_in_sec=1,
+        )
+        assert login_response.jwt_token == "DUMMY_TOKEN"

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -25,11 +25,6 @@ from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAut
 if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
 
-TEST_USER_1 = "test1"
-TEST_ROLE_1 = "viewer"
-TEST_USER_2 = "test2"
-TEST_ROLE_2 = "admin"
-
 
 class TestLogin:
     def setup_method(

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -50,7 +50,7 @@ class TestLogin:
         self.dummy_auth_manager.security_manager = self.dummy_security_manager
         self.dummy_security_manager.find_user.return_value = self.dummy_user
         self.dummy_auth_manager.get_jwt_token.return_value = self.dummy_token
-        self.dummy_security_manager.auth_user_db.return_value = self.dummy_user
+        self.dummy_security_manager.check_password.return_value = True
 
         login_response: LoginResponse = FABAuthManagerLogin.create_token(
             body=self.dummy_login_body,
@@ -62,7 +62,7 @@ class TestLogin:
         get_auth_manager.return_value = self.dummy_auth_manager
         self.dummy_auth_manager.security_manager = self.dummy_security_manager
         self.dummy_security_manager.find_user.return_value = None
-        self.dummy_security_manager.auth_user_db.return_value = None
+        self.dummy_security_manager.check_password.return_value = False
 
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(
@@ -77,7 +77,7 @@ class TestLogin:
         self.dummy_auth_manager.security_manager = self.dummy_security_manager
         self.dummy_security_manager.find_user.return_value = self.dummy_user
         self.dummy_user.password = "invalid_password"
-        self.dummy_security_manager.auth_user_db.return_value = None
+        self.dummy_security_manager.check_password.return_value = False
 
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(
@@ -93,6 +93,7 @@ class TestLogin:
         self.dummy_security_manager.find_user.return_value = self.dummy_user
         self.dummy_login_body.username = ""
         self.dummy_login_body.password = ""
+        self.dummy_security_manager.check_password.return_value = False
 
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -52,3 +52,26 @@ class TestFabAirflowSecurityManagerOverride:
         sm.load_user.assert_called_once_with("test_identity")
         assert actual_user is mock_user
         assert mock_g.user is mock_user
+
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.check_password_hash")
+    def test_check_password(self, check_password):
+        sm = EmptySecurityManager()
+        mock_user = Mock()
+        sm.find_user = Mock(return_value=mock_user)
+        check_password.return_value = True
+        assert sm.check_password("test_user", "test_password")
+
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.check_password_hash")
+    def test_check_password_user_not_found(self, check_password):
+        sm = EmptySecurityManager()
+        sm.find_user = Mock(return_value=None)
+        check_password.return_value = False
+        assert not sm.check_password("test_user", "test_password")
+
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.check_password_hash")
+    def test_check_password_not_match(self, check_password):
+        sm = EmptySecurityManager()
+        mock_user = Mock()
+        sm.find_user = Mock(return_value=mock_user)
+        check_password.return_value = False
+        assert not sm.check_password("test_user", "test_password")

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -52,3 +52,13 @@ class TestFabAirflowSecurityManagerOverride:
         sm.load_user.assert_called_once_with("test_identity")
         assert actual_user is mock_user
         assert mock_g.user is mock_user
+
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.get_jwt_identity")
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.create_access_token")
+    def test_refresh_token(self, mock_create_access_token, mock_get_jwt_identity):
+        dummy_token = "DUMMY_TOKEN"
+        sm = EmptySecurityManager()
+        mock_create_access_token.return_value = dummy_token
+        mock_get_jwt_identity.return_value = Mock()
+        token = sm.refresh_jwt_token()
+        assert token == dummy_token

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -52,13 +52,3 @@ class TestFabAirflowSecurityManagerOverride:
         sm.load_user.assert_called_once_with("test_identity")
         assert actual_user is mock_user
         assert mock_g.user is mock_user
-
-    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.get_jwt_identity")
-    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.create_access_token")
-    def test_refresh_token(self, mock_create_access_token, mock_get_jwt_identity):
-        dummy_token = "DUMMY_TOKEN"
-        sm = EmptySecurityManager()
-        mock_create_access_token.return_value = dummy_token
-        mock_get_jwt_identity.return_value = Mock()
-        token = sm.refresh_jwt_token()
-        assert token == dummy_token

--- a/scripts/in_container/run_update_fastapi_api_spec.py
+++ b/scripts/in_container/run_update_fastapi_api_spec.py
@@ -23,12 +23,16 @@ from fastapi.openapi.utils import get_openapi
 
 from airflow.api_fastapi.app import create_app
 from airflow.auth.managers.simple.simple_auth_manager import SimpleAuthManager
+from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
 OPENAPI_SPEC_FILE = "airflow/api_fastapi/core_api/openapi/v1-generated.yaml"
 SIMPLE_AUTH_MANAGER_OPENAPI_SPEC_FILE = "airflow/auth/managers/simple/openapi/v1-generated.yaml"
+FAB_AUTH_MANAGER_OPENAPI_SPEC_FILE = (
+    "providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml"
+)
 
 
 def generate_file(app: FastAPI, file_path: str, prefix: str = ""):
@@ -60,9 +64,16 @@ def generate_file(app: FastAPI, file_path: str, prefix: str = ""):
 
 
 # Generate main application openapi spec
-generate_file(create_app(), OPENAPI_SPEC_FILE)
+generate_file(app=create_app(), file_path=OPENAPI_SPEC_FILE)
 
 # Generate simple auth manager openapi spec
 simple_auth_manager_app = SimpleAuthManager().get_fastapi_app()
 if simple_auth_manager_app:
-    generate_file(simple_auth_manager_app, SIMPLE_AUTH_MANAGER_OPENAPI_SPEC_FILE, "/auth")
+    generate_file(
+        app=simple_auth_manager_app, file_path=SIMPLE_AUTH_MANAGER_OPENAPI_SPEC_FILE, prefix="/auth"
+    )
+
+# Generate FAB auth manager openapi spec
+fab_auth_manager_app = FabAuthManager().get_fastapi_app()
+if fab_auth_manager_app:
+    generate_file(app=fab_auth_manager_app, file_path=FAB_AUTH_MANAGER_OPENAPI_SPEC_FILE)

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -118,6 +118,7 @@ class TestProjectStructure:
             "providers/edge/tests/unit/edge/worker_api/test_auth.py",
             "providers/edge/tests/unit/edge/worker_api/test_datamodels.py",
             "providers/elasticsearch/tests/unit/elasticsearch/test_version_compat.py",
+            "providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/test_login.py",
             "providers/fab/tests/unit/fab/migrations/test_env.py",
             "providers/fab/tests/unit/fab/www/api_connexion/test_exceptions.py",
             "providers/fab/tests/unit/fab/www/api_connexion/test_parameters.py",

--- a/tests/auth/managers/simple/services/test_login.py
+++ b/tests/auth/managers/simple/services/test_login.py
@@ -78,4 +78,5 @@ class TestLogin:
                 body=LoginBody(username=json_body["username"], password=json_body["password"]),
                 expiration_time_in_sec=1,
             )
+        assert ex.value.status_code == 400
         assert "Username and password must be provided" in ex.value.detail


### PR DESCRIPTION
closes: #46916
relates: #47055

Remaining Work:

- In between making this global and implementing custom expiration logic for fab. - Done
- Move it to a new structure with FastAPI routes, datamodels. - Done
- Unit tests. - Done

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
