### PR TITLE
Fix get_hook() got an unexpected keyword argument 'hook_params' in SQLExecuteQueryTrigger

### DIFF
--- a/providers/common/sql/tests/unit/common/sql/triggers/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/triggers/test_sql.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 
 from unittest import mock
 
+from airflow.models.connection import Connection
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.common.sql.triggers.sql import SQLExecuteQueryTrigger
 from airflow.triggers.base import TriggerEvent
 
-from airflow.models.connection import Connection
 from tests_common.test_utils.operators.run_deferrable import run_trigger
 
 

--- a/providers/common/sql/tests/unit/common/sql/triggers/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/triggers/test_sql.py
@@ -22,16 +22,19 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.common.sql.triggers.sql import SQLExecuteQueryTrigger
 from airflow.triggers.base import TriggerEvent
 
+from airflow.models.connection import Connection
 from tests_common.test_utils.operators.run_deferrable import run_trigger
 
 
 class TestSQLExecuteQueryTrigger:
-    @mock.patch("airflow.hooks.base.BaseHook.get_hook")
-    def test_run(self, mock_get_hook):
+    @mock.patch("airflow.hooks.base.BaseHook.get_connection")
+    def test_run(self, mock_get_connection):
         data = [(1, "Alice"), (2, "Bob")]
+        mock_connection = mock.MagicMock(spec=Connection)
         mock_hook = mock.MagicMock(spec=DbApiHook)
         mock_hook.get_records.side_effect = lambda sql: data
-        mock_get_hook.return_value = mock_hook
+        mock_get_connection.return_value = mock_connection
+        mock_connection.get_hook.side_effect = lambda hook_params: mock_hook
 
         trigger = SQLExecuteQueryTrigger(sql="SELECT * FROM users;", conn_id="test_conn_id")
         actual = run_trigger(trigger)


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: [#44809](https://github.com/apache/airflow/pull/44809)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Refactored the way how to get the hook as the common sql provider has still to be Airflow 2.9 compatible, so introduced a get_hook method in SQLExecuteQueryTrigger which gets the connection first for given conn_id and then gets the hook with given hook_params on that returned connection as the shortcut method doesn't exist yet in Airflow 2.9

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
