### PR TITLE
Fix static checks in v2-10-test branch

### DIFF
--- a/airflow/serialization/serializers/iceberg.py
+++ b/airflow/serialization/serializers/iceberg.py
@@ -48,7 +48,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         properties[k] = fernet.encrypt(v.encode("utf-8")).decode("utf-8")
 
     data = {
-        "identifier": o.identifier,
+        "identifier": o.name(),
         "catalog_properties": properties,
     }
 

--- a/scripts/in_container/run_mypy.sh
+++ b/scripts/in_container/run_mypy.sh
@@ -20,19 +20,7 @@
 . "$( dirname "${BASH_SOURCE[0]}" )/_in_container_script_init.sh"
 export PYTHONPATH=${AIRFLOW_SOURCES}
 
-ADDITIONAL_MYPY_OPTIONS=()
-
 export MYPY_FORCE_COLOR=true
 export TERM=ansi
 
-if [[ ${SUSPENDED_PROVIDERS_FOLDERS=} != "" ]];
-then
-    for folder in ${SUSPENDED_PROVIDERS_FOLDERS=}
-    do
-        ADDITIONAL_MYPY_OPTIONS+=(
-            "--exclude" "airflow/providers/${folder}/*"
-            "--exclude" "tests/providers/${folder}/*"
-        )
-    done
-fi
-mypy "${ADDITIONAL_MYPY_OPTIONS[@]}" "${@}"
+mypy --exclude airflow/providers --exclude tests/providers "${@}"


### PR DESCRIPTION
I saw that static checks fail (amoungst others) in v2-10-test PRs. I'll attempt to fix this.

This is the first PR that fixes static checks. Mainly by disabling / excluding provider sources from mypy. Providers are validated against old Airflow versions in main CI anyway.