### PR TITLE
Format log timestamp and level. Filter logs by level

### DIFF
--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -78,7 +78,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
   });
 
   return (
-    <VStack alignItems="flex-start" gap={1} my={3}>
+    <VStack alignItems="flex-start" gap={1} mb={3}>
       <Heading size="md">Task Tries</Heading>
       {showDropdown ? (
         <Select.Root

--- a/airflow/ui/src/constants/searchParams.ts
+++ b/airflow/ui/src/constants/searchParams.ts
@@ -19,6 +19,7 @@
 export enum SearchParamsKeys {
   LAST_DAG_RUN_STATE = "last_dag_run_state",
   LIMIT = "limit",
+  LOG_LEVEL = "log_level",
   NAME_PATTERN = "name_pattern",
   OFFSET = "offset",
   PAUSED = "paused",

--- a/airflow/ui/src/constants/searchParams.ts
+++ b/airflow/ui/src/constants/searchParams.ts
@@ -25,6 +25,7 @@ export enum SearchParamsKeys {
   PAUSED = "paused",
   SORT = "sort",
   TAGS = "tags",
+  TRY_NUMBER = "try_number",
   VERSION_NUMBER = "version_number",
 }
 

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -25,7 +25,6 @@ import { Dialog } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { useLogs } from "src/queries/useLogs";
-import type { LogLevel } from "src/utils/logs";
 
 import { TaskLogContent } from "./TaskLogContent";
 import { TaskLogHeader } from "./TaskLogHeader";
@@ -35,7 +34,7 @@ export const Logs = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const tryNumberParam = searchParams.get(SearchParamsKeys.TRY_NUMBER);
-  const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
+  const logLevelFilters = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
 
   const {
     data: taskInstance,
@@ -77,7 +76,7 @@ export const Logs = () => {
     isLoading: isLoadingLogs,
   } = useLogs({
     dagId,
-    logLevels: logLevels as Array<LogLevel>,
+    logLevelFilters,
     taskInstance,
     tryNumber: tryNumber === 0 ? 1 : tryNumber,
   });

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -22,8 +22,10 @@ import { useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
 import { Dialog } from "src/components/ui";
+import { SearchParamsKeys } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { useLogs } from "src/queries/useLogs";
+import type { LogLevel } from "src/utils/logs";
 
 import { TaskLogContent } from "./TaskLogContent";
 import { TaskLogHeader } from "./TaskLogHeader";
@@ -32,7 +34,8 @@ export const Logs = () => {
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const tryNumberParam = searchParams.get("try_number");
+  const tryNumberParam = searchParams.get(SearchParamsKeys.TRY_NUMBER);
+  const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
 
   const {
     data: taskInstance,
@@ -47,9 +50,9 @@ export const Logs = () => {
 
   const onSelectTryNumber = (newTryNumber: number) => {
     if (newTryNumber === taskInstance?.try_number) {
-      searchParams.delete("try_number");
+      searchParams.delete(SearchParamsKeys.TRY_NUMBER);
     } else {
-      searchParams.set("try_number", newTryNumber.toString());
+      searchParams.set(SearchParamsKeys.TRY_NUMBER, newTryNumber.toString());
     }
     setSearchParams(searchParams);
   };
@@ -74,6 +77,7 @@ export const Logs = () => {
     isLoading: isLoadingLogs,
   } = useLogs({
     dagId,
+    logLevels: logLevels as Array<LogLevel>,
     taskInstance,
     tryNumber: tryNumber === 0 ? 1 : tryNumber,
   });

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Badge, HStack, IconButton, type SelectValueChangeDetails } from "@chakra-ui/react";
+import { Badge, Box, HStack, IconButton, type SelectValueChangeDetails } from "@chakra-ui/react";
 import { useCallback } from "react";
 import { MdOutlineOpenInFull } from "react-icons/md";
 import { useSearchParams } from "react-router-dom";
@@ -69,7 +69,7 @@ export const TaskLogHeader = ({
   );
 
   return (
-    <HStack justifyContent="space-between" mb={2}>
+    <Box>
       {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? undefined : (
         <TaskTrySelect
           onSelectTryNumber={onSelectTryNumber}
@@ -77,52 +77,54 @@ export const TaskLogHeader = ({
           taskInstance={taskInstance}
         />
       )}
-      <Select.Root
-        collection={logLevelOptions}
-        maxW="250px"
-        multiple
-        onValueChange={handleStateChange}
-        value={hasLogLevels ? logLevels : ["all"]}
-      >
-        <Select.Trigger {...(hasLogLevels ? { clearable: true } : {})} isActive={Boolean(logLevels)}>
-          <Select.ValueText>
-            {() =>
-              hasLogLevels ? (
-                <HStack gap="10px">
-                  {logLevels.map((level) => (
-                    <Badge colorPalette={logLevelColorMapping[level as LogLevel]} key={level}>
-                      {level.toUpperCase()}
-                    </Badge>
-                  ))}
-                </HStack>
-              ) : (
-                "All Log Levels"
-              )
-            }
-          </Select.ValueText>
-        </Select.Trigger>
-        <Select.Content>
-          {logLevelOptions.items.map((option) => (
-            <Select.Item item={option} key={option.label}>
-              {option.value === "all" ? (
-                option.label
-              ) : (
-                <Badge colorPalette={logLevelColorMapping[option.value as LogLevel]}>{option.label}</Badge>
-              )}
-            </Select.Item>
-          ))}
-        </Select.Content>
-      </Select.Root>
-      <HStack>
-        <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
-          {wrap ? "Unwrap" : "Wrap"}
-        </Button>
-        {!isFullscreen && (
-          <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
-            <MdOutlineOpenInFull />
-          </IconButton>
-        )}
+      <HStack justifyContent="space-between" mb={2}>
+        <Select.Root
+          collection={logLevelOptions}
+          maxW="250px"
+          multiple
+          onValueChange={handleStateChange}
+          value={hasLogLevels ? logLevels : ["all"]}
+        >
+          <Select.Trigger {...(hasLogLevels ? { clearable: true } : {})} isActive={Boolean(logLevels)}>
+            <Select.ValueText>
+              {() =>
+                hasLogLevels ? (
+                  <HStack gap="10px">
+                    {logLevels.map((level) => (
+                      <Badge colorPalette={logLevelColorMapping[level as LogLevel]} key={level}>
+                        {level.toUpperCase()}
+                      </Badge>
+                    ))}
+                  </HStack>
+                ) : (
+                  "All Log Levels"
+                )
+              }
+            </Select.ValueText>
+          </Select.Trigger>
+          <Select.Content>
+            {logLevelOptions.items.map((option) => (
+              <Select.Item item={option} key={option.label}>
+                {option.value === "all" ? (
+                  option.label
+                ) : (
+                  <Badge colorPalette={logLevelColorMapping[option.value as LogLevel]}>{option.label}</Badge>
+                )}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+        <HStack>
+          <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
+            {wrap ? "Unwrap" : "Wrap"}
+          </Button>
+          {!isFullscreen && (
+            <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
+              <MdOutlineOpenInFull />
+            </IconButton>
+          )}
+        </HStack>
       </HStack>
-    </HStack>
+    </Box>
   );
 };

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -90,7 +90,7 @@ export const TaskLogHeader = ({
               hasLogLevels ? (
                 <HStack gap="10px">
                   {logLevels.map((level) => (
-                    <Badge colorPalette={logLevelColorMapping[level.toUpperCase() as LogLevel]} key={level}>
+                    <Badge colorPalette={logLevelColorMapping[level as LogLevel]} key={level}>
                       {level.toUpperCase()}
                     </Badge>
                   ))}
@@ -107,9 +107,7 @@ export const TaskLogHeader = ({
               {option.value === "all" ? (
                 option.label
               ) : (
-                <Badge colorPalette={logLevelColorMapping[option.value.toUpperCase() as LogLevel]}>
-                  {option.label}
-                </Badge>
+                <Badge colorPalette={logLevelColorMapping[option.value as LogLevel]}>{option.label}</Badge>
               )}
             </Select.Item>
           ))}

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -16,12 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, IconButton } from "@chakra-ui/react";
+import { Badge, HStack, IconButton, type SelectValueChangeDetails } from "@chakra-ui/react";
+import { useCallback } from "react";
 import { MdOutlineOpenInFull } from "react-icons/md";
+import { useSearchParams } from "react-router-dom";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
-import { Button } from "src/components/ui";
+import { Button, Select } from "src/components/ui";
+import { SearchParamsKeys } from "src/constants/searchParams";
+import { type LogLevel, logLevelColorMapping, logLevelOptions } from "src/utils/logs";
 
 type Props = {
   readonly isFullscreen?: boolean;
@@ -41,26 +45,86 @@ export const TaskLogHeader = ({
   toggleWrap,
   tryNumber,
   wrap,
-}: Props) => (
-  <HStack justifyContent="space-between" mb={2}>
-    {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? (
-      <div />
-    ) : (
-      <TaskTrySelect
-        onSelectTryNumber={onSelectTryNumber}
-        selectedTryNumber={tryNumber}
-        taskInstance={taskInstance}
-      />
-    )}
-    <HStack>
-      <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
-        {wrap ? "Unwrap" : "Wrap"}
-      </Button>
-      {!isFullscreen && (
-        <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
-          <MdOutlineOpenInFull />
-        </IconButton>
+}: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
+  const hasLogLevels = logLevels.length > 0;
+
+  const handleStateChange = useCallback(
+    ({ value }: SelectValueChangeDetails<string>) => {
+      const [val, ...rest] = value;
+
+      if ((val === undefined || val === "all") && rest.length === 0) {
+        searchParams.delete(SearchParamsKeys.LOG_LEVEL);
+      } else {
+        searchParams.delete(SearchParamsKeys.LOG_LEVEL);
+        value
+          .filter((state) => state !== "all")
+          .map((state) => searchParams.append(SearchParamsKeys.LOG_LEVEL, state));
+      }
+      setSearchParams(searchParams);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  return (
+    <HStack justifyContent="space-between" mb={2}>
+      {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? undefined : (
+        <TaskTrySelect
+          onSelectTryNumber={onSelectTryNumber}
+          selectedTryNumber={tryNumber}
+          taskInstance={taskInstance}
+        />
       )}
+      <Select.Root
+        collection={logLevelOptions}
+        maxW="250px"
+        multiple
+        onValueChange={handleStateChange}
+        value={hasLogLevels ? logLevels : ["all"]}
+      >
+        <Select.Trigger {...(hasLogLevels ? { clearable: true } : {})} isActive={Boolean(logLevels)}>
+          <Select.ValueText>
+            {() =>
+              hasLogLevels ? (
+                <HStack gap="10px">
+                  {logLevels.map((level) => (
+                    <Badge colorPalette={logLevelColorMapping[level.toUpperCase() as LogLevel]} key={level}>
+                      {level.toUpperCase()}
+                    </Badge>
+                  ))}
+                </HStack>
+              ) : (
+                "All Log Levels"
+              )
+            }
+          </Select.ValueText>
+        </Select.Trigger>
+        <Select.Content>
+          {logLevelOptions.items.map((option) => (
+            <Select.Item item={option} key={option.label}>
+              {option.value === "all" ? (
+                option.label
+              ) : (
+                <Badge colorPalette={logLevelColorMapping[option.value.toUpperCase() as LogLevel]}>
+                  {option.label}
+                </Badge>
+              )}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+      <HStack>
+        <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
+          {wrap ? "Unwrap" : "Wrap"}
+        </Button>
+        {!isFullscreen && (
+          <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
+            <MdOutlineOpenInFull />
+          </IconButton>
+        )}
+      </HStack>
     </HStack>
-  </HStack>
-);
+  );
+};

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Badge } from "@chakra-ui/react";
 import dayjs from "dayjs";
+import { useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
 import type {
@@ -24,7 +26,10 @@ import type {
   TaskInstanceResponse,
   TaskInstancesLogResponse,
 } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+import { SearchParamsKeys } from "src/constants/searchParams";
 import { isStatePending, useAutoRefresh } from "src/utils";
+import { type LogLevel, logLevelColorMapping } from "src/utils/logs";
 
 type Props = {
   dagId: string;
@@ -34,31 +39,39 @@ type Props = {
 
 type ParseLogsProps = {
   data: TaskInstancesLogResponse["content"];
+  logLevels?: Array<LogLevel>;
 };
 
-const renderStructuredLog = (logMessage: string | StructuredLogMessage, index: number) => {
+const renderStructuredLog = (
+  logMessage: string | StructuredLogMessage,
+  index: number,
+  logLevels?: Array<string>,
+) => {
   if (typeof logMessage === "string") {
     return <p key={index}>{logMessage}</p>;
   }
 
   const { event, level = undefined, timestamp, ...structured } = logMessage;
+
   const elements = [];
 
+  if (
+    logLevels !== undefined &&
+    Boolean(logLevels.length) &&
+    ((typeof level === "string" && !logLevels.includes(level.toLowerCase())) || !Boolean(level))
+  ) {
+    return "";
+  }
+
   if (Boolean(timestamp)) {
-    elements.push(
-      "[",
-      <time dateTime={timestamp} key={0}>
-        {timestamp}
-      </time>,
-      "] ",
-    );
+    elements.push("[", <Time datetime={timestamp} key={0} />, "] ");
   }
 
   if (typeof level === "string") {
     elements.push(
-      <span className={`log-level ${level}`} key={1}>
+      <Badge colorPalette={logLevelColorMapping[level.toUpperCase() as LogLevel]} key={1} size="sm">
         {level.toUpperCase()}
-      </span>,
+      </Badge>,
       " - ",
     );
   }
@@ -84,12 +97,12 @@ const renderStructuredLog = (logMessage: string | StructuredLogMessage, index: n
 };
 
 // TODO: add support for log groups, colors, formats, filters
-const parseLogs = ({ data }: ParseLogsProps) => {
+const parseLogs = ({ data, logLevels }: ParseLogsProps) => {
   let warning;
   let parsedLines;
 
   try {
-    parsedLines = data.map((datum, index) => renderStructuredLog(datum, index));
+    parsedLines = data.map((datum, index) => renderStructuredLog(datum, index, logLevels));
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "An error occurred.";
 
@@ -109,6 +122,8 @@ const parseLogs = ({ data }: ParseLogsProps) => {
 
 export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
   const refetchInterval = useAutoRefresh({ dagId });
+  const [searchParams] = useSearchParams();
+  const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
 
   const { data, ...rest } = useTaskInstanceServiceGetLog(
     {
@@ -131,6 +146,7 @@ export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
 
   const parsedData = parseLogs({
     data: data?.content ?? [],
+    logLevels: logLevels as Array<LogLevel>,
   });
 
   return { data: parsedData, ...rest };

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -18,7 +18,6 @@
  */
 import { Badge } from "@chakra-ui/react";
 import dayjs from "dayjs";
-import { useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
 import type {
@@ -27,12 +26,12 @@ import type {
   TaskInstancesLogResponse,
 } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
-import { SearchParamsKeys } from "src/constants/searchParams";
 import { isStatePending, useAutoRefresh } from "src/utils";
 import { type LogLevel, logLevelColorMapping } from "src/utils/logs";
 
 type Props = {
   dagId: string;
+  logLevels?: Array<LogLevel>;
   taskInstance?: TaskInstanceResponse;
   tryNumber?: number;
 };
@@ -120,10 +119,8 @@ const parseLogs = ({ data, logLevels }: ParseLogsProps) => {
   };
 };
 
-export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
+export const useLogs = ({ dagId, logLevels, taskInstance, tryNumber = 1 }: Props) => {
   const refetchInterval = useAutoRefresh({ dagId });
-  const [searchParams] = useSearchParams();
-  const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
 
   const { data, ...rest } = useTaskInstanceServiceGetLog(
     {
@@ -146,7 +143,7 @@ export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
 
   const parsedData = parseLogs({
     data: data?.content ?? [],
-    logLevels: logLevels as Array<LogLevel>,
+    logLevels,
   });
 
   return { data: parsedData, ...rest };

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -58,7 +58,7 @@ const renderStructuredLog = (
   if (
     logLevels !== undefined &&
     Boolean(logLevels.length) &&
-    ((typeof level === "string" && !logLevels.includes(level.toLowerCase())) || !Boolean(level))
+    ((typeof level === "string" && !logLevels.includes(level)) || !Boolean(level))
   ) {
     return "";
   }
@@ -69,7 +69,7 @@ const renderStructuredLog = (
 
   if (typeof level === "string") {
     elements.push(
-      <Badge colorPalette={logLevelColorMapping[level.toUpperCase() as LogLevel]} key={1} size="sm">
+      <Badge colorPalette={logLevelColorMapping[level as LogLevel]} key={1} size="sm">
         {level.toUpperCase()}
       </Badge>,
       " - ",

--- a/airflow/ui/src/utils/logs.ts
+++ b/airflow/ui/src/utils/logs.ts
@@ -1,0 +1,34 @@
+/* eslint-disable perfectionist/sort-enums */
+
+/* eslint-disable perfectionist/sort-objects */
+import { createListCollection } from "@chakra-ui/react";
+
+export enum LogLevel {
+  DEBUG = "DEBUG",
+  INFO = "INFO",
+  WARNING = "WARNING",
+  ERROR = "ERROR",
+  CRITICAL = "CRITICAL",
+}
+
+export const logLevelColorMapping = {
+  [LogLevel.DEBUG]: "gray",
+  [LogLevel.INFO]: "green",
+  [LogLevel.WARNING]: "yellow",
+  [LogLevel.ERROR]: "orange",
+  [LogLevel.CRITICAL]: "red",
+};
+
+export const logLevelOptions = createListCollection<{
+  label: string;
+  value: string;
+}>({
+  items: [
+    { label: "All Levels", value: "all" },
+    { label: LogLevel.DEBUG, value: "debug" },
+    { label: LogLevel.INFO, value: "info" },
+    { label: LogLevel.WARNING, value: "warning" },
+    { label: LogLevel.ERROR, value: "error" },
+    { label: LogLevel.CRITICAL, value: "critical" },
+  ],
+});

--- a/airflow/ui/src/utils/logs.ts
+++ b/airflow/ui/src/utils/logs.ts
@@ -1,6 +1,24 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /* eslint-disable perfectionist/sort-enums */
-
 /* eslint-disable perfectionist/sort-objects */
+
 import { createListCollection } from "@chakra-ui/react";
 
 export enum LogLevel {

--- a/airflow/ui/src/utils/logs.ts
+++ b/airflow/ui/src/utils/logs.ts
@@ -4,11 +4,11 @@
 import { createListCollection } from "@chakra-ui/react";
 
 export enum LogLevel {
-  DEBUG = "DEBUG",
-  INFO = "INFO",
-  WARNING = "WARNING",
-  ERROR = "ERROR",
-  CRITICAL = "CRITICAL",
+  DEBUG = "debug",
+  INFO = "info",
+  WARNING = "warning",
+  ERROR = "error",
+  CRITICAL = "critical",
 }
 
 export const logLevelColorMapping = {
@@ -25,10 +25,10 @@ export const logLevelOptions = createListCollection<{
 }>({
   items: [
     { label: "All Levels", value: "all" },
-    { label: LogLevel.DEBUG, value: "debug" },
-    { label: LogLevel.INFO, value: "info" },
-    { label: LogLevel.WARNING, value: "warning" },
-    { label: LogLevel.ERROR, value: "error" },
-    { label: LogLevel.CRITICAL, value: "critical" },
+    { label: LogLevel.DEBUG.toUpperCase(), value: LogLevel.DEBUG },
+    { label: LogLevel.INFO.toUpperCase(), value: LogLevel.INFO },
+    { label: LogLevel.WARNING.toUpperCase(), value: LogLevel.WARNING },
+    { label: LogLevel.ERROR.toUpperCase(), value: LogLevel.WARNING },
+    { label: LogLevel.CRITICAL.toUpperCase(), value: LogLevel.CRITICAL },
   ],
 });

--- a/airflow/ui/src/utils/logs.ts
+++ b/airflow/ui/src/utils/logs.ts
@@ -47,7 +47,7 @@ export const logLevelOptions = createListCollection<{
     { label: LogLevel.DEBUG.toUpperCase(), value: LogLevel.DEBUG },
     { label: LogLevel.INFO.toUpperCase(), value: LogLevel.INFO },
     { label: LogLevel.WARNING.toUpperCase(), value: LogLevel.WARNING },
-    { label: LogLevel.ERROR.toUpperCase(), value: LogLevel.WARNING },
+    { label: LogLevel.ERROR.toUpperCase(), value: LogLevel.ERROR },
     { label: LogLevel.CRITICAL.toUpperCase(), value: LogLevel.CRITICAL },
   ],
 });

--- a/airflow/ui/src/utils/logs.ts
+++ b/airflow/ui/src/utils/logs.ts
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* eslint-disable perfectionist/sort-enums */
-/* eslint-disable perfectionist/sort-objects */
 
+/* eslint-disable perfectionist/sort-enums */
+
+/* eslint-disable perfectionist/sort-objects */
 import { createListCollection } from "@chakra-ui/react";
 
 export enum LogLevel {


### PR DESCRIPTION
Format log timestamps with our `<Time>` component/
Format log level with a `Badge` component

Add a MultiSelect to filter logs by level, if logs have a parsable level

<img width="1337" alt="Screenshot 2025-02-27 at 5 49 52 PM" src="https://github.com/user-attachments/assets/bcccf2a2-2304-4cf8-9b7c-9d0cb6341a74" />

<img width="1342" alt="Screenshot 2025-02-27 at 5 50 52 PM" src="https://github.com/user-attachments/assets/2e323c71-1953-4c15-bece-c8dca0f947e0" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
