### PR TITLE
Fix black color hiding note icon in dark theme.

### DIFF
--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -42,7 +42,7 @@ export const Header = ({
         {dagRun.note === null || dagRun.note.length === 0 ? undefined : (
           <DisplayMarkdownButton
             header="Dag Run Note"
-            icon={<FiMessageSquare color="black" />}
+            icon={<FiMessageSquare />}
             mdContent={dagRun.note}
             text="Note"
           />

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -63,7 +63,7 @@ export const Header = ({
             {taskInstance.note === null || taskInstance.note.length === 0 ? undefined : (
               <DisplayMarkdownButton
                 header="Task Instance Note"
-                icon={<FiMessageSquare color="black" />}
+                icon={<FiMessageSquare />}
                 mdContent={taskInstance.note}
                 text="Note"
               />


### PR DESCRIPTION
Adding black color to the icon makes it hardly visible in dark theme. I don't see this added to other icons and the icon framework seems to handle this internally.

Before 

![image](https://github.com/user-attachments/assets/ee83d8b4-d6b2-418c-a8c7-9d42fde3fb5d)

After PR

![image](https://github.com/user-attachments/assets/f0a8d18f-25e4-4172-a9df-0241ee287845)
