### PR TITLE
Fix kafka connection refuse issue in kafka provider tests

### DIFF
--- a/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_client.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_client.py
@@ -54,7 +54,10 @@ class TestKafkaAdminClientHook:
         )
         self.hook = KafkaAdminClientHook(kafka_config_id="kafka_d")
 
-    def test_get_conn(self):
+    @patch("airflow.providers.apache.kafka.hooks.base.AdminClient")
+    def test_get_conn(self, mock_client):
+        mock_client_spec = MagicMock(spec=AdminClient)
+        mock_client.return_value = mock_client_spec
         assert isinstance(self.hook.get_conn, AdminClient)
 
     @patch(

--- a/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_consume.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_consume.py
@@ -17,8 +17,10 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
+from confluent_kafka.admin import AdminClient
 
 from airflow.models import Connection
 
@@ -54,5 +56,8 @@ class TestConsumerHook:
         )
         self.hook = KafkaConsumerHook(["test_1"], kafka_config_id="kafka_d")
 
-    def test_get_consumer(self):
+    @patch("airflow.providers.apache.kafka.hooks.base.AdminClient")
+    def test_get_consumer(self, mock_client):
+        mock_client_spec = MagicMock(spec=AdminClient)
+        mock_client.return_value = mock_client_spec
         assert self.hook.get_consumer() == self.hook.get_conn

--- a/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_produce.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_produce.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 import json
 import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
+from confluent_kafka.admin import AdminClient
 
 from airflow.models import Connection
 from airflow.providers.apache.kafka.hooks.produce import KafkaProducerHook
@@ -56,5 +58,8 @@ class TestProducerHook:
         )
         self.hook = KafkaProducerHook(kafka_config_id="kafka_d")
 
-    def test_get_producer(self):
+    @patch("airflow.providers.apache.kafka.hooks.base.AdminClient")
+    def test_get_producer(self, mock_client):
+        mock_client_spec = MagicMock(spec=AdminClient)
+        mock_client.return_value = mock_client_spec
         assert self.hook.get_producer() == self.hook.get_conn


### PR DESCRIPTION
We are observing side effects from the Kafka provider tests, where the AdminClient attempts to establish a connection using the bootstrap server connection string. Since these are unit tests and no Kafka server is running, it results in connection refusals, see the below logs.

https://github.com/apache/airflow/actions/runs/13555901653/job/37890520619?pr=46503#step:6:5354

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
