### PR TITLE
Pinning fastapi to not use 0.115.10 temporarily

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -370,7 +370,8 @@ DEPENDENCIES = [
     # Required for python 3.9 to work with new annotations styles. Check package
     # description on PyPI for more details: https://pypi.org/project/eval-type-backport/
     'eval-type-backport>=0.2.0;python_version<"3.10"',
-    "fastapi[standard]>=0.112.2",
+    # temporarily pinning fastapi after the recent release started breaking tests
+    "fastapi[standard]>=0.112.2,<0.115.10",
     "flask-caching>=2.0.0",
     # Flask-Session 0.6 add new arguments into the SqlAlchemySessionInterface constructor as well as
     # all parameters now are mandatory which make AirflowDatabaseSessionInterface incompatible with this version.

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -371,7 +371,7 @@ DEPENDENCIES = [
     # description on PyPI for more details: https://pypi.org/project/eval-type-backport/
     'eval-type-backport>=0.2.0;python_version<"3.10"',
     # temporarily pinning fastapi after the recent release started breaking tests
-    "fastapi[standard]>=0.112.2,<0.115.10",
+    "fastapi[standard]>=0.112.2,!=0.115.10",
     "flask-caching>=2.0.0",
     # Flask-Session 0.6 add new arguments into the SqlAlchemySessionInterface constructor as well as
     # all parameters now are mandatory which make AirflowDatabaseSessionInterface incompatible with this version.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fastapi released a new version 0.115.10 which started breaking our tests:
```
The above exception was the direct cause of the following exception:
tests/api_fastapi/core_api/routes/ui/test_dashboard.py:176: in test_historical_metrics_data
    response = test_client.get("/ui/dashboard/historical_metrics_data", params=params)
/usr/local/lib/python3.12/site-packages/starlette/testclient.py:465: in get
    return super().get(
/usr/local/lib/python3.12/site-packages/httpx/_client.py:1054: in get
    return self.request(
/usr/local/lib/python3.12/site-packages/starlette/testclient.py:437: in request
    return super().request(
/usr/local/lib/python3.12/site-packages/httpx/_client.py:827: in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
/usr/local/lib/python3.12/site-packages/httpx/_client.py:914: in send
    response = self._send_handling_auth(
/usr/local/lib/python3.12/site-packages/httpx/_client.py:942: in _send_handling_auth
    response = self._send_handling_redirects(
/usr/local/lib/python3.12/site-packages/httpx/_client.py:979: in _send_handling_redirects
    response = self._send_single_request(request)
/usr/local/lib/python3.12/site-packages/httpx/_client.py:1015: in _send_single_request
    response = transport.handle_request(request)
/usr/local/lib/python3.12/site-packages/starlette/testclient.py:340: in handle_request
    raise exc
/usr/local/lib/python3.12/site-packages/starlette/testclient.py:337: in handle_request
    portal.call(self.app, scope, receive, send)
/usr/local/lib/python3.12/site-packages/anyio/from_thread.py:290: in call
    return cast(T_Retval, self.start_task_soon(func, *args).result())
/usr/local/lib/python3.12/concurrent/futures/_base.py:456: in result
    return self.__get_result()
/usr/local/lib/python3.12/concurrent/futures/_base.py:401: in __get_result
    raise self._exception
/usr/local/lib/python3.12/site-packages/anyio/from_thread.py:221: in _call_func
    retval = await retval_or_awaitable
/usr/local/lib/python3.12/site-packages/fastapi/applications.py:1054: in __call__
    await super().__call__(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/applications.py:112: in __call__
    await self.middleware_stack(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py:187: in __call__
    raise exc
/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py:165: in __call__
    await self.app(scope, receive, _send)
/usr/local/lib/python3.12/site-packages/starlette/middleware/gzip.py:29: in __call__
    await responder(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/middleware/gzip.py:126: in __call__
    await super().__call__(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/middleware/gzip.py:46: in __call__
    await self.app(scope, receive, self.send_with_compression)
/usr/local/lib/python3.12/site-packages/starlette/middleware/cors.py:85: in __call__
    await self.app(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py:173: in __call__
    with recv_stream, send_stream, collapse_excgroups():
/usr/local/lib/python3.12/contextlib.py:158: in __exit__
    self.gen.throw(value)
/usr/local/lib/python3.12/site-packages/starlette/_utils.py:82: in collapse_excgroups
    raise exc
/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py:175: in __call__
    response = await self.dispatch_func(request, call_next)
airflow/api_fastapi/core_api/middleware.py:28: in dispatch
    response = await call_next(request)
/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py:153: in call_next
    raise app_exc
/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py:140: in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py:62: in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py:53: in wrapped_app
    raise exc
/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py:42: in wrapped_app
    await app(scope, receive, sender)
/usr/local/lib/python3.12/site-packages/starlette/routing.py:714: in __call__
    await self.middleware_stack(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/routing.py:734: in app
    await route.handle(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/routing.py:288: in handle
    await self.app(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/routing.py:76: in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py:53: in wrapped_app
    raise exc
/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py:42: in wrapped_app
    await app(scope, receive, sender)
/usr/local/lib/python3.12/site-packages/starlette/routing.py:73: in app
    response = await f(request)
/usr/local/lib/python3.12/site-packages/fastapi/routing.py:301: in app
    raw_response = await run_endpoint_function(
/usr/local/lib/python3.12/site-packages/fastapi/routing.py:214: in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
/usr/local/lib/python3.12/site-packages/starlette/concurrency.py:37: in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
/usr/local/lib/python3.12/site-packages/anyio/to_thread.py:56: in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:2461: in run_sync_in_worker_thread
    return await future
/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:962: in run
    result = context.run(func, *args)
airflow/api_fastapi/core_api/routes/ui/dashboard.py:47: in historical_metrics
    dag_run_types = session.execute(
/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py:1717: in execute
    result = conn._execute_20(statement, params or {}, execution_options)
/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py:1710: in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
/usr/local/lib/python3.12/site-packages/sqlalchemy/sql/elements.py:334: in _execute_on_connection
    return connection._execute_clauseelement(
/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py:1577: in _execute_clauseelement
    ret = self._execute_context(
/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py:1816: in _execute_context
    self._handle_dbapi_exception(
/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py:2134: in _handle_dbapi_exception
    util.raise_(
/usr/local/lib/python3.12/site-packages/sqlalchemy/util/compat.py:211: in raise_
    raise exception
/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py:1810: in _execute_context
    context = constructor(
/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py:1078: in _init_compiled
    processors[key](compiled_params[key])
/usr/local/lib/python3.12/site-packages/sqlalchemy/sql/type_api.py:1673: in process
    return process_param(value, dialect)
airflow/utils/sqlalchemy.py:71: in process_bind_param
    raise TypeError(f"expected datetime.datetime, not {value!r}")
E   sqlalchemy.exc.StatementError: (builtins.TypeError) expected datetime.datetime, not '2023-01-01T00:00'
E   [SQL: SELECT dag_run.run_type, count(dag_run.run_id) AS count_1 
E   FROM dag_run 
E   WHERE dag_run.start_date >= %s AND coalesce(dag_run.end_date, %s) <= coalesce(%s, %s) GROUP BY dag_run.run_type]
```

Example failures: https://github.com/apache/airflow/actions/runs/13592806440?pr=47008

Temporarily pinning it till we figure out the root cause. Linking relevant discussion too https://github.com/fastapi/fastapi/discussions/13431


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
