### PR TITLE
Close the logger's file descriptor once the process is complete.

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -458,8 +458,7 @@ class DagFileProcessorManager(LoggingMixin):
         now_seconds = time.monotonic()
         if now_seconds < next_check:
             self.log.debug(
-                "Not time to check if DAG Bundles need refreshed yet - skipping. "
-                "Next check in %.2f seconds",
+                "Not time to check if DAG Bundles need refreshed yet - skipping. Next check in %.2f seconds",
                 next_check - now_seconds,
             )
             return
@@ -762,6 +761,7 @@ class DagFileProcessorManager(LoggingMixin):
                 self.log.warning("Stopping processor for %s", file)
                 Stats.decr("dag_processing.processes", tags={"file_path": file, "action": "stop"})
                 processor.kill(signal.SIGKILL)
+                processor.filehandle.close()
                 self._file_stats.pop(file, None)
 
     @provide_session
@@ -786,7 +786,8 @@ class DagFileProcessorManager(LoggingMixin):
             )
 
         for file in finished:
-            self._processors.pop(file)
+            processor = self._processors.pop(file)
+            processor.filehandle.close()
 
     def _get_log_dir(self) -> str:
         return os.path.join(self.base_log_dir, timezone.utcnow().strftime("%Y-%m-%d"))
@@ -829,14 +830,18 @@ class DagFileProcessorManager(LoggingMixin):
     def _get_logger_for_dag_file(self, dag_file: DagFileInfo):
         log_filename = self._render_log_filename(dag_file)
         log_file = init_log_file(log_filename)
-        underlying_logger = structlog.BytesLogger(log_file.open("ab"))
+        filehandle = log_file.open("ab")
+        underlying_logger = structlog.BytesLogger(filehandle)
         processors = logging_processors(enable_pretty_log=False)[0]
-        return structlog.wrap_logger(underlying_logger, processors=processors, logger_name="processor").bind()
+        return structlog.wrap_logger(
+            underlying_logger, processors=processors, logger_name="processor"
+        ).bind(), filehandle
 
     def _create_process(self, dag_file: DagFileInfo) -> DagFileProcessorProcess:
         id = uuid7()
 
         callback_to_execute_for_file = self._callback_to_execute.pop(dag_file, [])
+        logger, filehandle = self._get_logger_for_dag_file(dag_file)
 
         return DagFileProcessorProcess.start(
             id=id,
@@ -844,7 +849,8 @@ class DagFileProcessorManager(LoggingMixin):
             bundle_path=cast(Path, dag_file.bundle_path),
             callbacks=callback_to_execute_for_file,
             selector=self.selector,
-            logger=self._get_logger_for_dag_file(dag_file),
+            logger=logger,
+            filehandle=filehandle,
         )
 
     def _start_new_processes(self):
@@ -985,7 +991,8 @@ class DagFileProcessorManager(LoggingMixin):
 
         # Clean up `self._processors` after iterating over it
         for proc in processors_to_remove:
-            self._processors.pop(proc)
+            processor = self._processors.pop(proc)
+            processor.filehandle.close()
 
     def _add_files_to_queue(self, files: list[DagFileInfo], add_at_front: bool):
         """Add stuff to the back or front of the file queue, unless it's already present."""

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -220,7 +220,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
     in core Airflow.
     """
 
-    filehandle: BinaryIO
+    logger_filehandle: BinaryIO
     parsing_result: DagFileParsingResult | None = None
     decoder: ClassVar[TypeAdapter[ToManager]] = TypeAdapter[ToManager](ToManager)
 

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -21,7 +21,7 @@ import os
 import sys
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Callable, ClassVar, Literal, Union
+from typing import TYPE_CHECKING, Annotated, BinaryIO, Callable, ClassVar, Literal, Union
 
 import attrs
 from pydantic import BaseModel, Field, TypeAdapter
@@ -220,6 +220,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
     in core Airflow.
     """
 
+    filehandle: BinaryIO
     parsing_result: DagFileParsingResult | None = None
     decoder: ClassVar[TypeAdapter[ToManager]] = TypeAdapter[ToManager](ToManager)
 

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -134,6 +134,7 @@ class TestDagFileProcessorManager:
 
     def mock_processor(self) -> DagFileProcessorProcess:
         proc = MagicMock()
+        filehandle = MagicMock()
         proc.create_time.return_value = time.time()
         proc.wait.return_value = 0
         ret = DagFileProcessorProcess(
@@ -143,6 +144,7 @@ class TestDagFileProcessorManager:
             process=proc,
             stdin=io.BytesIO(),
             requests_fd=123,
+            filehandle=filehandle,
         )
         ret._num_open_sockets = 0
         return ret
@@ -774,7 +776,11 @@ class TestDagFileProcessorManager:
                 assert session.query(DbCallbackRequest).count() == 1
 
     @mock.patch.object(DagFileProcessorManager, "_get_logger_for_dag_file")
