### PR TITLE
Fix comment typo in PythonOperator

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -212,13 +212,11 @@ class PythonOperator(BaseOperator):
         """
         try:
             from airflow.utils.operator_helpers import ExecutionCallableRunner
-
-            asset_events = self._asset_events if AIRFLOW_V_3_0_PLUS else self._dataset_events
-
-            runner = ExecutionCallableRunner(self.python_callable, asset_events, logger=self.log)
         except ImportError:
-            # Handle Pre Airflow 3.10 case where ExecutionCallableRunner was not available
+            # Handle Pre Airflow 2.10 case where ExecutionCallableRunner was not available
             return self.python_callable(*self.op_args, **self.op_kwargs)
+        asset_events = self._asset_events if AIRFLOW_V_3_0_PLUS else self._dataset_events
+        runner = ExecutionCallableRunner(self.python_callable, asset_events, logger=self.log)
         return runner.run(*self.op_args, **self.op_kwargs)
 
 


### PR DESCRIPTION
Just a minor typo, it’s 2.10 not 3.10.

Also moved some code out of the try block so it’s more obvious what we’re handling.