### PR TITLE
fix(taskinstnace): set internal asset_type of all Asset subclass to "Asset"

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -362,7 +362,12 @@ def _run_raw_task(
                 events = context["outlet_events"]
                 for obj in ti.task.outlets or []:
                     # Lineage can have other types of objects besides assets
-                    asset_type = type(obj).__name__
+                    #
+                    # The asset_type here is not Asset.asset_type but the obj type instead.
+                    # Only Asset is expected to be subclassed so
+                    # any subclass of Asset should be set as Asset to be handled correctly.
+                    # TODO: We should rename it later.
+                    asset_type = "Asset" if isinstance(obj, Asset) else type(obj).__name__
                     if isinstance(obj, Asset):
                         task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, asset_type=asset_type))
                         outlet_events.append(attrs.asdict(events[obj]))  # type: ignore

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -366,7 +366,7 @@ def _run_raw_task(
                     # The asset_type here is not Asset.asset_type but the obj type instead.
                     # Only Asset is expected to be subclassed so
                     # any subclass of Asset should be set as Asset to be handled correctly.
-                    # TODO: We should rename it later.
+                    # TODO: We should rename it or probably rework the logic later.
                     asset_type = "Asset" if isinstance(obj, Asset) else type(obj).__name__
                     if isinstance(obj, Asset):
                         task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, asset_type=asset_type))

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -527,7 +527,7 @@ def _process_outlets(context: Context, outlets: list[AssetProfile]):
         # The asset_type here is not Asset.asset_type but the obj type instead.
         # Only Asset is expected to be subclassed so
         # any subclass of Asset should be set as Asset to be handled correctly.
-        # TODO: We should rename it later.
+        # TODO: We should rename it or probably rework the logic later.
         asset_type = "Asset" if isinstance(obj, Asset) else type(obj).__name__
         if isinstance(obj, Asset):
             task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, asset_type=asset_type))

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -523,7 +523,12 @@ def _process_outlets(context: Context, outlets: list[AssetProfile]):
 
     for obj in outlets or []:
         # Lineage can have other types of objects besides assets
-        asset_type = type(obj).__name__
+        #
+        # The asset_type here is not Asset.asset_type but the obj type instead.
+        # Only Asset is expected to be subclassed so
+        # any subclass of Asset should be set as Asset to be handled correctly.
+        # TODO: We should rename it later.
+        asset_type = "Asset" if isinstance(obj, Asset) else type(obj).__name__
         if isinstance(obj, Asset):
             task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, asset_type=asset_type))
             outlet_events.append(attrs.asdict(events[obj]))  # type: ignore

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -52,7 +52,9 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstance,
     TerminalTIState,
 )
-from airflow.sdk.definitions.asset import Asset, AssetAlias
+from airflow.sdk.definitions.asset import Asset, AssetAlias, Dataset, Model
+
+# from airflow.sdk.definitions.asset.decorators import AssetDefinition
 from airflow.sdk.definitions.param import DagParam
 from airflow.sdk.definitions.variable import Variable
 from airflow.sdk.execution_time.comms import (
@@ -703,6 +705,43 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
             ),
             id="asset",
         ),
+        pytest.param(
+            [Dataset(name="s3://bucket/my-task", uri="s3://bucket/my-task")],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", asset_type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                        "asset_alias_events": [],
+                    }
+                ],
+            ),
+            id="dataset",
+        ),
+        pytest.param(
+            [Model(name="s3://bucket/my-task", uri="s3://bucket/my-task")],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", asset_type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                        "asset_alias_events": [],
+                    }
+                ],
+            ),
+            id="model",
+        ),
+        # TODO: asset name ref and asset uri ref are not checked and should be added later
         pytest.param(
             [AssetAlias(name="example-alias", group="asset")],
             SucceedTask(


### PR DESCRIPTION
**It's a temporary, unclean workaround and should be reworked later, but it can solve the current bug**

## Why
Currently, `asset_type` decides how we register asset events.
(Note that the `asset_type` here is asset object type (e.g., `Asset`, `AssetAlias`) instead of `Asset.asset_type`)
As `Asset` might be subclassed, all instances of `Asset` subclasses should have `"Asset"` as their `asset_type`.

## What
If the object is an instance of `Asset`, set the `asset_type` (the one we use to decide how we register asset events) to `"Asset"`



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
