### PR TITLE
Allow truncatedtext to wrap to two lines

### DIFF
--- a/airflow/ui/src/components/TruncatedText.tsx
+++ b/airflow/ui/src/components/TruncatedText.tsx
@@ -22,12 +22,19 @@ type Props = {
   readonly text: string;
 } & TextProps;
 
-export const TruncatedText = ({ text, ...rest }: Props) => {
-  const truncatedText = text.length <= 25 ? text : `…${text.slice(-22)}`;
-
-  return (
-    <Text title={text} {...rest}>
-      {truncatedText}
-    </Text>
-  );
-};
+export const TruncatedText = ({ text, ...rest }: Props) => (
+  <Text
+    display="-webkit-box"
+    overflow="hidden"
+    style={{
+      WebkitBoxOrient: "vertical",
+      WebkitLineClamp: 2,
+    }}
+    title={text}
+    width="200px"
+    wordBreak="break-word"
+    {...rest}
+  >
+    {text}
+  </Text>
+);


### PR DESCRIPTION
<img width="657" alt="Screenshot 2025-03-05 at 3 01 24 PM" src="https://github.com/user-attachments/assets/e0e0449c-9177-4c4e-b742-fa304a5bbc60" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
