### PR TITLE
Update bug report template for Airflow 3

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -26,7 +26,7 @@ body:
       multiple: false
       options:
         - "2.10.5"
-        - "3.0.0a1"
+        - "3.0.0"
         - "main (development)"
         - "Other Airflow 2 version (please specify below)"
     validations:


### PR DESCRIPTION
It doesn't really matter on which alpha version the report is submitted.
We will check all reported issues regardless. If needed we can know which version by the date of submission. 
I'm changing this because some people asked what version to use if they can't find the correct tag..