### PR TITLE
Fix k8s flaky test - JWT secret might be different

### DIFF
--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -38,6 +38,11 @@ from urllib3.util.retry import Retry
 CLUSTER_FORWARDED_PORT = os.environ.get("CLUSTER_FORWARDED_PORT") or "8080"
 KUBERNETES_HOST_PORT = (os.environ.get("CLUSTER_HOST") or "localhost") + ":" + CLUSTER_FORWARDED_PORT
 EXECUTOR = os.environ.get("EXECUTOR")
+CONFIG_MAP_NAME = "airflow-config"
+CONFIG_MAP_KEY = "airflow.cfg"
+AIRFLOW_API_SERVER_JWT_SECRET = os.environ.get(
+    "AIRFLOW_API_SERVER_JWT_SECRET", "airflow_api_server_jwt_secret"
+)
 
 print()
 print(f"Cluster host/port used: ${KUBERNETES_HOST_PORT}")
@@ -60,9 +65,12 @@ class BaseK8STest:
 
     @pytest.fixture(autouse=True)
     def base_tests_setup(self, request):
+        # only restart the deployment if the configmap was updated
+        # speed up the test and make the airflow-api-server deployment more stable
         if self.set_api_server_base_url_config():
-            # only restart the deployment if the configmap was updated
-            # speed up the test and make the airflow-api-server deployment more stable
+            self.rollout_restart_deployment("airflow-api-server")
+            self.ensure_deployment_health("airflow-api-server")
+        if self.set_api_auth_jwt_secret_config():
             self.rollout_restart_deployment("airflow-api-server")
             self.ensure_deployment_health("airflow-api-server")
 
@@ -315,42 +323,58 @@ class BaseK8STest:
         # escape newlines and double quotes
         return airflow_cfg_str.replace("\n", "\\n").replace('"', '\\"')
 
-    def set_api_server_base_url_config(self) -> bool:
-        """Set [api/base_url] with `f"http://{KUBERNETES_HOST_PORT}"` as env in k8s configmap.
+    def set_airflow_cfg_in_kubernetes_configmap(self, section: str, key: str, value: str) -> bool:
+        """Set [section/key] with `value` in airflow.cfg in k8s configmap.
 
         :return: True if the configmap was updated successfully, False otherwise
         """
-        configmap_name = "airflow-config"
-        configmap_key = "airflow.cfg"
         original_configmap_json_str = check_output(
-            ["kubectl", "get", "configmap", configmap_name, "-n", "airflow", "-o", "json"]
+            ["kubectl", "get", "configmap", CONFIG_MAP_NAME, "-n", "airflow", "-o", "json"]
         ).decode()
         original_config_map = json.loads(original_configmap_json_str)
-        original_airflow_cfg = original_config_map["data"][configmap_key]
-        # set [api/base_url] with `f"http://{KUBERNETES_HOST_PORT}"` in airflow.cfg
+        original_airflow_cfg = original_config_map["data"][CONFIG_MAP_KEY]
+        # set [section/key] with `value` in airflow.cfg
         # The airflow.cfg is toml format, so we need to convert it to json
         airflow_cfg_dict = self._parse_airflow_cfg_as_dict(original_airflow_cfg)
-        if "api" not in airflow_cfg_dict:
-            airflow_cfg_dict["api"] = {}
-        airflow_cfg_dict["api"]["base_url"] = f"http://{KUBERNETES_HOST_PORT}"
+        if section not in airflow_cfg_dict:
+            airflow_cfg_dict[section] = {}
+        airflow_cfg_dict[section][key] = value
         # update the configmap with the new airflow.cfg
         patch_configmap_result = check_output(
             [
                 "kubectl",
                 "patch",
                 "configmap",
-                configmap_name,
+                CONFIG_MAP_NAME,
                 "-n",
                 "airflow",
                 "--type",
                 "merge",
                 "-p",
-                f'{{"data": {{"{configmap_key}": "{self._parse_airflow_cfg_dict_as_escaped_toml(airflow_cfg_dict)}"}}}}',
+                f'{{"data": {{"{CONFIG_MAP_KEY}": "{self._parse_airflow_cfg_dict_as_escaped_toml(airflow_cfg_dict)}"}}}}',
             ]
         ).decode()
         if "(no change)" in patch_configmap_result:
             return False
         return True
+
+    def set_api_server_base_url_config(self) -> bool:
+        """Set [api/base_url] with `f"http://{KUBERNETES_HOST_PORT}"` as env in k8s configmap.
+
+        :return: True if the configmap was updated successfully, False otherwise
+        """
+        return self.set_airflow_cfg_in_kubernetes_configmap(
+            "api", "base_url", f"http://{KUBERNETES_HOST_PORT}"
+        )
+
+    def set_api_auth_jwt_secret_config(self) -> bool:
+        """Set [api/auth_jwt_secret] with AIRFLOW_API_SERVER_JWT_SECRET as env in k8s configmap."
+
+        :return: True if the configmap was updated successfully, False otherwise"
+        """
+        return self.set_airflow_cfg_in_kubernetes_configmap(
+            "api", "auth_jwt_secret", AIRFLOW_API_SERVER_JWT_SECRET
+        )
 
     def ensure_dag_expected_state(self, host, logical_date, dag_id, expected_final_state, timeout):
         tries = 0


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/47532#issuecomment-2718668749

## What  

Ensure that `[api/auth_jwt_secret]` in `airflow.cfg` is consistent in the Kubernetes ConfigMap for the `airflow-api-server` deployment.