### PR TITLE
Don't remove log groups from example_glue.py

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_glue.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue.py
@@ -195,7 +195,8 @@ with DAG(
             ("/aws-glue/jobs/logs-v2", submit_glue_job.output),
             ("/aws-glue/jobs/error", submit_glue_job.output),
             ("/aws-glue/jobs/output", submit_glue_job.output),
-        ]
+        ],
+        delete_log_groups=False,
     )
 
     chain(

--- a/providers/amazon/tests/system/amazon/aws/utils/__init__.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/__init__.py
@@ -115,7 +115,10 @@ def _fetch_from_ssm(key: str, test_name: str | None = None) -> str:
     except hook.conn.exceptions.ParameterNotFound as e:
         log.info("SSM does not contain any parameter for this test: %s", e)
     except KeyError as e:
-        log.info("SSM contains one parameter for this test, but not the requested value: %s", e)
+        log.info(
+            "SSM contains one parameter for this test, but not the requested value: %s",
+            e,
+        )
     return value
 
 
@@ -286,6 +289,7 @@ def prune_logs(
     force_delete: bool = False,
     retry: bool = False,
     retry_times: int = 3,
+    delete_log_groups: bool = True,
     ti=None,
 ):
     """
@@ -300,11 +304,13 @@ def prune_logs(
         cases, the log group/stream is created seconds after the main resource has
         been created. By default, it retries for 3 times with a 5s waiting period.
     :param retry_times: Number of retries.
+    :param delete_log_groups: Whether to delete the log groups if they are empty.
+        Overridden by force_delete.
     :param ti: Used to check the status of the tasks. This gets pulled from the
         DAG's context and does not need to be passed manually.
     """
     if all_tasks_passed(ti):
-        _purge_logs(logs, force_delete, retry, retry_times)
+        _purge_logs(logs, force_delete, retry, retry_times, delete_log_groups)
     else:
         client: BaseClient = boto3.client("logs")
         for group, _ in logs:
@@ -316,6 +322,7 @@ def _purge_logs(
     force_delete: bool = False,
     retry: bool = False,
     retry_times: int = 3,
+    delete_log_groups: bool = True,
 ) -> None:
     """
     Accepts a tuple in the format: ('log group name', 'log stream prefix').
@@ -332,6 +339,8 @@ def _purge_logs(
         is created seconds after the main resource has been created. By default, it retries for 3 times
         with a 5s waiting period
     :param retry_times: Number of retries
+    :param delete_log_groups: Whether to delete the log groups if they are empty.
+        Overridden by force_delete.
     """
     client: BaseClient = boto3.client("logs")
 
@@ -346,7 +355,9 @@ def _purge_logs(
                 for stream_name in [stream["logStreamName"] for stream in log_streams]:
                     client.delete_log_stream(logGroupName=group, logStreamName=stream_name)
 
-            if force_delete or not client.describe_log_streams(logGroupName=group)["logStreams"]:
+            if force_delete or (
+                delete_log_groups and not client.describe_log_streams(logGroupName=group)["logStreams"]
+            ):
                 client.delete_log_group(logGroupName=group)
         except ClientError as e:
             if not retry or retry_times == 0 or e.response["Error"]["Code"] != "ResourceNotFoundException":


### PR DESCRIPTION
This system test creates logs in static log groups (always the same), so there is no concern of them scaling out of control, and can actually cause issues when running concurrent tests if the log group is deleted.

I tested by running the system test with the new code changes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
