### PR TITLE
Add Security menu button with iframes

### DIFF
--- a/airflow/ui/src/layouts/Nav/AuthButton.tsx
+++ b/airflow/ui/src/layouts/Nav/AuthButton.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Link } from "@chakra-ui/react";
+import { FiLock } from "react-icons/fi";
+
+import { useAuthLinksServiceGetAuthLinks } from "openapi/queries";
+import { Menu } from "src/components/ui";
+
+import { NavButton } from "./NavButton";
+
+export const AuthButton = () => {
+  const { data: authLinks } = useAuthLinksServiceGetAuthLinks();
+
+  if (authLinks?.total_entries === undefined || authLinks.total_entries < 1) {
+    return undefined;
+  }
+
+  return (
+    <Menu.Root positioning={{ placement: "right" }}>
+      <Menu.Trigger asChild>
+        <NavButton icon={<FiLock size="1.75rem" />} title="Security" />
+      </Menu.Trigger>
+      <Menu.Content>
+        {authLinks.menu_items.map(({ href, text }) => (
+          <Menu.Item asChild key={text} value={text}>
+            <Link aria-label={text} href={href} rel="noopener noreferrer" target="_blank">
+              {text}
+            </Link>
+          </Menu.Item>
+        ))}
+      </Menu.Content>
+    </Menu.Root>
+  );
+};

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -24,6 +24,7 @@ import { AirflowPin } from "src/assets/AirflowPin";
 import { DagIcon } from "src/assets/DagIcon";
 
 import { AdminButton } from "./AdminButton";
+import { AuthButton } from "./AuthButton";
 import { BrowseButton } from "./BrowseButton";
 import { DocsButton } from "./DocsButton";
 import { NavButton } from "./NavButton";
@@ -54,6 +55,7 @@ export const Nav = () => {
         <NavButton icon={<FiDatabase size="1.75rem" />} title="Assets" to="assets" />
         <BrowseButton />
         <AdminButton />
+        <AuthButton />
       </Flex>
       <Flex flexDir="column">
         <DocsButton />

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -24,10 +24,10 @@ import { AirflowPin } from "src/assets/AirflowPin";
 import { DagIcon } from "src/assets/DagIcon";
 
 import { AdminButton } from "./AdminButton";
-import { AuthButton } from "./AuthButton";
 import { BrowseButton } from "./BrowseButton";
 import { DocsButton } from "./DocsButton";
 import { NavButton } from "./NavButton";
+import { SecurityButton } from "./SecurityButton";
 import { UserSettingsButton } from "./UserSettingsButton";
 
 export const Nav = () => {
@@ -55,7 +55,7 @@ export const Nav = () => {
         <NavButton icon={<FiDatabase size="1.75rem" />} title="Assets" to="assets" />
         <BrowseButton />
         <AdminButton />
-        <AuthButton />
+        <SecurityButton />
       </Flex>
       <Flex flexDir="column">
         <DocsButton />

--- a/airflow/ui/src/layouts/Nav/SecurityButton.tsx
+++ b/airflow/ui/src/layouts/Nav/SecurityButton.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FiLock } from "react-icons/fi";
+import { Link } from "react-router-dom";
+
+import { useAuthLinksServiceGetAuthLinks } from "openapi/queries";
+import { Menu } from "src/components/ui";
+
+import { NavButton } from "./NavButton";
+
+export const SecurityButton = () => {
+  const { data: authLinks } = useAuthLinksServiceGetAuthLinks();
+
+  if (authLinks?.total_entries === undefined || authLinks.total_entries < 1) {
+    return undefined;
+  }
+
+  return (
+    <Menu.Root positioning={{ placement: "right" }}>
+      <Menu.Trigger asChild>
+        <NavButton icon={<FiLock size="1.75rem" />} title="Security" />
+      </Menu.Trigger>
+      <Menu.Content>
+        {authLinks.menu_items.map(({ text }) => (
+          <Menu.Item asChild key={text} value={text}>
+            <Link aria-label={text} to={`security/${text.toLowerCase().replace(" ", "-")}`}>
+              {text}
+            </Link>
+          </Menu.Item>
+        ))}
+      </Menu.Content>
+    </Menu.Root>
+  );
+};

--- a/airflow/ui/src/pages/Security.tsx
+++ b/airflow/ui/src/pages/Security.tsx
@@ -16,35 +16,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link } from "@chakra-ui/react";
-import { FiLock } from "react-icons/fi";
+import { Box } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
 
 import { useAuthLinksServiceGetAuthLinks } from "openapi/queries";
-import { Menu } from "src/components/ui";
+import { ProgressBar } from "src/components/ui";
 
-import { NavButton } from "./NavButton";
+import { ErrorPage } from "./Error";
 
-export const AuthButton = () => {
-  const { data: authLinks } = useAuthLinksServiceGetAuthLinks();
+export const Security = () => {
+  const { page } = useParams();
 
-  if (authLinks?.total_entries === undefined || authLinks.total_entries < 1) {
-    return undefined;
+  const { data: authLinks, isLoading } = useAuthLinksServiceGetAuthLinks();
+
+  const link = authLinks?.menu_items.find((mi) => mi.text.toLowerCase().replace(" ", "-") === page);
+
+  if (!link) {
+    if (isLoading) {
+      return (
+        <Box flexGrow={1}>
+          <ProgressBar />
+        </Box>
+      );
+    }
+
+    return <ErrorPage />;
   }
 
   return (
-    <Menu.Root positioning={{ placement: "right" }}>
-      <Menu.Trigger asChild>
-        <NavButton icon={<FiLock size="1.75rem" />} title="Security" />
-      </Menu.Trigger>
-      <Menu.Content>
-        {authLinks.menu_items.map(({ href, text }) => (
-          <Menu.Item asChild key={text} value={text}>
-            <Link aria-label={text} href={href} rel="noopener noreferrer" target="_blank">
-              {text}
-            </Link>
-          </Menu.Item>
-        ))}
-      </Menu.Content>
-    </Menu.Root>
+    <Box flexGrow={1} m={-3}>
+      <iframe
+        sandbox="allow-same-origin allow-forms"
+        src={link.href}
+        style={{ height: "100%", width: "100%" }}
+        title={link.text}
+      />
+    </Box>
   );
 };

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -52,6 +52,7 @@ import { TaskInstances } from "src/pages/TaskInstances";
 import { Variables } from "src/pages/Variables";
 import { XCom } from "src/pages/XCom";
 
+import { Security } from "./pages/Security";
 import { queryClient } from "./queryClient";
 
 const taskInstanceRoutes = [
@@ -122,6 +123,10 @@ export const routerConfig = [
       {
         element: <Plugins />,
         path: "plugins",
+      },
+      {
+        element: <Security />,
+        path: "security/:page",
       },
       {
         element: <Connections />,


### PR DESCRIPTION
use our new auth links endpoint to see if the Navbar should render a Security MenuButton. Then render the auth link in a full page iframe.

<img width="1537" alt="Screenshot 2025-03-13 at 12 54 55 PM" src="https://github.com/user-attachments/assets/1450061c-6f2e-4100-89fe-26d185716f26" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
