### PR TITLE
Fix backfill trigger modal

### DIFF
--- a/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -205,7 +205,9 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
         <Spacer />
         {affectedTasks.total_entries > 0 ? (
           <Alert>{affectedTasks.total_entries} runs will be triggered</Alert>
-        ) : undefined}
+        ) : (
+          <Alert>No runs matching selected criteria.</Alert>
+        )}
       </VStack>
       {dag.is_paused ? (
         <Checkbox checked={unpause} colorPalette="blue" onChange={() => setUnpause(!unpause)}>

--- a/airflow/ui/src/constants/reprocessBehaviourParams.ts
+++ b/airflow/ui/src/constants/reprocessBehaviourParams.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 export const reprocessBehaviors = [
-  { label: "Missing Runs", value: "failed" },
-  { label: "Missing and Errored Runs", value: "completed" },
-  { label: "All Runs", value: "none" },
+  { label: "Missing Runs", value: "none" },
+  { label: "Missing and Errored Runs", value: "failed" },
+  { label: "All Runs", value: "completed" },
 ];


### PR DESCRIPTION
Previously the modal language was mismatched with the reprocess behavior.  This lines them up properly.  Also, I ensure that user is always given feedback about how many runs would be triggered, even if zero.

resolves https://github.com/apache/airflow/issues/47670

When no runs would be triggered:
![image](https://github.com/user-attachments/assets/e4d2808a-4aad-421b-bb4e-b653a70765bb)
