### PR TITLE
Fix `get_menu_items` in FAB auth manager

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -434,33 +434,27 @@ class FabAuthManager(BaseAuthManager[User]):
             {
                 "resource_type": "List Users",
                 "text": "Users",
-                "href": AUTH_MANAGER_FASTAPI_APP_PREFIX
-                + url_for(f"{self.security_manager.user_view.__class__.__name__}.list", _external=False),
+                "href": f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/users/list/",
             },
             {
                 "resource_type": "List Roles",
                 "text": "Roles",
-                "href": AUTH_MANAGER_FASTAPI_APP_PREFIX
-                + url_for("CustomRoleModelView.list", _external=False),
+                "href": f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/roles/list/",
             },
             {
                 "resource_type": "Actions",
                 "text": "Actions",
-                "href": AUTH_MANAGER_FASTAPI_APP_PREFIX + url_for("ActionModelView.list", _external=False),
+                "href": f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/actions/list/",
             },
             {
                 "resource_type": "Resources",
                 "text": "Resources",
-                "href": AUTH_MANAGER_FASTAPI_APP_PREFIX + url_for("ResourceModelView.list", _external=False),
+                "href": f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/resources/list/",
             },
             {
                 "resource_type": "Permission Pairs",
                 "text": "Permissions",
-                "href": AUTH_MANAGER_FASTAPI_APP_PREFIX
-                + url_for(
-                    "PermissionPairModelView.list",
-                    _external=False,
-                ),
+                "href": f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/permissions/list/",
             },
         ]
 

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -587,8 +587,7 @@ class TestFabAuthManager:
 
     @mock.patch.object(FabAuthManager, "_is_authorized", return_value=True)
     def test_get_menu_items(self, _, auth_manager_with_appbuilder, flask_app):
-        with flask_app.app_context():
-            auth_manager_with_appbuilder.register_views()
-            result = auth_manager_with_appbuilder.get_menu_items(user=Mock())
-            assert len(result) == 5
-            assert all(item.href.startswith(AUTH_MANAGER_FASTAPI_APP_PREFIX) for item in result)
+        auth_manager_with_appbuilder.register_views()
+        result = auth_manager_with_appbuilder.get_menu_items(user=Mock())
+        assert len(result) == 5
+        assert all(item.href.startswith(AUTH_MANAGER_FASTAPI_APP_PREFIX) for item in result)


### PR DESCRIPTION
As reported in #47662, there is a bug in the method `get_menu_items` of FAB auth manager.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
