### PR TITLE
Add in 500 error logging for the ExecutionAPI app

### DIFF
--- a/airflow/api_fastapi/execution_api/app.py
+++ b/airflow/api_fastapi/execution_api/app.py
@@ -22,11 +22,16 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 import attrs
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
 
 if TYPE_CHECKING:
     import httpx
+
+import structlog
+
+logger = structlog.get_logger(logger_name=__name__)
 
 
 @asynccontextmanager
@@ -86,6 +91,16 @@ def create_task_execution_api_app() -> FastAPI:
     app.openapi = custom_openapi  # type: ignore[method-assign]
 
     app.include_router(execution_api_router)
+
+    # As we are mounted as a sub app, we don't get any logs for unhandled exceptions without this!
+    @app.exception_handler(Exception)
+    def handle_exceptions(request: Request, exc: Exception):
+        logger.exception("Handle died with an error", exc_info=(type(exc), exc, exc.__traceback__))
+        content = {"message": "Internal server error"}
+        if "correlation-id" in request.headers:
+            content["correlation-id"] = request.headers["correlation-id"]
+        return JSONResponse(status_code=500, content=content)
+
     return app
 
 


### PR DESCRIPTION
This makes the process of developing and debugging much more plesant, as
without this we get 0 logging (just a "500" access log line) in case of an
unhandled exception.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
