### PR TITLE
Add failed task log preview to Dag Overview page

### DIFF
--- a/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -105,7 +105,7 @@ export const DagBreadcrumb = () => {
   }
 
   return (
-    <Breadcrumb.Root mb={1} separator={<LiaSlashSolid />}>
+    <Breadcrumb.Root separator={<LiaSlashSolid />}>
       {links.map((link, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <Stat.Root gap={0} key={`${link.title}-${index}`}>

--- a/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -59,7 +59,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
 
   return (
     <OpenGroupsProvider dagId={dagId}>
-      <HStack justifyContent="space-between" mb={2}>
+      <HStack justifyContent="space-between">
         <DagBreadcrumb />
         <Flex gap={1}>
           <SearchDagsButton />

--- a/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
@@ -1,0 +1,63 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, Heading, Button } from "@chakra-ui/react";
+import { useState } from "react";
+
+import type { TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
+import { useConfig } from "src/queries/useConfig";
+
+import { TaskLogPreview } from "./TaskLogPreview";
+
+export const FailedLogs = ({
+  failedTasks,
+}: {
+  readonly failedTasks: TaskInstanceCollectionResponse | undefined;
+}) => {
+  const defaultWrap = Boolean(useConfig("default_wrap"));
+  const [wrap, setWrap] = useState(defaultWrap);
+
+  const taskLogs = failedTasks?.task_instances.slice(0, 5);
+
+  const toggleWrap = () => setWrap(!wrap);
+
+  if (taskLogs === undefined || taskLogs.length <= 0) {
+    return undefined;
+  }
+
+  return (
+    <Flex flexDirection="column" gap={3}>
+      <Flex alignItems="center" justifyContent="space-between">
+        <Heading size="md">Recent Failed Task Logs</Heading>
+        <Button
+          aria-label={wrap ? "Unwrap" : "Wrap"}
+          bg="bg.panel"
+          fontSize="sm"
+          onClick={toggleWrap}
+          size="sm"
+          variant="outline"
+        >
+          {wrap ? "Unwrap" : "Wrap"}
+        </Button>
+      </Flex>
+      {taskLogs.map((taskInstance) => (
+        <TaskLogPreview key={taskInstance.id} taskInstance={taskInstance} wrap={wrap} />
+      ))}
+    </Flex>
+  );
+};

--- a/airflow/ui/src/pages/Dag/Overview/FailedTaskLog.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/FailedTaskLog.tsx
@@ -1,0 +1,67 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Flex, Link } from "@chakra-ui/react";
+import { Link as RouterLink } from "react-router-dom";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import { ClearTaskInstanceButton } from "src/components/Clear";
+import { StateBadge } from "src/components/StateBadge";
+import Time from "src/components/Time";
+import { TaskLogContent } from "src/pages/TaskInstance/Logs/TaskLogContent";
+import { useConfig } from "src/queries/useConfig";
+import { useLogs } from "src/queries/useLogs";
+import { getTaskInstanceLink } from "src/utils/links";
+
+export const FailedTaskLog = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
+  const defaultWrap = Boolean(useConfig("default_wrap"));
+
+  const { data, error, isLoading } = useLogs({
+    dagId: taskInstance.dag_id,
+    logLevelFilters: ["warning", "error", "critical"],
+    taskInstance,
+    tryNumber: taskInstance.try_number,
+  });
+
+  return (
+    <Box borderRadius={4} borderStyle="solid" borderWidth={1} key={taskInstance.id} p={2} width="100%">
+      <Flex justifyContent="space-between">
+        <Box>
+          <StateBadge mr={1} state={taskInstance.state} />
+          {taskInstance.task_display_name}
+          <Time datetime={taskInstance.run_after} ml={1} />
+        </Box>
+        <Flex gap={1}>
+          <ClearTaskInstanceButton taskInstance={taskInstance} withText={false} />
+          <Link asChild color="fg.info" fontSize="sm">
+            <RouterLink to={getTaskInstanceLink(taskInstance)}>View full logs</RouterLink>
+          </Link>
+        </Flex>
+      </Flex>
+      <Box maxHeight="200px" overflow="auto">
+        <TaskLogContent
+          error={error}
+          isLoading={isLoading}
+          logError={error}
+          parsedLogs={data.parsedLogs}
+          wrap={defaultWrap}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Skeleton, SimpleGrid, Flex, Heading } from "@chakra-ui/react";
+import { Box, HStack, Skeleton, SimpleGrid } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -27,7 +27,7 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
-import { FailedTaskLog } from "./FailedTaskLog";
+import { FailedLogs } from "./FailedLogs";
 
 const defaultHour = "168";
 
@@ -67,8 +67,6 @@ export const Overview = () => {
         query.state.data?.dag_runs.some((run) => isStatePending(run.state)) ? refetchInterval : false,
     },
   );
-
-  const taskLogs = failedTasks?.task_instances.slice(0, 5);
 
   return (
     <Box m={4}>
@@ -122,14 +120,7 @@ export const Overview = () => {
           )}
         </Box>
       </SimpleGrid>
-      {taskLogs && taskLogs.length > 0 ? (
-        <Flex flexDirection="column" gap={3}>
-          <Heading size="md">Recent Failed Task Logs</Heading>
-          {taskLogs.map((taskInstance) => (
-            <FailedTaskLog key={taskInstance.id} taskInstance={taskInstance} />
-          ))}
-        </Flex>
-      ) : undefined}
+      <FailedLogs failedTasks={failedTasks} />
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Skeleton, SimpleGrid } from "@chakra-ui/react";
+import { Box, HStack, Skeleton, SimpleGrid, Flex, Heading } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -26,6 +26,8 @@ import { DurationChart } from "src/components/DurationChart";
 import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { isStatePending, useAutoRefresh } from "src/utils";
+
+import { FailedTaskLog } from "./FailedTaskLog";
 
 const defaultHour = "168";
 
@@ -65,6 +67,8 @@ export const Overview = () => {
         query.state.data?.dag_runs.some((run) => isStatePending(run.state)) ? refetchInterval : false,
     },
   );
+
+  const taskLogs = failedTasks?.task_instances.slice(0, 5);
 
   return (
     <Box m={4}>
@@ -118,6 +122,14 @@ export const Overview = () => {
           )}
         </Box>
       </SimpleGrid>
+      {taskLogs && taskLogs.length > 0 ? (
+        <Flex flexDirection="column" gap={3}>
+          <Heading size="md">Recent Failed Task Logs</Heading>
+          {taskLogs.map((taskInstance) => (
+            <FailedTaskLog key={taskInstance.id} taskInstance={taskInstance} />
+          ))}
+        </Flex>
+      ) : undefined}
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -24,13 +24,16 @@ import { ClearTaskInstanceButton } from "src/components/Clear";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { TaskLogContent } from "src/pages/TaskInstance/Logs/TaskLogContent";
-import { useConfig } from "src/queries/useConfig";
 import { useLogs } from "src/queries/useLogs";
 import { getTaskInstanceLink } from "src/utils/links";
 
-export const FailedTaskLog = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
-  const defaultWrap = Boolean(useConfig("default_wrap"));
-
+export const TaskLogPreview = ({
+  taskInstance,
+  wrap,
+}: {
+  readonly taskInstance: TaskInstanceResponse;
+  readonly wrap: boolean;
+}) => {
   const { data, error, isLoading } = useLogs({
     dagId: taskInstance.dag_id,
     logLevelFilters: ["warning", "error", "critical"],
@@ -39,8 +42,8 @@ export const FailedTaskLog = ({ taskInstance }: { readonly taskInstance: TaskIns
   });
 
   return (
-    <Box borderRadius={4} borderStyle="solid" borderWidth={1} key={taskInstance.id} p={2} width="100%">
-      <Flex justifyContent="space-between">
+    <Box borderRadius={4} borderStyle="solid" borderWidth={1} key={taskInstance.id} width="100%">
+      <Flex alignItems="center" justifyContent="space-between" px={2}>
         <Box>
           <StateBadge mr={1} state={taskInstance.state} />
           {taskInstance.task_display_name}
@@ -53,13 +56,13 @@ export const FailedTaskLog = ({ taskInstance }: { readonly taskInstance: TaskIns
           </Link>
         </Flex>
       </Flex>
-      <Box maxHeight="200px" overflow="auto">
+      <Box maxHeight="100px" overflow="auto">
         <TaskLogContent
           error={error}
           isLoading={isLoading}
           logError={error}
           parsedLogs={data.parsedLogs}
-          wrap={defaultWrap}
+          wrap={wrap}
         />
       </Box>
     </Box>

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Code, Skeleton, VStack } from "@chakra-ui/react";
+import { Box, Code, VStack } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
@@ -33,7 +33,6 @@ type Props = {
 export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: Props) => (
   <Box>
     <ErrorAlert error={error ?? logError} />
-    <Skeleton />
     <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
     <Code overflow="auto" py={3} textWrap={wrap ? "pre" : "nowrap"} width="100%">
       <VStack alignItems="flex-start">{parsedLogs}</VStack>

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -71,6 +71,7 @@ const renderStructuredLog = (
       <Badge
         colorPalette={level.toUpperCase() in LogLevel ? logLevelColorMapping[level as LogLevel] : undefined}
         key={1}
+        minH={3}
         size="sm"
       >
         {level.toUpperCase()}


### PR DESCRIPTION
Add a "Recent Failed Task Logs" section to the Dag Overview page. It will take the latest 5 failed task instances and look up their logs. The logs are filtered by lines with a warning, error, or critical level. There are buttons to clear the task instance immediately or to link over the full logs with all task instance details.

<img width="1474" alt="Screenshot 2025-02-28 at 2 01 31 PM" src="https://github.com/user-attachments/assets/f8e9532b-36c5-4472-8d2a-7aa48aa40fb6" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
