### PR TITLE
Switch asset decorator to use the DAG class in SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -179,7 +179,7 @@ class _DAGFactory:
     tags: Collection[str] = attrs.field(factory=set)
 
     def create_dag(self, *, default_dag_id: str) -> DAG:
-        from airflow.models.dag import DAG  # TODO: Use the SDK DAG when it works.
+        from airflow.sdk.definitions.dag import DAG
 
         dag_id = self.dag_id or default_dag_id
         return DAG(

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -199,7 +199,7 @@ class TestAssetMultiDecorator:
 
 class TestAssetDefinition:
     @mock.patch("airflow.sdk.definitions.asset.decorators._AssetMainOperator.from_definition")
-    @mock.patch("airflow.models.dag.DAG")
+    @mock.patch("airflow.sdk.definitions.dag.DAG")
     def test__attrs_post_init__(self, DAG, from_definition, example_asset_func_with_valid_arg_as_inlet_asset):
         asset_definition = asset(schedule=None, uri="s3://bucket/object", group="MLModel", extra={"k": "v"})(
             example_asset_func_with_valid_arg_as_inlet_asset
@@ -225,7 +225,7 @@ class TestAssetDefinition:
 
 class TestMultiAssetDefinition:
     @mock.patch("airflow.sdk.definitions.asset.decorators._AssetMainOperator.from_definition")
-    @mock.patch("airflow.models.dag.DAG")
+    @mock.patch("airflow.sdk.definitions.dag.DAG")
     def test__attrs_post_init__(self, DAG, from_definition, example_asset_func_with_valid_arg_as_inlet_asset):
         definition = asset.multi(
             schedule=None,


### PR DESCRIPTION
This does not work just yet because the example dags test is not set up correctly and cannot handle the SDK's DAG class.

WIP.