### PR TITLE
fix: OpenLineage serialization of dataset timetables for Airflow 2.9

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -326,25 +326,35 @@ class DagInfo(InfoJsonEncodable):
 
     @classmethod
     def serialize_timetable(cls, dag: DAG) -> dict[str, Any]:
-        serialized = dag.timetable.serialize()
-        if serialized != {} and serialized is not None:
-            return serialized
-        if (
-            hasattr(dag, "dataset_triggers")
-            and isinstance(dag.dataset_triggers, list)
-            and len(dag.dataset_triggers)
-        ):
-            triggers = dag.dataset_triggers
-            return {
-                "dataset_condition": {
+        # This is enough for Airflow 2.10+ and has all the information needed
+        serialized = dag.timetable.serialize() or {}
+
+        # In Airflow 2.9 when using Dataset scheduling we do not receive datasets in serialized timetable
+        # Also for DatasetOrTimeSchedule, we only receive timetable without dataset_condition
+        if hasattr(dag, "dataset_triggers") and "dataset_condition" not in serialized:
+            try:
+                # Make sure we are in Airflow version where these are importable
+                from airflow.datasets import BaseDatasetEventInput, DatasetAll, DatasetAny
+            except ImportError:
+                log.warning("OpenLineage could not serialize full dag's timetable for dag `%s`.", dag.dag_id)
+                return serialized
+
+            def _serialize_ds(ds: BaseDatasetEventInput) -> dict[str, Any]:
+                if isinstance(ds, (DatasetAny, DatasetAll)):
+                    return {
+                        "__type": "dataset_all" if isinstance(ds, DatasetAll) else "dataset_any",
+                        "objects": [_serialize_ds(child) for child in ds.objects],
+                    }
+                return {"__type": "dataset", "uri": ds.uri, "extra": ds.extra}
+
+            if isinstance(dag.dataset_triggers, BaseDatasetEventInput):
+                serialized["dataset_condition"] = _serialize_ds(dag.dataset_triggers)
+            elif isinstance(dag.dataset_triggers, list) and len(dag.dataset_triggers):
+                serialized["dataset_condition"] = {
                     "__type": "dataset_all",
-                    "objects": [
-                        {"__type": "dataset", "uri": trigger.uri, "extra": trigger.extra}
-                        for trigger in triggers
-                    ],
+                    "objects": [_serialize_ds(trigger) for trigger in dag.dataset_triggers],
                 }
-            }
-        return {}
+        return serialized
 
 
 class DagRunInfo(InfoJsonEncodable):

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -28,7 +28,7 @@ from attrs import define
 from openlineage.client.utils import RedactMixin
 from pkg_resources import parse_version
 
-from airflow.models import DagModel
+from airflow.models import DAG, DagModel
 from airflow.providers.common.compat.assets import Asset
 from airflow.providers.openlineage.plugins.facets import AirflowDebugRunFacet
 from airflow.providers.openlineage.utils.utils import (
@@ -43,7 +43,7 @@ from airflow.providers.openlineage.utils.utils import (
     get_processing_engine_facet,
     is_operator_disabled,
 )
-from airflow.serialization.enums import DagAttributeTypes
+from airflow.serialization.enums import DagAttributeTypes, Encoding
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -344,9 +344,8 @@ def test_does_not_include_full_task_info(mock_include_full_task_info):
     )
 
 
-@pytest.mark.db_test
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
-def test_serialize_timetable():
+def test_serialize_timetable_complex_with_alias():
     from airflow.providers.common.compat.assets import AssetAlias, AssetAll, AssetAny
     from airflow.timetables.simple import AssetTriggeredTimetable
 
@@ -405,12 +404,168 @@ def test_serialize_timetable():
     }
 
 
