### PR TITLE
Update task log styling

### DIFF
--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -35,7 +35,9 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
     <ErrorAlert error={error ?? logError} />
     <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
     <Code overflow="auto" py={3} textWrap={wrap ? "pre" : "nowrap"} width="100%">
-      <VStack alignItems="flex-start">{parsedLogs}</VStack>
+      <VStack alignItems="flex-start" gap={0}>
+        {parsedLogs}
+      </VStack>
     </Code>
   </Box>
 );

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -34,7 +34,17 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
   <Box>
     <ErrorAlert error={error ?? logError} />
     <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
-    <Code overflow="auto" py={3} textWrap={wrap ? "pre" : "nowrap"} width="100%">
+    <Code
+      css={{
+        "& *::selection": {
+          bg: "blue.subtle",
+        },
+      }}
+      overflow="auto"
+      py={3}
+      textWrap={wrap ? "pre" : "nowrap"}
+      width="100%"
+    >
       <VStack alignItems="flex-start" gap={0}>
         {parsedLogs}
       </VStack>

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Badge, Text } from "@chakra-ui/react";
+import { chakra, Code } from "@chakra-ui/react";
 import type { UseQueryOptions } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import innerText from "react-innertext";
@@ -50,9 +50,9 @@ const renderStructuredLog = (
 ) => {
   if (typeof logMessage === "string") {
     return (
-      <Text key={index} py={1}>
+      <chakra.span key={index} lineHeight={1.5}>
         {logMessage}
-      </Text>
+      </chakra.span>
     );
   }
 
@@ -74,14 +74,15 @@ const renderStructuredLog = (
 
   if (typeof level === "string") {
     elements.push(
-      <Badge
+      <Code
         colorPalette={level.toUpperCase() in LogLevel ? logLevelColorMapping[level as LogLevel] : undefined}
         key={1}
-        minH={3}
-        size="sm"
+        lineHeight={1.5}
+        minH={0}
+        px={0}
       >
         {level.toUpperCase()}
-      </Badge>,
+      </Code>,
       " - ",
     );
   }
@@ -104,9 +105,9 @@ const renderStructuredLog = (
   }
 
   return (
-    <Text key={index} py={1}>
+    <chakra.span key={index} lineHeight={1.5}>
       {elements}
-    </Text>
+    </chakra.span>
   );
 };
 
@@ -143,9 +144,9 @@ const parseLogs = ({ data, logLevelFilters }: ParseLogsProps) => {
       const group = (
         <details key={groupName} style={{ width: "100%" }}>
           <summary data-testid={`summary-${groupName}`}>
-            <Text as="span" color="fg.info" cursor="pointer">
+            <chakra.span color="fg.info" cursor="pointer">
               {groupName}
-            </Text>
+            </chakra.span>
           </summary>
           {groupLines}
         </details>


### PR DESCRIPTION
- Change the selection color for task logs. (Maybe in the future we should change it for the entire app, but I want to start small)
- Get rid of excess padding
- Move the Log Level to a code block so it is maintained in copy/paste actions


<img width="1025" alt="Screenshot 2025-03-06 at 3 13 09 PM" src="https://github.com/user-attachments/assets/af4b2f40-7df8-4d31-9195-a9ed0f511277" />
<img width="925" alt="Screenshot 2025-03-06 at 3 13 13 PM" src="https://github.com/user-attachments/assets/8b7ccae4-ed20-4487-b1fc-152fa21e381d" />




---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
