### PR TITLE
Avoid Title underline too short

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
@@ -63,7 +63,7 @@ Misc
 {%- if classified_changes and classified_changes.docs %}
 
 Doc-only
-~~~~
+~~~~~~~~
 {% for doc in classified_changes.docs %}
 * ``{{ doc.message_without_backticks | safe }}``
 {%- endfor %}


### PR DESCRIPTION
avoid the following error:
```
------------------------------ Error   5 --------------------
 WARNING: Title underline too short.

File path: apache-airflow-providers-apache-spark/changelog.rst (46)
------------------------------ Error   6 --------------------
 WARNING: Title underline too short.

File path: apache-airflow-providers-apache-spark/changelog.rst (46)
```