### PR TITLE
Bugfix typing after google-ads release 26.0.0 release

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -655,7 +655,7 @@
       "gcloud-aio-bigquery>=6.1.2",
       "gcloud-aio-storage>=9.0.0",
       "gcsfs>=2023.10.0",
-      "google-ads>=25.1.0",
+      "google-ads>=26.0.0",
       "google-analytics-admin>=0.9.0",
       "google-api-core>=2.11.0,!=2.16.0,!=2.18.0",
       "google-api-python-client>=2.0.2",

--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -69,7 +69,7 @@ PIP package                                 Version required
 ``gcloud-aio-bigquery``                     ``>=6.1.2``
 ``gcloud-aio-storage``                      ``>=9.0.0``
 ``gcsfs``                                   ``>=2023.10.0``
-``google-ads``                              ``>=25.1.0``
+``google-ads``                              ``>=26.0.0``
 ``google-analytics-admin``                  ``>=0.9.0``
 ``google-api-core``                         ``>=2.11.0,!=2.16.0,!=2.18.0``
 ``google-api-python-client``                ``>=2.0.2``

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "gcloud-aio-bigquery>=6.1.2",
     "gcloud-aio-storage>=9.0.0",
     "gcsfs>=2023.10.0",
-    "google-ads>=25.1.0",
+    "google-ads>=26.0.0",
     "google-analytics-admin>=0.9.0",
     # Google-api-core 2.16.0 back-compat issue:
     # - https://github.com/googleapis/python-api-core/issues/576

--- a/providers/google/src/airflow/providers/google/ads/hooks/ads.py
+++ b/providers/google/src/airflow/providers/google/ads/hooks/ads.py
@@ -35,8 +35,8 @@ from airflow.providers.google.common.hooks.base_google import get_field
 if TYPE_CHECKING:
     from google.ads.googleads.v18.services.services.customer_service import CustomerServiceClient
     from google.ads.googleads.v18.services.services.google_ads_service import GoogleAdsServiceClient
+    from google.ads.googleads.v18.services.services.google_ads_service.pagers import SearchPager
     from google.ads.googleads.v18.services.types.google_ads_service import GoogleAdsRow
-    from google.api_core.page_iterator import GRPCIterator
 
 
 class GoogleAdsHook(BaseHook):
@@ -178,7 +178,7 @@ class GoogleAdsHook(BaseHook):
         """
         try:
             accessible_customers = self._get_customer_service.list_accessible_customers()
-            return accessible_customers.resource_names
+            return list(accessible_customers.resource_names)
         except GoogleAdsException as ex:
             for error in ex.failure.errors:
                 self.log.error('\tError with message "%s".', error.message)
@@ -306,11 +306,11 @@ class GoogleAdsHook(BaseHook):
 
         return self._extract_rows(iterators)
 
-    def _extract_rows(self, iterators: list[GRPCIterator]) -> list[GoogleAdsRow]:
+    def _extract_rows(self, iterators: list[SearchPager]) -> list[GoogleAdsRow]:
         """
-        Convert Google Page Iterator (GRPCIterator) objects to Google Ads Rows.
+        Convert Google Page Iterator (SearchPager) objects to Google Ads Rows.
 
-        :param iterators: List of Google Page Iterator (GRPCIterator) objects
+        :param iterators: List of Google Page Iterator (SearchPager) objects
         :return: API response for all clients in the form of Google Ads Row object(s)
         """
         try:

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1590,7 +1590,7 @@ def get_provider_info():
             "gcloud-aio-bigquery>=6.1.2",
             "gcloud-aio-storage>=9.0.0",
             "gcsfs>=2023.10.0",
-            "google-ads>=25.1.0",
+            "google-ads>=26.0.0",
             "google-analytics-admin>=0.9.0",
             "google-api-core>=2.11.0,!=2.16.0,!=2.18.0",
             "google-api-python-client>=2.0.2",


### PR DESCRIPTION
Fix for broken canary in https://github.com/apache/airflow/actions/runs/13706617108/job/38334811986

It seems that `google-ads` released version 26.0.0 with changed typing. This PR just jumps on the new version and adjusts types to be back green again.