### PR TITLE
Correctly assign asset type in AssetProfile

### DIFF
--- a/airflow/api_fastapi/execution_api/datamodels/asset.py
+++ b/airflow/api_fastapi/execution_api/datamodels/asset.py
@@ -38,14 +38,18 @@ class AssetAliasResponse(BaseModel):
 
 class AssetProfile(StrictBaseModel):
     """
-    Profile of an Asset.
+    Profile of an asset-like object.
 
-    Asset will have name, uri and asset_type defined.
-    AssetNameRef will have name and asset_type defined.
-    AssetUriRef will have uri and asset_type defined.
+    Asset will have name, uri defined, with type set to 'Asset'.
+    AssetNameRef will have name defined, type set to 'AssetNameRef'.
+    AssetUriRef will have uri defined, type set to 'AssetUriRef'.
+    AssetAlias will have name defined, type set to 'AssetAlias'.
 
+    Note that 'type' here is distinct from 'asset_type' the user declares on an
+    Asset (or subclass). This field is for distinguishing between different
+    asset-related types (Asset, AssetRef, or AssetAlias).
     """
 
     name: str | None = None
     uri: str | None = None
-    asset_type: str
+    type: str

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -362,19 +362,18 @@ def _run_raw_task(
                 events = context["outlet_events"]
                 for obj in ti.task.outlets or []:
                     # Lineage can have other types of objects besides assets
-                    asset_type = type(obj).__name__
                     if isinstance(obj, Asset):
-                        task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, asset_type=asset_type))
+                        task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, type=Asset.__name__))
                         outlet_events.append(attrs.asdict(events[obj]))  # type: ignore
                     elif isinstance(obj, AssetNameRef):
-                        task_outlets.append(AssetProfile(name=obj.name, asset_type=asset_type))
+                        task_outlets.append(AssetProfile(name=obj.name, type=AssetNameRef.__name__))
                         outlet_events.append(attrs.asdict(events))  # type: ignore
                     elif isinstance(obj, AssetUriRef):
-                        task_outlets.append(AssetProfile(uri=obj.uri, asset_type=asset_type))
+                        task_outlets.append(AssetProfile(uri=obj.uri, type=AssetUriRef.__name__))
                         outlet_events.append(attrs.asdict(events))  # type: ignore
                     elif isinstance(obj, AssetAlias):
                         if not added_alias_to_task_outlet:
-                            task_outlets.append(AssetProfile(asset_type=asset_type))
+                            task_outlets.append(AssetProfile(name=obj.name, type=AssetAlias.__name__))
                             added_alias_to_task_outlet = True
                         for asset_alias_event in events[obj].asset_alias_events:
                             outlet_events.append(attrs.asdict(asset_alias_event))
@@ -2758,18 +2757,18 @@ class TaskInstance(Base, LoggingMixin):
         for obj in task_outlets:
             ti.log.debug("outlet obj %s", obj)
             # Lineage can have other types of objects besides assets
-            if obj.asset_type == Asset.__name__:
+            if obj.type == Asset.__name__:
                 asset_manager.register_asset_change(
                     task_instance=ti,
                     asset=Asset(name=obj.name, uri=obj.uri),  # type: ignore
                     extra=outlet_events[0]["extra"],
                     session=session,
                 )
-            elif obj.asset_type == AssetNameRef.__name__:
+            elif obj.type == AssetNameRef.__name__:
                 asset_name_refs.add(obj.name)  # type: ignore
-            elif obj.asset_type == AssetUriRef.__name__:
+            elif obj.type == AssetUriRef.__name__:
                 asset_uri_refs.add(obj.uri)  # type: ignore
