### PR TITLE
Remove 100% memory consumption warning

### DIFF
--- a/dev/breeze/doc/04_troubleshooting.rst
+++ b/dev/breeze/doc/04_troubleshooting.rst
@@ -65,24 +65,6 @@ Then run the failed command, copy-and-paste the output from your terminal to the
 `Airflow Slack <https://s.apache.org/airflow-slack>`_  ``#airflow-breeze`` channel and
 describe your problem.
 
-
-.. warning::
-
-    Some operating systems (Fedora, ArchLinux, RHEL, Rocky) have recently introduced Kernel changes that result in
-    Airflow in Breeze consuming 100% memory when run inside the community Docker implementation maintained
-    by the OS teams.
-
-    This is an issue with backwards-incompatible containerd configuration that some of Airflow dependencies
-    have problems with and is tracked in a few issues:
-
-    * `Moby issue <https://github.com/moby/moby/issues/43361>`_
-    * `Containerd issue <https://github.com/containerd/containerd/pull/7566>`_
-
-    There is no solution yet from the containerd team, but seems that installing
-    `Docker Desktop on Linux <https://docs.docker.com/desktop/install/linux-install/>`_ solves the problem as
-    stated in `This comment <https://github.com/moby/moby/issues/43361#issuecomment-1227617516>`_ and allows to
-    run Breeze with no problems.
-
 Cannot import name 'cache' or Python >=3.9 required
 ---------------------------------------------------
 

--- a/docs/apache-airflow/howto/docker-compose/index.rst
+++ b/docs/apache-airflow/howto/docker-compose/index.rst
@@ -50,25 +50,6 @@ Older versions of ``docker-compose`` do not support all the features required by
 
         docker run --rm "debian:bookworm-slim" bash -c 'numfmt --to iec $(echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE))))'
 
-.. warning::
-
-    Some operating systems (Fedora, ArchLinux, RHEL, Rocky) have recently introduced Kernel changes that result in
-    Airflow in Docker Compose consuming 100% memory when run inside the community Docker implementation maintained
-    by the OS teams.
-
-    This is an issue with backwards-incompatible containerd configuration that some of Airflow dependencies
-    have problems with and is tracked in a few issues:
-
-    * `Moby issue <https://github.com/moby/moby/issues/43361>`_
-    * `Containerd issue <https://github.com/containerd/containerd/>`_
-
-    There is no solution yet from the containerd team, but seems that installing
-    `Docker Desktop on Linux <https://docs.docker.com/desktop/install/linux-install/>`_ solves the problem as
-    stated in `This comment <https://github.com/moby/moby/issues/43361#issuecomment-1227617516>`_ and allows to
-    run Breeze with no problems.
-
-
-
 Fetching ``docker-compose.yaml``
 ================================
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

`containerd` fixes this upstream in [PR 8924](https://github.com/containerd/containerd/pull/8924) by removing the `LimitNOFILE` declaration, relying on the underlying operating systems to set minimum and maximum memory constraints. (This was pushed to `containerd` in October 2023.)

`containerd` [release notes](https://github.com/containerd/containerd/releases/tag/v2.0.0#:~:text=%238924) for v2.0.0 reference the change.

The Docker Engine pulled this update from `containerd` in v25.0.0 ([changelog](https://docs.docker.com/engine/release-notes/25.0/#:~:text=The%20daemon%20now,topic%20in%20detail.)).

I'm not sure there's a reason to keep these warnings in the documentation -- if I'm wrong, the documentation should at least be updated to indicate the version of `containerd` and `docker` in which the issue is resolved.
