### PR TITLE
Fix and simplify `get_permitted_dag_ids` in auth manager

### DIFF
--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -34,7 +34,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
-    from collections.abc import Container, Sequence
+    from collections.abc import Sequence
 
     from fastapi import FastAPI
     from sqlalchemy.orm import Session
@@ -331,7 +331,7 @@ class BaseAuthManager(Generic[T], LoggingMixin):
         self,
         *,
         user: T,
-        methods: Container[ResourceMethod] | None = None,
+        method: ResourceMethod = "GET",
         session: Session = NEW_SESSION,
     ) -> set[str]:
         """
@@ -342,45 +342,31 @@ class BaseAuthManager(Generic[T], LoggingMixin):
         implementation to provide a more efficient implementation.
 
         :param user: the user
-        :param methods: whether filter readable or writable
+        :param method: the method to filter on
         :param session: the session
         """
         dag_ids = {dag.dag_id for dag in session.execute(select(DagModel.dag_id))}
-        return self.filter_permitted_dag_ids(dag_ids=dag_ids, methods=methods, user=user)
+        return self.filter_permitted_dag_ids(dag_ids=dag_ids, method=method, user=user)
 
     def filter_permitted_dag_ids(
         self,
         *,
         dag_ids: set[str],
         user: T,
-        methods: Container[ResourceMethod] | None = None,
+        method: ResourceMethod = "GET",
     ) -> set[str]:
         """
         Filter readable or writable DAGs for user.
 
         :param dag_ids: the list of DAG ids
         :param user: the user
-        :param methods: whether filter readable or writable
+        :param method: the method to filter on
         """
-        if not methods:
-            methods = ["PUT", "GET"]
 
-        if ("GET" in methods and self.is_authorized_dag(method="GET", user=user)) or (
-            "PUT" in methods and self.is_authorized_dag(method="PUT", user=user)
-        ):
-            # If user is authorized to read/edit all DAGs, return all DAGs
-            return dag_ids
+        def _is_permitted_dag_id(method: ResourceMethod, dag_id: str):
+            return self.is_authorized_dag(method=method, details=DagDetails(id=dag_id), user=user)
 
-        def _is_permitted_dag_id(method: ResourceMethod, methods: Container[ResourceMethod], dag_id: str):
-            return method in methods and self.is_authorized_dag(
-                method=method, details=DagDetails(id=dag_id), user=user
-            )
-
-        return {
-            dag_id
-            for dag_id in dag_ids
-            if _is_permitted_dag_id("GET", methods, dag_id) or _is_permitted_dag_id("PUT", methods, dag_id)
-        }
+        return {dag_id for dag_id in dag_ids if _is_permitted_dag_id(method, dag_id)}
 
     @staticmethod
     def get_cli_commands() -> list[CLICommand]:

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import argparse
 from collections import defaultdict
-from collections.abc import Container, Sequence
+from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
@@ -283,23 +283,18 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
         *,
         dag_ids: set[str],
         user: AwsAuthManagerUser,
-        methods: Container[ResourceMethod] | None = None,
+        method: ResourceMethod = "GET",
     ):
-        if not methods:
-            methods = ["PUT", "GET"]
-
         requests: dict[str, dict[ResourceMethod, IsAuthorizedRequest]] = defaultdict(dict)
         requests_list: list[IsAuthorizedRequest] = []
         for dag_id in dag_ids:
-            for method in ["GET", "PUT"]:
-                if method in methods:
-                    request: IsAuthorizedRequest = {
-                        "method": cast("ResourceMethod", method),
-                        "entity_type": AvpEntities.DAG,
-                        "entity_id": dag_id,
-                    }
-                    requests[dag_id][cast("ResourceMethod", method)] = request
-                    requests_list.append(request)
+            request: IsAuthorizedRequest = {
+                "method": method,
+                "entity_type": AvpEntities.DAG,
+                "entity_id": dag_id,
+            }
+            requests[dag_id][method] = request
+            requests_list.append(request)
 
         batch_is_authorized_results = self.avp_facade.get_batch_is_authorized_results(
             requests=requests_list, user=user
@@ -311,16 +306,7 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
             )
             return result["decision"] == "ALLOW"
 
