### PR TITLE
feat: inject OpenLineage configuration to LivyOperator

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -246,6 +246,7 @@
   "apache.livy": {
     "deps": [
       "aiohttp>=3.9.2",
+      "apache-airflow-providers-common-compat>=1.5.0",
       "apache-airflow-providers-http>=5.1.0",
       "apache-airflow>=2.9.0",
       "asgiref>=2.3.0"
@@ -253,6 +254,7 @@
     "devel-deps": [],
     "plugins": [],
     "cross-providers-deps": [
+      "common.compat",
       "http"
     ],
     "excluded-python-versions": [],

--- a/providers/apache/livy/README.rst
+++ b/providers/apache/livy/README.rst
@@ -50,14 +50,15 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-=================================  ==================
-PIP package                        Version required
-=================================  ==================
-``apache-airflow``                 ``>=2.9.0``
-``apache-airflow-providers-http``  ``>=5.1.0``
-``aiohttp``                        ``>=3.9.2``
-``asgiref``                        ``>=2.3.0``
-=================================  ==================
+==========================================  ==================
+PIP package                                 Version required
+==========================================  ==================
+``apache-airflow``                          ``>=2.9.0``
+``apache-airflow-providers-http``           ``>=5.1.0``
+``apache-airflow-providers-common-compat``  ``>=1.5.0``
+``aiohttp``                                 ``>=3.9.2``
+``asgiref``                                 ``>=2.3.0``
+==========================================  ==================
 
 Cross provider package dependencies
 -----------------------------------
@@ -69,14 +70,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-apache-livy[http]
+    pip install apache-airflow-providers-apache-livy[common.compat]
 
 
-================================================================================================  ========
-Dependent package                                                                                 Extra
-================================================================================================  ========
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_  ``http``
-================================================================================================  ========
+==================================================================================================================  =================
+Dependent package                                                                                                   Extra
+==================================================================================================================  =================
+`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
+`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
+==================================================================================================================  =================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-livy/4.2.1/changelog.html>`_.

--- a/providers/apache/livy/pyproject.toml
+++ b/providers/apache/livy/pyproject.toml
@@ -59,6 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.9.0",
     "apache-airflow-providers-http>=5.1.0",
+    "apache-airflow-providers-common-compat>=1.5.0",
     "aiohttp>=3.9.2",
     "asgiref>=2.3.0",
 ]
@@ -68,6 +69,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-http",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]

--- a/providers/apache/livy/src/airflow/providers/apache/livy/get_provider_info.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/get_provider_info.py
@@ -104,6 +104,7 @@ def get_provider_info():
         "dependencies": [
             "apache-airflow>=2.9.0",
             "apache-airflow-providers-http>=5.1.0",
+            "apache-airflow-providers-common-compat>=1.5.0",
             "aiohttp>=3.9.2",
             "asgiref>=2.3.0",
         ],

--- a/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
@@ -28,6 +28,10 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
 from airflow.providers.apache.livy.triggers.livy import LivyTrigger
+from airflow.providers.common.compat.openlineage.utils.spark import (
+    inject_parent_job_information_into_spark_properties,
+    inject_transport_information_into_spark_properties,
+)
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -94,9 +98,18 @@ class LivyOperator(BaseOperator):
         extra_headers: dict[str, Any] | None = None,
         retry_args: dict[str, Any] | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        openlineage_inject_parent_job_info: bool = conf.getboolean(
+            "openlineage", "spark_inject_parent_job_info", fallback=False
+        ),
+        openlineage_inject_transport_info: bool = conf.getboolean(
+            "openlineage", "spark_inject_transport_info", fallback=False
+        ),
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+
+        if conf is None:
+            conf = {}
 
         spark_params = {
             # Prepare spark parameters, it will be templated later.
@@ -128,6 +141,8 @@ class LivyOperator(BaseOperator):
         self._batch_id: int | str | None = None
         self.retry_args = retry_args
         self.deferrable = deferrable
+        self.openlineage_inject_parent_job_info = openlineage_inject_parent_job_info
+        self.openlineage_inject_transport_info = openlineage_inject_transport_info
 
     @cached_property
     def hook(self) -> LivyHook:
@@ -145,6 +160,17 @@ class LivyOperator(BaseOperator):
         )
 
     def execute(self, context: Context) -> Any:
+        if self.openlineage_inject_parent_job_info:
+            self.log.debug("Injecting parent job information into Spark properties")
+            self.spark_params["conf"] = inject_parent_job_information_into_spark_properties(
+                self.spark_params["conf"], context
+            )
+        if self.openlineage_inject_transport_info:
+            self.log.debug("Injecting transport information into Spark properties")
+            self.spark_params["conf"] = inject_transport_information_into_spark_properties(
+                self.spark_params["conf"], context
+            )
+
         _batch_id: int | str = self.hook.post_batch(**self.spark_params)
         self._batch_id = _batch_id
         self.log.info("Generated batch-id is %s", self._batch_id)


### PR DESCRIPTION
This PR is a followup to https://github.com/apache/airflow/pull/47508

When explicitly enabled by the user for supported operators, we will automatically inject parent job information into the Spark job properties. For example, when submitting a Spark job using the LivyOperator, we will include details about the Airflow task that triggered it so that the OpenLineage Spark integration can include them in parentRunFacet.

More detailed description is in https://github.com/apache/airflow/pull/44477 - this adds the same feature, but for different operator.