### PR TITLE
AIP-84 Add latest dag version to dag details

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -8232,6 +8232,12 @@ components:
           title: Concurrency
           description: Return max_active_tasks as concurrency.
           readOnly: true
+        latest_dag_version:
+          anyOf:
+          - $ref: '#/components/schemas/DagVersionResponse'
+          - type: 'null'
+          description: Return the latest DagVersion.
+          readOnly: true
       type: object
       required:
       - dag_id
@@ -8270,6 +8276,7 @@ components:
       - last_parsed
       - file_token
       - concurrency
+      - latest_dag_version
       title: DAGDetailsResponse
       description: Specific serializer for DAG Details responses.
     DAGPatchBody:

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1868,6 +1868,18 @@ export const $DAGDetailsResponse = {
       description: "Return max_active_tasks as concurrency.",
       readOnly: true,
     },
+    latest_dag_version: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/DagVersionResponse",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Return the latest DagVersion.",
+      readOnly: true,
+    },
   },
   type: "object",
   required: [
@@ -1907,6 +1919,7 @@ export const $DAGDetailsResponse = {
     "last_parsed",
     "file_token",
     "concurrency",
+    "latest_dag_version",
   ],
   title: "DAGDetailsResponse",
   description: "Specific serializer for DAG Details responses.",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -540,6 +540,10 @@ export type DAGDetailsResponse = {
    * Return max_active_tasks as concurrency.
    */
   readonly concurrency: number;
+  /**
+   * Return the latest DagVersion.
+   */
+  readonly latest_dag_version: DagVersionResponse | null;
 };
 
 /**

--- a/tests/api_fastapi/core_api/routes/public/test_dags.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dags.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 import pendulum
 import pytest
@@ -333,6 +334,7 @@ class TestDagDetails(TestDagEndpoint):
             ({}, DAG2_ID, 200, DAG2_ID, "2021-06-15T00:00:00Z"),
         ],
     )
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_dag_details(
         self, test_client, query_params, dag_id, expected_status_code, dag_display_name, start_date
     ):
@@ -364,6 +366,15 @@ class TestDagDetails(TestDagEndpoint):
             "is_active": True,
             "is_paused": False,
             "is_paused_upon_creation": None,
+            "latest_dag_version": {
+                "bundle_name": "dag_maker",
+                "bundle_url": None,
+                "bundle_version": None,
+                "created_at": mock.ANY,
+                "dag_id": "test_dag2",
+                "id": mock.ANY,
+                "version_number": 1,
+            },
             "last_expired": None,
             "last_parsed": last_parsed,
             "last_parsed_time": last_parsed_time,
@@ -474,6 +485,7 @@ class TestDeleteDAG(TestDagEndpoint):
             (DAG5_ID, DAG5_DISPLAY_NAME, 409, 200, True, True),
         ],
     )
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_delete_dag(
         self,
         dag_maker,


### PR DESCRIPTION
When fetching one particular DAG on the API, add the `latest_dag_version` information. This will be useful in the front-end to specify the dag version in the header.

This will not be available on the `list` dag endpoints yet because there is no way to eager load this in bulk for multiple.