### PR TITLE
 Retry k8s API requests in `KubernetesPodTrigger`

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -834,6 +834,8 @@ class KubernetesPodOperator(BaseOperator):
             last_log_time = event.get("last_log_time")
 
             if event["status"] in ("error", "failed", "timeout"):
+                if event["status"] == "error":
+                    self.log.error("Trigger emitted an error event, failing the task: %s", event["message"])
                 # fetch some logs when pod is failed
                 if self.get_logs:
                     self._write_logs(self.pod, follow=follow, since_time=last_log_time)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -834,8 +834,10 @@ class KubernetesPodOperator(BaseOperator):
             last_log_time = event.get("last_log_time")
 
             if event["status"] in ("error", "failed", "timeout"):
-                if event["status"] == "error":
-                    self.log.error("Trigger emitted an error event, failing the task: %s", event["message"])
+                event_message = event.get("message", "No message provided")
+                self.log.error(
+                    "Trigger emitted an %s event, failing the task: %s", event["status"], event_message
+                )
                 # fetch some logs when pod is failed
                 if self.get_logs:
                     self._write_logs(self.pod, follow=follow, since_time=last_log_time)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -274,14 +274,18 @@ class KubernetesPodTrigger(BaseTrigger):
             pod = cast(V1Pod, pod)
         return pod
 
-    @cached_property
-    def hook(self) -> AsyncKubernetesHook:
+    def _get_async_hook(self) -> AsyncKubernetesHook:
+        # TODO: Remove this method when the min version of kubernetes provider is 7.12.0 in Google provider.
         return AsyncKubernetesHook(
             conn_id=self.kubernetes_conn_id,
             in_cluster=self.in_cluster,
             config_dict=self.config_dict,
             cluster_context=self.cluster_context,
         )
+
+    @cached_property
+    def hook(self) -> AsyncKubernetesHook:
+        return self._get_async_hook()
 
     def define_container_state(self, pod: V1Pod) -> ContainerState:
         pod_containers = pod.status.container_statuses

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -261,12 +261,7 @@ class KubernetesPodTrigger(BaseTrigger):
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
     async def _get_pod(self) -> V1Pod:
-        """
-        Get the pod from Kubernetes.
-
-        Separate method for retrying. Retry logic here should mimic the retry logic in
-        PodManager.read_pod method.
-        """
+        """Get the pod from Kubernetes with retries."""
         pod = await self.hook.get_pod(name=self.pod_name, namespace=self.pod_namespace)
         # Due to AsyncKubernetesHook overriding get_pod, we need to cast the return
         # value to kubernetes_asyncio.V1Pod, because it's perceived as different type

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -25,6 +25,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 import tenacity
+from kubernetes_asyncio.client.models import V1Pod
 
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
@@ -35,7 +36,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
-    from kubernetes_asyncio.client.models import V1Pod
     from pendulum import DateTime
 
 
@@ -270,9 +270,7 @@ class KubernetesPodTrigger(BaseTrigger):
         pod = await self.hook.get_pod(name=self.pod_name, namespace=self.pod_namespace)
         # Due to AsyncKubernetesHook overriding get_pod, we need to cast the return
         # value to kubernetes_asyncio.V1Pod, because it's perceived as different type
-        if TYPE_CHECKING:
-            pod = cast(V1Pod, pod)
-        return pod
+        return cast(V1Pod, pod)
 
     def _get_async_hook(self) -> AsyncKubernetesHook:
         # TODO: Remove this method when the min version of kubernetes provider is 7.12.0 in Google provider.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -257,18 +257,14 @@ class KubernetesPodTrigger(BaseTrigger):
             self.log.debug("Sleeping for %s seconds.", self.poll_interval)
             await asyncio.sleep(self.poll_interval)
 
-    def _get_async_hook(self) -> AsyncKubernetesHook:
-        # TODO: Remove this method when the min version of kubernetes provider is 7.12.0 in Google provider.
+    @cached_property
+    def hook(self) -> AsyncKubernetesHook:
         return AsyncKubernetesHook(
             conn_id=self.kubernetes_conn_id,
             in_cluster=self.in_cluster,
             config_dict=self.config_dict,
             cluster_context=self.cluster_context,
         )
-
-    @cached_property
-    def hook(self) -> AsyncKubernetesHook:
-        return self._get_async_hook()
 
     def define_container_state(self, pod: V1Pod) -> ContainerState:
         pod_containers = pod.status.container_statuses

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -22,7 +22,9 @@ import traceback
 from collections.abc import AsyncIterator
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+import tenacity
 
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
@@ -200,7 +202,7 @@ class KubernetesPodTrigger(BaseTrigger):
     async def _wait_for_pod_start(self) -> ContainerState:
         """Loops until pod phase leaves ``PENDING`` If timeout is reached, throws error."""
         while True:
-            pod = await self.hook.get_pod(self.pod_name, self.pod_namespace)
+            pod = await self._get_pod()
             if not pod.status.phase == "Pending":
                 return self.define_container_state(pod)
 
