### PR TITLE
Add `test_connection` method to `WinRMHook`

### DIFF
--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
@@ -289,7 +289,7 @@ class WinRMHook(BaseHook):
 
     def test_connection(self):
         try:
-            (r_code, std_out, std_err) = self.run("pwd")
+            (r_code, std_out, std_err) = self.run('cd')
             if r_code != 0:
                 raise RuntimeError(std_err)
             return True, "Connection successful."

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
@@ -286,3 +286,12 @@ class WinRMHook(BaseHook):
             raise AirflowException(f"WinRM operator error: {e}")
         finally:
             winrm_client.close_shell(shell_id)
+
+    def test_connection(self):
+        try:
+            (r_code, std_out, std_err) = self.run("pwd")
+            if r_code != 0:
+                raise RuntimeError(std_err)
+            return True, "Connection successful."
+        except Exception as e:
+            return False, str(e)

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
@@ -289,7 +289,7 @@ class WinRMHook(BaseHook):
 
     def test_connection(self):
         try:
-            (r_code, std_out, std_err) = self.run('cd')
+            (r_code, std_out, std_err) = self.run("cd")
             if r_code != 0:
                 raise RuntimeError(std_err)
             return True, "Connection successful."


### PR DESCRIPTION
Adds a `test_connection` method to `WinRMHook`, which is an older SSH-equivalent for Windows
