### PR TITLE
Fix k8s flaky test - Improve Backoff Retry

### DIFF
--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -154,7 +154,10 @@ class BaseK8STest:
         :return: The JWT token
         """
         # get csrf token from login page
-        retry = Retry(total=5, backoff_factor=10)
+        Retry.DEFAULT_BACKOFF_MAX = 32
+        retry = Retry(total=10, backoff_factor=1)
+        # Backoff Retry Formula: min(1 × (2^(retry - 1)), 32) seconds
+        # 1 + 2 + 4 + 8 + 16 + 32 + 32 + 32 + 32 + 32 = 191 sec (~3.2 min)
         session = requests.Session()
         session.mount("http://", HTTPAdapter(max_retries=retry))
         session.mount("https://", HTTPAdapter(max_retries=retry))


### PR DESCRIPTION
## Why  

Flaky Kubernetes tests have been failing: https://github.com/apache/airflow/actions/runs/13853802423/job/38770312000
All failures occur at `_ ERROR at setup of TestKubernetesPodOperator.test_kubernetes_pod_operator_active_deadline_seconds[10] _`.  
( The root cause is still unclear, and there may be other side effects.  )

For now, I am fine-tuning the backoff retry configuration to improve stability.  

## What  

Improved the backoff retry configuration to increase retry frequency while maintaining a balanced total retry duration.  
The previous strategy had long delays between retries and did not provide enough opportunities to recover from transient failures.  

### **Comparison of Retry Strategies**  

| Feature             | **New Strategy** (`total=10, backoff_factor=1`) DEFAULT_BACKOFF_MAX = 32 | **Old Strategy** (`total=5, backoff_factor=10`) |
|--------------------|------------------------------------------------|----------------------------------|
| **Total Retries**   | 10                                              | 5                                |
| **Backoff Factor**  | 1                                               | 10                               |
| **Max Wait Time**   | **Capped at 32 sec**                            | No cap (exponential growth)      |
| **Backoff Formula** | `min(1 × (2^(retry - 1)), 32)`                  | `10 × (2^(retry - 1))`           |
| **Backoff Times**   | `1, 2, 4, 8, 16, 32, 32, 32, 32, 32`            | `10, 20, 40, 80, 160`            |
| **Total Time**      | **191 sec (~3.2 min)**                          | **310 sec (~5.2 min)**           |
