### PR TITLE
Load dag run in grid if outside of initial fetch

### DIFF
--- a/airflow/ui/src/hooks/useSelectedVersion.ts
+++ b/airflow/ui/src/hooks/useSelectedVersion.ts
@@ -74,7 +74,7 @@ const useSelectedVersion = (): number | undefined => {
   const selectedVersionNumber =
     (selectedVersionUrl === null ? undefined : parseInt(selectedVersionUrl, 10)) ??
     mappedTaskInstanceData?.dag_version?.version_number ??
-    runData?.dag_versions.at(-1)?.version_number ??
+    (runData?.dag_versions ?? []).at(-1)?.version_number ??
     dagData?.latest_dag_version?.version_number;
 
   return selectedVersionNumber;

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -23,6 +23,7 @@ import { useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
 import {
+  useDagRunServiceGetDagRun,
   useDependenciesServiceGetDependencies,
   useGridServiceGridData,
   useStructureServiceStructureData,
@@ -108,6 +109,15 @@ export const Graph = () => {
     { enabled: dependencies === "all" },
   );
 
+  const { data: dagRun } = useDagRunServiceGetDagRun(
+    {
+      dagId,
+      dagRunId: runId ?? "",
+    },
+    undefined,
+    { enabled: runId !== "" },
+  );
+
   const dagDepEdges = dependencies === "all" ? dagDependencies.edges : [];
   const dagDepNodes = dependencies === "all" ? dagDependencies.nodes : [];
 
@@ -124,29 +134,31 @@ export const Graph = () => {
     versionNumber: selectedVersion,
   });
 
+  // Filter grid data to get only a single dag run
   const { data: gridData } = useGridServiceGridData(
     {
       dagId,
-      limit: 25,
+      limit: 1,
       offset: 0,
-      orderBy: "-run_after",
+      runAfterGte: dagRun?.run_after,
+      runAfterLte: dagRun?.run_after,
     },
     undefined,
     {
-      enabled: Boolean(runId),
+      enabled: dagRun !== undefined,
       refetchInterval: (query) =>
         query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) && refetchInterval,
     },
   );
 
-  const dagRun = gridData?.dag_runs.find((dr) => dr.dag_run_id === runId);
+  const gridRun = gridData?.dag_runs.find((dr) => dr.dag_run_id === runId);
 
   // Add task instances to the node data but without having to recalculate how the graph is laid out
   const nodes =
-    dagRun?.task_instances === undefined
+    gridRun?.task_instances === undefined
       ? data?.nodes
       : data?.nodes.map((node) => {
-          const taskInstance = dagRun.task_instances.find((ti) => ti.task_id === node.id);
+          const taskInstance = gridRun.task_instances.find((ti) => ti.task_id === node.id);
 
           return {
             ...node,

--- a/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -17,17 +17,15 @@
  * under the License.
  */
 import { Box, Flex, IconButton } from "@chakra-ui/react";
-import { keepPreviousData } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import dayjsDuration from "dayjs/plugin/duration";
 import { useMemo } from "react";
-import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
-import { useParams, useSearchParams } from "react-router-dom";
+import { FiChevronsRight } from "react-icons/fi";
+import { Link, useParams } from "react-router-dom";
 
-import { useGridServiceGridData, useStructureServiceStructureData } from "openapi/queries";
-import type { GridResponse } from "openapi/requests/types.gen";
+import { useStructureServiceStructureData } from "openapi/queries";
 import { useOpenGroups } from "src/context/openGroups";
-import { isStatePending, useAutoRefresh } from "src/utils";
+import { useGrid } from "src/queries/useGrid";
 
 import { Bar } from "./Bar";
 import { DurationAxis } from "./DurationAxis";
@@ -37,9 +35,6 @@ import { flattenNodes, type RunWithDuration } from "./utils";
 
 dayjs.extend(dayjsDuration);
 
-const OFFSET_CHANGE = 10;
-const limit = 14;
-
 export const Grid = () => {
   const { openGroupIds } = useOpenGroups();
   const { dagId = "" } = useParams();
@@ -47,27 +42,7 @@ export const Grid = () => {
     dagId,
   });
 
-  const [searchParams, setSearchParams] = useSearchParams();
-  const refetchInterval = useAutoRefresh({ dagId });
-
-  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
-
-  // This is necessary for keepPreviousData
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
-  const { data: gridData } = useGridServiceGridData<GridResponse>(
-    {
-      dagId,
-      limit,
-      offset,
-      orderBy: "-run_after",
-    },
-    undefined,
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval: (query) =>
-        query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) && refetchInterval,
-    },
-  );
+  const { data: gridData, isLoading, runAfter } = useGrid();
 
   const runs: Array<RunWithDuration> = useMemo(
     () =>
@@ -90,24 +65,6 @@ export const Grid = () => {
     runs.map((dr) => dr.duration),
   );
 
-  const onIncrement = () => {
-    if (offset - OFFSET_CHANGE > 0) {
-      const newOffset = offset - OFFSET_CHANGE;
-
-      searchParams.set("offset", newOffset.toString());
-    } else {
-      searchParams.delete("offset");
-    }
-    setSearchParams(searchParams);
-  };
-
-  const onDecrement = () => {
-    const newOffset = offset + OFFSET_CHANGE;
-
-    searchParams.set("offset", newOffset.toString());
-    setSearchParams(searchParams);
-  };
-
   const { flatNodes } = useMemo(
     () => flattenNodes(structure?.nodes ?? [], openGroupIds),
     [structure?.nodes, openGroupIds],
@@ -120,19 +77,6 @@ export const Grid = () => {
       </Box>
       <Box>
         <Flex position="relative">
-          <IconButton
-            aria-label={`-${OFFSET_CHANGE} older dag runs`}
-            disabled={runs.length < limit}
-            height="98px"
-            minW={0}
-            mr={10}
-            onClick={onDecrement}
-            title={`-${OFFSET_CHANGE} older dag runs`}
-            variant="surface"
-            zIndex={1}
-          >
-            <FiChevronLeft />
-          </IconButton>
           <DurationAxis top="100px" />
           <DurationAxis top="50px" />
           <DurationAxis top="4px" />
@@ -150,19 +94,22 @@ export const Grid = () => {
               <Bar key={dr.dag_run_id} max={max} nodes={flatNodes} run={dr} />
             ))}
           </Flex>
-          <IconButton
-            aria-label={`+${OFFSET_CHANGE} newer dag runs`}
-            disabled={offset === 0}
-            height="98px"
-            minW={0}
-            ml={1}
-            onClick={onIncrement}
-            title={`+${OFFSET_CHANGE} newer dag runs`}
-            variant="surface"
-            zIndex={1}
-          >
-            <FiChevronRight />
-          </IconButton>
+          {runAfter === undefined ? undefined : (
+            <Link to={`/dags/${dagId}`}>
+              <IconButton
+                aria-label="Reset to latest"
+                height="98px"
+                loading={isLoading}
+                minW={0}
+                ml={1}
+                title="Reset to latest"
+                variant="surface"
+                zIndex={1}
+              >
+                <FiChevronsRight />
+              </IconButton>
+            </Link>
+          )}
         </Flex>
       </Box>
     </Flex>

--- a/airflow/ui/src/pages/MappedTaskInstance/MappedTaskInstance.tsx
+++ b/airflow/ui/src/pages/MappedTaskInstance/MappedTaskInstance.tsx
@@ -20,7 +20,11 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { MdOutlineTask } from "react-icons/md";
 import { useParams } from "react-router-dom";
 
-import { useDagServiceGetDagDetails, useGridServiceGridData } from "openapi/queries";
+import {
+  useDagRunServiceGetDagRun,
+  useDagServiceGetDagDetails,
+  useGridServiceGridData,
+} from "openapi/queries";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -40,14 +44,29 @@ export const MappedTaskInstance = () => {
     dagId,
   });
 
+  const { data: dagRun } = useDagRunServiceGetDagRun(
+    {
+      dagId,
+      dagRunId: runId,
+    },
+    undefined,
+    { enabled: runId !== "" },
+  );
+
+  // Filter grid data to get only a single dag run
   const { data, error, isLoading } = useGridServiceGridData(
     {
       dagId,
+      limit: 1,
+      offset: 0,
+      runAfterGte: dagRun?.run_after,
+      runAfterLte: dagRun?.run_after,
     },
     undefined,
     {
+      enabled: dagRun !== undefined,
       refetchInterval: (query) =>
-        query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) ? refetchInterval : false,
+        query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) && refetchInterval,
     },
   );
 