-        return {
-            dag_id
-            for dag_id in dag_ids
-            if (
-                "GET" in methods
-                and _has_access_to_dag(requests[dag_id]["GET"])
-                or "PUT" in methods
-                and _has_access_to_dag(requests[dag_id]["PUT"])
-            )
-        }
+        return {dag_id for dag_id in dag_ids if _has_access_to_dag(requests[dag_id][method])}
 
     def get_url_login(self, **kwargs) -> str:
         return f"{self.apiserver_endpoint}/auth/login"

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -445,26 +445,30 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "methods, user",
+        "method, user, expected_result",
         [
-            (None, AwsAuthManagerUser(user_id="test_user_id", groups=[])),
-            (["PUT", "GET"], AwsAuthManagerUser(user_id="test_user_id", groups=[])),
+            ("GET", AwsAuthManagerUser(user_id="test_user_id1", groups=[]), {"dag_1"}),
+            ("PUT", AwsAuthManagerUser(user_id="test_user_id1", groups=[]), set()),
+            ("GET", AwsAuthManagerUser(user_id="test_user_id2", groups=[]), set()),
+            ("PUT", AwsAuthManagerUser(user_id="test_user_id2", groups=[]), {"dag_2"}),
         ],
     )
-    def test_filter_permitted_dag_ids(self, methods, user, auth_manager, test_user):
+    def test_filter_permitted_dag_ids(self, method, user, auth_manager, test_user, expected_result):
         dag_ids = {"dag_1", "dag_2"}
