### PR TITLE
Remove ResourceWarnings from TaskSDK

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -500,7 +500,7 @@ def dispose_orm():
         NonScopedSession = None
         close_all_sessions()
 
-    if "engine" in _globals:
+    if "engine" in _globals and engine is not None:
         engine.dispose()
         engine = None
 

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -31,7 +31,7 @@ from collections.abc import Generator
 from contextlib import suppress
 from datetime import datetime, timezone
 from http import HTTPStatus
-from socket import socket, socketpair
+from socket import SocketIO, socket, socketpair
 from typing import (
     TYPE_CHECKING,
     BinaryIO,
@@ -129,16 +129,10 @@ def mkpipe(remote_read: Literal[True]) -> tuple[socket, BinaryIO]: ...
 def mkpipe(
     remote_read: bool = False,
 ) -> tuple[socket, socket | BinaryIO]:
-    """
-    Create a pair of connected sockets.
-
-    The inheritable flag will be set correctly so that the end destined for the subprocess is kept open but
-    the end for this process is closed automatically by the OS.
-    """
+    """Create a pair of connected sockets."""
     rsock, wsock = socketpair()
     local, remote = (wsock, rsock) if remote_read else (rsock, wsock)
 
-    remote.set_inheritable(True)
     local.setblocking(False)
 
     io: BinaryIO | socket
@@ -399,7 +393,8 @@ class WatchedSubprocess:
 
         pid = os.fork()
         if pid == 0:
-            # Parent ends of the sockets are closed by the OS as they are set as non-inheritable
+            # Close and delete of the parent end of the sockets.
+            cls._close_unused_sockets(feed_stdin, read_stdout, read_stderr, read_msgs, read_logs)
 
             # Python GC should delete these for us, but lets make double sure that we don't keep anything
             # around in the forked processes, especially things that might involve open files or sockets!
@@ -501,6 +496,10 @@ class WatchedSubprocess:
     def _close_unused_sockets(*sockets):
         """Close unused ends of sockets after fork."""
         for sock in sockets:
+            if isinstance(sock, SocketIO):
+                # If we have the socket IO object, we need to close the underlying socket foricebly here too,
+                # else we get unclosed socket warnings, and likely leaking FDs too
+                sock._sock.close()
             sock.close()
 
     def kill(
@@ -617,6 +616,7 @@ class WatchedSubprocess:
             try:
                 self._exit_code = self._process.wait(timeout=0)
                 log.debug("Workload process exited", exit_code=self._exit_code)
+                self._close_unused_sockets(self.stdin)
             except psutil.TimeoutExpired:
                 if raise_on_timeout:
                     raise


### PR DESCRIPTION
It turns out that the way SocketIO (which is the class you get from)
`sock.makefile` doesn't _actually_ close the socket when you close the IO
object, which normally is fine as the socket won't be around and will clean up
nicely, but due to forking and us _actually_ wanting to close the socket, we
need to be a bit more careful about how we do this.

It also turns out I misunderstood when `set_inheritable` applies. It is not
about when forking, but specifically only when execing. So I've removed that
setting as we don't need it.

Closes #46048, and relates to #47294 (it might close it, it might not, unsure
at this point)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
