### PR TITLE
Trigger CI-buld dependent static checks on provider's project config

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -748,6 +748,7 @@ class SelectiveChecks:
             or self.run_kubernetes_tests
             or self.needs_helm_tests
             or self.pyproject_toml_changed
+            or self.any_provider_yaml_or_pyproject_toml_changed
         )
 
     @cached_property
@@ -974,6 +975,17 @@ class SelectiveChecks:
     @cached_property
     def hatch_build_changed(self) -> bool:
         return "hatch_build.py" in self._files
+
+    @cached_property
+    def any_provider_yaml_or_pyproject_toml_changed(self) -> bool:
+        if not self._commit_ref:
+            get_console().print("[warning]Cannot determine changes as commit is missing[/]")
+            return False
+        for file in self._files:
+            path_file = Path(file)
+            if path_file.name == "provider.yaml" or path_file.name == "pyproject.toml":
+                return True
+        return False
 
     @cached_property
     def pyproject_toml_changed(self) -> bool:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -2016,6 +2016,60 @@ def test_helm_tests_trigger_ci_build(files: tuple[str, ...], expected_outputs: d
 
 
 @pytest.mark.parametrize(
+    "files, expected_outputs,",
+    [
+        pytest.param(
+            ("providers/amazon/provider.yaml",),
+            {
+                "ci-image-build": "true",
+                "prod-image-build": "false",
+                "needs-helm-tests": "false",
+            },
+            id="Amazon provider.yaml",
+        ),
+        pytest.param(
+            ("providers/amazon/pyproject.toml",),
+            {
+                "ci-image-build": "true",
+                "prod-image-build": "false",
+                "needs-helm-tests": "false",
+            },
+            id="Amazon pyproject.toml",
+        ),
+        pytest.param(
+            ("providers/cncf/kubernetes/provider.yaml",),
+            {
+                "ci-image-build": "true",
+                "prod-image-build": "true",
+                "needs-helm-tests": "false",
+            },
+            id="CNCF Kubernetes provider.yaml",
+        ),
+        pytest.param(
+            ("providers/cncf/kubernetes/pyproject.toml",),
+            {
+                "ci-image-build": "true",
+                "prod-image-build": "true",
+                "needs-helm-tests": "false",
+            },
+            id="CNCF Kubernetes pyproject.toml",
+        ),
+    ],
+)
+def test_provider_yaml_or_pyproject_toml_changes_trigger_ci_build(
+    files: tuple[str, ...], expected_outputs: dict[str, str]
+):
+    stderr = SelectiveChecks(
+        files=files,
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+        pr_labels=(),
+        default_branch="main",
+    )
+    assert_outputs_are_printed(expected_outputs, str(stderr))
+
+
+@pytest.mark.parametrize(
     (
         "github_event, github_actor, github_repository, pr_labels, "
         "github_context_dict, runs_on_as_json_default, runs_on_as_docs_build, is_self_hosted_runner, "


### PR DESCRIPTION
When provider.yaml or pypyroject.toml changes for a provider, that should trigger CI-image bound static checks - because only there we verify provider.yaml and it might trigger CI image build to get new dependencies that might fail the CI image build.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
