### PR TITLE
Fix indentation in core conf test

### DIFF
--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -641,11 +641,11 @@ key3 = value3
 
     def test_command_from_env(self):
         test_cmdenv_config = """[testcmdenv]
-            itsacommand = NOT OK
-            notacommand = OK
+            itsacommand=NOT OK
+            notacommand=OK
         """
         test_cmdenv_conf = AirflowConfigParser()
-        test_cmdenv_conf.read_string(test_cmdenv_config)
+        test_cmdenv_conf.read_string(textwrap.dedent(test_cmdenv_config))
         test_cmdenv_conf.sensitive_config_values.add(("testcmdenv", "itsacommand"))
         with mock.patch.dict("os.environ"):
             # AIRFLOW__TESTCMDENV__ITSACOMMAND_CMD maps to ('testcmdenv', 'itsacommand') in

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -641,9 +641,9 @@ key3 = value3
 
     def test_command_from_env(self):
         test_cmdenv_config = """[testcmdenv]
-itsacommand = NOT OK
-notacommand = OK
-"""
+            itsacommand = NOT OK
+            notacommand = OK
+        """
         test_cmdenv_conf = AirflowConfigParser()
         test_cmdenv_conf.read_string(test_cmdenv_config)
         test_cmdenv_conf.sensitive_config_values.add(("testcmdenv", "itsacommand"))

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -640,12 +640,13 @@ key3 = value3
                 )
 
     def test_command_from_env(self):
-        test_cmdenv_config = """[testcmdenv]
+        test_cmdenv_config = textwrap.dedent("""\
+            [testcmdenv]
             itsacommand=NOT OK
             notacommand=OK
-        """
+        """)
         test_cmdenv_conf = AirflowConfigParser()
-        test_cmdenv_conf.read_string(textwrap.dedent(test_cmdenv_config))
+        test_cmdenv_conf.read_string(test_cmdenv_config)
         test_cmdenv_conf.sensitive_config_values.add(("testcmdenv", "itsacommand"))
         with mock.patch.dict("os.environ"):
             # AIRFLOW__TESTCMDENV__ITSACOMMAND_CMD maps to ('testcmdenv', 'itsacommand') in


### PR DESCRIPTION
Fix indentation in core conf test
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
