### PR TITLE
Disable data interval by default

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2453,7 +2453,7 @@ scheduler:
       version_added: 2.9.0
       type: boolean
       example: ~
-      default: "True"
+      default: "False"
       see_also: ':ref:`Differences between "trigger" and "data interval" timetables`'
     create_delta_data_intervals:
       description: |
@@ -2472,7 +2472,7 @@ scheduler:
       version_added: 2.11.0
       type: boolean
       example: ~
-      default: "True"
+      default: "False"
       see_also: ':ref:`Differences between "trigger" and "data interval" timetables`'
     enable_tracemalloc:
       description: |

--- a/airflow/config_templates/unit_tests.cfg
+++ b/airflow/config_templates/unit_tests.cfg
@@ -87,6 +87,9 @@ result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
 # Those values are set so that during unit tests things run faster than usual
 job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5
+# Defaults are changed in 3.0, but there are too many tests on data interval to fix.
+create_cron_data_intervals = true
+create_delta_data_intervals = true
 
 [dag_processor]
 parsing_processes = 2

--- a/newsfragments/47070.significant.rst
+++ b/newsfragments/47070.significant.rst
@@ -1,0 +1,25 @@
+Auto data interval calculation is disabled by default
+
+Configurations ``[scheduler] create_cron_data_intervals`` and ``create_delta_data_intervals`` are now *False*
+by default. This means schedules specified using cron expressions or time deltas now have their logical date
+set to *when a new run can start* instead of one data interval before.
+
+See :ref:`Differences between "trigger" and "data interval" timetables` for more information.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [x] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes
+
+* Migration rules needed
+
+  * ``airflow config lint``
+
+    * [ ] ``scheduler.create_cron_data_intervals``
+    * [ ] ``scheduler.create_delta_data_intervals``


### PR DESCRIPTION
The “trigger” timetables are more intuitive to newcomers. Let’s have them as the default when you specify a cron expression or time delta. The old data-interval-based-logical-date-one-interval-earlier behaviour is still available by flipping the switch, or importing the timetables directly.

- [ ] Backport DeltaTriggerTimetable and config (#47074)
- [x] Newsfragment & migration note