### PR TITLE
Remove link to the legacy UI

### DIFF
--- a/airflow/ui/.env.example
+++ b/airflow/ui/.env.example
@@ -19,4 +19,3 @@
 
 
 # This is an example. You should make your own `.env.local` file for development
-VITE_LEGACY_API_URL="http://localhost:28080/home"

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Box, Flex, VStack, Link } from "@chakra-ui/react";
-import { FiCornerUpLeft, FiDatabase, FiHome } from "react-icons/fi";
+import { FiDatabase, FiHome } from "react-icons/fi";
 
 import { useVersionServiceGetVersion } from "openapi/queries";
 import { AirflowPin } from "src/assets/AirflowPin";
@@ -56,11 +56,6 @@ export const Nav = () => {
         <AdminButton />
       </Flex>
       <Flex flexDir="column">
-        <NavButton
-          icon={<FiCornerUpLeft size="1.75rem" />}
-          title="Legacy UI"
-          to={import.meta.env.VITE_LEGACY_API_URL || "http://localhost:28080/home"}
-        />
         <DocsButton />
         <UserSettingsButton />
         <Link

--- a/airflow/ui/src/vite-env.d.ts
+++ b/airflow/ui/src/vite-env.d.ts
@@ -20,10 +20,6 @@
 
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly VITE_LEGACY_API_URL: string;
-}
-
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
We are in the process of ripping out the legacy UI, so now is the time to stop directing folks back 🎉

Before:
![Screenshot 2025-02-25 at 11 52 03 AM](https://github.com/user-attachments/assets/e376a024-6445-4704-acc3-e54f9ced713a)



After:
![Screenshot 2025-02-25 at 11 49 05 AM](https://github.com/user-attachments/assets/38c688fd-dc29-4c18-97f1-23a50692ea53)