@@ -223,7 +225,7 @@ class KubernetesPodTrigger(BaseTrigger):
         if self.logging_interval is not None:
             time_get_more_logs = time_begin + datetime.timedelta(seconds=self.logging_interval)
         while True:
-            pod = await self.hook.get_pod(self.pod_name, self.pod_namespace)
+            pod = await self._get_pod()
             container_state = self.define_container_state(pod)
             if container_state == ContainerState.TERMINATED:
                 return TriggerEvent(
@@ -256,6 +258,21 @@ class KubernetesPodTrigger(BaseTrigger):
                 )
             self.log.debug("Sleeping for %s seconds.", self.poll_interval)
             await asyncio.sleep(self.poll_interval)
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    async def _get_pod(self) -> V1Pod:
+        """
+        Get the pod from Kubernetes.
+
+        Separate method for retrying. Retry logic here should mimic the retry logic in
+        PodManager.read_pod method.
+        """
+        pod = await self.hook.get_pod(name=self.pod_name, namespace=self.pod_namespace)
+        # Due to AsyncKubernetesHook overriding get_pod, we need to cast the return
+        # value to kubernetes_asyncio.V1Pod, because it's perceived as different type
+        if TYPE_CHECKING:
+            pod = cast(V1Pod, pod)
+        return pod
 
     @cached_property
     def hook(self) -> AsyncKubernetesHook:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2091,10 +2091,11 @@ class TestKubernetesPodOperatorAsync:
         ti_mock.xcom_push.assert_any_call(key="pod_namespace", value=TEST_NAMESPACE)
         assert isinstance(exc.value.trigger, KubernetesPodTrigger)
 
+    @pytest.mark.parametrize("status", ["error", "failed", "timeout"])
     @patch(KUB_OP_PATH.format("log"))
     @patch(KUB_OP_PATH.format("cleanup"))
     @patch(HOOK_CLASS)
-    def test_async_create_pod_should_throw_exception(self, mocked_hook, mocked_cleanup, mocked_log):
+    def test_async_create_pod_should_throw_exception(self, mocked_hook, mocked_cleanup, mocked_log, status):
         """Tests that an AirflowException is raised in case of error event and event is logged"""
 
         mocked_hook.return_value.get_pod.return_value = MagicMock()
@@ -2112,20 +2113,20 @@ class TestKubernetesPodOperatorAsync:
             deferrable=True,
         )
 
-        error_message = "Some error"
+        message = "Some message"
         with pytest.raises(AirflowException):
             k.trigger_reentry(
                 context=None,
                 event={
-                    "status": "error",
-                    "message": error_message,
+                    "status": status,
+                    "message": message,
                     "name": TEST_NAME,
                     "namespace": TEST_NAMESPACE,
                 },
             )
 
-        log_message = "Trigger emitted an error event, failing the task: %s"
-        mocked_log.error.assert_called_once_with(log_message, error_message)
+        log_message = "Trigger emitted an %s event, failing the task: %s"
+        mocked_log.error.assert_called_once_with(log_message, status, message)
 
     @pytest.mark.parametrize(
         "kwargs, actual_exit_code, expected_exc, pod_status, event_status",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -386,3 +386,47 @@ class TestKubernetesPodTrigger:
             )
             == actual
         )
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test__get_pod(self, mock_hook, trigger):
+        """
+        Test that KubernetesPodTrigger _get_pod is called with the correct arguments.
+        """
+
+        mock_hook.get_pod.return_value = self._mock_pod_result(mock.MagicMock())
+
+        await trigger._get_pod()
+        mock_hook.get_pod.assert_called_with(name=POD_NAME, namespace=NAMESPACE)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc_count, call_count",
+        [
+            pytest.param(0, 1, id="no exception"),
+            pytest.param(2, 3, id="2 exc, 1 success"),
+            pytest.param(3, 3, id="max retries"),
+        ],
+    )
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test__get_pod_retries(
+        self,
+        mock_hook,
+        trigger,
+        exc_count,
+        call_count,
+    ):
+        """
+        Test that KubernetesPodTrigger _get_pod retries in case of an exception during
+        the hook.get_pod call.
+        """
+
+        side_effects = [Exception("Test exception") for _ in range(exc_count)] + [MagicMock()]
+
+        mock_hook.get_pod.side_effect = mock.AsyncMock(side_effect=side_effects)
+        if exc_count > 2:
+            with pytest.raises(Exception, match="Test exception"):
+                await trigger._get_pod()
+        else:
+            await trigger._get_pod()
+        assert mock_hook.get_pod.call_count == call_count


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add retries for k8s API requests in `KubernetesPodTrigger` to increase reliability and avoid task failure in case of single API call failure.

- There is only one method calling the k8s API in `KubernetesPodTrigger` -> `hook.get_pod`, so it was covered by 
`@tenacity.retry` the same way as `PodManager.read_pod`
- Added extra log of failing trigger events inside `KubernetesPodOperator` as requested in the issue
- Expand `KubernetesPodTrigger` and `KubernetesPodOperator` tests

closes: #46908

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
