### PR TITLE
Add DagRunSelect to Graph view + other UI improvements

### DIFF
--- a/airflow/ui/src/components/DagVersionSelect.tsx
+++ b/airflow/ui/src/components/DagVersionSelect.tsx
@@ -84,6 +84,7 @@ const DagVersionSelect = ({ disabled = false }: { readonly disabled?: boolean })
         loadOptions={loadVersions}
         onChange={handleStateChange}
         placeholder="Dag Version"
+        size="sm"
         value={
           selectedVersion === undefined
             ? undefined

--- a/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -66,7 +66,9 @@ export const TaskNode = ({
           <Flex
             // Alternate background color for nested open groups
             bg={isOpen && depth !== undefined && depth % 2 === 0 ? "bg.muted" : "bg"}
-            borderColor={taskInstance?.state ? `${taskInstance.state}.solid` : "border"}
+            borderColor={
+              taskInstance?.state ? `${taskInstance.state}.solid` : isSelected ? "border.inverted" : "border"
+            }
             borderRadius={5}
             borderWidth={isSelected ? 6 : 2}
             height={`${height}px`}

--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -135,6 +135,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
                     onSelectTryNumber(ti.try_number);
                   }
                 }}
+                size="sm"
                 variant={selectedTryNumber === ti.try_number ? "surface" : "outline"}
               >
                 {ti.try_number}

--- a/airflow/ui/src/layouts/Details/DagRunSelect.tsx
+++ b/airflow/ui/src/layouts/Details/DagRunSelect.tsx
@@ -18,11 +18,12 @@
  */
 import { createListCollection, type SelectValueChangeDetails } from "@chakra-ui/react";
 import { forwardRef, type RefObject } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { useGridServiceGridData } from "openapi/queries";
 import type { GridDAGRunwithTIs } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
