### PR TITLE
Add  missing `methodtools` dependency of the `common-sql` provider

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -419,6 +419,7 @@
   "common.sql": {
     "deps": [
       "apache-airflow>=2.9.0",
+      "methodtools>=0.4.7",
       "more-itertools>=9.0.0",
       "sqlparse>=0.5.1"
     ],

--- a/providers/common/sql/README.rst
+++ b/providers/common/sql/README.rst
@@ -56,6 +56,7 @@ PIP package         Version required
 ``apache-airflow``  ``>=2.9.0``
 ``sqlparse``        ``>=0.5.1``
 ``more-itertools``  ``>=9.0.0``
+``methodtools``     ``>=0.4.7``
 ==================  ==================
 
 Cross provider package dependencies

--- a/providers/common/sql/provider.yaml
+++ b/providers/common/sql/provider.yaml
@@ -65,6 +65,10 @@ versions:
   - 1.1.0
   - 1.0.0
 
+dependencies:
+  # The methodtools dependency is necessary since the introduction of dialects: https://github.com/apache/airflow/pull/41327/files
+  - methodtools>=0.4.7
+
 integrations:
   - integration-name: Common SQL
     external-doc-url: https://en.wikipedia.org/wiki/SQL

--- a/providers/common/sql/provider.yaml
+++ b/providers/common/sql/provider.yaml
@@ -65,11 +65,6 @@ versions:
   - 1.1.0
   - 1.0.0
 
-dependencies:
-  # The methodtools dependency is necessary since the introduction of dialects:
-  # https://github.com/apache/airflow/pull/41327/files
-  - methodtools>=0.4.7
-
 integrations:
   - integration-name: Common SQL
     external-doc-url: https://en.wikipedia.org/wiki/SQL

--- a/providers/common/sql/provider.yaml
+++ b/providers/common/sql/provider.yaml
@@ -66,7 +66,8 @@ versions:
   - 1.0.0
 
 dependencies:
-  # The methodtools dependency is necessary since the introduction of dialects: https://github.com/apache/airflow/pull/41327/files
+  # The methodtools dependency is necessary since the introduction of dialects:
+  # https://github.com/apache/airflow/pull/41327/files
   - methodtools>=0.4.7
 
 integrations:

--- a/providers/common/sql/pyproject.toml
+++ b/providers/common/sql/pyproject.toml
@@ -58,6 +58,9 @@ dependencies = [
     "apache-airflow>=2.9.0",
     "sqlparse>=0.5.1",
     "more-itertools>=9.0.0",
+    # The methodtools dependency is necessary since the introduction of dialects:
+    # https://github.com/apache/airflow/pull/41327/files
+    "methodtools>=0.4.7"
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/common/sql/src/airflow/providers/common/sql/get_provider_info.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/get_provider_info.py
@@ -111,7 +111,12 @@ def get_provider_info():
         "sensors": [
             {"integration-name": "Common SQL", "python-modules": ["airflow.providers.common.sql.sensors.sql"]}
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "sqlparse>=0.5.1", "more-itertools>=9.0.0"],
+        "dependencies": [
+            "apache-airflow>=2.9.0",
+            "sqlparse>=0.5.1",
+            "more-itertools>=9.0.0",
+            "methodtools>=0.4.7",
+        ],
         "optional-dependencies": {
             "pandas": ["pandas>=2.1.2,<2.2"],
             "openlineage": ["apache-airflow-providers-openlineage"],


### PR DESCRIPTION
Since `apache-airflow-providers-common-sql==1.23.0`, released on 26 February 2025, users started facing the error:

```
    from cosmos.operators._asynchronous.bigquery import DbtRunAirflowAsyncBigqueryOperator
cosmos/operators/_asynchronous/bigquery.py:8: in <module>
    from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
../../../.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.12-2.9/lib/python3.12/site-packages/airflow/providers/google/cloud/operators/bigquery.py:32: in <module>
    from airflow.providers.common.sql.operators.sql import (  # type: ignore[attr-defined] # for _parse_boolean
../../../.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.12-2.9/lib/python3.12/site-packages/airflow/providers/common/sql/operators/sql.py:[29](https://github.com/astronomer/astronomer-cosmos/actions/runs/13544957799/job/37854234771#step:6:30): in <module>
    from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, return_single_query_results
../../../.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.12-2.9/lib/python3.12/site-packages/airflow/providers/common/sql/hooks/sql.py:37: in <module>
    from methodtools import lru_cache
E   ModuleNotFoundError: No module named 'methodtools'
```

When trying to import:
```
from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
```

It seems this started happening since https://github.com/apache/airflow/pull/41327.

This PR aims to solve this issue.

Closes: https://github.com/apache/airflow/issues/47147