### PR TITLE
Remove remaining pieces of k8s exec specific UI pages

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/config.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/config.py
@@ -39,6 +39,5 @@ class ConfigResponse(BaseModel):
     warn_deployment_exposure: bool
     audit_view_excluded_events: str
     audit_view_included_events: str
-    is_k8s: bool
     test_connection: str
     state_color_mapping: dict

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -7993,9 +7993,6 @@ components:
         audit_view_included_events:
           type: string
           title: Audit View Included Events
-        is_k8s:
-          type: boolean
-          title: Is K8S
         test_connection:
           type: string
           title: Test Connection
@@ -8021,7 +8018,6 @@ components:
       - warn_deployment_exposure
       - audit_view_excluded_events
       - audit_view_included_events
-      - is_k8s
       - test_connection
       - state_color_mapping
       title: ConfigResponse

--- a/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -24,7 +24,7 @@ from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.config import ConfigResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.configuration import conf
-from airflow.settings import IS_K8S_OR_K8SCELERY_EXECUTOR, STATE_COLORS
+from airflow.settings import STATE_COLORS
 
 config_router = AirflowRouter(tags=["Config"])
 
@@ -62,7 +62,6 @@ def get_configs() -> ConfigResponse:
         "audit_view_excluded_events": conf.get("webserver", "audit_view_excluded_events", fallback=""),
         "test_connection": conf.get("core", "test_connection", fallback="Disabled"),
         "state_color_mapping": STATE_COLORS,
-        "is_k8s": IS_K8S_OR_K8SCELERY_EXECUTOR,
     }
 
     config.update({key: value for key, value in additional_config.items()})

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -37,7 +37,6 @@ from sqlalchemy.pool import NullPool
 from airflow import __version__ as airflow_version, policies
 from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # noqa: F401
 from airflow.exceptions import AirflowInternalRuntimeError
-from airflow.executors import executor_constants
 from airflow.logging_config import configure_logging
 from airflow.utils.orm_event_handlers import setup_event_handlers
 from airflow.utils.sqlalchemy import is_sqlalchemy_v1
@@ -679,9 +678,6 @@ LAZY_LOAD_PLUGINS: bool = conf.getboolean("core", "lazy_load_plugins", fallback=
 # Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
 # loaded from module.
 LAZY_LOAD_PROVIDERS: bool = conf.getboolean("core", "lazy_discover_providers", fallback=True)
-
-# Determines if the executor utilizes Kubernetes
-IS_K8S_OR_K8SCELERY_EXECUTOR = conf.get("core", "EXECUTOR") == executor_constants.KUBERNETES_EXECUTOR
 
 # Executors can set this to true to configure logging correctly for
 # containerized executors.

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1215,10 +1215,6 @@ export const $ConfigResponse = {
       type: "string",
       title: "Audit View Included Events",
     },
-    is_k8s: {
-      type: "boolean",
-      title: "Is K8S",
-    },
     test_connection: {
       type: "string",
       title: "Test Connection",
@@ -1247,7 +1243,6 @@ export const $ConfigResponse = {
     "warn_deployment_exposure",
     "audit_view_excluded_events",
     "audit_view_included_events",
-    "is_k8s",
     "test_connection",
     "state_color_mapping",
   ],

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -411,7 +411,6 @@ export type ConfigResponse = {
   warn_deployment_exposure: boolean;
   audit_view_excluded_events: string;
   audit_view_included_events: string;
-  is_k8s: boolean;
   test_connection: string;
   state_color_mapping: {
     [key: string]: unknown;

--- a/airflow/ui/src/mocks/handlers/config.ts
+++ b/airflow/ui/src/mocks/handlers/config.ts
@@ -30,7 +30,6 @@ export const handlers: Array<HttpHandler> = [
       hide_paused_dags_by_default: false,
       instance_name: "Airflow",
       instance_name_has_markup: false,
-      is_k8s: false,
       navbar_color: "#fff",
       navbar_hover_color: "#eee",
       navbar_logo_text_color: "#51504f",

--- a/tests/api_fastapi/core_api/routes/ui/test_config.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_config.py
@@ -40,7 +40,6 @@ mock_config_response = {
     "warn_deployment_exposure": False,
     "audit_view_excluded_events": "",
     "audit_view_included_events": "",
-    "is_k8s": False,
     "test_connection": "Disabled",
     "state_color_mapping": {
         "deferred": "mediumpurple",


### PR DESCRIPTION
See this conversation for more context: https://github.com/apache/airflow/pull/47322#discussion_r1978488825

tl;dr: We have had one remaining executor coupling (re AIP-51, see 6a [here](https://github.com/apache/airflow/issues/27933)) with the k8s executor having a UI page which renders the kube config. This coupling has stayed unfixed because we have had two options:
1) Create a mechanism for all executors to vend UI pages. This has remained undone because we only have one example of this requirement so it doesn't seem to warrant the complexity and time it would take to build such a mechanism. Also, the state of UI in Airflow has been under flux in recent times.
2) Drop support for the k8s use case, which would remove the requirement of building 1). But this is a breaking change and we have not found a right time to do it, until now :)

As far as I can tell this page has actually already been removed in the recent PR to deprecate the old UI in Airflow, and the kube config endpoint as not as yet been re-created in the new UI. So this PR simply removes some of the remaining bits and pieces that used to trigger that endpoint to be present.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
