### PR TITLE
AIP-38 Fix dialog note state

### DIFF
--- a/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -42,7 +42,7 @@ const ClearRunButton = ({ dagRun, withText = true }: Props) => {
         withText={withText}
       />
 
-      <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} />
+      {open ? <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} /> : undefined}
     </Box>
   );
 };

--- a/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -42,7 +42,9 @@ const ClearTaskInstanceButton = ({ taskInstance, withText = true }: Props) => {
         withText={withText}
       />
 
-      <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
+      {open ? (
+        <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
+      ) : undefined}
     </Box>
   );
 };

--- a/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -71,7 +71,7 @@ const MarkRunAsButton = ({ dagRun, withText = true }: Props) => {
         </Menu.Content>
       </Menu.Root>
 
-      <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} />
+      {open ? <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} /> : undefined}
     </Box>
   );
 };

--- a/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -72,7 +72,9 @@ const MarkTaskInstanceAsButton = ({ taskInstance, withText = true }: Props) => {
         </Menu.Content>
       </Menu.Root>
 
-      <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
+      {open ? (
+        <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
+      ) : undefined}
     </Box>
   );
 };


### PR DESCRIPTION
These buttons are always mounted. Therefore the associated dialog component is always mounted too.

The problem with that is the `note` state. The initial value will never be updated with the new TaskInstance.note after invalidation.

If you clear a TI, while updating the node, and then open the `MarkAs` dialog by trying to then mark the task as `Success`, you will see that the note displayed in the accordion is not up to date. (the react state saved the old TI.note).

Unmounting the dialog when it is not open solves the issue.