### PR TITLE
Fix breeze api-server - missed it during config move

### DIFF
--- a/dev/breeze/doc/03_developer_tasks.rst
+++ b/dev/breeze/doc/03_developer_tasks.rst
@@ -156,7 +156,7 @@ You can change the used host port numbers by setting appropriate environment var
 
 * ``SSH_PORT``
 * ``WEBSERVER_HOST_PORT``
-* ``FASTAPI_API_HOST_PORT``
+* ``API_SERVER_HOST_PORT``
 * ``POSTGRES_HOST_PORT``
 * ``MYSQL_HOST_PORT``
 * ``MSSQL_HOST_PORT``

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -336,7 +336,7 @@ REDIS_HOST_PORT = "26379"
 SSH_PORT = "12322"
 WEBSERVER_HOST_PORT = "28080"
 VITE_DEV_PORT = "5173"
-FASTAPI_API_HOST_PORT = "29091"
+API_SERVER_HOST_PORT = "29091"
 
 CELERY_BROKER_URLS_MAP = {"rabbitmq": "amqp://guest:guest@rabbitmq:5672", "redis": "redis://redis:6379/0"}
 SQLITE_URL = "sqlite:////root/airflow/sqlite/airflow.db"

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -35,6 +35,7 @@ from airflow_breeze.global_constants import (
     ALLOWED_POSTGRES_VERSIONS,
     ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS,
     APACHE_AIRFLOW_GITHUB_REPOSITORY,
+    API_SERVER_HOST_PORT,
     CELERY_BROKER_URLS_MAP,
     CELERY_EXECUTOR,
     DEFAULT_CELERY_BROKER,
@@ -42,7 +43,6 @@ from airflow_breeze.global_constants import (
     DOCKER_DEFAULT_PLATFORM,
     DRILL_HOST_PORT,
     EDGE_EXECUTOR,
-    FASTAPI_API_HOST_PORT,
     FLOWER_HOST_PORT,
     KEYCLOAK_INTEGRATION,
     MOUNT_ALL,
@@ -507,7 +507,7 @@ class ShellParams:
         _set_var(_env, "AIRFLOW_VERSION", self.airflow_version)
         _set_var(_env, "AIRFLOW__CELERY__BROKER_URL", self.airflow_celery_broker_url)
         _set_var(_env, "AIRFLOW__CORE__EXECUTOR", self.executor)
-        _set_var(_env, "AIRFLOW__FASTAPI__BASE_URL", f"http://localhost:{FASTAPI_API_HOST_PORT}")
+        _set_var(_env, "AIRFLOW__API__BASE_URL", f"http://localhost:{API_SERVER_HOST_PORT}")
         if self.executor == EDGE_EXECUTOR:
             _set_var(
                 _env, "AIRFLOW__CORE__EXECUTOR", "airflow.providers.edge.executors.edge_executor.EdgeExecutor"
@@ -618,7 +618,7 @@ class ShellParams:
         _set_var(_env, "VERBOSE_COMMANDS", self.verbose_commands)
         _set_var(_env, "VERSION_SUFFIX_FOR_PYPI", self.version_suffix_for_pypi)
         _set_var(_env, "WEBSERVER_HOST_PORT", None, WEBSERVER_HOST_PORT)
-        _set_var(_env, "FASTAPI_API_HOST_PORT", None, FASTAPI_API_HOST_PORT)
+        _set_var(_env, "API_SERVER_HOST_PORT", None, API_SERVER_HOST_PORT)
         _set_var(_env, "_AIRFLOW_RUN_DB_TESTS_ONLY", self.run_db_tests_only)
         _set_var(_env, "_AIRFLOW_SKIP_DB_TESTS", self.skip_db_tests)
         self._generate_env_for_docker_compose_file_if_needed(_env)

--- a/dev/breeze/src/airflow_breeze/utils/visuals.py
+++ b/dev/breeze/src/airflow_breeze/utils/visuals.py
@@ -21,7 +21,7 @@ Visuals displayed to the user when entering Breeze shell.
 from __future__ import annotations
 
 from airflow_breeze.global_constants import (
-    FASTAPI_API_HOST_PORT,
+    API_SERVER_HOST_PORT,
     FLOWER_HOST_PORT,
     MYSQL_HOST_PORT,
     POSTGRES_HOST_PORT,
@@ -83,7 +83,7 @@ CHEATSHEET = f"""
         Ports are forwarded to the running docker containers for webserver and database
           * {SSH_PORT} -> forwarded to Airflow ssh server -> airflow:22
           * {WEBSERVER_HOST_PORT} -> forwarded to Airflow webserver -> airflow:8080
-          * {FASTAPI_API_HOST_PORT} -> forwarded to Airflow FastAPI API -> airflow:9091
+          * {API_SERVER_HOST_PORT} -> forwarded to Airflow api server API -> airflow:9091
           * {FLOWER_HOST_PORT} -> forwarded to Flower dashboard -> airflow:5555
           * {POSTGRES_HOST_PORT} -> forwarded to Postgres database -> postgres:5432
           * {MYSQL_HOST_PORT} -> forwarded to MySQL database  -> mysql:3306
@@ -93,7 +93,7 @@ CHEATSHEET = f"""
 
           * ssh connection for remote debugging: ssh -p {SSH_PORT} airflow@127.0.0.1 (password: airflow)
           * Webserver: http://127.0.0.1:{WEBSERVER_HOST_PORT}
-          * FastAPI API:    http://127.0.0.1:{FASTAPI_API_HOST_PORT}
+          * API server:    http://127.0.0.1:{API_SERVER_HOST_PORT}
           * Flower:    http://127.0.0.1:{FLOWER_HOST_PORT}
           * Postgres:  jdbc:postgresql://127.0.0.1:{POSTGRES_HOST_PORT}/airflow?user=postgres&password=airflow
           * Mysql:     jdbc:mysql://127.0.0.1:{MYSQL_HOST_PORT}/airflow?user=root

--- a/scripts/ci/docker-compose/base-ports.yml
+++ b/scripts/ci/docker-compose/base-ports.yml
@@ -20,5 +20,5 @@ services:
     ports:
       - "${SSH_PORT}:22"
       - "${WEBSERVER_HOST_PORT}:8080"
-      - "${FASTAPI_API_HOST_PORT}:9091"
+      - "${API_SERVER_HOST_PORT}:9091"
       - "${FLOWER_HOST_PORT}:5555"


### PR DESCRIPTION
When I renamed the command to start the fastapi api server, I missed updating the breeze config to reflect the new config section.
