### PR TITLE
Move `airflow.www.auth` to `airflow.providers.fab.www.auth`

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -153,7 +153,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("airflow/api/file.py",),
                 {
-                    "selected-providers-list-as-string": "amazon common.compat fab",
+                    "selected-providers-list-as-string": "amazon common.compat databricks edge fab",
                     "all-python-versions": "['3.9']",
                     "all-python-versions-list-as-string": "3.9",
                     "python-versions": "['3.9']",
@@ -168,8 +168,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "mypy-docs,mypy-providers,mypy-task-sdk,ts-compile-format-lint-ui",
                     "upgrade-to-newer-dependencies": "false",
                     "core-test-types-list-as-string": "API Always",
-                    "providers-test-types-list-as-string": "Providers[amazon] Providers[common.compat,fab]",
-                    "individual-providers-test-types-list-as-string": "Providers[amazon] Providers[common.compat] Providers[fab]",
+                    "providers-test-types-list-as-string": "Providers[amazon] Providers[common.compat,databricks,edge,fab]",
+                    "individual-providers-test-types-list-as-string": "Providers[amazon] Providers[common.compat] Providers[databricks] Providers[edge] Providers[fab]",
                     "testable-core-integrations": "['celery', 'kerberos']",
                     "testable-providers-integrations": "['cassandra', 'drill', 'kafka', 'mongo', 'pinot', 'qdrant', 'redis', 'trino', 'ydb']",
                     "needs-mypy": "true",
@@ -318,7 +318,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "providers/postgres/tests/unit/postgres/file.py",
                 ),
                 {
-                    "selected-providers-list-as-string": "amazon common.compat common.sql fab google openlineage "
+                    "selected-providers-list-as-string": "amazon common.compat common.sql databricks edge fab google openlineage "
                     "pgvector postgres",
                     "all-python-versions": "['3.9']",
                     "all-python-versions-list-as-string": "3.9",
@@ -335,9 +335,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "upgrade-to-newer-dependencies": "false",
                     "core-test-types-list-as-string": "API Always",
                     "providers-test-types-list-as-string": "Providers[amazon] "
-                    "Providers[common.compat,common.sql,fab,openlineage,pgvector,postgres] Providers[google]",
+                    "Providers[common.compat,common.sql,databricks,edge,fab,openlineage,pgvector,postgres] Providers[google]",
                     "individual-providers-test-types-list-as-string": "Providers[amazon] Providers[common.compat] Providers[common.sql] "
-                    "Providers[fab] Providers[google] Providers[openlineage] Providers[pgvector] "
+                    "Providers[databricks] Providers[edge] Providers[fab] Providers[google] Providers[openlineage] Providers[pgvector] "
                     "Providers[postgres]",
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-airflow', 'mypy-providers']",

--- a/docs/apache-airflow/administration-and-deployment/plugins.rst
+++ b/docs/apache-airflow/administration-and-deployment/plugins.rst
@@ -163,7 +163,7 @@ definitions in Airflow.
     # This is the class you derive to create a plugin
     from airflow.plugins_manager import AirflowPlugin
     from airflow.security import permissions
-    from airflow.www.auth import has_access
+    from airflow.providers.fab.www.auth import has_access
 
     from fastapi import FastAPI
     from flask import Blueprint

--- a/docs/apache-airflow/empty_plugin/empty_plugin.py
+++ b/docs/apache-airflow/empty_plugin/empty_plugin.py
@@ -24,7 +24,7 @@ from flask_appbuilder import BaseView, expose
 
 from airflow.auth.managers.models.resource_details import AccessView
 from airflow.plugins_manager import AirflowPlugin
-from airflow.www.auth import has_access_view
+from airflow.providers.fab.www.auth import has_access_view
 
 
 class EmptyPluginView(BaseView):

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -464,7 +464,8 @@
       }
     ],
     "cross-providers-deps": [
-      "common.sql"
+      "common.sql",
+      "fab"
     ],
     "excluded-python-versions": [],
     "state": "ready"
