### PR TITLE
Add consumed_asset_events to DagRun exec API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/asset.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/asset.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 
 
@@ -53,3 +54,13 @@ class AssetProfile(StrictBaseModel):
     name: str | None = None
     uri: str | None = None
     type: str
+
+
+class AssetEvent(BaseModel):
+    """Asset event schema with fields that are needed for Runtime."""
+
+    asset: AssetResponse
+    source_aliases: list[AssetAliasResponse]
+    # source_task_instance: TaskInstance | None  # TODO: Resolve cyclic import.
+    extra: dict
+    timetstamp: UtcDateTime

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -32,7 +32,7 @@ from pydantic import (
 
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
-from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
+from airflow.api_fastapi.execution_api.datamodels.asset import AssetEvent, AssetProfile
 from airflow.api_fastapi.execution_api.datamodels.connection import ConnectionResponse
 from airflow.api_fastapi.execution_api.datamodels.variable import VariableResponse
 from airflow.utils.state import IntermediateTIState, TaskInstanceState as TIState, TerminalTIState
@@ -290,6 +290,8 @@ class DagRun(StrictBaseModel):
     run_type: DagRunType
     conf: Annotated[dict[str, Any], Field(default_factory=dict)]
     consumed_asset_events: list[AssetEventDagRunReference]
+
+    consumed_asset_events: list[AssetEvent]
 
 
 class TIRunContext(BaseModel):


### PR DESCRIPTION
Need this information so we can implement `triggering_asset_events` in context.

Not sure how to resolve imports but I think this needs more work anyway.