### PR TITLE
Limit confluent-kafka temporarily to exclude 2.8.1

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -218,7 +218,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "asgiref>=2.3.0",
-      "confluent-kafka>=2.3.0"
+      "confluent-kafka>=2.3.0,!=2.8.1"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/apache/kafka/README.rst
+++ b/providers/apache/kafka/README.rst
@@ -50,13 +50,13 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-===================  ==================
+===================  ===================
 PIP package          Version required
-===================  ==================
+===================  ===================
 ``apache-airflow``   ``>=2.9.0``
 ``asgiref``          ``>=2.3.0``
-``confluent-kafka``  ``>=2.3.0``
-===================  ==================
+``confluent-kafka``  ``>=2.3.0,!=2.8.1``
+===================  ===================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-kafka/1.7.0/changelog.html>`_.

--- a/providers/apache/kafka/pyproject.toml
+++ b/providers/apache/kafka/pyproject.toml
@@ -57,7 +57,10 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.9.0",
     "asgiref>=2.3.0",
-    "confluent-kafka>=2.3.0",
+    # Confluent kafka 2.8.1 has been released without binary wheels on 28 Feb 2025
+    # It's likely this will be fixed, but until it is, we need to exclude it
+    # See https://github.com/confluentinc/confluent-kafka-python/issues/1927
+    "confluent-kafka>=2.3.0,!=2.8.1",
 ]
 
 [project.urls]

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/get_provider_info.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/get_provider_info.py
@@ -89,5 +89,5 @@ def get_provider_info():
                 "connection-type": "kafka",
             }
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "asgiref>=2.3.0", "confluent-kafka>=2.3.0"],
+        "dependencies": ["apache-airflow>=2.9.0", "asgiref>=2.3.0", "confluent-kafka>=2.3.0,!=2.8.1"],
     }


### PR DESCRIPTION
Confluent kafka 2.8.1 has been released without binary wheels on 28 Feb 2025 It's likely this will be fixed, but until it is, we need to exclude it S ee https://github.com/confluentinc/confluent-kafka-python/issues/1927

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
