### PR TITLE
Do not send creds as querystring in Simple auth manager

### DIFF
--- a/airflow/auth/managers/simple/ui/src/login/LoginForm.tsx
+++ b/airflow/auth/managers/simple/ui/src/login/LoginForm.tsx
@@ -38,32 +38,30 @@ export const LoginForm = ({ onLogin, isPending }: LoginFormProps) => {
     });
 
     return <Stack spacing={4}>
-        <form>
-            <Controller
-                name="username"
-                control={control}
-                render={({field, fieldState}) => (
-                    <Field.Root invalid={Boolean(fieldState.error)} required>
-                        <Field.Label>Username</Field.Label>
-                        <Input {...field} />
-                    </Field.Root>)}
-                rules={{required: true}}
-            />
+        <Controller
+            name="username"
+            control={control}
+            render={({field, fieldState}) => (
+                <Field.Root invalid={Boolean(fieldState.error)} required>
+                    <Field.Label>Username</Field.Label>
+                    <Input {...field} />
+                </Field.Root>)}
+            rules={{required: true}}
+        />
 
-            <Controller
-                name="password"
-                control={control}
-                render={({field, fieldState}) => (
-                    <Field.Root invalid={Boolean(fieldState.error)} required>
-                        <Field.Label>Password</Field.Label>
-                        <Input {...field} type="password"/>
-                    </Field.Root>)}
-                rules={{required: true}}
-            />
+        <Controller
+            name="password"
+            control={control}
+            render={({field, fieldState}) => (
+                <Field.Root invalid={Boolean(fieldState.error)} required>
+                    <Field.Label>Password</Field.Label>
+                    <Input {...field} type="password"/>
+                </Field.Root>)}
+            rules={{required: true}}
+        />
 
-            <Button disabled={!isValid || isPending} colorPalette="blue" onClick={() => void handleSubmit(onLogin)()} type="submit">
-                Sign in
-            </Button>
-        </form>
+        <Button disabled={!isValid || isPending} colorPalette="blue" onClick={() => void handleSubmit(onLogin)()}>
+            Sign in
+        </Button>
     </Stack>
 }


### PR DESCRIPTION
When logging in with simple auth manager, credentials are sent as querystring. This is bad for security purposes. We should not use a `form`, this is what sends the credentials as a new request. Logging is handled by `handleSubmit`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
