### PR TITLE
Fix pausing dag in the breadrcumb

### DIFF
--- a/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -69,37 +69,29 @@ export const DagBreadcrumb = () => {
     },
   );
 
-  const links: Array<{ label: ReactNode | string; title?: string; value?: string }> = [
-    { label: "Dags", value: "/dags" },
-    {
-      label: (
-        <HStack>
+  const links: Array<{ label: ReactNode | string; labelExtra?: ReactNode; title?: string; value?: string }> =
+    [
+      { label: "Dags", value: "/dags" },
+      {
+        label: dag?.dag_display_name ?? dagId,
+        labelExtra: (
           <TogglePause
             dagDisplayName={dag?.dag_display_name}
             dagId={dagId}
             isPaused={Boolean(dag?.is_paused)}
             skipConfirm
           />
-          {dag?.dag_display_name ?? dagId}
-        </HStack>
-      ),
-      title: "Dag",
-      value: `/dags/${dagId}`,
-    },
-  ];
+        ),
+        title: "Dag",
+        value: `/dags/${dagId}`,
+      },
+    ];
 
   // Add dag run breadcrumb
   if (runId !== undefined) {
     links.push({
-      label:
-        dagRun === undefined ? (
-          runId
-        ) : (
-          <HStack>
-            <StateBadge fontSize="xs" state={dagRun.state} />
-            <Time datetime={dagRun.run_after} />
-          </HStack>
-        ),
+      label: dagRun === undefined ? runId : <Time datetime={dagRun.run_after} />,
+      labelExtra: dagRun === undefined ? undefined : <StateBadge fontSize="xs" state={dagRun.state} />,
       title: "Dag Run",
       value: `/dags/${dagId}/runs/${runId}`,
     });
@@ -129,10 +121,18 @@ export const DagBreadcrumb = () => {
           </Stat.Label>
           <Stat.ValueText fontSize="sm" fontWeight="normal">
             {index === links.length - 1 ? (
-              <Breadcrumb.CurrentLink>{link.label}</Breadcrumb.CurrentLink>
+              <Breadcrumb.CurrentLink>
+                <HStack>
+                  {link.labelExtra}
+                  {link.label}
+                </HStack>
+              </Breadcrumb.CurrentLink>
             ) : (
               <Breadcrumb.Link asChild color="fg.info">
-                <RouterLink to={link.value ?? ""}>{link.label}</RouterLink>
+                <HStack>
+                  {link.labelExtra}
+                  <RouterLink to={link.value ?? ""}>{link.label}</RouterLink>
+                </HStack>
               </Breadcrumb.Link>
             )}
           </Stat.ValueText>


### PR DESCRIPTION
In refactoring the dag breadcrumb, the dag pause checkbox was inside the dag details link. Therefore, you couldn't unpause a dag without switching pages.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
