### PR TITLE
Create asset event modal

### DIFF
--- a/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
+++ b/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
@@ -17,18 +17,13 @@
  * under the License.
  */
 import { Text } from "@chakra-ui/react";
-import { json } from "@codemirror/lang-json";
-import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
-import CodeMirror from "@uiw/react-codemirror";
 import { useState } from "react";
 
-import { useColorMode } from "src/context/colorMode";
-
 import type { FlexibleFormElementProps } from ".";
+import { JsonEditor } from "../JsonEditor";
 import { paramPlaceholder, useParamStore } from "../TriggerDag/useParamStore";
 
 export const FieldAdvancedArray = ({ name }: FlexibleFormElementProps) => {
-  const { colorMode } = useColorMode();
   const { paramsDict, setParamsDict } = useParamStore();
   const param = paramsDict[name] ?? paramPlaceholder;
   const [error, setError] = useState<unknown>(undefined);
@@ -76,29 +71,13 @@ export const FieldAdvancedArray = ({ name }: FlexibleFormElementProps) => {
 
   return (
     <>
-      <CodeMirror
-        basicSetup={{
-          autocompletion: true,
-          bracketMatching: true,
-          foldGutter: true,
-          lineNumbers: true,
-        }}
-        extensions={[json()]}
-        height="200px"
+      <JsonEditor
         id={`element_${name}`}
         onChange={handleChange}
-        style={{
-          border: "1px solid var(--chakra-colors-border)",
-          borderRadius: "8px",
-          outline: "none",
-          padding: "2px",
-          width: "100%",
-        }}
-        theme={colorMode === "dark" ? githubDark : githubLight}
         value={JSON.stringify(param.value ?? [], undefined, 2)}
       />
       {Boolean(error) ? (
-        <Text color="red.solid" fontSize="xs">
+        <Text color="fg.error" fontSize="xs">
           {String(error)}
         </Text>
       ) : undefined}

--- a/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
+++ b/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
@@ -17,19 +17,13 @@
  * under the License.
  */
 import { Text } from "@chakra-ui/react";
-import { json } from "@codemirror/lang-json";
-import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
-import CodeMirror from "@uiw/react-codemirror";
 import { useState } from "react";
 
-import { useColorMode } from "src/context/colorMode";
-
 import type { FlexibleFormElementProps } from ".";
+import { JsonEditor } from "../JsonEditor";
 import { paramPlaceholder, useParamStore } from "../TriggerDag/useParamStore";
 
 export const FieldObject = ({ name }: FlexibleFormElementProps) => {
-  const { colorMode } = useColorMode();
-
   const { paramsDict, setParamsDict } = useParamStore();
   const param = paramsDict[name] ?? paramPlaceholder;
   const [error, setError] = useState<unknown>(undefined);
@@ -53,28 +47,12 @@ export const FieldObject = ({ name }: FlexibleFormElementProps) => {
 
   return (
     <>
-      <CodeMirror
-        basicSetup={{
-          autocompletion: true,
-          bracketMatching: true,
-          foldGutter: true,
-          lineNumbers: true,
-        }}
-        extensions={[json()]}
-        height="200px"
+      <JsonEditor
         id={`element_${name}`}
         onChange={handleChange}
-        style={{
-          border: "1px solid var(--chakra-colors-border)",
-          borderRadius: "8px",
-          outline: "none",
-          padding: "2px",
-          width: "100%",
-        }}
-        theme={colorMode === "dark" ? githubDark : githubLight}
-        value={JSON.stringify(param.value ?? {}, undefined, 2)}
+        value={JSON.stringify(param.value ?? [], undefined, 2)}
       />
-      {Boolean(error) ? <Text color="red">{String(error)}</Text> : undefined}
+      {Boolean(error) ? <Text color="fg,.error">{String(error)}</Text> : undefined}
     </>
   );
 };

--- a/airflow/ui/src/components/JsonEditor.tsx
+++ b/airflow/ui/src/components/JsonEditor.tsx
@@ -1,0 +1,49 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { json } from "@codemirror/lang-json";
+import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
+import CodeMirror, { type ReactCodeMirrorProps } from "@uiw/react-codemirror";
+
+import { useColorMode } from "src/context/colorMode";
+
+export const JsonEditor = (props: ReactCodeMirrorProps) => {
+  const { colorMode } = useColorMode();
+
+  return (
+    <CodeMirror
+      basicSetup={{
+        autocompletion: true,
+        bracketMatching: true,
+        foldGutter: true,
+        lineNumbers: true,
+      }}
+      extensions={[json()]}
+      height="200px"
+      style={{
+        border: "1px solid var(--chakra-colors-border)",
+        borderRadius: "8px",
+        outline: "none",
+        padding: "2px",
+        width: "100%",
+      }}
+      theme={colorMode === "dark" ? githubDark : githubLight}
+      {...props}
+    />
+  );
+};

--- a/airflow/ui/src/components/JsonEditor.tsx
+++ b/airflow/ui/src/components/JsonEditor.tsx
@@ -18,11 +18,12 @@
  */
 import { json } from "@codemirror/lang-json";
 import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
-import CodeMirror, { type ReactCodeMirrorProps } from "@uiw/react-codemirror";
+import CodeMirror, { type ReactCodeMirrorProps, type ReactCodeMirrorRef } from "@uiw/react-codemirror";
+import { forwardRef } from "react";
 
 import { useColorMode } from "src/context/colorMode";
 
-export const JsonEditor = (props: ReactCodeMirrorProps) => {
+export const JsonEditor = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>((props, ref) => {
   const { colorMode } = useColorMode();
 
   return (
@@ -35,6 +36,7 @@ export const JsonEditor = (props: ReactCodeMirrorProps) => {
       }}
       extensions={[json()]}
       height="200px"
+      ref={ref}
       style={{
         border: "1px solid var(--chakra-colors-border)",
         borderRadius: "8px",
@@ -46,4 +48,4 @@ export const JsonEditor = (props: ReactCodeMirrorProps) => {
       {...props}
     />
   );
-};
+});

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -17,19 +17,16 @@
  * under the License.
  */
 import { Input, Button, Box, Spacer, HStack, Field, Stack } from "@chakra-ui/react";
-import { json } from "@codemirror/lang-json";
-import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
-import CodeMirror from "@uiw/react-codemirror";
 import { useEffect, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { FiPlay } from "react-icons/fi";
 
-import { useColorMode } from "src/context/colorMode";
 import { useDagParams } from "src/queries/useDagParams";
 import { useTrigger } from "src/queries/useTrigger";
 
 import { ErrorAlert } from "../ErrorAlert";
 import { FlexibleForm, flexibleFormDefaultSection } from "../FlexibleForm";
+import { JsonEditor } from "../JsonEditor";
 import { Accordion } from "../ui";
 import EditableMarkdown from "./EditableMarkdown";
 import { useParamStore } from "./useParamStore";
@@ -102,8 +99,6 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
     setErrors((prev) => ({ ...prev, date: undefined }));
   };
 
-  const { colorMode } = useColorMode();
-
   return (
     <>
       <Accordion.Root
@@ -166,27 +161,11 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
                 render={({ field }) => (
                   <Field.Root invalid={Boolean(errors.conf)} mt={6}>
                     <Field.Label fontSize="md">Configuration JSON</Field.Label>
-                    <CodeMirror
+                    <JsonEditor
                       {...field}
-                      basicSetup={{
-                        autocompletion: true,
-                        bracketMatching: true,
-                        foldGutter: true,
-                        lineNumbers: true,
-                      }}
-                      extensions={[json()]}
-                      height="200px"
                       onBlur={() => {
                         field.onChange(validateAndPrettifyJson(field.value));
                       }}
-                      style={{
-                        border: "1px solid var(--chakra-colors-border)",
-                        borderRadius: "8px",
-                        outline: "none",
-                        padding: "2px",
-                        width: "100%",
-                      }}
-                      theme={colorMode === "dark" ? githubDark : githubLight}
                     />
                     {Boolean(errors.conf) ? <Field.ErrorText>{errors.conf}</Field.ErrorText> : undefined}
                   </Field.Root>

--- a/airflow/ui/src/pages/Asset/Asset.tsx
+++ b/airflow/ui/src/pages/Asset/Asset.tsx
@@ -24,9 +24,10 @@ import { useParams } from "react-router-dom";
 import { useAssetServiceGetAsset } from "openapi/queries";
 import { AssetEvents } from "src/components/Assets/AssetEvents";
 import { BreadcrumbStats } from "src/components/BreadcrumbStats";
-import { ProgressBar } from "src/components/ui";
+import { ProgressBar, Toaster } from "src/components/ui";
 
 import { AssetGraph } from "./AssetGraph";
+import { CreateAssetEvent } from "./CreateAssetEvent";
 import { Header } from "./Header";
 
 export const Asset = () => {
@@ -50,8 +51,10 @@ export const Asset = () => {
 
   return (
     <ReactFlowProvider>
+      <Toaster />
       <HStack justifyContent="space-between" mb={2}>
         <BreadcrumbStats links={links} />
+        <CreateAssetEvent asset={asset} />
       </HStack>
       <ProgressBar size="xs" visibility={Boolean(isLoading) ? "visible" : "hidden"} />
       <Box flex={1} minH={0}>

--- a/airflow/ui/src/pages/Asset/CreateAssetEvent.tsx
+++ b/airflow/ui/src/pages/Asset/CreateAssetEvent.tsx
@@ -46,7 +46,7 @@ export const CreateAssetEvent = ({ asset, withText = true }: Props) => {
         withText={withText}
       />
 
-      {asset === undefined ? undefined : (
+      {asset === undefined || !open ? undefined : (
         <CreateAssetEventModal asset={asset} onClose={onClose} open={open} />
       )}
     </Box>

--- a/airflow/ui/src/pages/Asset/CreateAssetEvent.tsx
+++ b/airflow/ui/src/pages/Asset/CreateAssetEvent.tsx
@@ -1,0 +1,54 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box } from "@chakra-ui/react";
+import { useDisclosure } from "@chakra-ui/react";
+import { FiPlay } from "react-icons/fi";
+
+import type { AssetResponse } from "openapi/requests/types.gen";
+import ActionButton from "src/components/ui/ActionButton";
+
+import { CreateAssetEventModal } from "./CreateAssetEventModal";
+
+type Props = {
+  readonly asset?: AssetResponse;
+  readonly withText?: boolean;
+};
+
+export const CreateAssetEvent = ({ asset, withText = true }: Props) => {
+  const { onClose, onOpen, open } = useDisclosure();
+
+  return (
+    <Box>
+      <ActionButton
+        actionName="Create Asset Event"
+        colorPalette="blue"
+        disabled={asset === undefined}
+        icon={<FiPlay />}
+        onClick={onOpen}
+        text="Create Asset Event"
+        variant="solid"
+        withText={withText}
+      />
+
+      {asset === undefined ? undefined : (
+        <CreateAssetEventModal asset={asset} onClose={onClose} open={open} />
+      )}
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
+++ b/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
@@ -1,0 +1,168 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, Field, Heading, HStack, VStack, Text } from "@chakra-ui/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { FiPlay } from "react-icons/fi";
+
+import {
+  useAssetServiceCreateAssetEvent,
+  UseAssetServiceGetAssetEventsKeyFn,
+  useAssetServiceMaterializeAsset,
+  useDependenciesServiceGetDependencies,
+} from "openapi/queries";
+import type { AssetResponse } from "openapi/requests/types.gen";
+import { ErrorAlert } from "src/components/ErrorAlert";
+import { JsonEditor } from "src/components/JsonEditor";
+import { Dialog, toaster } from "src/components/ui";
+import { RadioCardItem, RadioCardRoot } from "src/components/ui/RadioCard";
+
+type Props = {
+  readonly asset: AssetResponse;
+  readonly onClose: () => void;
+  readonly open: boolean;
+};
+
+export const CreateAssetEventModal = ({ asset, onClose, open }: Props) => {
+  const [eventType, setEventType] = useState("manual");
+  const [extraError, setExtraError] = useState<string | undefined>();
+  const [extra, setExtra] = useState("{}");
+  const queryClient = useQueryClient();
+
+  const { data } = useDependenciesServiceGetDependencies({ nodeId: `asset:${asset.name}` }, undefined, {
+    enabled: Boolean(asset) && Boolean(asset.name),
+  });
+
+  const hasUpstreamDag = data?.edges.some(
+    (edge) => edge.target_id === `asset:${asset.name}` && edge.source_id.startsWith("dag:"),
+  );
+
+  const validateAndPrettifyJson = (newValue: string) => {
+    try {
+      const parsedJson = JSON.parse(newValue) as JSON;
+
+      setExtraError(undefined);
+
+      const formattedJson = JSON.stringify(parsedJson, undefined, 2);
+
+      if (formattedJson !== extra) {
+        setExtra(formattedJson); // Update only if the value is different
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error occurred.";
+
+      // console.log(errorMessage);
+      setExtraError(errorMessage);
+    }
+  };
+
+  const onSuccess = async () => {
+    setExtra("{}");
+    setExtraError(undefined);
+    onClose();
+
+    const queryKeys = [UseAssetServiceGetAssetEventsKeyFn({ assetId: asset.id }, [{ assetId: asset.id }])];
+
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
+
+    toaster.create({
+      description:
+        eventType === "materialize"
+          ? "Upstream Dag was successfully triggered"
+          : "Manual asset event creation was successful",
+      title: eventType === "materialize" ? "Materializing Asset" : "Asset Event Created",
+      type: "success",
+    });
+  };
+
+  const {
+    error: manualError,
+    isPending,
+    mutate: createAssetEvent,
+  } = useAssetServiceCreateAssetEvent({ onSuccess });
+  const {
+    error: materializeError,
+    isPending: isMaterilizePending,
+    mutate: materializeAsset,
+  } = useAssetServiceMaterializeAsset({
+    onSuccess,
+  });
+
+  const handleSubmit = () => {
+    if (eventType === "materialize") {
+      materializeAsset({ assetId: asset.id });
+    } else {
+      createAssetEvent({
+        requestBody: { asset_id: asset.id, extra: JSON.parse(extra) as Record<string, unknown> },
+      });
+    }
+  };
+
+  return (
+    <Dialog.Root lazyMount onOpenChange={onClose} open={open} size="xl" unmountOnExit>
+      <Dialog.Content backdrop>
+        <Dialog.Header paddingBottom={0}>
+          <VStack align="start" gap={4}>
+            <Heading size="xl">Create Asset Event for {asset.name}</Heading>
+          </VStack>
+        </Dialog.Header>
+
+        <Dialog.CloseTrigger />
+
+        <Dialog.Body>
+          <RadioCardRoot
+            mb={6}
+            onChange={(event) => {
+              setEventType((event.target as HTMLInputElement).value);
+            }}
+            value={eventType}
+          >
+            <HStack align="stretch">
+              <RadioCardItem
+                description="Trigger the Dag upstream of this Asset"
+                disabled={!hasUpstreamDag}
+                label="Materialize"
+                value="materialize"
+              />
+              <RadioCardItem description="Directly create an Asset Event" label="Manual" value="manual" />
+            </HStack>
+          </RadioCardRoot>
+          {eventType === "manual" ? (
+            <Field.Root mt={6}>
+              <Field.Label fontSize="md">Asset Event Extra</Field.Label>
+              <JsonEditor onChange={validateAndPrettifyJson} value={extra} />
+              <Text color="fg.error">{extraError}</Text>
+            </Field.Root>
+          ) : undefined}
+          <ErrorAlert error={eventType === "manual" ? manualError : materializeError} />
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button
+            colorPalette="blue"
+            disabled={Boolean(extraError)}
+            loading={isPending || isMaterilizePending}
+            onClick={handleSubmit}
+          >
+            <FiPlay /> Create Event
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};


### PR DESCRIPTION
Add a Create Asset Event Modal. It has two options to materialize or manually create the asset event. Materialize is only allowed if there is an upstream dag. Extra is only shown for manual asset event creation.



<img width="1434" alt="Screenshot 2025-03-05 at 4 55 06 PM" src="https://github.com/user-attachments/assets/a025f257-1eb3-4fdc-848e-fc23dd74ecc8" />
<img width="925" alt="Screenshot 2025-03-05 at 4 55 14 PM" src="https://github.com/user-attachments/assets/80b19390-9433-46c7-9691-594cab67c6be" />
<img width="955" alt="Screenshot 2025-03-05 at 4 55 10 PM" src="https://github.com/user-attachments/assets/edcba8b5-5dd8-41da-9bab-69e094336aed" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
