### PR TITLE
Remove the option import create_session from db.py util

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -57,9 +57,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import import_all_models
 from airflow.utils import helpers
 from airflow.utils.db_manager import RunDBManager
-
-# TODO: remove create_session once we decide to break backward compatibility
-from airflow.utils.session import NEW_SESSION, create_session, provide_session  # noqa: F401
+from airflow.utils.session import NEW_SESSION, provide_session   # noqa: F401
 from airflow.utils.task_instance_session import get_current_task_instance_session
 
 if TYPE_CHECKING:

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -57,7 +57,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import import_all_models
 from airflow.utils import helpers
 from airflow.utils.db_manager import RunDBManager
-from airflow.utils.session import NEW_SESSION, provide_session   # noqa: F401
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.task_instance_session import get_current_task_instance_session
 
 if TYPE_CHECKING:

--- a/newsfragments/47599.significant.rst
+++ b/newsfragments/47599.significant.rst
@@ -1,0 +1,15 @@
+Remove the option import create_session from db.py util
+
+The ability to create session from ``utils/db.py`` is removed.
+
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -43,9 +43,6 @@ from airflow.utils.db import (
     compare_server_default,
     compare_type,
     create_default_connections,
-    # The create_session is not used. It is imported here to
-    # guard against removing it from utils.db accidentally
-    create_session,  # noqa: F401
     downgrade,
     resetdb,
     upgradedb,


### PR DESCRIPTION
This was planned to be removed in 2020 but was put on hold due to possible user impact with user facing module https://github.com/apache/airflow/pull/7484/files#r382925828
Now that we release Airflow 3 we can safely remove this.