### PR TITLE
Separate git sync environment variables between version 3 and 4

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -209,6 +209,116 @@ If release name contains chart name it will be used as a full name.
     defaultMode: 288
 {{- end }}
 
+{{/* Git sync environment variables for version 3 */}}
+{{- define "git_sync_envs_ver_3" }}
+  {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
+  - name: GIT_SSH_KEY_FILE
+    value: "/etc/git-secret/ssh"
+  - name: GIT_SYNC_SSH
+    value: "true"
+  {{- if .Values.dags.gitSync.knownHosts }}
+  - name: GIT_KNOWN_HOSTS
+    value: "true"
+  - name: GIT_SSH_KNOWN_HOSTS_FILE
+    value: "/etc/git-secret/known_hosts"
+  {{- else }}
+  - name: GIT_KNOWN_HOSTS
+    value: "false"
+  {{- end }}
+  {{ else if .Values.dags.gitSync.credentialsSecret }}
+  - name: GIT_SYNC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+        key: GIT_SYNC_USERNAME
+  - name: GIT_SYNC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+        key: GIT_SYNC_PASSWORD
+  {{- end }}
+  - name: GIT_SYNC_REV
+    value: {{ .Values.dags.gitSync.rev | quote }}
+  - name: GIT_SYNC_BRANCH
+    value: {{ .Values.dags.gitSync.branch | quote }}
+  - name: GIT_SYNC_REPO
+    value: {{ .Values.dags.gitSync.repo | quote }}
+  - name: GIT_SYNC_DEPTH
+    value: {{ .Values.dags.gitSync.depth | quote }}
+  - name: GIT_SYNC_ROOT
+    value: "/git"
+  - name: GIT_SYNC_DEST
+    value: "repo"
+  - name: GIT_SYNC_ADD_USER
+    value: "true"
+  {{- if .Values.dags.gitSync.wait }}
+  - name: GIT_SYNC_WAIT
+    value: {{ .Values.dags.gitSync.wait | quote }}
+  {{- end }}
+  - name: GIT_SYNC_MAX_SYNC_FAILURES
+    value: {{ .Values.dags.gitSync.maxFailures | quote }}
+  {{- if .is_init }}
+  - name: GIT_SYNC_ONE_TIME
+    value: "true"
+  {{- end }}
+{{- end }}
+
+{{/* Git sync environment variables for version 4 */}}
+{{- define "git_sync_envs_ver_4" }}
+  {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
+  - name: GITSYNC_SSH_KEY_FILE
+    value: "/etc/git-secret/ssh"
+  {{- if .Values.dags.gitSync.knownHosts }}
+  - name: GITSYNC_KNOWN_HOSTS
+    value: "true"
+  - name: GIT_SYNC_SSH_KNOWN_HOSTS_FILE
+    value: "/etc/git-secret/known_hosts"
+  {{- else }}
+  - name: GITSYNC_KNOWN_HOSTS
+    value: "false"
+  {{- end }}
+  {{ else if .Values.dags.gitSync.credentialsSecret }}
+  - name: GIT_SYNC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+        key: GIT_SYNC_USERNAME
+  - name: GIT_SYNC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+        key: GIT_SYNC_PASSWORD
+  {{- end }}
+  - name: GITSYNC_REF
+    value: {{ .Values.dags.gitSync.ref | quote }}
+  - name: GIT_SYNC_REV
+    value: {{ .Values.dags.gitSync.rev | quote }}
+  - name: GIT_SYNC_BRANCH
+    value: {{ .Values.dags.gitSync.branch | quote }}
+  - name: GITSYNC_REPO
+    value: {{ .Values.dags.gitSync.repo | quote }}
+  - name: GITSYNC_DEPTH
+    value: {{ .Values.dags.gitSync.depth | quote }}
+  - name: GIT_SYNC_ROOT
+    value: "/git"
+  - name: GITSYNC_LINK
+    value: "repo"
+  - name: GITSYNC_ADD_USER
+    value: "true"
+  {{- if .Values.dags.gitSync.wait }}
+  - name: GIT_SYNC_WAIT
+    value: {{ .Values.dags.gitSync.wait | quote }}
+  {{- end }}
+  - name: GITSYNC_PERIOD
+    value: {{ .Values.dags.gitSync.period | quote }}
+  - name: GITSYNC_MAX_FAILURES
+    value: {{ .Values.dags.gitSync.maxFailures | quote }}
+  {{- if .is_init }}
+  - name: GITSYNC_ONE_TIME
+    value: "true"
+  {{- end }}
+{{- end }}
+
 {{/*  Git sync container */}}
 {{- define "git_sync_container" }}
 - name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
@@ -217,93 +327,11 @@ If release name contains chart name it will be used as a full name.
   securityContext: {{- include "localContainerSecurityContext" .Values.dags.gitSync | nindent 4 }}
   envFrom: {{- include "custom_git_sync_environment_from" . | default "\n  []" | indent 2 }}
   env:
-    {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
-    - name: GIT_SSH_KEY_FILE
-      value: "/etc/git-secret/ssh"
-    - name: GITSYNC_SSH_KEY_FILE
-      value: "/etc/git-secret/ssh"
-    - name: GIT_SYNC_SSH
-      value: "true"
-    - name: GITSYNC_SSH
-      value: "true"
-    {{- if .Values.dags.gitSync.knownHosts }}
-    - name: GIT_KNOWN_HOSTS
-      value: "true"
-    - name: GITSYNC_SSH_KNOWN_HOSTS
-      value: "true"
-    - name: GIT_SSH_KNOWN_HOSTS_FILE
-      value: "/etc/git-secret/known_hosts"
-    - name: GITSYNC_SSH_KNOWN_HOSTS_FILE
-      value: "/etc/git-secret/known_hosts"
+    {{- $gitSyncTag := trimPrefix "v" .Values.images.gitSync.tag -}}
+    {{- if semverCompare ">=4.0.0" $gitSyncTag }}
+      {{- include "git_sync_envs_ver_4" . | indent 2 }}
     {{- else }}
-    - name: GIT_KNOWN_HOSTS
-      value: "false"
-    - name: GITSYNC_SSH_KNOWN_HOSTS
-      value: "false"
-    {{- end }}
-    {{ else if .Values.dags.gitSync.credentialsSecret }}
-    - name: GIT_SYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GIT_SYNC_USERNAME
-    - name: GITSYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_USERNAME
-    - name: GIT_SYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GIT_SYNC_PASSWORD
-    - name: GITSYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_PASSWORD
-    {{- end }}
-    - name: GIT_SYNC_REV
-      value: {{ .Values.dags.gitSync.rev | quote }}
-    - name: GITSYNC_REF
-      value: {{ .Values.dags.gitSync.ref | quote }}
-    - name: GIT_SYNC_BRANCH
-      value: {{ .Values.dags.gitSync.branch | quote }}
-    - name: GIT_SYNC_REPO
-      value: {{ .Values.dags.gitSync.repo | quote }}
-    - name: GITSYNC_REPO
-      value: {{ .Values.dags.gitSync.repo | quote }}
-    - name: GIT_SYNC_DEPTH
-      value: {{ .Values.dags.gitSync.depth | quote }}
-    - name: GITSYNC_DEPTH
-      value: {{ .Values.dags.gitSync.depth | quote }}
-    - name: GIT_SYNC_ROOT
-      value: "/git"
-    - name: GITSYNC_ROOT
-      value: "/git"
-    - name: GIT_SYNC_DEST
-      value: "repo"
-    - name: GITSYNC_LINK
-      value: "repo"
-    - name: GIT_SYNC_ADD_USER
-      value: "true"
-    - name: GITSYNC_ADD_USER
-      value: "true"
-    {{- if .Values.dags.gitSync.wait }}
-    - name: GIT_SYNC_WAIT
-      value: {{ .Values.dags.gitSync.wait | quote }}
-    {{- end }}
-    - name: GITSYNC_PERIOD
-      value: {{ .Values.dags.gitSync.period | quote }}
-    - name: GIT_SYNC_MAX_SYNC_FAILURES
-      value: {{ .Values.dags.gitSync.maxFailures | quote }}
-    - name: GITSYNC_MAX_FAILURES
-      value: {{ .Values.dags.gitSync.maxFailures | quote }}
-    {{- if .is_init }}
-    - name: GIT_SYNC_ONE_TIME
-      value: "true"
-    - name: GITSYNC_ONE_TIME
-      value: "true"
+      {{- include "git_sync_envs_ver_3" . | indent 2 }}
     {{- end }}
     {{- with .Values.dags.gitSync.env }}
     {{- toYaml . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2812,7 +2812,7 @@ dags:
     # sshKeySecret: airflow-ssh-secret
     #
     # Or set sshKeySecret with your key
-    # sshKey: |-
+    # sshKey: |+
     #   -----BEGIN {OPENSSH PRIVATE KEY}-----
     #   ...
     #   -----END {OPENSSH PRIVATE KEY}-----

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2787,12 +2787,8 @@ dags:
     #   metadata:
     #     name: git-credentials
     #   data:
-    #     # For git-sync v3
     #     GIT_SYNC_USERNAME: <base64_encoded_git_username>
     #     GIT_SYNC_PASSWORD: <base64_encoded_git_password>
-    #     # For git-sync v4
-    #     GITSYNC_USERNAME: <base64_encoded_git_username>
-    #     GITSYNC_PASSWORD: <base64_encoded_git_password>
     # and specify the name of the secret below
     #
     # credentialsSecret: git-credentials

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -772,9 +772,10 @@ class TestDagProcessor:
             assert expected_volume not in created_volumes
             assert expected_volume_mount not in created_volume_mounts
 
-    def test_validate_if_ssh_params_are_added_with_git_ssh_key(self):
+    def test_validate_if_ssh_params_are_added_with_git_ssh_key_ver_3(self):
         docs = render_chart(
             values={
+                "images": {"gitSync": {"tag": "v3.6.9"}},
                 "dagProcessor": {"enabled": True},
                 "dags": {
                     "gitSync": {
@@ -790,19 +791,37 @@ class TestDagProcessor:
         assert {"name": "GIT_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
-        assert {"name": "GITSYNC_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
-            "spec.template.spec.containers[1].env", docs[0]
-        )
         assert {"name": "GIT_SYNC_SSH", "value": "true"} in jmespath.search(
-            "spec.template.spec.containers[1].env", docs[0]
-        )
-        assert {"name": "GITSYNC_SSH", "value": "true"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
         assert {"name": "GIT_KNOWN_HOSTS", "value": "false"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
-        assert {"name": "GITSYNC_SSH_KNOWN_HOSTS", "value": "false"} in jmespath.search(
+        assert {
+            "name": "git-sync-ssh-key",
+            "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
+    def test_validate_if_ssh_params_are_added_with_git_ssh_key_ver_4(self):
+        docs = render_chart(
+            values={
+                "images": {"gitSync": {"tag": "v4.3.0"}},
+                "dagProcessor": {"enabled": True},
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "sshKey": "my-ssh-key",
+                    },
+                    "persistence": {"enabled": False},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+
+        assert {"name": "GITSYNC_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )
+        assert {"name": "GITSYNC_KNOWN_HOSTS", "value": "false"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
         assert {

--- a/helm_tests/other/test_git_sync_triggerer.py
+++ b/helm_tests/other/test_git_sync_triggerer.py
@@ -42,15 +42,16 @@ class TestGitSyncTriggerer:
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
 
-    def test_validate_if_ssh_params_are_added_with_git_ssh_key(self):
+    def test_validate_if_ssh_params_are_added_with_git_ssh_key_ver_3(self):
         docs = render_chart(
             values={
+                "images": {"gitSync": {"tag": "v3.6.9"}},
                 "dags": {
                     "gitSync": {
                         "enabled": True,
                         "sshKey": "dummy-ssh-key",
                     }
-                }
+                },
             },
             show_only=["templates/triggerer/triggerer-deployment.yaml"],
         )
@@ -58,19 +59,35 @@ class TestGitSyncTriggerer:
         assert {"name": "GIT_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
-        assert {"name": "GITSYNC_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
-            "spec.template.spec.containers[1].env", docs[0]
-        )
         assert {"name": "GIT_SYNC_SSH", "value": "true"} in jmespath.search(
-            "spec.template.spec.containers[1].env", docs[0]
-        )
-        assert {"name": "GITSYNC_SSH", "value": "true"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
         assert {"name": "GIT_KNOWN_HOSTS", "value": "false"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
-        assert {"name": "GITSYNC_SSH_KNOWN_HOSTS", "value": "false"} in jmespath.search(
+        assert {
+            "name": "git-sync-ssh-key",
+            "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
+    def test_validate_if_ssh_params_are_added_with_git_ssh_key_ver_4(self):
+        docs = render_chart(
+            values={
+                "images": {"gitSync": {"tag": "v4.3.0"}},
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "sshKey": "dummy-ssh-key",
+                    }
+                },
+            },
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert {"name": "GITSYNC_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )
+        assert {"name": "GITSYNC_KNOWN_HOSTS", "value": "false"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
         assert {

--- a/helm_tests/other/test_git_sync_worker.py
+++ b/helm_tests/other/test_git_sync_worker.py
@@ -133,15 +133,16 @@ class TestGitSyncWorker:
 
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
 
-    def test_validate_if_ssh_params_are_added_with_git_ssh_key(self):
+    def test_validate_if_ssh_params_are_added_with_git_ssh_key_ver_3(self):
         docs = render_chart(
             values={
+                "images": {"gitSync": {"tag": "v3.6.9"}},
                 "dags": {
                     "gitSync": {
                         "enabled": True,
                         "sshKey": "dummy-ssh-key",
                     }
-                }
+                },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
         )
@@ -149,19 +150,35 @@ class TestGitSyncWorker:
         assert {"name": "GIT_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
-        assert {"name": "GITSYNC_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
-            "spec.template.spec.containers[1].env", docs[0]
-        )
         assert {"name": "GIT_SYNC_SSH", "value": "true"} in jmespath.search(
-            "spec.template.spec.containers[1].env", docs[0]
-        )
-        assert {"name": "GITSYNC_SSH", "value": "true"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
         assert {"name": "GIT_KNOWN_HOSTS", "value": "false"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
-        assert {"name": "GITSYNC_SSH_KNOWN_HOSTS", "value": "false"} in jmespath.search(
+        assert {
+            "name": "git-sync-ssh-key",
+            "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
+    def test_validate_if_ssh_params_are_added_with_git_ssh_key_ver_4(self):
+        docs = render_chart(
+            values={
+                "images": {"gitSync": {"tag": "v4.3.0"}},
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "sshKey": "dummy-ssh-key",
+                    }
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert {"name": "GITSYNC_SSH_KEY_FILE", "value": "/etc/git-secret/ssh"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )
+        assert {"name": "GITSYNC_KNOWN_HOSTS", "value": "false"} in jmespath.search(
             "spec.template.spec.containers[1].env", docs[0]
         )
         assert {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I noticed that there are a lot of environment variables in git-sync container defined between major versions 3 and 4 with some duplications. I removed all duplicated variables and distinguished between variables used for versions 3 and 4. I checked all the variables with git-sync version 3.3.0 (the first version used in the first release of Helm Chart), the last 3 version (3.6.9) and the current used by default in airflow 4.3.0. For version 4, all of the variables are these which are not result in the deprecation message in the logs.

I tested the change configuration locally on 3.6.9 and 4.3.0 versions - everything worked fine.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
