### PR TITLE
Update upgrading.rst to streamline upgrade documentation as discussed in #47539

### DIFF
--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -57,15 +57,8 @@ when you choose to upgrade airflow via their UI.
 How to upgrade
 ==============
 
-Reinstall Apache Airflow®, specifying the desired new version.
-
-To upgrade a bootstrapped local instance, you can set the ``AIRFLOW_VERSION`` environment variable to the
-intended version prior to rerunning the installation command. Upgrade incrementally by patch version: e.g.,
-if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For more detailed guidance, see
-:doc:`/start`.
-
-To upgrade a PyPI package, rerun the ``pip install`` command in your environment using the desired version
-as a constraint. For more detailed guidance, see :doc:`/installation/installing-from-pypi`.
+To upgrade Apache Airflow® installed as PyPI package, rerun the ``pip install`` command in your environment using the desired version set in ``AIRFLOW_VERSION`` environment variable
+as a constraint. For more detailed guidance, see chapter "Installation and upgrade scenarios" from :doc:`/installation/installing-from-pypi.html#installation-and-upgrade-scenarios`.
 
 In order to manually migrate the database you should run the ``airflow db migrate`` command in your
 environment. It can be run either in your virtual environment or in the containers that give


### PR DESCRIPTION
First paragraph is removed.  
The link in the second paragraph is updated to https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html#installation-and-upgrade-scenarios  
Closes: #47539
