### PR TITLE
Send task logs from KubeExecutor tasks to pod stdout too

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -389,8 +389,13 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
     Session = scoped_session(NonScopedSession)
 
     # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork
-    os.register_at_fork(after_in_child=lambda: engine.dispose(close=False))
-    os.register_at_fork(after_in_child=lambda: async_engine.sync_engine.dispose(close=False))
+    def clean_in_fork():
+        if engine:
+            engine.dispose(close=False)
+        if async_engine:
+            async_engine.sync_engine.dispose(close=False)
+
+    os.register_at_fork(after_in_child=clean_in_fork)
 
 
 DEFAULT_ENGINE_ARGS = {
@@ -480,15 +485,16 @@ def prepare_engine_args(disable_connection_pool=False, pool_class=None):
     return engine_args
 
 
-def dispose_orm():
+def dispose_orm(do_log: bool = True):
     """Properly close pooled database connections."""
     global Session, engine, NonScopedSession
 
     _globals = globals()
-    if "engine" not in _globals and "Session" not in _globals:
+    if _globals.get("engine") is None and _globals.get("Session") is None:
         return
 
-    log.debug("Disposing DB connection pool (PID %s)", os.getpid())
+    if do_log:
+        log.debug("Disposing DB connection pool (PID %s)", os.getpid())
 
     if "Session" in _globals and Session is not None:
         from sqlalchemy.orm.session import close_all_sessions

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -369,7 +369,10 @@ class WatchedSubprocess:
 
     selector: selectors.BaseSelector = attrs.field(factory=selectors.DefaultSelector)
 
-    log: FilteringBoundLogger
+    process_log: FilteringBoundLogger
+
+    subprocess_logs_to_stdout: bool = False
+    """Duplicate log messages to stdout, or only send them to ``self.process_log``."""
 
     @classmethod
     def start(
@@ -425,7 +428,7 @@ class WatchedSubprocess:
             stdin=feed_stdin,
             process=psutil.Process(pid),
             requests_fd=requests_fd,
-            log=logger,
+            process_log=logger,
             **constructor_kwargs,
         )
 
@@ -445,17 +448,22 @@ class WatchedSubprocess:
         # alternatives are used automatically) -- this is a way of having "event-based" code, but without
         # needing full async, to read and process output from each socket as it is received.
 
-        self.selector.register(stdout, selectors.EVENT_READ, self._create_socket_handler(self.log, "stdout"))
+        target_loggers: tuple[FilteringBoundLogger, ...] = (self.process_log,)
+        if self.subprocess_logs_to_stdout:
+            target_loggers += (log,)
+        self.selector.register(
+            stdout, selectors.EVENT_READ, self._create_socket_handler(target_loggers, channel="stdout")
+        )
         self.selector.register(
             stderr,
             selectors.EVENT_READ,
-            self._create_socket_handler(self.log, "stderr", log_level=logging.ERROR),
+            self._create_socket_handler(target_loggers, channel="stderr", log_level=logging.ERROR),
         )
         self.selector.register(
             logs,
             selectors.EVENT_READ,
             make_buffered_socket_reader(
-                process_log_messages_from_subprocess(self.log), on_close=self._on_socket_closed
+                process_log_messages_from_subprocess(target_loggers), on_close=self._on_socket_closed
             ),
         )
         self.selector.register(
@@ -464,10 +472,10 @@ class WatchedSubprocess:
             make_buffered_socket_reader(self.handle_requests(log), on_close=self._on_socket_closed),
         )
 
-    def _create_socket_handler(self, logger, channel, log_level=logging.INFO) -> Callable[[socket], bool]:
+    def _create_socket_handler(self, loggers, channel, log_level=logging.INFO) -> Callable[[socket], bool]:
         """Create a socket handler that forwards logs to a logger."""
         return make_buffered_socket_reader(
-            forward_to_log(logger.bind(chan=channel), level=log_level), on_close=self._on_socket_closed
+            forward_to_log(loggers, chan=channel, level=log_level), on_close=self._on_socket_closed
         )
 
     def _on_socket_closed(self):
@@ -746,7 +754,7 @@ class ActivitySubprocess(WatchedSubprocess):
             if self._what
             else {}
         )
