### PR TITLE
[task sdk] Remove non-standard log_meta_dict param from upload_to_remote

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -651,8 +651,6 @@ class ActivitySubprocess(WatchedSubprocess):
     TASK_OVERTIME_THRESHOLD: ClassVar[float] = 20.0
     _task_end_time_monotonic: float | None = attrs.field(default=None, init=False)
 
-    _what: TaskInstance | None = attrs.field(default=None, init=False)
-
     decoder: ClassVar[TypeAdapter[ToSupervisor]] = TypeAdapter(ToSupervisor)
 
     @classmethod
@@ -675,7 +673,6 @@ class ActivitySubprocess(WatchedSubprocess):
 
     def _on_child_started(self, ti: TaskInstance, dag_rel_path: str | os.PathLike[str], bundle_info):
         """Send startup message to the subprocess."""
-        self._what = ti
         start_date = datetime.now(tz=timezone.utc)
         try:
             # We've forked, but the task won't start doing anything until we send it the StartupDetails
@@ -744,17 +741,7 @@ class ActivitySubprocess(WatchedSubprocess):
         """
         from airflow.sdk.log import upload_to_remote
 
-        log_meta_dict = (
-            {
-                "dag_id": self._what.dag_id,
-                "task_id": self._what.task_id,
-                "run_id": self._what.run_id,
-                "try_number": str(self._what.try_number),
-            }
-            if self._what
-            else {}
-        )
-        upload_to_remote(self.process_log, log_meta_dict)
+        upload_to_remote(self.process_log)
 
     def _monitor_subprocess(self):
         """

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -477,7 +477,7 @@ def load_remote_log_handler() -> logging.Handler | None:
         configure_logging()
 
 
-def upload_to_remote(logger: FilteringBoundLogger, log_meta_dict: dict[str, Any]):
+def upload_to_remote(logger: FilteringBoundLogger):
     # We haven't yet switched the Remote log handlers over, they are still wired up in providers as
     # logging.Handlers (but we should re-write most of them to just be the upload and read instead of full
     # variants.) In the mean time, lets just create the right handler directly
@@ -511,7 +511,6 @@ def upload_to_remote(logger: FilteringBoundLogger, log_meta_dict: dict[str, Any]
     # set_context() which opens a real FH again. (And worse, in some cases it _truncates_ the file too). This
     # is just for the first Airflow 3 betas, but we will re-write a better remote log interface that isn't
     # tied to being a logging Handler.
-    handler.log_meta_dict = log_meta_dict  # type: ignore[attr-defined]
     handler.log_relative_path = relative_path.as_posix()  # type: ignore[attr-defined]
     handler.upload_on_close = True  # type: ignore[attr-defined]
 


### PR DESCRIPTION
Remove the log_meta_dict parameter from the `upload_to_remote` function in the Task SDK which is a non-standard attribute of a log handler and should not be set here. The presence of this parameter was breaking the triggerer.

closes: #47733

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
