### PR TITLE
Workaround PyPI constraint generation error caused by confluent-kafka…

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1283,8 +1283,11 @@ COPY . ${AIRFLOW_SOURCES}/
 # Those are additional constraints that are needed for some extras but we do not want to
 # force them on the main Airflow package. Currently we need no extra limits as PIP 23.1+ has much better
 # dependency resolution and we do not need to limit the versions of the dependencies
+# The `confluent-kafka==2.8.1` currently breaks installation of kafka provider from PyPI
+# So we need to add limit here to get our constraints generation for PyPI packages work
+# This can be removed when https://github.com/confluentinc/confluent-kafka-python/issues/1927 is solved
 #
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=""
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="confluent-kafka!=2.8.1"
 ARG UPGRADE_INVALIDATION_STRING=""
 ARG VERSION_SUFFIX_FOR_PYPI=""
 


### PR DESCRIPTION
… 2.8.1

The https://github.com/confluentinc/confluent-kafka-python/issues/1927 describes the problem in detail. We need to limit confluent-kafka to have our constraint generation work again for PyPI packages.

This also means that users of the kafka provider have the same problem now (because the released kafka provider does not limit that wrongly released confluent-kafka package.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
