### PR TITLE
Handle default values from Airflow 2 gracefully

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -791,15 +791,17 @@ ARG_OPTIONAL_SECTION = Arg(
     ("--section",),
     help="The section name",
 )
-ARG_LINT_CONFIG_UPGRADE_DEFAULTS = Arg(
-    ("--upgrade-defaults",),
+ARG_LINT_CONFIG_UPGRADE_PROBLEMATIC_DEFAULTS = Arg(
+    ("--upgrade-problematic-defaults",),
     help="Automatically upgrade problematic default values from Airflow 2 to the new recommended values.",
     action="store_true",
+    default=True,
 )
-ARG_LINT_CONFIG_SKIP_DEFAULT_CHECKS = Arg(
-    ("--skip-default-checks",),
+ARG_LINT_CONFIG_SKIP_PROBLEMATIC_DEFAULT_CHECKS = Arg(
+    ("--skip-problematic-default-checks",),
     help="Skip checking for default values from Airflow 2 that may be problematic in Airflow 3.",
     action="store_true",
+    default=False,
 )
 
 # jobs check
@@ -1651,8 +1653,8 @@ CONFIG_COMMANDS = (
             ARG_LINT_CONFIG_IGNORE_SECTION,
             ARG_LINT_CONFIG_IGNORE_OPTION,
             ARG_VERBOSE,
-            ARG_LINT_CONFIG_UPGRADE_DEFAULTS,
-            ARG_LINT_CONFIG_SKIP_DEFAULT_CHECKS,
+            ARG_LINT_CONFIG_UPGRADE_PROBLEMATIC_DEFAULTS,
+            ARG_LINT_CONFIG_SKIP_PROBLEMATIC_DEFAULT_CHECKS,
         ),
     ),
 )

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -791,6 +791,16 @@ ARG_OPTIONAL_SECTION = Arg(
     ("--section",),
     help="The section name",
 )
+ARG_LINT_CONFIG_UPGRADE_DEFAULTS = Arg(
+    ("--upgrade-defaults",),
+    help="Automatically upgrade problematic default values from Airflow 2 to the new recommended values.",
+    action="store_true",
+)
+ARG_LINT_CONFIG_SKIP_DEFAULT_CHECKS = Arg(
+    ("--skip-default-checks",),
+    help="Skip checking for default values from Airflow 2 that may be problematic in Airflow 3.",
+    action="store_true",
+)
 
 # jobs check
 ARG_JOB_TYPE_FILTER = Arg(
@@ -1641,6 +1651,8 @@ CONFIG_COMMANDS = (
             ARG_LINT_CONFIG_IGNORE_SECTION,
             ARG_LINT_CONFIG_IGNORE_OPTION,
             ARG_VERBOSE,
+            ARG_LINT_CONFIG_UPGRADE_DEFAULTS,
+            ARG_LINT_CONFIG_SKIP_DEFAULT_CHECKS,
         ),
     ),
 )

--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -501,13 +501,13 @@ def lint_config(args) -> None:
             Enables detailed output, including the list of ignored sections and options.
             Example: --verbose
 
-        --upgrade-defaults: flag (optional)
+        --upgrade-problematic-defaults: flag (optional)
             Automatically upgrade problematic default values from Airflow 2 to the new recommended values.
-            Example: --upgrade-defaults
+            Example: --upgrade-problematic-defaults
 
-        --skip-default-checks: flag (optional)
+        --skip-problematic-default-checks: flag (optional)
             Skip checking for default values from Airflow 2 that may be problematic in Airflow 3.
-            Example: --skip-default-checks
+            Example: --skip-problematic-default-checks
 
     Examples:
         1. Lint all sections and options:
@@ -529,10 +529,10 @@ def lint_config(args) -> None:
             airflow config lint --verbose
 
         7. Automatically upgrade problematic default values:
-            airflow config lint --upgrade-defaults
+            airflow config lint --upgrade-problematic-defaults
 
         8. Skip checking default values:
-            airflow config lint --skip-default-checks
+            airflow config lint --skip-problematic-default-checks
 
     :param args: The CLI arguments for linting configurations.
     """
@@ -544,9 +544,6 @@ def lint_config(args) -> None:
 
     ignore_sections = args.ignore_section or []
     ignore_options = args.ignore_option or []
-
-    skip_default_checks = args.skip_default_checks or False
-    upgrade_defaults = args.upgrade_defaults or True
 
     for configuration in CONFIGS_CHANGES:
         if section_to_check_if_provided and configuration.config.section not in section_to_check_if_provided:
@@ -563,11 +560,8 @@ def lint_config(args) -> None:
         ):
             lint_issues.append(configuration.message)
 
-        if not skip_default_checks:
-            if upgrade_defaults:
-                conf.handle_incompatible_airflow2_defaults(upgrade=True)
-            else:
-                conf.handle_incompatible_airflow2_defaults(upgrade=False)
+        if not args.skip_problematic_default_checks:
+            conf.handle_incompatible_airflow2_defaults(upgrade=args.upgrade_problematic_defaults)
 
     if lint_issues:
         console.print("[red]Found issues in your airflow.cfg:[/red]")

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -414,6 +414,24 @@ class AirflowConfigParser(ConfigParser):
             "3.0",
             "The default value for 'log_filename_template' from Airflow 2 may break task logs in the new UI.",
         ),
+        ("core", "dag_ignore_file_syntax"): (
+            re.compile(r"^regexp$"),
+            "3.0",
+            "The default value changed from 'regexp' in Airflow 2.x to 'glob' in Airflow 3.0.",
+        ),
+        ("api", "auth_backends"): (
+            re.compile(r"^airflow\.api\.auth\.backend\.session$"),
+            "3.0",
+            "The default auth backend has changed from 'airflow.api.auth.backend.session' to "
+            "'airflow.providers.fab.auth_manager.api.auth.backend.session' in Airflow 3.0.",
+        ),
+        ("scheduler", "task_instance_heartbeat_timeout"): (
+            re.compile(r"^300$"),
+            "3.0",
+            "Airflow 2.x used 'scheduler_zombie_task_threshold' with a default of 300. In 3.0 this setting "
+            "has been renamed to 'task_instance_heartbeat_timeout' (with the same numeric default), which may "
+            "cause legacy configurations to be ignored.",
+        ),
     }
 
     def handle_incompatible_airflow2_defaults(self, upgrade: bool | None = True) -> None:

--- a/tests/cli/commands/remote_commands/test_config_command.py
+++ b/tests/cli/commands/remote_commands/test_config_command.py
@@ -467,7 +467,7 @@ class TestConfigLint:
                 else False,
             ),
         ):
-            args = cli_parser.get_parser().parse_args(["config", "lint", "--upgrade-defaults"])
+            args = cli_parser.get_parser().parse_args(["config", "lint", "--upgrade-problematic-defaults"])
             with pytest.warns(FutureWarning) as record:
                 config_command.lint_config(args)
             warning_messages = " ".join(str(w.message) for w in record)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
- Handle default values from Airflow 2.x gracefully, which breaks in Airflow 3.0. This change adds a method in the `AirflowConfigParser` class called `handle_incompatible_airflow2_defaults` for this. It runs by default while loading config.
- Add two more option in `airflow config lint` 
    1. Automatically upgrade problematic default values:
            ```airflow config lint --upgrade-problematic-defaults```

    2. Skip checking default values:
            ```airflow config lint --skip-problematic-default-checks```

Screenshot of testing done locally:
- `airflow config lint` and importing `conf` in shell
<img width="1643" alt="Screenshot 2025-03-13 at 3 20 04 PM" src="https://github.com/user-attachments/assets/52921157-69a2-4fe1-847a-5e54d6105175" />

<p>Below is a summary table of the changes:</p>

Parameter Key | Legacy (Airflow 2.x) Default | New (Airflow 3.0) Default
-- | -- | --
logging.log_filename_template | Either {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log or a variant like dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{%% if ti.map_index >= 0 %%}map_index={{ ti.map_index }}/{%% endif %%}attempt={{ try_number }}.log | Uses logical_date (with a Jinja filter on try_number), for example a template that looks like dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/ {%% if ti.map_index >= 0 %%}map_index={{ ti.map_index }}/{%% endif %%}attempt={{ try_number|default(ti.try_number) }}.log
core.dag_ignore_file_syntax | "regexp" | "glob"


closes: [#46972](https://github.com/apache/airflow/issues/46972)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