-@pytest.mark.db_test
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
+def test_serialize_timetable_single_asset():
+    dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=Asset("a"))
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "asset_condition": {
+            "__type": DagAttributeTypes.ASSET,
+            "uri": "a",
+            "name": "a",
+            "group": "asset",
+            "extra": {},
+        }
+    }
+
+
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
+def test_serialize_timetable_list_of_assets():
+    dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=[Asset("a"), Asset("b")])
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "asset_condition": {
+            "__type": DagAttributeTypes.ASSET_ALL,
+            "objects": [
+                {"__type": DagAttributeTypes.ASSET, "uri": "a", "name": "a", "group": "asset", "extra": {}},
+                {"__type": DagAttributeTypes.ASSET, "uri": "b", "name": "b", "group": "asset", "extra": {}},
+            ],
+        }
+    }
+
+
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
+def test_serialize_timetable_with_complex_logical_condition():
+    dag = DAG(
+        dag_id="test",
+        start_date=datetime.datetime(2025, 1, 1),
+        schedule=(Asset("ds1", extra={"some_extra": 1}) | Asset("ds2"))
+        & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
+    )
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "asset_condition": {
+            "__type": DagAttributeTypes.ASSET_ALL,
+            "objects": [
+                {
+                    "__type": DagAttributeTypes.ASSET_ANY,
+                    "objects": [
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds1",
+                            "extra": {"some_extra": 1},
+                            "name": "ds1",
+                            "group": "asset",
+                        },
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds2",
+                            "extra": {},
+                            "name": "ds2",
+                            "group": "asset",
+                        },
+                    ],
+                },
+                {
+                    "__type": DagAttributeTypes.ASSET_ANY,
+                    "objects": [
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds3",
+                            "extra": {},
+                            "name": "ds3",
+                            "group": "asset",
+                        },
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds4",
+                            "extra": {"another_extra": 345},
+                            "name": "ds4",
+                            "group": "asset",
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
+def test_serialize_timetable_with_dataset_or_time_schedule():
+    from airflow.timetables.assets import AssetOrTimeSchedule
+    from airflow.timetables.trigger import CronTriggerTimetable
+
+    dag = DAG(
+        dag_id="test",
+        start_date=datetime.datetime(2025, 1, 1),
+        schedule=AssetOrTimeSchedule(
+            timetable=CronTriggerTimetable("0 0 * 3 *", timezone="UTC"),
+            assets=(Asset("ds1", extra={"some_extra": 1}) | Asset("ds2"))
+            & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
+        ),
+    )
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "timetable": {
+            Encoding.TYPE: "airflow.timetables.trigger.CronTriggerTimetable",
+            Encoding.VAR: {
+                "expression": "0 0 * 3 *",
+                "timezone": "UTC",
+                "interval": 0.0,
+                "run_immediately": False,
+            },
+        },
+        "asset_condition": {
+            "__type": DagAttributeTypes.ASSET_ALL,
+            "objects": [
+                {
+                    "__type": DagAttributeTypes.ASSET_ANY,
+                    "objects": [
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds1",
+                            "extra": {"some_extra": 1},
+                            "name": "ds1",
+                            "group": "asset",
+                        },
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds2",
+                            "extra": {},
+                            "name": "ds2",
+                            "group": "asset",
+                        },
+                    ],
+                },
+                {
+                    "__type": DagAttributeTypes.ASSET_ANY,
+                    "objects": [
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds3",
+                            "extra": {},
+                            "name": "ds3",
+                            "group": "asset",
+                        },
+                        {
+                            "__type": DagAttributeTypes.ASSET,
+                            "uri": "ds4",
+                            "extra": {"another_extra": 345},
+                            "name": "ds4",
+                            "group": "asset",
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
 @pytest.mark.skipif(
     not AIRFLOW_V_2_10_PLUS or AIRFLOW_V_3_0_PLUS,
     reason="This test checks serialization only in 2.10 conditions",
 )
-def test_serialize_timetable_2_10():
+def test_serialize_timetable_2_10_complex_with_alias():
     from airflow.providers.common.compat.assets import AssetAlias, AssetAll, AssetAny
     from airflow.timetables.simple import DatasetTriggeredTimetable
 
@@ -444,11 +599,126 @@ def test_serialize_timetable_2_10():
     }
 
 
+@pytest.mark.skipif(
+    not AIRFLOW_V_2_10_PLUS or AIRFLOW_V_3_0_PLUS,
+    reason="This test checks serialization only in 2.10 conditions",
+)
+def test_serialize_timetable_2_10_single_asset():
+    dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=Asset("a"))
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "dataset_condition": {"__type": DagAttributeTypes.DATASET, "uri": "a", "extra": None}
+    }
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_2_10_PLUS or AIRFLOW_V_3_0_PLUS,
+    reason="This test checks serialization only in 2.10 conditions",
+)
+def test_serialize_timetable_2_10_list_of_assets():
+    dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=[Asset("a"), Asset("b")])
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "dataset_condition": {
+            "__type": DagAttributeTypes.DATASET_ALL,
+            "objects": [
+                {"__type": DagAttributeTypes.DATASET, "extra": None, "uri": "a"},
+                {"__type": DagAttributeTypes.DATASET, "extra": None, "uri": "b"},
+            ],
+        }
+    }
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_2_10_PLUS or AIRFLOW_V_3_0_PLUS,
+    reason="This test checks serialization only in 2.10 conditions",
+)
+def test_serialize_timetable_2_10_with_complex_logical_condition():
+    dag = DAG(
+        dag_id="test",
+        start_date=datetime.datetime(2025, 1, 1),
+        schedule=(Asset("ds1", extra={"some_extra": 1}) | Asset("ds2"))
+        & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
+    )
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "dataset_condition": {
+            "__type": DagAttributeTypes.DATASET_ALL,
+            "objects": [
+                {
+                    "__type": DagAttributeTypes.DATASET_ANY,
+                    "objects": [
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds1", "extra": {"some_extra": 1}},
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds2", "extra": None},
+                    ],
+                },
+                {
+                    "__type": DagAttributeTypes.DATASET_ANY,
+                    "objects": [
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds3", "extra": None},
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds4", "extra": {"another_extra": 345}},
+                    ],
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_2_10_PLUS or AIRFLOW_V_3_0_PLUS,
+    reason="This test checks serialization only in 2.10 conditions",
+)
+def test_serialize_timetable_2_10_with_dataset_or_time_schedule():
+    from airflow.timetables.datasets import DatasetOrTimeSchedule
+    from airflow.timetables.trigger import CronTriggerTimetable
+
+    dag = DAG(
+        dag_id="test",
+        start_date=datetime.datetime(2025, 1, 1),
+        schedule=DatasetOrTimeSchedule(
+            timetable=CronTriggerTimetable("0 0 * 3 *", timezone="UTC"),
+            datasets=(Asset("ds1", extra={"some_extra": 1}) | Asset("ds2"))
+            & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
+        ),
+    )
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "timetable": {
+            "__type": "airflow.timetables.trigger.CronTriggerTimetable",
+            "__var": {"expression": "0 0 * 3 *", "timezone": "UTC", "interval": 0.0},
+        },
+        "dataset_condition": {
+            "__type": DagAttributeTypes.DATASET_ALL,
+            "objects": [
+                {
+                    "__type": DagAttributeTypes.DATASET_ANY,
+                    "objects": [
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds1", "extra": {"some_extra": 1}},
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds2", "extra": None},
+                    ],
+                },
+                {
+                    "__type": DagAttributeTypes.DATASET_ANY,
+                    "objects": [
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds3", "extra": None},
+                        {"__type": DagAttributeTypes.DATASET, "uri": "ds4", "extra": {"another_extra": 345}},
+                    ],
+                },
+            ],
+        },
+    }
+
+
 @pytest.mark.skipif(AIRFLOW_V_2_10_PLUS, reason="This test checks serialization only in 2.9 conditions")
-def test_serialize_timetable_2_9():
-    dag = MagicMock()
-    dag.timetable.serialize.return_value = {}
-    dag.dataset_triggers = [Asset("a"), Asset("b")]
+def test_serialize_timetable_2_9_single_asset():
+    dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=Asset("a"))
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {"dataset_condition": {"__type": "dataset", "uri": "a", "extra": None}}
+
+
+@pytest.mark.skipif(AIRFLOW_V_2_10_PLUS, reason="This test checks serialization only in 2.9 conditions")
+def test_serialize_timetable_2_9_list_of_assets():
+    dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=[Asset("a"), Asset("b")])
     dag_info = DagInfo(dag)
     assert dag_info.timetable == {
         "dataset_condition": {
@@ -458,6 +728,80 @@ def test_serialize_timetable_2_9():
                 {"__type": "dataset", "extra": None, "uri": "b"},
             ],
         }
