### PR TITLE
AIP-38 :: created new dag warning banner added to dag details page

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
@@ -1,0 +1,39 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex } from "@chakra-ui/react";
+
+import { Alert } from "./ui";
+
+type Props = {
+  readonly warning?: {
+    message: string;
+  };
+};
+
+export const WarningAlert = ({ warning }: Props) => {
+  if (!Boolean(warning)) {
+    return undefined;
+  }
+
+  return (
+    <Alert status="warning">
+      <Flex align="center">{warning?.message}</Flex>
+    </Alert>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -57,8 +57,6 @@ export const DetailsLayout = ({ children, error, isLoading, tabs, warning }: Pro
 
   const { fitView, getZoom } = useReactFlow();
 
-  console.log("warning", warning);
-
   return (
     <OpenGroupsProvider dagId={dagId}>
       <HStack justifyContent="space-between" mb={2}>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -57,6 +57,8 @@ export const DetailsLayout = ({ children, error, isLoading, tabs, warning }: Pro
 
   const { fitView, getZoom } = useReactFlow();
 
+  console.log("warning", warning);
+
   return (
     <OpenGroupsProvider dagId={dagId}>
       <HStack justifyContent="space-between" mb={2}>
@@ -94,7 +96,10 @@ export const DetailsLayout = ({ children, error, isLoading, tabs, warning }: Pro
               <VStack ml={2} my={2}>
                 <ErrorAlert error={error} />
                 {warning?.dag_warnings.map((warningItem) => (
-                  <WarningAlert key={warningItem.dag_id} warning={warningItem} />
+                  <WarningAlert
+                    key={`${warningItem.dag_id}-${warningItem.timestamp}`}
+                    warning={warningItem}
+                  />
                 ))}
               </VStack>
               <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -32,7 +32,7 @@ import { SearchDagsButton } from "src/components/SearchDags";
 import { StateBadge } from "src/components/StateBadge";
 import TriggerDAGButton from "src/components/TriggerDag/TriggerDAGButton";
 import { WarningAlert } from "src/components/WarningAlert";
-import { Accordion, Button, ProgressBar } from "src/components/ui";
+import { Accordion, ProgressBar } from "src/components/ui";
 import { Toaster } from "src/components/ui";
 import { OpenGroupsProvider } from "src/context/openGroups";
 
@@ -97,12 +97,21 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
             <Box display="flex" flexDirection="column" h="100%">
               {children}
               {(Boolean(error) || (warningData?.dag_warnings.length ?? 0) > 0) && (
-                <Accordion.Root collapsible mb={4} mt={4} size="lg" variant="outline">
+                <Accordion.Root
+                  collapsible
+                  height="full"
+                  maxH="fit-content"
+                  mb={4}
+                  mt={4}
+                  overflow="auto"
+                  size="lg"
+                  variant="outline"
+                >
                   <Accordion.Item key="dagIssues" mx={2} value="dagIssues">
                     <Accordion.ItemTrigger cursor="button">
                       <Flex gap="0.5rem">
-                        <StateBadge as={Button} colorPalette="failed" height={7} title="Dag Issues">
-                          <LuFileWarning size="0.5rem" />
+                        <StateBadge colorPalette="failed" height={7} title="Dag Issues">
+                          <LuFileWarning size="1.25rem" />
                         </StateBadge>
                         <p>Issues</p>
                       </Flex>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Flex } from "@chakra-ui/react";
+import { Box, HStack, Flex, VStack } from "@chakra-ui/react";
 import { useReactFlow } from "@xyflow/react";
 import type { PropsWithChildren, ReactNode } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
@@ -29,6 +29,7 @@ import BackfillBanner from "src/components/Banner/BackfillBanner";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchDagsButton } from "src/components/SearchDags";
 import TriggerDAGButton from "src/components/TriggerDag/TriggerDAGButton";
+import { WarningAlert } from "src/components/WarningAlert";
 import { ProgressBar } from "src/components/ui";
 import { Toaster } from "src/components/ui";
 import { OpenGroupsProvider } from "src/context/openGroups";
@@ -39,14 +40,25 @@ import { Grid } from "./Grid";
 import { NavTabs } from "./NavTabs";
 import { PanelButtons } from "./PanelButtons";
 
+type DagWarningItem = {
+  dag_id: string;
+  message: string;
+};
+
+type DagWarningsResponse = {
+  dag_warnings: Array<DagWarningItem>;
+  total_entries: number;
+};
+
 type Props = {
   readonly dag?: DAGResponse;
   readonly error?: unknown;
   readonly isLoading?: boolean;
   readonly tabs: Array<{ icon: ReactNode; label: string; value: string }>;
+  readonly warning?: DagWarningsResponse;
 } & PropsWithChildren;
 
-export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
+export const DetailsLayout = ({ children, error, isLoading, tabs, warning }: Props) => {
   const { dagId = "" } = useParams();
 
   const { data: dag } = useDagServiceGetDag({ dagId });
@@ -89,7 +101,12 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
           <Panel defaultSize={dagView === "graph" ? 30 : 80} minSize={20}>
             <Box display="flex" flexDirection="column" h="100%">
               {children}
-              <ErrorAlert error={error} />
+              <VStack ml={2} my={2}>
+                <ErrorAlert error={error} />
+                {warning?.dag_warnings.map((warningItem) => (
+                  <WarningAlert key={warningItem.dag_id} warning={warningItem} />
+                ))}
+              </VStack>
               <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
               <NavTabs tabs={tabs} />
               <Box h="100%" overflow="auto" px={2}>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -24,7 +24,7 @@ import { Outlet, useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
 import { useDagServiceGetDag } from "openapi/queries";
-import type { DAGResponse } from "openapi/requests/types.gen";
+import type { DAGResponse, DAGWarningCollectionResponse } from "openapi/requests/types.gen";
 import BackfillBanner from "src/components/Banner/BackfillBanner";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchDagsButton } from "src/components/SearchDags";
@@ -40,22 +40,12 @@ import { Grid } from "./Grid";
 import { NavTabs } from "./NavTabs";
 import { PanelButtons } from "./PanelButtons";
 
-type DagWarningItem = {
-  dag_id: string;
-  message: string;
-};
-
-type DagWarningsResponse = {
-  dag_warnings: Array<DagWarningItem>;
-  total_entries: number;
-};
-
 type Props = {
   readonly dag?: DAGResponse;
   readonly error?: unknown;
   readonly isLoading?: boolean;
   readonly tabs: Array<{ icon: ReactNode; label: string; value: string }>;
-  readonly warning?: DagWarningsResponse;
+  readonly warning?: DAGWarningCollectionResponse;
 } & PropsWithChildren;
 
 export const DetailsLayout = ({ children, error, isLoading, tabs, warning }: Props) => {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -23,11 +23,7 @@ import { MdDetails, MdOutlineEventNote } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { useParams } from "react-router-dom";
 
-import {
-  useDagServiceGetDagDetails,
-  useDagsServiceRecentDagRuns,
-  useDagWarningServiceListDagWarnings,
-} from "openapi/queries";
+import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
 import { TaskIcon } from "src/assets/TaskIcon";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
@@ -55,10 +51,6 @@ export const Dag = () => {
     dagId,
   });
 
-  const { data: warningData, isLoading: isWarningLoading } = useDagWarningServiceListDagWarnings({
-    dagId,
-  });
-
   const refetchInterval = useAutoRefresh({ dagId });
 
   // TODO: replace with with a list dag runs by dag id request
@@ -83,9 +75,8 @@ export const Dag = () => {
       <DetailsLayout
         dag={dag}
         error={error ?? runsError}
-        isLoading={isLoading || isLoadingRuns || isWarningLoading}
+        isLoading={isLoading || isLoadingRuns}
         tabs={tabs.filter((tab) => !(dag?.timetable_summary === null && tab.value === "backfills"))}
-        warning={warningData}
       >
         <Header
           dag={dag}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -23,7 +23,11 @@ import { MdDetails, MdOutlineEventNote } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { useParams } from "react-router-dom";
 
-import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
+import {
+  useDagServiceGetDagDetails,
+  useDagsServiceRecentDagRuns,
+  useDagWarningServiceListDagWarnings,
+} from "openapi/queries";
 import { TaskIcon } from "src/assets/TaskIcon";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
@@ -51,6 +55,10 @@ export const Dag = () => {
     dagId,
   });
 
+  const { data: warningData, isLoading: isWarningLoading } = useDagWarningServiceListDagWarnings({
+    dagId,
+  });
+
   const refetchInterval = useAutoRefresh({ dagId });
 
   // TODO: replace with with a list dag runs by dag id request
@@ -75,8 +83,9 @@ export const Dag = () => {
       <DetailsLayout
         dag={dag}
         error={error ?? runsError}
-        isLoading={isLoading || isLoadingRuns}
+        isLoading={isLoading || isLoadingRuns || isWarningLoading}
         tabs={tabs.filter((tab) => !(dag?.timetable_summary === null && tab.value === "backfills"))}
+        warning={warningData}
       >
         <Header
           dag={dag}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: [#47430](https://github.com/apache/airflow/issues/47430)

Hello! My name is Tyrell. This is my first PR / Contribution to this repo 🙂

I created a new warning component to iterate through and display DAG warnings from the `/public/dagWarnings` endpoint.

I utilized the existing Alert component from chakra, and utilized the `status="warning"` variation:

![Screenshot 2025-03-15 at 10 00 45 PM](https://github.com/user-attachments/assets/ad4076fb-bec8-458f-aef7-d422bc6349e3)

I also placed the `WarningAlert` along with the existing `ErrorAlert` component within a `VStack` to give them some space between each other if they are both displayed:

![Screenshot 2025-03-15 at 10 13 38 PM](https://github.com/user-attachments/assets/4c295346-92d3-4790-81e2-6ba3eed05dab)

This also applies if there are multiple errors (I duplicated the warning just for demonstration):

![Screenshot 2025-03-15 at 9 59 48 PM](https://github.com/user-attachments/assets/608758c3-291c-4e9f-a1b6-0d9112fa6c5f)

I also ensured the left/right margin matches the rest of the UI for the Alerts. 

I hope this is what the team was hoping for! I am open to feedback or changes if any come up.

Thanks all

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
