### PR TITLE
FIX: BigQuery traceability labels missing in TaskGroup

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2897,7 +2897,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
 
     def _add_job_labels(self) -> None:
         dag_label = self.dag_id.lower()
-        task_label = self.task_id.lower()
+        task_label = self.task_id.lower().replace('.','-')
 
         if LABEL_REGEX.match(dag_label) and LABEL_REGEX.match(task_label):
             automatic_labels = {"airflow-dag": dag_label, "airflow-task": task_label}

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2897,7 +2897,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
 
     def _add_job_labels(self) -> None:
         dag_label = self.dag_id.lower()
-        task_label = self.task_id.lower().replace('.','-')
+        task_label = self.task_id.lower().replace(".", "-")
 
         if LABEL_REGEX.match(dag_label) and LABEL_REGEX.match(task_label):
             automatic_labels = {"airflow-dag": dag_label, "airflow-task": task_label}

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -79,8 +79,8 @@ from airflow.providers.google.cloud.triggers.bigquery import (
     BigQueryIntervalCheckTrigger,
     BigQueryValueCheckTrigger,
 )
-from airflow.utils.timezone import datetime
 from airflow.utils.task_group import TaskGroup
+from airflow.utils.timezone import datetime
 
 pytestmark = pytest.mark.db_test
 
@@ -2317,19 +2317,19 @@ class TestBigQueryInsertJobOperator:
             },
         }
         with dag_maker("dag_replace_dots_with_hyphens"):
-           op = BigQueryInsertJobOperator(
+            op = BigQueryInsertJobOperator(
                 task_id="task.name.with.dots",
                 configuration=configuration,
                 location=TEST_DATASET_LOCATION,
                 project_id=TEST_GCP_PROJECT_ID,
-              )
+            )
         op._add_job_labels()
         assert "labels" in configuration
         assert configuration["labels"]["airflow-dag"] == "dag_replace_dots_with_hyphens"
         assert configuration["labels"]["airflow-task"] == "task-name-with-dots"
 
         with dag_maker("dag_with_taskgroup"):
-            with TaskGroup("task_group") as tg:
+            with TaskGroup("task_group"):
                 op = BigQueryInsertJobOperator(
                     task_id="task_name",
                     configuration=configuration,
@@ -2349,7 +2349,7 @@ class TestBigQueryInsertJobOperator:
             },
         }
         with dag_maker("dag_with_taskgroup"):
