### PR TITLE
Disable past/future Clear TI buttons when logical date is null

### DIFF
--- a/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -105,8 +105,8 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
               multiple
               onChange={setSelectedOptions}
               options={[
-                { label: "Past", value: "past" },
-                { label: "Future", value: "future" },
+                { disabled: taskInstance.logical_date === null, label: "Past", value: "past" },
+                { disabled: taskInstance.logical_date === null, label: "Future", value: "future" },
                 { label: "Upstream", value: "upstream" },
                 { label: "Downstream", value: "downstream" },
                 { label: "Only Failed", value: "onlyFailed" },


### PR DESCRIPTION
Past and Future don't make sense on Task Instances without a logical_date

<img width="842" alt="Screenshot 2025-02-27 at 3 02 15 PM" src="https://github.com/user-attachments/assets/34961a78-bd52-476d-b655-07e5172e635e" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
