### PR TITLE
Adding OAuth support for SnowflakeHook 

### DIFF
--- a/providers/snowflake/docs/connections/snowflake.rst
+++ b/providers/snowflake/docs/connections/snowflake.rst
@@ -39,10 +39,11 @@ Configuring the Connection
 --------------------------
 
 Login
-    Specify the snowflake username.
+    Specify the snowflake username. For OAuth, the OAuth Client ID.
 
 Password
     Specify the snowflake password. For public key authentication, the passphrase for the private key.
+    For OAuth, the OAuth Client Secret.
 
 Schema (optional)
     Specify the snowflake schema to be used.

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -318,8 +318,7 @@ class SnowflakeHook(DbApiHook):
             conn_config.pop("user", None)
             conn_config.pop("password", None)
 
-            access_token = self.get_oauth_token(conn_config=conn_config)
-            conn_config["token"] = access_token
+            conn_config["token"] = self.get_oauth_token(conn_config=conn_config)
 
         # configure custom target hostname and port, if specified
         snowflake_host = extra_dict.get("host")

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -26,8 +26,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 from urllib.parse import urlparse
 
+import requests
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from requests.auth import HTTPBasicAuth
 from snowflake import connector
 from snowflake.connector import DictCursor, SnowflakeConnection, util_text
 from snowflake.sqlalchemy import URL
@@ -185,6 +187,30 @@ class SnowflakeHook(DbApiHook):
             return extra_dict[field_name] or None
         return extra_dict.get(backcompat_key) or None
 
+    def get_oauth_token(self, conn_config: dict) -> str:
+        """Generate temporary OAuth access token using refresh token in connection details."""
+        url = f"https://{conn_config['account']}.snowflakecomputing.com/oauth/token-request"
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": conn_config["refresh_token"],
+            "redirect_uri": conn_config.get("redirect_uri", "https://localhost.com"),
+        }
+        response = requests.post(
+            url,
+            data=data,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            auth=HTTPBasicAuth(conn_config["client_id"], conn_config["client_secret"]),  # type: ignore[arg-type]
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:  # pragma: no cover
+            msg = f"Response: {e.response.content.decode()} Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
+        return response.json()["access_token"]
+
     @cached_property
     def _get_conn_params(self) -> dict[str, str | None]:
         """
@@ -289,7 +315,11 @@ class SnowflakeHook(DbApiHook):
             conn_config["client_id"] = conn.login
             conn_config["client_secret"] = conn.password
             conn_config.pop("login", None)
+            conn_config.pop("user", None)
             conn_config.pop("password", None)
+
+            access_token = self.get_oauth_token(conn_config=conn_config)
+            conn_config["token"] = access_token
 
         # configure custom target hostname and port, if specified
         snowflake_host = extra_dict.get("host")


### PR DESCRIPTION
This PR enhances the SnowflakeHook in the Airflow repo by completing the OAuth authentication flow. It adds logic to fetch the access token using the refresh_token, client_id, and client_secret, which are already managed in the extras of the Snowflake connection object.

Changes & Fixes:
Implements logic to exchange the refresh_token for a new access token before establishing a connection.
Resolves an issue where using refresh_token, client_id, and client_secret directly with SnowflakeHook results in the error:
main/newsfragments).

```
snowflake.connector.errors.DatabaseError: 250001 (08001): None: Failed to connect to DB: <account>.snowflakecomputing.com:443. Invalid OAuth access token.
```

Duplicate of #47073, Reopening because I messed up the updates
