### PR TITLE
Move XComOperatorLink to serialized_objects as only API server uses it

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/baseoperatorlink.py
+++ b/task-sdk/src/airflow/sdk/definitions/baseoperatorlink.py
@@ -22,47 +22,9 @@ from typing import TYPE_CHECKING, ClassVar
 
 import attrs
 
-from airflow.models.xcom import BaseXCom
-from airflow.utils.log.logging_mixin import LoggingMixin
-
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
-
-
-@attrs.define()
-class XComOperatorLink(LoggingMixin):
-    """A generic operator link class that can retrieve link only using XCOMs. Used while deserializing operators."""
-
-    name: str
-    xcom_key: str
-
-    def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
-        """
-        Retrieve the link from the XComs.
-
-        :param operator: The Airflow operator object this link is associated to.
-        :param ti_key: TaskInstance ID to return link for.
-        :return: link to external system, but by pulling it from XComs
-        """
-        self.log.info(
-            "Attempting to retrieve link from XComs with key: %s for task id: %s", self.xcom_key, ti_key
-        )
-        value = BaseXCom.get_one(
-            key=self.xcom_key,
-            run_id=ti_key.run_id,
-            dag_id=ti_key.dag_id,
-            task_id=ti_key.task_id,
-            map_index=ti_key.map_index,
-        )
-        if not value:
-            self.log.debug(
-                "No link with name: %s present in XCom as key: %s, returning empty link",
-                self.name,
-                self.xcom_key,
-            )
-            return ""
-        return value
 
 
 @attrs.define()

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -67,7 +67,6 @@ from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.sensors.bash import BashSensor
 from airflow.sdk.definitions.asset import Asset
-from airflow.sdk.definitions.baseoperatorlink import XComOperatorLink
 from airflow.sdk.definitions.param import Param, ParamsDict
 from airflow.security import permissions
 from airflow.serialization.enums import Encoding
@@ -76,6 +75,7 @@ from airflow.serialization.serialized_objects import (
     BaseSerialization,
     SerializedBaseOperator,
     SerializedDAG,
+    XComOperatorLink,
 )
 from airflow.task.priority_strategy import _DownstreamPriorityWeightStrategy
 from airflow.timetables.simple import NullTimetable, OnceTimetable


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/46613 introduced a machinery for operator links to be used via xcoms and task sdk by introducing a new class `XComOperatorLink` and https://github.com/apache/airflow/pull/47008 moved it to the task sdk. Now that I think about it, it should not reside in the task sdk because it is only used by the DAG processor while serialising / deserialising that too while actually running it (api servrer)


Moving it to serialised_objects instead, where its used.

Plugin present:
![image](https://github.com/user-attachments/assets/0a3b9307-1c38-45e6-8376-403cb2b655d0)


Plugin used:
```
from airflow.plugins_manager import AirflowPlugin
from airflow.sdk.definitions.baseoperatorlink import BaseOperatorLink
from airflow.providers.standard.operators.python import PythonOperator


# define the extra link
class HTTPDocsLink(BaseOperatorLink):
    # name the link button in the UI
    name = "HTTP docs"

    # add the button to one or more operators
    operators = [PythonOperator]

    # provide the link
    def get_link(self, operator, *, ti_key=None):
        return "https://developer.mozilla.org/en-US/docs/Web/HTTP"

# define the plugin class
class AirflowExtraLinkPlugin(AirflowPlugin):
    name = "extra_link_plugin"
    operator_extra_links = [
        HTTPDocsLink(),
    ]

```

Ran this dag:
```
from airflow.models.dag import DAG
2from pendulum import datetime
3
4from airflow.providers.standard.operators.python import PythonOperator
5
6
7def handler():
8    print("Hello from the python operator!!")
9
10with DAG(
11    dag_id="extra_links_plugin",
12    start_date=datetime(2022, 11, 1),
13    schedule=None,
14    catchup=False,
15    tags=["extra_links"],
16):
17
18    call_api_simple = PythonOperator(
19        task_id="call_api_simple",
20        python_callable=handler,
21    )
```

Extra link present:
![image](https://github.com/user-attachments/assets/17fc4e74-3dc3-49ae-827f-0e0791df3c82)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
