### PR TITLE
Improve Dag/Task page responsiveness

### DIFF
--- a/airflow/ui/src/components/HeaderCard.tsx
+++ b/airflow/ui/src/components/HeaderCard.tsx
@@ -16,27 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, GridItem, Heading, HStack, SimpleGrid, Spinner } from "@chakra-ui/react";
-import { type ReactNode, useRef } from "react";
+import { Box, Flex, GridItem, Heading, HStack, Spinner } from "@chakra-ui/react";
+import type { ReactNode } from "react";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { Stat } from "src/components/Stat";
 import { StateBadge } from "src/components/StateBadge";
-import { useContainerWidth } from "src/utils";
-
-const getColumnCount = (width: number) => {
-  if (width < 400) {
-    return 2;
-  }
-  if (width < 800) {
-    return 4;
-  }
-  if (width < 1000) {
-    return 6;
-  }
-
-  return 8;
-};
 
 type Props = {
   readonly actions?: ReactNode;
@@ -48,34 +33,24 @@ type Props = {
   readonly title: ReactNode | string;
 };
 
-export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle, title }: Props) => {
-  const containerRef = useRef<HTMLDivElement>();
-  const containerWidth = useContainerWidth(containerRef);
-
-  return (
-    <Box borderColor="border" borderRadius={8} borderWidth={1} m={2} p={2} ref={containerRef}>
-      <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
-        <Flex alignItems="center" flexWrap="wrap" gap={2}>
-          <Heading size="xl">{icon}</Heading>
-          <Heading size="lg">{title}</Heading>
-          <Heading size="lg">{subTitle}</Heading>
-          {state === undefined ? undefined : <StateBadge state={state}>{state}</StateBadge>}
-          {isRefreshing ? <Spinner /> : <div />}
-        </Flex>
-        <HStack gap={1}>{actions}</HStack>
+export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle, title }: Props) => (
+  <Box borderColor="border" borderRadius={8} borderWidth={1} m={2} p={2}>
+    <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
+      <Flex alignItems="center" flexWrap="wrap" gap={2}>
+        <Heading size="xl">{icon}</Heading>
+        <Heading size="lg">{title}</Heading>
+        <Heading size="lg">{subTitle}</Heading>
+        {state === undefined ? undefined : <StateBadge state={state}>{state}</StateBadge>}
+        {isRefreshing ? <Spinner /> : <div />}
       </Flex>
-      <SimpleGrid
-        autoFlow="row dense"
-        gap={4}
-        my={2}
-        templateColumns={`repeat(${getColumnCount(containerWidth)}, 1fr)`}
-      >
-        {stats.map(({ label, value }) => (
-          <GridItem key={label}>
-            <Stat label={label}>{value}</Stat>
-          </GridItem>
-        ))}
-      </SimpleGrid>
-    </Box>
-  );
-};
+      <HStack gap={1}>{actions}</HStack>
+    </Flex>
+    <HStack alignItems="flex-start" flexWrap="wrap" gap={5} justifyContent="space-between" my={2}>
+      {stats.map(({ label, value }) => (
+        <GridItem key={label}>
+          <Stat label={label}>{value}</Stat>
+        </GridItem>
+      ))}
+    </HStack>
+  </Box>
+);

--- a/airflow/ui/src/components/TimeRangeSelector.tsx
+++ b/airflow/ui/src/components/TimeRangeSelector.tsx
@@ -58,7 +58,7 @@ const TimeRangeSelector = ({
   };
 
   return (
-    <HStack>
+    <HStack flexWrap="wrap">
       <FiCalendar />
       <Select.Root
         collection={timeOptions}

--- a/airflow/ui/src/components/TrendCountButton.tsx
+++ b/airflow/ui/src/components/TrendCountButton.tsx
@@ -52,7 +52,7 @@ export const TrendCountButton = ({
     <Skeleton borderRadius={4} height="45px" width="350px" />
   ) : (
     <Link to={route}>
-      <HStack borderRadius={4} borderWidth={1} p={3} width="max-content">
+      <HStack borderRadius={4} borderWidth={1} p={3} width="350px">
         <Badge borderRadius="50%" colorPalette={colorPalette} variant="solid">
           {count}
         </Badge>

--- a/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -25,6 +25,7 @@ import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import { DurationChart } from "src/components/DurationChart";
 import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 const defaultHour = "168";
 
@@ -34,6 +35,8 @@ export const Overview = () => {
   const now = dayjs();
   const [startDate, setStartDate] = useState(now.subtract(Number(defaultHour), "hour").toISOString());
   const [endDate, setEndDate] = useState(now.toISOString());
+
+  const refetchInterval = useAutoRefresh({});
 
   const { data: failedTaskInstances, isLoading: isFailedTaskInstancesLoading } =
     useTaskInstanceServiceGetTaskInstances({
@@ -46,13 +49,20 @@ export const Overview = () => {
       taskId,
     });
 
-  const { data: taskInstances, isLoading: isLoadingTaskInstances } = useTaskInstanceServiceGetTaskInstances({
-    dagId,
-    dagRunId: "~",
-    limit: 14,
-    orderBy: "-run_after",
-    taskId,
-  });
+  const { data: taskInstances, isLoading: isLoadingTaskInstances } = useTaskInstanceServiceGetTaskInstances(
+    {
+      dagId,
+      dagRunId: "~",
+      limit: 14,
+      orderBy: "-run_after",
+      taskId,
+    },
+    undefined,
+    {
+      refetchInterval: (query) =>
+        query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) ? refetchInterval : false,
+    },
+  );
 
   return (
     <Box m={4}>
@@ -65,7 +75,7 @@ export const Overview = () => {
           startDate={startDate}
         />
       </Box>
-      <HStack>
+      <HStack flexWrap="wrap">
         <TrendCountButton
           colorPalette="failed"
           count={failedTaskInstances?.total_entries ?? 0}
@@ -83,7 +93,7 @@ export const Overview = () => {
         />
       </HStack>
       <SimpleGrid columns={3} gap={5} my={5}>
-        <Box borderRadius={4} borderStyle="solid" borderWidth={1} p={2}>
+        <Box borderRadius={4} borderStyle="solid" borderWidth={1} p={2} width="350px">
           {isLoadingTaskInstances ? (
             <Skeleton height="200px" w="full" />
           ) : (


### PR DESCRIPTION
- Our HeaderCard grid was more complicated than it needed to be. Instead it can be just a flex with a wrap.
- Wrap the timerange selector
- Put a set width to the duration charts so they're no resizing.
- Add autorefresh to the duration charts

Before:
![Feb-27-2025 16-58-41](https://github.com/user-attachments/assets/b76cd798-5747-46ea-9a45-fbf1c55159d6)


After:
![Feb-27-2025 16-57-47](https://github.com/user-attachments/assets/d2e1ea21-8e5e-4e84-9262-4a671e749641)

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
