### PR TITLE
Sync asset and alias property changes into db

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1876,8 +1876,8 @@ class DAG(TaskSDKDag, LoggingMixin):
 
         asset_op = AssetModelOperation.collect(dag_op.dags)
 
-        orm_assets = asset_op.add_assets(session=session)
-        orm_asset_aliases = asset_op.add_asset_aliases(session=session)
+        orm_assets = asset_op.sync_assets(session=session)
+        orm_asset_aliases = asset_op.sync_asset_aliases(session=session)
         session.flush()  # This populates id so we can create fks in later calls.
 
         orm_dags = dag_op.find_orm_dags(session=session)  # Refetch so relationship is up to date.


### PR DESCRIPTION
I missed updating group and extra into the database when rewriting the sync process. (Before the rewrite, the asset table is always wipped and repopulated.) This makes sure any property changes are written into the database.

Fix #46831.