### PR TITLE
Add asset event create button to asset list.

### DIFF
--- a/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -28,6 +28,7 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { CreateAssetEvent } from "src/pages/Asset/CreateAssetEvent";
 import { pluralize } from "src/utils";
 
 import { DependencyPopover } from "./DependencyPopover";
@@ -66,6 +67,12 @@ const columns: Array<ColumnDef<AssetResponse>> = [
       ) : undefined,
     enableSorting: false,
     header: () => "Producing Tasks",
+  },
+  {
+    accessorKey: "trigger",
+    cell: ({ row }) => <CreateAssetEvent asset={row.original} withText={false} />,
+    enableSorting: false,
+    header: "",
   },
 ];
 


### PR DESCRIPTION
This adds a trigger button similar to dag trigger button in dags list to create asset event from asset list page.

![image](https://github.com/user-attachments/assets/91705615-0e36-4275-9758-ac21f38a6e01)
