### PR TITLE
Add `CliDefinitionLoader` for provider module level CLI Commands

### DIFF
--- a/airflow/cli/cli_definition_loader.py
+++ b/airflow/cli/cli_definition_loader.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from airflow.exceptions import (
+    AirflowLoadCliDefinitionsException,
+    AirflowLoadProviderCliDefinitionException,
+)
+from airflow.providers_manager import ProvidersManager
+from airflow.utils.module_loading import import_string
+
+if TYPE_CHECKING:
+    from airflow.cli.cli_config import CLICommand
+
+log = logging.getLogger(__name__)
+
+
+class CliDefinitionLoader:
+    """
+    CLI Definition Loader.
+
+    Similar to `ExecutorLoader`, but designed for CLI definitions.
+    Currently, only `AuthManager.get_cli_commands()` and `Executor.get_cli_commands()` are called and extended in `cli_parser`. By introducing this class, we can enable provider-level modules to register their own CLI commands dynamically.
+    Additionally, this change can improve CLI performance by **3-4x**, as demonstrated in the [benchmark](https://github.com/apache/airflow/issues/46789).
+    """
+
+    # Currently only kubernetes provider has **provider module level** CLI commands
+    # https://github.com/apache/airflow/issues/46978
+    providers_cli_definitions: dict[str, str] = {
+        "apache-airflow-providers-cncf-kubernetes": "airflow.providers.cncf.kubernetes.cli.definition.KUBERNETES_GROUP_COMMANDS",
+    }
+    # TODO: Further step, decuple the `get_cli_commands` method from `Executor` and `AuthManager`
+    # PoC: https://github.com/apache/airflow/commit/2750c0a336d57f9044e458b3fb1b348562da4f35
+
+    @classmethod
+    def _load_provider_cli_definitions(
+        self,
+    ) -> tuple[list[CLICommand], list[AirflowLoadProviderCliDefinitionException]]:
+        """Load provider module level CLI definitions based on ProvidersManager."""
+        errors = []
+        provider_cli_definitions = []
+        for provider_name in ProvidersManager().providers.keys():
+            if provider_name in self.providers_cli_definitions:
+                module_name = self.providers_cli_definitions[provider_name]
+                try:
+                    provider_cli_definitions.extend(import_string(module_name))
+                except Exception:
+                    # don't raise exception here, since we still want to load other provider CLI commands
+                    errors.append(
+                        AirflowLoadProviderCliDefinitionException(
+                            f"Failed to load CLI commands from provider: {provider_name}"
+                        )
+                    )
+        return provider_cli_definitions, errors
+
+    @classmethod
+    def get_cli_commands(self) -> Iterable[CLICommand]:
+        """Get CLI commands from Providers, Executors, and AuthManager."""
+        cli_commands = []
+        errors = []
+        for loader in [
+            self._load_provider_cli_definitions,
+            # self._load_executor_cli_definitions,     # Executor and AuthManager CLI commands will be integrated in the next PR
+            # self._load_auth_manager_cli_definitions,
+        ]:
+            commands, loader_errors = loader()
+            cli_commands.extend(commands)
+            errors.extend(loader_errors)
+
+        yield from cli_commands
+        # Raise all errors at once after yielding all commands
+        if errors:
+            raise AirflowLoadCliDefinitionsException(errors)

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -44,8 +44,9 @@ from airflow.cli.cli_config import (
     GroupCommand,
     core_commands,
 )
+from airflow.cli.cli_definition_loader import CliDefinitionLoader
 from airflow.cli.utils import CliConflictError
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowLoadCliDefinitionsException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.utils.helpers import partition
 
@@ -59,6 +60,12 @@ airflow_commands = core_commands.copy()  # make a copy to prevent bad interactio
 
 log = logging.getLogger(__name__)
 
+# add provider level CLI commands
+try:
+    airflow_commands.extend(CliDefinitionLoader.get_cli_commands())
+except AirflowLoadCliDefinitionsException as e:
+    for error in e.args[0]:
+        log.error(error)
 
 for executor_name in ExecutorLoader.get_executor_names():
     try:

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -66,6 +66,14 @@ class AirflowConfigException(AirflowException):
     """Raise when there is configuration problem."""
 
 
+class AirflowLoadCliDefinitionsException(AirflowException):
+    """Raise when there is a error when loading CLI commands from CliDefinitionLoader."""
+
+
+class AirflowLoadProviderCliDefinitionException(AirflowException):
+    """Raise when there is a error when loading CLI commands from provider module level CLI definitions."""
+
+
 class AirflowSensorTimeout(AirflowException):
     """Raise when there is a timeout on sensor polling."""
 