+import Time from "src/components/Time";
 import { Select } from "src/components/ui";
 
 type DagRunSelected = {
@@ -32,16 +33,12 @@ type DagRunSelected = {
 
 export const DagRunSelect = forwardRef<HTMLDivElement>((_, ref) => {
   const { dagId = "", runId, taskId } = useParams();
-  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-
-  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
 
   const { data, isLoading } = useGridServiceGridData(
     {
       dagId,
       limit: 25,
-      offset,
       orderBy: "-run_after",
     },
     undefined,
@@ -54,34 +51,40 @@ export const DagRunSelect = forwardRef<HTMLDivElement>((_, ref) => {
     })),
   });
 
-  const selectDagRun = ({ items }: SelectValueChangeDetails<DagRunSelected>) =>
+  const selectDagRun = ({ items }: SelectValueChangeDetails<DagRunSelected>) => {
+    const run = items.length > 0 ? `/runs/${items[0]?.run.dag_run_id}` : "";
+
     navigate({
-      pathname: `/dags/${dagId}/runs/${items[0]?.run.dag_run_id}/${taskId === undefined ? "" : `tasks/${taskId}`}`,
-      search: searchParams.toString(),
+      pathname: `/dags/${dagId}${run}/${taskId === undefined ? "" : `tasks/${taskId}`}`,
     });
+  };
 
   return (
     <Select.Root
+      bg="bg"
       collection={runOptions}
-      colorPalette="blue"
       data-testid="dag-run-select"
       disabled={isLoading}
-      maxWidth="500px"
       onValueChange={selectDagRun}
+      size="sm"
       value={runId === undefined ? [] : [runId]}
-      variant="subtle"
+      width="250px"
     >
-      <Select.Trigger>
-        <Select.ValueText placeholder="Run">
+      <Select.Trigger clearable>
+        <Select.ValueText placeholder="All Runs">
           {(items: Array<DagRunSelected>) => (
-            <StateBadge state={items[0]?.run.state}>{items[0]?.value}</StateBadge>
+            <>
+              <Time datetime={items[0]?.run.run_after} />
+              <StateBadge ml={2} state={items[0]?.run.state} />
+            </>
           )}
         </Select.ValueText>
       </Select.Trigger>
       <Select.Content portalRef={ref as RefObject<HTMLElement>} zIndex="popover">
         {runOptions.items.map((option) => (
           <Select.Item item={option} key={option.value}>
-            <StateBadge state={option.run.state}>{option.value}</StateBadge>
+            <Time datetime={option.run.run_after} />
+            <StateBadge ml={2} state={option.run.state} />
           </Select.Item>
         ))}
       </Select.Content>

--- a/airflow/ui/src/layouts/Details/DagRunSelect.tsx
+++ b/airflow/ui/src/layouts/Details/DagRunSelect.tsx
@@ -20,11 +20,11 @@ import { createListCollection, type SelectValueChangeDetails } from "@chakra-ui/
 import { forwardRef, type RefObject } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { useGridServiceGridData } from "openapi/queries";
 import type { GridDAGRunwithTIs } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
+import { useGrid } from "src/queries/useGrid";
 
 type DagRunSelected = {
   run: GridDAGRunwithTIs;
@@ -35,14 +35,7 @@ export const DagRunSelect = forwardRef<HTMLDivElement>((_, ref) => {
   const { dagId = "", runId, taskId } = useParams();
   const navigate = useNavigate();
 
-  const { data, isLoading } = useGridServiceGridData(
-    {
-      dagId,
-      limit: 25,
-      orderBy: "-run_after",
-    },
-    undefined,
-  );
+  const { data, isLoading } = useGrid();
 
   const runOptions = createListCollection<DagRunSelected>({
     items: (data?.dag_runs ?? []).map((dr: GridDAGRunwithTIs) => ({

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -154,21 +154,18 @@ export const Graph = () => {
   const gridRun = gridData?.dag_runs.find((dr) => dr.dag_run_id === runId);
 
   // Add task instances to the node data but without having to recalculate how the graph is laid out
-  const nodes =
-    gridRun?.task_instances === undefined
-      ? data?.nodes
-      : data?.nodes.map((node) => {
-          const taskInstance = gridRun.task_instances.find((ti) => ti.task_id === node.id);
+  const nodes = data?.nodes.map((node) => {
+    const taskInstance = gridRun?.task_instances.find((ti) => ti.task_id === node.id);
 
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              isSelected: node.id === taskId,
-              taskInstance,
-            },
-          };
-        });
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        isSelected: node.id === taskId,
+        taskInstance,
+      },
+    };
+  });
 
   const edges = (data?.edges ?? []).map((edge) => ({
     ...edge,

--- a/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
@@ -77,7 +77,7 @@ export const TaskNames = ({ nodes }: Props) => {
           </chakra.button>
         </Flex>
       ) : (
-        <Link asChild data-testid={node.id}>
+        <Link asChild data-testid={node.id} display="inline">
           <RouterLink
             replace
             to={{
@@ -90,7 +90,6 @@ export const TaskNames = ({ nodes }: Props) => {
               fontWeight="normal"
               isMapped={Boolean(node.is_mapped)}
               label={node.label}
-              mb={1}
               paddingLeft={node.depth * 3 + 2}
               setupTeardownType={node.setup_teardown_type}
             />

--- a/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -33,6 +33,8 @@ import { useLocalStorage } from "usehooks-ts";
 import DagVersionSelect from "src/components/DagVersionSelect";
 import { Select } from "src/components/ui";
 
+import { DagRunSelect } from "./DagRunSelect";
+
 type Props = {
   readonly dagView: string;
   readonly setDagView: (x: "graph" | "grid") => void;
@@ -98,25 +100,29 @@ export const PanelButtons = ({ dagView, setDagView, ...rest }: Props) => {
       <Stack alignItems="flex-end" gap={1} mr={2}>
         <DagVersionSelect disabled={dagView !== "graph"} />
         {dagView === "graph" ? (
-          <Select.Root
-            bg="bg"
-            collection={options}
-            data-testid="filter-duration"
-            onValueChange={handleDepsChange}
-            value={[dependencies]}
-            width="210px"
-          >
-            <Select.Trigger>
-              <Select.ValueText placeholder="Dependencies" />
-            </Select.Trigger>
-            <Select.Content>
-              {options.items.map((option) => (
-                <Select.Item item={option} key={option.value}>
-                  {option.label}
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select.Root>
+          <>
+            <Select.Root
+              bg="bg"
+              collection={options}
+              data-testid="filter-duration"
+              onValueChange={handleDepsChange}
+              size="sm"
+              value={[dependencies]}
+              width="210px"
+            >
+              <Select.Trigger>
+                <Select.ValueText placeholder="Dependencies" />
+              </Select.Trigger>
+              <Select.Content>
+                {options.items.map((option) => (
+                  <Select.Item item={option} key={option.value}>
+                    {option.label}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+            <DagRunSelect />
+          </>
         ) : undefined}
       </Stack>
     </HStack>


### PR DESCRIPTION
Add a dropdown to the graph page to allow a user to quickly switch between dag runs:
<img width="991" alt="Screenshot 2025-03-13 at 11 19 08 AM" src="https://github.com/user-attachments/assets/94fc61b6-59d0-4594-aad6-e6add9105fb3" />

Update a selected task's border when there is no run selected:
<img width="357" alt="Screenshot 2025-03-13 at 11 19 17 AM" src="https://github.com/user-attachments/assets/fcddb08a-66da-4809-b842-97f20e79862f" />

Center task names in a grid row. before it was at the bottom and looking cut off:
<img width="926" alt="Screenshot 2025-03-13 at 11 19 30 AM" src="https://github.com/user-attachments/assets/5c489c16-bb63-43fe-aae3-7512e016c3db" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
