### PR TITLE
[v2-10-test] Backport pinecone package name change

### DIFF
--- a/airflow/providers/pinecone/provider.yaml
+++ b/airflow/providers/pinecone/provider.yaml
@@ -44,7 +44,7 @@ integrations:
 
 dependencies:
   - apache-airflow>=2.7.0
-  - pinecone-client>=3.1.0
+  - pinecone>=3.1.0
 
 hooks:
   - integration-name: Pinecone

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1036,7 +1036,7 @@
   "pinecone": {
     "deps": [
       "apache-airflow>=2.7.0",
-      "pinecone-client>=3.1.0"
+      "pinecone>=3.1.0"
     ],
     "devel-deps": [],
     "plugins": [],


### PR DESCRIPTION
See #46980. Due to project structure change, this is not an actual backport; I made the change manually instead.