### PR TITLE
AIP-38 Fix graph mapped task instance link

### DIFF
--- a/airflow/ui/src/layouts/Details/Graph/TaskLink.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/TaskLink.tsx
@@ -39,7 +39,7 @@ export const TaskLink = ({ id, isGroup, isMapped, ...rest }: Props) => {
       <RouterLink
         to={{
           // Do not include runId if there is no selected run, clicking a second time will deselect a task id
-          pathname: `/dags/${dagId}/${runId === undefined ? "" : `runs/${runId}/`}${taskId === id ? "" : `tasks/${id}`}${isMapped ? "/mapped" : ""}`,
+          pathname: `/dags/${dagId}/${runId === undefined ? "" : `runs/${runId}/`}${taskId === id ? "" : `tasks/${id}`}${isMapped && taskId !== id && runId !== undefined ? "/mapped" : ""}`,
           search: searchParams.toString(),
         }}
       >


### PR DESCRIPTION
There were two problems:
- When a dagrun was selected, clicking multiple times on a mapped task instance on the graph would result in an wrong url -> corresponding to no router (unselect the mapped TI)
- When no dagrun was selected, clicking on the mapped TI in the graph would also end up on a 404 front-end page corresponding to no router. We want to query the `Tasks` API in this case, not the TI one.

## issue 1
![Screenshot 2025-02-28 at 15 21 28](https://github.com/user-attachments/assets/1db00ad8-00ce-4c21-bfa8-e158265e214e)

Click on 'generate_value []' task in the graph
![Screenshot 2025-02-28 at 15 21 39](https://github.com/user-attachments/assets/898b43ac-c786-478b-80e3-5048edd4121b)

## issue 2
![Screenshot 2025-02-28 at 15 22 19](https://github.com/user-attachments/assets/fa308c3e-4ec5-4c25-a694-ae4bcc202787)

Click on 'generate_value []' task in the graph
![Screenshot 2025-02-28 at 15 22 36](https://github.com/user-attachments/assets/f4e97238-26e5-4ac9-b857-ea5948b2ea8e)

