### PR TITLE
Adding xmlsec pin in amazon provider

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -39,7 +39,8 @@
       "python3-saml>=1.16.0",
       "redshift_connector>=2.0.918",
       "sagemaker-studio>=1.0.9",
-      "watchtower>=3.0.0,!=3.3.0,<4"
+      "watchtower>=3.0.0,!=3.3.0,<4",
+      "xmlsec<1.3.15"
     ],
     "devel-deps": [
       "aiobotocore>=2.13.0",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -40,7 +40,7 @@
       "redshift_connector>=2.0.918",
       "sagemaker-studio>=1.0.9",
       "watchtower>=3.0.0,!=3.3.0,<4",
-      "xmlsec<1.3.15"
+      "xmlsec!=1.3.15"
     ],
     "devel-deps": [
       "aiobotocore>=2.13.0",

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -67,7 +67,7 @@ PIP package                                 Version required
 ``PyAthena``                                ``>=3.0.10``
 ``jmespath``                                ``>=0.7.0``
 ``python3-saml``                            ``>=1.16.0``
-``xmlsec``                                  ``<1.3.15``
+``xmlsec``                                  ``!=1.3.15``
 ``sagemaker-studio``                        ``>=1.0.9``
 ==========================================  ======================
 

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -67,6 +67,7 @@ PIP package                                 Version required
 ``PyAthena``                                ``>=3.0.10``
 ``jmespath``                                ``>=0.7.0``
 ``python3-saml``                            ``>=1.16.0``
+``xmlsec``                                  ``<1.3.15``
 ``sagemaker-studio``                        ``>=1.0.9``
 ==========================================  ======================
 

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -75,6 +75,8 @@ dependencies = [
     "PyAthena>=3.0.10",
     "jmespath>=0.7.0",
     "python3-saml>=1.16.0",
+    # python3-saml is dependent on xmlsec and seems they do not pin it, pinning here would be needed
+    "xmlsec<1.3.15",
     "sagemaker-studio>=1.0.9",
 ]
 

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -76,7 +76,8 @@ dependencies = [
     "jmespath>=0.7.0",
     "python3-saml>=1.16.0",
     # python3-saml is dependent on xmlsec and seems they do not pin it, pinning here would be needed
-    "xmlsec<1.3.15",
+    # We can remove it after https://github.com/xmlsec/python-xmlsec/issues/344 is fixed
+    "xmlsec!=1.3.15",
     "sagemaker-studio>=1.0.9",
 ]
 

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1385,7 +1385,7 @@ def get_provider_info():
             "PyAthena>=3.0.10",
             "jmespath>=0.7.0",
             "python3-saml>=1.16.0",
-            "xmlsec<1.3.15",
+            "xmlsec!=1.3.15",
             "sagemaker-studio>=1.0.9",
         ],
         "optional-dependencies": {

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1385,6 +1385,7 @@ def get_provider_info():
             "PyAthena>=3.0.10",
             "jmespath>=0.7.0",
             "python3-saml>=1.16.0",
+            "xmlsec<1.3.15",
             "sagemaker-studio>=1.0.9",
         ],
         "optional-dependencies": {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Python3-saml doesn't pin their version for xmlsec, so it seems to install 1.3.15 for us, which is a breaking one for our CI, so as a workaround, we need to pin the xmlsec temporarily for now. Python3-saml pyproject https://github.com/SAML-Toolkits/python3-saml/blob/master/pyproject.toml#L21

The root cause is lack of wheels for linux in 1.3.15 xmlsed


Example failure https://github.com/apache/airflow/actions/runs/13802039284

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
