### PR TITLE
Fix providers redirects.txt github reference link

### DIFF
--- a/dev/breeze/doc/09_release_management_tasks.rst
+++ b/dev/breeze/doc/09_release_management_tasks.rst
@@ -567,7 +567,7 @@ You have to specify which packages you run it on. For example you can run it for
 
 .. code-block:: bash
 
-     release-management add-back-references --airflow-site-directory DIRECTORY all-providers
+     breeze release-management add-back-references --airflow-site-directory DIRECTORY all-providers
 
 The flag ``--airflow-site-directory`` takes the path of the cloned ``airflow-site``. The command will
 not proceed if this is an invalid path.

--- a/dev/breeze/src/airflow_breeze/utils/add_back_references.py
+++ b/dev/breeze/src/airflow_breeze/utils/add_back_references.py
@@ -64,8 +64,10 @@ def get_redirect_content(url: str):
     return f'<html><head><meta http-equiv="refresh" content="0; url={url}"/></head></html>'
 
 
-def get_github_redirects_url(provider_name: str):
-    return f"https://raw.githubusercontent.com/apache/airflow/main/docs/{provider_name}/redirects.txt"
+def get_github_provider_redirects_url(provider_name: str):
+    return (
+        f"https://raw.githubusercontent.com/apache/airflow/main/providers/{provider_name}/docs/redirects.txt"
+    )
 
 
 def crete_redirect_html_if_not_exist(path: Path, content: str):
@@ -145,9 +147,11 @@ def start_generating_back_references(airflow_site_directory: Path, short_provide
         get_console().print("[info]Skipping apache-airflow-providers package. No back-reference needed.")
         short_provider_ids.remove("apache-airflow-providers")
     if short_provider_ids:
-        all_providers = [
-            f"apache-airflow-providers-{package.replace('.','-')}" for package in short_provider_ids
-        ]
-        for p in all_providers:
-            get_console().print(f"Processing airflow provider: {p}")
-            generate_back_references(get_github_redirects_url(p), docs_archive_path / p)
+        for p in short_provider_ids:
+            slash_based_short_provider_id = p.replace(".", "/")
+            full_provider_name = f"apache-airflow-providers-{p.replace('.','-')}"
+            get_console().print(f"Processing airflow provider: {full_provider_name}")
+            generate_back_references(
+                get_github_provider_redirects_url(slash_based_short_provider_id),
+                docs_archive_path / full_provider_name,
+            )


### PR DESCRIPTION
After provider restructure, the location changed, it requires updated url
While preparing scripts for s3 docs publishing, noticed this change.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
