### PR TITLE
Update Dag and Asset panel defaults

### DIFF
--- a/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -69,7 +69,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
       <Toaster />
       <Box flex={1} minH={0}>
         <PanelGroup autoSaveId={dagId} direction="horizontal">
-          <Panel defaultSize={20} minSize={6}>
+          <Panel defaultSize={dagView === "graph" ? 70 : 20} minSize={6}>
             <Box height="100%" position="relative" pr={2}>
               <PanelButtons dagView={dagView} setDagView={setDagView} />
               {dagView === "graph" ? <Graph /> : <Grid />}
@@ -87,7 +87,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
           >
             <Box bg="fg.subtle" cursor="col-resize" h="100%" transition="background 0.2s" w={0.5} />
           </PanelResizeHandle>
-          <Panel defaultSize={50} minSize={20}>
+          <Panel defaultSize={dagView === "graph" ? 30 : 80} minSize={20}>
             <Box display="flex" flexDirection="column" h="100%">
               {children}
               <ErrorAlert error={error} />

--- a/airflow/ui/src/pages/Asset/Asset.tsx
+++ b/airflow/ui/src/pages/Asset/Asset.tsx
@@ -56,7 +56,7 @@ export const Asset = () => {
       <ProgressBar size="xs" visibility={Boolean(isLoading) ? "visible" : "hidden"} />
       <Box flex={1} minH={0}>
         <PanelGroup autoSaveId={assetId} direction="horizontal">
-          <Panel defaultSize={20} minSize={6}>
+          <Panel defaultSize={70} minSize={6}>
             <Box height="100%" position="relative" pr={2}>
               <AssetGraph asset={asset} />
             </Box>
@@ -64,7 +64,7 @@ export const Asset = () => {
           <PanelResizeHandle className="resize-handle">
             <Box bg="fg.subtle" cursor="col-resize" h="100%" transition="background 0.2s" w={0.5} />
           </PanelResizeHandle>
-          <Panel defaultSize={50} minSize={20}>
+          <Panel defaultSize={30} minSize={20}>
             <Header asset={asset} />
             <Box h="100%" overflow="auto" px={2}>
               <AssetEvents assetId={asset?.id} />


### PR DESCRIPTION
Default Asset view panel to have the graph take up most of the page

Change Dag panel default sizes depending on if we're displaying a grid or graph view.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
