### PR TITLE
[Internal API][only 2.10] Fix issue that task instance note field not possible to set via the internal api. 

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -801,6 +801,8 @@ def _execute_task(task_instance: TaskInstance | TaskInstancePydantic, context: C
 
 
 def _set_ti_attrs(target, source, include_dag_run=False):
+    from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
+
     # Fields ordered per model definition
     target.start_date = source.start_date
     target.end_date = source.end_date
@@ -826,6 +828,8 @@ def _set_ti_attrs(target, source, include_dag_run=False):
     target.trigger_id = source.trigger_id
     target.next_method = source.next_method
     target.next_kwargs = source.next_kwargs
+    if source.note and isinstance(source, TaskInstancePydantic):
+        target.note = source.note
 
     if include_dag_run:
         target.execution_date = source.execution_date

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -123,6 +123,7 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
     dag_model: Optional[DagModelPydantic]
     raw: Optional[bool]
     is_trigger_log_context: Optional[bool]
+    note: Optional[str] = None
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 
     @property


### PR DESCRIPTION
# Overview

This PR fixes the issue that it is not possible to set the task instance note field view the internal api. Without this the Edge worker is not able to update the note filed of the task_instance. To fix this the TaskInstancePydantic model was updated with the note field and the function which converts sets the ti attributes to convert pydantic into TaskInstance set the note field. This enables the Edge worker to set the note field of an task instance. This is pointing to only to the 2.10 test branch as the code will be complete change in Airflow 3.

# Details of change:
* Add note field to the TaskInstancePydantic class.
* Allow _set_ti_attrs function to set the note field of the task instance.
* Only relevant for the 2.10 versions.