+    }
+
+
+@pytest.mark.skipif(AIRFLOW_V_2_10_PLUS, reason="This test checks serialization only in 2.9 conditions")
+def test_serialize_timetable_2_9_with_complex_logical_condition():
+    dag = DAG(
+        dag_id="test",
+        start_date=datetime.datetime(2025, 1, 1),
+        schedule=(Asset("ds1", extra={"some_extra": 1}) | Asset("ds2"))
+        & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
+    )
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "dataset_condition": {
+            "__type": "dataset_all",
+            "objects": [
+                {
+                    "__type": "dataset_any",
+                    "objects": [
+                        {"__type": "dataset", "uri": "ds1", "extra": {"some_extra": 1}},
+                        {"__type": "dataset", "uri": "ds2", "extra": None},
+                    ],
+                },
+                {
+                    "__type": "dataset_any",
+                    "objects": [
+                        {"__type": "dataset", "uri": "ds3", "extra": None},
+                        {"__type": "dataset", "uri": "ds4", "extra": {"another_extra": 345}},
+                    ],
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.skipif(AIRFLOW_V_2_10_PLUS, reason="This test checks serialization only in 2.9 conditions")
+def test_serialize_timetable_2_9_with_dataset_or_time_schedule():
+    from airflow.timetables.datasets import DatasetOrTimeSchedule
+    from airflow.timetables.trigger import CronTriggerTimetable
+
+    dag = DAG(
+        dag_id="test",
+        start_date=datetime.datetime(2025, 1, 1),
+        schedule=DatasetOrTimeSchedule(
+            timetable=CronTriggerTimetable("0 0 * 3 *", timezone="UTC"),
+            datasets=(Asset("ds1", extra={"some_extra": 1}) | Asset("ds2"))
+            & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
+        ),
+    )
+    dag_info = DagInfo(dag)
+    assert dag_info.timetable == {
+        "timetable": {
+            "__type": "airflow.timetables.trigger.CronTriggerTimetable",
+            "__var": {"expression": "0 0 * 3 *", "timezone": "UTC", "interval": 0.0},
+        },
+        "dataset_condition": {
+            "__type": "dataset_all",
+            "objects": [
+                {
+                    "__type": "dataset_any",
+                    "objects": [
+                        {"__type": "dataset", "uri": "ds1", "extra": {"some_extra": 1}},
+                        {"__type": "dataset", "uri": "ds2", "extra": None},
+                    ],
+                },
+                {
+                    "__type": "dataset_any",
+                    "objects": [
+                        {"__type": "dataset", "uri": "ds3", "extra": None},
+                        {"__type": "dataset", "uri": "ds4", "extra": {"another_extra": 345}},
+                    ],
+                },
+            ],
+        },
     }
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In #43434 we added OL support for serialization of timetables for Airflow 2.8 and 2.9. In 2.9 however, airflow introduced new ways of defining a dataset schedule that were not covered by our integration, so we received empty timetables. This PR fixes it, now timetable should be present and serialized in a similar way to how it looks like in 2.10+.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
