### PR TITLE
AIP-38 Responsive dag run actions

### DIFF
--- a/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -1,0 +1,119 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Heading, VStack, Editable, Text, Flex } from "@chakra-ui/react";
+import { type ChangeEvent, type ReactElement, useState } from "react";
+
+import { Button, Dialog } from "src/components/ui";
+
+import ReactMarkdown from "./ReactMarkdown";
+import ActionButton from "./ui/ActionButton";
+
+const EditableMarkdownButton = ({
+  header,
+  icon,
+  isPending,
+  mdContent,
+  onConfirm,
+  placeholder,
+  setMdContent,
+  text,
+  withText = true,
+}: {
+  readonly header: string;
+  readonly icon: ReactElement;
+  readonly isPending: boolean;
+  readonly mdContent?: string | null;
+  readonly onConfirm: () => void;
+  readonly placeholder: string;
+  readonly setMdContent: (value: string) => void;
+  readonly text: string;
+  readonly withText?: boolean;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Box>
+      <ActionButton
+        actionName={placeholder}
+        icon={icon}
+        onClick={() => setIsOpen(true)}
+        text={text}
+        withText={withText}
+      />
+      <Dialog.Root
+        data-testid="markdown-modal"
+        lazyMount
+        onOpenChange={() => setIsOpen(false)}
+        open={isOpen}
+        size="md"
+      >
+        <Dialog.Content backdrop>
+          <Dialog.Header bg="blue.muted">
+            <Heading size="xl">{header}</Heading>
+            <Dialog.CloseTrigger closeButtonProps={{ size: "xl" }} />
+          </Dialog.Header>
+          <Dialog.Body alignItems="flex-start" as={VStack} gap="0">
+            <Editable.Root
+              onChange={(event: ChangeEvent<HTMLInputElement>) => setMdContent(event.target.value)}
+              value={mdContent ?? ""}
+            >
+              <Editable.Preview
+                _hover={{ backgroundColor: "transparent" }}
+                alignItems="flex-start"
+                as={VStack}
+                gap="0"
+                height="200px"
+                overflowY="auto"
+                width="100%"
+              >
+                {Boolean(mdContent) ? (
+                  <ReactMarkdown>{mdContent}</ReactMarkdown>
+                ) : (
+                  <Text color="fg.subtle">{placeholder}</Text>
+                )}
+              </Editable.Preview>
+              <Editable.Textarea
+                data-testid="markdown-input"
+                height="200px"
+                overflowY="auto"
+                placeholder={placeholder}
+                resize="none"
+              />
+            </Editable.Root>
+
+            <Flex justifyContent="end" mt={3} width="100%">
+              <Button
+                colorPalette="blue"
+                loading={isPending}
+                onClick={() => {
+                  onConfirm();
+                  setIsOpen(false);
+                }}
+              >
+                {icon} Confirm
+              </Button>
+            </Flex>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+    </Box>
+  );
+};
+
+export default EditableMarkdownButton;

--- a/airflow/ui/src/components/TriggerDag/EditableMarkdown.tsx
+++ b/airflow/ui/src/components/TriggerDag/EditableMarkdown.tsx
@@ -19,7 +19,7 @@
 import { Editable, Text, VStack } from "@chakra-ui/react";
 import type { ChangeEvent } from "react";
 
