### PR TITLE
Add custom svg for backfill icon

### DIFF
--- a/airflow/ui/src/components/BackfillIcon.tsx
+++ b/airflow/ui/src/components/BackfillIcon.tsx
@@ -1,0 +1,36 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { createIcon } from "@chakra-ui/react";
+
+export const BackfillIcon = createIcon({
+  defaultProps: {
+    height: "1.5em",
+    width: "1.5em",
+  },
+  displayName: "Backfill",
+  path: (
+    <path
+      clipRule="evenodd"
+      d="M20.5 3.5v17a1 1 0 0 1-1 1h-3.278c-.562 0-.722-.541-.722-1.25V3.75c0-.709.16-1.25.722-1.25H19.5a1 1 0 0 1 1 1Zm-6 0v17a1 1 0 0 1-1 1h-3.278c-.562 0-.722-.541-.722-1.25V3.75c0-.709.16-1.25.722-1.25H13.5a1 1 0 0 1 1 1Zm-6 16.1v-1h-1v1h1Zm-1 .9h-.003v1H7.5a1 1 0 0 0 .995-.9H7.5v-.1Zm-1.003 1v-1h-1v1h1Zm-2 0v-1h-.99c.038.582.222 1 .715 1h.275ZM3.5 19.507h1v-.994h-1v.994Zm0-1.987h1v-.994h-1v.994Zm0-1.987h1v-.993h-1v.993Zm0-1.986h1v-.994h-1v.994Zm0-1.987h1v-.994h-1v.994Zm0-1.987h1V8.58h-1v.993Zm0-1.986h1v-.994h-1v.994Zm0-1.987h1v-.907h-1V5.6Zm0-1.9h1v-.2h-.003v-1h-.275c-.548 0-.714.516-.722 1.2Zm1.997-1.2v1h1v-1h-1Zm2 0v1H7.5v.1h1v-.1a1 1 0 0 0-1-1h-.003ZM8.5 4.6h-1v1h1v-1Zm0 2h-1v1h1v-1Zm0 2h-1v1h1v-1Zm0 2h-1v1h1v-1Zm0 2h-1v1h1v-1Zm0 2h-1v1h1v-1Zm0 2h-1v1h1v-1Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  ),
+  viewBox: "0 0 24 24",
+});

--- a/airflow/ui/src/components/Menu/RunBackfillButton.tsx
+++ b/airflow/ui/src/components/Menu/RunBackfillButton.tsx
@@ -18,7 +18,6 @@
  */
 import { Box } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
-import { TbArrowBackUpDouble } from "react-icons/tb";
 
 import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
@@ -29,13 +28,30 @@ type Props = {
   readonly dag: DAGResponse | DAGWithLatestDagRunsResponse;
 };
 
+const BackfillIcon = () => (
+  <svg
+    fill="none"
+    height="100"
+    stroke="black"
+    strokeWidth="5"
+    viewBox="0 0 100 100"
+    width="100"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    {/* Grid structure */}
+    <rect fill="white" height="80" strokeDasharray="20 10" width="20" x="10" y="10" />
+    <rect fill="black" height="80" width="20" x="40" y="10" />
+    <rect fill="black" height="80" width="20" x="70" y="10" />
+  </svg>
+);
+
 const RunBackfillButton: React.FC<Props> = ({ dag }) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   return (
     <Box>
       <Button aria-label="Run Backfill" border="none" height={5} onClick={onOpen} variant="ghost">
-        <TbArrowBackUpDouble />
+        <BackfillIcon />
         Run Backfill
       </Button>
       <RunBackfillModal dag={dag} onClose={onClose} open={open} />

--- a/airflow/ui/src/components/Menu/RunBackfillButton.tsx
+++ b/airflow/ui/src/components/Menu/RunBackfillButton.tsx
@@ -20,6 +20,7 @@ import { Box } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
 
 import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import { BackfillIcon } from "src/components/BackfillIcon.tsx";
 
 import { Button } from "../ui";
 import RunBackfillModal from "./RunBackfillModal";
@@ -27,23 +28,6 @@ import RunBackfillModal from "./RunBackfillModal";
 type Props = {
   readonly dag: DAGResponse | DAGWithLatestDagRunsResponse;
 };
-
-const BackfillIcon = () => (
-  <svg
-    fill="none"
-    height="100"
-    stroke="black"
-    strokeWidth="5"
-    viewBox="0 0 100 100"
-    width="100"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    {/* Grid structure */}
-    <rect fill="white" height="80" strokeDasharray="20 10" width="20" x="10" y="10" />
-    <rect fill="black" height="80" width="20" x="40" y="10" />
-    <rect fill="black" height="80" width="20" x="70" y="10" />
-  </svg>
-);
 
 const RunBackfillButton: React.FC<Props> = ({ dag }) => {
   const { onClose, onOpen, open } = useDisclosure();


### PR DESCRIPTION
Add an icon that does a little better job of representing a backfill

old: 

<img width="119" alt="image" src="https://github.com/user-attachments/assets/c739b3f4-f617-432f-93a7-b2462f19e09d" />

new:

<img width="496" alt="image" src="https://github.com/user-attachments/assets/c966f519-a2dd-4e35-8dd5-e9ab4a985e19" />


Not sure if this is ok to do or if better way.