### PR TITLE
Decrease size of docker context by two orders of magnitude

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -80,9 +80,10 @@
 
 # Git version is dynamically generated
 airflow/git_version
-airflow/ui/node_modules
-airflow/auth/managers/simple/ui/node_modules
 
+# Exclude node/pmpme caches..
+**/.pnpm-store
+**/node_modules
 # Exclude link to docs
 airflow/ui/static/docs
 
@@ -90,6 +91,14 @@ airflow/ui/static/docs
 airflow/www/static/docs
 airflow/www/static/dist
 airflow/www/node_modules
+
+# Exclude any .venv and .ruff_cache
+**/.venv
+**/.ruff_cache/
+
+# Exclude docs artifacts
+**/_inventory_cache/
+docs/**/_api/**
 
 # Exclude python generated files
 **/__pycache__/
@@ -99,7 +108,7 @@ airflow/www/node_modules
 **/env/
 **/build/
 **/develop-eggs/
-/dist/
+**/dist/
 **/downloads/
 **/eggs/
 **/.eggs/

--- a/dev/MANUALLY_BUILDING_IMAGES.md
+++ b/dev/MANUALLY_BUILDING_IMAGES.md
@@ -22,6 +22,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Building docker images](#building-docker-images)
+- [Keeping your docker context small](#keeping-your-docker-context-small)
 - [Setting environment with emulation](#setting-environment-with-emulation)
 - [Setting up cache refreshing with hardware ARM/AMD support](#setting-up-cache-refreshing-with-hardware-armamd-support)
 
@@ -36,6 +37,31 @@ you do not have those two installed.
 
 You also need to have the right permissions to push the images, so you should run
 `docker login` before and authenticate with your DockerHub token.
+
+## Keeping your docker context small
+
+Sometimes, especially when you generate node assets, some of the files generated are kept in the source
+directory. This can make the docker context very large when building images, because the whole context
+is transferred to the docker daemon. In order to avoid this we have .dockerignore where we exclude certain
+paths from being treated as part of the context - similar to .gitignore that keeps them away from git.
+
+If your context gets large you see a long (minutes) preliminary step before dockeer build is run
+where the context is being transmitted.
+
+You can see all the context files by running:
+
+```shell script
+printf 'FROM scratch\nCOPY . /' | DOCKER_BUILDKIT=1 docker build -q -f- -o- . | tar t
+```
+
+Once you see something that should be excluded from the context, you should add it to `.dockerignore` file.
+
+You can also check the size of the context by running:
+
+```shell script
+printf 'FROM scratch\nCOPY . /' | DOCKER_BUILDKIT=1 docker build -q -f- -o- . | wc -c | numfmt --to=iec --suffix=B
+```
+
 
 ## Setting environment with emulation
 


### PR DESCRIPTION
When building docker image, local source files are sent as context. Unfortunately node and pnmp are adding a lot of cache inside the source tree and if we are not carefuly with excludin those, we end up with GBs of context being sent to docker before the build even starts (which takes minutes)

This PR removes .pnpm-store folders that were the root cause for sending 1.5GB of context. It also adds simple instructions how you can check which files are in the context and how to see the size of the context. With this change, the context is down from 1.5 GB to 90 MB - cutting docker build context sending time from ~ minute to under a second.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
