### PR TITLE
Move `fastapi-api` command to `api-server`

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -61,9 +61,9 @@ async def lifespan(app: FastAPI):
 def create_app(apps: str = "all") -> FastAPI:
     apps_list = apps.split(",") if apps else ["all"]
 
-    fastapi_base_url = conf.get("fastapi", "base_url")
+    fastapi_base_url = conf.get("api", "base_url")
     if fastapi_base_url.endswith("/"):
-        raise AirflowConfigException("fastapi.base_url conf cannot have a trailing slash.")
+        raise AirflowConfigException("`[api] base_url` config option cannot have a trailing slash.")
 
     root_path = urlsplit(fastapi_base_url).path
     if not root_path or root_path == "/":

--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -79,7 +79,7 @@ def init_views(app: FastAPI) -> None:
     def webapp(request: Request, rest_of_path: str):
         return templates.TemplateResponse(
             "/index.html",
-            {"request": request, "backend_server_base_url": conf.get("fastapi", "base_url")},
+            {"request": request, "backend_server_base_url": conf.get("api", "base_url")},
             media_type="text/html",
         )
 

--- a/airflow/api_fastapi/gunicorn_config.py
+++ b/airflow/api_fastapi/gunicorn_config.py
@@ -27,7 +27,7 @@ def post_worker_init(_):
     """
     Set process title.
 
-    This is used by airflow.cli.commands.local_commands.fastapi_api_command to track the status of the worker.
+    This is used by airflow.cli.commands.local_commands.api_server_command to track the status of the worker.
     """
     old_title = setproctitle.getproctitle()
     setproctitle.setproctitle(settings.GUNICORN_WORKER_READY_PREFIX + old_title)

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -697,48 +697,48 @@ ARG_ACCESS_LOGFORMAT = Arg(
     help="The access log format for gunicorn logs",
 )
 
