### PR TITLE
Correctly support resuming tasks after triggers

### DIFF
--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -130,10 +130,10 @@ class TIDeferredStatePayload(StrictBaseModel):
 
     trigger_timeout: timedelta | None = None
     next_method: str
-    """The name of themethod on the operator to call in the worker after the trigger has fired."""
+    """The name of the method on the operator to call in the worker after the trigger has fired."""
     next_kwargs: Annotated[dict[str, Any] | str, Field(default_factory=dict)]
     """
-    Kwargs to pass to the above method, either a plain dict or an ecnrypted string.
+    Kwargs to pass to the above method, either a plain dict or an encrypted string.
 
     Both forms will be passed along to the TaskSDK upon resume, the server will not handle either.
     """

--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -28,7 +28,6 @@ from pydantic import (
     Tag,
     TypeAdapter,
     WithJsonSchema,
-    field_validator,
 )
 
 from airflow.api_fastapi.common.types import UtcDateTime
@@ -122,15 +121,22 @@ class TIDeferredStatePayload(StrictBaseModel):
         ),
     ]
     classpath: str
-    trigger_kwargs: Annotated[dict[str, Any], Field(default_factory=dict)]
-    next_method: str
-    trigger_timeout: timedelta | None = None
+    trigger_kwargs: Annotated[dict[str, Any] | str, Field(default_factory=dict)]
+    """
+    Kwargs to pass to the trigger constructor, either a plain dict or an ecnrypted string.
 
-    @field_validator("trigger_kwargs")
-    def validate_moment(cls, v):
-        if "moment" in v:
-            v["moment"] = AwareDatetimeAdapter.validate_strings(v["moment"])
-        return v
+    Both forms will be passed along to the trigger, the server will not handle either.
+    """
+
+    trigger_timeout: timedelta | None = None
+    next_method: str
+    """The name of themethod on the operator to call in the worker after the trigger has fired."""
+    next_kwargs: Annotated[dict[str, Any] | str, Field(default_factory=dict)]
+    """
+    Kwargs to pass to the above method, either a plain dict or an ecnrypted string.
+
+    Both forms will be passed along to the TaskSDK upon resume, the server will not handle either.
+    """
 
 
 class TIRescheduleStatePayload(StrictBaseModel):
@@ -251,6 +257,15 @@ class TIRunContext(BaseModel):
     """Connections that can be accessed by the task instance."""
 
     upstream_map_indexes: dict[str, int] | None = None
+
+    next_method: str | None = None
+    """Method to call. Set when task resumes from a trigger."""
+    next_kwargs: dict[str, Any] | str | None = None
+    """
+    Args to pass to ``next_method``.
+
+    Can either be a "decorated" dict, or a string encrypted with the shared Fernet key.
+    """
 
 
 class PrevSuccessfulDagRunResponse(BaseModel):

--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -123,7 +123,7 @@ class TIDeferredStatePayload(StrictBaseModel):
     classpath: str
     trigger_kwargs: Annotated[dict[str, Any] | str, Field(default_factory=dict)]
     """
-    Kwargs to pass to the trigger constructor, either a plain dict or an ecnrypted string.
+    Kwargs to pass to the trigger constructor, either a plain dict or an encrypted string.
 
     Both forms will be passed along to the trigger, the server will not handle either.
     """

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -35,7 +35,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    NoReturn,
     TypeVar,
 )
 
@@ -47,9 +46,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
-    TaskDeferralError,
-    TaskDeferralTimeout,
-    TaskDeferred,
 )
 from airflow.lineage import apply_lineage, prepare_lineage
 
