### PR TITLE
Fix MSSQL provider dependency on common-sql

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -865,7 +865,7 @@
   },
   "microsoft.mssql": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.20.0",
+      "apache-airflow-providers-common-sql>=1.23.0",
       "apache-airflow>=2.9.0",
       "methodtools>=0.4.7",
       "pymssql>=2.3.0"

--- a/providers/microsoft/mssql/README.rst
+++ b/providers/microsoft/mssql/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                              Version required
 =======================================  ==================
 ``apache-airflow``                       ``>=2.9.0``
-``apache-airflow-providers-common-sql``  ``>=1.20.0``
+``apache-airflow-providers-common-sql``  ``>=1.23.0``
 ``pymssql``                              ``>=2.3.0``
 ``methodtools``                          ``>=0.4.7``
 =======================================  ==================

--- a/providers/microsoft/mssql/pyproject.toml
+++ b/providers/microsoft/mssql/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.9.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.23.0",
     "pymssql>=2.3.0",
     # The methodtools dependency can be removed with min airflow version >=2.9.1
     # as it was added in https://github.com/apache/airflow/pull/37757

--- a/providers/microsoft/mssql/src/airflow/providers/microsoft/mssql/get_provider_info.py
+++ b/providers/microsoft/mssql/src/airflow/providers/microsoft/mssql/get_provider_info.py
@@ -90,7 +90,7 @@ def get_provider_info():
         ],
         "dependencies": [
             "apache-airflow>=2.9.0",
-            "apache-airflow-providers-common-sql>=1.20.0",
+            "apache-airflow-providers-common-sql>=1.23.0",
             "pymssql>=2.3.0",
             "methodtools>=0.4.7",
         ],


### PR DESCRIPTION
The MSSQL provider currently requires common-sql >= 1.20.0, but it's using the dialects module which was only introduced in common-sql 1.23.0.
Closes: #47185 