### PR TITLE
Harden secret key usage in some other areas

### DIFF
--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -35,6 +35,7 @@ from airflow.api_fastapi.core_api.middleware import FlaskExceptionsMiddleware
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.settings import AIRFLOW_PATH
+from airflow.utils.jwt_signer import get_signing_key
 
 log = logging.getLogger(__name__)
 
@@ -162,7 +163,7 @@ def init_config(app: FastAPI) -> None:
     # and 9 (slowest, most compression)
     app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
 
-    app.state.secret_key = conf.get("webserver", "secret_key")
+    app.state.secret_key = get_signing_key("webserver", "secret_key")
 
 
 def init_error_handlers(app: FastAPI) -> None:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -96,11 +96,11 @@ def _fetch_logs_from_service(url, log_relative_path):
     # Import occurs in function scope for perf. Ref: https://github.com/apache/airflow/pull/21438
     import requests
 
-    from airflow.utils.jwt_signer import JWTSigner
+    from airflow.utils.jwt_signer import JWTSigner, get_signing_key
 
     timeout = conf.getint("webserver", "log_fetch_timeout_sec", fallback=None)
     signer = JWTSigner(
-        secret_key=conf.get("webserver", "secret_key"),
+        secret_key=get_signing_key("webserver", "secret_key"),
         expiration_time_in_seconds=conf.getint("webserver", "log_request_clock_grace", fallback=30),
         audience="task-instance-logs",
     )

--- a/airflow/utils/serve_logs.py
+++ b/airflow/utils/serve_logs.py
@@ -37,7 +37,7 @@ from werkzeug.exceptions import HTTPException
 
 from airflow.configuration import conf
 from airflow.utils.docs import get_docs_url
-from airflow.utils.jwt_signer import JWTSigner
+from airflow.utils.jwt_signer import JWTSigner, get_signing_key
 from airflow.utils.module_loading import import_string
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ def create_app():
         except Exception as e:
             raise ImportError(f"Unable to load {log_config_class} due to error: {e}")
     signer = JWTSigner(
-        secret_key=conf.get("webserver", "secret_key"),
+        secret_key=get_signing_key("webserver", "secret_key"),
         expiration_time_in_seconds=expiration_time_in_seconds,
         audience="task-instance-logs",
     )


### PR DESCRIPTION
While backporting #46966 into #47755 I saw some other areas where the secret key of Airflow is used ... added a similar safeguard to ensure no empty string is used in case of a bad configuration.