### PR TITLE
[Edge] Export ti.success and ti.finish metrics from edge worker

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -23,7 +23,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.19.0pre0``
+Release: ``0.20.0pre0``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -36,7 +36,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.19.0pre0/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/>`_.
 
 Installation
 ------------
@@ -59,4 +59,4 @@ PIP package         Version required
 ==================  ===================
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.19.0pre0/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.20.0pre0
+..........
+
+Misc
+~~~~
+
+* ``Edge worker exports not ti.start and ti.finished metrics.``
+
+
 0.19.0pre0
 ..........
 
@@ -34,6 +43,7 @@ Misc
 ~~~~
 
 * ``Edge worker can be set to maintenance via CLI and also return to normal operation.``
+
 
 
 0.18.1pre0

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1737371680
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.19.0pre0
+  - 0.20.0pre0
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.19.0pre0"
+version = "0.20.0pre0"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -61,8 +61,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.19.0pre0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.19.0pre0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.19.0pre0"
+__version__ = "0.20.0pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -292,7 +292,7 @@ class EdgeExecutor(BaseExecutor):
                     "state": str(job.state),
                 }
                 Stats.incr(
-                    f"edge_worker.ti.finish.{job.queue}.{job.state}.{job.task.dag_id}.{job.task.task_id}",
+                    f"edge_worker.ti.finish.{job.queue}.{job.state}.{job.dag_id}.{job.task_id}",
                     tags=tags,
                 )
                 Stats.incr("edge_worker.ti.finish", tags=tags)

--- a/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/edge/src/airflow/providers/edge/executors/edge_executor.py
@@ -216,19 +216,20 @@ class EdgeExecutor(BaseExecutor):
             )
             job.state = ti.state if ti else TaskInstanceState.REMOVED
 
-            # Edge worker does not backport emitted Airflow metrics, so export some metrics
-            # Export metrics as failed as these jobs will be deleted in the future
-            tags = {
-                "dag_id": job.dag_id,
-                "task_id": job.task_id,
-                "queue": job.queue,
-                "state": str(TaskInstanceState.FAILED),
-            }
-            Stats.incr(
-                f"edge_worker.ti.finish.{job.queue}.{TaskInstanceState.FAILED}.{job.dag_id}.{job.task_id}",
-                tags=tags,
-            )
-            Stats.incr("edge_worker.ti.finish", tags=tags)
+            if job.state != TaskInstanceState.RUNNING:
+                # Edge worker does not backport emitted Airflow metrics, so export some metrics
+                # Export metrics as failed as these jobs will be deleted in the future
+                tags = {
+                    "dag_id": job.dag_id,
+                    "task_id": job.task_id,
+                    "queue": job.queue,
+                    "state": str(TaskInstanceState.FAILED),
+                }
+                Stats.incr(
+                    f"edge_worker.ti.finish.{job.queue}.{TaskInstanceState.FAILED}.{job.dag_id}.{job.task_id}",
+                    tags=tags,
+                )
+                Stats.incr("edge_worker.ti.finish", tags=tags)
 
         return bool(lifeless_jobs)
 

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1737371680,
-        "versions": ["0.19.0pre0"],
+        "versions": ["0.20.0pre0"],
         "plugins": [
             {
                 "name": "edge_executor",

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
@@ -141,10 +141,10 @@ def state(
             "dag_id": job.dag_id,
             "task_id": job.task_id,
             "queue": job.queue,
-            "state": str(job.state),
+            "state": str(state),
         }
         Stats.incr(
-            f"edge_worker.ti.finish.{job.queue}.{job.state}.{job.dag_id}.{job.task_id}",
+            f"edge_worker.ti.finish.{job.queue}.{state}.{job.dag_id}.{job.task_id}",
             tags=tags,
         )
         Stats.incr("edge_worker.ti.finish", tags=tags)

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
@@ -136,16 +136,12 @@ def state(
 
     if state == TaskInstanceState.SUCCESS or state == TaskInstanceState.FAILED:
         # need to execute the query to catch the queue from the job
-        query = (
-            select(EdgeJobModel)
-            .where(
-                EdgeJobModel.dag_id == dag_id,
-                EdgeJobModel.task_id == task_id,
-                EdgeJobModel.run_id == run_id,
-                EdgeJobModel.map_index == map_index,
-                EdgeJobModel.try_number == try_number,
-            )
-            .first()
+        query = select(EdgeJobModel).where(
+            EdgeJobModel.dag_id == dag_id,
+            EdgeJobModel.task_id == task_id,
+            EdgeJobModel.run_id == run_id,
+            EdgeJobModel.map_index == map_index,
+            EdgeJobModel.try_number == try_number,
         )
         job = session.scalar(query)
         if job:

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
@@ -121,6 +121,34 @@ def state(
     session: SessionDep,
 ) -> None:
     """Update the state of a job running on the edge worker."""
+    # execute query to catch the queue and check if state toggles to success or failed
+    # otherwise possible that Executor resets orphaned jobs and stats are exported 2 times
+    query = select(EdgeJobModel).where(
+        EdgeJobModel.dag_id == dag_id,
+        EdgeJobModel.task_id == task_id,
+        EdgeJobModel.run_id == run_id,
+        EdgeJobModel.map_index == map_index,
+        EdgeJobModel.try_number == try_number,
+    )
+    job = session.scalar(query)
+    if (
+        job
+        and job.state == TaskInstanceState.RUNNING
+        and (state == TaskInstanceState.SUCCESS or state == TaskInstanceState.FAILED)
+    ):
+        # Edge worker does not backport emitted Airflow metrics, so export some metrics
+        tags = {
+            "dag_id": job.dag_id,
+            "task_id": job.task_id,
+            "queue": job.queue,
+            "state": str(job.state),
+        }
+        Stats.incr(
+            f"edge_worker.ti.finish.{job.queue}.{job.state}.{job.dag_id}.{job.task_id}",
+            tags=tags,
+        )
+        Stats.incr("edge_worker.ti.finish", tags=tags)
+
     query = (
         update(EdgeJobModel)
         .where(
@@ -133,27 +161,3 @@ def state(
         .values(state=state, last_update=timezone.utcnow())
     )
     session.execute(query)
-
-    if state == TaskInstanceState.SUCCESS or state == TaskInstanceState.FAILED:
-        # need to execute the query to catch the queue from the job
-        query = select(EdgeJobModel).where(
-            EdgeJobModel.dag_id == dag_id,
-            EdgeJobModel.task_id == task_id,
-            EdgeJobModel.run_id == run_id,
-            EdgeJobModel.map_index == map_index,
-            EdgeJobModel.try_number == try_number,
-        )
-        job = session.scalar(query)
-        if job:
-            # Edge worker does not backport emitted Airflow metrics, so export some metrics
-            tags = {
-                "dag_id": job.dag_id,
-                "task_id": job.task_id,
-                "queue": job.queue,
-                "state": str(job.state),
-            }
-            Stats.incr(
-                f"edge_worker.ti.finish.{job.queue}.{job.state}.{job.dag_id}.{job.task_id}",
-                tags=tags,
-            )
-            Stats.incr("edge_worker.ti.finish", tags=tags)

--- a/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/routes/jobs.py
@@ -88,7 +88,7 @@ def fetch(
     session.commit()
     # Edge worker does not backport emitted Airflow metrics, so export some metrics manually
     tags = {"dag_id": job.dag_id, "task_id": job.task_id, "queue": job.queue}
-    Stats.incr(f"edge_worker.ti.start.{job.queue}.{job.task.dag_id}.{job.task.task_id}", tags=tags)
+    Stats.incr(f"edge_worker.ti.start.{job.queue}.{job.dag_id}.{job.task_id}", tags=tags)
     Stats.incr("edge_worker.ti.start", tags=tags)
     return EdgeJobFetched(
         dag_id=job.dag_id,

--- a/providers/edge/tests/unit/edge/worker_api/routes/test_jobs.py
+++ b/providers/edge/tests/unit/edge/worker_api/routes/test_jobs.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from airflow.providers.edge.models.edge_job import EdgeJobModel
+from airflow.providers.edge.worker_api.routes.jobs import state
+from airflow.utils.session import create_session
+from airflow.utils.state import TaskInstanceState
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+pytestmark = pytest.mark.db_test
+
+
+DAG_ID = "my_dag"
+TASK_ID = "my_task"
+RUN_ID = "manual__2024-11-24T21:03:01+01:00"
+QUEUE = "test"
+
+
+class TestJobsApiRoutes:
+    @pytest.fixture(autouse=True)
+    def setup_test_cases(self, dag_maker, session: Session):
+        session.query(EdgeJobModel).delete()
+        session.commit()
+
+    @patch("airflow.stats.Stats.incr")
+    def test_state(self, mock_stats_incr, session: Session):
+        with create_session() as session:
+            job = EdgeJobModel(
+                dag_id=DAG_ID,
+                task_id=TASK_ID,
+                run_id=RUN_ID,
+                try_number=1,
+                map_index=-1,
+                state=TaskInstanceState.RUNNING,
+                queue=QUEUE,
+                concurrency_slots=1,
+                command="execute",
+            )
+            session.add(job)
+            session.commit()
+            state(
+                dag_id=DAG_ID,
+                task_id=TASK_ID,
+                run_id=RUN_ID,
+                try_number=1,
+                map_index=-1,
+                state=TaskInstanceState.RUNNING,
+                session=session,
+            )
+
+            mock_stats_incr.assert_not_called()
+
+            state(
+                dag_id=DAG_ID,
+                task_id=TASK_ID,
+                run_id=RUN_ID,
+                try_number=1,
+                map_index=-1,
+                state=TaskInstanceState.SUCCESS,
+                session=session,
+            )
+
+            mock_stats_incr.assert_called_with(
+                "edge_worker.ti.finish",
+                tags={
+                    "dag_id": DAG_ID,
+                    "queue": QUEUE,
+                    "state": TaskInstanceState.SUCCESS,
+                    "task_id": TASK_ID,
+                },
+            )
+            mock_stats_incr.call_count == 2
+
+            assert session.query(EdgeJobModel).scalar().state == TaskInstanceState.SUCCESS


### PR DESCRIPTION
# Overview

The Edge worker currently does not move metrics which are emitted during task execution to the main Airflow instance. 
This is not so easy to implement, so this PR adds the emit of ti.start and ti.finish metric. Like the main application., but with queue label extension.


# Details of changes:
* Emit ti.start and ti.finish metric for the edge worker.
* Metrics include the queue name as label.