### PR TITLE
Avoid old www geenrated assets and node_modules to be part of context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -84,7 +84,12 @@ airflow/ui/node_modules
 airflow/auth/managers/simple/ui/node_modules
 
 # Exclude link to docs
+airflow/ui/static/docs
+
+# Legacy www exclusions (just to exclude things in case you switch to old branches and generate assets)
 airflow/www/static/docs
+airflow/www/static/dist
+airflow/www/node_modules
 
 # Exclude python generated files
 **/__pycache__/


### PR DESCRIPTION
We need to keep old deleted generated files in .dockerignore even if we do not have them now.

When Docker builds an image it transfer everything not excluded in .gitignore to Docker builder before it attempts to build an image.

If you had locally built assets and node_modules and assets from www, they were excluded in .gitignore, but it also means they were not deleted when www folder was cleaned - and you might stil have them.

Since they were removed from .dockerignore and included now, they might cause 1.5 GB extra transfer of context before image is built.

That also helps in the situation when you switch to airflow 2 branch and build assets. When you switch back to main, those assets and node_modules in www will still be there.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
