### PR TITLE
Fix false warning about usage outside of ti for extended operators

### DIFF
--- a/tests/models/test_baseoperatormeta.py
+++ b/tests/models/test_baseoperatormeta.py
@@ -19,15 +19,15 @@ from __future__ import annotations
 
 import datetime
 import threading
+from threading import local
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from airflow.configuration import conf
 from airflow.decorators import task
 from airflow.exceptions import AirflowException, AirflowRescheduleException, AirflowSkipException
-from airflow.models.baseoperator import BaseOperator, ExecutorSafeguard
+from airflow.models.baseoperator import BaseOperator, ExecutorSafeguard, chain
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState, State
@@ -46,36 +46,51 @@ class ExtendedHelloWorldOperator(HelloWorldOperator):
         return super().execute(context)
 
 
+class Dummy:
+    pass
+
+
+class DeeplyExtendedHelloWorldOperator(ExtendedHelloWorldOperator, Dummy):
+    def execute(self, context: Context) -> Any:
+        return super().execute(context)
+
+
+class UnusedOperator(BaseOperator):
+    def execute(self, context: Context) -> Any:
+        return f"Hello {self.owner}!"
+
+
+class ExtendedAndUsedOperator(UnusedOperator):
+    def execute(self, context: Context) -> Any:
+        return super().execute(context)
+
+
 class TestExecutorSafeguard:
     def setup_method(self):
+        self._test_mode_before = ExecutorSafeguard.test_mode
+        self._sentinel_before = ExecutorSafeguard._sentinel
+        self._sentinel_callers_before = ExecutorSafeguard._sentinel.callers
         ExecutorSafeguard.test_mode = False
+        ExecutorSafeguard._sentinel = local()
+        ExecutorSafeguard._sentinel.callers = {}
 
     def teardown_method(self, method):
-        ExecutorSafeguard.test_mode = conf.getboolean("core", "unit_test_mode")
+        ExecutorSafeguard.test_mode = self._test_mode_before
+        ExecutorSafeguard._sentinel = self._sentinel_before
+        ExecutorSafeguard._sentinel.callers = self._sentinel_callers_before
 
     @pytest.mark.db_test
-    @patch.object(HelloWorldOperator, "log")
-    def test_executor_when_classic_operator_called_from_dag(self, mock_log, dag_maker):
+    @pytest.mark.parametrize(
+        "operator", [ExtendedHelloWorldOperator, ExtendedAndUsedOperator, HelloWorldOperator]
+    )
+    def test_executor_when_classic_operator_called_from_dag(self, dag_maker, operator):
+        operator.log = MagicMock()
         with dag_maker() as dag:
-            HelloWorldOperator(task_id="hello_operator")
+            operator(task_id="hello_operator")
 
         dag_run = dag.test()
         assert dag_run.state == DagRunState.SUCCESS
-        mock_log.warning.assert_not_called()
-
-    @pytest.mark.db_test
-    @patch.object(HelloWorldOperator, "log")
-    def test_executor_when_extended_classic_operator_called_from_dag(
-        self,
-        mock_log,
-        dag_maker,
-    ):
-        with dag_maker() as dag:
-            ExtendedHelloWorldOperator(task_id="hello_operator")
-
-        dag_run = dag.test()
-        assert dag_run.state == DagRunState.SUCCESS
-        mock_log.warning.assert_not_called()
+        operator.log.warning.assert_not_called()
 
     @pytest.mark.parametrize(
         "state, exception, retries",
@@ -124,14 +139,17 @@ class TestExecutorSafeguard:
         assert ti.state == state
 
     @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "operator_class", [ExtendedHelloWorldOperator, ExtendedAndUsedOperator, HelloWorldOperator]
+    )
     def test_executor_when_classic_operator_called_from_decorated_task_with_allow_nested_operators_false(
-        self, dag_maker
+        self, dag_maker, operator_class
     ):
         with dag_maker() as dag:
 
             @task(task_id="task_id", dag=dag)
             def say_hello(**context):
-                operator = HelloWorldOperator(task_id="hello_operator", allow_nested_operators=False)
+                operator = operator_class(task_id="hello_operator", allow_nested_operators=False)
                 return operator.execute(context=context)
 
             say_hello()
@@ -140,26 +158,97 @@ class TestExecutorSafeguard:
         assert dag_run.state == DagRunState.FAILED
 
     @pytest.mark.db_test
-    @patch.object(HelloWorldOperator, "log")
+    @pytest.mark.parametrize(
+        "operator_class", [ExtendedHelloWorldOperator, ExtendedAndUsedOperator, HelloWorldOperator]
+    )
     def test_executor_when_classic_operator_called_from_decorated_task_without_allow_nested_operators(
         self,
-        mock_log,
         dag_maker,
+        operator_class,
     ):
+        operator_class.log = MagicMock()
+
         with dag_maker() as dag:
 
             @task(task_id="task_id", dag=dag)
             def say_hello(**context):
-                operator = HelloWorldOperator(task_id="hello_operator")
+                operator = operator_class(task_id="hello_operator")
                 return operator.execute(context=context)
 
             say_hello()
 
         dag_run = dag.test()
         assert dag_run.state == DagRunState.SUCCESS
