### PR TITLE
AIP-84 Add safe url helper method

### DIFF
--- a/airflow/api_fastapi/core_api/routes/public/login.py
+++ b/airflow/api_fastapi/core_api/routes/public/login.py
@@ -16,11 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Request, status
+from fastapi import HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.security import is_safe_url
 
 login_router = AirflowRouter(tags=["Login"], prefix="/login")
 
@@ -32,6 +33,9 @@ login_router = AirflowRouter(tags=["Login"], prefix="/login")
 def login(request: Request, next: None | str = None) -> RedirectResponse:
     """Redirect to the login URL depending on the AuthManager configured."""
     login_url = request.app.state.auth_manager.get_url_login()
+
+    if next and not is_safe_url(next):
+        raise HTTPException(status_code=400, detail="Invalid or unsafe next URL")
 
     if next:
         login_url += f"?next={next}"

--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -16,8 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-import posixpath
 from functools import cache
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Callable
 from urllib.parse import urljoin, urlparse
 
@@ -226,16 +226,13 @@ def is_safe_url(target_url: str) -> bool:
     is a valid normalized path.
     """
     base_url = conf.get("api", "base_url")
+
     parsed_base = urlparse(base_url)
     parsed_target = urlparse(urljoin(base_url, target_url))  # Resolves relative URLs
 
-    normalized_target_path = posixpath.normpath(parsed_target.path)
+    target_path = Path(parsed_target.path).resolve()
 
-    if (
-        normalized_target_path
-        and parsed_base.path
-        and not normalized_target_path.startswith(parsed_base.path)
-    ):
+    if target_path and parsed_base.path and not target_path.is_relative_to(parsed_base.path):
         return False
 
     return parsed_target.scheme in {"http", "https"} and parsed_target.netloc == parsed_base.netloc

--- a/tests/api_fastapi/core_api/test_security.py
+++ b/tests/api_fastapi/core_api/test_security.py
@@ -25,7 +25,7 @@ from jwt import ExpiredSignatureError, InvalidTokenError
 from airflow.api_fastapi.app import create_app
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
-from airflow.api_fastapi.core_api.security import get_user, requires_access_dag
+from airflow.api_fastapi.core_api.security import get_user, is_safe_url, requires_access_dag
 
 from tests_common.test_utils.config import conf_vars
 
@@ -109,3 +109,28 @@ class TestFastApiSecurity:
             requires_access_dag("GET", DagAccessEntity.CODE)(mock_request, Mock())
 
         auth_manager.is_authorized_dag.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "url, expected_is_safe",
+        [
+            ("https://server_base_url.com/prefix/some_page?with_param=3", True),
+            ("https://server_base_url.com/prefix/", True),
+            ("https://server_base_url.com/prefix", True),
+            ("/prefix/some_other", True),
+            ("prefix/some_other", True),
+            # Relative path, will go up one level escaping the prefix folder
+            ("some_other", False),
+            ("./some_other", False),
+            # wrong scheme
+            ("javascript://server_base_url.com/prefix/some_page?with_param=3", False),
+            # wrong netloc
+            ("https://some_netlock.com/prefix/some_page?with_param=3", False),
+            # Absolute path escaping the prefix folder
+            ("/some_other_page/", False),
+            # traversal, escaping the `prefix` folder
+            ("/../../../../some_page?with_param=3", False),
+        ],
+    )
+    @conf_vars({("api", "base_url"): "https://server_base_url.com/prefix"})
+    def test_is_safe_url(self, url, expected_is_safe):
+        assert is_safe_url(url) == expected_is_safe


### PR DESCRIPTION
Even if the `next` url is then passed to the AuthManager and later on the auth manager will do the safe url check at redirection time, it's better to not rely on a deferred check and validate user data right away when it's submitted to the application.