### PR TITLE
openlineage, common.io: convert non-absolute file path to prevent namespace explosion

### DIFF
--- a/providers/common/io/tests/unit/common/io/assets/test_file.py
+++ b/providers/common/io/tests/unit/common/io/assets/test_file.py
@@ -47,21 +47,32 @@ def test_sanitize_uri_invalid(uri):
         sanitize_uri(urlsplit(uri))
 
 
-def test_file_asset():
-    assert create_asset(path="/asdf/fdsa") == Asset(uri="file:///asdf/fdsa")
+@pytest.mark.parametrize(
+    ("path", "uri"),
+    (
+        ("/asdf/fdsa", "file:///asdf/fdsa"),
+        ("file:///asdf/fdsa", "file:///asdf/fdsa"),
+        ("file://asdf/fdsa", "file://asdf/fdsa"),
+        ("file://127.0.0.1:8080/dir/file.csv", "file://127.0.0.1:8080/dir/file.csv"),
+    ),
+)
+def test_file_asset(path, uri):
+    assert create_asset(path=path) == Asset(uri=uri)
 
 
 @pytest.mark.parametrize(
-    ("uri", "ol_dataset"),
+    ("path", "ol_dataset"),
     (
-        ("file:///valid/path", OpenLineageDataset(namespace="file", name="/valid/path")),
+        ("/valid/path", OpenLineageDataset(namespace="file", name="/valid/path")),
         (
             "file://127.0.0.1:8080/dir/file.csv",
             OpenLineageDataset(namespace="file://127.0.0.1:8080", name="/dir/file.csv"),
         ),
         ("file:///C://dir/file", OpenLineageDataset(namespace="file", name="/C://dir/file")),
+        ("file://asdf.pdf", OpenLineageDataset(namespace="file", name="/asdf.pdf")),
+        ("file:///asdf.pdf", OpenLineageDataset(namespace="file", name="/asdf.pdf")),
     ),
 )
-def test_convert_asset_to_openlineage(uri, ol_dataset):
-    result = convert_asset_to_openlineage(Asset(uri=uri), None)
+def test_convert_asset_to_openlineage(path, ol_dataset):
+    result = convert_asset_to_openlineage(create_asset(path=path), None)
     assert result == ol_dataset


### PR DESCRIPTION
When receiving malformed file assets with non-absolute paths, converted assets will contain file name in namespace. This does not match OL naming scheme and can cause explosion in namespace table size for OpenLineage users.  

Fixes OL issue: https://github.com/OpenLineage/OpenLineage/issues/3557