--- a/airflow/ui/src/queries/useGrid.ts
+++ b/airflow/ui/src/queries/useGrid.ts
@@ -1,0 +1,74 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { keepPreviousData } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import { useDagRunServiceGetDagRun, useGridServiceGridData } from "openapi/queries";
+import type { GridResponse } from "openapi/requests/types.gen";
+import { isStatePending, useAutoRefresh } from "src/utils";
+
+const limit = 14;
+
+export const useGrid = () => {
+  const { dagId = "", runId = "" } = useParams();
+  const [runAfter, setRunAfter] = useState<string | undefined>();
+
+  const { data: dagRun } = useDagRunServiceGetDagRun(
+    {
+      dagId,
+      dagRunId: runId,
+    },
+    undefined,
+    { enabled: runId !== "" },
+  );
+
+  const refetchInterval = useAutoRefresh({ dagId });
+
+  // This is necessary for keepPreviousData
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+  const { data: gridData, ...rest } = useGridServiceGridData<GridResponse>(
+    {
+      dagId,
+      limit,
+      orderBy: "-run_after",
+      runAfterLte: runAfter,
+    },
+    undefined,
+    {
+      placeholderData: keepPreviousData,
+      refetchInterval: (query) =>
+        query.state.data?.dag_runs.some((dr) => isStatePending(dr.state)) && refetchInterval,
+    },
+  );
+
+  // Check if the selected dag run is inside of the grid response, if not, we'll update the grid filters
+  // Eventually we should redo the api endpoint to make this work better
+  useEffect(() => {
+    if (gridData?.dag_runs && dagRun) {
+      const hasRun = gridData.dag_runs.find((dr) => dr.dag_run_id === dagRun.dag_run_id);
+
+      if (!hasRun) {
+        setRunAfter(dagRun.run_after);
+      }
+    }
+  }, [dagRun, gridData?.dag_runs, runAfter]);
+
+  return { data: gridData, runAfter, ...rest };
+};


### PR DESCRIPTION

![Mar-12-2025 15-24-45](https://github.com/user-attachments/assets/351ffb25-0853-4769-9d26-747d1a82e832)


I still don't like the grid being slow or flickering when trying to load an old dag run, but it does work.



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
