### PR TITLE
Add asset expression schedule popover

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/dags.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/dags.py
@@ -25,6 +25,7 @@ from airflow.api_fastapi.core_api.datamodels.dags import DAGResponse
 class DAGWithLatestDagRunsResponse(DAGResponse):
     """DAG with latest dag runs response serializer."""
 
+    asset_expression: dict | None
     latest_dag_runs: list[DAGRunResponse]
 
 

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -9046,6 +9046,11 @@ components:
             type: string
           type: array
           title: Owners
+        asset_expression:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Asset Expression
         latest_dag_runs:
           items:
             $ref: '#/components/schemas/DAGRunResponse'
@@ -9079,6 +9084,7 @@ components:
       - next_dagrun_data_interval_end
       - next_dagrun_run_after
       - owners
+      - asset_expression
       - latest_dag_runs
       - file_token
       title: DAGWithLatestDagRunsResponse

--- a/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -134,9 +134,11 @@ def recent_dag_runs(
         dag_run_response = DAGRunResponse.model_validate(dag_run)
         if dag_id not in dag_runs_by_dag_id:
             dag_response = DAGResponse.model_validate(dag)
+            dag_model: DagModel = session.get(DagModel, dag.dag_id)
             dag_runs_by_dag_id[dag_id] = DAGWithLatestDagRunsResponse.model_validate(
                 {
                     **dag_response.model_dump(),
+                    "asset_expression": dag_model.asset_expression,
                     "latest_dag_runs": [dag_run_response],
                 }
             )

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2878,6 +2878,17 @@ export const $DAGWithLatestDagRunsResponse = {
       type: "array",
       title: "Owners",
     },
+    asset_expression: {
+      anyOf: [
+        {
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Asset Expression",
+    },
     latest_dag_runs: {
       items: {
         $ref: "#/components/schemas/DAGRunResponse",
@@ -2915,6 +2926,7 @@ export const $DAGWithLatestDagRunsResponse = {
     "next_dagrun_data_interval_end",
     "next_dagrun_run_after",
     "owners",
+    "asset_expression",
     "latest_dag_runs",
     "file_token",
   ],

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -750,6 +750,9 @@ export type DAGWithLatestDagRunsResponse = {
   next_dagrun_data_interval_end: string | null;
   next_dagrun_run_after: string | null;
   owners: Array<string>;
+  asset_expression: {
+    [key: string]: unknown;
+  } | null;
   latest_dag_runs: Array<DAGRunResponse>;
   /**
    * Return file token.

--- a/airflow/ui/src/components/AssetExpression/AndGateNode.tsx
+++ b/airflow/ui/src/components/AssetExpression/AndGateNode.tsx
@@ -1,0 +1,53 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, VStack, Badge } from "@chakra-ui/react";
+import type { PropsWithChildren } from "react";
+import { TbLogicAnd } from "react-icons/tb";
+
+export const AndGateNode = ({ children }: PropsWithChildren) => (
+  <Box
+    bg="bg.emphasized"
+    border="2px dashed"
+    borderRadius="lg"
+    display="inline-block"
+    minW="fit-content"
+    p={4}
+    position="relative"
+  >
+    <Badge
+      alignItems="center"
+      borderRadius="full"
+      display="flex"
+      fontSize="sm"
+      gap={1}
+      left="50%"
+      position="absolute"
+      px={3}
+      py={1}
+      top="-3"
+      transform="translateX(-50%)"
+    >
+      <TbLogicAnd size={18} />
+      AND
+    </Badge>
+    <VStack align="center" gap={4} mt={3}>
+      {children}
+    </VStack>
+  </Box>
+);

--- a/airflow/ui/src/components/AssetExpression/AssetExpression.tsx
+++ b/airflow/ui/src/components/AssetExpression/AssetExpression.tsx
@@ -1,0 +1,79 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Badge } from "@chakra-ui/react";
+import { Fragment } from "react";
+import { TbLogicOr } from "react-icons/tb";
+
+import type { QueuedEventResponse } from "openapi/requests/types.gen";
+
+import { AndGateNode } from "./AndGateNode";
+import { AssetNode } from "./AssetNode";
+import { OrGateNode } from "./OrGateNode";
+import type { ExpressionType } from "./types";
+
+export const AssetExpression = ({
+  events,
+  expression,
+}: {
+  readonly events?: Array<QueuedEventResponse>;
+  readonly expression: ExpressionType | null;
+}) => {
+  if (expression === null) {
+    return undefined;
+  }
+
+  return (
+    <>
+      {expression.any ? (
+        <OrGateNode>
+          {expression.any.map((item, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={`any-${index}`}>
+              {"asset" in item ? (
+                <AssetNode asset={item.asset} />
+              ) : (
+                <AssetExpression events={events} expression={item} />
+              )}
+              {expression.any && index === expression.any.length - 1 ? undefined : (
+                <Badge alignItems="center" borderRadius="full" fontSize="sm" px={3} py={1}>
+                  <TbLogicOr size={18} />
+                  OR
+                </Badge>
+              )}
+            </Fragment>
+          ))}
+        </OrGateNode>
+      ) : undefined}
+      {expression.all ? (
+        <AndGateNode>
+          {expression.all.map((item, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Box display="inline-block" key={`all-${index}`}>
+              {"asset" in item ? (
+                <AssetNode asset={item.asset} />
+              ) : (
+                <AssetExpression events={events} expression={item} />
+              )}
+            </Box>
+          ))}
+        </AndGateNode>
+      ) : undefined}
+    </>
+  );
+};

--- a/airflow/ui/src/components/AssetExpression/AssetNode.tsx
+++ b/airflow/ui/src/components/AssetExpression/AssetNode.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Text, VStack, HStack } from "@chakra-ui/react";
+import { FiDatabase } from "react-icons/fi";
+
+import type { QueuedEventResponse } from "openapi/requests/types.gen";
+
+import Time from "../Time";
+import type { AssetSummary } from "./types";
+
+export const AssetNode = ({
+  asset,
+  event,
+}: {
+  readonly asset: AssetSummary["asset"];
+  readonly event?: QueuedEventResponse;
+}) => (
+  <Box
+    bg="bg.muted"
+    border="1px solid"
+    borderRadius="md"
+    borderWidth={Boolean(event?.created_at) ? 3 : 1}
+    display="inline-block"
+    minW="fit-content"
+    p={3}
+    position="relative"
+  >
+    <VStack align="start" gap={2}>
+      <HStack gap={2}>
+        <FiDatabase />
+        {/* TODO add events back in when asset_expression contains asset_id */}
+        {/* {event?.id === undefined ? ( */}
+        <Text fontSize="sm">{asset.uri}</Text>
+        {/* ) : (
+          <Link asChild color="fg.info" display="block" py={2}>
+            <RouterLink to={`/assets/${event.id}`}>{asset.uri}</RouterLink>
+          </Link>
+        )} */}
+      </HStack>
+      <Time datetime={event?.created_at} />
+    </VStack>
+  </Box>
+);

--- a/airflow/ui/src/components/AssetExpression/OrGateNode.tsx
+++ b/airflow/ui/src/components/AssetExpression/OrGateNode.tsx
@@ -1,0 +1,28 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, HStack } from "@chakra-ui/react";
+import type { PropsWithChildren } from "react";
+
+export const OrGateNode = ({ children }: PropsWithChildren) => (
+  <Box bg="bg.emphasized" border="2px dashed" borderRadius="lg" minW="fit-content" p={4} position="relative">
+    <HStack align="center" gap={4} mt={3}>
+      {children}
+    </HStack>
+  </Box>
+);

--- a/airflow/ui/src/components/AssetExpression/index.ts
+++ b/airflow/ui/src/components/AssetExpression/index.ts
@@ -1,0 +1,21 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { AssetExpression } from "./AssetExpression";
+export type { ExpressionType, AssetSummary } from "./types";

--- a/airflow/ui/src/components/AssetExpression/types.ts
+++ b/airflow/ui/src/components/AssetExpression/types.ts
@@ -1,0 +1,32 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type AssetSummary = {
+  asset: {
+    group: string;
+    name: string;
+    timestamp?: string;
+    uri: string;
+  };
+};
+
+export type ExpressionType = {
+  all?: Array<AssetSummary | ExpressionType>;
+  any?: Array<AssetSummary | ExpressionType>;
+};

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Text } from "@chakra-ui/react";
-import { FiBookOpen, FiCalendar } from "react-icons/fi";
+import { FiBookOpen } from "react-icons/fi";
 import { useParams } from "react-router-dom";
 
 import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
@@ -27,9 +26,9 @@ import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import MenuButton from "src/components/Menu/MenuButton";
 import { TogglePause } from "src/components/TogglePause";
-import { Tooltip } from "src/components/ui";
 
 import { DagTags } from "../DagsList/DagTags";
+import { Schedule } from "../DagsList/Schedule";
 
 export const Header = ({
   dag,
@@ -47,13 +46,7 @@ export const Header = ({
   const stats = [
     {
       label: "Schedule",
-      value: Boolean(dag?.timetable_summary) ? (
-        <Tooltip content={dag?.timetable_description}>
-          <Text fontSize="sm">
-            <FiCalendar style={{ display: "inline" }} /> {dag?.timetable_summary}
-          </Text>
-        </Tooltip>
-      ) : undefined,
+      value: dag === undefined ? undefined : <Schedule dag={dag} />,
     },
     {
       label: "Latest Run",

--- a/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -27,6 +27,7 @@ import { Wrapper } from "src/utils/Wrapper";
 import { DagCard } from "./DagCard";
 
 const mockDag = {
+  asset_expression: null,
   dag_display_name: "nested_groups",
   dag_id: "nested_groups",
   description: null,

--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -17,17 +17,38 @@
  * under the License.
  */
 import { Text } from "@chakra-ui/react";
+import { FiCalendar } from "react-icons/fi";
 
-import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
-import { Tooltip } from "src/components/ui";
+import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import { AssetExpression, type ExpressionType } from "src/components/AssetExpression";
+import { Button, Popover, Tooltip } from "src/components/ui";
 
 type Props = {
-  readonly dag: DAGWithLatestDagRunsResponse;
+  readonly dag: DAGDetailsResponse | DAGWithLatestDagRunsResponse;
 };
 
 export const Schedule = ({ dag }: Props) =>
-  Boolean(dag.timetable_summary) && dag.timetable_description !== "Never, external triggers only" ? (
-    <Tooltip content={dag.timetable_description}>
-      <Text fontSize="sm">{dag.timetable_summary}</Text>
-    </Tooltip>
+  Boolean(dag.timetable_summary) ? (
+    dag.asset_expression === null ? (
+      <Tooltip content={dag.timetable_description}>
+        <Text fontSize="sm">
+          <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}
+        </Text>
+      </Tooltip>
+    ) : (
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      <Popover.Root autoFocus={false} lazyMount unmountOnExit>
+        <Popover.Trigger asChild>
+          <Button size="sm" variant="ghost">
+            <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content width="fit-content">
+          <Popover.Arrow />
+          <Popover.Body>
+            <AssetExpression expression={dag.asset_expression as ExpressionType} />
+          </Popover.Body>
+        </Popover.Content>
+      </Popover.Root>
+    )
   ) : undefined;

--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -37,7 +37,7 @@ export const Schedule = ({ dag }: Props) =>
       </Tooltip>
     ) : (
       // eslint-disable-next-line jsx-a11y/no-autofocus
-      <Popover.Root autoFocus={false} lazyMount unmountOnExit>
+      <Popover.Root autoFocus={false} lazyMount positioning={{ placement: "bottom-end" }} unmountOnExit>
         <Popover.Trigger asChild>
           <Button size="sm" variant="ghost">
             <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}

--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -68,6 +68,8 @@ export const useDags = (
     const dagWithRuns = runsData?.dags.find((runsDag) => runsDag.dag_id === dag.dag_id);
 
     return {
+      // eslint-disable-next-line unicorn/no-null
+      asset_expression: null,
       latest_dag_runs: [],
       ...dagWithRuns,
       ...dag,


### PR DESCRIPTION
For asset triggered dags, add a popover to the Schedule component to see a visualization of the asset conditions to trigger the dag.
- For regularly scheduled dags, the schedule is just text with a tooltip. For Asset-triggered dags, it is a button to open a popover
- Added `asset_expression` to `ui/dags`


- To Do: Add event info and links to the asset details page when we add `asset_id` to `asset_expression`. Right now there is no good way to connect an expression to its actual asset. We can use this to show the queue for the next dag run, or if a dag run is selected, what events caused that dag to trigger. We could also add the Asset Event Creation trigger inside this popover.

<img width="399" alt="Screenshot 2025-03-11 at 5 12 25 PM" src="https://github.com/user-attachments/assets/bb46c5eb-79a8-46fb-baf0-16f8650c32f0" />
<img width="798" alt="Screenshot 2025-03-11 at 5 12 36 PM" src="https://github.com/user-attachments/assets/ed7af4aa-4106-423b-9a40-a1aa80b3e899" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
