### PR TITLE
Add custom AWS Region support for STS endpoint to `hashicorp` provider

### DIFF
--- a/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -77,6 +77,8 @@ class _VaultClient(LoggingMixin):
     :param assume_role_kwargs: AWS assume role param.
         See AWS STS Docs:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role.html
+    :param region: AWS region for STS API calls. Inferred from the boto3 client configuration if not provided
+        (for ``aws_iam`` auth_type).
     :param kubernetes_role: Role for Authentication (for ``kubernetes`` auth_type).
     :param kubernetes_jwt_path: Path for kubernetes jwt token (for ``kubernetes`` auth_type, default:
         ``/var/run/secrets/kubernetes.io/serviceaccount/token``).
@@ -108,6 +110,7 @@ class _VaultClient(LoggingMixin):
         secret_id: str | None = None,
         assume_role_kwargs: dict | None = None,
         role_id: str | None = None,
+        region: str | None = None,
         kubernetes_role: str | None = None,
         kubernetes_jwt_path: str | None = "/var/run/secrets/kubernetes.io/serviceaccount/token",
         gcp_key_path: str | None = None,
@@ -166,6 +169,7 @@ class _VaultClient(LoggingMixin):
         self.secret_id = secret_id
         self.role_id = role_id
         self.assume_role_kwargs = assume_role_kwargs
+        self.region = region
         self.kubernetes_role = kubernetes_role
         self.kubernetes_jwt_path = kubernetes_jwt_path
         self.gcp_key_path = gcp_key_path
@@ -329,7 +333,6 @@ class _VaultClient(LoggingMixin):
             auth_args = {
                 "access_key": self.key_id,
                 "secret_key": self.secret_id,
-                "role": self.role_id,
             }
         else:
             import boto3
@@ -341,6 +344,7 @@ class _VaultClient(LoggingMixin):
                     "access_key": credentials["Credentials"]["AccessKeyId"],
                     "secret_key": credentials["Credentials"]["SecretAccessKey"],
                     "session_token": credentials["Credentials"]["SessionToken"],
+                    "region": sts_client.meta.region_name,
                 }
             else:
                 session = boto3.Session()
@@ -349,10 +353,15 @@ class _VaultClient(LoggingMixin):
                     "access_key": credentials.access_key,
                     "secret_key": credentials.secret_key,
                     "session_token": credentials.token,
+                    "region": session.region_name,
                 }
 
         if self.auth_mount_point:
             auth_args["mount_point"] = self.auth_mount_point
+        if self.region:
+            auth_args["region"] = self.region
+        if self.role_id:
+            auth_args["role"] = self.role_id
 
         _client.auth.aws.iam_login(**auth_args)
 

--- a/providers/hashicorp/src/airflow/providers/hashicorp/hooks/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/hooks/vault.py
@@ -85,6 +85,7 @@ class VaultHook(BaseHook):
     :param kv_engine_version: Select the version of the engine to run (``1`` or ``2``). Defaults to
           version defined in connection or ``2`` if not defined in connection.
     :param role_id: Role ID for ``aws_iam`` Authentication.
+    :param region: AWS region for STS API calls (for ``aws_iam`` auth_type).
     :param kubernetes_role: Role for Authentication (for ``kubernetes`` auth_type)
     :param kubernetes_jwt_path: Path for kubernetes jwt token (for ``kubernetes`` auth_type, default:
         ``/var/run/secrets/kubernetes.io/serviceaccount/token``)
@@ -113,6 +114,7 @@ class VaultHook(BaseHook):
         auth_mount_point: str | None = None,
         kv_engine_version: int | None = None,
         role_id: str | None = None,
+        region: str | None = None,
         kubernetes_role: str | None = None,
         kubernetes_jwt_path: str | None = None,
         token_path: str | None = None,
@@ -151,6 +153,8 @@ class VaultHook(BaseHook):
         if auth_type == "aws_iam":
             if not role_id:
                 role_id = self.connection.extra_dejson.get("role_id")
