### PR TITLE
Limit secrets passed to reusable workflows

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -102,7 +102,6 @@ jobs:
       # This write is only given here for `push` events from "apache/airflow" repo. It is not given for PRs
       # from forks. This is to prevent malicious PRs from creating images in the "apache/airflow" repo.
       packages: write
-    secrets: inherit
     with:
       runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
       runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}
@@ -165,7 +164,6 @@ jobs:
 #    permissions:
 #      contents: read
 #      packages: write
-#    secrets: inherit
 #    with:
 #      platform: "linux/arm64"
 #      push-image: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,6 @@ jobs:
       # This write is only given here for `push` events from "apache/airflow" repo. It is not given for PRs
       # from forks. This is to prevent malicious PRs from creating images in the "apache/airflow" repo.
       packages: write
-    secrets: inherit
     with:
       runs-on-as-json-public: ${{ needs.build-info.outputs.runs-on-as-json-public }}
       runs-on-as-json-self-hosted: ${{ needs.build-info.outputs.runs-on-as-json-self-hosted }}
@@ -264,7 +263,6 @@ jobs:
     name: "CI image checks"
     needs: [build-info, build-ci-images]
     uses: ./.github/workflows/ci-image-checks.yml
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       runs-on-as-json-docs-build: ${{ needs.build-info.outputs.runs-on-as-json-docs-build }}
@@ -296,7 +294,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     if: >
       needs.build-info.outputs.skip-providers-tests != 'true' &&
       needs.build-info.outputs.latest-versions-only != 'true'
@@ -320,7 +317,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       runs-on-as-json-public: ${{ needs.build-info.outputs.runs-on-as-json-public }}
@@ -339,7 +335,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       backend: "postgres"
@@ -366,7 +361,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       backend: "mysql"
@@ -393,7 +387,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       backend: "sqlite"
@@ -422,7 +415,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       backend: "sqlite"
@@ -450,7 +442,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     if: >
       needs.build-info.outputs.run-tests == 'true' &&
       (needs.build-info.outputs.canary-run == 'true' ||
@@ -480,7 +471,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-public: ${{ needs.build-info.outputs.runs-on-as-json-public }}
       testable-core-integrations: ${{ needs.build-info.outputs.testable-core-integrations }}
@@ -502,7 +492,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     if: >
       needs.build-info.outputs.run-tests == 'true'
     with:
@@ -534,7 +523,6 @@ jobs:
       # This write is only given here for `push` events from "apache/airflow" repo. It is not given for PRs
       # from forks. This is to prevent malicious PRs from creating images in the "apache/airflow" repo.
       packages: write
-    secrets: inherit
     with:
       runs-on-as-json-public: ${{ needs.build-info.outputs.runs-on-as-json-public }}
       build-type: "Regular"
@@ -578,7 +566,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       platform: "linux/amd64"
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
@@ -598,7 +585,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
@@ -616,7 +602,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    secrets: inherit
     needs:
       - build-info
       - generate-constraints

--- a/.github/workflows/finalize-tests.yml
+++ b/.github/workflows/finalize-tests.yml
@@ -139,7 +139,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    secrets: inherit
     with:
       runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
       runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}
@@ -163,7 +162,6 @@ jobs:
   #    permissions:
   #      contents: read
   #      packages: write
-  #    secrets: inherit
   #    with:
   #      runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
   #      runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -89,7 +89,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       downgrade-sqlalchemy: "true"
@@ -113,7 +112,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       upgrade-boto: "true"
@@ -138,7 +136,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       downgrade-pendulum: "true"
@@ -163,7 +160,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "Postgres"
@@ -187,7 +183,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "Postgres"
@@ -213,7 +208,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    secrets: inherit
     with:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "SystemTest"


### PR DESCRIPTION
Good practice (pointed out by zizmor) is to explicitly only pass the needed secrets to called reusable workflows. This PR does exactly this.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