--- a/providers/cncf/kubernetes/docs/cli-ref.rst
+++ b/providers/cncf/kubernetes/docs/cli-ref.rst
@@ -24,6 +24,6 @@ Kubernetes Executor Commands
    the core Airflow documentation for the list of CLI commands and parameters available.
 
 .. argparse::
-   :module: airflow.providers.cncf.kubernetes.executors.kubernetes_executor
+   :module: airflow.providers.cncf.kubernetes.cli.definition
    :func: _get_parser
    :prog: airflow

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# The CLI definition should import as less as possible from other modules to reduce the overhead of importing the module.
+from __future__ import annotations
+
+import argparse
+
+from airflow.configuration import conf
+
+try:
+    from airflow.cli.cli_config import ARG_LOGICAL_DATE
+except ImportError:  # 2.x compatibility.
+    from airflow.cli.cli_config import (  # type: ignore[attr-defined, no-redef]
+        ARG_EXECUTION_DATE as ARG_LOGICAL_DATE,
+    )
+from airflow.cli.cli_config import (
+    ARG_DAG_ID,
+    ARG_OUTPUT_PATH,
+    ARG_SUBDIR,
+    ARG_VERBOSE,
+    ActionCommand,
+    Arg,
+    GroupCommand,
+    lazy_load_command,
+    positive_int,
+)
+
+# CLI Args
+ARG_NAMESPACE = Arg(
+    ("--namespace",),
+    default=conf.get("kubernetes_executor", "namespace"),
+    help="Kubernetes Namespace. Default value is `[kubernetes] namespace` in configuration.",
+)
+
+ARG_MIN_PENDING_MINUTES = Arg(
+    ("--min-pending-minutes",),
+    default=30,
+    type=positive_int(allow_zero=False),
+    help=(
+        "Pending pods created before the time interval are to be cleaned up, "
+        "measured in minutes. Default value is 30(m). The minimum value is 5(m)."
+    ),
+)
+
+# CLI Commands
+KUBERNETES_COMMANDS = (
+    ActionCommand(
+        name="cleanup-pods",
+        help=(
+            "Clean up Kubernetes pods "
+            "(created by KubernetesExecutor/KubernetesPodOperator) "
+            "in evicted/failed/succeeded/pending states"
+        ),
+        func=lazy_load_command("airflow.providers.cncf.kubernetes.cli.kubernetes_command.cleanup_pods"),
+        args=(ARG_NAMESPACE, ARG_MIN_PENDING_MINUTES, ARG_VERBOSE),
+    ),
+    ActionCommand(
+        name="generate-dag-yaml",
+        help="Generate YAML files for all tasks in DAG. Useful for debugging tasks without "
+        "launching into a cluster",
+        func=lazy_load_command("airflow.providers.cncf.kubernetes.cli.kubernetes_command.generate_pod_yaml"),
+        args=(ARG_DAG_ID, ARG_LOGICAL_DATE, ARG_SUBDIR, ARG_OUTPUT_PATH, ARG_VERBOSE),
+    ),
+)
+
+# CLI Groups
+KUBERNETES_GROUP_COMMANDS: list[GroupCommand] = [
+    GroupCommand(
+        name="kubernetes",
+        help="Tools to help run the KubernetesExecutor",
+        subcommands=KUBERNETES_COMMANDS,
+    )
+]
+
+
+def _get_parser() -> argparse.ArgumentParser:
+    """
+    Generate documentation; used by Sphinx.
+
+    :meta private:
+    """
+    from airflow.cli.cli_config import DefaultHelpParser
+    from airflow.cli.cli_parser import AirflowHelpFormatter, _add_command
+
+    parser = DefaultHelpParser(prog="airflow", formatter_class=AirflowHelpFormatter)
+    subparsers = parser.add_subparsers(dest="subcommand", metavar="GROUP_OR_COMMAND")
+    for group_command in KUBERNETES_GROUP_COMMANDS:
+        _add_command(subparsers, group_command)
+    return parser

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -40,26 +40,6 @@ from deprecated import deprecated
 from kubernetes.dynamic import DynamicClient
 from sqlalchemy import select
 
-from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
-
-try:
-    from airflow.cli.cli_config import ARG_LOGICAL_DATE
-except ImportError:  # 2.x compatibility.
-    from airflow.cli.cli_config import (  # type: ignore[attr-defined, no-redef]
-        ARG_EXECUTION_DATE as ARG_LOGICAL_DATE,
-    )
-from airflow.cli.cli_config import (
-    ARG_DAG_ID,
-    ARG_OUTPUT_PATH,
-    ARG_SUBDIR,
-    ARG_VERBOSE,
-    ActionCommand,
-    Arg,
-    GroupCommand,
-    lazy_load_command,
-    positive_int,
-)
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
@@ -70,18 +50,19 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types impor
 )
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import remove_escape_codes
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
-    import argparse
-
     from kubernetes import client
     from kubernetes.client import models as k8s
     from sqlalchemy.orm import Session
 
