### PR TITLE
Sort version/try and update query key for dag graph

### DIFF
--- a/airflow/ui/src/components/DagVersionSelect.tsx
+++ b/airflow/ui/src/components/DagVersionSelect.tsx
@@ -48,7 +48,7 @@ const DagVersionSelect = ({ disabled = false }: { readonly disabled?: boolean })
         DagVersionService.getDagVersions({
           dagId,
         }).then((data: DAGVersionCollectionResponse) => {
-          const options = data.dag_versions.map((version: DagVersionResponse) => {
+          const options = [...data.dag_versions].reverse().map((version: DagVersionResponse) => {
             const versionNumber = version.version_number.toString();
 
             return {

--- a/airflow/ui/src/components/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/components/Graph/useGraphLayout.ts
@@ -231,9 +231,17 @@ const generateElkGraph = ({
 type LayoutProps = {
   dagId: DAGResponse["dag_id"];
   openGroupIds: Array<string>;
+  versionNumber?: number;
 } & StructureDataResponse;
 
-export const useGraphLayout = ({ arrange = "LR", dagId, edges, nodes, openGroupIds = [] }: LayoutProps) =>
+export const useGraphLayout = ({
+  arrange = "LR",
+  dagId,
+  edges,
+  nodes,
+  openGroupIds = [],
+  versionNumber,
+}: LayoutProps) =>
   useQuery({
     queryFn: async () => {
       const font = `bold 18px ${globalThis.getComputedStyle(document.body).fontFamily}`;
@@ -265,5 +273,5 @@ export const useGraphLayout = ({ arrange = "LR", dagId, edges, nodes, openGroupI
 
       return { edges: formattedEdges, nodes: flattenedData.nodes };
     },
-    queryKey: ["graphLayout", nodes.length, openGroupIds, arrange, dagId],
+    queryKey: ["graphLayout", nodes.length, openGroupIds, arrange, dagId, versionNumber, edges.length],
   });

--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -70,8 +70,13 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
   const logAttemptDropdownLimit = 10;
   const showDropdown = finalTryNumber > logAttemptDropdownLimit;
 
+  // For some reason tries aren't sorted by try_number
+  const sortedTries = [...(tiHistory?.task_instances ?? [])].sort(
+    (tryA, tryB) => tryA.try_number - tryB.try_number,
+  );
+
   const tryOptions = createListCollection({
-    items: (tiHistory?.task_instances ?? []).map((ti) => ({
+    items: sortedTries.map((ti) => ({
       task_instance: ti,
       value: ti.try_number.toString(),
     })),
@@ -119,7 +124,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
         </Select.Root>
       ) : (
         <HStack>
-          {tiHistory?.task_instances.map((ti) => (
+          {sortedTries.map((ti) => (
             <TaskInstanceTooltip key={ti.try_number} taskInstance={ti}>
               <Button
                 colorPalette="blue"

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -79,16 +79,18 @@ export const Graph = () => {
   const { openGroupIds } = useOpenGroups();
 
   const selectedColor = colorMode === "dark" ? selectedDarkColor : selectedLightColor;
+  const versionNumber = selectedVersion === undefined ? undefined : parseInt(selectedVersion, 10);
 
   const { data: graphData = { arrange: "LR", edges: [], nodes: [] } } = useStructureServiceStructureData({
     dagId,
-    versionNumber: selectedVersion === undefined ? undefined : parseInt(selectedVersion, 10),
+    versionNumber,
   });
 
   const { data } = useGraphLayout({
     ...graphData,
     dagId,
     openGroupIds,
+    versionNumber,
   });
 
   const refetchInterval = useAutoRefresh({ dagId });


### PR DESCRIPTION
Sort Dag Versions from latest->oldest
Sort Task History by try_number
Rerender the graph when changing version numbers


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
