### PR TITLE
Delete paused query parameter when filter value is all.

### DIFF
--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -77,7 +77,7 @@ export const DagsFilters = () => {
     ({ value }: SelectValueChangeDetails<string>) => {
       const [val] = value;
 
-      if (val === undefined) {
+      if (val === undefined || val === "all") {
         searchParams.delete(PAUSED_PARAM);
       } else {
         searchParams.set(PAUSED_PARAM, val);


### PR DESCRIPTION
When all is selected after filter change then the paused query parameter still remains with value as all showing the "reset filter" button. When all is selected remove the query parameter so that reset filter is not shown.

Closes #47604