+    from airflow.cli.cli_config import GroupCommand
     from airflow.executors import workloads
     from airflow.executors.base_executor import CommandType
     from airflow.models.taskinstance import TaskInstance
@@ -93,44 +74,6 @@ if TYPE_CHECKING:
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
         AirflowKubernetesScheduler,
     )
-
-# CLI Args
-ARG_NAMESPACE = Arg(
-    ("--namespace",),
-    default=conf.get("kubernetes_executor", "namespace"),
-    help="Kubernetes Namespace. Default value is `[kubernetes] namespace` in configuration.",
-)
-
-ARG_MIN_PENDING_MINUTES = Arg(
-    ("--min-pending-minutes",),
-    default=30,
-    type=positive_int(allow_zero=False),
-    help=(
-        "Pending pods created before the time interval are to be cleaned up, "
-        "measured in minutes. Default value is 30(m). The minimum value is 5(m)."
-    ),
-)
-
-# CLI Commands
-KUBERNETES_COMMANDS = (
-    ActionCommand(
-        name="cleanup-pods",
-        help=(
-            "Clean up Kubernetes pods "
-            "(created by KubernetesExecutor/KubernetesPodOperator) "
-            "in evicted/failed/succeeded/pending states"
-        ),
-        func=lazy_load_command("airflow.providers.cncf.kubernetes.cli.kubernetes_command.cleanup_pods"),
-        args=(ARG_NAMESPACE, ARG_MIN_PENDING_MINUTES, ARG_VERBOSE),
-    ),
-    ActionCommand(
-        name="generate-dag-yaml",
-        help="Generate YAML files for all tasks in DAG. Useful for debugging tasks without "
-        "launching into a cluster",
-        func=lazy_load_command("airflow.providers.cncf.kubernetes.cli.kubernetes_command.generate_pod_yaml"),
-        args=(ARG_DAG_ID, ARG_LOGICAL_DATE, ARG_SUBDIR, ARG_OUTPUT_PATH, ARG_VERBOSE),
-    ),
-)
 
 
 class KubernetesExecutor(BaseExecutor):
@@ -735,19 +678,9 @@ class KubernetesExecutor(BaseExecutor):
 
     @staticmethod
     def get_cli_commands() -> list[GroupCommand]:
-        return [
-            GroupCommand(
-                name="kubernetes",
-                help="Tools to help run the KubernetesExecutor",
-                subcommands=KUBERNETES_COMMANDS,
-            )
-        ]
+        """
+        Get CLI commands.
 
-
-def _get_parser() -> argparse.ArgumentParser:
-    """
-    Generate documentation; used by Sphinx.
-
-    :meta private:
-    """
-    return KubernetesExecutor._get_parser()
+        The CLI commands are moved to provider level CLI definition located in airflow.providers.cncf.kubernetes.cli.definition module.
+        """
+        return []

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_definition.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_definition.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+import airflow.providers.cncf.kubernetes.cli.definition as kubernetes_cli_definition
+from airflow.cli.cli_config import GroupCommand
+
+
+class TestCliDefinition:
+    def test_kubernetes_group_commands(self):
+        assert isinstance(kubernetes_cli_definition.KUBERNETES_COMMANDS, list)
+        assert len(kubernetes_cli_definition.KUBERNETES_COMMANDS) > 0
+        assert isinstance(kubernetes_cli_definition.KUBERNETES_COMMANDS[0], GroupCommand)
+
+    def test__get_parser(self):
+        parser = kubernetes_cli_definition._get_parser()
+        assert isinstance(parser, ArgumentParser)

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -84,6 +84,7 @@ class TestProjectStructure:
             "providers/celery/tests/unit/celery/executors/test_default_celery.py",
             "providers/celery/tests/unit/celery/test_version_compat.py",
             "providers/cloudant/tests/unit/cloudant/test_cloudant_fake.py",
+            "providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_definitions.py",
             "providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor_types.py",
             "providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor_utils.py",
             "providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_kubernetes_pod.py",

