### PR TITLE
Amazon rdshook invalid waiter

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/rds.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/rds.py
@@ -259,7 +259,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
             return self.get_db_instance_state(db_instance_id)
 
         target_state = target_state.lower()
-        if target_state in ("available", "deleted", "stopped"):
+        if target_state in ("available", "deleted"):
             waiter = self.conn.get_waiter(f"db_instance_{target_state}")  # type: ignore
             wait(
                 waiter=waiter,
@@ -310,7 +310,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
             return self.get_db_cluster_state(db_cluster_id)
 
         target_state = target_state.lower()
-        if target_state in ("available", "deleted", "stopped"):
+        if target_state in ("available", "deleted"):
             waiter = self.conn.get_waiter(f"db_cluster_{target_state}")  # type: ignore
             waiter.wait(
                 DBClusterIdentifier=db_cluster_id,

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_rds.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_rds.py
@@ -151,7 +151,7 @@ class TestRdsHook:
 
     def test_wait_for_db_instance_state_boto_waiters(self, rds_hook: RdsHook, db_instance_id: str):
         """Checks that the DB instance waiter uses AWS boto waiters where possible"""
-        for state in ("available", "deleted", "stopped"):
+        for state in ("available", "deleted"):
             with patch.object(rds_hook.conn, "get_waiter") as mock:
                 rds_hook.wait_for_db_instance_state(db_instance_id, target_state=state, **self.waiter_args)
                 mock.assert_called_once_with(f"db_instance_{state}")
@@ -170,7 +170,7 @@ class TestRdsHook:
 
     def test_wait_for_db_cluster_state_boto_waiters(self, rds_hook: RdsHook, db_cluster_id: str):
         """Checks that the DB cluster waiter uses AWS boto waiters where possible"""
-        for state in ("available", "deleted", "stopped"):
+        for state in ("available", "deleted"):
             with patch.object(rds_hook.conn, "get_waiter") as mock:
                 rds_hook.wait_for_db_cluster_state(db_cluster_id, target_state=state, **self.waiter_args)
                 mock.assert_called_once_with(f"db_cluster_{state}")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
The latest boto3 Amazon RDS documentation states that only the following waiters are available for RDS clusters and instances:

* DBClusterAvailable
* DBClusterDeleted
* DBInstanceAvailable
* DBInstanceDeleted

The RdsHook, tries to create a waiter for the `target_state` `stopped`. This gives the following error:

```
...
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/providers/amazon/aws/hooks/rds.py", line 263, in wait_for_db_instance_state
    waiter = self.conn.get_waiter(f"db_instance_{target_state}")  # type: ignore
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/botocore/client.py", line 1267, in get_waiter
    raise ValueError(f"Waiter does not exist: {waiter_name}")
ValueError: Waiter does not exist: db_instance_stopped
``` 

This PR aims to correct this error by making sure that no waiter is created for that `target_state`