+            if not region:
+                region = self.connection.extra_dejson.get("region")
 
         azure_resource, azure_tenant_id = (
             self._get_azure_parameters_from_connection(azure_resource, azure_tenant_id)
@@ -210,6 +214,7 @@ class VaultHook(BaseHook):
             key_id=self.connection.login,
             secret_id=self.connection.password,
             role_id=role_id,
+            region=region,
             kubernetes_role=kubernetes_role,
             kubernetes_jwt_path=kubernetes_jwt_path,
             gcp_key_path=gcp_key_path,

--- a/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
@@ -74,6 +74,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     :param assume_role_kwargs: AWS assume role param.
         See AWS STS Docs:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role.html
+    :param region: AWS region for STS API calls (for ``aws_iam`` auth_type).
     :param kubernetes_role: Role for Authentication (for ``kubernetes`` auth_type).
     :param kubernetes_jwt_path: Path for kubernetes jwt token (for ``kubernetes`` auth_type, default:
         ``/var/run/secrets/kubernetes.io/serviceaccount/token``).
@@ -108,6 +109,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         secret_id: str | None = None,
         role_id: str | None = None,
         assume_role_kwargs: dict | None = None,
+        region: str | None = None,
         kubernetes_role: str | None = None,
         kubernetes_jwt_path: str = "/var/run/secrets/kubernetes.io/serviceaccount/token",
         gcp_key_path: str | None = None,
@@ -149,6 +151,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
             secret_id=secret_id,
             role_id=role_id,
             assume_role_kwargs=assume_role_kwargs,
+            region=region,
             kubernetes_role=kubernetes_role,
             kubernetes_jwt_path=kubernetes_jwt_path,
             gcp_key_path=gcp_key_path,

--- a/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
@@ -154,6 +154,30 @@ class TestVaultClient:
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_aws_iam_different_region(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        vault_client = _VaultClient(
+            auth_type="aws_iam",
+            role_id="role",
+            url="http://localhost:8180",
+            key_id="user",
+            secret_id="pass",
+            session=None,
+            region="us-east-2",
+        )
+        client = vault_client.client
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
+        client.auth.aws.iam_login.assert_called_with(
+            access_key="user",
+            secret_key="pass",
+            role="role",
+            region="us-east-2",
+        )
+        client.is_authenticated.assert_called_with()
+        assert vault_client.kv_engine_version == 2
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_azure(self, mock_hvac):
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client

--- a/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
@@ -306,6 +306,7 @@ class TestVaultHook:
             "auth_type": "aws_iam",
             "role_id": "role",
             "session": None,
+            "region": "us-east-2",
         }
 
         test_hook = VaultHook(**kwargs)
@@ -313,9 +314,7 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.aws.iam_login.assert_called_with(
-            access_key="user",
-            secret_key="pass",
-            role="role",
+            access_key="user", secret_key="pass", role="role", region="us-east-2"
         )
         test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
@@ -328,7 +327,7 @@ class TestVaultHook:
         mock_connection = self.get_mock_connection()
         mock_get_connection.return_value = mock_connection
 
-        connection_dict = {"auth_type": "aws_iam", "role_id": "role"}
+        connection_dict = {"auth_type": "aws_iam", "role_id": "role", "region": "us-east-2"}
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
@@ -344,21 +343,21 @@ class TestVaultHook:
             access_key="user",
             secret_key="pass",
             role="role",
+            region="us-east-2",
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     @mock.patch.dict(
         "os.environ",
-        AIRFLOW_CONN_VAULT_CONN_ID="https://login:pass@vault.example.com?auth_type=aws_iam&role_id=role",
+        AIRFLOW_CONN_VAULT_CONN_ID="https://login:pass@vault.example.com?auth_type=aws_iam&role_id=role"
+        "&region=us-east-2",
     )
     def test_aws_uri(self, mock_hvac):
         test_hook = VaultHook(vault_conn_id="vault_conn_id", session=None)
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="https://vault.example.com", session=None)
         test_client.auth.aws.iam_login.assert_called_with(
-            access_key="login",
-            secret_key="pass",
-            role="role",
+            access_key="login", secret_key="pass", role="role", region="us-east-2"
         )
         test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #47470
related: #47470

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
<!-- Please keep an empty line above the dashes. -->
---
# Summary
This PR introduces a configurable AWS region parameter for Vault authentication via AWS IAM in the HashiCorp provider. Previously, the `airflow.providers.hashicorp._internal_client.vault_client._VaultClient._auth_aws_iam()` method did not pass a region parameter to `hvac.api.auth_methods.Aws.iam_login()`, causing authentication failures when Vault was configured with an STS endpoint outside `us-east-1`.

# Changes Introduced
- Added a region parameter to VaultBackend, VaultHook, and _VaultClient, allowing users to specify the AWS region for STS authentication.
- If region is not explicitly provided, it defaults to the region configured in boto3 (e.g., via environment variables or instance metadata).
- Passed the region parameter to `iam_login()` in hvac.
- Updated tests to validate region configuration.
- Passed the role_id parameter to `iam_login()` even when not using key_id and secret_id for authentication. If not passed to `iam_login()`, the login endpoint looks for a role bearing the name of the AMI ID of the EC2 instance that is trying to login if using the ec2 auth method, or the "friendly name" (i.e., role name or username) of the IAM principal authenticated. If the name does not match the Vault role, login fails.

# Related Issue
closes: #47470
 
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
