### PR TITLE
Scroll to a line number in log by link

### DIFF
--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Code, VStack } from "@chakra-ui/react";
+import { Box, Code, VStack, useToken } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { useLayoutEffect } from "react";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { ProgressBar } from "src/components/ui";
+import { useColorMode } from "src/context/colorMode";
 
 type Props = {
   readonly error: unknown;
@@ -32,19 +33,26 @@ type Props = {
 };
 
 export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: Props) => {
+  const { colorMode } = useColorMode();
+  const [bgLight, bgDark] = useToken("colors", ["blue.400", "blue.700"]);
+
   useLayoutEffect(() => {
     if (location.hash) {
       const hash = location.hash.replace("#", "");
 
       setTimeout(() => {
-        const element = document.querySelector(`[id='${hash}']`);
+        const element = document.querySelector<HTMLElement>(`[id='${hash}']`);
 
+        if (element !== null) {
+          element.style.background = (colorMode === "light" ? bgLight : bgDark) as string;
+        }
         element?.scrollIntoView({
           behavior: "smooth",
+          block: "center",
         });
       }, 100);
     }
-  });
+  }, [isLoading, bgDark, bgLight, colorMode]);
 
   return (
     <Box>

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, Code, VStack } from "@chakra-ui/react";
 import type { ReactNode } from "react";
+import { useLayoutEffect } from "react";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { ProgressBar } from "src/components/ui";
@@ -30,24 +31,40 @@ type Props = {
   readonly wrap: boolean;
 };
 
