### PR TITLE
Fix deprecation warnings in common.sql

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
@@ -26,7 +26,8 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, NoReturn, SupportsAbs
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, SkipMixin
-from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, return_single_query_results
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler, return_single_query_results
+from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.utils.helpers import merge_dicts
 
 if TYPE_CHECKING:

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
@@ -29,7 +29,8 @@ from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONF
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from airflow.providers.common.sql.dialects.dialect import Dialect
-from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, fetch_one_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler, fetch_one_handler
+from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 
 class DbApiHookInProvider(DbApiHook):

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -29,7 +29,8 @@ from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONF
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.common.sql.dialects.dialect import Dialect
-from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, resolve_dialects
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
+from airflow.providers.common.sql.hooks.sql import DbApiHook, resolve_dialects
 from airflow.utils.session import provide_session
 
 from tests_common.test_utils.common_sql import mock_db_hook

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
@@ -27,7 +27,7 @@ import pytest
 from airflow import DAG
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import Connection, DagRun, TaskInstance as TI, XCom
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.common.sql.operators.sql import (
     BaseSQLOperator,
     BranchSQLOperator,

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql_execute.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql_execute.py
@@ -31,7 +31,8 @@ from airflow.providers.common.compat.openlineage.facet import (
     SchemaDatasetFacetFields,
     SQLJobFacet,
 )
-from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
+from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.openlineage.extractors.base import OperatorLineage
 

--- a/providers/databricks/src/airflow/providers/databricks/sensors/databricks_partition.py
+++ b/providers/databricks/src/airflow/providers/databricks/sensors/databricks_partition.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from databricks.sql.utils import ParamEscaper
 
 from airflow.exceptions import AirflowException
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
 from airflow.sensors.base import BaseSensorOperator
 

--- a/providers/databricks/src/airflow/providers/databricks/sensors/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/sensors/databricks_sql.py
@@ -25,7 +25,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable
 
 from airflow.exceptions import AirflowException
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
 from airflow.sensors.base import BaseSensorOperator
 

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -29,7 +29,7 @@ from databricks.sql.types import Row
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook, create_timeout_thread
 from airflow.utils.session import provide_session
 

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
@@ -25,7 +25,7 @@ from unittest.mock import patch
 import pytest
 from databricks.sql.types import Row
 
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.operators.databricks_sql import DatabricksSqlOperator
 
 DATE = "2017-04-20"

--- a/providers/databricks/tests/unit/databricks/sensors/test_databricks_partition.py
+++ b/providers/databricks/tests/unit/databricks/sensors/test_databricks_partition.py
@@ -25,7 +25,7 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.sensors.databricks_partition import DatabricksPartitionSensor
 from airflow.utils import timezone
 

--- a/providers/exasol/tests/unit/exasol/hooks/test_sql.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_sql.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.models import Connection
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.exasol.hooks.exasol import ExasolHook
 from airflow.utils.session import provide_session
 

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_sql.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_sql.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock
 import pytest
 from snowflake.connector import DictCursor
 
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 
 TASK_ID = "sql-operator"

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake_sql.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake_sql.py
@@ -30,7 +30,7 @@ from airflow.providers.common.compat.openlineage.facet import (
     InputField,
     SQLJobFacet,
 )
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 

--- a/providers/teradata/src/airflow/providers/teradata/triggers/teradata_compute_cluster.py
+++ b/providers/teradata/src/airflow/providers/teradata/triggers/teradata_compute_cluster.py
@@ -21,7 +21,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from airflow.exceptions import AirflowException
-from airflow.providers.common.sql.hooks.sql import fetch_one_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_one_handler
 from airflow.providers.teradata.hooks.teradata import TeradataHook
 from airflow.providers.teradata.utils.constants import Constants
 from airflow.triggers.base import BaseTrigger, TriggerEvent

--- a/providers/teradata/tests/unit/teradata/operators/test_teradata.py
+++ b/providers/teradata/tests/unit/teradata/operators/test_teradata.py
@@ -21,7 +21,7 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock
 
 from airflow.exceptions import AirflowException
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.teradata.hooks.teradata import TeradataHook
 from airflow.providers.teradata.operators.teradata import TeradataOperator, TeradataStoredProcedureOperator
 

--- a/providers/teradata/tests/unit/teradata/triggers/test_teradata_compute_cluster.py
+++ b/providers/teradata/tests/unit/teradata/triggers/test_teradata_compute_cluster.py
@@ -21,7 +21,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from airflow.providers.common.sql.hooks.sql import fetch_one_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_one_handler
 from airflow.providers.teradata.hooks.teradata import TeradataHook
 from airflow.providers.teradata.triggers.teradata_compute_cluster import TeradataComputeClusterSyncTrigger
 from airflow.providers.teradata.utils.constants import Constants

--- a/providers/vertica/src/airflow/providers/vertica/hooks/vertica.py
+++ b/providers/vertica/src/airflow/providers/vertica/hooks/vertica.py
@@ -22,7 +22,8 @@ from typing import Any, Callable, overload
 
 from vertica_python import connect
 
-from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
+from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 
 def vertica_fetch_all_handler(cursor) -> list[tuple] | None:

--- a/providers/ydb/tests/integration/ydb/operators/test_ydb.py
+++ b/providers/ydb/tests/integration/ydb/operators/test_ydb.py
@@ -24,7 +24,7 @@ import ydb
 
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.ydb.operators.ydb import YDBExecuteQueryOperator
 from airflow.utils import timezone
 

--- a/providers/ydb/tests/unit/ydb/operators/test_ydb.py
+++ b/providers/ydb/tests/unit/ydb/operators/test_ydb.py
@@ -24,7 +24,7 @@ import ydb
 
 from airflow.models import Connection
 from airflow.models.dag import DAG
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler, fetch_one_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler, fetch_one_handler
 from airflow.providers.ydb.operators.ydb import YDBExecuteQueryOperator
 
 


### PR DESCRIPTION
Common.sql self-deprecated itself after #43747 by importing handlers from the old location.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
