### PR TITLE
AIP-84 Add Get single DagVersion endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -6849,6 +6849,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/dags/{dag_id}/dagVersions/{version_number}:
+    get:
+      tags:
+      - DagVersion
+      summary: Get Dag Version
+      description: Get one Dag Version.
+      operationId: get_dag_version
+      parameters:
+      - name: dag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dag Id
+      - name: version_number
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Version Number
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DagVersionResponse'
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /public/dags/{dag_id}/dagVersions:
     get:
       tags:

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -1665,6 +1665,24 @@ export const UseVariableServiceGetVariablesKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [useVariableServiceGetVariablesKey, ...(queryKey ?? [{ limit, offset, orderBy, variableKeyPattern }])];
+export type DagVersionServiceGetDagVersionDefaultResponse = Awaited<
+  ReturnType<typeof DagVersionService.getDagVersion>
+>;
+export type DagVersionServiceGetDagVersionQueryResult<
+  TData = DagVersionServiceGetDagVersionDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useDagVersionServiceGetDagVersionKey = "DagVersionServiceGetDagVersion";
+export const UseDagVersionServiceGetDagVersionKeyFn = (
+  {
+    dagId,
+    versionNumber,
+  }: {
+    dagId: string;
+    versionNumber: number;
+  },
+  queryKey?: Array<unknown>,
+) => [useDagVersionServiceGetDagVersionKey, ...(queryKey ?? [{ dagId, versionNumber }])];
 export type DagVersionServiceGetDagVersionsDefaultResponse = Awaited<
   ReturnType<typeof DagVersionService.getDagVersions>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -2341,6 +2341,29 @@ export const prefetchUseVariableServiceGetVariables = (
     queryFn: () => VariableService.getVariables({ limit, offset, orderBy, variableKeyPattern }),
   });
 /**
+ * Get Dag Version
+ * Get one Dag Version.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.versionNumber
+ * @returns DagVersionResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseDagVersionServiceGetDagVersion = (
+  queryClient: QueryClient,
+  {
+    dagId,
+    versionNumber,
+  }: {
+    dagId: string;
+    versionNumber: number;
+  },
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseDagVersionServiceGetDagVersionKeyFn({ dagId, versionNumber }),
+    queryFn: () => DagVersionService.getDagVersion({ dagId, versionNumber }),
+  });
+/**
  * Get Dag Versions
  * Get all DAG Versions.
  *

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -2760,6 +2760,35 @@ export const useVariableServiceGetVariables = <
     ...options,
   });
 /**
+ * Get Dag Version
+ * Get one Dag Version.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.versionNumber
+ * @returns DagVersionResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagVersionServiceGetDagVersion = <
+  TData = Common.DagVersionServiceGetDagVersionDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+    versionNumber,
+  }: {
+    dagId: string;
+    versionNumber: number;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseDagVersionServiceGetDagVersionKeyFn({ dagId, versionNumber }, queryKey),
+    queryFn: () => DagVersionService.getDagVersion({ dagId, versionNumber }) as TData,
+    ...options,
+  });
+/**
  * Get Dag Versions
  * Get all DAG Versions.
  *

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -2737,6 +2737,35 @@ export const useVariableServiceGetVariablesSuspense = <
     ...options,
   });
 /**
+ * Get Dag Version
+ * Get one Dag Version.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.versionNumber
+ * @returns DagVersionResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagVersionServiceGetDagVersionSuspense = <
+  TData = Common.DagVersionServiceGetDagVersionDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+    versionNumber,
+  }: {
+    dagId: string;
+    versionNumber: number;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseDagVersionServiceGetDagVersionKeyFn({ dagId, versionNumber }, queryKey),
+    queryFn: () => DagVersionService.getDagVersion({ dagId, versionNumber }) as TData,
+    ...options,
+  });
+/**
  * Get Dag Versions
  * Get all DAG Versions.
  *

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -203,6 +203,8 @@ import type {
   BulkVariablesResponse,
   ReparseDagFileData,
   ReparseDagFileResponse,
+  GetDagVersionData,
+  GetDagVersionResponse,
   GetDagVersionsData,
   GetDagVersionsResponse,
   GetHealthResponse,
@@ -3405,6 +3407,32 @@ export class DagParsingService {
 }
 
 export class DagVersionService {
+  /**
+   * Get Dag Version
+   * Get one Dag Version.
+   * @param data The data for the request.
+   * @param data.dagId
+   * @param data.versionNumber
+   * @returns DagVersionResponse Successful Response
+   * @throws ApiError
+   */
+  public static getDagVersion(data: GetDagVersionData): CancelablePromise<GetDagVersionResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/dags/{dag_id}/dagVersions/{version_number}",
+      path: {
+        dag_id: data.dagId,
+        version_number: data.versionNumber,
+      },
+      errors: {
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        422: "Validation Error",
+      },
+    });
+  }
+
   /**
    * Get Dag Versions
    * Get all DAG Versions.

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2497,6 +2497,13 @@ export type ReparseDagFileData = {
 
 export type ReparseDagFileResponse = null;
 
+export type GetDagVersionData = {
+  dagId: string;
+  versionNumber: number;
+};
+
+export type GetDagVersionResponse = DagVersionResponse;
+
 export type GetDagVersionsData = {
   bundleName?: string;
   bundleVersion?: string | null;
@@ -5194,6 +5201,33 @@ export type $OpenApiTs = {
          * Successful Response
          */
         201: null;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/dags/{dag_id}/dagVersions/{version_number}": {
