### PR TITLE
Add Dag Dependencies as option to Dag Graph view

### DIFF
--- a/airflow/ui/src/components/DagVersionSelect.tsx
+++ b/airflow/ui/src/components/DagVersionSelect.tsx
@@ -76,7 +76,7 @@ const DagVersionSelect = ({ disabled = false }: { readonly disabled?: boolean })
   );
 
   return (
-    <Field.Root disabled={disabled} width="fit-content">
+    <Field.Root bg="bg" disabled={disabled} width="fit-content">
       <AsyncSelect
         defaultOptions
         filterOption={undefined}

--- a/airflow/ui/src/components/Graph/AliasNode.tsx
+++ b/airflow/ui/src/components/Graph/AliasNode.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, Heading, HStack } from "@chakra-ui/react";
+import type { NodeProps, Node as NodeType } from "@xyflow/react";
+import { PiRectangleDashed } from "react-icons/pi";
+
+import { NodeWrapper } from "./NodeWrapper";
+import type { CustomNodeProps } from "./reactflowUtils";
+
+export const AliasNode = ({
+  data: { height, isSelected, label, width },
+}: NodeProps<NodeType<CustomNodeProps, "asset">>) => (
+  <NodeWrapper>
+    <Flex
+      bg="bg"
+      borderColor={isSelected ? "border.inverted" : "border"}
+      borderRadius={5}
+      borderWidth={isSelected ? 6 : 2}
+      cursor="default"
+      flexDirection="column"
+      height={`${height}px`}
+      px={3}
+      py={isSelected ? 0 : 1}
+      width={`${width}px`}
+    >
+      <HStack>
+        <Heading size="sm">
+          <PiRectangleDashed />
+        </Heading>
+        {label}
+      </HStack>
+    </Flex>
+  </NodeWrapper>
+);

--- a/airflow/ui/src/components/Graph/AssetConditionNode.tsx
+++ b/airflow/ui/src/components/Graph/AssetConditionNode.tsx
@@ -16,21 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export enum SearchParamsKeys {
-  DEPENDENCIES = "dependencies",
-  END_DATE = "end_date",
-  LAST_DAG_RUN_STATE = "last_dag_run_state",
-  LIMIT = "limit",
-  LOG_LEVEL = "log_level",
-  NAME_PATTERN = "name_pattern",
-  OFFSET = "offset",
-  PAUSED = "paused",
-  SORT = "sort",
-  START_DATE = "start_date",
-  STATE = "state",
-  TAGS = "tags",
-  TRY_NUMBER = "try_number",
-  VERSION_NUMBER = "version_number",
-}
+import { Box } from "@chakra-ui/react";
+import type { NodeProps, Node as NodeType } from "@xyflow/react";
+import { TbLogicAnd, TbLogicOr } from "react-icons/tb";
 
-export type SearchParamsKeysType = Record<keyof typeof SearchParamsKeys, string>;
+import { NodeWrapper } from "./NodeWrapper";
+import type { CustomNodeProps } from "./reactflowUtils";
+
+export const AssetConditionNode = ({ data }: NodeProps<NodeType<CustomNodeProps, "asset-condition">>) => (
+  <NodeWrapper>
+    <Box
+      bg="bg"
+      borderRadius={4}
+      borderWidth={1}
+      height={`${data.height}px`}
+      title={data.assetCondition === "and-gate" ? "All" : "Any"}
+      width={`${data.width}px`}
+    >
+      {data.assetCondition === "or-gate" ? (
+        <TbLogicOr size={`${data.height}px`} />
+      ) : (
+        <TbLogicAnd size={`${data.height}px`} />
+      )}
+    </Box>
+  </NodeWrapper>
+);

