### PR TITLE
Add Dag Details tab and add Dag Version to all details tabs

### DIFF
--- a/airflow/ui/src/components/DagVersionDetails.tsx
+++ b/airflow/ui/src/components/DagVersionDetails.tsx
@@ -1,0 +1,63 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Link, Table } from "@chakra-ui/react";
+
+import type { DagVersionResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+
+export const DagVersionDetails = ({ dagVersion }: { readonly dagVersion?: DagVersionResponse | null }) => {
+  if (dagVersion === null || dagVersion === undefined) {
+    return undefined;
+  }
+
+  return (
+    <Table.Root striped>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>Version Number</Table.Cell>
+          <Table.Cell>v{dagVersion.version_number}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>Bundle Name</Table.Cell>
+          <Table.Cell>{dagVersion.bundle_name}</Table.Cell>
+        </Table.Row>
+        {dagVersion.bundle_version === null ? undefined : (
+          <Table.Row>
+            <Table.Cell>Bundle Version</Table.Cell>
+            <Table.Cell>{dagVersion.bundle_version}</Table.Cell>
+          </Table.Row>
+        )}
+        {dagVersion.bundle_url === null ? undefined : (
+          <Table.Row>
+            <Table.Cell>Bundle Link</Table.Cell>
+            <Table.Cell>
+              <Link href={dagVersion.bundle_url}>{dagVersion.bundle_url}</Link>
+            </Table.Cell>
+          </Table.Row>
+        )}
+        <Table.Row>
+          <Table.Cell>Created At</Table.Cell>
+          <Table.Cell>
+            <Time datetime={dagVersion.created_at} />
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  );
+};

--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -19,7 +19,7 @@
 import { ReactFlowProvider } from "@xyflow/react";
 import { FiBarChart, FiCode, FiRotateCcw } from "react-icons/fi";
 import { LuChartColumn } from "react-icons/lu";
-import { MdOutlineEventNote } from "react-icons/md";
+import { MdDetails, MdOutlineEventNote } from "react-icons/md";
 import { useParams } from "react-router-dom";
 
 import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
@@ -36,6 +36,7 @@ const tabs = [
   { icon: <FiRotateCcw />, label: "Backfills", value: "backfills" },
   { icon: <MdOutlineEventNote />, label: "Events", value: "events" },
   { icon: <FiCode />, label: "Code", value: "code" },
+  { icon: <MdDetails />, label: "Details", value: "details" },
 ];
 
 export const Dag = () => {

--- a/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow/ui/src/pages/Dag/Details.tsx
@@ -100,7 +100,7 @@ export const Details = () => {
             </Table.Row>
             <Table.Row>
               <Table.Cell>Has Task Concurrency Limits</Table.Cell>
-              <Table.Cell>{dag.has_task_concurrency_limits}</Table.Cell>
+              <Table.Cell>{dag.has_task_concurrency_limits.toString()}</Table.Cell>
             </Table.Row>
             <Table.Row>
               <Table.Cell>Dag Run Timeout</Table.Cell>

--- a/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow/ui/src/pages/Dag/Details.tsx
@@ -1,0 +1,138 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Code, HStack, Table } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { useDagServiceGetDagDetails } from "openapi/queries";
+import { DagVersionDetails } from "src/components/DagVersionDetails";
+import RenderedJsonField from "src/components/RenderedJsonField";
+import Time from "src/components/Time";
+import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+
+export const Details = () => {
+  const { dagId = "" } = useParams();
+
+  const { data: dag } = useDagServiceGetDagDetails({
+    dagId,
+  });
+
+  return (
+    <Box p={2}>
+      {dag === undefined ? (
+        <div />
+      ) : (
+        <Table.Root striped>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Dag ID</Table.Cell>
+              <Table.Cell>
+                <HStack>
+                  {dag.dag_id}
+                  <ClipboardRoot value={dag.dag_id}>
+                    <ClipboardIconButton />
+                  </ClipboardRoot>
+                </HStack>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Description</Table.Cell>
+              <Table.Cell>{dag.description}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Timezone</Table.Cell>
+              <Table.Cell>{dag.timezone}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>File Location</Table.Cell>
+              <Table.Cell>
+                <Code>{dag.fileloc}</Code>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Last Parsed</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dag.last_parsed} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Latest Dag Version</Table.Cell>
+              <Table.Cell>
+                <DagVersionDetails dagVersion={dag.latest_dag_version} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Start Date</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dag.start_date} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>End Date</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dag.end_date} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Last Expired</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dag.last_expired} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Concurrency</Table.Cell>
+              <Table.Cell>{dag.concurrency}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Has Task Concurrency Limits</Table.Cell>
+              <Table.Cell>{dag.has_task_concurrency_limits}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Dag Run Timeout</Table.Cell>
+              <Table.Cell>{dag.dag_run_timeout}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Max Active Runs</Table.Cell>
+              <Table.Cell>{dag.max_active_runs}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Max Active Tasks</Table.Cell>
+              <Table.Cell>{dag.max_active_tasks}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Max Consecutive Failed Dag Runs</Table.Cell>
+              <Table.Cell>{dag.max_consecutive_failed_dag_runs}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Catchup</Table.Cell>
+              <Table.Cell>{dag.catchup}</Table.Cell>
+            </Table.Row>
+            {dag.params === null ? undefined : (
+              <Table.Row>
+                <Table.Cell>Params</Table.Cell>
+                <Table.Cell>
+                  <RenderedJsonField content={dag.params} />
+                </Table.Cell>
+              </Table.Row>
+            )}
+          </Table.Body>
+        </Table.Root>
+      )}
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow/ui/src/pages/Dag/Details.tsx
@@ -120,7 +120,7 @@ export const Details = () => {
             </Table.Row>
             <Table.Row>
               <Table.Cell>Catchup</Table.Cell>
-              <Table.Cell>{dag.catchup}</Table.Cell>
+              <Table.Cell>{dag.catchup.toString()}</Table.Cell>
             </Table.Row>
             {dag.params === null ? undefined : (
               <Table.Row>

--- a/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow/ui/src/pages/Run/Details.tsx
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, Table, Text } from "@chakra-ui/react";
+import { Box, Flex, HStack, StackSeparator, Table, Text, VStack } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRun, useDagRunServiceGetUpstreamAssetEvents } from "openapi/queries";
 import { AssetEvents } from "src/components/Assets/AssetEvents";
+import { DagVersionDetails } from "src/components/DagVersionDetails";
 import RenderedJsonField from "src/components/RenderedJsonField";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
@@ -130,6 +131,16 @@ export const Details = () => {
             <Table.Row>
               <Table.Cell>Trigger Source</Table.Cell>
               <Table.Cell>{dagRun.triggered_by}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Dag Version(s)</Table.Cell>
+              <Table.Cell>
+                <VStack separator={<StackSeparator />}>
+                  {dagRun.dag_versions.map((dagVersion) => (
+                    <DagVersionDetails dagVersion={dagVersion} key={dagVersion.id} />
+                  ))}
+                </VStack>
+              </Table.Cell>
             </Table.Row>
             <Table.Row>
               <Table.Cell>Run Config</Table.Cell>

--- a/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -25,6 +25,7 @@ import {
   useTaskInstanceServiceGetTaskInstanceTryDetails,
 } from "openapi/queries";
 import { AssetEvents } from "src/components/Assets/AssetEvents";
+import { DagVersionDetails } from "src/components/DagVersionDetails";
 import { StateBadge } from "src/components/StateBadge";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
 import Time from "src/components/Time";
@@ -165,6 +166,12 @@ export const Details = () => {
             <Table.Cell>Ended</Table.Cell>
             <Table.Cell>
               <Time datetime={tryInstance?.end_date} />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Dag Version</Table.Cell>
+            <Table.Cell>
+              <DagVersionDetails dagVersion={taskInstance?.dag_version} />
             </Table.Cell>
           </Table.Row>
           <Table.Row>

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -29,6 +29,7 @@ import { Connections } from "src/pages/Connections";
 import { Dag } from "src/pages/Dag";
 import { Backfills } from "src/pages/Dag/Backfills";
 import { Code } from "src/pages/Dag/Code";
+import { Details as DagDetails } from "src/pages/Dag/Details";
 import { Overview } from "src/pages/Dag/Overview";
 import { Tasks } from "src/pages/Dag/Tasks";
 import { DagRuns } from "src/pages/DagRuns";
@@ -45,7 +46,7 @@ import { Details as DagRunDetails } from "src/pages/Run/Details";
 import { Task } from "src/pages/Task";
 import { Overview as TaskOverview } from "src/pages/Task/Overview";
 import { TaskInstance, Logs } from "src/pages/TaskInstance";
-import { Details } from "src/pages/TaskInstance/Details";
+import { Details as TaskInstanceDetails } from "src/pages/TaskInstance/Details";
 import { RenderedTemplates } from "src/pages/TaskInstance/RenderedTemplates";
 import { TaskInstances } from "src/pages/TaskInstances";
 import { Variables } from "src/pages/Variables";
@@ -58,7 +59,7 @@ const taskInstanceRoutes = [
   { element: <Events />, path: "events" },
   { element: <XCom />, path: "xcom" },
   { element: <Code />, path: "code" },
-  { element: <Details />, path: "details" },
+  { element: <TaskInstanceDetails />, path: "details" },
   { element: <RenderedTemplates />, path: "rendered_templates" },
   { element: <TaskInstances />, path: "task_instances" },
 ];
@@ -134,6 +135,7 @@ export const routerConfig = [
           { element: <Backfills />, path: "backfills" },
           { element: <Events />, path: "events" },
           { element: <Code />, path: "code" },
+          { element: <DagDetails />, path: "details" },
         ],
         element: <Dag />,
         path: "dags/:dagId",


### PR DESCRIPTION
Add a Details tab to the Dag page to dump all its metadata.

Add Dag Version(s) to Dag, Dag Run and Task Instance details tabs


<img width="1505" alt="Screenshot 2025-03-11 at 7 46 25 PM" src="https://github.com/user-attachments/assets/6a210cac-f63f-4e30-96ca-b64cdc4be331" />
<img width="1498" alt="Screenshot 2025-03-11 at 7 46 33 PM" src="https://github.com/user-attachments/assets/1b591c88-b77d-4f94-9f30-c9a8c6fa1858" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