+    get: {
+      req: GetDagVersionData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DagVersionResponse;
         /**
          * Unauthorized
          */

--- a/tests/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -111,11 +111,11 @@ class TestGetDagVersion(TestDagVersionEndpoint):
         assert response.json() == expected_response
 
     def test_get_dag_version_404(self, test_client):
-        response = test_client.get(
-            "/public/dags/dag_with_multiple_versions/dagVersions/MISSING_VERSION_NUMBER"
-        )
+        response = test_client.get("/public/dags/dag_with_multiple_versions/dagVersions/99")
         assert response.status_code == 404
-        assert response.json() == {}
+        assert response.json() == {
+            "detail": "The DagVersion with dag_id: `dag_with_multiple_versions` and version_number: `99` was not found",
+        }
 
 
 class TestGetDagVersions(TestDagVersionEndpoint):

--- a/tests/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -46,6 +46,78 @@ class TestDagVersionEndpoint:
         )
 
 
+class TestGetDagVersion(TestDagVersionEndpoint):
+    @pytest.mark.parametrize(
+        "dag_id, dag_version, expected_response",
+        [
+            [
+                "ANOTHER_DAG_ID",
+                1,
+                {
+                    "bundle_name": "another_bundle_name",
+                    "bundle_version": "some_commit_hash",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash",
+                    "created_at": mock.ANY,
+                    "dag_id": "ANOTHER_DAG_ID",
+                    "id": mock.ANY,
+                    "version_number": 1,
+                },
+            ],
+            [
+                "dag_with_multiple_versions",
+                1,
+                {
+                    "bundle_name": "dag_maker",
+                    "bundle_version": "some_commit_hash1",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1",
+                    "created_at": mock.ANY,
+                    "dag_id": "dag_with_multiple_versions",
+                    "id": mock.ANY,
+                    "version_number": 1,
+                },
+            ],
+            [
+                "dag_with_multiple_versions",
+                2,
+                {
+                    "bundle_name": "dag_maker",
+                    "bundle_version": "some_commit_hash2",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2",
+                    "created_at": mock.ANY,
+                    "dag_id": "dag_with_multiple_versions",
+                    "id": mock.ANY,
+                    "version_number": 2,
+                },
+            ],
+            [
+                "dag_with_multiple_versions",
+                3,
+                {
+                    "bundle_name": "dag_maker",
+                    "bundle_version": "some_commit_hash3",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3",
+                    "created_at": mock.ANY,
+                    "dag_id": "dag_with_multiple_versions",
+                    "id": mock.ANY,
+                    "version_number": 3,
+                },
+            ],
+        ],
+    )
+    @pytest.mark.usefixtures("make_dag_with_multiple_versions")
+    def test_get_dag_version(self, test_client, dag_id, dag_version, expected_response):
+        response = test_client.get(f"/public/dags/{dag_id}/dagVersions/{dag_version}")
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+    def test_get_dag_version_404(self, test_client):
+        response = test_client.get(
+            "/public/dags/dag_with_multiple_versions/dagVersions/MISSING_VERSION_NUMBER"
+        )
+        assert response.status_code == 404
+        assert response.json() == {}
+
+
 class TestGetDagVersions(TestDagVersionEndpoint):
     @pytest.mark.parametrize(
         "dag_id, expected_response",


### PR DESCRIPTION
Part 1 of https://github.com/apache/airflow/issues/47392

Add the `Get Dag Version` endpoint. This will allow us to retrieve specific informations for the selected version_number in the front_end.