### PR TITLE
Move asset evaluation logic out of SDK

### DIFF
--- a/airflow/assets/evaluation.py
+++ b/airflow/assets/evaluation.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import attrs
+
+from airflow.models.asset import expand_alias_to_assets, resolve_ref_to_asset
+from airflow.sdk.definitions.asset import (
+    Asset,
+    AssetAlias,
+    AssetBooleanCondition,
+    AssetRef,
+    AssetUniqueKey,
+    BaseAsset,
+)
+from airflow.sdk.definitions.asset.decorators import MultiAssetDefinition
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@attrs.define
+class AssetEvaluator:
+    """Evaluates whether an asset-like object has been satisfied."""
+
+    _session: Session
+
+    def _resolve_asset_ref(self, o: AssetRef) -> Asset | None:
+        asset = resolve_ref_to_asset(**attrs.asdict(o), session=self._session)
+        return asset.to_public() if asset else None
+
+    def _resolve_asset_alias(self, o: AssetAlias) -> list[Asset]:
+        asset_models = expand_alias_to_assets(o.name, session=self._session)
+        return [m.to_public() for m in asset_models]
+
+    @functools.singledispatchmethod
+    def run(self, o: BaseAsset, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        raise NotImplementedError(f"can not evaluate {o!r}")
+
+    @run.register
+    def _(self, o: Asset, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        return statuses.get(AssetUniqueKey.from_asset(o), False)
+
+    @run.register
+    def _(self, o: AssetRef, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        if asset := self._resolve_asset_ref(o):
+            return self.run(asset, statuses)
+        return False
+
+    @run.register
+    def _(self, o: AssetAlias, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        return any(self.run(x, statuses) for x in self._resolve_asset_alias(o))
+
+    @run.register
+    def _(self, o: AssetBooleanCondition, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        return o.agg_func(self.run(x, statuses) for x in o.objects)
+
+    @run.register
+    def _(self, o: MultiAssetDefinition, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        return all(self.run(x, statuses) for x in o.iter_outlets())

--- a/airflow/models/asset.py
+++ b/airflow/models/asset.py
@@ -70,14 +70,14 @@ def fetch_active_assets_by_uri(uris: Iterable[str], session: Session) -> dict[st
     }
 
 
-def expand_alias_to_assets(alias_name: str, session: Session) -> Iterable[AssetModel]:
+def expand_alias_to_assets(alias_name: str, *, session: Session) -> Iterable[AssetModel]:
     """Expand asset alias to resolved assets."""
     asset_alias_obj = session.scalar(
         select(AssetAliasModel).where(AssetAliasModel.name == alias_name).limit(1)
     )
     if asset_alias_obj:
-        return list(asset_alias_obj.assets)
-    return []
+        return iter(asset_alias_obj.assets)
+    return iter(())
 
 
 def resolve_ref_to_asset(

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import operator
 import os
@@ -33,8 +32,6 @@ from airflow.serialization.dag_dependency import DagDependency
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
     from urllib.parse import SplitResult
-
-    from sqlalchemy.orm import Session
 
     from airflow.models.asset import AssetModel
     from airflow.serialization.serialized_objects import SerializedAssetWatcher
@@ -231,9 +228,6 @@ class BaseAsset:
 
         :meta private:
         """
-        raise NotImplementedError
-
-    def evaluate(self, statuses: dict[AssetUniqueKey, bool], *, session: Session | None = None) -> bool:
         raise NotImplementedError
 
     def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
@@ -442,9 +436,6 @@ class Asset(os.PathLike, BaseAsset):
     def iter_asset_refs(self) -> Iterator[AssetRef]:
         return iter(())
 
-    def evaluate(self, statuses: dict[AssetUniqueKey, bool], *, session: Session | None = None) -> bool:
-        return statuses.get(AssetUniqueKey.from_asset(self), False)
-
     def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
         """
         Iterate an asset as dag dependency.
@@ -488,19 +479,6 @@ class AssetRef(BaseAsset, AttrsInstance):
 
     def iter_asset_refs(self) -> Iterator[AssetRef]:
         yield self
-
-    def _resolve_asset(self, *, session: Session | None = None) -> Asset | None:
-        from airflow.models.asset import resolve_ref_to_asset
-        from airflow.utils.session import create_session
-
-        with contextlib.nullcontext(session) if session else create_session() as session:
-            asset = resolve_ref_to_asset(**attrs.asdict(self), session=session)
-        return asset.to_public() if asset else None
-
-    def evaluate(self, statuses: dict[AssetUniqueKey, bool], *, session: Session | None = None) -> bool:
-        if asset := self._resolve_asset(session=session):
-            return asset.evaluate(statuses=statuses, session=session)
-        return False
 
     def iter_dag_dependencies(self, *, source: str = "", target: str = "") -> Iterator[DagDependency]:
         (dependency_id,) = attrs.astuple(self)
@@ -553,14 +531,6 @@ class AssetAlias(BaseAsset):
     name: str = attrs.field(validator=_validate_non_empty_identifier)
     group: str = attrs.field(kw_only=True, default="asset", validator=_validate_identifier)
 
-    def _resolve_assets(self, session: Session | None = None) -> list[Asset]:
-        from airflow.models.asset import expand_alias_to_assets
-        from airflow.utils.session import create_session
-
-        with contextlib.nullcontext(session) if session else create_session() as session:
-            asset_models = expand_alias_to_assets(self.name, session)
-        return [m.to_public() for m in asset_models]
-
     def as_expression(self) -> Any:
         """
         Serialize the asset alias into its scheduling expression.
@@ -568,9 +538,6 @@ class AssetAlias(BaseAsset):
         :meta private:
         """
         return {"alias": {"name": self.name, "group": self.group}}
-
-    def evaluate(self, statuses: dict[AssetUniqueKey, bool], *, session: Session | None = None) -> bool:
-        return any(x.evaluate(statuses=statuses, session=session) for x in self._resolve_assets(session))
 
     def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
         return iter(())
@@ -613,8 +580,12 @@ class AssetAlias(BaseAsset):
             )
 
 
-class _AssetBooleanCondition(BaseAsset):
-    """Base class for asset boolean logic."""
+class AssetBooleanCondition(BaseAsset):
+    """
+    Base class for asset boolean logic.
+
+    :meta private:
+    """
 
     agg_func: Callable[[Iterable], bool]
 
@@ -622,9 +593,6 @@ class _AssetBooleanCondition(BaseAsset):
         if not all(isinstance(o, BaseAsset) for o in objects):
             raise TypeError("expect asset expressions in condition")
         self.objects = objects
-
-    def evaluate(self, statuses: dict[AssetUniqueKey, bool], *, session: Session | None = None) -> bool:
-        return self.agg_func(x.evaluate(statuses=statuses, session=session) for x in self.objects)
 
     def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
         for o in self.objects:
@@ -648,7 +616,7 @@ class _AssetBooleanCondition(BaseAsset):
             yield from obj.iter_dag_dependencies(source=source, target=target)
 
 
-class AssetAny(_AssetBooleanCondition):
+class AssetAny(AssetBooleanCondition):
     """Use to combine assets schedule references in an "or" relationship."""
 
     agg_func = any
@@ -671,7 +639,7 @@ class AssetAny(_AssetBooleanCondition):
         return {"any": [o.as_expression() for o in self.objects]}
 
 
-class AssetAll(_AssetBooleanCondition):
+class AssetAll(AssetBooleanCondition):
     """Use to combine assets schedule references in an "and" relationship."""
 
     agg_func = all

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -482,20 +482,12 @@ class AssetRef(BaseAsset, AttrsInstance):
 
     def iter_dag_dependencies(self, *, source: str = "", target: str = "") -> Iterator[DagDependency]:
         (dependency_id,) = attrs.astuple(self)
-        if asset := self._resolve_asset():
-            yield DagDependency(
-                source=f"asset-ref:{dependency_id}" if source else "asset",
-                target="asset" if source else f"asset-ref:{dependency_id}",
-                dependency_type="asset",
-                dependency_id=asset.name,
-            )
-        else:
-            yield DagDependency(
-                source=source or "asset-ref",
-                target=target or "asset-ref",
-                dependency_type="asset-ref",
-                dependency_id=dependency_id,
-            )
+        yield DagDependency(
+            source=source or "asset-ref",
+            target=target or "asset-ref",
+            dependency_type="asset-ref",
+            dependency_id=dependency_id,
+        )
 
 
 @attrs.define(hash=True)
@@ -554,30 +546,12 @@ class AssetAlias(BaseAsset):
 
         :meta private:
         """
-        if not (resolved_assets := self._resolve_assets()):
-            yield DagDependency(
-                source=source or "asset-alias",
-                target=target or "asset-alias",
-                dependency_type="asset-alias",
-                dependency_id=self.name,
-            )
-            return
-        for asset in resolved_assets:
-            asset_name = asset.name
-            # asset
-            yield DagDependency(
-                source=f"asset-alias:{self.name}" if source else "asset",
-                target="asset" if source else f"asset-alias:{self.name}",
-                dependency_type="asset",
-                dependency_id=asset_name,
-            )
-            # asset alias
-            yield DagDependency(
-                source=source or f"asset:{asset_name}",
-                target=target or f"asset:{asset_name}",
-                dependency_type="asset-alias",
-                dependency_id=self.name,
-            )
+        yield DagDependency(
+            source=source or "asset-alias",
+            target=target or "asset-alias",
+            dependency_type="asset-alias",
+            dependency_id=self.name,
+        )
 
 
 class AssetBooleanCondition(BaseAsset):

--- a/tests/assets/test_evaluation.py
+++ b/tests/assets/test_evaluation.py
@@ -1,0 +1,199 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.assets.evaluation import AssetEvaluator
+from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetUniqueKey
+from airflow.serialization.serialized_objects import BaseSerialization
+
+pytestmark = pytest.mark.db_test
+
+asset1 = Asset(uri="s3://bucket1/data1", name="asset-1")
+asset2 = Asset(uri="s3://bucket2/data2", name="asset-2")
+
+
+@pytest.fixture
+def evaluator(session):
+    return AssetEvaluator(session)
+
+
+@pytest.mark.parametrize(
+    "statuses, result",
+    [
+        ({AssetUniqueKey.from_asset(asset1): True}, True),
+        ({AssetUniqueKey.from_asset(asset1): False}, False),
+        ({}, False),
+    ],
+)
+def test_asset_evaluate(evaluator, statuses, result):
+    assert evaluator.run(asset1, statuses) is result
+
+
+@pytest.mark.parametrize(
+    "condition, statuses, result",
+    [
+        (
+            AssetAny(asset1, asset2),
+            {AssetUniqueKey.from_asset(asset1): False, AssetUniqueKey.from_asset(asset2): True},
+            True,
+        ),
+        (
+            AssetAll(asset1, asset2),
+            {AssetUniqueKey.from_asset(asset1): True, AssetUniqueKey.from_asset(asset2): False},
+            False,
+        ),
+    ],
+)
+def test_assset_boolean_condition_evaluate_iter(evaluator, condition, statuses, result):
+    """
+    Tests _AssetBooleanCondition's evaluate and iter_assets methods through AssetAny and AssetAll.
+
+    Ensures AssetAny evaluate returns True with any true condition, AssetAll evaluate returns False if
+    any condition is false, and both classes correctly iterate over assets without duplication.
+    """
+    assert evaluator.run(condition, statuses) is result
+    assert dict(condition.iter_assets()) == {
+        AssetUniqueKey("asset-1", "s3://bucket1/data1"): asset1,
+        AssetUniqueKey("asset-2", "s3://bucket2/data2"): asset2,
+    }
+
+
+@pytest.mark.parametrize(
+    "inputs, scenario, expected",
+    [
+        # Scenarios for AssetAny
+        ((True, True, True), "any", True),
+        ((True, True, False), "any", True),
+        ((True, False, True), "any", True),
+        ((True, False, False), "any", True),
+        ((False, False, True), "any", True),
+        ((False, True, False), "any", True),
+        ((False, True, True), "any", True),
+        ((False, False, False), "any", False),
+        # Scenarios for AssetAll
+        ((True, True, True), "all", True),
+        ((True, True, False), "all", False),
+        ((True, False, True), "all", False),
+        ((True, False, False), "all", False),
+        ((False, False, True), "all", False),
+        ((False, True, False), "all", False),
+        ((False, True, True), "all", False),
+        ((False, False, False), "all", False),
+    ],
+)
+def test_asset_logical_conditions_evaluation_and_serialization(evaluator, inputs, scenario, expected):
+    class_ = AssetAny if scenario == "any" else AssetAll
+    assets = [Asset(uri=f"s3://abc/{i}", name=f"asset_{i}") for i in range(123, 126)]
+    condition = class_(*assets)
+
+    statuses = {AssetUniqueKey.from_asset(asset): status for asset, status in zip(assets, inputs)}
+    assert (
+        evaluator.run(condition, statuses) == expected
+    ), f"Condition evaluation failed for inputs {inputs} and scenario '{scenario}'"
+
+    # Serialize and deserialize the condition to test persistence
+    serialized = BaseSerialization.serialize(condition)
+    deserialized = BaseSerialization.deserialize(serialized)
+    assert evaluator.run(deserialized, statuses) == expected, "Serialization round-trip failed"
+
+
+@pytest.mark.parametrize(
+    "status_values, expected_evaluation",
+    [
+        pytest.param(
+            (False, True, True),
+            False,
+            id="f & (t | t)",
+        ),  # AssetAll requires all conditions to be True, but asset1 is False
+        pytest.param(
+            (True, True, True),
+            True,
+            id="t & (t | t)",
+        ),  # All conditions are True
+        pytest.param(
+            (True, False, True),
+            True,
+            id="t & (f | t)",
+        ),  # asset1 is True, and AssetAny condition (asset2 or asset3 being True) is met
+        pytest.param(
+            (True, False, False),
+            False,
+            id="t & (f | f)",
+        ),  # asset1 is True, but neither asset2 nor asset3 meet the AssetAny condition
+    ],
+)
+def test_nested_asset_conditions_with_serialization(evaluator, status_values, expected_evaluation):
+    # Define assets
+    asset1 = Asset(uri="s3://abc/123")
+    asset2 = Asset(uri="s3://abc/124")
+    asset3 = Asset(uri="s3://abc/125")
+
+    # Create a nested condition: AssetAll with asset1 and AssetAny with asset2 and asset3
+    nested_condition = AssetAll(asset1, AssetAny(asset2, asset3))
+
+    statuses = {
+        AssetUniqueKey.from_asset(asset1): status_values[0],
+        AssetUniqueKey.from_asset(asset2): status_values[1],
+        AssetUniqueKey.from_asset(asset3): status_values[2],
+    }
+
+    assert evaluator.run(nested_condition, statuses) == expected_evaluation, "Initial evaluation mismatch"
+
+    serialized_condition = BaseSerialization.serialize(nested_condition)
+    deserialized_condition = BaseSerialization.deserialize(serialized_condition)
+
+    assert (
+        evaluator.run(deserialized_condition, statuses) == expected_evaluation
+    ), "Post-serialization evaluation mismatch"
+
+
+class TestAssetAlias:
+    @pytest.fixture
+    def asset(self):
+        """Example asset links to asset alias resolved_asset_alias_2."""
+        return Asset(uri="test://asset1/", name="test_name", group="asset")
+
+    @pytest.fixture
+    def asset_alias_1(self):
+        """Example asset alias links to no assets."""
+        return AssetAlias(name="test_name", group="test")
+
+    @pytest.fixture
+    def resolved_asset_alias_2(self):
+        """Example asset alias links to asset."""
+        return AssetAlias(name="test_name_2")
+
+    @pytest.fixture
+    def evaluator(self, session, asset_alias_1, resolved_asset_alias_2, asset):
+        class _AssetEvaluator(AssetEvaluator):  # Can't use mock because AssetEvaluator sets __slots__.
+            def _resolve_asset_alias(self, o):
+                if o is asset_alias_1:
+                    return []
+                elif o is resolved_asset_alias_2:
+                    return [asset]
+                return super()._resolve_asset_alias(o)
+
+        return _AssetEvaluator(session)
+
+    def test_evaluate_empty(self, evaluator, asset_alias_1, asset):
+        assert evaluator.run(asset_alias_1, {AssetUniqueKey.from_asset(asset): True}) is False
+
+    def test_evalute_resolved(self, evaluator, resolved_asset_alias_2, asset):
+        assert evaluator.run(resolved_asset_alias_2, {AssetUniqueKey.from_asset(asset): True}) is True

--- a/tests/models/test_asset.py
+++ b/tests/models/test_asset.py
@@ -72,7 +72,7 @@ class TestAssetAliasModel:
         return asset_alias_2
 
     def test_expand_alias_to_assets_empty(self, session, asset_alias_1):
-        assert expand_alias_to_assets(asset_alias_1.name, session) == []
+        assert list(expand_alias_to_assets(asset_alias_1.name, session=session)) == []
 
     def test_expand_alias_to_assets_resolved(self, session, resolved_asset_alias_2, asset_model):
-        assert expand_alias_to_assets(resolved_asset_alias_2.name, session) == [asset_model]
+        assert list(expand_alias_to_assets(resolved_asset_alias_2.name, session=session)) == [asset_model]


### PR DESCRIPTION
Asset evaluation is only done in the scheduler, and requires the database in various cases. It is better to split it out into a dedicated class in Airflow core.

Close #47378
Fix #47483