### PR TITLE
Add `airflow webserver` to legacy commands

### DIFF
--- a/airflow/cli/commands/legacy_commands.py
+++ b/airflow/cli/commands/legacy_commands.py
@@ -48,6 +48,7 @@ COMMAND_MAP = {
     "create_user": "users create",
     "delete_user": "users delete",
     "dags backfill": "backfill create",
+    "webserver": "api-server",
 }
 
 

--- a/newsfragments/47131.significant.rst
+++ b/newsfragments/47131.significant.rst
@@ -1,0 +1,12 @@
+The Airflow UI is now started with the ``airflow api-server`` command. The ``airflow webserver`` command has been removed.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [x] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes


### PR DESCRIPTION
`airflow webserver` was added to the list of legacy commands, which means users will be informed of the replacement instead of just getting a generic error:

```
$ airflow webserver
Usage: airflow [-h] GROUP_OR_COMMAND ...
...
airflow command error: argument GROUP_OR_COMMAND: Command `airflow webserver` has been removed. Please use `airflow api-server`, see help above.
```