### PR TITLE
AIP-84 | Add Auth for Job

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3941,6 +3941,8 @@ paths:
       summary: Get Jobs
       description: Get all jobs.
       operationId: get_jobs
+      security:
+      - OAuth2PasswordBearer: []
       parameters:
       - name: is_alive
         in: query

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -39,6 +39,7 @@ from airflow.api_fastapi.core_api.datamodels.job import (
     JobCollectionResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.security import AccessView, requires_access_view
 from airflow.jobs.job import Job
 from airflow.utils.state import JobState
 
@@ -48,6 +49,7 @@ job_router = AirflowRouter(tags=["Job"], prefix="/jobs")
 @job_router.get(
     "",
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST]),
+    dependencies=[Depends(requires_access_view(AccessView.JOBS))],
 )
 def get_jobs(
     start_date_range: Annotated[

--- a/tests/api_fastapi/core_api/routes/public/test_job.py
+++ b/tests/api_fastapi/core_api/routes/public/test_job.py
@@ -163,3 +163,11 @@ class TestGetJobs(TestJobEndpoint):
                 "unixname": self.scheduler_jobs[idx].unixname,
             }
             assert resp_job == expected_job
+
+    def test_should_raises_401_unauthenticated(self, unauthenticated_test_client):
+        response = unauthenticated_test_client.get("/public/jobs")
+        assert response.status_code == 401
+
+    def test_should_raises_403_unauthorized(self, unauthorized_test_client):
+        response = unauthorized_test_client.get("/public/jobs")
+        assert response.status_code == 403


### PR DESCRIPTION

related: #42360 


### What  

The Legacy API does not have Job endpoints, and `AccessView.JOBS` is only used in the `www` (as introduced in #35000 ).  

For now, I have assigned `Job` to `requires_access_view` to align with the existing usage.
However, we could also consider adding `JOB` to `DagAccessEntity` or defining it as a separate entity.
