### PR TITLE
AIP-38 Add modelName to Providers and Plugins table

### DIFF
--- a/airflow/ui/src/pages/Plugins.tsx
+++ b/airflow/ui/src/pages/Plugins.tsx
@@ -47,6 +47,7 @@ export const Plugins = () => {
         columns={columns}
         data={data?.plugins ?? []}
         errorMessage={<ErrorAlert error={error} />}
+        modelName="Plugin"
         total={data?.total_entries}
       />
     </Box>

--- a/airflow/ui/src/pages/Providers.tsx
+++ b/airflow/ui/src/pages/Providers.tsx
@@ -79,6 +79,7 @@ export const Providers = () => {
         columns={columns}
         data={data?.providers ?? []}
         errorMessage={<ErrorAlert error={error} />}
+        modelName="Provider"
         total={data?.total_entries}
       />
     </Box>


### PR DESCRIPTION
Really small PR to add the `modelName` to Plugins and Providers table.

Without this the message would be inaccurate when we don't find any providers or plugins.
 
 ### Before
![Screenshot 2025-03-07 at 17 08 22](https://github.com/user-attachments/assets/c9c0f3d4-634d-4b54-b82b-f984d3f02c80)
### After
![Screenshot 2025-03-07 at 17 09 17](https://github.com/user-attachments/assets/fd64b73b-5964-4c47-adee-310899f325f8)

