### PR TITLE
Added clarity about task operators being re-created for deferred exec…

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/baseoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/baseoperator.py
@@ -1547,6 +1547,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     ) -> NoReturn:
         """
         Mark this Operator "deferred", suspending its execution until the provided trigger fires an event.
+        When resumed, a new instance of this Operator will be created to continue execution - any local state
+        will be lost.
 
         This is achieved by raising a special exception (TaskDeferred)
         which is caught in the main _execute_task wrapper. Triggers can send execution back to task or end


### PR DESCRIPTION
…ution.

This adds a sentence in the baseoperator.defer() that clears up my confusion experienced in https://github.com/apache/airflow/pull/38916#issuecomment-2700006625.
The authoritative documentation can be found at https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html#triggering-deferral under the code block

Does anything else need to be done for a merge since there's no code changes?