@@ -62,7 +58,6 @@ from airflow.models.abstractoperator import (
 from airflow.models.base import _sentinel
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.taskmixin import DependencyMixin
-from airflow.models.trigger import TRIGGER_FAIL_REPR, TriggerFailureReason
 from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator as TaskSDKAbstractOperator
 from airflow.sdk.definitions.baseoperator import (
     BaseOperatorMeta as TaskSDKBaseOperatorMeta,
@@ -98,7 +93,7 @@ if TYPE_CHECKING:
     from airflow.models.operator import Operator
     from airflow.sdk.definitions.node import DAGNode
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-    from airflow.triggers.base import BaseTrigger, StartTriggerArgs
+    from airflow.triggers.base import StartTriggerArgs
 
 TaskPreExecuteHook = Callable[[Context], None]
 TaskPostExecuteHook = Callable[[Context, Any], None]
@@ -740,44 +735,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator, metaclass=BaseOperator
     def serialize_for_task_group(self) -> tuple[DagAttributeTypes, Any]:
         """Serialize; required by DAGNode."""
         return DagAttributeTypes.OP, self.task_id
-
-    def defer(
-        self,
-        *,
-        trigger: BaseTrigger,
-        method_name: str,
-        kwargs: dict[str, Any] | None = None,
-        timeout: timedelta | int | float | None = None,
-    ) -> NoReturn:
-        """
-        Mark this Operator "deferred", suspending its execution until the provided trigger fires an event.
-
-        This is achieved by raising a special exception (TaskDeferred)
-        which is caught in the main _execute_task wrapper. Triggers can send execution back to task or end
-        the task instance directly. If the trigger will end the task instance itself, ``method_name`` should
-        be None; otherwise, provide the name of the method that should be used when resuming execution in
-        the task.
-        """
-        raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
-
-    def resume_execution(self, next_method: str, next_kwargs: dict[str, Any] | None, context: Context):
-        """Call this method when a deferred task is resumed."""
-        # __fail__ is a special signal value for next_method that indicates
-        # this task was scheduled specifically to fail.
-        if next_method == TRIGGER_FAIL_REPR:
-            next_kwargs = next_kwargs or {}
-            traceback = next_kwargs.get("traceback")
-            if traceback is not None:
-                self.log.error("Trigger failed:\n%s", "\n".join(traceback))
-            if (error := next_kwargs.get("error", "Unknown")) == TriggerFailureReason.TRIGGER_TIMEOUT:
-                raise TaskDeferralTimeout(error)
-            else:
-                raise TaskDeferralError(error)
-        # Grab the callable off the Operator/Task and add in any kwargs
-        execute_callable = getattr(self, next_method)
-        if next_kwargs:
-            execute_callable = functools.partial(execute_callable, **next_kwargs)
-        return execute_callable(context)
 
     def unmap(self, resolve: None | dict[str, Any] | tuple[Context, Session]) -> BaseOperator:
         """

--- a/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -117,9 +117,10 @@ class TIDeferredStatePayload(BaseModel):
     )
     state: Annotated[Literal["deferred"] | None, Field(title="State")] = "deferred"
     classpath: Annotated[str, Field(title="Classpath")]
-    trigger_kwargs: Annotated[dict[str, Any] | None, Field(title="Trigger Kwargs")] = None
-    next_method: Annotated[str, Field(title="Next Method")]
+    trigger_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Trigger Kwargs")] = None
     trigger_timeout: Annotated[timedelta | None, Field(title="Trigger Timeout")] = None
+    next_method: Annotated[str, Field(title="Next Method")]
+    next_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Next Kwargs")] = None
 
 
 class TIEnterRunningPayload(BaseModel):
@@ -316,6 +317,8 @@ class TIRunContext(BaseModel):
     variables: Annotated[list[VariableResponse] | None, Field(title="Variables")] = None
     connections: Annotated[list[ConnectionResponse] | None, Field(title="Connections")] = None
     upstream_map_indexes: Annotated[dict[str, int] | None, Field(title="Upstream Map Indexes")] = None
+    next_method: Annotated[str | None, Field(title="Next Method")] = None
+    next_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Next Kwargs")] = None
 
 
 class TITerminalStatePayload(BaseModel):

--- a/task_sdk/src/airflow/sdk/definitions/baseoperator.py
+++ b/task_sdk/src/airflow/sdk/definitions/baseoperator.py
@@ -27,9 +27,10 @@ import warnings
 from collections.abc import Callable, Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from enum import Enum
 from functools import total_ordering, wraps
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Final, NoReturn, TypeVar, cast
 
 import attrs
 
@@ -77,11 +78,38 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.serialization.enums import DagAttributeTypes
     from airflow.task.priority_strategy import PriorityWeightStrategy
+    from airflow.triggers.base import BaseTrigger
     from airflow.typing_compat import Self
     from airflow.utils.operator_resources import Resources
 
+__all__ = [
+    "BaseOperator",
+]
+
 # TODO: Task-SDK
 AirflowException = RuntimeError
+
+
+class TriggerFailureReason(str, Enum):
+    """
+    Reasons for trigger failures.
+
+    Internal use only.
+
+    :meta private:
+    """
+
+    TRIGGER_TIMEOUT = "Trigger timeout"
+    TRIGGER_FAILURE = "Trigger failure"
+
+
+TRIGGER_FAIL_REPR = "__fail__"
+"""String value to represent trigger failure.
+
+Internal use only.
+
+:meta private:
+"""
 
 
 def _get_parent_defaults(dag: DAG | None, task_group: TaskGroup | None) -> tuple[dict, ParamsDict]:
@@ -1434,3 +1462,44 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if not jinja_env:
             jinja_env = self.get_template_env()
         self._do_render_template_fields(self, self.template_fields, context, jinja_env, set())
+
+    def defer(
+        self,
+        *,
+        trigger: BaseTrigger,
+        method_name: str,
+        kwargs: dict[str, Any] | None = None,
+        timeout: timedelta | int | float | None = None,
+    ) -> NoReturn:
+        """
+        Mark this Operator "deferred", suspending its execution until the provided trigger fires an event.
+
+        This is achieved by raising a special exception (TaskDeferred)
+        which is caught in the main _execute_task wrapper. Triggers can send execution back to task or end
+        the task instance directly. If the trigger will end the task instance itself, ``method_name`` should
+        be None; otherwise, provide the name of the method that should be used when resuming execution in
+        the task.
+        """
+        from airflow.exceptions import TaskDeferred
+
+        raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
+
+    def resume_execution(self, next_method: str, next_kwargs: dict[str, Any], context: Context):
+        """Entrypoint method called by the Task Runner (instead of execute) when this task is resumed."""
+        from airflow.exceptions import TaskDeferralError, TaskDeferralTimeout
+
+        # __fail__ is a special signal value for next_method that indicates
+        # this task was scheduled specifically to fail.
+
+        if next_method == TRIGGER_FAIL_REPR:
+            next_kwargs = next_kwargs or {}
+            traceback = next_kwargs.get("traceback")
+            if traceback is not None:
+                self.log.error("Trigger failed:\n%s", "\n".join(traceback))
+            if (error := next_kwargs.get("error", "Unknown")) == TriggerFailureReason.TRIGGER_TIMEOUT:
+                raise TaskDeferralTimeout(error)
+            else:
+                raise TaskDeferralError(error)
+        # Grab the callable off the Operator/Task and add in any kwargs
+        execute_callable = getattr(self, next_method)
+        return execute_callable(context, **next_kwargs)

--- a/task_sdk/src/airflow/sdk/definitions/baseoperator.py
+++ b/task_sdk/src/airflow/sdk/definitions/baseoperator.py
@@ -1484,10 +1484,12 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
         raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
 
-    def resume_execution(self, next_method: str, next_kwargs: dict[str, Any], context: Context):
+    def resume_execution(self, next_method: str, next_kwargs: dict[str, Any] | None, context: Context):
         """Entrypoint method called by the Task Runner (instead of execute) when this task is resumed."""
         from airflow.exceptions import TaskDeferralError, TaskDeferralTimeout
 
+        if next_kwargs is None:
+            next_kwargs = {}
         # __fail__ is a special signal value for next_method that indicates
         # this task was scheduled specifically to fail.
 

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -962,16 +962,18 @@ def supervise(
     # TODO: Use logging providers to handle the chunked upload for us etc.
     logger: FilteringBoundLogger | None = None
     if log_path:
-        # If we are told to write logs to a file, redirect the task logger to it.
+        # If we are told to write logs to a file, redirect the task logger to it. Make sure we append to the
+        # file though, otherwise when we resume we would loose the logs from the start->deferral segment if it
+        # lands on the same node as before.
         from airflow.sdk.log import init_log_file, logging_processors
 
         log_file = init_log_file(log_path)
 
         pretty_logs = False
         if pretty_logs:
-            underlying_logger: WrappedLogger = structlog.WriteLogger(log_file.open("w", buffering=1))
+            underlying_logger: WrappedLogger = structlog.WriteLogger(log_file.open("a", buffering=1))
         else:
-            underlying_logger = structlog.BytesLogger(log_file.open("wb"))
+            underlying_logger = structlog.BytesLogger(log_file.open("ab"))
         processors = logging_processors(enable_pretty_log=pretty_logs)[0]
         logger = structlog.wrap_logger(underlying_logger, processors=processors, logger_name="task").bind()
 

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -963,7 +963,7 @@ def supervise(
     logger: FilteringBoundLogger | None = None
     if log_path:
         # If we are told to write logs to a file, redirect the task logger to it. Make sure we append to the
-        # file though, otherwise when we resume we would loose the logs from the start->deferral segment if it
+        # file though, otherwise when we resume we would lose the logs from the start->deferral segment if it
         # lands on the same node as before.
         from airflow.sdk.log import init_log_file, logging_processors
 

--- a/task_sdk/tests/api/test_client.py
+++ b/task_sdk/tests/api/test_client.py
@@ -268,14 +268,24 @@ class TestTaskInstanceOperations:
         # Simulate a successful response from the server that defers a task
         ti_id = uuid6.uuid7()
 
+        msg = DeferTask(
+            classpath="airflow.providers.standard.triggers.temporal.DateTimeTrigger",
+            next_method="execute_complete",
+            trigger_kwargs={
+                "__type": "dict",
+                "__var": {
+                    "moment": {"__type": "datetime", "__var": 1730982899.0},
+                    "end_from_trigger": False,
+                },
+            },
+            next_kwargs={"__type": "dict", "__var": {}},
+        )
+
         def handle_request(request: httpx.Request) -> httpx.Response:
             if request.url.path == f"/task-instances/{ti_id}/state":
                 actual_body = json.loads(request.read())
                 assert actual_body["state"] == "deferred"
-                assert actual_body["trigger_kwargs"] == {
-                    "moment": "2024-11-07T12:34:59Z",
-                    "end_from_trigger": False,
-                }
+                assert actual_body["trigger_kwargs"] == msg.trigger_kwargs
                 assert (
                     actual_body["classpath"] == "airflow.providers.standard.triggers.temporal.DateTimeTrigger"
                 )
@@ -286,11 +296,6 @@ class TestTaskInstanceOperations:
             return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
         client = make_client(transport=httpx.MockTransport(handle_request))
-        msg = DeferTask(
-            classpath="airflow.providers.standard.triggers.temporal.DateTimeTrigger",
-            trigger_kwargs={"moment": "2024-11-07T12:34:59Z", "end_from_trigger": False},
-            next_method="execute_complete",
-        )
         client.task_instances.defer(ti_id, msg)
 
     def test_task_instance_reschedule(self):

--- a/task_sdk/tests/dags/super_basic_deferred_run.py
+++ b/task_sdk/tests/dags/super_basic_deferred_run.py
@@ -28,7 +28,7 @@ from airflow.utils import timezone
 def super_basic_deferred_run():
     DateTimeSensorAsync(
         task_id="async",
-        target_time=str(timezone.utcnow() + datetime.timedelta(seconds=3)),
+        target_time=timezone.utcnow() + datetime.timedelta(seconds=3),
         poke_interval=60,
         timeout=600,
     )

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -347,10 +347,18 @@ class TestWatchedSubprocess:
         mock_client.task_instances.heartbeat.assert_called_once_with(ti.id, pid=mocker.ANY)
         mock_client.task_instances.defer.assert_called_once_with(
             ti.id,
+            # Since the message as serialized in the client upon sending, we expect it to be already encoded
             DeferTask(
                 classpath="airflow.providers.standard.triggers.temporal.DateTimeTrigger",
-                trigger_kwargs={"moment": "2024-11-07T12:34:59Z", "end_from_trigger": False},
                 next_method="execute_complete",
+                trigger_kwargs={
+                    "__type": "dict",
+                    "__var": {
+                        "moment": {"__type": "datetime", "__var": 1730982899.0},
+                        "end_from_trigger": False,
+                    },
+                },
+                next_kwargs={"__type": "dict", "__var": {}},
             ),
         )
 


### PR DESCRIPTION
There was a number of issues here that prevented us from correctly resuming a
task after it's trigger fired.

First off, only ever ran the execute method and we didn't respect next_method.
So we added that info the the TI context we send in the server in response
to the `.../run` endpoint.

Once we'd fixed that, we then ran into the net problem that we were
incorrectly setting the same value for trigger_kwargs (which are the kwargs we
pass to the trigger constructor) and to the next_kwargs (which are the kwargs
to use when resuming the task) -- they needed to be different. This involved
adding the new field (`kwargs`) onto the TIDeferredStatePayload.

The next complication after that was the "ExtendedJSON" type on the
next_kwargs column of TI: this is a type decorator that automatically applies
the BaseSerialization encode/decode step (__var and __type etc). The problem
with that is that we need to do the serialization on the client in order to
send a JSON HTTP request, so we don't want to encode _again_ on the server
ideally. I was able to do that easily on the write/update side but not so
easily on the read side -- there I left a comment and for now we will hae SQLA
decode it for us, and then we have to encode it again. Not the best, but not a
disaster either.

The other change I did here was to have the DeferTask automatically apply the
serde encoding when serializing, just so that there are fewer places in the
code that need to be aware of that detail (So the Task subprocess will encode
it before making the request toe the Supervisor, and in the Supervisor it will be
kept encoded and passed along as is to it's HTTP request). This means you can
once again pass datetime objects to a trigger "natively", not only strings.

For consistency with the user facing code I renamed `next_method` on
`DeferTask` message to `method_name`. I'm not sure this really makes sense on
in the API request to the API server though.

Closes #47013

# Testing:

I tested with this dag

```python 
from airflow import DAG
from airflow.providers.standard.sensors.date_time import DateTimeSensorAsync
from airflow.providers.standard.sensors.time_delta import WaitSensor

with DAG("trigger_test"):
    wait = DateTimeSensorAsync(
        task_id="wait_for_time",
        target_time="""{{ macros.datetime.utcnow() + macros.timedelta(minutes=1) }}""",
    )
```

And the task state now goes to success, and showing a snippet of task logs.

The initial start + defer:
```json
{"timestamp":"2025-02-25T14:44:01.823199","level":"info","event":"DAG bundles loaded: dags-folder","logger":"airflow.dag_processing.bundles.manager.DagBundlesManager"}
{"timestamp":"2025-02-25T14:44:01.823360","level":"info","event":"Filling up the DagBag from /files/dags/kafka_test.py","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-02-25T14:44:01.823732","level":"debug","event":"Importing /files/dags/kafka_test.py","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-02-25T14:44:01.828547","level":"debug","event":"Loaded DAG <DAG: trigger_test>","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-02-25T14:44:01.828767","level":"debug","event":"DAG file parsed","file":"kafka_test.py","logger":"task"}
{"timestamp":"2025-02-25T14:44:01.853442","level":"info","event":"Pausing task as DEFERRED. ","dag_id":"trigger_test","task_id":"wait_for_time","run_id":"manual__2025-02-25T14:44:01.007863+00:00_xeVPbb1o","logger":"task"}
{"timestamp":"2025-02-25T14:44:01.853690","level":"debug","event":"Sending request","json":"{\"state\":\"deferred\",\"classpath\":\"airflow.providers.standard.triggers.temporal.DateTimeTrigger\",\"trigger_kwargs\":{\"__var\":{\"moment\":{\"__var\":1740494701.834626,\"__type\":\"datetime\"},\"end_from_trigger\":false},\"__type\":\"dict\"},\"trigger_timeout\":null,\"method_name\":\"execute_complete\",\"kwargs\":{\"__var\":{},\"__type\":\"dict\"},\"type\":\"DeferTask\"}\n","logger":"task"}
```

Here's the bit from the trigger:
```json
{"timestamp":"2025-02-25T14:44:03.133222","level":"info","event":"trigger trigger_test/manual__2025-02-25T14:44:01.007863+00:00_xeVPbb1o/wait_for_time/-1/1 (ID 6) starting"}
{"timestamp":"2025-02-25T14:44:03.133478","level":"info","event":"trigger starting","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:03.135572","level":"info","event":"58 seconds remaining; sleeping 10 seconds","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:13.138648","level":"info","event":"48 seconds remaining; sleeping 10 seconds","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:23.140705","level":"info","event":"38 seconds remaining; sleeping 10 seconds","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:33.145052","level":"info","event":"28 seconds remaining; sleeping 10 seconds","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:43.151867","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:44.158527","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:45.164749","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:46.166918","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:47.173182","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:48.175339","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:49.180447","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:50.186073","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:51.190796","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:52.194850","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:53.196601","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:54.203250","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:55.209000","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:56.213201","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:57.215168","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:58.218028","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:44:59.221094","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:45:00.221974","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:45:01.223881","level":"info","event":"sleeping 1 second...","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:45:02.227491","level":"info","event":"yielding event with payload DateTime(2025, 2, 25, 14, 45, 1, 834626, tzinfo=Timezone('UTC'))","logger":"airflow.providers.standard.triggers.temporal.DateTimeTrigger"}
{"timestamp":"2025-02-25T14:45:02.228959","level":"info","event":"Trigger fired event","name":"trigger_test/manual__2025-02-25T14:44:01.007863+00:00_xeVPbb1o/wait_for_time/-1/1 (ID 6)","result":"TriggerEvent<DateTime(2025, 2, 25, 14, 45, 1, 834626, tzinfo=Timezone('UTC'))>"}
{"timestamp":"2025-02-25T14:45:02.230003","level":"info","event":"trigger completed","name":"trigger_test/manual__2025-02-25T14:44:01.007863+00:00_xeVPbb1o/wait_for_time/-1/1 (ID 6)"}
```

And back on the worker:

```json
{"timestamp":"2025-02-25T14:45:03.180834","level":"info","event":"DAG bundles loaded: dags-folder","logger":"airflow.dag_processing.bundles.manager.DagBundlesManager"}
{"timestamp":"2025-02-25T14:45:03.181018","level":"info","event":"Filling up the DagBag from /files/dags/kafka_test.py","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-02-25T14:45:03.181425","level":"debug","event":"Importing /files/dags/kafka_test.py","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-02-25T14:45:03.187019","level":"debug","event":"Loaded DAG <DAG: trigger_test>","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-02-25T14:45:03.187235","level":"debug","event":"DAG file parsed","file":"kafka_test.py","logger":"task"}
{"timestamp":"2025-02-25T14:45:03.194373","level":"debug","event":"Sending request","json":"{\"rendered_fields\":{\"target_time\":\"2025-02-25 14:46:03.194255\"},\"type\":\"SetRenderedFields\"}\n","logger":"task"}
{"timestamp":"2025-02-25T14:45:03.194493","level":"debug","event":"Calling 'on_task_instance_running' with {'previous_state': <TaskInstanceState.QUEUED: 'queued'>, 'task_instance': RuntimeTaskInstance(id=UUID('01953d90-9785-790b-99e0-535a92b6f179'), task_id='wait_for_time', dag_id='trigger_test', run_id='manual__2025-02-25T14:44:01.007863+00:00_xeVPbb1o', try_number=1, map_index=-1, hostname='d250d05894d8', task=<Task(DateTimeSensorAsync): wait_for_time>, max_tries=0, start_date=datetime.datetime(2025, 2, 25, 14, 45, 3, 164729, tzinfo=TzInfo(UTC)))}","logger":"airflow.listeners.listener"}
{"timestamp":"2025-02-25T14:45:03.194523","level":"debug","event":"Hook impls: []","logger":"airflow.listeners.listener"}
{"timestamp":"2025-02-25T14:45:03.194548","level":"debug","event":"Result from 'on_task_instance_running': []","logger":"airflow.listeners.listener"}
{"timestamp":"2025-02-25T14:45:03.194723","level":"debug","event":"Sending request","json":"{\"state\":\"success\",\"end_date\":\"2025-02-25T14:45:03.194658Z\",\"task_outlets\":[],\"outlet_events\":[],\"type\":\"SucceedTask\"}\n","logger":"task"}
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
