### PR TITLE
Restrict pymongo to less than 4.11 for our CI

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -910,7 +910,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "dnspython>=1.13.0",
-      "pymongo>=4.0.0,<=4.11"
+      "pymongo>=4.0.0,<4.11"
     ],
     "devel-deps": [
       "mongomock>=4.0.0"

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -910,7 +910,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "dnspython>=1.13.0",
-      "pymongo>=4.0.0,!=4.11,!=4.11.1"
+      "pymongo>=4.0.0,!=4.11,!=4.11.1,!=4.11.2"
     ],
     "devel-deps": [
       "mongomock>=4.0.0"

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -910,7 +910,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "dnspython>=1.13.0",
-      "pymongo>=4.0.0,!=4.11,!=4.11.1,!=4.11.2"
+      "pymongo>=4.0.0,<=4.11"
     ],
     "devel-deps": [
       "mongomock>=4.0.0"

--- a/providers/mongo/README.rst
+++ b/providers/mongo/README.rst
@@ -55,7 +55,7 @@ PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.9.0``
 ``dnspython``       ``>=1.13.0``
-``pymongo``         ``>=4.0.0,<=4.11``
+``pymongo``         ``>=4.0.0,<4.11``
 ==================  ==================
 
 The changelog for the provider package can be found in the

--- a/providers/mongo/README.rst
+++ b/providers/mongo/README.rst
@@ -50,13 +50,13 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-==================  ===========================
+==================  ====================================
 PIP package         Version required
-==================  ===========================
+==================  ====================================
 ``apache-airflow``  ``>=2.9.0``
 ``dnspython``       ``>=1.13.0``
-``pymongo``         ``>=4.0.0,!=4.11,!=4.11.1``
-==================  ===========================
+``pymongo``         ``>=4.0.0,!=4.11,!=4.11.1,!=4.11.2``
+==================  ====================================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-mongo/5.0.1/changelog.html>`_.

--- a/providers/mongo/README.rst
+++ b/providers/mongo/README.rst
@@ -50,13 +50,13 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-==================  ====================================
+==================  ==================
 PIP package         Version required
-==================  ====================================
+==================  ==================
 ``apache-airflow``  ``>=2.9.0``
 ``dnspython``       ``>=1.13.0``
-``pymongo``         ``>=4.0.0,!=4.11,!=4.11.1,!=4.11.2``
-==================  ====================================
+``pymongo``         ``>=4.0.0,<=4.11``
+==================  ==================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-mongo/5.0.1/changelog.html>`_.

--- a/providers/mongo/pyproject.toml
+++ b/providers/mongo/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # pymongo 4.11 had incompatible change leading to
     # TypeError: BulkOperationBuilder.add_replace() got an unexpected keyword argument 'sort'
     # See https://github.com/apache/airflow/issues/46215
-    "pymongo>=4.0.0,<=4.11",
+    "pymongo>=4.0.0,<4.11",
 ]
 
 # The dependency groups should be modified in place in the generated file

--- a/providers/mongo/pyproject.toml
+++ b/providers/mongo/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # pymongo 4.11 had incompatible change leading to
     # TypeError: BulkOperationBuilder.add_replace() got an unexpected keyword argument 'sort'
     # See https://github.com/apache/airflow/issues/46215
-    "pymongo>=4.0.0,!=4.11,!=4.11.1,!=4.11.2",
+    "pymongo>=4.0.0,<=4.11",
 ]
 
 # The dependency groups should be modified in place in the generated file

--- a/providers/mongo/pyproject.toml
+++ b/providers/mongo/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # pymongo 4.11 had incompatible change leading to
     # TypeError: BulkOperationBuilder.add_replace() got an unexpected keyword argument 'sort'
     # See https://github.com/apache/airflow/issues/46215
-    "pymongo>=4.0.0,!=4.11,!=4.11.1",
+    "pymongo>=4.0.0,!=4.11,!=4.11.1,!=4.11.2",
 ]
 
 # The dependency groups should be modified in place in the generated file

--- a/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
+++ b/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
@@ -73,10 +73,6 @@ def get_provider_info():
         "connection-types": [
             {"hook-class-name": "airflow.providers.mongo.hooks.mongo.MongoHook", "connection-type": "mongo"}
         ],
-        "dependencies": [
-            "apache-airflow>=2.9.0",
-            "dnspython>=1.13.0",
-            "pymongo>=4.0.0,!=4.11,!=4.11.1,!=4.11.2",
-        ],
+        "dependencies": ["apache-airflow>=2.9.0", "dnspython>=1.13.0", "pymongo>=4.0.0,<=4.11"],
         "devel-dependencies": ["mongomock>=4.0.0"],
     }

--- a/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
+++ b/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
@@ -73,6 +73,6 @@ def get_provider_info():
         "connection-types": [
             {"hook-class-name": "airflow.providers.mongo.hooks.mongo.MongoHook", "connection-type": "mongo"}
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "dnspython>=1.13.0", "pymongo>=4.0.0,<=4.11"],
+        "dependencies": ["apache-airflow>=2.9.0", "dnspython>=1.13.0", "pymongo>=4.0.0,<4.11"],
         "devel-dependencies": ["mongomock>=4.0.0"],
     }

--- a/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
+++ b/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
@@ -73,6 +73,10 @@ def get_provider_info():
         "connection-types": [
             {"hook-class-name": "airflow.providers.mongo.hooks.mongo.MongoHook", "connection-type": "mongo"}
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "dnspython>=1.13.0", "pymongo>=4.0.0,!=4.11,!=4.11.1"],
+        "dependencies": [
+            "apache-airflow>=2.9.0",
+            "dnspython>=1.13.0",
+            "pymongo>=4.0.0,!=4.11,!=4.11.1,!=4.11.2",
+        ],
         "devel-dependencies": ["mongomock>=4.0.0"],
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We ran into https://github.com/apache/airflow/issues/46215 again. 4.11.2 breaks CI, restritcing it.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
