### PR TITLE
AIP-38 Default value for version selector

### DIFF
--- a/airflow/ui/src/components/DagVersionSelect.tsx
+++ b/airflow/ui/src/components/DagVersionSelect.tsx
@@ -21,25 +21,23 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { OptionsOrGroups, GroupBase, SingleValue } from "chakra-react-select";
 import { AsyncSelect } from "chakra-react-select";
 import { useCallback } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 
 import { UseDagVersionServiceGetDagVersionsKeyFn } from "openapi/queries";
 import { DagVersionService } from "openapi/requests/services.gen";
 import type { DAGVersionCollectionResponse, DagVersionResponse } from "openapi/requests/types.gen";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import useSelectedVersion from "src/hooks/useSelectedVersion";
 import type { Option } from "src/utils/option";
 
-const DagVersionSelect = ({
-  dagId,
-  disabled = false,
-}: {
-  readonly dagId: string | undefined;
-  readonly disabled?: boolean;
-}) => {
+const DagVersionSelect = ({ disabled = false }: { readonly disabled?: boolean }) => {
   const queryClient = useQueryClient();
 
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedVersion = searchParams.get(SearchParamsKeys.VERSION_NUMBER);
+
+  const selectedVersion = useSelectedVersion();
+
+  const { dagId = "" } = useParams();
 
   const loadVersions = (
     _: string,
@@ -48,7 +46,7 @@ const DagVersionSelect = ({
     queryClient.fetchQuery({
       queryFn: () =>
         DagVersionService.getDagVersions({
-          dagId: dagId ?? "",
+          dagId,
         }).then((data: DAGVersionCollectionResponse) => {
           const options = data.dag_versions.map((version: DagVersionResponse) => {
             const versionNumber = version.version_number.toString();
@@ -63,7 +61,7 @@ const DagVersionSelect = ({
 
           return options;
         }),
-      queryKey: UseDagVersionServiceGetDagVersionsKeyFn({ dagId: dagId ?? "" }),
+      queryKey: UseDagVersionServiceGetDagVersionsKeyFn({ dagId }),
       staleTime: 0,
     });
 
@@ -86,9 +84,9 @@ const DagVersionSelect = ({
         loadOptions={loadVersions}
         onChange={handleStateChange}
         placeholder="Dag Version"
-        // null is required https://github.com/JedWatson/react-select/issues/3066
-        // eslint-disable-next-line unicorn/no-null
-        value={selectedVersion === null ? null : { label: `v${selectedVersion}`, value: selectedVersion }}
+        value={
+          selectedVersion === undefined ? undefined : { label: `v${selectedVersion}`, value: selectedVersion }
+        }
       />
     </Field.Root>
   );

--- a/airflow/ui/src/hooks/useSelectedVersion.ts
+++ b/airflow/ui/src/hooks/useSelectedVersion.ts
@@ -31,9 +31,7 @@ const useSelectedVersion = (): string | undefined => {
 
   const selectedVersionUrl = searchParams.get(SearchParamsKeys.VERSION_NUMBER);
 
-  const { dagId = "", mapIndexParam = "-1", runId = "", taskId = "" } = useParams();
-
-  const mapIndex = parseInt(mapIndexParam, 10);
+  const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
 
   const { data: dagData } = useDagServiceGetDagDetails(
     {
@@ -65,12 +63,12 @@ const useSelectedVersion = (): string | undefined => {
     {
       dagId,
       dagRunId: runId,
-      mapIndex,
+      mapIndex: parseInt(mapIndex, 10),
       taskId,
     },
     undefined,
     // Do not enable on a task instance summary. Mapped task but no mapIndex defined.
-    { enabled: taskData !== undefined && !Boolean(mapIndex === -1 && taskData.is_mapped) },
+    { enabled: taskData !== undefined && !Boolean(mapIndex === "-1" && taskData.is_mapped) },
   );
 
   const selectedVersionNumber =

--- a/airflow/ui/src/hooks/useSelectedVersion.ts
+++ b/airflow/ui/src/hooks/useSelectedVersion.ts
@@ -1,0 +1,85 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useParams, useSearchParams } from "react-router-dom";
+
+import {
+  useDagRunServiceGetDagRun,
+  useDagServiceGetDagDetails,
+  useTaskInstanceServiceGetMappedTaskInstance,
+  useTaskServiceGetTask,
+} from "openapi/queries";
+import { SearchParamsKeys } from "src/constants/searchParams";
+
+const useSelectedVersion = (): string | undefined => {
+  const [searchParams] = useSearchParams();
+
+  const selectedVersionUrl = searchParams.get(SearchParamsKeys.VERSION_NUMBER);
+
+  const { dagId = "", mapIndexParam = "-1", runId = "", taskId = "" } = useParams();
+
+  const mapIndex = parseInt(mapIndexParam, 10);
+
+  const { data: dagData } = useDagServiceGetDagDetails(
+    {
+      dagId,
+    },
+    undefined,
+    { enabled: Boolean(dagId) },
+  );
+
+  const { data: runData } = useDagRunServiceGetDagRun(
+    {
+      dagId,
+      dagRunId: runId,
+    },
+    undefined,
+    { enabled: Boolean(dagId) && Boolean(runId) },
+  );
+
+  const { data: taskData } = useTaskServiceGetTask(
+    {
+      dagId,
+      taskId,
+    },
+    undefined,
+    { enabled: Boolean(dagId) && Boolean(runId) && Boolean(taskId) },
+  );
+
+  const { data: mappedTaskInstanceData } = useTaskInstanceServiceGetMappedTaskInstance(
+    {
+      dagId,
+      dagRunId: runId,
+      mapIndex,
+      taskId,
+    },
+    undefined,
+    // Do not enable on a task instance summary. Mapped task but no mapIndex defined.
+    { enabled: taskData !== undefined && !Boolean(mapIndex === -1 && taskData.is_mapped) },
+  );
+
+  const selectedVersionNumber =
+    selectedVersionUrl ??
+    mappedTaskInstanceData?.dag_version?.version_number ??
+    runData?.dag_versions.at(-1)?.version_number ??
+    dagData?.latest_dag_version?.version_number;
+
+  return selectedVersionNumber?.toString();
+};
+
+export default useSelectedVersion;

--- a/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -71,7 +71,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
         <PanelGroup autoSaveId={dagId} direction="horizontal">
           <Panel defaultSize={20} minSize={6}>
             <Box height="100%" position="relative" pr={2}>
-              <PanelButtons dagId={dagId} dagView={dagView} setDagView={setDagView} />
+              <PanelButtons dagView={dagView} setDagView={setDagView} />
               {dagView === "graph" ? <Graph /> : <Grid />}
             </Box>
           </Panel>

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -19,12 +19,12 @@
 import { useToken } from "@chakra-ui/react";
 import { ReactFlow, Controls, Background, MiniMap, type Node as ReactFlowNode } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { useGridServiceGridData, useStructureServiceStructureData } from "openapi/queries";
-import { SearchParamsKeys } from "src/constants/searchParams";
 import { useColorMode } from "src/context/colorMode";
 import { useOpenGroups } from "src/context/openGroups";
+import useSelectedVersion from "src/hooks/useSelectedVersion";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 import Edge from "./Edge";
@@ -32,8 +32,6 @@ import { JoinNode } from "./JoinNode";
 import { TaskNode } from "./TaskNode";
 import type { CustomNodeProps } from "./reactflowUtils";
 import { useGraphLayout } from "./useGraphLayout";
-
-const VERSION_NUMBER_PARAM = SearchParamsKeys.VERSION_NUMBER;
 
 const nodeColor = (
   { data: { depth, height, isOpen, taskInstance, width }, type }: ReactFlowNode<CustomNodeProps>,
@@ -67,8 +65,7 @@ export const Graph = () => {
   const { colorMode = "light" } = useColorMode();
   const { dagId = "", runId, taskId } = useParams();
 
-  const [searchParams] = useSearchParams();
-  const selectedVersion = searchParams.get(VERSION_NUMBER_PARAM);
+  const selectedVersion = useSelectedVersion();
 
   // corresponds to the "bg", "bg.emphasized", "border.inverted" semantic tokens
   const [oddLight, oddDark, evenLight, evenDark, selectedDarkColor, selectedLightColor] = useToken("colors", [
@@ -86,7 +83,7 @@ export const Graph = () => {
 
   const { data: graphData = { arrange: "LR", edges: [], nodes: [] } } = useStructureServiceStructureData({
     dagId,
-    versionNumber: selectedVersion === null ? undefined : parseInt(selectedVersion, 10),
+    versionNumber: selectedVersion === undefined ? undefined : parseInt(selectedVersion, 10),
   });
 
   const { data } = useGraphLayout({

--- a/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -23,12 +23,11 @@ import { MdOutlineAccountTree } from "react-icons/md";
 import DagVersionSelect from "src/components/DagVersionSelect";
 
 type Props = {
-  readonly dagId: string;
   readonly dagView: string;
   readonly setDagView: (x: "graph" | "grid") => void;
 } & StackProps;
 
-export const PanelButtons = ({ dagId, dagView, setDagView, ...rest }: Props) => (
+export const PanelButtons = ({ dagView, setDagView, ...rest }: Props) => (
   <HStack justifyContent="space-between" position="absolute" top={0} width="100%" zIndex={1} {...rest}>
     <ButtonGroup attached size="sm" variant="outline">
       <IconButton
@@ -51,7 +50,7 @@ export const PanelButtons = ({ dagId, dagView, setDagView, ...rest }: Props) => 
       </IconButton>
     </ButtonGroup>
     <Box bg="bg" mr={2}>
-      <DagVersionSelect dagId={dagId} disabled={dagView !== "graph"} />
+      <DagVersionSelect disabled={dagView !== "graph"} />
     </Box>
   </HStack>
 );

--- a/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -18,7 +18,7 @@
  */
 import { Box, Button, Heading, HStack } from "@chakra-ui/react";
 import { useState } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { createElement, PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
 import { oneLight, oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -28,18 +28,16 @@ import DagVersionSelect from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { ProgressBar } from "src/components/ui";
-import { SearchParamsKeys } from "src/constants/searchParams";
 import { useColorMode } from "src/context/colorMode";
+import useSelectedVersion from "src/hooks/useSelectedVersion";
 import { useConfig } from "src/queries/useConfig";
 
 SyntaxHighlighter.registerLanguage("python", python);
 
-const VERSION_NUMBER_PARAM = SearchParamsKeys.VERSION_NUMBER;
-
 export const Code = () => {
   const { dagId } = useParams();
-  const [searchParams] = useSearchParams();
-  const selectedVersion = searchParams.get(VERSION_NUMBER_PARAM);
+
+  const selectedVersion = useSelectedVersion();
 
   const {
     data: dag,
@@ -55,7 +53,7 @@ export const Code = () => {
     isLoading: isCodeLoading,
   } = useDagSourceServiceGetDagSource({
     dagId: dagId ?? "",
-    versionNumber: selectedVersion === null ? undefined : parseInt(selectedVersion, 10),
+    versionNumber: selectedVersion === undefined ? undefined : parseInt(selectedVersion, 10),
   });
 
   const defaultWrap = Boolean(useConfig("default_wrap"));
@@ -81,7 +79,7 @@ export const Code = () => {
           </Heading>
         )}
         <HStack>
-          <DagVersionSelect dagId={dagId} />
+          <DagVersionSelect />
           <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
             {wrap ? "Unwrap" : "Wrap"}
           </Button>


### PR DESCRIPTION
This adds some logic to pre-select the appropriate dag version depending on the current url.

If the user explicitly uses the version selector, or there is a `dag_version` param in the URL, nothing happens.

If there is no `dag_version` explicitely specified in the URL, then we pre-select the dag version based on:
- on a dag -> latest_dag_version 
![Screenshot 2025-02-27 at 16 57 02](https://github.com/user-attachments/assets/64c24abf-146f-4a11-872e-69e4e200858b)
- on a DagRun -> latest dag version of the DagRun
![Screenshot 2025-02-27 at 16 57 17](https://github.com/user-attachments/assets/1983f03d-65ed-498a-a7c9-422d38c0bd03)
- on a TI -> dag version of the TI. Handled the case of the `MappedTaskInstance` summary -> fallsback to the `DagRun` case. 
![Screenshot 2025-02-27 at 16 57 46](https://github.com/user-attachments/assets/61deed9f-5c2b-42a0-91e7-9802a5ddf243)


Clicking on TIs in the graph without a version explicitely set will dynamically update the graph based on the TI version. If we want to freeze the dag for  a specific version to navigate the graph -> explicitely to so using the version selector.



