### PR TITLE
AIP-84 | Fix `test_python_client` after Adding Permission to API

### DIFF
--- a/clients/python/test_python_client.py
+++ b/clients/python/test_python_client.py
@@ -42,6 +42,9 @@ except ImportError:
 from airflow_client.client.api import config_api, dag_api, dag_run_api
 from airflow_client.client.model.dag_run import DAGRun
 
+from airflow.auth.managers.simple.simple_auth_manager import SimpleAuthManager
+from airflow.auth.managers.simple.user import SimpleAuthManagerUser
+
 # The client must use the authentication and authorization parameters
 # in accordance with the API server security policy.
 # Examples for each auth method are provided below, use the example that
@@ -57,8 +60,17 @@ from airflow_client.client.model.dag_run import DAGRun
 # privileges in Airflow
 
 # Configure HTTP basic authorization: Basic
+auth_manager = SimpleAuthManager()
 configuration = airflow_client.client.Configuration(
-    host="http://localhost:8080/public", username="admin", password="admin"
+    host="http://localhost:8080/public",
+    api_key={
+        "Authorization": "Bearer "
+        + auth_manager._get_token_signer().generate_signed_token(
+            {
+                **auth_manager.serialize_user(SimpleAuthManagerUser(username="test", role="admin")),
+            }
+        )
+    },
 )
 
 # Make sure in the [core] section, the  `load_examples` config is set to True in your airflow.cfg


### PR DESCRIPTION

related: #42360, #47208

## What

After adding `requires_access_<entity>` to routers ( e.g. https://github.com/apache/airflow/blob/main/airflow/api_fastapi/core_api/routes/public/dags.py#L72 ), we should add JWT token to API client.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