-import ReactMarkdown from "./ReactMarkdown";
+import ReactMarkdown from "src/components/ReactMarkdown";
 
 type EditableMarkdownProps = {
   readonly field: {

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -28,10 +28,10 @@ import { useColorMode } from "src/context/colorMode";
 import { useDagParams } from "src/queries/useDagParams";
 import { useTrigger } from "src/queries/useTrigger";
 
-import EditableMarkdown from "../EditableMarkdown";
 import { ErrorAlert } from "../ErrorAlert";
 import { FlexibleForm, flexibleFormDefaultSection } from "../FlexibleForm";
 import { Accordion } from "../ui";
+import EditableMarkdown from "./EditableMarkdown";
 import { useParamStore } from "./useParamStore";
 
 type TriggerDAGFormProps = {

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -17,16 +17,18 @@
  * under the License.
  */
 import { HStack, Text } from "@chakra-ui/react";
+import { useCallback, useState } from "react";
 import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
-import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
+import EditableMarkdownButton from "src/components/EditableMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
 import { MarkRunAsButton } from "src/components/MarkAs";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
+import { usePatchDagRun } from "src/queries/usePatchDagRun";
 import { getDuration } from "src/utils";
 
 export const Header = ({
@@ -35,55 +37,79 @@ export const Header = ({
 }: {
   readonly dagRun: DAGRunResponse;
   readonly isRefreshing?: boolean;
-}) => (
-  <HeaderCard
-    actions={
-      <>
-        {dagRun.note === null || dagRun.note.length === 0 ? undefined : (
-          <DisplayMarkdownButton
+}) => {
+  const [note, setNote] = useState<string | null>(dagRun.note);
+
+  const dagId = dagRun.dag_id;
+  const dagRunId = dagRun.dag_run_id;
+
+  const { isPending, mutate } = usePatchDagRun({
+    dagId,
+    dagRunId,
+  });
+
+  const onConfirm = useCallback(() => {
+    if (note !== dagRun.note) {
+      mutate({
+        dagId,
+        dagRunId,
+        requestBody: { note },
+      });
+    }
+  }, [dagId, dagRun.note, dagRunId, mutate, note]);
+
+  return (
+    <HeaderCard
+      actions={
+        <>
+          <EditableMarkdownButton
             header="Dag Run Note"
             icon={<FiMessageSquare />}
-            mdContent={dagRun.note}
-            text="Note"
+            isPending={isPending}
+            mdContent={note}
+            onConfirm={onConfirm}
+            placeholder="Add a note..."
+            setMdContent={setNote}
+            text={Boolean(dagRun.note) ? "Note" : "Add a note"}
           />
-        )}
-        <ClearRunButton dagRun={dagRun} />
-        <MarkRunAsButton dagRun={dagRun} />
-      </>
-    }
-    icon={<FiBarChart />}
-    isRefreshing={isRefreshing}
-    state={dagRun.state}
-    stats={[
-      ...(dagRun.logical_date === null
-        ? []
-        : [
-            {
-              label: "Logical Date",
-              value: <Time datetime={dagRun.logical_date} />,
-            },
-          ]),
-      {
-        label: "Run Type",
-        value: (
-          <HStack>
-            <RunTypeIcon runType={dagRun.run_type} />
-            <Text>{dagRun.run_type}</Text>
-          </HStack>
-        ),
-      },
-      { label: "Start", value: <Time datetime={dagRun.start_date} /> },
-      { label: "End", value: <Time datetime={dagRun.end_date} /> },
-      { label: "Duration", value: `${getDuration(dagRun.start_date, dagRun.end_date)}s` },
-      {
-        label: "Dag Version(s)",
-        value: (
-          <LimitedItemsList
-            items={dagRun.dag_versions.map(({ version_number: versionNumber }) => `v${versionNumber}`)}
-          />
-        ),
-      },
-    ]}
-    title={<Time datetime={dagRun.run_after} />}
-  />
-);
+          <ClearRunButton dagRun={dagRun} />
+          <MarkRunAsButton dagRun={dagRun} />
+        </>
+      }
+      icon={<FiBarChart />}
+      isRefreshing={isRefreshing}
+      state={dagRun.state}
+      stats={[
+        ...(dagRun.logical_date === null
+          ? []
+          : [
+              {
+                label: "Logical Date",
+                value: <Time datetime={dagRun.logical_date} />,
+              },
+            ]),
+        {
+          label: "Run Type",
+          value: (
+            <HStack>
+              <RunTypeIcon runType={dagRun.run_type} />
+              <Text>{dagRun.run_type}</Text>
+            </HStack>
+          ),
+        },
+        { label: "Start", value: <Time datetime={dagRun.start_date} /> },
+        { label: "End", value: <Time datetime={dagRun.end_date} /> },
+        { label: "Duration", value: `${getDuration(dagRun.start_date, dagRun.end_date)}s` },
+        {
+          label: "Dag Version(s)",
+          value: (
+            <LimitedItemsList
+              items={dagRun.dag_versions.map(({ version_number: versionNumber }) => `v${versionNumber}`)}
+            />
+          ),
+        },
+      ]}
+      title={<Time datetime={dagRun.run_after} />}
+    />
+  );
+};

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, Text } from "@chakra-ui/react";
-import { useCallback, useState } from "react";
+import { HStack, Text, Box } from "@chakra-ui/react";
+import { useCallback, useState, useRef } from "react";
 import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -29,7 +29,7 @@ import { MarkRunAsButton } from "src/components/MarkAs";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
 import { usePatchDagRun } from "src/queries/usePatchDagRun";
-import { getDuration } from "src/utils";
+import { getDuration, useContainerWidth } from "src/utils";
 
 export const Header = ({
   dagRun,
@@ -57,59 +57,64 @@ export const Header = ({
       });
     }
   }, [dagId, dagRun.note, dagRunId, mutate, note]);
+  const containerRef = useRef<HTMLDivElement>();
+  const containerWidth = useContainerWidth(containerRef);
 
   return (
-    <HeaderCard
-      actions={
-        <>
-          <EditableMarkdownButton
-            header="Dag Run Note"
-            icon={<FiMessageSquare />}
-            isPending={isPending}
-            mdContent={note}
-            onConfirm={onConfirm}
-            placeholder="Add a note..."
-            setMdContent={setNote}
-            text={Boolean(dagRun.note) ? "Note" : "Add a note"}
-          />
-          <ClearRunButton dagRun={dagRun} />
-          <MarkRunAsButton dagRun={dagRun} />
-        </>
-      }
-      icon={<FiBarChart />}
-      isRefreshing={isRefreshing}
-      state={dagRun.state}
-      stats={[
-        ...(dagRun.logical_date === null
-          ? []
-          : [
-              {
-                label: "Logical Date",
-                value: <Time datetime={dagRun.logical_date} />,
-              },
-            ]),
-        {
-          label: "Run Type",
-          value: (
-            <HStack>
-              <RunTypeIcon runType={dagRun.run_type} />
-              <Text>{dagRun.run_type}</Text>
-            </HStack>
-          ),
-        },
-        { label: "Start", value: <Time datetime={dagRun.start_date} /> },
-        { label: "End", value: <Time datetime={dagRun.end_date} /> },
-        { label: "Duration", value: `${getDuration(dagRun.start_date, dagRun.end_date)}s` },
-        {
-          label: "Dag Version(s)",
-          value: (
-            <LimitedItemsList
-              items={dagRun.dag_versions.map(({ version_number: versionNumber }) => `v${versionNumber}`)}
+    <Box ref={containerRef}>
+      <HeaderCard
+        actions={
+          <>
+            <EditableMarkdownButton
+              header="Dag Run Note"
+              icon={<FiMessageSquare />}
+              isPending={isPending}
+              mdContent={note}
+              onConfirm={onConfirm}
+              placeholder="Add a note..."
+              setMdContent={setNote}
+              text={Boolean(dagRun.note) ? "Note" : "Add a note"}
+              withText={containerWidth > 700}
             />
-          ),
-        },
-      ]}
-      title={<Time datetime={dagRun.run_after} />}
-    />
+            <ClearRunButton dagRun={dagRun} withText={containerWidth > 700} />
+            <MarkRunAsButton dagRun={dagRun} withText={containerWidth > 700} />
+          </>
+        }
+        icon={<FiBarChart />}
+        isRefreshing={isRefreshing}
+        state={dagRun.state}
+        stats={[
+          ...(dagRun.logical_date === null
+            ? []
+            : [
+                {
+                  label: "Logical Date",
+                  value: <Time datetime={dagRun.logical_date} />,
+                },
+              ]),
+          {
+            label: "Run Type",
+            value: (
+              <HStack>
+                <RunTypeIcon runType={dagRun.run_type} />
+                <Text>{dagRun.run_type}</Text>
+              </HStack>
+            ),
+          },
+          { label: "Start", value: <Time datetime={dagRun.start_date} /> },
+          { label: "End", value: <Time datetime={dagRun.end_date} /> },
+          { label: "Duration", value: `${getDuration(dagRun.start_date, dagRun.end_date)}s` },
+          {
+            label: "Dag Version(s)",
+            value: (
+              <LimitedItemsList
+                items={dagRun.dag_versions.map(({ version_number: versionNumber }) => `v${versionNumber}`)}
+              />
+            ),
+          },
+        ]}
+        title={<Time datetime={dagRun.run_after} />}
+      />
+    </Box>
   );
 };

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -17,16 +17,17 @@
  * under the License.
  */
 import { Box } from "@chakra-ui/react";