-export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: Props) => (
-  <Box>
-    <ErrorAlert error={error ?? logError} />
-    <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
-    <Code
-      css={{
-        "& *::selection": {
-          bg: "blue.subtle",
-        },
-      }}
-      overflow="auto"
-      py={3}
-      textWrap={wrap ? "pre" : "nowrap"}
-      width="100%"
-    >
-      <VStack alignItems="flex-start" gap={0}>
-        {parsedLogs}
-      </VStack>
-    </Code>
-  </Box>
-);
+export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: Props) => {
+  useLayoutEffect(() => {
+    if (location.hash) {
+      const hash = location.hash.replace("#", "");
+
+      setTimeout(() => {
+        const element = document.querySelector(`[id='${hash}']`);
+
+        element?.scrollIntoView({
+          behavior: "smooth",
+        });
+      }, 100);
+    }
+  });
+
+  return (
+    <Box>
+      <ErrorAlert error={error ?? logError} />
+      <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
+      <Code
+        css={{
+          "& *::selection": {
+            bg: "blue.subtle",
+          },
+        }}
+        overflow="auto"
+        py={3}
+        textWrap={wrap ? "pre" : "nowrap"}
+        width="100%"
+      >
+        <VStack alignItems="flex-start" gap={0}>
+          {parsedLogs}
+        </VStack>
+      </Code>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -22,7 +22,6 @@ import { useLayoutEffect } from "react";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { ProgressBar } from "src/components/ui";
-import { useColorMode } from "src/context/colorMode";
 
 type Props = {
   readonly error: unknown;
@@ -33,8 +32,7 @@ type Props = {
 };
 
 export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: Props) => {
-  const { colorMode } = useColorMode();
-  const [bgLight, bgDark] = useToken("colors", ["blue.400", "blue.700"]);
+  const [bgLine] = useToken("colors", ["blue.emphasized"]);
 
   useLayoutEffect(() => {
     if (location.hash) {
@@ -44,7 +42,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
         const element = document.querySelector<HTMLElement>(`[id='${hash}']`);
 
         if (element !== null) {
-          element.style.background = (colorMode === "light" ? bgLight : bgDark) as string;
+          element.style.background = bgLine as string;
         }
         element?.scrollIntoView({
           behavior: "smooth",
@@ -52,7 +50,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
         });
       }, 100);
     }
-  }, [isLoading, bgDark, bgLight, colorMode]);
+  }, [isLoading, bgLine]);
 
   return (
     <Box>

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -20,6 +20,7 @@ import { chakra, Code } from "@chakra-ui/react";
 import type { UseQueryOptions } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import innerText from "react-innertext";
+import { Link } from "react-router-dom";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
 import type {
@@ -43,6 +44,7 @@ type ParseLogsProps = {
   data: TaskInstancesLogResponse["content"];
   logLevelFilters?: Array<string>;
   sourceFilters?: Array<string>;
+  taskInstance?: TaskInstanceResponse;
 };
 
 type RenderStructuredLogProps = {
@@ -50,6 +52,7 @@ type RenderStructuredLogProps = {
   logLevelFilters?: Array<string>;
   logMessage: string | StructuredLogMessage;
   sourceFilters?: Array<string>;
+  taskInstance?: TaskInstanceResponse;
 };
 
 const renderStructuredLog = ({
@@ -57,6 +60,7 @@ const renderStructuredLog = ({
   logLevelFilters,
   logMessage,
   sourceFilters,
+  taskInstance,
 }: RenderStructuredLogProps) => {
   if (typeof logMessage === "string") {
     return (
@@ -124,13 +128,18 @@ const renderStructuredLog = ({
   }
 
   return (
-    <chakra.p key={index} lineHeight={1.5}>
-      {elements}
-    </chakra.p>
+    <Link
+      key={index}
+      to={`/dags/${taskInstance?.dag_id}/runs/${taskInstance?.dag_run_id}/tasks/${taskInstance?.task_id}#${index}`}
+    >
+      <chakra.p id={index.toString()} key={index} lineHeight={1.5}>
+        {elements}
+      </chakra.p>
+    </Link>
   );
 };
 
-const parseLogs = ({ data, logLevelFilters, sourceFilters }: ParseLogsProps) => {
+const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance }: ParseLogsProps) => {
   let warning;
   let parsedLines;
   let startGroup = false;
@@ -148,7 +157,7 @@ const parseLogs = ({ data, logLevelFilters, sourceFilters }: ParseLogsProps) => 
         }
       }
 
-      return renderStructuredLog({ index, logLevelFilters, logMessage: datum, sourceFilters });
+      return renderStructuredLog({ index, logLevelFilters, logMessage: datum, sourceFilters, taskInstance });
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "An error occurred.";
@@ -232,6 +241,7 @@ export const useLogs = (
     data: data?.content ?? [],
     logLevelFilters,
     sourceFilters,
+    taskInstance,
   });
 
   return { data: parsedData, ...rest };

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -91,6 +91,16 @@ const renderStructuredLog = ({
     return "";
   }
 
+  elements.push(
+    <Link
+      key={`line_${index}`}
+      to={`/dags/${taskInstance?.dag_id}/runs/${taskInstance?.dag_run_id}/tasks/${taskInstance?.task_id}#${index}`}
+    >
+      {index}
+    </Link>,
+    " ",
+  );
+
   if (Boolean(timestamp)) {
     elements.push("[", <Time datetime={timestamp} key={0} />, "] ");
   }
@@ -128,14 +138,9 @@ const renderStructuredLog = ({
   }
 
   return (
-    <Link
-      key={index}
-      to={`/dags/${taskInstance?.dag_id}/runs/${taskInstance?.dag_run_id}/tasks/${taskInstance?.task_id}#${index}`}
-    >
-      <chakra.p id={index.toString()} key={index} lineHeight={1.5}>
-        {elements}
-      </chakra.p>
-    </Link>
+    <chakra.p id={index.toString()} key={index} lineHeight={1.5}>
+      {elements}
+    </chakra.p>
   );
 };
 

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -152,6 +152,9 @@ const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance }: Parse
   let groupName = "";
   const sources: Array<string> = [];
 
+  // open the summary when hash is present since the link might have a hash linking to a line
+  const open = Boolean(location.hash);
+
   try {
     parsedLines = data.map((datum, index) => {
       if (typeof datum !== "string" && "logger" in datum) {
@@ -185,7 +188,7 @@ const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance }: Parse
     } else if (text.includes("::endgroup::")) {
       startGroup = false;
       const group = (
-        <details key={groupName} style={{ width: "100%" }}>
+        <details key={groupName} open={open} style={{ width: "100%" }}>
           <summary data-testid={`summary-${groupName}`}>
             <chakra.span color="fg.info" cursor="pointer">
               {groupName}


### PR DESCRIPTION
The implementation adds an `id` per log line span element. The line number is prepended to the log line. Then on clicking the line number the page scrolls to the line. Then the URL with line number in hash can be copied and shared. On opening the URL the hash value line number is detected and scrolls to the line number. When the hash is present then log groups are expanded on load since the page scrolls to the id and the id can be part of content inside the log group.

Notes to reviewer and self

1. On clicking a line inside the log group I am seeing the group getting duplicated. I have seen this in in progress task logs with log group too sometime back I guess. On page refresh the rendering is correct with no duplicates. This could be unrelated to this PR and perhaps a separate issue.
2. Perhaps on clicking the line number don't scroll and just copy the url content to be shared.

Closes https://github.com/apache/airflow/issues/47787

Demo video

https://github.com/user-attachments/assets/364f137d-8967-475f-b57f-7df36a199f6d

