### PR TITLE
Fix issue with bad log debug merge of context vars

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -166,8 +166,8 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
                 versions_path=self.versions_dir,
                 git_conn_id=self.git_conn_id,
                 repo_url=self.repo_url,
-                **kwargs,
             )
+            context.update(kwargs)
 
             for k, v in context.items():
                 msg += f" {k}='{v}'"


### PR DESCRIPTION
In the debug log helper, I didn't properly merge in additional kwargs.  Needed to update instead of `**`.