+        # test_user_id1 has GET permissions on dag_1
+        # test_user_id2 has PUT permissions on dag_2
         batch_is_authorized_output = [
             {
                 "request": {
-                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id"},
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id1"},
                     "action": {"actionType": "Airflow::Action", "actionId": "Dag.GET"},
                     "resource": {"entityType": "Airflow::Dag", "entityId": "dag_1"},
                 },
-                "decision": "DENY",
+                "decision": "ALLOW",
             },
             {
                 "request": {
-                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id"},
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id1"},
                     "action": {"actionType": "Airflow::Action", "actionId": "Dag.PUT"},
                     "resource": {"entityType": "Airflow::Dag", "entityId": "dag_1"},
                 },
@@ -472,7 +476,7 @@ class TestAwsAuthManager:
             },
             {
                 "request": {
-                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id"},
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id1"},
                     "action": {"actionType": "Airflow::Action", "actionId": "Dag.GET"},
                     "resource": {"entityType": "Airflow::Dag", "entityId": "dag_2"},
                 },
@@ -480,7 +484,39 @@ class TestAwsAuthManager:
             },
             {
                 "request": {
-                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id"},
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id1"},
+                    "action": {"actionType": "Airflow::Action", "actionId": "Dag.PUT"},
+                    "resource": {"entityType": "Airflow::Dag", "entityId": "dag_2"},
+                },
+                "decision": "DENY",
+            },
+            {
+                "request": {
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id2"},
+                    "action": {"actionType": "Airflow::Action", "actionId": "Dag.GET"},
+                    "resource": {"entityType": "Airflow::Dag", "entityId": "dag_1"},
+                },
+                "decision": "DENY",
+            },
+            {
+                "request": {
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id2"},
+                    "action": {"actionType": "Airflow::Action", "actionId": "Dag.PUT"},
+                    "resource": {"entityType": "Airflow::Dag", "entityId": "dag_1"},
+                },
+                "decision": "DENY",
+            },
+            {
+                "request": {
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id2"},
+                    "action": {"actionType": "Airflow::Action", "actionId": "Dag.GET"},
+                    "resource": {"entityType": "Airflow::Dag", "entityId": "dag_2"},
+                },
+                "decision": "DENY",
+            },
+            {
+                "request": {
+                    "principal": {"entityType": "Airflow::User", "entityId": "test_user_id2"},
                     "action": {"actionType": "Airflow::Action", "actionId": "Dag.PUT"},
                     "resource": {"entityType": "Airflow::Dag", "entityId": "dag_2"},
                 },
@@ -493,12 +529,12 @@ class TestAwsAuthManager:
 
         result = auth_manager.filter_permitted_dag_ids(
             dag_ids=dag_ids,
-            methods=methods,
+            method=method,
             user=user,
         )
 
         auth_manager.avp_facade.get_batch_is_authorized_results.assert_called()
-        assert result == {"dag_2"}
+        assert result == expected_result
 
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Container
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -58,6 +57,7 @@ from airflow.providers.fab.auth_manager.cli_commands.definition import (
     USERS_COMMANDS,
 )
 from airflow.providers.fab.auth_manager.models import Permission, Role, User
+from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
 from airflow.providers.fab.www.app import create_app
 from airflow.providers.fab.www.constants import SWAGGER_BUNDLE, SWAGGER_ENABLED
 from airflow.providers.fab.www.extensions.init_views import _CustomErrorRequestBodyValidator, _LazyResolver
@@ -355,30 +355,24 @@ class FabAuthManager(BaseAuthManager[User]):
         self,
         *,
         user: User,
-        methods: Container[ResourceMethod] | None = None,
+        method: ResourceMethod = "GET",
         session: Session = NEW_SESSION,
     ) -> set[str]:
-        if not methods:
-            methods = ["PUT", "GET"]
-
-        if not self.is_logged_in():
-            roles = user.roles
-        else:
-            if ("GET" in methods and self.is_authorized_dag(method="GET", user=user)) or (
-                "PUT" in methods and self.is_authorized_dag(method="PUT", user=user)
-            ):
-                # If user is authorized to read/edit all DAGs, return all DAGs
-                return {dag.dag_id for dag in session.execute(select(DagModel.dag_id))}
-            user_query = session.scalar(
-                select(User)
-                .options(
-                    joinedload(User.roles)
-                    .subqueryload(Role.permissions)
-                    .options(joinedload(Permission.action), joinedload(Permission.resource))
-                )
-                .where(User.id == user.id)
+        if self._is_authorized(method=method, resource_type=RESOURCE_DAG, user=user):
+            # If user is authorized to access all DAGs, return all DAGs
+            return {dag.dag_id for dag in session.execute(select(DagModel.dag_id))}
+        if isinstance(user, AnonymousUser):
+            return set()
+        user_query = session.scalar(
+            select(User)
+            .options(
+                joinedload(User.roles)
+                .subqueryload(Role.permissions)
+                .options(joinedload(Permission.action), joinedload(Permission.resource))
             )
-            roles = user_query.roles
+            .where(User.id == user.id)
+        )
+        roles = user_query.roles
 
         map_fab_action_name_to_method_name = get_method_from_fab_action_map()
         resources = set()
@@ -387,7 +381,7 @@ class FabAuthManager(BaseAuthManager[User]):
                 action = permission.action.name
                 if (
                     action in map_fab_action_name_to_method_name
-                    and map_fab_action_name_to_method_name[action] in methods
+                    and map_fab_action_name_to_method_name[action] == method
                 ):
                     resource = permission.resource.name
                     if resource == permissions.RESOURCE_DAG:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -973,12 +973,12 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     @staticmethod
     def get_readable_dag_ids(user=None) -> set[str]:
         """Get the DAG IDs readable by authenticated user."""
-        return get_auth_manager().get_permitted_dag_ids(methods=["GET"], user=user)
+        return get_auth_manager().get_permitted_dag_ids(user=user)
 
     @staticmethod
     def get_editable_dag_ids(user=None) -> set[str]:
         """Get the DAG IDs editable by authenticated user."""
-        return get_auth_manager().get_permitted_dag_ids(methods=["PUT"], user=user)
+        return get_auth_manager().get_permitted_dag_ids(method="PUT", user=user)
 
     def can_access_some_dags(self, action: str, dag_id: str | None = None) -> bool:
         """Check if user has read or write access to some dags."""

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -544,7 +544,7 @@ def test_dont_get_inaccessible_dag_ids_for_dag_resource_permission(
                 dag_id, access_control={role_name: permission_action}
             )
 
-            assert get_auth_manager().get_permitted_dag_ids(methods=["GET"], user=user) == set()
+            assert get_auth_manager().get_permitted_dag_ids(user=user) == set()
 
 
 def test_has_access(security_manager):

--- a/tests/auth/managers/test_base_auth_manager.py
+++ b/tests/auth/managers/test_base_auth_manager.py
@@ -258,34 +258,23 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "access_all, access_per_dag, dag_ids, expected",
+        "access_per_dag, dag_ids, expected",
         [
-            # Access to all dags
-            (
-                True,
-                {},
-                ["dag1", "dag2"],
-                {"dag1", "dag2"},
-            ),
             # No access to any dag
             (
-                False,
                 {},
                 ["dag1", "dag2"],
                 set(),
             ),
             # Access to specific dags
             (
-                False,
                 {"dag1": True},
                 ["dag1", "dag2"],
                 {"dag1"},
             ),
         ],
     )
-    def test_get_permitted_dag_ids(
-        self, auth_manager, access_all: bool, access_per_dag: dict, dag_ids: list, expected: set
-    ):
+    def test_get_permitted_dag_ids(self, auth_manager, access_per_dag: dict, dag_ids: list, expected: set):
         def side_effect_func(
             *,
             method: ResourceMethod,
@@ -294,7 +283,7 @@ class TestBaseAuthManager:
             user: BaseAuthManagerUserTest | None = None,
         ):
             if not details:
-                return access_all
+                return False
             else:
                 return access_per_dag.get(details.id, False)
 


### PR DESCRIPTION
There is a bug currently in FAB auth manager. An error is thrown when trying to list DAGs with this following error:
```
AttributeError: 'NoneType' object has no attribute 'is_anonymous'
```

This PR fixes the issue but more importantly, it simplifies the methods `get_permitted_dag_ids` and `filter_permitted_dag_ids` which were overly complicated for no reason.

I also created tests for `get_permitted_dag_ids` in FAB auth manager.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
