### PR TITLE
HTTP SSL proxy option

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -926,6 +926,7 @@ class HiveServer2Hook(DbApiHook):
 
         scheme = db.extra_dejson.get("scheme", None)
         ssl_context = None
+        ssl_cert_value = None
 
         # If HTTPS, create ssl_context to pass in, built for proxy settings
         if scheme == "https":
@@ -937,11 +938,17 @@ class HiveServer2Hook(DbApiHook):
             check_hostname = db.extra_dejson.get("check_hostname", "false").lower() == "true"
             ssl_context.check_hostname = check_hostname
 
-            # ssl_verify
-            ssl_verify = db.extra_dejson.get("ssl_verify", "none").lower()
-            if ssl_verify == "required":
+            # Get ssl_cert parameter and set verification mode
+            ssl_cert = db.extra_dejson.get("ssl_cert", "none")
+
+            # Convert to lowercase if it's a string
+            if isinstance(ssl_cert, str):
+                ssl_cert = ssl_cert.lower()
+
+            ssl_cert_value = ssl_cert
+            if ssl_cert == "required":
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
-            elif ssl_verify == "optional":
+            elif ssl_cert == "optional":
                 ssl_context.verify_mode = ssl.CERT_OPTIONAL
             else:
                 ssl_context.verify_mode = ssl.CERT_NONE
@@ -964,6 +971,7 @@ class HiveServer2Hook(DbApiHook):
             port=db.port,
             scheme=scheme,
             ssl_context=ssl_context,
+            ssl_cert=ssl_cert_value,
             auth=auth_mechanism,
             kerberos_service_name=kerberos_service_name,
             username=db.login or username,

--- a/providers/apache/hive/tests/provider_tests/apache/__init__.py
+++ b/providers/apache/hive/tests/provider_tests/apache/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/hive/tests/provider_tests/apache/hive/__init__.py
+++ b/providers/apache/hive/tests/provider_tests/apache/hive/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/apache/hive/tests/provider_tests/apache/hive/hooks/__init__.py
+++ b/providers/apache/hive/tests/provider_tests/apache/hive/hooks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
**Depends On:**
pyHive [release v1.11.0](https://github.com/apache/kyuubi/milestone/42)
pyHive from Kyuubi is may not yet be released on PyPi investigating.

Purpose:
Needed to have secure mTLS communication with an NGINX reverse proxy serving incoming HTTP wrapped Thrift traffic to a HiveServer2 instance.

Context:
In the new version of pyHive, now adopted by the Apache Kyuubi project, the latest merge to master, awaiting next release, ssl_context is now a parameter that can be passed into the connection object. This allows a user to create their own ssl_context, rather than passing in individual parameters to create one.

Change:
HiveServer2Hook--> get_conn:
- if scheme == https, ssl context is created  and looks for as many options as it can, first enabling TLS, and mTLS is client cert and key are provided.
HiveMetastoreHook--> get_metastore_client:
- if use_http_proxy, thrift traffic is wrapped in HTTP using THTTPClient. Looks progressively to build ssl_context, first for TLS, and then mTLS is provided. Wraps transport layer in HTTP, otherwise continues to use existing behavior.
Pre-Commit added files:
Pre-Commit added files to commit, those have been included.

Testing:
Added all tests to match new behavior, as well as edited old tests to expect new default parameter in the upcoming pyHive update, which defaults to `None`.

Comments:
Still very new to contributing, happy to abide and comply with requests and rules.

Issue:
[#46023 ](https://github.com/apache/airflow/issues/46023)
@nevcohen 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
