### PR TITLE
Rewrite asset event registration

### DIFF
--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -97,7 +97,7 @@ class TISuccessStatePayload(StrictBaseModel):
     """When the task completed executing"""
 
     task_outlets: Annotated[list[AssetProfile], Field(default_factory=list)]
-    outlet_events: Annotated[list[Any], Field(default_factory=list)]
+    outlet_events: Annotated[list[dict[str, Any]], Field(default_factory=list)]
 
 
 class TITargetStatePayload(StrictBaseModel):

--- a/airflow/assets/manager.py
+++ b/airflow/assets/manager.py
@@ -110,8 +110,7 @@ class AssetManager(LoggingMixin):
         task_instance: TaskInstance | None = None,
         asset: Asset | AssetModel | AssetUniqueKey,
         extra=None,
-        aliases: Collection[AssetAlias] = (),
-        source_alias_names: Iterable[str] | None = None,
+        source_alias_names: Collection[str] = (),
         session: Session,
         **kwargs,
     ) -> AssetEvent | None:
@@ -136,7 +135,7 @@ class AssetManager(LoggingMixin):
             return None
 
         cls._add_asset_alias_association(
-            alias_names={alias.name for alias in aliases}, asset_model=asset_model, session=session
+            alias_names=source_alias_names, asset_model=asset_model, session=session
         )
 
         event_kwargs = {

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -27,13 +27,13 @@ from datetime import timedelta
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from airflow.sdk.definitions.asset import AssetNameRef, AssetUniqueKey, AssetUriRef
 from airflow.utils.trigger_rule import TriggerRule
 
 if TYPE_CHECKING:
     from collections.abc import Sized
 
     from airflow.models import DagRun
-    from airflow.sdk.definitions.asset import AssetUniqueKey
 
 
 class AirflowException(Exception):
@@ -113,33 +113,42 @@ class AirflowFailException(AirflowException):
     """Raise when the task should be failed without retrying."""
 
 
-class AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
+class _AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
     """Raise when the task is executed with inactive assets."""
 
-    def __init__(self, inactive_asset_unikeys: Collection[AssetUniqueKey]) -> None:
-        self.inactive_asset_unique_keys = inactive_asset_unikeys
+    main_message: str
+
+    def __init__(self, inactive_asset_keys: Collection[AssetUniqueKey | AssetNameRef | AssetUriRef]) -> None:
+        self.inactive_asset_keys = inactive_asset_keys
+
+    @staticmethod
+    def _render_asset_key(key: AssetUniqueKey | AssetNameRef | AssetUriRef) -> str:
+        if isinstance(key, AssetUniqueKey):
+            return f"Asset(name={key.name!r}, uri={key.uri!r})"
+        elif isinstance(key, AssetNameRef):
+            return f"Asset.ref(name={key.name!r})"
+        elif isinstance(key, AssetUriRef):
+            return f"Asset.ref(uri={key.uri!r})"
+        return repr(key)  # Should not happen, but let's fails more gracefully in an exception.
+
+    def __str__(self) -> str:
+        return f"{self.main_message}: {self.inactive_assets_message}"
 
     @property
-    def inactive_assets_error_msg(self):
-        return ", ".join(
-            f'Asset(name="{key.name}", uri="{key.uri}")' for key in self.inactive_asset_unique_keys
-        )
+    def inactive_assets_message(self):
+        return ", ".join(self._render_asset_key(key) for key in self.inactive_asset_keys)
 
 
-class AirflowInactiveAssetInInletOrOutletException(AirflowExecuteWithInactiveAssetExecption):
+class AirflowInactiveAssetInInletOrOutletException(_AirflowExecuteWithInactiveAssetExecption):
     """Raise when the task is executed with inactive assets in its inlet or outlet."""
 
-    def __str__(self) -> str:
-        return f"Task has the following inactive assets in its inlets or outlets: {self.inactive_assets_error_msg}"
+    main_message = "Task has the following inactive assets in its inlets or outlets"
 
 
-class AirflowInactiveAssetAddedToAssetAliasException(AirflowExecuteWithInactiveAssetExecption):
+class AirflowInactiveAssetAddedToAssetAliasException(_AirflowExecuteWithInactiveAssetExecption):
     """Raise when inactive assets are added to an asset alias."""
 
-    def __str__(self) -> str:
-        return (
-            f"The following assets accessed by an AssetAlias are inactive: {self.inactive_assets_error_msg}"
-        )
+    main_message = "The following assets accessed by an AssetAlias are inactive"
 
 
 class AirflowOptionalProviderFeatureException(AirflowException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -114,8 +114,6 @@ class AirflowFailException(AirflowException):
 
 
 class _AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
-    """Raise when the task is executed with inactive assets."""
-
     main_message: str
 
     def __init__(self, inactive_asset_keys: Collection[AssetUniqueKey | AssetNameRef | AssetUriRef]) -> None:
@@ -135,7 +133,7 @@ class _AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
         return f"{self.main_message}: {self.inactive_assets_message}"
 
     @property
-    def inactive_assets_message(self):
+    def inactive_assets_message(self) -> str:
         return ", ".join(self._render_asset_key(key) for key in self.inactive_asset_keys)
 
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2828,7 +2828,7 @@ class TaskInstance(Base, LoggingMixin):
                 asset_manager.register_asset_change(
                     task_instance=ti,
                     asset=asset_key,
-                    aliases=aliases,
+                    source_alias_names=event_aliase_names,
                     extra=dict(extra_key),
                     session=session,
                 )

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2827,6 +2827,8 @@ class TaskInstance(Base, LoggingMixin):
                     alias_name = event["source_alias_name"]
                 except KeyError:
                     continue
+                if alias_name not in outlet_alias_names:
+                    continue
                 asset_key = AssetUniqueKey(**event["dest_asset_key"])
                 extra_key = frozenset(event["extra"].items())
                 d[asset_key, extra_key].add(alias_name)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2806,15 +2806,16 @@ class TaskInstance(Base, LoggingMixin):
                 d[asset_key, extra_key].add(alias_name)
             return d
 
-        outlet_alias_names = {o.name for o in task_outlets if o.type == AssetAlias.__name__ if o.name}
+        outlet_alias_names = {o.name for o in task_outlets if o.type == AssetAlias.__name__ and o.name}
         if outlet_alias_names and (event_from_aliases := asset_event_extras_from_aliases()):
-            asset_alias_models: dict[str, AssetAliasModel] = dict(
-                session.execute(
+            asset_alias_models: dict[str, AssetAliasModel] = {
+                name: model
+                for name, model in session.execute(
                     select(AssetAliasModel.name, AssetAliasModel).where(
                         AssetAliasModel.name.in_(outlet_alias_names)
                     )
                 )
-            )
+            }
             for (asset_key, extra_key), event_aliase_names in event_from_aliases.items():
                 aliases = [
                     alias_model

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2817,9 +2817,6 @@ class TaskInstance(Base, LoggingMixin):
                     session=session,
                 )
 
-        if bad_asset_keys:
-            raise AirflowInactiveAssetInInletOrOutletException(bad_asset_keys)
-
         def _asset_event_extras_from_aliases() -> dict[tuple[AssetUniqueKey, frozenset], set[str]]:
             d = defaultdict(set)
             for event in outlet_events:
@@ -2853,6 +2850,9 @@ class TaskInstance(Base, LoggingMixin):
                 )
             if bad_alias_asset_keys:
                 raise AirflowInactiveAssetAddedToAssetAliasException(bad_alias_asset_keys)
+
+        if bad_asset_keys:
+            raise AirflowInactiveAssetInInletOrOutletException(bad_asset_keys)
 
     def _execute_task_with_callbacks(self, context: Context, test_mode: bool = False, *, session: Session):
         """Prepare Task for Execution."""

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -26,7 +26,6 @@ import pytest
 from airflow.decorators import setup, task as task_decorator, teardown
 from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException, XComNotFound
-from airflow.models.asset import AssetActive, AssetModel
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.utils import timezone
@@ -970,9 +969,11 @@ def test_no_warnings(reset_logging_config, caplog):
 
 def test_task_decorator_asset(dag_maker, session):
     if AIRFLOW_V_3_0_PLUS:
+        from airflow.models.asset import AssetActive, AssetModel
         from airflow.sdk.definitions.asset import Asset
     else:
         from airflow.datasets import Dataset as Asset
+        from airflow.models.dataset import DatasetModel as AssetModel
 
     result = None
     uri = "s3://bucket/name"
@@ -983,7 +984,8 @@ def test_task_decorator_asset(dag_maker, session):
     else:
         asset = Asset(uri)
     session.add(AssetModel.from_public(asset))
-    session.add(AssetActive.for_asset(asset))
+    if AIRFLOW_V_3_0_PLUS:
+        session.add(AssetActive.for_asset(asset))
 
     with dag_maker(session=session) as dag:
 

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -209,7 +209,7 @@ class TISuccessStatePayload(BaseModel):
     state: Annotated[Literal["success"] | None, Field(title="State")] = "success"
     end_date: Annotated[datetime, Field(title="End Date")]
     task_outlets: Annotated[list[AssetProfile] | None, Field(title="Task Outlets")] = None
-    outlet_events: Annotated[list | None, Field(title="Outlet Events")] = None
+    outlet_events: Annotated[list[dict[str, Any]] | None, Field(title="Outlet Events")] = None
 
 
 class TITargetStatePayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -60,7 +60,7 @@ log = logging.getLogger(__name__)
 
 
 @attrs.define(frozen=True)
-class AssetUniqueKey:
+class AssetUniqueKey(attrs.AttrsInstance):
     """
     Columns to identify an unique asset.
 

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -637,7 +637,7 @@ class AssetAll(AssetBooleanCondition):
 
 
 @attrs.define
-class AssetAliasEvent:
+class AssetAliasEvent(attrs.AttrsInstance):
     """Representation of asset event to be triggered by an asset alias."""
 
     source_alias_name: str

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -226,7 +226,7 @@ class OutletEventAccessors(Mapping[Union[Asset, AssetAlias], OutletEventAccessor
     def __len__(self) -> int:
         return len(self._dict)
 
-    def __getitem__(self, key: Asset | AssetAlias) -> OutletEventAccessor:
+    def __getitem__(self, key: Asset | AssetAlias | AssetRef) -> OutletEventAccessor:
         hashable_key: BaseAssetUniqueKey
         if isinstance(key, Asset):
             hashable_key = AssetUniqueKey.from_asset(key)
@@ -284,6 +284,8 @@ class OutletEventAccessors(Mapping[Union[Asset, AssetAlias], OutletEventAccessor
 
 @attrs.define(init=False)
 class InletEventsAccessors(Mapping[Union[int, Asset, AssetAlias, AssetRef], Any]):
+    """Lazy mapping of inlet asset event accessors."""
+
     _inlets: list[Any]
     _assets: dict[AssetUniqueKey, Asset]
     _asset_aliases: dict[AssetAliasUniqueKey, AssetAlias]

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -23,7 +23,7 @@ import contextvars
 import functools
 import os
 import sys
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from datetime import datetime, timezone
 from io import FileIO
 from pathlib import Path
@@ -46,7 +46,7 @@ from airflow.sdk.api.datamodels._generated import (
 )
 from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
-from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUriRef
+from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
 from airflow.sdk.definitions.baseoperator import BaseOperator, ExecutorSafeguard
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.param import process_params
@@ -515,33 +515,27 @@ def _serialize_rendered_fields(task: AbstractOperator) -> dict[str, JsonValue]:
     return {field: serialize_template_field(getattr(task, field), field) for field in task.template_fields}
 
 
-def _process_outlets(context: Context, outlets: list[AssetProfile]):
-    added_alias_to_task_outlet = False
-    task_outlets: list[AssetProfile] = []
-    outlet_events: list[Any] = []
-    events = context["outlet_events"]
-
-    for obj in outlets or []:
-        # Lineage can have other types of objects besides assets
+def _build_asset_profiles(lineage_objects: list) -> Iterator[AssetProfile]:
+    # Lineage can have other types of objects besides assets, so we need to process them a bit.
+    for obj in lineage_objects or ():
         if isinstance(obj, Asset):
-            task_outlets.append(AssetProfile(name=obj.name, uri=obj.uri, type=Asset.__name__))
-            outlet_events.append(attrs.asdict(events[obj]))  # type: ignore
+            yield AssetProfile(name=obj.name, uri=obj.uri, type=Asset.__name__)
         elif isinstance(obj, AssetNameRef):
-            task_outlets.append(AssetProfile(name=obj.name, type=AssetNameRef.__name__))
-            # Send all events, filtering can be done in API server.
-            outlet_events.append(attrs.asdict(events))  # type: ignore
+            yield AssetProfile(name=obj.name, type=AssetNameRef.__name__)
         elif isinstance(obj, AssetUriRef):
-            task_outlets.append(AssetProfile(uri=obj.uri, type=AssetUriRef.__name__))
-            # Send all events, filtering can be done in API server.
-            outlet_events.append(attrs.asdict(events))  # type: ignore
+            yield AssetProfile(uri=obj.uri, type=AssetUriRef.__name__)
         elif isinstance(obj, AssetAlias):
-            if not added_alias_to_task_outlet:
-                task_outlets.append(AssetProfile(name=obj.name, type=AssetAlias.__name__))
-                added_alias_to_task_outlet = True
-            for asset_alias_event in events[obj].asset_alias_events:
-                outlet_events.append(attrs.asdict(asset_alias_event))
+            yield AssetProfile(name=obj.name, type=AssetAlias.__name__)
 
-    return task_outlets, outlet_events
+
+def _serialize_outlet_events(events: OutletEventAccessors) -> Iterator[dict[str, Any]]:
+    # We just collect everything the user recorded in the accessors.
+    # Further filtering will be done in the API server.
+    for key, accessor in events._dict.items():
+        if isinstance(key, AssetUniqueKey):
+            yield {"dest_asset_key": key, "extra": accessor.extra}
+        for alias_event in accessor.asset_alias_events:
+            yield attrs.asdict(alias_event)
 
 
 def _prepare(ti: RuntimeTaskInstance, log: Logger, context: Context) -> ToSupervisor | None:
@@ -610,11 +604,10 @@ def run(
 
         _push_xcom_if_needed(result, ti, log)
 
-        task_outlets, outlet_events = _process_outlets(context, ti.task.outlets)
         msg = SucceedTask(
             end_date=datetime.now(tz=timezone.utc),
-            task_outlets=task_outlets,
-            outlet_events=outlet_events,
+            task_outlets=list(_build_asset_profiles(ti.task.outlets)),
+            outlet_events=list(_serialize_outlet_events(context["outlet_events"])),  # type: ignore
         )
         state = TerminalTIState.SUCCESS
     except TaskDeferred as defer:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -536,7 +536,7 @@ def _serialize_outlet_events(events: OutletEventAccessorsProtocol) -> Iterator[d
     # Further filtering will be done in the API server.
     for key, accessor in events._dict.items():
         if isinstance(key, AssetUniqueKey):
-            yield {"dest_asset_key": key, "extra": accessor.extra}
+            yield {"dest_asset_key": attrs.asdict(key), "extra": accessor.extra}
         for alias_event in accessor.asset_alias_events:
             yield attrs.asdict(alias_event)
 

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -20,13 +20,15 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Protocol, Union
 
+import attrs
+
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from datetime import datetime
 
-    from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAliasEvent, BaseAssetUniqueKey
+    from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAliasEvent, AssetRef, BaseAssetUniqueKey
     from airflow.sdk.definitions.baseoperator import BaseOperator
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.definitions.mappedoperator import MappedOperator
@@ -80,7 +82,7 @@ class RuntimeTaskInstanceProtocol(Protocol):
     def get_template_context(self) -> Context: ...
 
 
-class OutletEventAccessorProtocol(Protocol):
+class OutletEventAccessorProtocol(Protocol, attrs.AttrsInstance):
     """Protocol for managing access to a specific outlet event accessor."""
 
     key: BaseAssetUniqueKey
@@ -102,4 +104,4 @@ class OutletEventAccessorsProtocol(Protocol):
 
     def __iter__(self) -> Iterator[Asset | AssetAlias]: ...
     def __len__(self) -> int: ...
-    def __getitem__(self, key: Asset | AssetAlias) -> OutletEventAccessorProtocol: ...
+    def __getitem__(self, key: Asset | AssetAlias | AssetRef) -> OutletEventAccessorProtocol: ...

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -693,13 +693,7 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 task_outlets=[
                     AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
-                outlet_events=[
-                    {
-                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
-                        "extra": {},
-                        "asset_alias_events": [],
-                    }
-                ],
+                outlet_events=[],
             ),
             id="asset",
         ),
@@ -711,13 +705,7 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 task_outlets=[
                     AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
-                outlet_events=[
-                    {
-                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
-                        "extra": {},
-                        "asset_alias_events": [],
-                    }
-                ],
+                outlet_events=[],
             ),
             id="dataset",
         ),
@@ -729,13 +717,7 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 task_outlets=[
                     AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
-                outlet_events=[
-                    {
-                        "key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
-                        "extra": {},
-                        "asset_alias_events": [],
-                    }
-                ],
+                outlet_events=[],
             ),
             id="model",
         ),
@@ -745,15 +727,8 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 state="success",
                 end_date=timezone.datetime(2024, 12, 3, 10, 0),
                 task_outlets=[AssetProfile(name="s3://bucket/my-task", type="AssetNameRef")],
-                outlet_events=[
-                    {
-                        "key": {"name": "s3://bucket/my-task"},
-                        "extra": {},
-                        "asset_alias_events": [],
-                    }
-                ],
+                outlet_events=[],
             ),
-            marks=[pytest.mark.xfail],  # Currently not handled correctly in task runner.
             id="name-ref",
         ),
         pytest.param(
@@ -762,15 +737,8 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 state="success",
                 end_date=timezone.datetime(2024, 12, 3, 10, 0),
                 task_outlets=[AssetProfile(uri="s3://bucket/my-task", type="AssetUriRef")],
-                outlet_events=[
-                    {
-                        "key": {"uri": "s3://bucket/my-task"},
-                        "extra": {},
-                        "asset_alias_events": [],
-                    }
-                ],
+                outlet_events=[],
             ),
-            marks=[pytest.mark.xfail],  # Currently not handled correctly in task runner.
             id="uri-ref",
         ),
         pytest.param(
@@ -864,18 +832,7 @@ def test_run_with_asset_inlets(create_runtime_ti, mock_supervisor_comms):
                     AssetProfile(name="name", uri="s3://bucket/my-task", type="Asset"),
                     AssetProfile(name="new-name", uri="s3://bucket/my-task", type="Asset"),
                 ],
-                outlet_events=[
-                    {
-                        "asset_alias_events": [],
-                        "extra": {},
-                        "key": {"name": "name", "uri": "s3://bucket/my-task"},
-                    },
-                    {
-                        "asset_alias_events": [],
-                        "extra": {},
-                        "key": {"name": "new-name", "uri": "s3://bucket/my-task"},
-                    },
-                ],
+                outlet_events=[],
             ),
             id="runtime_checks_pass",
         ),

--- a/tests/assets/test_manager.py
+++ b/tests/assets/test_manager.py
@@ -34,7 +34,7 @@ from airflow.models.asset import (
     DagScheduleAssetReference,
 )
 from airflow.models.dag import DagModel
-from airflow.sdk.definitions.asset import Asset, AssetAlias
+from airflow.sdk.definitions.asset import Asset
 
 from tests.listeners import asset_listener
 
@@ -124,12 +124,10 @@ class TestAssetManager:
         session.flush()
 
         asset = Asset(uri="test://asset1", name="test_asset_uri")
-        asset_alias = AssetAlias(name="test_alias_name", group="test")
         asset_manager = AssetManager()
         asset_manager.register_asset_change(
             task_instance=mock_task_instance,
             asset=asset,
-            aliases=[asset_alias],
             source_alias_names=["test_alias_name"],
             session=session,
         )


### PR DESCRIPTION
There are many issues in the original implementation when you send something that's not a simple asset, I ended up almost rewritten the whole thing...

Now, the task runner collects everything the user writes into outlet_events, and send all of them with the task's outlets as declared by the user verbatim to the API server. The server does all the resolution and filtering instead.

Fix #46958 (in combination with https://github.com/apache/airflow/pull/47659).