### PR TITLE
AIP-38 Move token handling to axios interceptor

### DIFF
--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -27,9 +27,9 @@ import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
 
-import { TOKEN_STORAGE_KEY } from "./layouts/BaseLayout";
 import { queryClient } from "./queryClient";
 import { system } from "./theme";
+import { tokenHandler } from "./utils/tokenHandler";
 
 // redirect to login page if the API responds with unauthorized or forbidden errors
 axios.interceptors.response.use(
@@ -46,17 +46,7 @@ axios.interceptors.response.use(
   },
 );
 
-axios.interceptors.request.use((config) => {
-  const token: string | null = localStorage.getItem(TOKEN_STORAGE_KEY);
-
-  if (token !== null) {
-    // usehooks-ts stores a JSON.stringified version of values, we cannot use usehooks-ts here because we are outside of
-    // a react component. Therefore using bare localStorage.getItem and manually parsing the value.
-    config.headers.Authorization = `Bearer ${JSON.parse(token)}`;
-  }
-
-  return config;
-});
+axios.interceptors.request.use(tokenHandler);
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>

--- a/airflow/ui/src/utils/tokenHandler.ts
+++ b/airflow/ui/src/utils/tokenHandler.ts
@@ -16,27 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box } from "@chakra-ui/react";
-import type { PropsWithChildren } from "react";
-import { Outlet } from "react-router-dom";
+import type { InternalAxiosRequestConfig } from "axios";
 
-import { useConfig } from "src/queries/useConfig";
+export const TOKEN_STORAGE_KEY = "token";
+export const TOKEN_QUERY_PARAM_NAME = "token";
 
-import { Nav } from "./Nav";
+export const tokenHandler = (config: InternalAxiosRequestConfig) => {
+  const searchParams = new URLSearchParams(globalThis.location.search);
 
-export const BaseLayout = ({ children }: PropsWithChildren) => {
-  const instanceName = useConfig("instance_name");
+  const tokenUrl = searchParams.get(TOKEN_QUERY_PARAM_NAME);
 
-  if (typeof instanceName === "string") {
-    document.title = instanceName;
+  let token: string | null;
+
+  if (tokenUrl === null) {
+    token = localStorage.getItem(TOKEN_STORAGE_KEY);
+  } else {
+    localStorage.setItem(TOKEN_QUERY_PARAM_NAME, tokenUrl);
+    searchParams.delete(TOKEN_QUERY_PARAM_NAME);
+    globalThis.location.search = searchParams.toString();
+    token = tokenUrl;
   }
 
-  return (
-    <>
-      <Nav />
-      <Box display="flex" flexDirection="column" h="100vh" ml={20} p={3}>
-        {children ?? <Outlet />}
-      </Box>
-    </>
-  );
+  if (token !== null) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
 };

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -408,7 +408,7 @@ class FabAuthManager(BaseAuthManager[User]):
 
     def get_url_login(self, **kwargs) -> str:
         """Return the login page url."""
-        return f"{self.apiserver_endpoint}/auth/login"
+        return f"{self.apiserver_endpoint}/auth/login/"
 
     def get_url_logout(self):
         """Return the logout page url."""

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -556,7 +556,7 @@ class TestFabAuthManager:
 
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()
-        assert result == "http://localhost:8080/auth/login"
+        assert result == "http://localhost:8080/auth/login/"
 
     @pytest.mark.db_test
     def test_get_url_logout_when_auth_view_not_defined(self, auth_manager_with_appbuilder):


### PR DESCRIPTION
The problem is that the router loader query (config) is done before the token handler gets a chance to actually handle the token. (BaseLayout, but the router loader is done before rendering the BaseLayout)

https://github.com/apache/airflow/pull/47487 introduces auth/perm on the config endpoint which will induce a 401 redirection loop.

This moves the token handling to the axios interceptor, this way outside of rendering / loader consideration, the token handler (to retrieve, or save) is always executed before doing a request.