### PR TITLE
Link to asset from asset event in dashboard.

### DIFF
--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/AssetEvent.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/AssetEvent.tsx
@@ -51,7 +51,9 @@ export const AssetEvent = ({ event }: { readonly event: AssetEventResponse }) =>
           }
           showArrow
         >
-          <Text> {event.name ?? ""} </Text>
+          <Link to={`/assets/${event.asset_id}`}>
+            <Text color="fg.info"> {event.name ?? ""} </Text>
+          </Link>
         </Tooltip>
       </HStack>
       <HStack>


### PR DESCRIPTION
Since asset has a details page now added in https://github.com/apache/airflow/pull/47162,  the asset event from dashboard can be linked to corresponding asset . The task instance producing the event is already linked.

Screenshot with PR : 

![image](https://github.com/user-attachments/assets/139aaed4-b857-4fa7-90d2-2adb1ff3a5fb)
