### PR TITLE
Hide backfills button and tab if the dag has no schedule

### DIFF
--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -72,7 +72,12 @@ export const Dag = () => {
 
   return (
     <ReactFlowProvider>
-      <DetailsLayout dag={dag} error={error ?? runsError} isLoading={isLoading || isLoadingRuns} tabs={tabs}>
+      <DetailsLayout
+        dag={dag}
+        error={error ?? runsError}
+        isLoading={isLoading || isLoadingRuns}
+        tabs={tabs.filter((tab) => !(dag?.timetable_summary === null && tab.value === "backfills"))}
+      >
         <Header
           dag={dag}
           dagWithRuns={dagWithRuns}

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -101,7 +101,7 @@ export const Header = ({
                 text="Dag Docs"
               />
             )}
-            <RunBackfillButton dag={dag} />
+            {dag.timetable_summary === null ? undefined : <RunBackfillButton dag={dag} />}
             <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
           </>
         )


### PR DESCRIPTION
You can't run a backfill on a dag without a schedule. In that case, let's hide the button and tab

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
