### PR TITLE
Fix graph height from PanelButtons change

### DIFF
--- a/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, Box, VStack, Text } from "@chakra-ui/react";
+import { Flex, Box } from "@chakra-ui/react";
 import { useParams, useSearchParams } from "react-router-dom";
 
 import { RunTypeIcon } from "src/components/RunTypeIcon";
-import Time from "src/components/Time";
 
 import { GridButton } from "./GridButton";
 import { TaskInstances } from "./TaskInstances";
@@ -29,22 +28,18 @@ import type { GridTask, RunWithDuration } from "./utils";
 const BAR_HEIGHT = 100;
 
 type Props = {
-  readonly index: number;
-  readonly limit: number;
   readonly max: number;
   readonly nodes: Array<GridTask>;
   readonly run: RunWithDuration;
 };
 
-export const Bar = ({ index, limit, max, nodes, run }: Props) => {
+export const Bar = ({ max, nodes, run }: Props) => {
   const { dagId = "", runId } = useParams();
   const [searchParams] = useSearchParams();
 
   const isSelected = runId === run.dag_run_id;
 
   const search = searchParams.toString();
-
-  const shouldShowTick = index % 8 === 0 || index === limit - 1;
 
   return (
     <Box
@@ -78,20 +73,6 @@ export const Bar = ({ index, limit, max, nodes, run }: Props) => {
         >
           {run.run_type !== "scheduled" && <RunTypeIcon runType={run.run_type} size="10px" />}
         </GridButton>
-        {shouldShowTick ? (
-          <VStack gap={0} left="8px" position="absolute" top={0} width={0} zIndex={-1}>
-            <Text
-              color="border.emphasized"
-              fontSize="xs"
-              mt="-35px !important"
-              transform="rotate(-40deg) translateX(28px)"
-              whiteSpace="nowrap"
-            >
-              <Time datetime={run.run_after} format="MMM DD, HH:mm" />
-            </Text>
-            <Box borderLeftWidth={1} height="100px" opacity={0.7} zIndex={0} />
-          </VStack>
-        ) : undefined}
       </Flex>
       <TaskInstances nodes={nodes} runId={run.dag_run_id} taskInstances={run.task_instances} />
     </Box>

--- a/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -114,8 +114,8 @@ export const Grid = () => {
   );
 
   return (
-    <Flex justifyContent="flex-end" mr={3} position="relative" pt="75px" width="100%">
-      <Box position="absolute" top="175px" width="100%">
+    <Flex justifyContent="flex-end" mr={3} position="relative" pt={50} width="100%">
+      <Box position="absolute" top="150px" width="100%">
         <TaskNames nodes={flatNodes} />
       </Box>
       <Box>
@@ -146,8 +146,8 @@ export const Grid = () => {
             )}
           </Flex>
           <Flex flexDirection="row-reverse">
-            {runs.map((dr, index) => (
-              <Bar index={index} key={dr.dag_run_id} limit={limit} max={max} nodes={flatNodes} run={dr} />
+            {runs.map((dr) => (
+              <Bar key={dr.dag_run_id} max={max} nodes={flatNodes} run={dr} />
             ))}
           </Flex>
           <IconButton

--- a/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, IconButton, ButtonGroup } from "@chakra-ui/react";
+import { HStack, IconButton, ButtonGroup, type StackProps, Box } from "@chakra-ui/react";
 import { FiGrid } from "react-icons/fi";
 import { MdOutlineAccountTree } from "react-icons/md";
 
@@ -26,11 +26,11 @@ type Props = {
   readonly dagId: string;
   readonly dagView: string;
   readonly setDagView: (x: "graph" | "grid") => void;
-};
+} & StackProps;
 
-export const PanelButtons = ({ dagId, dagView, setDagView }: Props) => (
-  <HStack justifyContent="space-between" py={2}>
-    <ButtonGroup attached left={0} size="sm" top={0} variant="outline" zIndex={1}>
+export const PanelButtons = ({ dagId, dagView, setDagView, ...rest }: Props) => (
+  <HStack justifyContent="space-between" position="absolute" top={0} width="100%" zIndex={1} {...rest}>
+    <ButtonGroup attached size="sm" variant="outline">
       <IconButton
         aria-label="Show Grid"
         colorPalette="blue"
@@ -50,6 +50,8 @@ export const PanelButtons = ({ dagId, dagView, setDagView }: Props) => (
         <MdOutlineAccountTree />
       </IconButton>
     </ButtonGroup>
-    <DagVersionSelect dagId={dagId} disabled={dagView !== "graph"} />
+    <Box bg="bg" mr={2}>
+      <DagVersionSelect dagId={dagId} disabled={dagView !== "graph"} />
+    </Box>
   </HStack>
 );


### PR DESCRIPTION
When we added a PanelButtons component. It was pushing our Graph component down and the bottom part of the graph was being cut off.

Solution: Go back to the absolute positioning we had before

Before: (see how the minimap and centering buttons at the bottom are cutoff)
<img width="745" alt="Screenshot 2025-02-27 at 5 21 22 PM" src="https://github.com/user-attachments/assets/7cadf0e5-d855-4ae8-bb15-b392b8d9795e" />


After:
<img width="761" alt="Screenshot 2025-02-27 at 5 21 04 PM" src="https://github.com/user-attachments/assets/3864cb1e-d755-4c4b-b7f6-8900d284331c" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
