### PR TITLE
Added Copy Code Button to Cody Dag Code

### DIFF
--- a/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -31,6 +31,7 @@ import {
 import DagVersionSelect from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
+import { ClipboardRoot, ClipboardButton } from "src/components/ui";
 import { ProgressBar } from "src/components/ui";
 import { useColorMode } from "src/context/colorMode";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
@@ -117,6 +118,9 @@ export const Code = () => {
         </HStack>
         <HStack>
           <DagVersionSelect />
+          <ClipboardRoot value={code?.content ?? ""}>
+            <ClipboardButton />
+          </ClipboardRoot>
           <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
             {wrap ? "Unwrap" : "Wrap"}
           </Button>
@@ -138,6 +142,13 @@ export const Code = () => {
 
               // Skip line number span when applying line break styles https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/376#issuecomment-1584440759
               if (lineNumberElement) {
+                if (lineNumberElement.properties) {
+                  lineNumberElement.properties.style = {
+                    ...(lineNumberElement.properties.style as Record<string, string>),
+                    WebkitUserSelect: "none",
+                  };
+                }
+
                 row.children = [
                   lineNumberElement,
                   {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Added Copy Code Button to Cody Dag Code

Created a button to easily copy the code for a dag, similar to the wrap button. In addition, I implemented new styling to the SyntaxHighlighter used for the code display so that line numbers are not selected while selecting the code text in Safari.

This change is related to the issue https://github.com/apache/airflow/issues/47675
I made a previous pull request here: https://github.com/apache/airflow/pull/47793 but ran into issues with my local fork and was struggling to resolve it so I decided to make a new fork and implement fixes from scratch. Now using the clipboard component as suggested.