-import { useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { FiMessageSquare } from "react-icons/fi";
 import { MdOutlineTask } from "react-icons/md";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
-import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
+import EditableMarkdownButton from "src/components/EditableMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
+import { usePatchTaskInstance } from "src/queries/usePatchTaskInstance";
 import { getDuration, useContainerWidth } from "src/utils";
 
 export const Header = ({
@@ -55,19 +56,48 @@ export const Header = ({
     },
   ];
 
+  const [note, setNote] = useState<string | null>(taskInstance.note);
+
+  const dagId = taskInstance.dag_id;
+  const dagRunId = taskInstance.dag_run_id;
+  const taskId = taskInstance.task_id;
+  const mapIndex = taskInstance.map_index;
+
+  const { isPending, mutate } = usePatchTaskInstance({
+    dagId,
+    dagRunId,
+    mapIndex,
+    taskId,
+  });
+
+  const onConfirm = useCallback(() => {
+    if (note !== taskInstance.note) {
+      mutate({
+        dagId,
+        dagRunId,
+        mapIndex,
+        requestBody: { note },
+        taskId,
+      });
+    }
+  }, [dagId, dagRunId, mapIndex, mutate, note, taskId, taskInstance.note]);
+
   return (
     <Box ref={containerRef}>
       <HeaderCard
         actions={
           <>
-            {taskInstance.note === null || taskInstance.note.length === 0 ? undefined : (
-              <DisplayMarkdownButton
-                header="Task Instance Note"
-                icon={<FiMessageSquare />}
-                mdContent={taskInstance.note}
-                text="Note"
-              />
-            )}
+            <EditableMarkdownButton
+              header="Task Instance Note"
+              icon={<FiMessageSquare />}
+              isPending={isPending}
+              mdContent={note}
+              onConfirm={onConfirm}
+              placeholder="Add a note..."
+              setMdContent={setNote}
+              text={Boolean(taskInstance.note) ? "Note" : "Add a note"}
+              withText={containerWidth > 700}
+            />
             <ClearTaskInstanceButton taskInstance={taskInstance} withText={containerWidth > 700} />
             <MarkTaskInstanceAsButton taskInstance={taskInstance} withText={containerWidth > 700} />
           </>


### PR DESCRIPTION
Only the last commit is relevant, based on https://github.com/apache/airflow/pull/47393

Similarly to TaskInstance Actions in the header, DagRun action should be responsive and button should hide text when the screen is too small.

![Screenshot 2025-03-05 at 16 25 49](https://github.com/user-attachments/assets/1a6a6afa-b77b-4ca5-9246-c4cc5dc45c83)
![Screenshot 2025-03-05 at 16 26 09](https://github.com/user-attachments/assets/6ee3f1aa-ac9f-4af0-a14c-1b3e6ff43e36)
