### PR TITLE
Fix aws trigger tests, use get_async_conn for mock object

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_bedrock.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_bedrock.py
@@ -33,8 +33,6 @@ from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
 
 BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.bedrock."
 
-pytest.importorskip("aiobotocore")
-
 
 class TestBaseBedrockTrigger:
     EXPECTED_WAITER_NAME: str | None = None
@@ -58,7 +56,7 @@ class TestBedrockCustomizeModelCompletedTrigger(TestBaseBedrockTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(BedrockHook, "get_waiter")
-    @mock.patch.object(BedrockHook, "async_conn")
+    @mock.patch.object(BedrockHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -87,7 +85,7 @@ class TestBedrockProvisionModelThroughputCompletedTrigger(TestBaseBedrockTrigger
 
     @pytest.mark.asyncio
     @mock.patch.object(BedrockHook, "get_waiter")
-    @mock.patch.object(BedrockHook, "async_conn")
+    @mock.patch.object(BedrockHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -118,7 +116,7 @@ class TestBedrockKnowledgeBaseActiveTrigger(TestBaseBedrockTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(BedrockAgentHook, "get_waiter")
-    @mock.patch.object(BedrockAgentHook, "async_conn")
+    @mock.patch.object(BedrockAgentHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -154,7 +152,7 @@ class TestBedrockIngestionJobTrigger(TestBaseBedrockTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(BedrockAgentHook, "get_waiter")
-    @mock.patch.object(BedrockAgentHook, "async_conn")
+    @mock.patch.object(BedrockAgentHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_comprehend.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_comprehend.py
@@ -31,8 +31,6 @@ from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
 
 BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.comprehend."
 
-pytest.importorskip("aiobotocore")
-
 
 class TestBaseComprehendTrigger:
     EXPECTED_WAITER_NAME: str | None = None
@@ -58,7 +56,7 @@ class TestComprehendPiiEntitiesDetectionJobCompletedTrigger(TestBaseComprehendTr
 
     @pytest.mark.asyncio
     @mock.patch.object(ComprehendHook, "get_waiter")
-    @mock.patch.object(ComprehendHook, "async_conn")
+    @mock.patch.object(ComprehendHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -89,7 +87,7 @@ class TestComprehendCreateDocumentClassifierCompletedTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(ComprehendHook, "get_waiter")
-    @mock.patch.object(ComprehendHook, "async_conn")
+    @mock.patch.object(ComprehendHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_dms.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_dms.py
@@ -34,8 +34,6 @@ from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
 
 BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.dms."
 
-pytest.importorskip("aiobotocore")
-
 
 class TestBaseDmsTrigger:
     EXPECTED_WAITER_NAME: str | None = None
@@ -59,7 +57,7 @@ class TestDmsReplicationCompleteTrigger(TestBaseDmsTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(DmsHook, "get_waiter")
-    @mock.patch.object(DmsHook, "get_conn")
+    @mock.patch.object(DmsHook, "get_async_conn")
     async def test_complete(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -86,7 +84,7 @@ class TestDmsReplicationTerminalStatusTrigger(TestBaseDmsTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(DmsHook, "get_waiter")
-    @mock.patch.object(DmsHook, "get_conn")
+    @mock.patch.object(DmsHook, "get_async_conn")
     async def test_complete(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -115,7 +113,7 @@ class TestDmsReplicationConfigDeletedTrigger(TestBaseDmsTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(DmsHook, "get_waiter")
-    @mock.patch.object(DmsHook, "get_conn")
+    @mock.patch.object(DmsHook, "get_async_conn")
     async def test_complete(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -147,7 +145,7 @@ class TestDmsReplicationStoppedTrigger(TestBaseDmsTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(DmsHook, "get_waiter")
-    @mock.patch.object(DmsHook, "get_conn")
+    @mock.patch.object(DmsHook, "get_async_conn")
     async def test_complete(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -175,7 +173,7 @@ class TestDmsReplicationDeprovisionedTrigger(TestBaseDmsTrigger):
 
     @pytest.mark.asyncio
     @mock.patch.object(DmsHook, "get_waiter")
-    @mock.patch.object(DmsHook, "get_conn")
+    @mock.patch.object(DmsHook, "get_async_conn")
     async def test_complete(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -36,8 +36,6 @@ from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
 
 BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.glue."
 
-pytest.importorskip("aiobotocore")
-
 
 class TestGlueJobTrigger:
     @pytest.mark.asyncio
@@ -155,7 +153,7 @@ class TestGlueDataQualityEvaluationRunCompletedTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(GlueDataQualityHook, "get_waiter")
-    @mock.patch.object(GlueDataQualityHook, "async_conn")
+    @mock.patch.object(GlueDataQualityHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -182,7 +180,7 @@ class TestGlueDataQualityRuleRecommendationRunCompleteTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(GlueDataQualityHook, "get_waiter")
-    @mock.patch.object(GlueDataQualityHook, "async_conn")
+    @mock.patch.object(GlueDataQualityHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue_crawler.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue_crawler.py
@@ -26,8 +26,6 @@ from airflow.providers.amazon.aws.triggers.glue_crawler import GlueCrawlerComple
 from airflow.triggers.base import TriggerEvent
 from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
 
-pytest.importorskip("aiobotocore")
-
 
 class TestGlueCrawlerCompleteTrigger:
     def test_serialization(self):
@@ -52,7 +50,7 @@ class TestGlueCrawlerCompleteTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(GlueCrawlerHook, "get_waiter")
-    @mock.patch.object(GlueCrawlerHook, "async_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_kinesis_analytics.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_kinesis_analytics.py
@@ -30,8 +30,6 @@ from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
 
 BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.kinesis_analytics."
 
-pytest.importorskip("aiobotocore")
-
 
 class TestKinesisAnalyticsV2ApplicationOperationCompleteTrigger:
     APPLICATION_NAME = "demo"
@@ -47,7 +45,7 @@ class TestKinesisAnalyticsV2ApplicationOperationCompleteTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(KinesisAnalyticsV2Hook, "get_waiter")
-    @mock.patch.object(KinesisAnalyticsV2Hook, "async_conn")
+    @mock.patch.object(KinesisAnalyticsV2Hook, "get_async_conn")
     async def test_run_success_with_application_start_complete_waiter(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
@@ -64,7 +62,7 @@ class TestKinesisAnalyticsV2ApplicationOperationCompleteTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(KinesisAnalyticsV2Hook, "get_waiter")
-    @mock.patch.object(KinesisAnalyticsV2Hook, "async_conn")
+    @mock.patch.object(KinesisAnalyticsV2Hook, "get_async_conn")
     async def test_run_success_with_application_stop_complete_waiter(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_opensearch_serverless.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_opensearch_serverless.py
@@ -31,8 +31,6 @@ from unit.amazon.aws.triggers.test_base import TestAwsBaseWaiterTrigger
 
 BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.opensearch_serverless."
 
-pytest.importorskip("aiobotocore")
-
 
 class TestBaseBedrockTrigger(TestAwsBaseWaiterTrigger):
     EXPECTED_WAITER_NAME: str | None = None
@@ -77,7 +75,7 @@ class TestOpenSearchServerlessCollectionActiveTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(OpenSearchServerlessHook, "get_waiter")
-    @mock.patch.object(OpenSearchServerlessHook, "async_conn")
+    @mock.patch.object(OpenSearchServerlessHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
         mock_async_conn.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_serialization.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_serialization.py
@@ -108,9 +108,6 @@ AWS_CONN_ID = "aws_batch_job_conn"
 AWS_REGION = "us-east-2"
 
 
-pytest.importorskip("aiobotocore")
-
-
 def gen_test_name(trigger):
     """Gives to tests the name of the class being tested."""
     return trigger.__class__.__name__


### PR DESCRIPTION
Hope now the latestboto tests skipif not required  now.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
