### PR TITLE
Re-add UI dist files to published docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -122,6 +122,10 @@ docs/**/_api/**
 **/.installed.cfg
 **/*.egg
 
+# But ensure UI dist files are included
+!airflow/ui/dist
+!providers/fab/src/airflow/providers/fab/www/dist
+
 # Exclude temporary vi files
 **/*~
 


### PR DESCRIPTION
As reported in https://apache-airflow.slack.com/archives/C07813CNKA8/p1741383672419579 the dist files for UI were missing in docker... seems the cleaning in #47342 was a bit too much. Unfortunately the global glob for `dist` is overlapping between npm and Python...

This PR ensures the needed UI dist files are added to docker. In total this adds about 7MB to the image.