### PR TITLE
Test `MwaaHook`'s IAM fallback in system test

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_mwaa.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa.py
@@ -85,6 +85,10 @@ with DAG(
     )
     # [END howto_sensor_mwaa_dag_run]
 
+    # This task in the system test verifies that the MwaaHook's IAM fallback mechanism continues to work with
+    # the live MWAA API. This fallback depends on parsing a specific error message from the MWAA API, so we
+    # want to ensure we find out if the API response format ever changes. Unit tests cover this with mocked
+    # responses, but this system test validates against the real API.
     @task
     def test_iam_fallback(role_to_assume_arn, mwaa_env_name):
         sts_client = StsHook().conn

--- a/providers/amazon/tests/system/amazon/aws/example_mwaa.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa.py
@@ -18,8 +18,13 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import boto3
+
+from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
+from airflow.providers.amazon.aws.hooks.mwaa import MwaaHook
+from airflow.providers.amazon.aws.hooks.sts import StsHook
 from airflow.providers.amazon.aws.operators.mwaa import MwaaTriggerDagRunOperator
 from airflow.providers.amazon.aws.sensors.mwaa import MwaaDagRunSensor
 from system.amazon.aws.utils import SystemTestContextBuilder
@@ -29,6 +34,7 @@ DAG_ID = "example_mwaa"
 # Externally fetched variables:
 EXISTING_ENVIRONMENT_NAME_KEY = "ENVIRONMENT_NAME"
 EXISTING_DAG_ID_KEY = "DAG_ID"
+ROLE_WITHOUT_INVOKE_REST_API_ARN_KEY = "ROLE_WITHOUT_INVOKE_REST_API_ARN"
 
 sys_test_context_task = (
     SystemTestContextBuilder()
@@ -45,6 +51,7 @@ sys_test_context_task = (
     # Make sure to set the environment variables with appropriate values
     .add_variable(EXISTING_ENVIRONMENT_NAME_KEY)
     .add_variable(EXISTING_DAG_ID_KEY)
+    .add_variable(ROLE_WITHOUT_INVOKE_REST_API_ARN_KEY)
     .build()
 )
 
@@ -58,6 +65,7 @@ with DAG(
     test_context = sys_test_context_task()
     env_name = test_context[EXISTING_ENVIRONMENT_NAME_KEY]
     trigger_dag_id = test_context[EXISTING_DAG_ID_KEY]
+    restricted_role_arn = test_context[ROLE_WITHOUT_INVOKE_REST_API_ARN_KEY]
 
     # [START howto_operator_mwaa_trigger_dag_run]
     trigger_dag_run = MwaaTriggerDagRunOperator(
@@ -77,12 +85,32 @@ with DAG(
     )
     # [END howto_sensor_mwaa_dag_run]
 
+    @task
+    def test_iam_fallback(role_to_assume_arn, mwaa_env_name):
+        sts_client = StsHook().conn
+        assumed_role = sts_client.assume_role(
+            RoleArn=role_to_assume_arn, RoleSessionName="MwaaSysTestIamFallback"
+        )
+
+        credentials = assumed_role["Credentials"]
+        session = boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
+
+        mwaa_hook = MwaaHook()
+        mwaa_hook.conn = session.client("mwaa")
+        response = mwaa_hook.invoke_rest_api(env_name=mwaa_env_name, path="/dags", method="GET")
+        return "dags" in response["RestApiResponse"]
+
     chain(
         # TEST SETUP
         test_context,
         # TEST BODY
         trigger_dag_run,
         wait_for_dag_run,
+        test_iam_fallback(restricted_role_arn, env_name),
     )
 
     from tests_common.test_utils.watcher import watcher


### PR DESCRIPTION
After [discussion in another PR](https://github.com/apache/airflow/pull/47035#discussion_r1980163095), I added this test to make sure we find out if the the IAM fallback in `MwaaHook` (meant to facilitate users who don't have `airflow:InvokeRestApi` policy in their AWS IAM role) ever stops working, possibly due to the error response changing.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