--- a/tests/cli/test_cli_definition_loader.py
+++ b/tests/cli/test_cli_definition_loader.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from airflow.cli.cli_definition_loader import CliDefinitionLoader
+from airflow.exceptions import (
+    AirflowLoadCliDefinitionsException,
+    AirflowLoadProviderCliDefinitionException,
+)
+from airflow.providers_manager import ProvidersManager
+
+KUBERNETES_PROVIDER_NAME = "apache-airflow-providers-cncf-kubernetes"
+
+
+class TestCliDefinitionLoader:
+    @mock.patch("airflow.providers.cncf.kubernetes.cli.definition.KUBERNETES_GROUP_COMMANDS", autospec=True)
+    def test__load_provider_cli_definitions(self, mock_provider_cli_definitions):
+        mock_provider_cli_definitions = [MagicMock()]  # Ensure it's a list
+        with patch.object(
+            ProvidersManager, "providers", new_callable=PropertyMock
+        ) as mock_provider_manager_providers:
+            mock_provider_manager_providers.return_value = {KUBERNETES_PROVIDER_NAME: MagicMock()}
+            with patch("airflow.cli.cli_definition_loader.import_string") as mock_import_string:
+                mock_import_string.return_value = mock_provider_cli_definitions
+                assert CliDefinitionLoader._load_provider_cli_definitions() == (
+                    mock_provider_cli_definitions,
+                    [],
+                )
+                mock_import_string.assert_called_once_with(
+                    "airflow.providers.cncf.kubernetes.cli.definition.KUBERNETES_GROUP_COMMANDS"
+                )
+
+    @mock.patch.object(ProvidersManager, "providers", new_callable=PropertyMock)
+    def test__load_provider_cli_definitions_with_error(self, mock_provider_manager_providers):
+        mock_provider_manager_providers.return_value = {KUBERNETES_PROVIDER_NAME: MagicMock()}
+        with patch("airflow.cli.cli_definition_loader.import_string") as mock_import_string:
+            mock_import_string.side_effect = ImportError
+            loaded_cli, errors = CliDefinitionLoader._load_provider_cli_definitions()
+            assert loaded_cli == []
+            assert len(errors) == 1
+            assert str(errors[0]) == str(
+                AirflowLoadProviderCliDefinitionException(
+                    f"Failed to load CLI commands from provider: {KUBERNETES_PROVIDER_NAME}"
+                )
+            )
+
+    def test_get_cli_commands(self):
+        mock_command = MagicMock()
+        with mock.patch.object(
+            CliDefinitionLoader, "_load_provider_cli_definitions", return_value=([mock_command], [])
+        ):
+            commands = list(CliDefinitionLoader.get_cli_commands())
+            assert len(commands) == 1
+            assert commands[0] is mock_command
+
+    def test_get_cli_commands_with_error(self):
+        expected_provider_exception = AirflowLoadProviderCliDefinitionException("Test error")
+        with mock.patch.object(
+            CliDefinitionLoader,
+            "_load_provider_cli_definitions",
+            return_value=([], [expected_provider_exception]),
+        ):
+            with pytest.raises(AirflowLoadCliDefinitionsException) as excinfo:
+                list(CliDefinitionLoader.get_cli_commands())
+            assert expected_provider_exception in excinfo.value.args[0]


### PR DESCRIPTION

closes: #46978

## Why

By introducing `CliDefinitionLoader`, we can extend `cli_parser` to support **provider module-level** CLI commands.

> Additionally, as a next step, we could decouple the get_cli_commands method from both Executor and AuthManager. This would address the root cause of the current CLI slowdown and potentially improve CLI performance by 3–4x, as shown in the benchmark: #46789.

## How

This PR only add `CliDefinitionLoader` and **provider module-level** (only for kubernetes now) CLI commands.

## Benchmark

**Environment:**
- MacOS, M2 Chip, 16G RAB, In breeze container.
- Command:`breeze --python 3.9 shell --answer n --executor KubernetesExecutor`
- Benchmark Command:`/files/time.sh airflow --help` ( [benchmark script: time.sh](https://gist.github.com/jason810496/11b208fb964e0c490a6cd82f7d1882f7) )


Run | Original (seconds) | With CliDefinitionLoader (seconds) | Difference (seconds)
-- | -- | -- | --
1 | 3.88124 | 4.12564 | +0.24440
2 | 3.35908 | 3.60187 | +0.24279
3 | 3.38379 | 3.58633 | +0.20254
4 | 3.39347 | 3.59239 | +0.19892
5 | 3.36010 | 3.76085 | +0.40075
Average | 3.47554 | 3.73340 | +0.25786

As https://github.com/apache/airflow/issues/46978#issuecomment-2679446808 pointed out, using `ProviderManager` adds an overhead of approximately **200ms to 300ms** when discovering all available providers.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
