### PR TITLE
Add Dag Version to Dag Run & Task Instance tables

### DIFF
--- a/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -22,7 +22,7 @@ import { useParams, useSearchParams } from "react-router-dom";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 
 import { GridButton } from "./GridButton";
-import { TaskInstances } from "./TaskInstances";
+import { TaskInstancesColumn } from "./TaskInstancesColumn";
 import type { GridTask, RunWithDuration } from "./utils";
 
 const BAR_HEIGHT = 100;
@@ -74,7 +74,7 @@ export const Bar = ({ max, nodes, run }: Props) => {
           {run.run_type !== "scheduled" && <RunTypeIcon runType={run.run_type} size="10px" />}
         </GridButton>
       </Flex>
-      <TaskInstances nodes={nodes} runId={run.dag_run_id} taskInstances={run.task_instances} />
+      <TaskInstancesColumn nodes={nodes} runId={run.dag_run_id} taskInstances={run.task_instances} />
     </Box>
   );
 };

--- a/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
@@ -30,7 +30,7 @@ type Props = {
   taskInstances: Array<GridTaskInstanceSummary>;
 };
 
-export const TaskInstances = ({ nodes, runId, taskInstances }: Props) => {
+export const TaskInstancesColumn = ({ nodes, runId, taskInstances }: Props) => {
   const { dagId = "" } = useParams();
   const [searchParams] = useSearchParams();
 

--- a/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow/ui/src/pages/DagRuns.tsx
@@ -27,6 +27,7 @@ import { ClearRunButton } from "src/components/Clear";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { LimitedItemsList } from "src/components/LimitedItemsList";
 import { MarkRunAsButton } from "src/components/MarkAs";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
@@ -97,6 +98,16 @@ const runColumns = (dagId?: string): Array<ColumnDef<DAGRunResponse>> => [
   {
     cell: ({ row: { original } }) => getDuration(original.start_date, original.end_date),
     header: "Duration",
+  },
+  {
+    accessorKey: "dag_versions",
+    cell: ({ row: { original } }) => (
+      <LimitedItemsList
+        items={original.dag_versions.map(({ version_number: versionNumber }) => `v${versionNumber}`)}
+      />
+    ),
+    enableSorting: false,
+    header: "Dag Version(s)",
   },
   {
     accessorKey: "actions",

--- a/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -136,10 +136,15 @@ const taskInstanceColumns = (
     enableSorting: false,
     header: "Operator",
   },
-
   {
     cell: ({ row: { original } }) => `${getDuration(original.start_date, original.end_date)}s`,
     header: "Duration",
+  },
+  {
+    accessorKey: "dag_version",
+    cell: ({ row: { original } }) => `v${original.dag_version?.version_number}`,
+    enableSorting: false,
+    header: "Dag Version",
   },
   {
     accessorKey: "actions",


### PR DESCRIPTION
Add Dag Version to Dag Run & Task Instance tables. In the screenshot below, you can then see when a version changed in the middle of a dag run.

<img width="963" alt="Screenshot 2025-03-05 at 11 40 06 AM" src="https://github.com/user-attachments/assets/6d76c216-0238-40ad-b934-ff11de740670" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
