### PR TITLE
Including 'exc_notes' in our task-sdk tests coming from structlog

### DIFF
--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -131,6 +131,7 @@ def test_xcom_convert_to_kwargs_fails_task(run_ti: RunTI, mock_supervisor_comms,
                 "timestamp": mock.ANY,
                 "exception": [
                     {
+                        "exc_notes": [],
                         "exc_type": "ValueError",
                         "exc_value": "expand_kwargs() expects a list[dict], not list[None]",
                         "frames": mock.ANY,
@@ -174,6 +175,7 @@ def test_xcom_map_error_fails_task(mock_supervisor_comms, run_ti, captured_logs)
                 "timestamp": mock.ANY,
                 "exception": [
                     {
+                        "exc_notes": [],
                         "exc_type": "RuntimeError",
                         "exc_value": "nope",
                         "frames": mock.ANY,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Structlog released a new version: https://pypi.org/project/structlog/ (25.2.0) which now introduced a feature to have `exc_notes` to lookup notes attached to an exception: https://github.com/hynek/structlog/pull/684

This causes failures in our CI, example: https://github.com/apache/airflow/actions/runs/13805673163/job/38616566095?pr=47656



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
