### PR TITLE
Remove deprecated `[database] load_default_connections` config option

### DIFF
--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -450,6 +450,10 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("smtp", "smtp_password"),
         suggestion="Please use the SMTP connection (`smtp_default`).",
     ),
+    # database
+    ConfigChange(
+        config=ConfigParameter("database", "load_default_connections"),
+    ),
 ]
 
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -670,22 +670,6 @@ database:
       type: string
       example: 'airflow_local_settings._sessionmaker'
       default: ~
-    load_default_connections:
-      description: |
-        Whether to load the default connections that ship with Airflow when ``airflow db init`` is called.
-        It's good to get started, but you probably want to set this to ``False`` in a production environment.
-      version_added: 2.3.0
-      version_deprecated: 2.7.0
-      deprecation_reason: |
-        This option is only used by the deprecated "airflow db init" command.
-        This option has been used in previous versions of Airflow to determine if loading of the default
-        connections is done with the ``airflow db init`` command. This command has been deprecated and
-        replaced by two separate commands ``airflow db migrate`` and
-        ``airflow connections create-default-connections`` and ``load_default_connections`` is not
-        used anymore by those commands.
-      type: string
-      example: ~
-      default: "True"
     max_db_retries:
       description: |
         Number of times the code should be retried in case of DB Operational Errors.

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -766,7 +766,7 @@ def _create_db_from_orm(session):
 
 
 @provide_session
-def initdb(session: Session = NEW_SESSION, load_connections: bool = True):
+def initdb(session: Session = NEW_SESSION):
     """Initialize Airflow database."""
     # First validate external DB managers before running migration
     external_db_manager = RunDBManager()
@@ -781,8 +781,6 @@ def initdb(session: Session = NEW_SESSION, load_connections: bool = True):
         _create_db_from_orm(session=session)
 
     external_db_manager.initdb(session)
-    if conf.getboolean("database", "LOAD_DEFAULT_CONNECTIONS") and load_connections:
-        create_default_connections(session=session)
     # Add default pool & sync log_template
     add_default_pool_if_not_exists(session=session)
     synchronize_log_template(session=session)
@@ -1154,7 +1152,7 @@ def upgradedb(
     if not _get_current_revision(session=session):
         # Don't load default connections
         # New DB; initialize and exit
-        initdb(session=session, load_connections=False)
+        initdb(session=session)
         return
     with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
         import sqlalchemy.pool

--- a/newsfragments/123.significant.rst
+++ b/newsfragments/123.significant.rst
@@ -1,0 +1,17 @@
+Default connections no longer created by ``airflow db reset``
+
+When default connection creation was removed from the ``airflow db migrate`` command in in 2.7,
+``airflow db reset`` was missed and still used the deprecated configuration option
+``[database] load_default_connections``. ``airflow db reset`` no longer does, so after a DB reset you must call
+``airflow connections create-default-connections`` explicitly if you'd like the default connections to be created.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [x] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes


### PR DESCRIPTION
`airflow db reset`, turns out, was still creating default connections :( But, I've noted the change in the newsfragment.