### PR TITLE
Introduce `filter_authorized_menu_items` to filter menu items based on permissions

### DIFF
--- a/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -26,7 +26,7 @@ from sqlalchemy import select
 
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
 from airflow.api_fastapi.auth.managers.models.resource_details import BackfillDetails, DagDetails
-from airflow.api_fastapi.common.types import MenuItem
+from airflow.api_fastapi.common.types import ExtraMenuItem, MenuItem
 from airflow.configuration import conf
 from airflow.models import DagModel
 from airflow.typing_compat import Literal
@@ -281,6 +281,15 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         :param user: the user to performing the action
         """
 
+    @abstractmethod
+    def filter_authorized_menu_items(self, menu_items: list[MenuItem], *, user: T) -> list[MenuItem]:
+        """
+        Filter menu items based on user permissions.
+
+        :param menu_items: list of all menu items
+        :param user: the user
+        """
+
     def batch_is_authorized_connection(
         self,
         requests: Sequence[IsAuthorizedConnectionRequest],
@@ -429,7 +438,11 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         """
         return None
 
-    def get_menu_items(self, *, user: T) -> list[MenuItem]:
+    def get_authorized_menu_items(self, *, user: T) -> list[MenuItem]:
+        """Get all menu items the user has access to."""
+        return self.filter_authorized_menu_items(list(MenuItem), user=user)
+
+    def get_extra_menu_items(self, *, user: T) -> list[ExtraMenuItem]:
         """
         Provide additional links to be added to the menu.
 

--- a/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -36,6 +36,7 @@ from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
 from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
 from airflow.api_fastapi.auth.managers.models.resource_details import BackfillDetails
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
+from airflow.api_fastapi.common.types import MenuItem
 from airflow.configuration import AIRFLOW_HOME, conf
 
 if TYPE_CHECKING:
@@ -248,6 +249,11 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         self, *, method: ResourceMethod | str, resource_name: str, user: SimpleAuthManagerUser
     ):
         return self._is_authorized(method="GET", allow_role=SimpleAuthManagerRole.VIEWER, user=user)
+
+    def filter_authorized_menu_items(
+        self, menu_items: list[MenuItem], *, user: SimpleAuthManagerUser
+    ) -> list[MenuItem]:
+        return menu_items
 
     def get_fastapi_app(self) -> FastAPI | None:
         """

--- a/airflow/api_fastapi/common/types.py
+++ b/airflow/api_fastapi/common/types.py
@@ -76,8 +76,23 @@ class Mimetype(str, Enum):
 
 
 @dataclass
-class MenuItem:
-    """Define a menu item."""
+class ExtraMenuItem:
+    """Define a menu item that can be added to the menu by auth managers or plugins."""
 
     text: str
     href: str
+
+
+class MenuItem(Enum):
+    """Define all menu items defined in the menu."""
+
+    ASSETS = "Assets"
+    ASSET_EVENTS = "Asset Events"
+    CONNECTIONS = "Connections"
+    DAGS = "Dags"
+    DOCS = "Docs"
+    PLUGINS = "Plugins"
+    POOLS = "Pools"
+    PROVIDERS = "Providers"
+    VARIABLES = "Variables"
+    XCOMS = "XComs"

--- a/airflow/api_fastapi/core_api/routes/ui/auth.py
+++ b/airflow/api_fastapi/core_api/routes/ui/auth.py
@@ -31,7 +31,7 @@ auth_router = AirflowRouter(tags=["Auth Links"])
 def get_auth_links(
     user: GetUserDep,
 ) -> MenuItemCollectionResponse:
-    menu_items = get_auth_manager().get_menu_items(user=user)
+    menu_items = get_auth_manager().get_extra_menu_items(user=user)
 
     return MenuItemCollectionResponse(
         menu_items=cast(list[MenuItem], menu_items),

--- a/newsfragments/aip-79.significant.rst
+++ b/newsfragments/aip-79.significant.rst
@@ -10,6 +10,8 @@ As part of this change the following breaking changes have occurred:
 
   - A new abstract method ``serialize_user`` needs to be implemented
 
+  - A new abstract method ``filter_authorized_menu_items`` needs to be implemented
+
   - The property ``security_manager`` has been removed from the interface
 
   - The method ``get_url_logout`` is now optional

--- a/tests/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/tests/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -24,6 +24,7 @@ import pytest
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
 from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
+from airflow.api_fastapi.common.types import MenuItem
 
 from tests_common.test_utils.config import conf_vars
 
@@ -214,3 +215,10 @@ class TestSimpleAuthManager:
             getattr(auth_manager, api)(method=method, user=SimpleAuthManagerUser(username="test", role=role))
             is result
         )
+
+    def test_filter_authorized_menu_items(self, auth_manager):
+        items = [MenuItem.ASSETS]
+        results = auth_manager.filter_authorized_menu_items(
+            items, user=SimpleAuthManagerUser(username="test", role=None)
+        )
+        assert results == items

--- a/tests/api_fastapi/core_api/routes/ui/test_auth.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_auth.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.api_fastapi.common.types import MenuItem
+from airflow.api_fastapi.common.types import ExtraMenuItem
 
 pytestmark = pytest.mark.db_test
 
@@ -28,9 +28,9 @@ pytestmark = pytest.mark.db_test
 class TestGetAuthLinks:
     @mock.patch("airflow.api_fastapi.core_api.routes.ui.auth.get_auth_manager")
     def test_should_response_200(self, mock_get_auth_manager, test_client):
-        mock_get_auth_manager.return_value.get_menu_items.return_value = [
-            MenuItem(text="name1", href="path1"),
-            MenuItem(text="name2", href="path2"),
+        mock_get_auth_manager.return_value.get_extra_menu_items.return_value = [
+            ExtraMenuItem(text="name1", href="path1"),
+            ExtraMenuItem(text="name2", href="path2"),
         ]
         response = test_client.get("/ui/auth/links")
 


### PR DESCRIPTION
The menu in the UI should show items the user has access to. With this PR, you can get the list of menu items the user has access to by calling `get_auth_manager().get_authorized_menu_items(user=user)`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
