### PR TITLE
Add Created Asset Events to dag overview page

### DIFF
--- a/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -39,7 +39,6 @@ const cardDef = (assetId?: number): CardDef<AssetEventResponse> => ({
 type AssetEventProps = {
   readonly assetId?: number;
   readonly data?: AssetEventCollectionResponse;
-  readonly endDate?: string;
   readonly isLoading?: boolean;
   readonly setOrderBy?: (order: string) => void;
   readonly setTableUrlState?: (state: TableState) => void;

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -98,7 +98,6 @@ export const HistoricalMetrics = () => {
           <GridItem colSpan={{ base: 3 }}>
             <AssetEvents
               data={assetEventsData}
-              endDate={endDate}
               isLoading={isLoadingAssetEvents}
               setOrderBy={setAssetSortBy}
             />


### PR DESCRIPTION

<img width="666" alt="Screenshot 2025-03-12 at 11 42 56 AM" src="https://github.com/user-attachments/assets/bd966dd7-b12c-497f-8ee7-5c8713625e4b" />

Like the dashboard page, add a list of asset events to the Dag Overview page, showing recent asset events created by the Dag in question

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
