### PR TITLE
Fix `relative_fileloc` when DAGs are parsed with `dags reserialize`

### DIFF
--- a/airflow/cli/commands/remote_commands/dag_command.py
+++ b/airflow/cli/commands/remote_commands/dag_command.py
@@ -647,5 +647,5 @@ def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
         if bundle.name not in bundles_to_reserialize:
             continue
         bundle.initialize()
-        dag_bag = DagBag(bundle.path, include_examples=False)
+        dag_bag = DagBag(bundle.path, bundle_path=bundle.path, include_examples=False)
         dag_bag.sync_to_db(bundle.name, bundle_version=bundle.get_current_version(), session=session)

--- a/tests/cli/commands/remote_commands/test_dag_command.py
+++ b/tests/cli/commands/remote_commands/test_dag_command.py
@@ -788,6 +788,12 @@ class TestCliDagsReserialize:
         serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
         assert serialized_dag_ids == {"test_example_bash_operator", "test_dag_with_no_tags", "test_sensor"}
 
+        example_bash_op = session.execute(
+            select(DagModel).filter(DagModel.dag_id == "test_example_bash_operator")
+        ).scalar()
+        assert example_bash_op.relative_fileloc == "."  # the file _is_ the bundle path
+        assert example_bash_op.fileloc == str(TEST_DAGS_FOLDER / "test_example_bash_operator.py")
+
     @conf_vars({("core", "load_examples"): "false"})
     def test_reserialize_should_support_bundle_name_argument(self, configure_dag_bundles, session):
         with configure_dag_bundles(self.test_bundles_config):


### PR DESCRIPTION
We missed passing in the bundle path (or, maybe when we added bundle path to dagbag it was missed here), but either way this lead to the relative fileloc always being an absolute path.