### PR TITLE
Use a single http tag to report the server's location to front end, not two

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -61,13 +61,12 @@ async def lifespan(app: FastAPI):
 def create_app(apps: str = "all") -> FastAPI:
     apps_list = apps.split(",") if apps else ["all"]
 
-    fastapi_base_url = conf.get("api", "base_url")
-    if fastapi_base_url.endswith("/"):
-        raise AirflowConfigException("`[api] base_url` config option cannot have a trailing slash.")
+    fastapi_base_url = conf.get("api", "base_url", fallback="")
+    if fastapi_base_url and not fastapi_base_url.endswith("/"):
+        fastapi_base_url += "/"
+        conf.set("api", "base_url", fastapi_base_url)
 
-    root_path = urlsplit(fastapi_base_url).path
-    if not root_path or root_path == "/":
-        root_path = ""
+    root_path = urlsplit(fastapi_base_url).path.removesuffix("/")
 
     app = FastAPI(
         title="Airflow API",

--- a/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urljoin
+
 from fastapi import HTTPException, status
 from starlette.responses import RedirectResponse
 
@@ -60,7 +62,7 @@ def create_token_all_admins() -> RedirectResponse:
         username="Anonymous",
         role="ADMIN",
     )
-    url = f"{conf.get('api', 'base_url')}/?token={get_auth_manager().get_jwt_token(user)}"
+    url = urljoin(conf.get("api", "base_url"), f"?token={get_auth_manager().get_jwt_token(user)}")
     return RedirectResponse(url=url)
 
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1290,6 +1290,11 @@ class AirflowConfigParser(ConfigParser):
         """
         section = section.lower()
         option = option.lower()
+        defaults = self.configuration_description or {}
+        if not self.has_section(section) and section in defaults:
+            # Trying to set a key in a section that exists in default, but not in the user config;
+            # automatically create it
+            self.add_section(section)
         super().set(section, option, value)
 
     def remove_option(self, section: str, option: str, remove_default: bool = True):

--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -3,7 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
-    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
+    <base href="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="http://localhost:5173/public/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -2,10 +2,9 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
-    <base href="{{ backend_server_base_url }}/" />
+    <base href="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="/static/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="backend-server-base-url" content="{{ backend_server_base_url }}" />
     <title>Airflow 3.0</title>
   </head>
   <body style="height: 100%">

--- a/airflow/ui/src/queryClient.ts
+++ b/airflow/ui/src/queryClient.ts
@@ -21,7 +21,10 @@ import { QueryClient } from "@tanstack/react-query";
 import { OpenAPI } from "openapi/requests/core/OpenAPI";
 
 // Dynamically set the base URL for XHR requests based on the meta tag.
-OpenAPI.BASE = document.querySelector("meta[name='backend-server-base-url']")?.getAttribute("content") ?? "";
+OpenAPI.BASE = document.querySelector("head>base")?.getAttribute("href") ?? "";
+if (OpenAPI.BASE.endsWith("/")) {
+  OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
+}
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -25,6 +25,7 @@ from collections.abc import Generator, Iterable, Mapping, MutableMapping
 from datetime import datetime
 from functools import cache, reduce
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from urllib.parse import urljoin
 
 from lazy_object_proxy import Proxy
 
@@ -259,7 +260,7 @@ def build_airflow_dagrun_url(dag_id: str, run_id: str) -> str:
     http://localhost:8080/dags/hi/runs/manual__2025-02-23T18:27:39.051358+00:00_RZa1at4Q
     """
     baseurl = conf.get("api", "base_url")
-    return f"{baseurl}/dags/{dag_id}/runs/{run_id}"
+    return urljoin(baseurl, f"dags/{dag_id}/runs/{run_id}")
 
 
 # The 'template' argument is typed as Any because the jinja2.Template is too

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urljoin
 
 from fastapi import FastAPI
 
@@ -321,7 +322,7 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
         return {dag_id for dag_id in dag_ids if _has_access_to_dag(requests[dag_id][method])}
 
     def get_url_login(self, **kwargs) -> str:
-        return f"{self.apiserver_endpoint}/auth/login"
+        return urljoin(self.apiserver_endpoint, "auth/login")
 
     @staticmethod
     def get_cli_commands() -> list[CLICommand]:

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urljoin
 
 import anyio
 from fastapi import HTTPException, Request
@@ -79,7 +80,7 @@ def login_callback(request: Request):
         username=saml_auth.get_nameid(),
         email=attributes["email"][0] if "email" in attributes else None,
     )
-    url = f"{conf.get('api', 'base_url')}/?token={get_auth_manager().get_jwt_token(user)}"
+    url = urljoin(conf.get("api", "base_url"), f"?token={get_auth_manager().get_jwt_token(user)}")
     return RedirectResponse(url=url, status_code=303)
 
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -21,6 +21,7 @@ import argparse
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
 
 import packaging.version
 from connexion import FlaskApi
@@ -409,7 +410,7 @@ class FabAuthManager(BaseAuthManager[User]):
 
     def get_url_login(self, **kwargs) -> str:
         """Return the login page url."""
-        return f"{self.apiserver_endpoint}/auth/login/"
+        return urljoin(self.apiserver_endpoint, "auth/login/")
 
     def get_url_logout(self):
         """Return the logout page url."""

--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -70,7 +70,7 @@ class FabIndexView(IndexView):
     def index(self):
         if g.user is not None and g.user.is_authenticated:
             token = get_auth_manager().get_jwt_token(g.user)
-            return redirect(f"{conf.get('api', 'base_url')}/?token={token}", code=302)
+            return redirect(urljoin(conf.get("api", "base_url"), f"?token={token}"), code=302)
         else:
             return super().index()
 


### PR DESCRIPTION
Previously we had both a `<base href="">` tag and a `<meta
name="backend-server-base-url" content="">` tag that contained almost the same
value -- one had a trailing `/` and the other didn't.

That irked me, so I updated things so the XHR requests take the URL based on
the `<base>` tag instead.

In order to make this change I made the following changes:
 - Instead of erroring if the URL does have a trailing `/`, the behaviour is
   now to add it if it's missing. This makes it easier kn users
 - This necessitated updating the Auth Managers to use a proper URL function,
   not string concatenation, to build the URLs

The change to `conf.set` is a side-effect/fix to allow `conf.set("api",
"base_url")` to work -- otherwise it errored with "No section found" with only
the defaults present

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