-            elif obj.asset_type == AssetAlias.__name__:
+            elif obj.type == AssetAlias.__name__:
                 outlet_events = list(
                     map(
                         lambda event: {**event, "dest_asset_key": AssetUniqueKey(**event["dest_asset_key"])},

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -30,11 +30,16 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 class AssetProfile(BaseModel):
     """
-    Profile of an Asset.
+    Profile of an asset-like object.
 
-    Asset will have name, uri and asset_type defined.
-    AssetNameRef will have name and asset_type defined.
-    AssetUriRef will have uri and asset_type defined.
+    Asset will have name, uri defined, with type set to 'Asset'.
+    AssetNameRef will have name defined, type set to 'AssetNameRef'.
+    AssetUriRef will have uri defined, type set to 'AssetUriRef'.
+    AssetAlias will have name defined, type set to 'AssetAlias'.
+
+    Note that 'type' here is distinct from 'asset_type' the user declares on an
+    Asset (or subclass). This field is for distinguishing between different
+    asset-related types (Asset, AssetRef, or AssetAlias).
     """
 
     model_config = ConfigDict(
@@ -42,7 +47,7 @@ class AssetProfile(BaseModel):
     )
     name: Annotated[str | None, Field(title="Name")] = None
     uri: Annotated[str | None, Field(title="Uri")] = None
-    asset_type: Annotated[str, Field(title="Asset Type")]
+    type: Annotated[str, Field(title="Type")]
 
 
 class AssetResponse(BaseModel):

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -455,7 +455,7 @@ class Asset(os.PathLike, BaseAsset):
 
         :meta private:
         """
-        return AssetProfile(name=self.name or None, uri=self.uri or None, asset_type=Asset.__name__)
+        return AssetProfile(name=self.name or None, uri=self.uri or None, type=Asset.__name__)
 
 
 class AssetRef(BaseAsset, AttrsInstance):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -523,21 +523,20 @@ def _process_outlets(context: Context, outlets: list[AssetProfile]):
 
     for obj in outlets or []:
         # Lineage can have other types of objects besides assets
-        asset_type = type(obj).__name__
         if isinstance(obj, Asset):
-            task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, asset_type=asset_type))
+            task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, type=Asset.__name__))
             outlet_events.append(attrs.asdict(events[obj]))  # type: ignore
         elif isinstance(obj, AssetNameRef):
-            task_outlets.append(AssetProfile(name=obj.name, asset_type=asset_type))
+            task_outlets.append(AssetProfile(name=obj.name, type=AssetNameRef.__name__))
             # Send all events, filtering can be done in API server.
             outlet_events.append(attrs.asdict(events))  # type: ignore
         elif isinstance(obj, AssetUriRef):
-            task_outlets.append(AssetProfile(uri=obj.uri, asset_type=asset_type))
+            task_outlets.append(AssetProfile(uri=obj.uri, type=AssetUriRef.__name__))
             # Send all events, filtering can be done in API server.
             outlet_events.append(attrs.asdict(events))  # type: ignore
         elif isinstance(obj, AssetAlias):
             if not added_alias_to_task_outlet:
-                task_outlets.append(AssetProfile(asset_type=asset_type))
+                task_outlets.append(AssetProfile(name=obj.name, type=AssetAlias.__name__))
                 added_alias_to_task_outlet = True
             for asset_alias_event in events[obj].asset_alias_events:
                 outlet_events.append(attrs.asdict(asset_alias_event))

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -1273,8 +1273,8 @@ class TestHandleRequest:
             ),
             pytest.param(
                 RuntimeCheckOnTask(
-                    inlets=[AssetProfile(name="alias", uri="alias", asset_type="asset")],
-                    outlets=[AssetProfile(name="alias", uri="alias", asset_type="asset")],
+                    inlets=[AssetProfile(name="alias", uri="alias", type="asset")],
+                    outlets=[AssetProfile(name="alias", uri="alias", type="asset")],
                 ),
                 b'{"ok":true,"type":"OKResponse"}\n',
                 "task_instances.runtime_checks",
@@ -1282,8 +1282,8 @@ class TestHandleRequest:
                 {
                     "id": TI_ID,
                     "msg": RuntimeCheckOnTask(
-                        inlets=[AssetProfile(name="alias", uri="alias", asset_type="asset")],  # type: ignore
-                        outlets=[AssetProfile(name="alias", uri="alias", asset_type="asset")],  # type: ignore
+                        inlets=[AssetProfile(name="alias", uri="alias", type="asset")],
+                        outlets=[AssetProfile(name="alias", uri="alias", type="asset")],
                         type="RuntimeCheckOnTask",
                     ),
                 },

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -52,7 +52,7 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstance,
     TerminalTIState,
 )
-from airflow.sdk.definitions.asset import Asset, AssetAlias
+from airflow.sdk.definitions.asset import Asset, AssetAlias, Dataset, Model
 from airflow.sdk.definitions.param import DagParam
 from airflow.sdk.definitions.variable import Variable
 from airflow.sdk.execution_time.comms import (
@@ -691,7 +691,7 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 state="success",
                 end_date=timezone.datetime(2024, 12, 3, 10, 0),
                 task_outlets=[
-                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", asset_type="Asset")
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
                 outlet_events=[
                     {
@@ -704,11 +704,81 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
             id="asset",
         ),
         pytest.param(
+            [Dataset(name="s3://bucket/my-task", uri="s3://bucket/my-task")],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                        "asset_alias_events": [],
+                    }
+                ],
+            ),
+            id="dataset",
+        ),
+        pytest.param(
+            [Model(name="s3://bucket/my-task", uri="s3://bucket/my-task")],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                        "asset_alias_events": [],
+                    }
+                ],
+            ),
+            id="model",
+        ),
+        pytest.param(
+            [Asset.ref(name="s3://bucket/my-task")],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[AssetProfile(name="s3://bucket/my-task", type="AssetNameRef")],
+                outlet_events=[
+                    {
+                        "key": {"name": "s3://bucket/my-task"},
+                        "extra": {},
+                        "asset_alias_events": [],
+                    }
+                ],
+            ),
+            marks=[pytest.mark.xfail],  # Currently not handled correctly in task runner.
+            id="name-ref",
+        ),
+        pytest.param(
+            [Asset.ref(uri="s3://bucket/my-task")],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[AssetProfile(uri="s3://bucket/my-task", type="AssetUriRef")],
+                outlet_events=[
+                    {
+                        "key": {"uri": "s3://bucket/my-task"},
+                        "extra": {},
+                        "asset_alias_events": [],
+                    }
+                ],
+            ),
+            marks=[pytest.mark.xfail],  # Currently not handled correctly in task runner.
+            id="uri-ref",
+        ),
+        pytest.param(
             [AssetAlias(name="example-alias", group="asset")],
             SucceedTask(
                 state="success",
                 end_date=timezone.datetime(2024, 12, 3, 10, 0),
-                task_outlets=[AssetProfile(asset_type="AssetAlias")],
+                task_outlets=[AssetProfile(name="example-alias", type="AssetAlias")],
                 outlet_events=[],
             ),
             id="asset-alias",
@@ -791,8 +861,8 @@ def test_run_with_asset_inlets(create_runtime_ti, mock_supervisor_comms):
             SucceedTask(
                 end_date=timezone.datetime(2024, 12, 3, 10, 0),
                 task_outlets=[
-                    AssetProfile(name="name", uri="s3://bucket/my-task", asset_type="Asset"),
-                    AssetProfile(name="new-name", uri="s3://bucket/my-task", asset_type="Asset"),
+                    AssetProfile(name="name", uri="s3://bucket/my-task", type="Asset"),
+                    AssetProfile(name="new-name", uri="s3://bucket/my-task", type="Asset"),
                 ],
                 outlet_events=[
                     {
@@ -851,12 +921,12 @@ def test_run_with_inlets_and_outlets(
 
     expected = RuntimeCheckOnTask(
         inlets=[
-            AssetProfile(name="name", uri="s3://bucket/my-task", asset_type="Asset"),
-            AssetProfile(name="new-name", uri="s3://bucket/my-task", asset_type="Asset"),
+            AssetProfile(name="name", uri="s3://bucket/my-task", type="Asset"),
+            AssetProfile(name="new-name", uri="s3://bucket/my-task", type="Asset"),
         ],
         outlets=[
-            AssetProfile(name="name", uri="s3://bucket/my-task", asset_type="Asset"),
-            AssetProfile(name="new-name", uri="s3://bucket/my-task", asset_type="Asset"),
+            AssetProfile(name="name", uri="s3://bucket/my-task", type="Asset"),
+            AssetProfile(name="new-name", uri="s3://bucket/my-task", type="Asset"),
         ],
     )
     mock_supervisor_comms.send_request.assert_any_call(msg=expected, log=mock.ANY)

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -362,7 +362,7 @@ class TestTIUpdateState:
         ("task_outlets", "outlet_events"),
         [
             (
-                [{"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task", "asset_type": "Asset"}],
+                [{"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task", "type": "Asset"}],
                 [
                     {
                         "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
@@ -372,7 +372,7 @@ class TestTIUpdateState:
                 ],
             ),
             (
-                [{"asset_type": "AssetAlias"}],
+                [{"type": "AssetAlias"}],
                 [
                     {
                         "source_alias_name": "example-alias",
@@ -398,7 +398,7 @@ class TestTIUpdateState:
         )
         asset_active = AssetActive.for_asset(asset)
         session.add_all([asset, asset_active])
-        asset_type = task_outlets[0]["asset_type"]
+        asset_type = task_outlets[0]["type"]
         if asset_type == "AssetAlias":
             _create_asset_aliases(session, num=1)
             asset_alias = session.query(AssetAliasModel).all()


### PR DESCRIPTION
The asset_type field in AssetProfile is for distinguishing between different asset-related types (Asset, ref, or alias). However, it used type(obj).__name__, which does not account for subclasses correctly. Since we don't really care about asset subclasses in the scheduler (they are only meaningful to the user, either in UI and at runtime in the task runner), we can simply coerce them into the base class we care about. This means ditching the type() call altogether to just use the base class directly.

The field is also renamed to 'type' to avoid confusion since 'asset_type' has another meaning in the Asset class.

Two tests on asset ref around this has been marked as xfail since the task runner does not currently handle them correctly. They will be fixed in an upcoming PR.

Close #47598.