### PR TITLE
Handle `BaseHook.get_connection`'s new Task SDK exception when connection is not found

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -479,8 +479,18 @@ class Connection(Base, LoggingMixin):
                 if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
                     # TODO: AIP 72: Add deprecation here once we move this module to task sdk.
                     from airflow.sdk import Connection as TaskSDKConnection
+                    from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 
-                    return TaskSDKConnection.get(conn_id=conn_id)
+                    try:
+                        return TaskSDKConnection.get(conn_id=conn_id)
+                    except AirflowRuntimeError as e:
+                        if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
+                            log.exception(
+                                "Unable to retrieve connection from MetastoreBackend using Task SDK"
+                            )
+                            raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+                        else:
+                            raise
             try:
                 conn = secrets_backend.get_connection(conn_id=conn_id)
                 if conn:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -485,9 +485,7 @@ class Connection(Base, LoggingMixin):
                         return TaskSDKConnection.get(conn_id=conn_id)
                     except AirflowRuntimeError as e:
                         if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
-                            log.exception(
-                                "Unable to retrieve connection from MetastoreBackend using Task SDK"
-                            )
+                            log.debug("Unable to retrieve connection from MetastoreBackend using Task SDK")
                             raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
                         else:
                             raise
@@ -497,7 +495,7 @@ class Connection(Base, LoggingMixin):
                     SecretCache.save_connection_uri(conn_id, conn.get_uri())
                     return conn
             except Exception:
-                log.exception(
+                log.debug(
                     "Unable to retrieve connection from secrets backend (%s). "
                     "Checking subsequent secrets backend.",
                     type(secrets_backend).__name__,


### PR DESCRIPTION
When a Task SDK connection is not found, it currently throws `AirflowRuntimeError`. This PR catches it in this case and raises `AirflowNotFoundException` for consistency.

Earlier, I was changing `AwsGenericHook` to also catch the `AirflowRuntimeError` but I was getting import errors in tests. Then I realized it's probably better if this error handling is done where it was being done previously.

~~After #47048, the boto fallback strategy started breaking in `AwsGenericHook` (explained in more detail here:
https://github.com/apache/airflow/pull/47048#issuecomment-2704935024). I realized that this was because a new exception `AirflowRuntimeError` was introduced in `BaseHook`'s `get_connection`. It used to only throw `AirflowNotFoundException` earlier.~~

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
