### PR TITLE
Fix Dag Node link and clean up error messages

### DIFF
--- a/airflow/ui/src/components/ErrorAlert.tsx
+++ b/airflow/ui/src/components/ErrorAlert.tsx
@@ -56,8 +56,8 @@ export const ErrorAlert = ({ error: err }: Props) => {
   return (
     <Alert status="error">
       <HStack align="start" flexDirection="column" gap={2} mt={-1}>
-        {error.message}
-        <span>{detailMessage}</span>
+        {error.status} {error.message}
+        {detailMessage === error.message ? undefined : <span>{detailMessage}</span>}
       </HStack>
     </Alert>
   );

--- a/airflow/ui/src/components/Graph/DagNode.tsx
+++ b/airflow/ui/src/components/Graph/DagNode.tsx
@@ -48,7 +48,7 @@ export const DagNode = ({
         <HStack alignItems="center" gap={1}>
           <DagIcon />
           <Link asChild color="fg.info" mb={2}>
-            <RouterLink to={`/dags/${dag?.dag_id}`}>{dag?.dag_display_name ?? label}</RouterLink>
+            <RouterLink to={`/dags/${dag?.dag_id ?? label}`}>{dag?.dag_display_name ?? label}</RouterLink>
           </Link>
         </HStack>
         <TogglePause


### PR DESCRIPTION
- In asset graph, fallback to linking to the dag label if dag_id is undefined
- If error details and error message are the same. Only show one of them
- Include error code

Before:
<img width="294" alt="Screenshot 2025-03-05 at 1 20 49 PM" src="https://github.com/user-attachments/assets/90c5b6c3-9ba8-4c0c-b235-03de484050c3" />

After:
<img width="248" alt="Screenshot 2025-03-05 at 1 21 16 PM" src="https://github.com/user-attachments/assets/f1b02adb-e355-4a3e-af27-449faf87960b" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
