### PR TITLE
Bump minimum trino version to 0.319.0

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1336,7 +1336,7 @@
       "apache-airflow-providers-common-sql>=1.20.0",
       "apache-airflow>=2.9.0",
       "pandas>=2.1.2,<2.2",
-      "trino>=0.318.0"
+      "trino>=0.319.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/trino/README.rst
+++ b/providers/trino/README.rst
@@ -56,7 +56,7 @@ PIP package                              Version required
 ``apache-airflow``                       ``>=2.9.0``
 ``apache-airflow-providers-common-sql``  ``>=1.20.0``
 ``pandas``                               ``>=2.1.2,<2.2``
-``trino``                                ``>=0.318.0``
+``trino``                                ``>=0.319.0``
 =======================================  ==================
 
 Cross provider package dependencies

--- a/providers/trino/pyproject.toml
+++ b/providers/trino/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723
     # In addition FAB also limit sqlalchemy to < 2.0
     "pandas>=2.1.2,<2.2",
-    "trino>=0.318.0",
+    "trino>=0.319.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/trino/src/airflow/providers/trino/get_provider_info.py
+++ b/providers/trino/src/airflow/providers/trino/get_provider_info.py
@@ -101,7 +101,7 @@ def get_provider_info():
             "apache-airflow>=2.9.0",
             "apache-airflow-providers-common-sql>=1.20.0",
             "pandas>=2.1.2,<2.2",
-            "trino>=0.318.0",
+            "trino>=0.319.0",
         ],
         "optional-dependencies": {
             "google": ["apache-airflow-providers-google"],


### PR DESCRIPTION
The lower-depenendency check after removing www and it's dependencies revealed that trino should be abobe 0.320 to handle lack of the method _rfc_1738_quote in sqlalchemy as of SQLAlchemy v1.4.42

See https://github.com/trinodb/trino-python-client/blob/master/CHANGES.md#release-03190

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
