### PR TITLE
AIP-84 Add logout endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -7216,13 +7216,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionInfo'
-  /public/login:
+  /public/auth/login:
     get:
       tags:
       - Login
       summary: Login
       description: Redirect to the login URL depending on the AuthManager configured.
       operationId: login
+      parameters:
+      - name: next
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '307':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Temporary Redirect
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /public/auth/logout:
+    get:
+      tags:
+      - Login
+      summary: Logout
+      description: Logout the user.
+      operationId: logout
       parameters:
       - name: next
         in: query

--- a/airflow/api_fastapi/core_api/routes/public/__init__.py
+++ b/airflow/api_fastapi/core_api/routes/public/__init__.py
@@ -22,6 +22,7 @@ from fastapi import status
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.routes.public.assets import assets_router
+from airflow.api_fastapi.core_api.routes.public.auth import auth_router
 from airflow.api_fastapi.core_api.routes.public.backfills import backfills_router
 from airflow.api_fastapi.core_api.routes.public.config import config_router
 from airflow.api_fastapi.core_api.routes.public.connections import connections_router
@@ -39,7 +40,6 @@ from airflow.api_fastapi.core_api.routes.public.extra_links import extra_links_r
 from airflow.api_fastapi.core_api.routes.public.import_error import import_error_router
 from airflow.api_fastapi.core_api.routes.public.job import job_router
 from airflow.api_fastapi.core_api.routes.public.log import task_instances_log_router
-from airflow.api_fastapi.core_api.routes.public.login import login_router
 from airflow.api_fastapi.core_api.routes.public.monitor import monitor_router
 from airflow.api_fastapi.core_api.routes.public.plugins import plugins_router
 from airflow.api_fastapi.core_api.routes.public.pools import pools_router
@@ -90,4 +90,4 @@ public_router.include_router(authenticated_router)
 # Following routers are not included in common router, for now we don't expect it to have authentication
 public_router.include_router(monitor_router)
 public_router.include_router(version_router)
-public_router.include_router(login_router)
+public_router.include_router(auth_router)

--- a/airflow/api_fastapi/core_api/routes/public/auth.py
+++ b/airflow/api_fastapi/core_api/routes/public/auth.py
@@ -50,8 +50,7 @@ def logout(request: Request, next: None | str = None) -> RedirectResponse:
     """Logout the user."""
     logout_url = request.app.state.auth_manager.get_url_logout()
 
-    if logout_url:
-        return RedirectResponse(logout_url)
+    if not logout_url:
+        logout_url = request.app.state.auth_manager.get_url_login()
 
-    login_url = request.app.state.auth_manager.get_url_login()
-    return RedirectResponse(login_url)
+    return RedirectResponse(logout_url)

--- a/airflow/api_fastapi/core_api/routes/public/auth.py
+++ b/airflow/api_fastapi/core_api/routes/public/auth.py
@@ -23,11 +23,11 @@ from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import is_safe_url
 
-login_router = AirflowRouter(tags=["Login"], prefix="/login")
+auth_router = AirflowRouter(tags=["Login"], prefix="/auth")
 
 
-@login_router.get(
-    "",
+@auth_router.get(
+    "/login",
     responses=create_openapi_http_exception_doc([status.HTTP_307_TEMPORARY_REDIRECT]),
 )
 def login(request: Request, next: None | str = None) -> RedirectResponse:
@@ -39,4 +39,17 @@ def login(request: Request, next: None | str = None) -> RedirectResponse:
 
     if next:
         login_url += f"?next={next}"
+    return RedirectResponse(login_url)
+
+
+@auth_router.get(
+    "/logout",
+    responses=create_openapi_http_exception_doc([status.HTTP_307_TEMPORARY_REDIRECT]),
+)
+def logout(request: Request, next: None | str = None) -> RedirectResponse:
+    """Logout the user."""
+    request.app.state.auth_manager.logout()
+
+    login_url = request.app.state.auth_manager.get_url_login()
+
     return RedirectResponse(login_url)

--- a/airflow/api_fastapi/core_api/routes/public/auth.py
+++ b/airflow/api_fastapi/core_api/routes/public/auth.py
@@ -48,8 +48,10 @@ def login(request: Request, next: None | str = None) -> RedirectResponse:
 )
 def logout(request: Request, next: None | str = None) -> RedirectResponse:
     """Logout the user."""
-    request.app.state.auth_manager.logout()
+    logout_url = request.app.state.auth_manager.get_url_logout()
+
+    if logout_url:
+        return RedirectResponse(logout_url)
 
     login_url = request.app.state.auth_manager.get_url_login()
