### PR TITLE
Add OAuth token support for Snowflake connection configuration

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -291,6 +291,13 @@ class SnowflakeHook(DbApiHook):
             conn_config.pop("login", None)
             conn_config.pop("password", None)
 
+        token = self._get_field(extra_dict, "token") or ""
+        if token:
+            conn_config["token"] = token
+            conn_config["authenticator"] = "oauth"
+            conn_config.pop("login", None)
+            conn_config.pop("password", None)
+
         # configure custom target hostname and port, if specified
         snowflake_host = extra_dict.get("host")
         snowflake_port = extra_dict.get("port")


### PR DESCRIPTION
This pull request includes an enhancement to the Snowflake hook in the Airflow provider. The most important change is the addition of support for OAuth token authentication.

Enhancements to Snowflake hook:

* [`providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py`](diffhunk://#diff-54cff6b3744eb51be3efafabe90c546894a4d563cd7c8d81946e3f86c429492dR294-R300): Added support for OAuth token authentication by including the `token` and `authenticator` fields in the connection parameters, and removing `login` and `password` if a token is provided.