### PR TITLE
Adding ticks to user provided table names

### DIFF
--- a/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
+++ b/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
@@ -249,7 +249,7 @@ class MySqlHook(DbApiHook):
             raise ValueError(f"Invalid table name: {table}")
 
         cur.execute(
-            f"LOAD DATA LOCAL INFILE %s INTO TABLE {table}",
+            f"LOAD DATA LOCAL INFILE %s INTO TABLE `{table}`",
             (tmp_file,),
         )
         conn.commit()
@@ -266,7 +266,7 @@ class MySqlHook(DbApiHook):
             raise ValueError(f"Invalid table name: {table}")
 
         cur.execute(
-            f"SELECT * INTO OUTFILE %s FROM {table}",
+            f"SELECT * INTO OUTFILE %s FROM `{table}`",
             (tmp_file,),
         )
         conn.commit()
@@ -331,7 +331,7 @@ class MySqlHook(DbApiHook):
         cursor = conn.cursor()
 
         cursor.execute(
-            f"LOAD DATA LOCAL INFILE %s %s INTO TABLE {table} %s",
+            f"LOAD DATA LOCAL INFILE %s %s INTO TABLE `{table}` %s",
             (tmp_file, duplicate_key_handling, extra_options),
         )
 

--- a/providers/mysql/tests/unit/mysql/hooks/test_mysql.py
+++ b/providers/mysql/tests/unit/mysql/hooks/test_mysql.py
@@ -302,11 +302,13 @@ class TestMySqlHook:
 
     def test_bulk_load(self):
         self.db_hook.bulk_load("table", "/tmp/file")
-        self.cur.execute.assert_called_once_with("LOAD DATA LOCAL INFILE %s INTO TABLE table", ("/tmp/file",))
+        self.cur.execute.assert_called_once_with(
+            "LOAD DATA LOCAL INFILE %s INTO TABLE `table`", ("/tmp/file",)
+        )
 
     def test_bulk_dump(self):
         self.db_hook.bulk_dump("table", "/tmp/file")
-        self.cur.execute.assert_called_once_with("SELECT * INTO OUTFILE %s FROM table", ("/tmp/file",))
+        self.cur.execute.assert_called_once_with("SELECT * INTO OUTFILE %s FROM `table`", ("/tmp/file",))
 
     def test_serialize_cell(self):
         assert self.db_hook._serialize_cell("foo", None) == "foo"
@@ -322,7 +324,7 @@ class TestMySqlHook:
             IGNORE 1 LINES""",
         )
         self.cur.execute.assert_called_once_with(
-            f"LOAD DATA LOCAL INFILE %s %s INTO TABLE {table} %s",
+            f"LOAD DATA LOCAL INFILE %s %s INTO TABLE `{table}` %s",
             (
                 "/tmp/file",
                 "IGNORE",
@@ -459,7 +461,7 @@ class TestMySql:
             with closing(hook.get_conn()) as conn, closing(conn.cursor()) as cursor:
                 cursor.execute(
                     f"""
-                    CREATE TABLE IF NOT EXISTS {table} (
+                    CREATE TABLE IF NOT EXISTS `{table}`(
                         dummy VARCHAR(50)
                     )
                 """
@@ -500,5 +502,5 @@ class TestMySql:
             hook.bulk_dump(table, tmp_file)
 
             assert mock_execute.call_count == 1
-            query = f"SELECT * INTO OUTFILE %s FROM {table}"
+            query = f"SELECT * INTO OUTFILE %s FROM `{table}`"
             assert_equal_ignore_multiple_spaces(mock_execute.call_args.args[0], query)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


The mysql provider has few helper methods that demand user input, and since users can input table names, we need to take care of situations when a keyword tablename is passed, rare but possible. For ex: if "where" is a table :)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
