### PR TITLE
Fix `sync-perm` CLI command

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1117,6 +1117,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 action = self.create_permission(action_name, resource_name)
                 if self.auth_role_admin not in self.builtin_roles:
                     admin_role = self.find_role(self.auth_role_admin)
+                    if not admin_role:
+                        admin_role = self.add_role(self.auth_role_admin)
                     self.add_permission_to_role(admin_role, action)
         else:
             # Permissions on this view exist but....


### PR DESCRIPTION
If you run `airflow sync-perm` in main you'll get the error:

```
[2025-03-11T14:37:55.804+0000] {init_appbuilder.py:551} ERROR - 'NoneType' object has no attribute 'permissions'
Traceback (most recent call last):
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py", line 549, in _add_permission
    self.sm.add_permissions_view(baseview.base_permissions, baseview.class_permission_name)
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py", line 1120, in add_permissions_view
    self.add_permission_to_role(admin_role, action)
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py", line 1704, in add_permission_to_role
    if permission and permission not in role.permissions:
AttributeError: 'NoneType' object has no attribute 'permissions'
```

This PR fixes this issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
