### PR TITLE
AIP-38 Redirect to login page on invalid JWT token

### DIFF
--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -59,7 +59,7 @@ async def get_user(token_str: Annotated[str, Depends(oauth2_scheme)]) -> BaseUse
     except ExpiredSignatureError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Token Expired")
     except InvalidTokenError:
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "JWT token is not valid")
 
 
 GetUserDep = Annotated[BaseUser, Depends(get_user)]

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,6 +23,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
+import type { HTTPExceptionResponse } from "openapi/requests/types.gen";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
@@ -34,8 +35,11 @@ import { tokenHandler } from "./utils/tokenHandler";
 // redirect to login page if the API responds with unauthorized or forbidden errors
 axios.interceptors.response.use(
   (response) => response,
-  (error: AxiosError) => {
-    if (error.response?.status === 401) {
+  (error: AxiosError<HTTPExceptionResponse>) => {
+    if (
+      error.response?.status === 401 ||
+      (error.response?.status === 403 && error.response.data.detail === "JWT token is not valid")
+    ) {
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);

--- a/tests/api_fastapi/core_api/test_security.py
+++ b/tests/api_fastapi/core_api/test_security.py
@@ -66,7 +66,7 @@ class TestFastApiSecurity:
         auth_manager.get_user_from_token.side_effect = InvalidTokenError()
         mock_get_auth_manager.return_value = auth_manager
 
-        with pytest.raises(HTTPException, match="Forbidden"):
+        with pytest.raises(HTTPException, match="JWT token is not valid"):
             await get_user(token_str)
 
         auth_manager.get_user_from_token.assert_called_once_with(token_str)


### PR DESCRIPTION
Redirect users to the login page in case they have a token but it is invalid. (server was restarted with a new key or any other reason).

Other standard 403 forbidden because of permissions not met will still remain on the page and see a 403 error.