### PR TITLE
Fix section for base_url in FAB auth manager

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -70,7 +70,7 @@ class FabIndexView(IndexView):
     def index(self):
         if g.user is not None and g.user.is_authenticated:
             token = get_auth_manager().get_jwt_token(g.user)
-            return redirect(f"{conf.get('fastapi', 'base_url')}/?token={token}", code=302)
+            return redirect(f"{conf.get('api', 'base_url')}/?token={token}", code=302)
         else:
             return super().index()
 


### PR DESCRIPTION
Concurrent PRs meant this was missed.