### PR TITLE
Only grab DAGs from bundles being parsed in stale DAG cleanup

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -272,14 +272,14 @@ class DagFileProcessorManager(LoggingMixin):
     ):
         """Detect and deactivate DAGs which are no longer present in files."""
         to_deactivate = set()
+        bundle_names = {b.name for b in self._dag_bundles}
         query = select(
             DagModel.dag_id,
             DagModel.bundle_name,
             DagModel.fileloc,
             DagModel.last_parsed_time,
             DagModel.relative_fileloc,
-        ).where(DagModel.is_active)
-        # TODO: AIP-66 by bundle!
+        ).where(DagModel.is_active, DagModel.bundle_name.in_(bundle_names))
         dags_parsed = session.execute(query)
 
         for dag in dags_parsed:

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -420,6 +420,9 @@ class TestDagFileProcessorManager:
             max_runs=1,
             processor_timeout=10 * 60,
         )
+        bundle = MagicMock()
+        bundle.name = "testing"
+        manager._dag_bundles = [bundle]
 
         test_dag_path = DagFileInfo(
             bundle_name="testing",


### PR DESCRIPTION
Instead of bringing back every DAG, let's only select the DAGs that are in the bundles that the DAG processor is parsing. We won't deactivate others anyways, so it's just extra work for the db and DAG processor.