### PR TITLE
Overview page UX improvements

### DIFF
--- a/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
@@ -24,7 +24,7 @@ import { useConfig } from "src/queries/useConfig";
 
 import { TaskLogPreview } from "./TaskLogPreview";
 
-export const FailedLogs = ({
+const FailedLogs = ({
   failedTasks,
 }: {
   readonly failedTasks: TaskInstanceCollectionResponse | undefined;
@@ -61,3 +61,5 @@ export const FailedLogs = ({
     </Flex>
   );
 };
+
+export default FailedLogs;

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -18,7 +18,7 @@
  */
 import { Box, HStack, Skeleton, SimpleGrid } from "@chakra-ui/react";
 import dayjs from "dayjs";
-import { useState } from "react";
+import { lazy, useState, Suspense } from "react";
 import { useParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRuns, useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
@@ -27,9 +27,9 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
-import { FailedLogs } from "./FailedLogs";
+const FailedLogs = lazy(() => import("./FailedLogs"));
 
-const defaultHour = "168";
+const defaultHour = "24";
 
 export const Overview = () => {
   const { dagId } = useParams();
@@ -120,7 +120,9 @@ export const Overview = () => {
           )}
         </Box>
       </SimpleGrid>
-      <FailedLogs failedTasks={failedTasks} />
+      <Suspense fallback={<Skeleton height="100px" width="full" />}>
+        <FailedLogs failedTasks={failedTasks} />
+      </Suspense>
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -34,12 +34,18 @@ export const TaskLogPreview = ({
   readonly taskInstance: TaskInstanceResponse;
   readonly wrap: boolean;
 }) => {
-  const { data, error, isLoading } = useLogs({
-    dagId: taskInstance.dag_id,
-    logLevelFilters: ["warning", "error", "critical"],
-    taskInstance,
-    tryNumber: taskInstance.try_number,
-  });
+  const { data, error, isLoading } = useLogs(
+    {
+      dagId: taskInstance.dag_id,
+      logLevelFilters: ["error", "critical"],
+      taskInstance,
+      tryNumber: taskInstance.try_number,
+    },
+    {
+      refetchInterval: false,
+      retry: false,
+    },
+  );
 
   return (
     <Box borderRadius={4} borderStyle="solid" borderWidth={1} key={taskInstance.id} width="100%">

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -30,7 +30,7 @@ import { DagRunMetrics } from "./DagRunMetrics";
 import { MetricSectionSkeleton } from "./MetricSectionSkeleton";
 import { TaskInstanceMetrics } from "./TaskInstanceMetrics";
 
-const defaultHour = "168";
+const defaultHour = "24";
 
 export const HistoricalMetrics = () => {
   const now = dayjs();

--- a/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -27,7 +27,7 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
-const defaultHour = "168";
+const defaultHour = "24";
 
 export const Overview = () => {
   const { dagId = "", taskId } = useParams();

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Badge } from "@chakra-ui/react";
+import type { UseQueryOptions } from "@tanstack/react-query";
 import dayjs from "dayjs";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
@@ -124,7 +125,10 @@ const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
   };
 };
 
-export const useLogs = ({ dagId, logLevelFilters, taskInstance, tryNumber = 1 }: Props) => {
+export const useLogs = (
+  { dagId, logLevelFilters, taskInstance, tryNumber = 1 }: Props,
+  options?: Omit<UseQueryOptions<TaskInstancesLogResponse>, "queryFn" | "queryKey">,
+) => {
   const refetchInterval = useAutoRefresh({ dagId });
 
   const { data, ...rest } = useTaskInstanceServiceGetLog(
@@ -143,6 +147,7 @@ export const useLogs = ({ dagId, logLevelFilters, taskInstance, tryNumber = 1 }:
         dayjs(query.state.dataUpdatedAt).isBefore(taskInstance?.end_date)
           ? refetchInterval
           : false,
+      ...options,
     },
   );
 


### PR DESCRIPTION
Move our default time range for dashboard pages from 1 week to 1 day. One week was only for initial development

Remove `warning` logs from failed task log preview

Try to isolate Failed Task Logs from blocking the rest of the UI:
- lazy load component
- disable retry and refetch for log preview


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
