### PR TITLE
Preserve whitespace in events content and render each event per line inside a group.

### DIFF
--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -107,9 +107,9 @@ const renderStructuredLog = ({
   }
 
   elements.push(
-    <span className="event" key={2}>
+    <chakra.span className="event" key={2} style={{ whiteSpace: "pre-wrap" }}>
       {event}
-    </span>,
+    </chakra.span>,
   );
 
   for (const key in structured) {
@@ -124,9 +124,9 @@ const renderStructuredLog = ({
   }
 
   return (
-    <chakra.span key={index} lineHeight={1.5}>
+    <chakra.p key={index} lineHeight={1.5}>
       {elements}
-    </chakra.span>
+    </chakra.p>
   );
 };
 


### PR DESCRIPTION
Add pre tag to preserve whitespace in the events which makes stacktraces better. Use p tag for render each event as a line in a group. Example dag with grouping is `example_python_operator` task id `print_the_context` .

Before PR :

![image](https://github.com/user-attachments/assets/b93b5001-7387-4db3-bf71-eaf8b56a5591)

After PR : 

![image](https://github.com/user-attachments/assets/f08a48c2-d068-48ee-bcb6-643b07079f75)

Closes #47621