### PR TITLE
doc: fix the typo for glob regex  #47116

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/gcs.py
@@ -184,7 +184,7 @@ class GCSListObjectsOperator(GoogleCloudBaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :param match_glob: (Optional) filters objects based on the glob pattern given by the string
-        (e.g, ``'**/*/.json'``)
+        (e.g, ``'**/*.json'``)
 
     **Example**:
         The following Operator would list all the Avro files from ``sales/sales-2017``
@@ -194,7 +194,7 @@ class GCSListObjectsOperator(GoogleCloudBaseOperator):
                 task_id="GCS_Files",
                 bucket="data",
                 prefix="sales/sales-2017/",
-                match_glob="**/*/.avro",
+                match_glob="**/*.avro",
                 gcp_conn_id=google_cloud_conn_id,
             )
     """


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

closes: #47116
related: #47116

doc: fix the typo for glob regex  #47116

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!