@@ -549,7 +550,9 @@
         "plugin-class": "airflow.providers.edge.plugins.edge_executor_plugin.EdgeExecutorPlugin"
       }
     ],
-    "cross-providers-deps": [],
+    "cross-providers-deps": [
+      "fab"
+    ],
     "excluded-python-versions": [],
     "state": "not-ready"
   },

--- a/newsfragments/aip-79.significant.rst
+++ b/newsfragments/aip-79.significant.rst
@@ -34,6 +34,8 @@ As part of this change the following breaking changes have occurred:
     - ``batch_is_authorized_pool``
     - ``batch_is_authorized_variable``
 
+- The module ``airflow.www.auth`` has been moved to ``airflow.providers.fab.www.auth``
+
 * Types of change
 
   * [ ] Dag changes

--- a/providers/databricks/README.rst
+++ b/providers/databricks/README.rst
@@ -80,6 +80,7 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                             Extra
 ============================================================================================================  ==============
 `apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
+`apache-airflow-providers-fab <https://airflow.apache.org/docs/apache-airflow-providers-fab>`_                ``fab``
 ============================================================================================================  ==============
 
 The changelog for the provider package can be found in the

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -77,6 +77,9 @@ dependencies = [
 "azure-identity" = [
     "azure-identity>=1.3.1",
 ]
+"fab" = [
+    "apache-airflow-providers-fab"
+]
 
 # The dependency groups should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated

--- a/providers/databricks/src/airflow/providers/databricks/get_provider_info.py
+++ b/providers/databricks/src/airflow/providers/databricks/get_provider_info.py
@@ -189,6 +189,7 @@ def get_provider_info():
         "optional-dependencies": {
             "sdk": ["databricks-sdk==0.10.0"],
             "azure-identity": ["azure-identity>=1.3.1"],
+            "fab": ["apache-airflow-providers-fab"],
         },
         "devel-dependencies": ["deltalake>=0.12.0"],
     }

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -34,11 +34,16 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.models.xcom import XCom
 from airflow.plugins_manager import AirflowPlugin
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
+from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.providers.fab.www import auth
+else:
+    from airflow.www import auth  # type: ignore
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.task_group import TaskGroup
-from airflow.www import auth
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session

--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -58,5 +58,24 @@ PIP package         Version required
 ``retryhttp``       ``>=1.2.0,!=1.3.0``
 ==================  ===================
 
