### PR TITLE
Fix scheduler crash due to comparing Nullable value in query

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -859,6 +859,8 @@ class DagRun(Base, LoggingMixin):
         :param session: SQLAlchemy ORM Session
         """
         dag_run = session.get(DagRun, dag_run_id)
+        if not dag_run.logical_date:
+            return None
         return session.scalar(
             select(DagRun)
             .where(


### PR DESCRIPTION
Before using < for DR.logical_date in query, check if logical_date is not null.

closes: https://github.com/apache/airflow/issues/47296