### PR TITLE
Update Airflow back-compat version after 2.10.5 release

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -406,6 +406,7 @@ AIRFLOW_PYTHON_COMPATIBILITY_MATRIX = {
     "2.10.2": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "2.10.3": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "2.10.4": ["3.8", "3.9", "3.10", "3.11", "3.12"],
+    "2.10.5": ["3.8", "3.9", "3.10", "3.11", "3.12"],
 }
 
 DB_RESET = False
@@ -603,7 +604,7 @@ PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
     },
     {
         "python-version": "3.9",
-        "airflow-version": "2.10.4",
+        "airflow-version": "2.10.5",
         "remove-providers": "cloudant common.messaging fab",
         "run-tests": "true",
     },


### PR DESCRIPTION
I just realized that the backcompat tests still test using 2.10.4... seems we regularly forget to upgrade the checks when we make a new release :-D