+Cross provider package dependencies
+-----------------------------------
+
+Those are dependencies that might be needed in order to use all the features of the package.
+You need to install the specified provider packages in order to use them.
+
+You can install such cross-provider dependencies when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-edge[fab]
+
+
+==============================================================================================  =======
+Dependent package                                                                               Extra
+==============================================================================================  =======
+`apache-airflow-providers-fab <https://airflow.apache.org/docs/apache-airflow-providers-fab>`_  ``fab``
+==============================================================================================  =======
+
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/changelog.html>`_.

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -62,6 +62,13 @@ dependencies = [
     "retryhttp>=1.2.0,!=1.3.0",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"fab" = [
+    "apache-airflow-providers-fab"
+]
+
 [project.urls]
 "Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0"
 "Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/changelog.html"

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -100,4 +100,5 @@ def get_provider_info():
             }
         },
         "dependencies": ["apache-airflow>=2.10.0", "pydantic>=2.10.2", "retryhttp>=1.2.0,!=1.3.0"],
+        "optional-dependencies": {"fab": ["apache-airflow-providers-fab"]},
     }

--- a/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
+++ b/providers/edge/src/airflow/providers/edge/plugins/edge_executor_plugin.py
@@ -32,10 +32,14 @@ from airflow.exceptions import AirflowConfigException
 from airflow.models.taskinstance import TaskInstanceState
 from airflow.plugins_manager import AirflowPlugin
 from airflow.providers.edge.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.providers.fab.www.auth import has_access_view
+else:
+    from airflow.www.auth import has_access_view  # type: ignore
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.yaml import safe_load
 from airflow.www import utils as wwwutils
-from airflow.www.auth import has_access_view
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/providers/fab/src/airflow/providers/fab/www/auth.py
+++ b/providers/fab/src/airflow/providers/fab/www/auth.py
@@ -155,7 +155,7 @@ def _has_access(*, is_authorized: bool, func: Callable, args, kwargs):
     else:
         access_denied = get_access_denied_message()
         flash(access_denied, "danger")
-    return redirect(url_for("Airflow.index"))
+    return redirect(url_for("FabIndexView.index"))
 
 
 def has_access_configuration(method: ResourceMethod) -> Callable[[T], T]:

--- a/providers/fab/tests/unit/fab/www/test_auth.py
+++ b/providers/fab/tests/unit/fab/www/test_auth.py
@@ -21,11 +21,17 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-import airflow.www.auth as auth
+import airflow.providers.fab.www.auth as auth
 from airflow.auth.managers.models.resource_details import DagAccessEntity
 from airflow.models import Connection, Pool, Variable
+from airflow.providers.fab.www import app as application
 
 mock_call = Mock()
+
+
+@pytest.fixture
+def app():
+    return application.create_app(enable_plugins=False)
 
 
 @pytest.mark.parametrize(
@@ -44,7 +50,7 @@ class TestHasAccessNoDetails:
         mock_call()
         return True
 
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_no_details_when_authorized(
         self, mock_get_auth_manager, decorator_name, is_authorized_method_name
     ):
@@ -59,8 +65,8 @@ class TestHasAccessNoDetails:
         mock_call.assert_called_once()
         assert result is True
 
-    @patch("airflow.www.auth.get_auth_manager")
-    @patch("airflow.www.auth.render_template")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.render_template")
     def test_has_access_no_details_when_no_permission(
         self, mock_render_template, mock_get_auth_manager, decorator_name, is_authorized_method_name
     ):
@@ -78,7 +84,7 @@ class TestHasAccessNoDetails:
         mock_render_template.assert_called_once()
 
     @pytest.mark.db_test
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_no_details_when_not_logged_in(
         self, mock_get_auth_manager, app, decorator_name, is_authorized_method_name
     ):
@@ -132,7 +138,7 @@ class TestHasAccessWithDetails:
         mock_call()
         return True
 
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_with_details_when_authorized(
         self, mock_get_auth_manager, decorator_name, is_authorized_method_name, items, request
     ):
@@ -149,7 +155,7 @@ class TestHasAccessWithDetails:
         assert result is True
 
     @pytest.mark.db_test
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_with_details_when_unauthorized(
         self, mock_get_auth_manager, app, decorator_name, is_authorized_method_name, items, request
     ):
@@ -184,7 +190,7 @@ class TestHasAccessDagEntities:
         mock_call()
         return True
 
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_dag_entities_when_authorized(self, mock_get_auth_manager, dag_access_entity):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_dag.return_value = True
@@ -197,7 +203,7 @@ class TestHasAccessDagEntities:
         assert result is True
 
     @pytest.mark.db_test
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_dag_entities_when_unauthorized(self, mock_get_auth_manager, app, dag_access_entity):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_dag.return_value = False
@@ -208,10 +214,10 @@ class TestHasAccessDagEntities:
             result = auth.has_access_dag_entities("GET", dag_access_entity)(self.method_test)(None, items)
 
         mock_call.assert_not_called()
-        assert result.headers["Location"] == "/home"
+        assert result.headers["Location"] == "/"
 
     @pytest.mark.db_test
-    @patch("airflow.www.auth.get_auth_manager")
+    @patch("airflow.providers.fab.www.auth.get_auth_manager")
     def test_has_access_dag_entities_when_logged_out(self, mock_get_auth_manager, app, dag_access_entity):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_dag.return_value = False


### PR DESCRIPTION
`airflow.www.auth` is used a lot by plugins but because it relies on Flask, we should not keep it in main. We should have it in FAB provider.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