-    def test_callback_queue(self, mock_logger, configure_testing_dag_bundle):
+    def test_callback_queue(self, mock_logger_filehandle, configure_testing_dag_bundle):
+        mock_logger = MagicMock()
+        mock_filehandle = MagicMock()
+        mock_logger_filehandle.return_value = [mock_logger, mock_filehandle]
+
         tmp_path = "/green_eggs/ham"
         with configure_testing_dag_bundle(tmp_path):
             # given
@@ -855,7 +861,8 @@ class TestDagFileProcessorManager:
                     bundle_path=dag2_path.bundle_path,
                     callbacks=[dag2_req1],
                     selector=mock.ANY,
-                    logger=mock_logger.return_value,
+                    logger=mock_logger,
+                    filehandle=mock_filehandle,
                 ),
                 mock.call(
                     id=mock.ANY,
@@ -863,7 +870,8 @@ class TestDagFileProcessorManager:
                     bundle_path=dag1_path.bundle_path,
                     callbacks=[dag1_req1, dag1_req2],
                     selector=mock.ANY,
-                    logger=mock_logger.return_value,
+                    logger=mock_logger,
+                    filehandle=mock_filehandle,
                 ),
             ]
             # And removed from the queue

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -23,7 +23,7 @@ import sys
 import textwrap
 from socket import socketpair
 from typing import TYPE_CHECKING, Callable
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import structlog
@@ -133,6 +133,8 @@ class TestDagFileProcessor:
     def test_top_level_variable_access(
         self, spy_agency: SpyAgency, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ):
+        filehandle = MagicMock()
+
         def dag_in_a_fn():
             from airflow.sdk import DAG, Variable
 
@@ -143,10 +145,7 @@ class TestDagFileProcessor:
 
         monkeypatch.setenv("AIRFLOW_VAR_MYVAR", "abc")
         proc = DagFileProcessorProcess.start(
-            id=1,
-            path=path,
-            bundle_path=tmp_path,
-            callbacks=[],
+            id=1, path=path, bundle_path=tmp_path, callbacks=[], filehandle=filehandle
         )
 
         while not proc.is_ready:
@@ -158,6 +157,8 @@ class TestDagFileProcessor:
         assert result.serialized_dags[0].dag_id == "test_abc"
 
     def test_top_level_connection_access(self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+        filehandle = MagicMock()
+
         def dag_in_a_fn():
             from airflow.hooks.base import BaseHook
             from airflow.sdk import DAG
@@ -169,10 +170,7 @@ class TestDagFileProcessor:
 
         monkeypatch.setenv("AIRFLOW_CONN_MY_CONN", '{"conn_type": "aws"}')
         proc = DagFileProcessorProcess.start(
-            id=1,
-            path=path,
-            bundle_path=tmp_path,
-            callbacks=[],
+            id=1, path=path, bundle_path=tmp_path, callbacks=[], filehandle=filehandle
         )
 
         while not proc.is_ready:

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -133,7 +133,7 @@ class TestDagFileProcessor:
     def test_top_level_variable_access(
         self, spy_agency: SpyAgency, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ):
-        filehandle = MagicMock()
+        logger_filehandle = MagicMock()
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, Variable
@@ -145,7 +145,7 @@ class TestDagFileProcessor:
 
         monkeypatch.setenv("AIRFLOW_VAR_MYVAR", "abc")
         proc = DagFileProcessorProcess.start(
-            id=1, path=path, bundle_path=tmp_path, callbacks=[], filehandle=filehandle
+            id=1, path=path, bundle_path=tmp_path, callbacks=[], logger_filehandle=logger_filehandle
         )
 
         while not proc.is_ready:
@@ -157,7 +157,7 @@ class TestDagFileProcessor:
         assert result.serialized_dags[0].dag_id == "test_abc"
 
     def test_top_level_connection_access(self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
-        filehandle = MagicMock()
+        logger_filehandle = MagicMock()
 
         def dag_in_a_fn():
             from airflow.hooks.base import BaseHook
@@ -170,7 +170,7 @@ class TestDagFileProcessor:
 
         monkeypatch.setenv("AIRFLOW_CONN_MY_CONN", '{"conn_type": "aws"}')
         proc = DagFileProcessorProcess.start(
-            id=1, path=path, bundle_path=tmp_path, callbacks=[], filehandle=filehandle
+            id=1, path=path, bundle_path=tmp_path, callbacks=[], logger_filehandle=logger_filehandle
         )
 
         while not proc.is_ready:


### PR DESCRIPTION
Initially I thought of accessing the filehandle through `proc.log._logger._file` where `log` is the `BoundLogger` but they are private and mypy doesn't like it. The other approach I thought was to store the filehandle as part of `DagFileProcessorProcess` itself. Thus whenever the processor is popped out after everything is complete the filehandle associated with the `DagFileProcessorProcess` is also closed. `filehandle` could be renamed to `log_file_handle` or something. I opened the PR for discussion to see if there are other approaches.

Closes #46048

Tests can be improved by asserting for close call but wanted to check first if there are any better approaches.