### PR TITLE
Relocate SmoothOperator to standard provider and add tests

### DIFF
--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -48,7 +48,7 @@ operators:
       - airflow.providers.standard.operators.empty
       - airflow.providers.standard.operators.trigger_dagrun
       - airflow.providers.standard.operators.latest_only
-
+      - airflow.providers.standard.operators.smooth
 sensors:
   - integration-name: Standard
     python-modules:

--- a/providers/standard/src/airflow/providers/standard/get_provider_info.py
+++ b/providers/standard/src/airflow/providers/standard/get_provider_info.py
@@ -52,6 +52,7 @@ def get_provider_info():
                     "airflow.providers.standard.operators.empty",
                     "airflow.providers.standard.operators.trigger_dagrun",
                     "airflow.providers.standard.operators.latest_only",
+                    "airflow.providers.standard.operators.smooth",
                 ],
             }
         ],

--- a/providers/standard/src/airflow/providers/standard/operators/smooth.py
+++ b/providers/standard/src/airflow/providers/standard/operators/smooth.py
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.models.baseoperator import BaseOperator
+
+if TYPE_CHECKING:
+    from airflow.sdk.definitions.context import Context
+
+
+class SmoothOperator(BaseOperator):
+    """Operator that logs a YouTube link to Sade song "Smooth Operator"."""
+
+    ui_color = "#e8f7e4"
+    yt_link: str = "https://www.youtube.com/watch?v=4TYv2PhG89A"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+    def execute(self, context: Context):
+        self.log.info("Enjoy Sade - Smooth Operator: %s", self.yt_link)

--- a/providers/standard/tests/unit/standard/operators/test_smooth.py
+++ b/providers/standard/tests/unit/standard/operators/test_smooth.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,22 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
 
-from airflow.models.baseoperator import BaseOperator
-
-if TYPE_CHECKING:
-    from airflow.sdk.definitions.context import Context
+from airflow.providers.standard.operators.smooth import SmoothOperator
 
 
-class SmoothOperator(BaseOperator):
-    """Operator that does nothing, it logs a YouTube link to Sade song "Smooth Operator"."""
-
-    ui_color = "#e8f7e4"
-    yt_link: str = "https://www.youtube.com/watch?v=4TYv2PhG89A"
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-
-    def execute(self, context: Context):
-        self.log.info("Enjoy Sade - Smooth Operator: %s", self.yt_link)
+class TestSmoothOperator:
+    def test_execute(self, caplog):
+        op = SmoothOperator(task_id="test")
+        op.execute(None)
+        with caplog.at_level(logging.INFO):
+            assert "Enjoy Sade - Smooth Operator: https://www.youtube.com/watch?v=4TYv2PhG89A" in caplog.text


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Now that we relocate ShortCircuit and Branch operators to the standard provider, our beloved SmoothOperator might remain alone in `airflow/operators`. Considering the fact that it also executes logic (similar to the other standard operators), I thought that it would be appropriate to relocate it as well :)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