-        upload_to_remote(self.log, log_meta_dict)
+        upload_to_remote(self.process_log, log_meta_dict)
 
     def _monitor_subprocess(self):
         """
@@ -976,7 +984,9 @@ def make_buffered_socket_reader(
     return cb
 
 
-def process_log_messages_from_subprocess(log: FilteringBoundLogger) -> Generator[None, bytes, None]:
+def process_log_messages_from_subprocess(
+    loggers: tuple[FilteringBoundLogger, ...],
+) -> Generator[None, bytes, None]:
     from structlog.stdlib import NAME_TO_LEVEL
 
     while True:
@@ -1003,10 +1013,16 @@ def process_log_messages_from_subprocess(log: FilteringBoundLogger) -> Generator
         if exc := event.pop("exception", None):
             # TODO: convert the dict back to a pretty stack trace
             event["error_detail"] = exc
-        log.log(NAME_TO_LEVEL[event.pop("level")], event.pop("event", None), **event)
+
+        level = NAME_TO_LEVEL[event.pop("level")]
+        msg = event.pop("event", None)
+        for target in loggers:
+            target.log(level, msg, **event)
 
 
-def forward_to_log(target_log: FilteringBoundLogger, level: int) -> Generator[None, bytes, None]:
+def forward_to_log(
+    target_loggers: tuple[FilteringBoundLogger, ...], chan: str, level: int
+) -> Generator[None, bytes, None]:
     while True:
         buf = yield
         line = bytes(buf)
@@ -1014,10 +1030,10 @@ def forward_to_log(target_log: FilteringBoundLogger, level: int) -> Generator[No
         line = line.rstrip()
         try:
             msg = line.decode("utf-8", errors="replace")
-            target_log.log(level, msg)
         except UnicodeDecodeError:
             msg = line.decode("ascii", errors="replace")
-            target_log.log(level, msg)
+        for log in target_loggers:
+            log.log(level, msg, chan=chan)
 
 
 def supervise(
@@ -1029,6 +1045,7 @@ def supervise(
     server: str | None = None,
     dry_run: bool = False,
     log_path: str | None = None,
+    subprocess_logs_to_stdout: bool = False,
     client: Client | None = None,
 ) -> int:
     """
@@ -1041,6 +1058,7 @@ def supervise(
     :param server: Base URL of the API server.
     :param dry_run: If True, execute without actual task execution (simulate run).
     :param log_path: Path to write logs, if required.
+    :param subprocess_logs_to_stdout: Should task logs also be sent to stdout via the main logger.
     :param client: Optional preconfigured client for communication with the server (Mostly for tests).
     :return: Exit code of the process.
     """
@@ -1081,6 +1099,7 @@ def supervise(
         client=client,
         logger=logger,
         bundle_info=bundle_info,
+        subprocess_logs_to_stdout=subprocess_logs_to_stdout,
     )
 
     exit_code = process.wait()

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -516,7 +516,7 @@ class TestWatchedSubprocess:
         mock_kill = mocker.patch("airflow.sdk.execution_time.supervisor.WatchedSubprocess.kill")
 
         proc = ActivitySubprocess(
-            log=mocker.MagicMock(),
+            process_log=mocker.MagicMock(),
             id=TI_ID,
             pid=mock_process.pid,
             stdin=mocker.MagicMock(),
@@ -606,7 +606,7 @@ class TestWatchedSubprocess:
         monkeypatch.setattr(ActivitySubprocess, "TASK_OVERTIME_THRESHOLD", overtime_threshold)
 
         mock_watched_subprocess = ActivitySubprocess(
-            log=mocker.MagicMock(),
+            process_log=mocker.MagicMock(),
             id=TI_ID,
             pid=12345,
             stdin=mocker.Mock(),
@@ -751,7 +751,7 @@ class TestWatchedSubprocessKill:
     @pytest.fixture
     def watched_subprocess(self, mocker, mock_process):
         proc = ActivitySubprocess(
-            log=mocker.MagicMock(),
+            process_log=mocker.MagicMock(),
             id=TI_ID,
             pid=12345,
             stdin=mocker.Mock(),
@@ -937,7 +937,7 @@ class TestHandleRequest:
     def watched_subprocess(self, mocker):
         """Fixture to provide a WatchedSubprocess instance."""
         return ActivitySubprocess(
-            log=mocker.MagicMock(),
+            process_log=mocker.MagicMock(),
             id=TI_ID,
             pid=12345,
             stdin=BytesIO(),

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -138,7 +138,7 @@ class TestDagFileProcessorManager:
         proc.create_time.return_value = time.time()
         proc.wait.return_value = 0
         ret = DagFileProcessorProcess(
-            log=MagicMock(),
+            process_log=MagicMock(),
             id=uuid7(),
             pid=1234,
             process=proc,

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -149,7 +149,7 @@ def supervisor_builder(mocker, session):
 
         process = mocker.Mock(spec=psutil.Process, pid=10 * job.id + 1)
         proc = TriggerRunnerSupervisor(
-            log=mocker.Mock(),
+            process_log=mocker.Mock(),
             id=job.id,
             job=job,
             pid=process.pid,


### PR DESCRIPTION
This is needed so that when the KubeExecutor is asked to get logs for a
running pod they show up in the pod.

This changes the `airflow.sdk.execution_time.execute_workload` entrypoint to
a. produce all logs as JSON, and
b. ask the SDK to send all output log messages to the top level logger to, so
   they appear on stdout.

In order to make the output a bit nicer this also tidies up/removes some of
the logging from dispose_orm so that it doesn't "pollute" the logs (this was
required as due to the current hack we have to upload remote logs, we ended up
alling dispose_orm at the end and that _wasn't_ JSON formatted).

Closes #46894

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