-# fastapi-api
-ARG_FASTAPI_API_PORT = Arg(
+# api-server
+ARG_API_SERVER_PORT = Arg(
     ("-p", "--port"),
     default=9091,
     type=int,
-    help="The port on which to run the server",
+    help="The port on which to run the API server",
 )
-ARG_FASTAPI_API_WORKERS = Arg(
+ARG_API_SERVER_WORKERS = Arg(
     ("-w", "--workers"),
     default=4,
     type=int,
-    help="Number of workers to run the FastAPI API-on",
+    help="Number of workers to run on the API server",
 )
-ARG_FASTAPI_API_WORKER_TIMEOUT = Arg(
+ARG_API_SERVER_WORKER_TIMEOUT = Arg(
     ("-t", "--worker-timeout"),
     default=120,
     type=int,
-    help="The timeout for waiting on FastAPI API workers",
+    help="The timeout for waiting on API server workers",
 )
-ARG_FASTAPI_API_HOSTNAME = Arg(
+ARG_API_SERVER_HOSTNAME = Arg(
     ("-H", "--hostname"),
     default="0.0.0.0",  # nosec
-    help="Set the hostname on which to run the web server",
+    help="Set the hostname on which to run the API server",
 )
-ARG_FASTAPI_API_ACCESS_LOGFILE = Arg(
+ARG_API_SERVER_ACCESS_LOGFILE = Arg(
     ("-A", "--access-logfile"),
     help="The logfile to store the access log. Use '-' to print to stdout",
 )
-ARG_FASTAPI_API_ERROR_LOGFILE = Arg(
+ARG_API_SERVER_ERROR_LOGFILE = Arg(
     ("-E", "--error-logfile"),
     help="The logfile to store the error log. Use '-' to print to stderr",
 )
-ARG_FASTAPI_API_ACCESS_LOGFORMAT = Arg(
+ARG_API_SERVER_ACCESS_LOGFORMAT = Arg(
     ("-L", "--access-logformat"),
     help="The access log format for gunicorn logs",
 )
-ARG_FASTAPI_API_APPS = Arg(
+ARG_API_SERVER_APPS = Arg(
     ("--apps",),
     help="Applications to run (comma-separated). Default is all. Options: core, execution, all",
     default="all",
 )
-ARG_FASTAPI_API_ALLOW_PROXY_FORWARDING = Arg(
+ARG_API_SERVER_ALLOW_PROXY_FORWARDING = Arg(
     flags=("--proxy-headers",),
     help="Enable X-Forwarded-Proto, X-Forwarded-For, X-Forwarded-Port to populate remote address info.",
     action="store_true",
@@ -1881,27 +1881,27 @@ core_commands: list[CLICommand] = [
         ),
     ),
     ActionCommand(
-        name="fastapi-api",
-        help="Start an Airflow FastAPI API instance",
-        func=lazy_load_command("airflow.cli.commands.local_commands.fastapi_api_command.fastapi_api"),
+        name="api-server",
+        help="Start an Airflow API server instance",
+        func=lazy_load_command("airflow.cli.commands.local_commands.api_server_command.api_server"),
         args=(
-            ARG_FASTAPI_API_PORT,
-            ARG_FASTAPI_API_WORKERS,
-            ARG_FASTAPI_API_WORKER_TIMEOUT,
-            ARG_FASTAPI_API_HOSTNAME,
+            ARG_API_SERVER_PORT,
+            ARG_API_SERVER_WORKERS,
+            ARG_API_SERVER_WORKER_TIMEOUT,
+            ARG_API_SERVER_HOSTNAME,
             ARG_PID,
             ARG_DAEMON,
             ARG_STDOUT,
             ARG_STDERR,
-            ARG_FASTAPI_API_ACCESS_LOGFILE,
-            ARG_FASTAPI_API_ERROR_LOGFILE,
-            ARG_FASTAPI_API_ACCESS_LOGFORMAT,
-            ARG_FASTAPI_API_APPS,
+            ARG_API_SERVER_ACCESS_LOGFILE,
+            ARG_API_SERVER_ERROR_LOGFILE,
+            ARG_API_SERVER_ACCESS_LOGFORMAT,
+            ARG_API_SERVER_APPS,
             ARG_LOG_FILE,
             ARG_SSL_CERT,
             ARG_SSL_KEY,
             ARG_DEBUG,
-            ARG_FASTAPI_API_ALLOW_PROXY_FORWARDING,
+            ARG_API_SERVER_ALLOW_PROXY_FORWARDING,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/commands/local_commands/api_server_command.py
+++ b/airflow/cli/commands/local_commands/api_server_command.py
@@ -42,8 +42,8 @@ log = logging.getLogger(__name__)
 
 @cli_utils.action_cli
 @providers_configuration_loaded
-def fastapi_api(args):
-    """Start Airflow FastAPI API."""
+def api_server(args):
+    """Start Airflow API server."""
     print(settings.HEADER)
 
     apps = args.apps
@@ -54,7 +54,7 @@ def fastapi_api(args):
     proxy_headers = args.proxy_headers
 
     if args.debug:
-        print(f"Starting the FastAPI API server on port {args.port} and host {args.hostname} debug.")
+        print(f"Starting the API server on port {args.port} and host {args.hostname} debug.")
         log.warning("Running in dev mode, ignoring uvicorn args")
 
         run_args = [
@@ -83,7 +83,7 @@ def fastapi_api(args):
     else:
         if args.daemon:
             daemonize()
-            log.info("Daemonized the FastAPI API server process PID: %s", os.getpid())
+            log.info("Daemonized the API server process PID: %s", os.getpid())
 
         log.info(
             textwrap.dedent(
@@ -99,7 +99,7 @@ def fastapi_api(args):
             )
         )
         ssl_cert, ssl_key = _get_ssl_cert_and_key_filepaths(args)
-        setproctitle(f"airflow fastapi_api -- host:{args.hostname} port:{args.port}")
+        setproctitle(f"airflow api-server -- host:{args.hostname} port:{args.port}")
         uvicorn.run(
             "airflow.api_fastapi.main:app",
             host=args.hostname,

--- a/airflow/cli/commands/local_commands/api_server_command.py
+++ b/airflow/cli/commands/local_commands/api_server_command.py
@@ -99,7 +99,7 @@ def api_server(args):
             )
         )
         ssl_cert, ssl_key = _get_ssl_cert_and_key_filepaths(args)
-        setproctitle(f"airflow api-server -- host:{args.hostname} port:{args.port}")
+        setproctitle(f"airflow api_server -- host:{args.hostname} port:{args.port}")
         uvicorn.run(
             "airflow.api_fastapi.main:app",
             host=args.hostname,

--- a/airflow/cli/commands/local_commands/standalone_command.py
+++ b/airflow/cli/commands/local_commands/standalone_command.py
@@ -89,10 +89,10 @@ class StandaloneCommand:
             command=["webserver"],
             env=env,
         )
-        self.subcommands["fastapi-api"] = SubCommand(
+        self.subcommands["api-server"] = SubCommand(
             self,
-            name="fastapi-api",
-            command=["fastapi-api"],
+            name="api-server",
+            command=["api-server"],
             env=env,
         )
         self.subcommands["triggerer"] = SubCommand(
@@ -151,7 +151,7 @@ class StandaloneCommand:
         You can pass multiple lines to output if you wish; it will be split for you.
         """
         color: dict[str, Color] = {
-            "fastapi-api": "magenta",
+            "api-server": "magenta",
             "webserver": "green",
             "scheduler": "blue",
             "dag-processor": "yellow",

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1313,6 +1313,15 @@ debug:
 api:
   description: ~
   options:
+    base_url:
+      description: |
+        The base url of the API server. Airflow cannot guess what domain or CNAME you are using.
+        If the Airflow console (the front-end) and the API server are on a different domain, this config
+        should contain the API server endpoint.
+      version_added: ~
+      type: string
+      example: ~
+      default: "http://localhost:9091"
     auth_backends:
       description: |
         Comma separated list of auth backends to authenticate users of the API. See
@@ -2686,15 +2695,3 @@ dag_processor:
       type: integer
       example: ~
       default: "5"
-fastapi:
-  description: Configuration for the Fastapi webserver.
-  options:
-    base_url:
-      description: |
-        The base url of the Fastapi endpoint. Airflow cannot guess what domain or CNAME you are using.
-        If the Airflow console (the front-end) and the Fastapi apis are on a different domain, this config
-        should contain the Fastapi apis endpoint.
-      version_added: ~
-      type: string
-      example: ~
-      default: "http://localhost:9091"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4853,7 +4853,7 @@
                     "default": [
                         "bash",
                         "-c",
-                        "exec airflow fastapi-api"
+                        "exec airflow api-server"
                     ]
                 },
                 "strategy": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1261,7 +1261,7 @@ _apiServer:
   # Command to use when running the Airflow API server (templated).
   command: ~
   # Args to use when running the Airflow API server (templated).
-  args: ["bash", "-c", "exec airflow fastapi-api"]
+  args: ["bash", "-c", "exec airflow api-server"]
   env: []
   serviceAccount:
     # default value is true

--- a/docs/apache-airflow/administration-and-deployment/web-stack.rst
+++ b/docs/apache-airflow/administration-and-deployment/web-stack.rst
@@ -21,7 +21,7 @@ Web Stack
 =========
 
 Sometimes you want to deploy the backend and frontend behind a
-variable url path prefix. To do so, you can configure the url :ref:`config:fastapi__base_url`
+variable url path prefix. To do so, you can configure the url :ref:`config:api__base_url`
 for instance, set it to ``http://localhost:29091/d12345``. All the APIs routes will
 now be available through that additional ``d12345`` prefix. Without rebuilding
 the frontend, XHR requests and static file queries should be directed to the prefixed url

--- a/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
+++ b/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
@@ -136,7 +136,7 @@ services:
 
   airflow-apiserver:
     <<: *airflow-common
-    command: fastapi-api
+    command: api-server
     ports:
       - "9091:9091"
     healthcheck:

--- a/helm_tests/airflow_core/test_api_server.py
+++ b/helm_tests/airflow_core/test_api_server.py
@@ -533,7 +533,7 @@ class TestAPIServerDeployment:
         assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == [
             "bash",
             "-c",
-            "exec airflow fastapi-api",
+            "exec airflow api-server",
         ]
 
     @pytest.mark.parametrize("command", [None, ["custom", "command"]])

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -83,8 +83,8 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
         return AwsAuthManagerAmazonVerifiedPermissionsFacade()
 
     @cached_property
-    def fastapi_endpoint(self) -> str:
-        return conf.get("fastapi", "base_url")
+    def apiserver_endpoint(self) -> str:
+        return conf.get("api", "base_url")
 
     def get_user(self) -> AwsAuthManagerUser | None:
         return session["aws_user"] if self.is_logged_in() else None
@@ -377,7 +377,7 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
         return accessible_items
 
     def get_url_login(self, **kwargs) -> str:
-        return f"{self.fastapi_endpoint}/auth/login"
+        return f"{self.apiserver_endpoint}/auth/login"
 
     def get_url_logout(self) -> str:
         raise NotImplementedError()

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
@@ -79,13 +79,13 @@ def login_callback(request: Request):
         username=saml_auth.get_nameid(),
         email=attributes["email"][0] if "email" in attributes else None,
     )
-    url = f"{conf.get('fastapi', 'base_url')}/?token={get_auth_manager().get_jwt_token(user)}"
+    url = f"{conf.get('api', 'base_url')}/?token={get_auth_manager().get_jwt_token(user)}"
     return RedirectResponse(url=url, status_code=303)
 
 
 def _init_saml_auth(request: Request) -> OneLogin_Saml2_Auth:
     request_data = _prepare_request(request)
-    base_url = conf.get(section="fastapi", key="base_url")
+    base_url = conf.get(section="api", key="base_url")
     settings = {
         # We want to keep this flag on in case of errors.
         # It provides an error reasons, if turned off, it does not

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -158,8 +158,8 @@ class FabAuthManager(BaseAuthManager[User]):
             self._sync_appbuilder_roles()
 
     @cached_property
-    def fastapi_endpoint(self) -> str:
-        return conf.get("fastapi", "base_url")
+    def apiserver_endpoint(self) -> str:
+        return conf.get("api", "base_url")
 
     @staticmethod
     def get_cli_commands() -> list[CLICommand]:
@@ -455,7 +455,7 @@ class FabAuthManager(BaseAuthManager[User]):
             else:
                 return url_for(f"{self.security_manager.auth_view.endpoint}.login")
         else:
-            return f"{self.fastapi_endpoint}/auth/login"
+            return f"{self.apiserver_endpoint}/auth/login"
 
     def get_url_logout(self):
         """Return the logout page url."""

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -63,12 +63,12 @@ tmux send-keys 'airflow scheduler' C-m
 if [[ ! ${USE_AIRFLOW_VERSION=} =~ ^2\..*  ]]; then
   tmux split-window -h
   tmux select-pane -t 2
-  tmux set-option -p @airflow_component FastAPI
+  tmux set-option -p @airflow_component API Server
 
     if [[ ${DEV_MODE=} == "true" ]]; then
-        tmux send-keys 'airflow fastapi-api -d' C-m
+        tmux send-keys 'airflow api-server -d' C-m
     else
-        tmux send-keys 'airflow fastapi-api' C-m
+        tmux send-keys 'airflow api-server' C-m
     fi
 else
   tmux split-window -h

--- a/tests/cli/commands/local_commands/test_api_server_command.py
+++ b/tests/cli/commands/local_commands/test_api_server_command.py
@@ -21,7 +21,7 @@ from unittest import mock
 import pytest
 from rich.console import Console
 
-from airflow.cli.commands.local_commands import fastapi_api_command
+from airflow.cli.commands.local_commands import api_server_command
 from airflow.exceptions import AirflowConfigException
 
 from tests.cli.commands._common_cli_classes import _CommonCLIGunicornTestClass
@@ -31,13 +31,13 @@ console = Console(width=400, color_system="standard")
 
 @pytest.mark.db_test
 class TestCliFastAPI(_CommonCLIGunicornTestClass):
-    main_process_regexp = r"airflow fastapi-api"
+    main_process_regexp = r"airflow api-server"
 
     @pytest.mark.parametrize(
         "args, expected_command",
         [
             (
-                ["fastapi-api", "--port", "9092", "--hostname", "somehost", "--debug"],
+                ["api-server", "--port", "9092", "--hostname", "somehost", "--debug"],
                 [
                     "fastapi",
                     "dev",
@@ -49,7 +49,7 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
                 ],
             ),
             (
-                ["fastapi-api", "--port", "9092", "--hostname", "somehost", "--debug", "--proxy-headers"],
+                ["api-server", "--port", "9092", "--hostname", "somehost", "--debug", "--proxy-headers"],
                 [
                     "fastapi",
                     "dev",
@@ -68,7 +68,7 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
             mock.patch("subprocess.Popen") as Popen,
         ):
             args = self.parser.parse_args(args)
-            fastapi_api_command.fastapi_api(args)
+            api_server_command.api_server(args)
 
             Popen.assert_called_with(
                 expected_command,
@@ -78,7 +78,7 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
     def test_cli_fastapi_api_env_var_set_unset(self, app):
         """
         Test that AIRFLOW_API_APPS is set and unset in the environment when
-        calling the airflow fastapi-api command
+        calling the airflow api-server command
         """
         with (
             mock.patch("subprocess.Popen") as Popen,
@@ -90,14 +90,14 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
 
             # Parse the command line arguments
             args = self.parser.parse_args(
-                ["fastapi-api", "--port", port, "--hostname", hostname, "--apps", apps_value, "--debug"]
+                ["api-server", "--port", port, "--hostname", hostname, "--apps", apps_value, "--debug"]
             )
 
             # Ensure AIRFLOW_API_APPS is not set initially
             mock_environ.get.return_value = None
 
             # Call the fastapi_api command
-            fastapi_api_command.fastapi_api(args)
+            api_server_command.api_server(args)
 
             # Assert that AIRFLOW_API_APPS was set in the environment before subprocess
             mock_environ.__setitem__.assert_called_with("AIRFLOW_API_APPS", apps_value)
@@ -127,7 +127,7 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
         ):
             args = self.parser.parse_args(
                 [
-                    "fastapi-api",
+                    "api-server",
                     "--access-logformat",
                     "custom_log_format",
                     "--pid",
@@ -140,7 +140,7 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
                     "core",
                 ]
             )
-            fastapi_api_command.fastapi_api(args)
+            api_server_command.api_server(args)
 
             mock_run.assert_called_with(
                 "airflow.api_fastapi.main:app",
@@ -164,17 +164,17 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
         ],
     )
     def test_get_ssl_cert_and_key_filepaths_with_incorrect_usage(self, ssl_arguments, error_pattern):
-        args = self.parser.parse_args(["fastapi-api"] + ssl_arguments)
+        args = self.parser.parse_args(["api-server"] + ssl_arguments)
         with pytest.raises(AirflowConfigException, match=error_pattern):
-            fastapi_api_command._get_ssl_cert_and_key_filepaths(args)
+            api_server_command._get_ssl_cert_and_key_filepaths(args)
 
     def test_get_ssl_cert_and_key_filepaths_with_correct_usage(self, ssl_cert_and_key):
         cert_path, key_path = ssl_cert_and_key
 
         args = self.parser.parse_args(
-            ["fastapi-api"] + ["--ssl-cert", str(cert_path), "--ssl-key", str(key_path)]
+            ["api-server"] + ["--ssl-cert", str(cert_path), "--ssl-key", str(key_path)]
         )
-        assert fastapi_api_command._get_ssl_cert_and_key_filepaths(args) == (str(cert_path), str(key_path))
+        assert api_server_command._get_ssl_cert_and_key_filepaths(args) == (str(cert_path), str(key_path))
 
     @pytest.fixture
     def ssl_cert_and_key(self, tmp_path):


### PR DESCRIPTION
Time to move the cli command to it's final home: `api-server`

This also moves the `base_url` config option into the `api` section.