### PR TITLE
fix: fix parsing of private_key_content in snowflake hooks

### DIFF
--- a/providers/snowflake/docs/connections/snowflake.rst
+++ b/providers/snowflake/docs/connections/snowflake.rst
@@ -59,7 +59,7 @@ Extra (optional)
     * ``authenticator``: To connect using OAuth set this parameter ``oauth``.
     * ``refresh_token``: Specify refresh_token for OAuth connection.
     * ``private_key_file``: Specify the path to the private key file.
-    * ``private_key_content``: Specify the content of the private key file.
+    * ``private_key_content``: Specify the content of the private key file. To input a PEM-formatted private key, replace all actual newlines with the literal `\n` in the key. Ensure the entire key, including the headers and footers, is on a single line with `\n` used to represent line breaks.
     * ``session_parameters``: Specify `session level parameters <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_.
     * ``insecure_mode``: Turn off OCSP certificate checks. For details, see: `How To: Turn Off OCSP Checking in Snowflake Client Drivers - Snowflake Community <https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers>`_.
     * ``host``: Target Snowflake hostname to connect to (e.g., for local testing with LocalStack).

--- a/providers/snowflake/docs/connections/snowflake.rst
+++ b/providers/snowflake/docs/connections/snowflake.rst
@@ -59,7 +59,7 @@ Extra (optional)
     * ``authenticator``: To connect using OAuth set this parameter ``oauth``.
     * ``refresh_token``: Specify refresh_token for OAuth connection.
     * ``private_key_file``: Specify the path to the private key file.
-    * ``private_key_content``: Specify the content of the private key file. To input a PEM-formatted private key, replace all actual newlines with the literal `\n` in the key. Ensure the entire key, including the headers and footers, is on a single line with `\n` used to represent line breaks.
+    * ``private_key_content``: Specify the content of the private key file. To input a PEM-formatted private key, replace all actual newlines with the literal ``\n`` in the key. Ensure the entire key, including the headers and footers, is on a single line with ``\n`` used to represent line breaks.
     * ``session_parameters``: Specify `session level parameters <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_.
     * ``insecure_mode``: Turn off OCSP certificate checks. For details, see: `How To: Turn Off OCSP Checking in Snowflake Client Drivers - Snowflake Community <https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers>`_.
     * ``host``: Target Snowflake hostname to connect to (e.g., for local testing with LocalStack).

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -262,7 +262,7 @@ class SnowflakeHook(DbApiHook):
                 raise ValueError("The private_key_file size is too big. Please keep it less than 4 KB.")
             private_key_pem = Path(private_key_file_path).read_bytes()
         elif private_key_content:
-            private_key_pem = private_key_content.encode()
+            private_key_pem = private_key_content.replace("\\n", "\n").encode()
 
         if private_key_pem:
             passphrase = None

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -120,7 +120,9 @@ class SnowflakeSqlApiHook(SnowflakeHook):
         elif private_key_file:
             private_key_pem = Path(private_key_file).read_bytes()
         elif private_key_content:
-            private_key_pem = private_key_content.encode()
+            # BS3PasswordFieldWidget treats input text literally. So, \n is converted to \\n.
+            # We need to convert it back to \n.
+            private_key_pem = private_key_content.replace("\\n", "\n").encode()
 
         if private_key_pem:
             passphrase = None


### PR DESCRIPTION
fixes #47003

Copying comment from #47003 :

> After converting the field to a BS3PasswordFieldWidget , when we paste PEM key with new lines, this field automatically removes new lines.
> 
> For example:
> 
> key_start
> text
> key_end
> is now converted to a single line key_starttextkey_end .
> 
> And, when format the PEM key to replace new lines with "\n" , it is actually saved as "\n".
> 
> For example:
> key_start\ntext\nkey_end to become key_start\\ntext\\nkey_end
> 
> Here's what I'm thinking to do:
> 
> Update docs to inform users to pass PEM key by replacing new lines with \n's
> In the code, I'll just replace \\n with \n