### PR TITLE
Make LocalExecutor work under heavy load

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -35,7 +35,6 @@ from typing import TYPE_CHECKING, Optional
 
 from setproctitle import setproctitle
 
-from airflow import settings
 from airflow.executors import workloads
 from airflow.executors.base_executor import PARALLELISM, BaseExecutor
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -60,10 +59,6 @@ def _run_worker(
 
     log = logging.getLogger(logger_name)
     log.info("Worker starting up pid=%d", os.getpid())
-
-    # We know we've just started a new process, so lets disconnect from the metadata db now
-    settings.engine.pool.dispose()
-    settings.engine.dispose()
 
     while True:
         setproctitle("airflow worker -- LocalExecutor: <idle>")

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -234,8 +234,6 @@ def block_orm_access():
         from airflow import settings
         from airflow.configuration import conf
 
-        settings.dispose_orm()
-
         for attr in ("engine", "async_engine", "Session", "AsyncSession", "NonScopedSession"):
             if hasattr(settings, attr):
                 delattr(settings, attr)
@@ -329,7 +327,7 @@ def _fork_main(
         import traceback
 
         try:
-            last_chance_stderr.write("--- Last chance exception handler ---\n")
+            last_chance_stderr.write("--- Supervised process Last chance exception handler ---\n")
             traceback.print_exception(exc, value=v, tb=tb, file=last_chance_stderr)
             # Exit code 126 and 125 don't have any "special" meaning, they are only meant to serve as an
             # identifier that the task process died in a really odd way.


### PR DESCRIPTION
This change seems innocuous, and possibly even wrong, but it is the correct
behaviour since #47320 landed. We _do not_ want to call dispose_orm, as that
ends up reconnecting, and sometimes this results in the wrong connection
being shared between the parent and the child. I don't love the "sometimes"
nature of this bug, but the fix seems sound.

Prior to this running one or two runs concurrently would result in the
scheduler handing (stuck in SQLA code trying to roll back) or an error from
psycopg about "error with status PGRES_TUPLES_OK and no message from the libpq".

With this change we were able to repeatedly run 10 runs concurrently.

The reason we don't want this is that we registered an at_fork handler already
that closes/discards the socket object (without closing the DB level session)
so calling dispose can, perversely, resurrect that object and try reusing it!

Co-authored-by: Jed Cunningham <66968678+jedcunningham@users.noreply.github.com>
Co-authored-by: Kaxil Naik <kaxilnaik@apache.org>

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
