### PR TITLE
Make DAG reparse Button less prominent

### DIFF
--- a/airflow/ui/src/components/Menu/MenuButton.tsx
+++ b/airflow/ui/src/components/Menu/MenuButton.tsx
@@ -19,10 +19,10 @@
 import { MdMoreHoriz } from "react-icons/md";
 
 import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
-import ParseDag from "src/components/ParseDag";
 import { Menu } from "src/components/ui";
 
 import ActionButton from "../ui/ActionButton";
+import ParseDag from "./ParseDag";
 import RunBackfillButton from "./RunBackfillButton";
 
 type Props = {

--- a/airflow/ui/src/components/Menu/MenuButton.tsx
+++ b/airflow/ui/src/components/Menu/MenuButton.tsx
@@ -35,7 +35,7 @@ const MenuButton: React.FC<Props> = ({ dag }) => (
       <ActionButton actionName="" icon={<MdMoreHoriz />} text="" />
     </Menu.Trigger>
     <Menu.Content>
-      <Menu.Item value="Reparse Dag">
+      <Menu.Item asChild value="Reparse Dag">
         <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
       </Menu.Item>
       <Menu.Item asChild value="Run Backfill">

--- a/airflow/ui/src/components/Menu/MenuButton.tsx
+++ b/airflow/ui/src/components/Menu/MenuButton.tsx
@@ -35,7 +35,7 @@ const MenuButton: React.FC<Props> = ({ dag }) => (
       <ActionButton actionName="" icon={<MdMoreHoriz />} text="" />
     </Menu.Trigger>
     <Menu.Content>
-      <Menu.Item value="Run Backfill">
+      <Menu.Item value="Reparse Dag">
         <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
       </Menu.Item>
       <Menu.Item asChild value="Run Backfill">

--- a/airflow/ui/src/components/Menu/MenuButton.tsx
+++ b/airflow/ui/src/components/Menu/MenuButton.tsx
@@ -19,6 +19,7 @@
 import { MdMoreHoriz } from "react-icons/md";
 
 import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import ParseDag from "src/components/ParseDag";
 import { Menu } from "src/components/ui";
 
 import ActionButton from "../ui/ActionButton";
@@ -34,6 +35,9 @@ const MenuButton: React.FC<Props> = ({ dag }) => (
       <ActionButton actionName="" icon={<MdMoreHoriz />} text="" />
     </Menu.Trigger>
     <Menu.Content>
+      <Menu.Item value="Run Backfill">
+        <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
+      </Menu.Item>
       <Menu.Item asChild value="Run Backfill">
         <RunBackfillButton dag={dag} />
       </Menu.Item>

--- a/airflow/ui/src/components/Menu/ParseDag.tsx
+++ b/airflow/ui/src/components/Menu/ParseDag.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box } from "@chakra-ui/react";
 import { AiOutlineFileSync } from "react-icons/ai";
 
 import { Button } from "src/components/ui";
@@ -31,19 +30,17 @@ const ParseDag = ({ dagId, fileToken }: Props) => {
   const { isPending, mutate } = useDagParsing({ dagId });
 
   return (
-    <Box>
-      <Button
-        aria-label="Reparse Dag"
-        border="none"
-        height={5}
-        loading={isPending}
-        onClick={() => mutate({ fileToken })}
-        variant="ghost"
-      >
-        <AiOutlineFileSync height={5} width={5} />
-        Reparse Dag
-      </Button>
-    </Box>
+    <Button
+      aria-label="Reparse Dag"
+      border="none"
+      height={5}
+      loading={isPending}
+      onClick={() => mutate({ fileToken })}
+      variant="ghost"
+    >
+      <AiOutlineFileSync height={5} width={5} />
+      Reparse Dag
+    </Button>
   );
 };
 

--- a/airflow/ui/src/components/Menu/RunBackfillButton.tsx
+++ b/airflow/ui/src/components/Menu/RunBackfillButton.tsx
@@ -18,6 +18,7 @@
  */
 import { Box } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
+import { AiFillFastBackward } from "react-icons/ai";
 
 import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
@@ -34,6 +35,7 @@ const RunBackfillButton: React.FC<Props> = ({ dag }) => {
   return (
     <Box>
       <Button aria-label="Run Backfill" border="none" height={5} onClick={onOpen} variant="ghost">
+        <AiFillFastBackward />
         Run Backfill
       </Button>
       <RunBackfillModal dag={dag} onClose={onClose} open={open} />

--- a/airflow/ui/src/components/Menu/RunBackfillButton.tsx
+++ b/airflow/ui/src/components/Menu/RunBackfillButton.tsx
@@ -18,7 +18,7 @@
  */
 import { Box } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
-import { AiFillFastBackward } from "react-icons/ai";
+import { TbArrowBackUpDouble } from "react-icons/tb";
 
 import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
@@ -35,7 +35,7 @@ const RunBackfillButton: React.FC<Props> = ({ dag }) => {
   return (
     <Box>
       <Button aria-label="Run Backfill" border="none" height={5} onClick={onOpen} variant="ghost">
-        <AiFillFastBackward />
+        <TbArrowBackUpDouble />
         Run Backfill
       </Button>
       <RunBackfillModal dag={dag} onClose={onClose} open={open} />

--- a/airflow/ui/src/components/ParseDag.tsx
+++ b/airflow/ui/src/components/ParseDag.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Box } from "@chakra-ui/react";
 import { AiOutlineFileSync } from "react-icons/ai";
 
 import { Button } from "src/components/ui";
@@ -30,10 +31,19 @@ const ParseDag = ({ dagId, fileToken }: Props) => {
   const { isPending, mutate } = useDagParsing({ dagId });
 
   return (
-    <Button loading={isPending} onClick={() => mutate({ fileToken })} variant="outline">
-      <AiOutlineFileSync height={5} width={5} />
-      Reparse Dag
-    </Button>
+    <Box>
+      <Button
+        aria-label="Reparse Dag"
+        border="none"
+        height={5}
+        loading={isPending}
+        onClick={() => mutate({ fileToken })}
+        variant="ghost"
+      >
+        <AiOutlineFileSync height={5} width={5} />
+        Reparse Dag
+      </Button>
+    </Box>
   );
 };
 

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -26,7 +26,6 @@ import DagRunInfo from "src/components/DagRunInfo";
 import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import MenuButton from "src/components/Menu/MenuButton";
-import ParseDag from "src/components/ParseDag";
 import { TogglePause } from "src/components/TogglePause";
 import { Tooltip } from "src/components/ui";
 
@@ -108,7 +107,6 @@ export const Header = ({
                 text="Dag Docs"
               />
             )}
-            <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
             <MenuButton dag={dag} />
           </>
         )


### PR DESCRIPTION
It botheres me that the "Reparse Dag" Button is so prominent on the header card. I think this is a good function but not the first line.

Therefore I propose to push it to the menu where backfill also was added as screenshot below:
![image](https://github.com/user-attachments/assets/493b8e01-178d-4424-9de6-b8e82d51e736)