### PR TITLE
Handle token expired for UI to redirect to login page

### DIFF
--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Annotated, Callable
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
-from jwt import InvalidTokenError
+from jwt import ExpiredSignatureError, InvalidTokenError
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.auth.managers.models.base_user import BaseUser
@@ -47,6 +47,8 @@ def get_signer() -> JWTSigner:
 def get_user(token_str: Annotated[str, Depends(oauth2_scheme)]) -> BaseUser:
     try:
         return get_auth_manager().get_user_from_token(token_str)
+    except ExpiredSignatureError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Token Expired")
     except InvalidTokenError:
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
 
@@ -54,15 +56,10 @@ def get_user(token_str: Annotated[str, Depends(oauth2_scheme)]) -> BaseUser:
 async def get_user_with_exception_handling(request: Request) -> BaseUser | None:
     # Currently the UI does not support JWT authentication, this method defines a fallback if no token is provided by the UI.
     # We can remove this method when issue https://github.com/apache/airflow/issues/44884 is done.
-    try:
-        token_str = await oauth2_scheme(request)
-        if not token_str:  # Handle None or empty token
-            return None
-        return get_user(token_str)
-    except HTTPException as e:
-        if e.status_code == status.HTTP_401_UNAUTHORIZED:
-            return None
-        raise e
+    token_str = await oauth2_scheme(request)
+    if not token_str:  # Handle None or empty token
+        return None
+    return get_user(token_str)
 
 
 def requires_access_dag(method: ResourceMethod, access_entity: DagAccessEntity | None = None) -> Callable:


### PR DESCRIPTION
Disssociate the `ExpiredSignatureError` error handling from the broader `InvalidTokenError`. This will return a 401, as recommended in the [rfc6750](https://datatracker.ietf.org/doc/html/rfc6750). This will be clearer for API users, and also will allow the UI to automatically redirect to the `login` page on token expired.