### PR TITLE
Revert "AIP-38 Redirect to login page on invalid JWT token"

### DIFF
--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -59,7 +59,7 @@ async def get_user(token_str: Annotated[str, Depends(oauth2_scheme)]) -> BaseUse
     except ExpiredSignatureError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Token Expired")
     except InvalidTokenError:
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "JWT token is not valid")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
 
 
 GetUserDep = Annotated[BaseUser, Depends(get_user)]

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,7 +23,6 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
-import type { HTTPExceptionResponse } from "openapi/requests/types.gen";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
@@ -35,11 +34,8 @@ import { tokenHandler } from "./utils/tokenHandler";
 // redirect to login page if the API responds with unauthorized or forbidden errors
 axios.interceptors.response.use(
   (response) => response,
-  (error: AxiosError<HTTPExceptionResponse>) => {
-    if (
-      error.response?.status === 401 ||
-      (error.response?.status === 403 && error.response.data.detail === "JWT token is not valid")
-    ) {
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);

--- a/tests/api_fastapi/core_api/test_security.py
+++ b/tests/api_fastapi/core_api/test_security.py
@@ -66,7 +66,7 @@ class TestFastApiSecurity:
         auth_manager.get_user_from_token.side_effect = InvalidTokenError()
         mock_get_auth_manager.return_value = auth_manager
 
-        with pytest.raises(HTTPException, match="JWT token is not valid"):
+        with pytest.raises(HTTPException, match="Forbidden"):
             await get_user(token_str)
 
         auth_manager.get_user_from_token.assert_called_once_with(token_str)


### PR DESCRIPTION
Reverts apache/airflow#47791

We are experiencing issue with infinite redirection loop.