### PR TITLE
Extend documentation for bigquery view for BigQueryUpdateTableOperator

### DIFF
--- a/providers/google/docs/operators/cloud/bigquery.rst
+++ b/providers/google/docs/operators/cloud/bigquery.rst
@@ -96,6 +96,22 @@ method only replaces fields that are provided in the submitted Table resource.
     :start-after: [START howto_operator_bigquery_update_table]
     :end-before: [END howto_operator_bigquery_update_table]
 
+You can use this operator to update a view.
+
+.. exampleinclude:: /../../google/tests/system/google/cloud/bigquery/example_bigquery_tables.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_update_view]
+    :end-before: [END howto_operator_bigquery_update_view]
+
+And use the same operator to update a materialized view.
+
+.. exampleinclude:: /../../google/tests/system/google/cloud/bigquery/example_bigquery_tables.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_update_materialized_view]
+    :end-before: [END howto_operator_bigquery_update_materialized_view]
+
 .. _howto/operator:BigQueryUpdateDatasetOperator:
 
 Update dataset

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_tables.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_tables.py
@@ -141,6 +141,32 @@ with DAG(
     )
     # [END howto_operator_bigquery_update_table]
 
+    # [START howto_operator_bigquery_update_view]
+    update_view = BigQueryUpdateTableOperator(
+        task_id="update_view",
+        dataset_id=DATASET_NAME,
+        table_id="test_view",
+        fields=["friendlyName", "description"],
+        table_resource={
+            "friendlyName": "Updated View friendlyName",
+            "description": "Updated View description",
+        },
+    )
+    # [END howto_operator_bigquery_update_view]
+
+    # [START howto_operator_bigquery_update_materialized_view]
+    update_materialized_view = BigQueryUpdateTableOperator(
+        task_id="update_materialized_view",
+        dataset_id=DATASET_NAME,
+        table_id="test_materialized_view",
+        fields=["friendlyName", "description"],
+        table_resource={
+            "friendlyName": "Updated View friendlyName",
+            "description": "Updated View description",
+        },
+    )
+    # [END howto_operator_bigquery_update_materialized_view]
+
     # [START howto_operator_bigquery_upsert_table]
     upsert_table = BigQueryUpsertTableOperator(
         task_id="upsert_table",
@@ -230,11 +256,13 @@ with DAG(
         >> create_table
         >> create_view
         >> create_materialized_view
+        >> update_view
         >> [
             get_dataset_tables,
             delete_view,
         ]
         >> update_table
+        >> update_materialized_view
         >> upsert_table
         >> update_table_schema
         >> create_table_schema_json


### PR DESCRIPTION
Extend documentation for bigquery views and materialized views for `BigQueryUpdateTableOperator`. Right now only tables examples present.

Closes: https://github.com/apache/airflow/issues/40212