--- a/airflow/ui/src/components/Graph/DagNode.tsx
+++ b/airflow/ui/src/components/Graph/DagNode.tsx
@@ -28,14 +28,14 @@ import { NodeWrapper } from "./NodeWrapper";
 import type { CustomNodeProps } from "./reactflowUtils";
 
 export const DagNode = ({
-  data: { height, isSelected, label, width },
+  data: { height, isOpen, isSelected, label, width },
 }: NodeProps<NodeType<CustomNodeProps, "dag">>) => {
   const { data: dag } = useDagServiceGetDag({ dagId: label });
 
   return (
     <NodeWrapper>
       <Flex
-        bg="bg"
+        bg={isOpen ? "bg.muted" : "bg"}
         borderRadius={5}
         borderWidth={isSelected ? 6 : 2}
         cursor="default"

--- a/airflow/ui/src/components/Graph/Edge.tsx
+++ b/airflow/ui/src/components/Graph/Edge.tsx
@@ -67,7 +67,7 @@ const CustomEdge = ({ data }: Props) => {
           key={section.id}
           stroke={colorMode === "dark" ? darkStroke : lightStroke}
           strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}
-          strokeWidth={1}
+          strokeWidth={rest.isSelected ? 3 : 1}
           x={(point: ElkPoint) => point.x}
           y={(point: ElkPoint) => point.y}
         />

--- a/airflow/ui/src/components/Graph/Edge.tsx
+++ b/airflow/ui/src/components/Graph/Edge.tsx
@@ -67,7 +67,7 @@ const CustomEdge = ({ data }: Props) => {
           key={section.id}
           stroke={colorMode === "dark" ? darkStroke : lightStroke}
           strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}
-          strokeWidth={rest.isSelected ? 3 : 1}
+          strokeWidth={rest.isSelected ? 4 : 1}
           x={(point: ElkPoint) => point.x}
           y={(point: ElkPoint) => point.y}
         />

--- a/airflow/ui/src/components/Graph/reactflowUtils.ts
+++ b/airflow/ui/src/components/Graph/reactflowUtils.ts
@@ -24,6 +24,7 @@ import type { GridTaskInstanceSummary, NodeResponse } from "openapi/requests/typ
 import type { LayoutNode } from "./useGraphLayout";
 
 export type CustomNodeProps = {
+  assetCondition?: NodeResponse["asset_condition_type"];
   childCount?: number;
   depth?: number;
   height?: number;
@@ -131,7 +132,7 @@ type Edge = {
 } & ElkExtendedEdge;
 
 export type EdgeData = {
-  rest: { isSetupTeardown?: boolean } & ElkExtendedEdge;
+  rest: { isSelected?: boolean; isSetupTeardown?: boolean } & ElkExtendedEdge;
 };
 
 export const formatFlowEdges = ({ edges }: { edges: Array<Edge> }): Array<FlowEdgeType<EdgeData>> =>

--- a/airflow/ui/src/components/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/components/Graph/useGraphLayout.ts
@@ -36,6 +36,7 @@ type EdgeLabel = {
 };
 
 type FormattedNode = {
+  assetCondition?: NodeResponse["asset_condition_type"];
   childCount?: number;
   edges?: Array<FormattedEdge>;
   isGroup: boolean;
@@ -198,6 +199,7 @@ const generateElkGraph = ({
     }
 
     return {
+      assetCondition: node.asset_condition_type,
       childCount,
       height,
       id: node.id,

--- a/airflow/ui/src/components/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/components/Graph/useGraphLayout.ts
@@ -275,5 +275,5 @@ export const useGraphLayout = ({
 
       return { edges: formattedEdges, nodes: flattenedData.nodes };
     },
-    queryKey: ["graphLayout", nodes.length, openGroupIds, arrange, dagId, versionNumber, edges.length],
+    queryKey: ["graphLayout", nodes, openGroupIds, arrange, dagId, versionNumber, edges],
   });

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -27,6 +27,7 @@ import {
   useGridServiceGridData,
   useStructureServiceStructureData,
 } from "openapi/queries";
+import { AliasNode } from "src/components/Graph/AliasNode";
 import { AssetConditionNode } from "src/components/Graph/AssetConditionNode";
 import { AssetNode } from "src/components/Graph/AssetNode";
 import { DagNode } from "src/components/Graph/DagNode";
@@ -64,6 +65,7 @@ const nodeColor = (
 
 const nodeTypes = {
   asset: AssetNode,
+  "asset-alias": AliasNode,
   "asset-condition": AssetConditionNode,
   dag: DagNode,
   join: JoinNode,

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -90,7 +90,7 @@ export const Graph = () => {
   const { openGroupIds } = useOpenGroups();
   const refetchInterval = useAutoRefresh({ dagId });
 
-  const [dependencies] = useLocalStorage<"all" | "immediate" | "tasks">(`dependencies-${dagId}`, "tasks");
+  const [dependencies] = useLocalStorage<"all" | "immediate" | "tasks">(`dependencies-${dagId}`, "immediate");
 
   const selectedColor = colorMode === "dark" ? selectedDarkColor : selectedLightColor;
   const versionNumber = selectedVersion === undefined ? undefined : parseInt(selectedVersion, 10);

--- a/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -16,41 +16,104 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, IconButton, ButtonGroup, type StackProps, Box } from "@chakra-ui/react";
+import {
+  HStack,
+  IconButton,
+  ButtonGroup,
+  type StackProps,
+  Stack,
+  createListCollection,
+  type SelectValueChangeDetails,
+} from "@chakra-ui/react";
 import { FiGrid } from "react-icons/fi";
 import { MdOutlineAccountTree } from "react-icons/md";
+import { useSearchParams } from "react-router-dom";
 
 import DagVersionSelect from "src/components/DagVersionSelect";
+import { Select } from "src/components/ui";
+import { SearchParamsKeys } from "src/constants/searchParams";
 
 type Props = {
   readonly dagView: string;
   readonly setDagView: (x: "graph" | "grid") => void;
 } & StackProps;
 
-export const PanelButtons = ({ dagView, setDagView, ...rest }: Props) => (
-  <HStack justifyContent="space-between" position="absolute" top={0} width="100%" zIndex={1} {...rest}>
-    <ButtonGroup attached size="sm" variant="outline">
-      <IconButton
-        aria-label="Show Grid"
-        colorPalette="blue"
-        onClick={() => setDagView("grid")}
-        title="Show Grid"
-        variant={dagView === "grid" ? "solid" : "outline"}
-      >
-        <FiGrid />
-      </IconButton>
-      <IconButton
-        aria-label="Show Graph"
-        colorPalette="blue"
-        onClick={() => setDagView("graph")}
-        title="Show Graph"
-        variant={dagView === "graph" ? "solid" : "outline"}
-      >
-        <MdOutlineAccountTree />
-      </IconButton>
-    </ButtonGroup>
-    <Box bg="bg" mr={2}>
-      <DagVersionSelect disabled={dagView !== "graph"} />
-    </Box>
-  </HStack>
-);
+const options = createListCollection({
+  items: [
+    { label: "Only tasks", value: "" },
+    { label: "External conditions", value: "external" },
+    // { label: "All Dag Dependencies", value: "all" },
+  ],
+});
+
+export const PanelButtons = ({ dagView, setDagView, ...rest }: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const dependencies = [searchParams.get(SearchParamsKeys.DEPENDENCIES) ?? ""];
+
+  const handleDepsChange = (event: SelectValueChangeDetails<{ label: string; value: Array<string> }>) => {
+    if (event.value[0] === undefined || event.value[0] === "") {
+      searchParams.delete(SearchParamsKeys.DEPENDENCIES);
+    } else {
+      searchParams.set(SearchParamsKeys.DEPENDENCIES, event.value[0]);
+    }
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <HStack
+      alignItems="flex-start"
+      justifyContent="space-between"
+      position="absolute"
+      top={0}
+      width="100%"
+      zIndex={1}
+      {...rest}
+    >
+      <ButtonGroup attached size="sm" variant="outline">
+        <IconButton
+          aria-label="Show Grid"
+          colorPalette="blue"
+          onClick={() => setDagView("grid")}
+          title="Show Grid"
+          variant={dagView === "grid" ? "solid" : "outline"}
+        >
+          <FiGrid />
+        </IconButton>
+        <IconButton
+          aria-label="Show Graph"
+          colorPalette="blue"
+          onClick={() => setDagView("graph")}
+          title="Show Graph"
+          variant={dagView === "graph" ? "solid" : "outline"}
+        >
+          <MdOutlineAccountTree />
+        </IconButton>
+      </ButtonGroup>
+      <Stack alignItems="flex-end" gap={1} mr={2}>
+        <DagVersionSelect disabled={dagView !== "graph"} />
+        {dagView === "graph" ? (
+          <Select.Root
+            bg="bg"
+            collection={options}
+            data-testid="filter-duration"
+            onValueChange={handleDepsChange}
+            value={dependencies}
+            width="200px"
+          >
+            <Select.Trigger>
+              <Select.ValueText placeholder="Dependencies" />
+            </Select.Trigger>
+            <Select.Content>
+              {options.items.map((option) => (
+                <Select.Item item={option} key={option.value}>
+                  {option.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        ) : undefined}
+      </Stack>
+    </HStack>
+  );
+};

--- a/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -42,7 +42,7 @@ const options = createListCollection({
   items: [
     { label: "Only tasks", value: "" },
     { label: "External conditions", value: "external" },
-    // { label: "All Dag Dependencies", value: "all" },
+    { label: "All Dag Dependencies", value: "all" },
   ],
 });
 
@@ -99,7 +99,7 @@ export const PanelButtons = ({ dagView, setDagView, ...rest }: Props) => {
             data-testid="filter-duration"
             onValueChange={handleDepsChange}
             value={dependencies}
-            width="200px"
+            width="210px"
           >
             <Select.Trigger>
               <Select.ValueText placeholder="Dependencies" />

--- a/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -54,11 +54,11 @@ export const PanelButtons = ({ dagView, setDagView, ...rest }: Props) => {
   const { dagId = "" } = useParams();
   const [dependencies, setDependencies, removeDependencies] = useLocalStorage<Dependency>(
     `dependencies-${dagId}`,
-    "tasks",
+    "immediate",
   );
 
   const handleDepsChange = (event: SelectValueChangeDetails<{ label: string; value: Array<string> }>) => {
-    if (event.value[0] === undefined || event.value[0] === "tasks" || !deps.includes(event.value[0])) {
+    if (event.value[0] === undefined || event.value[0] === "immediate" || !deps.includes(event.value[0])) {
       removeDependencies();
     } else {
       setDependencies(event.value[0]);

--- a/airflow/ui/src/pages/Asset/AssetGraph.tsx
+++ b/airflow/ui/src/pages/Asset/AssetGraph.tsx
@@ -22,6 +22,7 @@ import "@xyflow/react/dist/style.css";
 
 import { useDependenciesServiceGetDependencies } from "openapi/queries";
 import type { AssetResponse } from "openapi/requests/types.gen";
+import { AliasNode } from "src/components/Graph/AliasNode";
 import { AssetNode } from "src/components/Graph/AssetNode";
 import { DagNode } from "src/components/Graph/DagNode";
 import Edge from "src/components/Graph/Edge";
@@ -31,6 +32,7 @@ import { useColorMode } from "src/context/colorMode";
 
 const nodeTypes = {
   asset: AssetNode,
+  "asset-alias": AliasNode,
   dag: DagNode,
 };
 const edgeTypes = { custom: Edge };

--- a/airflow/ui/src/pages/Asset/AssetGraph.tsx
+++ b/airflow/ui/src/pages/Asset/AssetGraph.tsx
@@ -59,11 +59,22 @@ export const AssetGraph = ({ asset }: { readonly asset?: AssetResponse }) => {
 
   const selectedColor = colorMode === "dark" ? selectedDarkColor : selectedLightColor;
 
+  const edges = (graphData?.edges ?? []).map((edge) => ({
+    ...edge,
+    data: {
+      ...edge.data,
+      rest: {
+        ...edge.data?.rest,
+        isSelected: `asset:${asset?.name}` === edge.source || `asset:${asset?.name}` === edge.target,
+      },
+    },
+  }));
+
   return (
     <ReactFlow
       colorMode={colorMode}
       defaultEdgeOptions={{ zIndex: 1 }}
-      edges={graphData?.edges ?? []}
+      edges={edges}
       edgeTypes={edgeTypes}
       // Fit view to selected task or the whole graph on render
       fitView


### PR DESCRIPTION
Use external_dependencies check on the dag structure endpoint and the dag dependencies endpoint to allow three options to render a dag graph:


1. Regular graph with only tasks
<img width="521" alt="Screenshot 2025-03-04 at 3 36 51 PM" src="https://github.com/user-attachments/assets/8932206a-3fc9-49ff-969a-0a57a5ca8cf0" />

2. Show immediate upstream/downstream with asset conditions (any or all)
<img width="517" alt="Screenshot 2025-03-04 at 3 36 45 PM" src="https://github.com/user-attachments/assets/cf9e9ffb-6479-4591-9c0c-7a511df803d2" />

3. Show all external dependencies with the task rendering inside a dag group:
<img width="518" alt="Screenshot 2025-03-04 at 3 37 02 PM" src="https://github.com/user-attachments/assets/be475891-e035-494f-8cfe-b7377e556456" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
