### PR TITLE
Add other executor tests to K8s tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -1468,10 +1468,7 @@ def _run_tests(
             f"[info]You can deploy airflow with {executor} by running:[/]\nbreeze k8s configure-cluster\nbreeze k8s deploy-airflow --multi-namespace-mode --executor {executor}"
         )
         return 1, f"Tests {kubectl_cluster_name}"
-    the_tests: list[str] = [
-        "kubernetes_tests/test_kubernetes_executor.py::TestKubernetesExecutor",
-        "kubernetes_tests/test_other_executors.py",
-    ]
+    the_tests: list[str] = ["kubernetes_tests/"]
     command_to_run = " ".join([quote(arg) for arg in ["python3", "-m", "pytest", *the_tests, *test_args]])
     get_console(output).print(f"[info] Command to run:[/] {command_to_run}")
     result = run_command(

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -1468,7 +1468,10 @@ def _run_tests(
             f"[info]You can deploy airflow with {executor} by running:[/]\nbreeze k8s configure-cluster\nbreeze k8s deploy-airflow --multi-namespace-mode --executor {executor}"
         )
         return 1, f"Tests {kubectl_cluster_name}"
-    the_tests: list[str] = ["kubernetes_tests/test_kubernetes_executor.py::TestKubernetesExecutor"]
+    the_tests: list[str] = [
+        "kubernetes_tests/test_kubernetes_executor.py::TestKubernetesExecutor",
+        "kubernetes_tests/test_other_executors.py",
+    ]
     command_to_run = " ".join([quote(arg) for arg in ["python3", "-m", "pytest", *the_tests, *test_args]])
     get_console(output).print(f"[info] Command to run:[/] {command_to_run}")
     result = run_command(

--- a/kubernetes_tests/test_other_executors.py
+++ b/kubernetes_tests/test_other_executors.py
@@ -31,6 +31,10 @@ from kubernetes_tests.test_base import (
 # Also, the skipping is necessary as there's no gain in running these tests in KubernetesExecutor
 @pytest.mark.skipif(EXECUTOR == "KubernetesExecutor", reason="Does not run on KubernetesExecutor")
 class TestCeleryAndLocalExecutor(BaseK8STest):
+    @pytest.mark.xfail(
+        EXECUTOR == "LocalExecutor",
+        reason="https://github.com/apache/airflow/issues/47518 needs to be fixed",
+    )
     def test_integration_run_dag(self):
         dag_id = "example_bash_operator"
         dag_run_id, logical_date = self.start_job_in_kubernetes(dag_id, self.host)
@@ -56,7 +60,7 @@ class TestCeleryAndLocalExecutor(BaseK8STest):
 
     @pytest.mark.xfail(
         EXECUTOR == "LocalExecutor",
-        reason="https://github.com/apache/airflow/issues/44481 needs to be implemented",
+        reason="https://github.com/apache/airflow/issues/47518 needs to be fixed",
     )
     def test_integration_run_dag_with_scheduler_failure(self):
         dag_id = "example_xcom"

--- a/scripts/ci/kubernetes/k8s_requirements.txt
+++ b/scripts/ci/kubernetes/k8s_requirements.txt
@@ -2,3 +2,4 @@
 -e ./task-sdk
 -e ./devel-common
 -e ./providers/cncf/kubernetes
+-e .  # Need this until all airflow.models are migrated to Task SDK


### PR DESCRIPTION
Somehow ONLY k8sExecutor used pytests in K8s CI deployments. @potiuk pointed me to the fact that other executors also had tests... but seems they were not called.

This PR (attempts) to add the tests for other executors