### PR TITLE
AIP-84 | Fix Merged Permission for Connections and Pools

### DIFF
--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -77,54 +77,45 @@ async def get_user_with_exception_handling(request: Request) -> BaseUser | None:
 
 def requires_access_dag(method: ResourceMethod, access_entity: DagAccessEntity | None = None) -> Callable:
     def inner(
+        user: Annotated[BaseUser, Depends(get_user)],
         dag_id: str | None = None,
-        user: Annotated[BaseUser | None, Depends(get_user)] = None,
     ) -> None:
-        def callback():
-            return get_auth_manager().is_authorized_dag(
+        _requires_access(
+            is_authorized_callback=lambda: get_auth_manager().is_authorized_dag(
                 method=method, access_entity=access_entity, details=DagDetails(id=dag_id), user=user
             )
-
-        _requires_access(
-            is_authorized_callback=callback,
         )
 
     return inner
 
 
-def requires_access_pool(method: ResourceMethod) -> Callable:
+def requires_access_pool(method: ResourceMethod) -> Callable[[Request, BaseUser], None]:
     def inner(
         request: Request,
-        user: Annotated[BaseUser | None, Depends(get_user)] = None,
+        user: Annotated[BaseUser, Depends(get_user)],
     ) -> None:
         pool_name = request.path_params.get("pool_name")
 
-        def callback():
-            return get_auth_manager().is_authorized_pool(
+        _requires_access(
+            is_authorized_callback=lambda: get_auth_manager().is_authorized_pool(
                 method=method, details=PoolDetails(name=pool_name), user=user
             )
-
-        _requires_access(
-            is_authorized_callback=callback,
         )
 
     return inner
 
 
-def requires_access_connection(method: ResourceMethod) -> Callable:
+def requires_access_connection(method: ResourceMethod) -> Callable[[Request, BaseUser], None]:
     def inner(
         request: Request,
-        user: Annotated[BaseUser | None, Depends(get_user)] = None,
+        user: Annotated[BaseUser, Depends(get_user)],
     ) -> None:
         connection_id = request.path_params.get("connection_id")
 
-        def callback():
-            return get_auth_manager().is_authorized_pool(
+        _requires_access(
+            is_authorized_callback=lambda: get_auth_manager().is_authorized_connection(
                 method=method, details=ConnectionDetails(conn_id=connection_id), user=user
             )
-
-        _requires_access(
-            is_authorized_callback=callback,
         )
 
     return inner


### PR DESCRIPTION
related: #42360 

## What

Fix #47194, #47129

- `airflow/api_fastapi/core_api/security.py`
    - Fix typo in `requires_access_connection` function ( should call `is_authorized_connection` instead of `is_authorized_pool` )
    - Use `lamda` instead of adding new callback definition in each `requires_access_<entity>`
    - Add type hint for `requires_access_<entity>` ( except for `requires_access_dag`, the #47062 PR will add type hint for the dag one )
- `tests/api_fastapi/conftest.py`
    - Retrieve auth_manger from `app.state` instead of creating a new one

