### PR TITLE
fix inconsistence between the get_conn and run in `WinRMHook`

### DIFF
--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
@@ -118,13 +118,9 @@ class WinRMHook(BaseHook):
         self.credssp_disable_tlsv1_2 = credssp_disable_tlsv1_2
         self.send_cbt = send_cbt
 
-        self.client = None
         self.winrm_protocol = None
 
     def get_conn(self):
-        if self.client:
-            return self.client
-
         self.log.debug("Creating WinRM client for conn_id: %s", self.ssh_conn_id)
         if self.ssh_conn_id is not None:
             conn = self.get_connection(self.ssh_conn_id)
@@ -213,15 +209,16 @@ class WinRMHook(BaseHook):
                     send_cbt=self.send_cbt,
                 )
 
-            self.log.info("Establishing WinRM connection to host: %s", self.remote_host)
-            self.client = self.winrm_protocol.open_shell()
-
         except Exception as error:
-            error_msg = f"Error connecting to host: {self.remote_host}, error: {error}"
+            error_msg = f"Error creating connection to host: {self.remote_host}, error: {error}"
             self.log.error(error_msg)
             raise AirflowException(error_msg)
 
-        return self.client
+        if not hasattr(self.winrm_protocol, "get_command_output_raw"):
+            # since pywinrm>=0.5 get_command_output_raw replace _raw_get_command_output
+            self.winrm_protocol.get_command_output_raw = self.winrm_protocol._raw_get_command_output
+
+        return self.winrm_protocol
 
     def run(
         self,
@@ -241,18 +238,25 @@ class WinRMHook(BaseHook):
         :return: returns a tuple containing return_code, stdout and stderr in order.
         """
         winrm_client = self.get_conn()
+        self.log.info("Establishing WinRM connection to host: %s", self.remote_host)
+        try:
+            shell_id = winrm_client.open_shell()
+        except Exception as error:
+            error_msg = f"Error connecting to host: {self.remote_host}, error: {error}"
+            self.log.error(error_msg)
+            raise AirflowException(error_msg)
 
         try:
             if ps_path is not None:
                 self.log.info("Running command as powershell script: '%s'...", command)
                 encoded_ps = b64encode(command.encode("utf_16_le")).decode("ascii")
-                command_id = self.winrm_protocol.run_command(  # type: ignore[attr-defined]
-                    winrm_client, f"{ps_path} -encodedcommand {encoded_ps}"
+                command_id = winrm_client.run_command(  # type: ignore[attr-defined]
+                    shell_id, f"{ps_path} -encodedcommand {encoded_ps}"
                 )
             else:
                 self.log.info("Running command: '%s'...", command)
-                command_id = self.winrm_protocol.run_command(  # type: ignore[attr-defined]
-                    winrm_client, command
+                command_id = winrm_client.run_command(  # type: ignore[attr-defined]
+                    shell_id, command
                 )
 
                 # See: https://github.com/diyan/pywinrm/blob/master/winrm/protocol.py
@@ -267,8 +271,8 @@ class WinRMHook(BaseHook):
                         stderr,
                         return_code,
                         command_done,
-                    ) = self.winrm_protocol._raw_get_command_output(  # type: ignore[attr-defined]
-                        winrm_client, command_id
+                    ) = winrm_client.get_command_output_raw(  # type: ignore[attr-defined]
+                        shell_id, command_id
                     )
 
                     # Only buffer stdout if we need to so that we minimize memory usage.
@@ -281,12 +285,12 @@ class WinRMHook(BaseHook):
                     for line in stderr.decode(output_encoding).splitlines():
                         self.log.warning(line)
 
-            self.winrm_protocol.cleanup_command(  # type: ignore[attr-defined]
-                winrm_client, command_id
+            winrm_client.cleanup_command(  # type: ignore[attr-defined]
+                shell_id, command_id
             )
 
             return return_code, stdout_buffer, stderr_buffer
         except Exception as e:
             raise AirflowException(f"WinRM operator error: {e}")
         finally:
-            self.winrm_protocol.close_shell(winrm_client)  # type: ignore[attr-defined]
+            winrm_client.close_shell(shell_id)  # type: ignore[attr-defined]

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -142,7 +142,7 @@ class TestWinRMHook:
         winrm_hook = WinRMHook(ssh_conn_id="conn_id")
 
         mock_protocol.return_value.run_command = MagicMock(return_value="command_id")
-        mock_protocol.return_value._raw_get_command_output = MagicMock(
+        mock_protocol.return_value.get_command_output_raw = MagicMock(
             return_value=(b"stdout", b"stderr", 0, True)
         )
 
@@ -183,7 +183,7 @@ class TestWinRMHook:
         winrm_hook = WinRMHook(ssh_conn_id="conn_id")
 
         mock_protocol.return_value.run_command = MagicMock(return_value="command_id")
-        mock_protocol.return_value._raw_get_command_output = MagicMock(
+        mock_protocol.return_value.get_command_output_raw = MagicMock(
             return_value=(b"stdout", b"stderr", 0, True)
         )
 

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -29,15 +29,6 @@ pytestmark = pytest.mark.db_test
 
 
 class TestWinRMHook:
-    @patch("airflow.providers.microsoft.winrm.hooks.winrm.Protocol")
-    def test_get_conn_exists(self, mock_protocol):
-        winrm_hook = WinRMHook()
-        winrm_hook.client = mock_protocol.return_value.open_shell.return_value
-
-        conn = winrm_hook.get_conn()
-
-        assert conn == winrm_hook.client
-
     def test_get_conn_missing_remote_host(self):
         with pytest.raises(AirflowException):
             WinRMHook().get_conn()
@@ -47,7 +38,7 @@ class TestWinRMHook:
         mock_protocol.side_effect = Exception("Error")
 
         with pytest.raises(AirflowException):
-            WinRMHook(remote_host="host").get_conn()
+            WinRMHook(remote_host="host", password="pwd").get_conn()
 
     @patch("airflow.providers.microsoft.winrm.hooks.winrm.Protocol", autospec=True)
     @patch(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

change get_conn behaviour, this will introduce a backward incompatibility for people who used low level wirnm function since instead of initiating distant remote shell and returning shell_id, it will return a winrm.protocol.Protocol object and you will have to call open_shell() to initiate the remote shell (.

for others (who just use hook.run or operator) it will change nothing (except that you can call run twice without instantiating a new hook)

I also made a small change to use protocol.get_command_output_raw (introduced in [v0.5.0](https://github.com/diyan/pywinrm/releases/tag/v0.5.0) of pywinrm) instead of _raw_get_command_output with preserving compatibility with earlier versions


closes: #46668

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