-            with TaskGroup("task_group", prefix_group_id = False) as tg:
+            with TaskGroup("task_group", prefix_group_id=False):
                 op = BigQueryInsertJobOperator(
                     task_id="task_name",
                     configuration=configuration,
@@ -2362,7 +2362,7 @@ class TestBigQueryInsertJobOperator:
         assert configuration["labels"]["airflow-task"] == "task_name"
 
         with dag_maker("dag_with_taskgroup_prefix_group_id_false_with_dots"):
-            with TaskGroup("task_group_prefix_group_id_false", prefix_group_id = False) as tg:
+            with TaskGroup("task_group_prefix_group_id_false", prefix_group_id=False):
                 op = BigQueryInsertJobOperator(
                     task_id="task.name.with.dots",
                     configuration=configuration,
@@ -2373,7 +2373,7 @@ class TestBigQueryInsertJobOperator:
         assert "labels" in configuration
         assert configuration["labels"]["airflow-dag"] == "dag_with_taskgroup_prefix_group_id_false_with_dots"
         assert configuration["labels"]["airflow-task"] == "task-name-with-dots"
-        
+
     def test_handle_job_error_raises_on_error_result_or_error(self, caplog):
         caplog.set_level(logging.ERROR)
         configuration = {

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -2344,7 +2344,7 @@ class TestBigQueryInsertJobOperator:
     def test_labels_with_task_group_prefix_group_id(self, dag_maker):
         configuration = {
             "query": {
-                "query": "SELECT * FROM `bigquery-public-data.america_health_rankings.ahr` LIMIT 1000;",
+                "query": "SELECT * FROM any",
                 "useLegacySql": False,
             },
         }

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -80,6 +80,7 @@ from airflow.providers.google.cloud.triggers.bigquery import (
     BigQueryValueCheckTrigger,
 )
 from airflow.utils.timezone import datetime
+from airflow.utils.task_group import TaskGroup
 
 pytestmark = pytest.mark.db_test
 
@@ -2300,15 +2301,6 @@ class TestBigQueryInsertJobOperator:
             },
         }
         op = BigQueryInsertJobOperator(
-            task_id="task.with.dots.is.allowed",
-            configuration=configuration,
-            location=TEST_DATASET_LOCATION,
-            project_id=TEST_GCP_PROJECT_ID,
-        )
-        op._add_job_labels()
-        assert "labels" not in configuration
-
-        op = BigQueryInsertJobOperator(
             task_id="task_id_with_exactly_64_characters_00000000000000000000000000000",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
@@ -2317,6 +2309,71 @@ class TestBigQueryInsertJobOperator:
         op._add_job_labels()
         assert "labels" not in configuration
 
+    def test_labels_replace_dots_with_hyphens(self, dag_maker):
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            },
+        }
+        with dag_maker("dag_replace_dots_with_hyphens"):
+           op = BigQueryInsertJobOperator(
+                task_id="task.name.with.dots",
+                configuration=configuration,
+                location=TEST_DATASET_LOCATION,
+                project_id=TEST_GCP_PROJECT_ID,
+              )
+        op._add_job_labels()
+        assert "labels" in configuration
+        assert configuration["labels"]["airflow-dag"] == "dag_replace_dots_with_hyphens"
+        assert configuration["labels"]["airflow-task"] == "task-name-with-dots"
+
+        with dag_maker("dag_with_taskgroup"):
+            with TaskGroup("task_group") as tg:
+                op = BigQueryInsertJobOperator(
+                    task_id="task_name",
+                    configuration=configuration,
+                    location=TEST_DATASET_LOCATION,
+                    project_id=TEST_GCP_PROJECT_ID,
+                )
+        op._add_job_labels()
+        assert "labels" in configuration
+        assert configuration["labels"]["airflow-dag"] == "dag_with_taskgroup"
+        assert configuration["labels"]["airflow-task"] == "task_group-task_name"
+
+    def test_labels_with_task_group_prefix_group_id(self, dag_maker):
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM `bigquery-public-data.america_health_rankings.ahr` LIMIT 1000;",
+                "useLegacySql": False,
+            },
+        }
+        with dag_maker("dag_with_taskgroup"):
+            with TaskGroup("task_group", prefix_group_id = False) as tg:
+                op = BigQueryInsertJobOperator(
+                    task_id="task_name",
+                    configuration=configuration,
+                    location=TEST_DATASET_LOCATION,
+                    project_id=TEST_GCP_PROJECT_ID,
+                )
+        op._add_job_labels()
+        assert "labels" in configuration
+        assert configuration["labels"]["airflow-dag"] == "dag_with_taskgroup"
+        assert configuration["labels"]["airflow-task"] == "task_name"
+
+        with dag_maker("dag_with_taskgroup_prefix_group_id_false_with_dots"):
+            with TaskGroup("task_group_prefix_group_id_false", prefix_group_id = False) as tg:
+                op = BigQueryInsertJobOperator(
+                    task_id="task.name.with.dots",
+                    configuration=configuration,
+                    location=TEST_DATASET_LOCATION,
+                    project_id=TEST_GCP_PROJECT_ID,
+                )
+        op._add_job_labels()
+        assert "labels" in configuration
+        assert configuration["labels"]["airflow-dag"] == "dag_with_taskgroup_prefix_group_id_false_with_dots"
+        assert configuration["labels"]["airflow-task"] == "task-name-with-dots"
+        
     def test_handle_job_error_raises_on_error_result_or_error(self, caplog):
         caplog.set_level(logging.ERROR)
         configuration = {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #47297 

This change addresses an issue in the BigQueryInsertJobOperator where labels for task ids inside task groups were not properly formatted. Previously, labels included periods  {taskgroup.task_id} which led to error in storing labels as gcp doesnt support any special character apart from hyphens and underscore in their labels .

reference : 
![image](https://github.com/user-attachments/assets/406e941f-ade8-4b8d-9b55-cd5d72fdb35b)

[supporting_doc](https://cloud.google.com/compute/docs/labeling-resources#:~:text=Requirements%20for%20labels,-The%20labels%20applied&text=Each%20label%20must%20be%20a,maximum%20length%20of%2063%20characters.) 

Now, while storing labels, any period is replaced with a hyphen. As a result, the labels are consistently formatted using the `taskgroup-task_id` format ensuring better traceability and clarity during job executions.

Before:
<img width="926" alt="image" src="https://github.com/user-attachments/assets/ee94eb94-7adf-4604-80ae-9297e19f6dc4" />


After:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/b3b39030-7425-4c26-a7e6-14544ceac125" />
