### PR TITLE
Remove Console Warning on Trigger Form in new UI

### DIFF
--- a/airflow/ui/src/components/EditableMarkdown.tsx
+++ b/airflow/ui/src/components/EditableMarkdown.tsx
@@ -46,7 +46,6 @@ const EditableMarkdown = ({ field, placeholder }: EditableMarkdownProps) => (
     <Editable.Textarea
       minHeight="150px"
       onChange={(event: ChangeEvent<HTMLTextAreaElement>) => field.onChange(event.target.value)}
-      value={field.value}
     />
   </Editable.Root>
 );


### PR DESCRIPTION
Fix the console warning in browser on trigger form

closes: #47110