-
     return RedirectResponse(login_url)

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -1778,6 +1778,20 @@ export const UseLoginServiceLoginKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [useLoginServiceLoginKey, ...(queryKey ?? [{ next }])];
+export type LoginServiceLogoutDefaultResponse = Awaited<ReturnType<typeof LoginService.logout>>;
+export type LoginServiceLogoutQueryResult<
+  TData = LoginServiceLogoutDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useLoginServiceLogoutKey = "LoginServiceLogout";
+export const UseLoginServiceLogoutKeyFn = (
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
+  queryKey?: Array<unknown>,
+) => [useLoginServiceLogoutKey, ...(queryKey ?? [{ next }])];
 export type AssetServiceCreateAssetEventMutationResult = Awaited<
   ReturnType<typeof AssetService.createAssetEvent>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -2486,3 +2486,23 @@ export const prefetchUseLoginServiceLogin = (
     queryKey: Common.UseLoginServiceLoginKeyFn({ next }),
     queryFn: () => LoginService.login({ next }),
   });
+/**
+ * Logout
+ * Logout the user.
+ * @param data The data for the request.
+ * @param data.next
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseLoginServiceLogout = (
+  queryClient: QueryClient,
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseLoginServiceLogoutKeyFn({ next }),
+    queryFn: () => LoginService.logout({ next }),
+  });

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -2954,6 +2954,32 @@ export const useLoginServiceLogin = <
     ...options,
   });
 /**
+ * Logout
+ * Logout the user.
+ * @param data The data for the request.
+ * @param data.next
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const useLoginServiceLogout = <
+  TData = Common.LoginServiceLogoutDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseLoginServiceLogoutKeyFn({ next }, queryKey),
+    queryFn: () => LoginService.logout({ next }) as TData,
+    ...options,
+  });
+/**
  * Create Asset Event
  * Create asset events.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -2930,3 +2930,29 @@ export const useLoginServiceLoginSuspense = <
     queryFn: () => LoginService.login({ next }) as TData,
     ...options,
   });
+/**
+ * Logout
+ * Logout the user.
+ * @param data The data for the request.
+ * @param data.next
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const useLoginServiceLogoutSuspense = <
+  TData = Common.LoginServiceLogoutDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    next,
+  }: {
+    next?: string;
+  } = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseLoginServiceLogoutKeyFn({ next }, queryKey),
+    queryFn: () => LoginService.logout({ next }) as TData,
+    ...options,
+  });

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -213,6 +213,8 @@ import type {
   GetVersionResponse,
   LoginData,
   LoginResponse,
+  LogoutData,
+  LogoutResponse,
 } from "./types.gen";
 
 export class AuthLinksService {
@@ -3546,7 +3548,29 @@ export class LoginService {
   public static login(data: LoginData = {}): CancelablePromise<LoginResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/login",
+      url: "/public/auth/login",
+      query: {
+        next: data.next,
+      },
+      errors: {
+        307: "Temporary Redirect",
+        422: "Validation Error",
+      },
+    });
+  }
+
+  /**
+   * Logout
+   * Logout the user.
+   * @param data The data for the request.
+   * @param data.next
+   * @returns unknown Successful Response
+   * @throws ApiError
+   */
+  public static logout(data: LogoutData = {}): CancelablePromise<LogoutResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/auth/logout",
       query: {
         next: data.next,
       },

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2593,6 +2593,12 @@ export type LoginData = {
 
 export type LoginResponse = unknown;
 
+export type LogoutData = {
+  next?: string | null;
+};
+
+export type LogoutResponse = unknown;
+
 export type $OpenApiTs = {
   "/ui/auth/links": {
     get: {
@@ -5381,9 +5387,28 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/login": {
+  "/public/auth/login": {
     get: {
       req: LoginData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: unknown;
+        /**
+         * Temporary Redirect
+         */
+        307: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/auth/logout": {
+    get: {
+      req: LogoutData;
       res: {
         /**
          * Successful Response

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -39,7 +39,7 @@ axios.interceptors.response.use(
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);
-      globalThis.location.replace(`/public/login?${params.toString()}`);
+      globalThis.location.replace(`/public/auth/login?${params.toString()}`);
     }
 
     return Promise.reject(error);

--- a/tests/api_fastapi/core_api/routes/test_routes.py
+++ b/tests/api_fastapi/core_api/routes/test_routes.py
@@ -20,7 +20,8 @@ from airflow.api_fastapi.core_api.routes.public import authenticated_router, pub
 
 # Set of paths that are allowed to be accessible without authentication
 NO_AUTH_PATHS = {
-    "/public/login",
+    "/public/auth/login",
+    "/public/auth/logout",
     "/public/version",
     "/public/monitor/health",
 }


### PR DESCRIPTION
related to: #47559

This add the logout endpoint.

When I try this locally with the `FabAuthManager` we get the same problem as https://github.com/apache/airflow/pull/47662, we are working outside of a request context.

I think we need to do the same thing we do for the login -> redirect to a flask `login_url` so this is rendered with the WSGI middleware and passing the flask context along. (Also this needs to not crash when no user is logged in)