### PR TITLE
[Metric] New ti.running metric with queue field label

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -251,6 +251,9 @@ Name                                                 Description
 ``triggerer.capacity_left.<hostname>``               Capacity left on a triggerer to run triggers (described by hostname)
 ``triggerer.capacity_left``                          Capacity left on a triggerer to run triggers (described by hostname).
                                                      Metric with hostname tagging.
+``ti.running.<queue>.<dag_id>.<task_id>``            Number of running tasks in a given dag. As ti.start and ti.finish can run out of sync this metric shows all running tis.
+``ti.running``                                       Number of running tasks in a given dag. As ti.start and ti.finish can run out of sync this metric shows all running tis.
+                                                     Metric with queue, dag_id and task_id tagging.
 ==================================================== ========================================================================
 
 Timers

--- a/airflow-core/docs/administration-and-deployment/scheduler.rst
+++ b/airflow-core/docs/administration-and-deployment/scheduler.rst
@@ -260,6 +260,14 @@ However, you can also look at other non-performance-related scheduler configurat
   this, so this should be set to match the same period as your StatsD roll-up
   period.
 
+
+- :ref:`config:scheduler__running_metrics_interval`
+
+  How often (in seconds) should running task instance stats be sent to StatsD
+  (if statsd_on is enabled). This is a *relatively* expensive query to compute
+  this, so this should be set to match the same period as your StatsD roll-up
+  period.
+
 - :ref:`config:scheduler__orphaned_tasks_check_interval`
 
   How often (in seconds) should the scheduler check for orphaned tasks or dead

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2339,6 +2339,13 @@ scheduler:
       type: float
       example: ~
       default: "5.0"
+    running_metrics_interval:
+      description: |
+        How often (in seconds) should running task instance stats be sent to StatsD (if statsd_on is enabled)
+      version_added: 3.0.0
+      type: float
+      example: ~
+      default: "30.0"
     scheduler_health_check_threshold:
       description: |
         If the last scheduler heartbeat happened more than ``[scheduler] scheduler_health_check_threshold``

--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -112,3 +112,10 @@ mappings:
     name: "airflow_executor_running_tasks"
     labels:
       executor: "$1"
+
+  - match: airflow.ti.running.*.*.*
+    name: "airflow_ti_running"
+    labels:
+      queue: "$1"
+      dag_id: "$2"
+      task_id: "$3"


### PR DESCRIPTION
Hi Airflow community,

with this PR we want to add a new metric named ti.running with the queue label. Let me explain why I decided to introduce this new metric:
In our Airflow deployment we are using different queues to shift different workflow to different worker types (EdgeWorker CeleryWorker). We want to have a dashboard which shows number of running tasks for the different queues. 

1) The issue by using the ti.start and ti.finish counters are that they are running out of sync if the statsd resets counters so only added the queue field into the metrics and make a query which sub ti.finish from ti.start does not work.
2) Then we have the executor.running_tasks metric. The issue with this metric is that the self.running in the executor contains only the TaskInstanceKey values which do not contain the queue.

We are open for new ideas to export this metric in a different way!
But for the moment we ended in this solution. We think also other people are interested in this metric by filter on the queue label in der future when using the Celery worker workload and Edge worker workload in the same Airflow instance. 