### PR TITLE
AIP-84 | Add Auth for Import Error

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3933,6 +3933,8 @@ paths:
       summary: Get Import Error
       description: Get an import error.
       operationId: get_import_error
+      security:
+      - OAuth2PasswordBearer: []
       parameters:
       - name: import_error_id
         in: path
@@ -3978,6 +3980,8 @@ paths:
       summary: Get Import Errors
       description: Get all import errors.
       operationId: get_import_errors
+      security:
+      - OAuth2PasswordBearer: []
       parameters:
       - name: limit
         in: query

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -36,6 +36,11 @@ from airflow.api_fastapi.core_api.datamodels.import_error import (
     ImportErrorResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.security import (
+    AccessView,
+    requires_access_dag,
+    requires_access_view,
+)
 from airflow.models.errors import ParseImportError
 
 import_error_router = AirflowRouter(tags=["Import Error"], prefix="/importErrors")
@@ -44,6 +49,10 @@ import_error_router = AirflowRouter(tags=["Import Error"], prefix="/importErrors
 @import_error_router.get(
     "/{import_error_id}",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
+    dependencies=[
+        Depends(requires_access_view(AccessView.IMPORT_ERRORS)),
+        Depends(requires_access_dag("GET")),
+    ],
 )
 def get_import_error(
     import_error_id: int,
@@ -62,6 +71,10 @@ def get_import_error(
 
 @import_error_router.get(
     "",
+    dependencies=[
+        Depends(requires_access_view(AccessView.IMPORT_ERRORS)),
+        Depends(requires_access_dag("GET")),
+    ],
 )
 def get_import_errors(
     limit: QueryLimit,

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -171,11 +171,11 @@ def get_import_errors(
         limit=limit,
         session=session,
     )
-    import_errors_result: Iterable[ParseImportError, Iterable[str]] = groupby(
+    import_errors_result: Iterable[tuple[ParseImportError, Iterable[str]]] = groupby(
         session.execute(import_errors_select), itemgetter(0)
     )
 
-    import_errors: list[ParseImportError] = []
+    import_errors = []
     for import_error, file_dag_ids in import_errors_result:
         # Check if user has read access to all the DAGs defined in the file
         requests: Sequence[IsAuthorizedDagRequest] = [

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -22,7 +22,7 @@ from operator import itemgetter
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import func, select
+from sqlalchemy import select
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.batch_apis import IsAuthorizedDagRequest

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -16,11 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.auth.managers.models.batch_apis import IsAuthorizedDagRequest
+from airflow.api_fastapi.auth.managers.models.resource_details import (
+    DagDetails,
+)
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
@@ -38,17 +44,26 @@ from airflow.api_fastapi.core_api.datamodels.import_error import (
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import (
     AccessView,
+    GetUserDep,
     requires_access_dag,
     requires_access_view,
 )
+from airflow.models import DagModel
 from airflow.models.errors import ParseImportError
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 import_error_router = AirflowRouter(tags=["Import Error"], prefix="/importErrors")
 
 
+def get_file_dag_ids(session: Session, filename: str) -> set[str]:
+    return {dag_id for dag_id in session.scalars(select(DagModel.dag_id).where(DagModel.fileloc == filename))}
+
+
 @import_error_router.get(
     "/{import_error_id}",
-    responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
+    responses=create_openapi_http_exception_doc([status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]),
     dependencies=[
         Depends(requires_access_view(AccessView.IMPORT_ERRORS)),
         Depends(requires_access_dag("GET")),
@@ -57,6 +72,7 @@ import_error_router = AirflowRouter(tags=["Import Error"], prefix="/importErrors
 def get_import_error(
     import_error_id: int,
     session: SessionDep,
+    user: GetUserDep,
 ) -> ImportErrorResponse:
     """Get an import error."""
     error = session.scalar(select(ParseImportError).where(ParseImportError.id == import_error_id))
@@ -65,6 +81,24 @@ def get_import_error(
             status.HTTP_404_NOT_FOUND,
             f"The ImportError with import_error_id: `{import_error_id}` was not found",
         )
+    session.expunge(error)
+
+    auth_manager = get_auth_manager()
+    can_read_all_dags = auth_manager.is_authorized_dag(method="GET", user=user)
+    if not can_read_all_dags:
+        readable_dag_ids = auth_manager.get_permitted_dag_ids(user=user)
+        file_dag_ids = get_file_dag_ids(session, error.filename)
+
+        # Can the user read any DAGs in the file?
+        if not readable_dag_ids.intersection(file_dag_ids):
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "You do not have read permission on any of the DAGs in the file",
+            )
+
+        # Check if user has read access to all the DAGs defined in the file
+        if not file_dag_ids.issubset(readable_dag_ids):
+            error.stacktrace = "REDACTED - you do not have read permission on all DAGs in the file"
 
     return error
 
@@ -96,16 +130,48 @@ def get_import_errors(
         ),
     ],
     session: SessionDep,
+    user: GetUserDep,
 ) -> ImportErrorCollectionResponse:
     """Get all import errors."""
+    statement = select(ParseImportError)
     import_errors_select, total_entries = paginated_select(
-        statement=select(ParseImportError),
+        statement=statement,
         order_by=order_by,
         offset=offset,
         limit=limit,
         session=session,
     )
+
+    auth_manager = get_auth_manager()
+    can_read_all_dags = auth_manager.is_authorized_dag(method="GET", user=user)
+    if not can_read_all_dags:
+        # if the user doesn't have access to all DAGs, only display errors from visible DAGs
+        readable_dag_ids = auth_manager.get_permitted_dag_ids(method="GET", user=user)
+        dagfiles_stmt = select(DagModel.fileloc).distinct().where(DagModel.dag_id.in_(readable_dag_ids))
+        statement = statement.where(ParseImportError.filename.in_(dagfiles_stmt))
+        import_errors_select, total_entries = paginated_select(
+            statement=statement,
+            order_by=order_by,
+            offset=offset,
+            limit=limit,
+            session=session,
+        )
+
     import_errors = session.scalars(import_errors_select)
+    if not can_read_all_dags:
+        for import_error in import_errors:
+            # Check if user has read access to all the DAGs defined in the file
+            file_dag_ids = get_file_dag_ids(session, import_error.filename)
+            requests: Sequence[IsAuthorizedDagRequest] = [
+                {
+                    "method": "GET",
+                    "details": DagDetails(id=dag_id),
+                }
+                for dag_id in file_dag_ids
+            ]
+            if not auth_manager.batch_is_authorized_dag(requests, user=user):
+                session.expunge(import_error)
+                import_error.stacktrace = "REDACTED - you do not have read permission on all DAGs in the file"
 
     return ImportErrorCollectionResponse(
         import_errors=import_errors,

--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -311,19 +311,6 @@ def requires_access_asset_alias(method: ResourceMethod) -> Callable:
     return inner
 
 
-def requires_access_view(access_view: AccessView) -> Callable[[BaseUser | None], None]:
-    def inner(
-        user: Annotated[BaseUser | None, Depends(get_user)] = None,
-    ) -> None:
-        _requires_access(
-            is_authorized_callback=lambda: get_auth_manager().is_authorized_view(
-                access_view=access_view, user=user
-            ),
-        )
-
-    return inner
-
-
 def _requires_access(
     *,
     is_authorized_callback: Callable[[], bool],

--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -311,6 +311,19 @@ def requires_access_asset_alias(method: ResourceMethod) -> Callable:
     return inner
 
 
+def requires_access_view(access_view: AccessView) -> Callable[[BaseUser | None], None]:
+    def inner(
+        user: Annotated[BaseUser | None, Depends(get_user)] = None,
+    ) -> None:
+        _requires_access(
+            is_authorized_callback=lambda: get_auth_manager().is_authorized_view(
+                access_view=access_view, user=user
+            ),
+        )
+
+    return inner
+
+
 def _requires_access(
     *,
     is_authorized_callback: Callable[[], bool],

--- a/tests/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/tests/api_fastapi/core_api/routes/public/test_import_error.py
@@ -24,7 +24,7 @@ import pytest
 
 from airflow.models import DagModel
 from airflow.models.errors import ParseImportError
-from airflow.utils.session import provide_session
+from airflow.utils.session import NEW_SESSION, provide_session
 
 from tests_common.test_utils.db import clear_db_dags, clear_db_import_errors
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu_without_ms
@@ -50,7 +50,7 @@ BUNDLE_NAME = "dag_maker"
 
 @pytest.fixture(scope="class")
 @provide_session
-def permitted_dag_model(session: Session | None = None) -> DagModel:
+def permitted_dag_model(session: Session = NEW_SESSION) -> DagModel:
     dag_model = DagModel(fileloc=FILENAME1, dag_id="dag_id1", is_paused=False)
     session.add(dag_model)
     session.commit()
@@ -59,7 +59,7 @@ def permitted_dag_model(session: Session | None = None) -> DagModel:
 
 @pytest.fixture(scope="class")
 @provide_session
-def not_permitted_dag_model(session: Session | None = None) -> DagModel:
+def not_permitted_dag_model(session: Session = NEW_SESSION) -> DagModel:
     dag_model = DagModel(fileloc=FILENAME1, dag_id="dag_id4", is_paused=False)
     session.add(dag_model)
     session.commit()
@@ -79,7 +79,7 @@ def clear_db():
 
 @pytest.fixture(autouse=True, scope="class")
 @provide_session
-def import_errors(session: Session | None = None) -> list[ParseImportError]:
+def import_errors(session: Session = NEW_SESSION) -> list[ParseImportError]:
     _import_errors = [
         ParseImportError(
             bundle_name=BUNDLE_NAME,

--- a/tests/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/tests/api_fastapi/core_api/routes/public/test_import_error.py
@@ -129,6 +129,16 @@ class TestGetImportError(TestImportErrorEndpoint):
         }
         assert response.json() == expected_json
 
+    def test_should_raises_401_unauthenticated(self, unauthenticated_test_client, setup):
+        import_error_id = setup[FILENAME1].id
+        response = unauthenticated_test_client.get(f"/public/importErrors/{import_error_id}")
+        assert response.status_code == 401
+
+    def test_should_raises_403_unauthorized(self, unauthorized_test_client, setup):
+        import_error_id = setup[FILENAME1].id
+        response = unauthorized_test_client.get(f"/public/importErrors/{import_error_id}")
+        assert response.status_code == 403
+
 
 class TestGetImportErrors(TestImportErrorEndpoint):
     @pytest.mark.parametrize(
@@ -225,3 +235,11 @@ class TestGetImportErrors(TestImportErrorEndpoint):
         assert [
             import_error["filename"] for import_error in response_json["import_errors"]
         ] == expected_filenames
+
+    def test_should_raises_401_unauthenticated(self, unauthenticated_test_client):
+        response = unauthenticated_test_client.get("/public/importErrors")
+        assert response.status_code == 401
+
+    def test_should_raises_403_unauthorized(self, unauthorized_test_client):
+        response = unauthorized_test_client.get("/public/importErrors")
+        assert response.status_code == 403


### PR DESCRIPTION
related: #42360 

### What

I have added the `requires_access_dag` dependency for the Import Error endpoints as well.

~However, the implementation still depends on the ongoing discussion in https://github.com/apache/airflow/pull/47062#discussion_r1975669524. ( I'm not sure if such granularity is needed for the Simple Auth Manager. If it is, I will add the necessary logic for `get_readable_dags` as well.  )~

~For reference, here are the Import Error implementations in the Legacy API:  
https://github.com/apache/airflow/blob/v2-10-test/airflow/api_connexion/endpoints/import_error_endpoint.py~

**Update**:
Yes, we should respect `readable_dag_ids`, so this PR is still depends on [AIP-84 | Add Auth for Dags #47433](https://github.com/apache/airflow/pull/47433) as it introduce `ReadableDagsFilterDep`.
