### PR TITLE
Highlight log lines by keyword.

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/config.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/config.py
@@ -42,3 +42,5 @@ class ConfigResponse(BaseModel):
     is_k8s: bool
     test_connection: str
     state_color_mapping: dict
+    color_log_error_keywords: list[str]
+    color_log_warning_keywords: list[str]

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -8010,6 +8010,16 @@ components:
         state_color_mapping:
           type: object
           title: State Color Mapping
+        color_log_error_keywords:
+          items:
+            type: string
+          type: array
+          title: Color Log Error Keywords
+        color_log_warning_keywords:
+          items:
+            type: string
+          type: array
+          title: Color Log Warning Keywords
       type: object
       required:
       - navbar_color
@@ -8032,6 +8042,8 @@ components:
       - is_k8s
       - test_connection
       - state_color_mapping
+      - color_log_error_keywords
+      - color_log_warning_keywords
       title: ConfigResponse
       description: configuration serializer.
     ConfigSection:

--- a/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -61,6 +61,10 @@ def get_configs() -> ConfigResponse:
         "audit_view_included_events": conf.get("webserver", "audit_view_included_events", fallback=""),
         "audit_view_excluded_events": conf.get("webserver", "audit_view_excluded_events", fallback=""),
         "test_connection": conf.get("core", "test_connection", fallback="Disabled"),
+        "color_log_error_keywords": conf.get("logging", "color_log_error_keywords", fallback="").split(","),
+        "color_log_warning_keywords": conf.get("logging", "color_log_warning_keywords", fallback="").split(
+            ","
+        ),
         "state_color_mapping": STATE_COLORS,
         "is_k8s": IS_K8S_OR_K8SCELERY_EXECUTOR,
     }

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1227,6 +1227,20 @@ export const $ConfigResponse = {
       type: "object",
       title: "State Color Mapping",
     },
+    color_log_error_keywords: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Color Log Error Keywords",
+    },
+    color_log_warning_keywords: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Color Log Warning Keywords",
+    },
   },
   type: "object",
   required: [
@@ -1250,6 +1264,8 @@ export const $ConfigResponse = {
     "is_k8s",
     "test_connection",
     "state_color_mapping",
+    "color_log_error_keywords",
+    "color_log_warning_keywords",
   ],
   title: "ConfigResponse",
   description: "configuration serializer.",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -416,6 +416,8 @@ export type ConfigResponse = {
   state_color_mapping: {
     [key: string]: unknown;
   };
+  color_log_error_keywords: Array<string>;
+  color_log_warning_keywords: Array<string>;
 };
 
 /**

--- a/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -37,9 +37,11 @@ export const TaskLogPreview = ({
   const { data, error, isLoading } = useLogs(
     {
       dagId: taskInstance.dag_id,
+      errorKeywords: [],
       logLevelFilters: ["error", "critical"],
       taskInstance,
       tryNumber: taskInstance.try_number,
+      warningKeywords: [],
     },
     {
       refetchInterval: false,

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -60,6 +60,8 @@ export const Logs = () => {
   const tryNumber = tryNumberParam === null ? taskInstance?.try_number : parseInt(tryNumberParam, 10);
 
   const defaultWrap = Boolean(useConfig("default_wrap"));
+  const errorKeywords = (useConfig("color_log_error_keywords") ?? []) as Array<string>;
+  const warningKeywords = (useConfig("color_log_warning_keywords") ?? []) as Array<string>;
 
   const [wrap, setWrap] = useState(defaultWrap);
   const [fullscreen, setFullscreen] = useState(false);
@@ -77,10 +79,12 @@ export const Logs = () => {
     isLoading: isLoadingLogs,
   } = useLogs({
     dagId,
+    errorKeywords,
     logLevelFilters,
     sourceFilters,
     taskInstance,
     tryNumber: tryNumber === 0 ? 1 : tryNumber,
+    warningKeywords,
   });
 
   return (

--- a/tests/api_fastapi/core_api/routes/ui/test_config.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_config.py
@@ -42,6 +42,8 @@ mock_config_response = {
     "audit_view_included_events": "",
     "is_k8s": False,
     "test_connection": "Disabled",
+    "color_log_error_keywords": ["error"],
+    "color_log_warning_keywords": ["warning"],
     "state_color_mapping": {
         "deferred": "mediumpurple",
         "failed": "red",
@@ -84,7 +86,11 @@ def mock_config_data():
                 "warn_deployment_exposure": "false",
                 "audit_view_excluded_events": "",
                 "audit_view_included_events": "",
-            }
+            },
+            "logging": {
+                "color_log_error_keywords": "error",
+                "color_log_warning_keywords": "warning",
+            },
         }
         with patch(
             "airflow.settings.STATE_COLORS",


### PR DESCRIPTION
Update API to return `color_log_error_keywords` and `color_log_warning_keywords` from airflow.cfg through config API. Then in frontend parse the log message to add color attribute to span tag based on the keyword.

Notes to self and review : 

1. The semantic tokens in light theme appear to be hard to read. I guess it could be due to the Code block adding some more background color.
2. For task log preview I have disabled highlighting since it didn't make sense and it was already filtered by error/critical level.

airflow.cfg values to test as per the screenshot

```ini
color_log_error_keywords = error,exception,group
color_log_warning_keywords = utils
```

![image](https://github.com/user-attachments/assets/5fdb233a-5de1-4e84-ab42-19b5faef53e9)

![image](https://github.com/user-attachments/assets/3164f27b-989e-4c02-8127-75eec882eade)