-        mock_log.warning.assert_called_once_with(
-            "HelloWorldOperator.execute cannot be called outside TaskInstance!"
+        name = operator_class.__name__
+        operator_class.log.warning.assert_called_once_with(
+            f"{name}.execute cannot be called outside TaskInstance!"
         )
+
+    @pytest.mark.db_test
+    def test_executor_when_classic_operator_called_from_decorated_task_and_classic(
+        self,
+        dag_maker,
+    ):
+        """
+        Test that the combination of wrong and correct usage of operators leads to the
+        correct warning messages count.
+        """
+        hello_world_log = MagicMock()
+        extended_hello_world_log = MagicMock()
+        unused_log = MagicMock()
+        extended_and_used_log = MagicMock()
+        HelloWorldOperator.log = hello_world_log  # type: ignore
+        ExtendedHelloWorldOperator.log = extended_hello_world_log  # type: ignore
+        UnusedOperator.log = unused_log  # type: ignore
+        ExtendedAndUsedOperator.log = extended_and_used_log  # type: ignore
+
+        with dag_maker() as dag:
+
+            @task(task_id="hello_from_task", dag=dag)
+            def hello_from_task(**context):
+                operator = HelloWorldOperator(task_id="hello_from_task")
+                return operator.execute(context=context)
+
+            @task(task_id="extended_hello_from_task", dag=dag)
+            def extended_hello_from_task(**context):
+                operator = ExtendedHelloWorldOperator(task_id="extended_hello_from_task")
+                return operator.execute(context=context)
+
+            @task(task_id="extended_and_used_from_task", dag=dag)
+            def extended_and_used_from_task(**context):
+                operator = ExtendedAndUsedOperator(task_id="extended_and_used_from_task")
+                return operator.execute(context=context)
+
+            hello = hello_from_task()
+            extended_hello = extended_hello_from_task()
+            extended_and_used_hello = extended_and_used_from_task()
+
+            hello_op = HelloWorldOperator(task_id="hello_from_dag")
+            extended_hello_op = ExtendedHelloWorldOperator(task_id="extended_hello_from_dag")
+            extended_and_used_op = ExtendedAndUsedOperator(task_id="extended_and_used_from_dag")
+
+            chain(
+                hello,
+                hello_op,
+                extended_hello,
+                extended_hello_op,
+                extended_and_used_hello,
+                extended_and_used_op,
+            )
+
+        dag_run = dag.test()
+        assert dag_run.state == DagRunState.SUCCESS
+
+        msg = "HelloWorldOperator.execute cannot be called outside TaskInstance!"
+        hello_world_log.warning.assert_called_once_with(msg)
+
+        msg = "ExtendedHelloWorldOperator.execute cannot be called outside TaskInstance!"
+        extended_hello_world_log.warning.assert_called_once_with(msg)
+
+        msg = "ExtendedAndUsedOperator.execute cannot be called outside TaskInstance!"
+        extended_and_used_log.warning.assert_called_once_with(msg)
+
+        assert unused_log.warning.call_count == 0
 
     @pytest.mark.db_test
     def test_executor_when_classic_operator_called_from_python_operator_with_allow_nested_operators_false(
@@ -182,16 +271,19 @@ class TestExecutorSafeguard:
         assert dag_run.state == DagRunState.FAILED
 
     @pytest.mark.db_test
-    @patch.object(HelloWorldOperator, "log")
+    @pytest.mark.parametrize(
+        "operator_class", [ExtendedHelloWorldOperator, ExtendedAndUsedOperator, HelloWorldOperator]
+    )
     def test_executor_when_classic_operator_called_from_python_operator_without_allow_nested_operators(
         self,
-        mock_log,
         dag_maker,
+        operator_class,
     ):
+        operator_class.log = MagicMock()
         with dag_maker() as dag:
 
             def say_hello(**context):
-                operator = HelloWorldOperator(task_id="hello_operator")
+                operator = operator_class(task_id="hello_operator")
                 return operator.execute(context=context)
 
             PythonOperator(
@@ -202,9 +294,25 @@ class TestExecutorSafeguard:
 
         dag_run = dag.test()
         assert dag_run.state == DagRunState.SUCCESS
-        mock_log.warning.assert_called_once_with(
-            "HelloWorldOperator.execute cannot be called outside TaskInstance!"
+        name = operator_class.__name__
+        operator_class.log.warning.assert_called_once_with(
+            f"{name}.execute cannot be called outside TaskInstance!"
         )
+
+    @pytest.mark.db_test
+    def test_safeguard_sentinel_callers_propagation(self, dag_maker):
+        """Test that only original caller is remaining in the sentinel callers"""
+        DeeplyExtendedHelloWorldOperator.log = MagicMock()  # type: ignore
+        with dag_maker() as dag:
+            DeeplyExtendedHelloWorldOperator(task_id="hello_operator")
+
+        dag_run = dag.test()
+        assert dag_run.state == DagRunState.SUCCESS
+        DeeplyExtendedHelloWorldOperator.log.warning.assert_not_called()
+
+        remaining_callers = list(ExecutorSafeguard._sentinel.callers)
+        expected_callers = ["DeeplyExtendedHelloWorldOperator__sentinel"]
+        assert remaining_callers == expected_callers
 
     def test_thread_local_executor_safeguard(self):
         class TestExecutorSafeguardThread(threading.Thread):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Current `ExecutorSafeguard` emits a false warning about extended operators' usage outside of the task instance.

In https://github.com/apache/airflow/pull/42849 the fix was introduced, but it's tests are flawed and depend on the testing order and values in `ExecutorSafeguard` leaking between tests.

An isolated call of `pytest -sv tests/models/test_baseoperatormeta.py::TestExecutorSafeguard::test_executor_when_extended_classic_operator_called_from_dag` shows tests fail while `pytest -sv tests/models/test_baseoperatormeta.py` is green.

Changes:
- adapt to wrapped `execute` methods calling orders for extended operator classes by propagating sentinel via base classes keys to callers
- emit warning only once per class chain
- clean  `ExecutorSafeguard` state between tests
- expand tests 

closes: #47511
related: #45498


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
