### PR TITLE
update breadcrumb spacing

### DIFF
--- a/airflow/ui/src/components/BreadcrumbStats.tsx
+++ b/airflow/ui/src/components/BreadcrumbStats.tsx
@@ -33,7 +33,7 @@ export const BreadcrumbStats = ({ links }: { readonly links: Links }) => (
         <Stat.Label fontSize="xs" fontWeight="bold">
           {link.title}
         </Stat.Label>
-        <Stat.ValueText fontSize="sm" fontWeight="normal">
+        <Stat.ValueText fontSize="sm" fontWeight="normal" lineHeight={1.5}>
           {index === links.length - 1 ? (
             <Breadcrumb.CurrentLink>
               <HStack>{link.label}</HStack>

--- a/airflow/ui/src/components/HeaderCard.tsx
+++ b/airflow/ui/src/components/HeaderCard.tsx
@@ -34,7 +34,7 @@ type Props = {
 };
 
 export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle, title }: Props) => (
-  <Box borderColor="border" borderRadius={8} borderWidth={1} m={2} p={2}>
+  <Box borderColor="border" borderRadius={8} borderWidth={1} ml={2} p={2}>
     <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
       <Flex alignItems="center" flexWrap="wrap" gap={2}>
         <Heading size="xl">{icon}</Heading>

--- a/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -51,7 +51,6 @@ export const DagBreadcrumb = () => {
 
   const links: Array<{ label: ReactNode | string; labelExtra?: ReactNode; title?: string; value?: string }> =
     [
-      { label: "Dags", value: "/dags" },
       {
         label: dag?.dag_display_name ?? dagId,
         labelExtra: (

--- a/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -59,7 +59,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
 
   return (
     <OpenGroupsProvider dagId={dagId}>
-      <HStack justifyContent="space-between">
+      <HStack justifyContent="space-between" mb={2}>
         <DagBreadcrumb />
         <Flex gap={1}>
           <SearchDagsButton />

--- a/airflow/ui/src/pages/Asset/Asset.tsx
+++ b/airflow/ui/src/pages/Asset/Asset.tsx
@@ -41,7 +41,6 @@ export const Asset = () => {
   );
 
   const links = [
-    { label: "Assets", value: "/assets" },
     {
       label: asset?.name,
       title: "Asset",
@@ -51,7 +50,7 @@ export const Asset = () => {
 
   return (
     <ReactFlowProvider>
-      <HStack justifyContent="space-between">
+      <HStack justifyContent="space-between" mb={2}>
         <BreadcrumbStats links={links} />
       </HStack>
       <ProgressBar size="xs" visibility={Boolean(isLoading) ? "visible" : "hidden"} />


### PR DESCRIPTION
- Drop "Dags" section of the breadcrumb, users can use the navbar
- Reduce spacing between label and value fo the breadcrumb
- Fix HeaderCard margins to line up with the "Trigger Dag" button to the right and the graph buttons at the top


Before:
<img width="736" alt="Screenshot 2025-03-05 at 11 19 47 AM" src="https://github.com/user-attachments/assets/4885539f-6707-4ec9-9b85-d220cdef667f" />


After:
<img width="1465" alt="Screenshot 2025-03-05 at 11 15 06 AM" src="https://github.com/user-attachments/assets/96aebab1-c75e-4734-b170-cc608db00f21" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
