### PR TITLE
Temporary fix to allow remote logging upload for task sdk

### DIFF
--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -458,13 +458,25 @@ def init_log_file(local_relative_path: str) -> Path:
     return full_path
 
 
-def upload_to_remote(logger: FilteringBoundLogger):
+def load_remote_log_handler() -> logging.Handler | None:
+    from airflow.logging_config import configure_logging as airflow_configure_logging
+    from airflow.utils.log.log_reader import TaskLogReader
+
+    try:
+        airflow_configure_logging()
+
+        return TaskLogReader().log_handler
+    finally:
+        # This is a _monstrosity_ but put our logging back immediately...
+        configure_logging()
+
+
+def upload_to_remote(logger: FilteringBoundLogger, log_meta_dict: dict[str, Any]):
     # We haven't yet switched the Remote log handlers over, they are still wired up in providers as
     # logging.Handlers (but we should re-write most of them to just be the upload and read instead of full
     # variants.) In the mean time, lets just create the right handler directly
     from airflow.configuration import conf
     from airflow.utils.log.file_task_handler import FileTaskHandler
-    from airflow.utils.log.log_reader import TaskLogReader
 
     raw_logger = getattr(logger, "_logger")
 
@@ -481,7 +493,7 @@ def upload_to_remote(logger: FilteringBoundLogger):
     base_log_folder = conf.get("logging", "base_log_folder")
     relative_path = Path(fname).relative_to(base_log_folder)
 
-    handler = TaskLogReader().log_handler
+    handler = load_remote_log_handler()
     if not isinstance(handler, FileTaskHandler):
         logger.warning(
             "Airflow core logging is not using a FileTaskHandler, can't upload logs to remote",
@@ -493,6 +505,7 @@ def upload_to_remote(logger: FilteringBoundLogger):
     # set_context() which opens a real FH again. (And worse, in some cases it _truncates_ the file too). This
     # is just for the first Airflow 3 betas, but we will re-write a better remote log interface that isn't
     # tied to being a logging Handler.
+    handler.log_meta_dict = log_meta_dict
     handler.log_relative_path = relative_path.as_posix()  # type: ignore[attr-defined]
     handler.upload_on_close = True  # type: ignore[attr-defined]
 

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -505,7 +505,7 @@ def upload_to_remote(logger: FilteringBoundLogger, log_meta_dict: dict[str, Any]
     # set_context() which opens a real FH again. (And worse, in some cases it _truncates_ the file too). This
     # is just for the first Airflow 3 betas, but we will re-write a better remote log interface that isn't
     # tied to being a logging Handler.
-    handler.log_meta_dict = log_meta_dict
+    handler.log_meta_dict = log_meta_dict  # type: ignore[attr-defined]
     handler.log_relative_path = relative_path.as_posix()  # type: ignore[attr-defined]
     handler.upload_on_close = True  # type: ignore[attr-defined]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In lieu of an expected improvement in the way remote log uploads are configured and handled in the Task SDK, this PR introduces a temporary fix for the Airflow 3 beta timeframe to allow remote log uploads to function. The current situation is that the `configure_logging` function in the Task SDK overwrites the Python logging configuration from Airflow's configured `logging_config` module. Thus, when the task supervisor attempts to perform the remote log upload there is no configured handler suitable and so uploading is skipped.

The "solution" in this PR is to temporarily re-configure Python's logging module (😬) to extract the correct handler and then put the logging configuration back. Since this happens at the end of a task's lifecycle, and in a forked process, the blast radius is small.

It also configures a `log_meta_dict` attribute which is expected to have TI metadata for some loggers. This is usually set in the `set_context` method of the respective handler but for reasons stated in the existing code comments we do not want to call this method as it will re-open file handles.

This PR is in no way meant to be the final implementation and will need to be replaced in due course but is a temporary expedient for the short term to "unblock" remote logging functionality.

related: #47634 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
