### PR TITLE
AIP-38 Redirect to login page on invalid JWT token

### DIFF
--- a/airflow/api_fastapi/core_api/security.py
+++ b/airflow/api_fastapi/core_api/security.py
@@ -59,7 +59,7 @@ async def get_user(token_str: Annotated[str, Depends(oauth2_scheme)]) -> BaseUse
     except ExpiredSignatureError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Token Expired")
     except InvalidTokenError:
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid JWT token")
 
 
 GetUserDep = Annotated[BaseUser, Depends(get_user)]

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -23,19 +23,24 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
+import type { HTTPExceptionResponse } from "openapi/requests/types.gen";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
 
 import { queryClient } from "./queryClient";
 import { system } from "./theme";
-import { tokenHandler } from "./utils/tokenHandler";
+import { clearToken, tokenHandler } from "./utils/tokenHandler";
 
 // redirect to login page if the API responds with unauthorized or forbidden errors
 axios.interceptors.response.use(
   (response) => response,
-  (error: AxiosError) => {
-    if (error.response?.status === 401) {
+  (error: AxiosError<HTTPExceptionResponse>) => {
+    if (
+      error.response?.status === 401 ||
+      (error.response?.status === 403 && error.response.data.detail === "Invalid JWT token")
+    ) {
+      clearToken();
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);

--- a/airflow/ui/src/utils/tokenHandler.ts
+++ b/airflow/ui/src/utils/tokenHandler.ts
@@ -47,3 +47,7 @@ export const tokenHandler = (config: InternalAxiosRequestConfig) => {
 
   return config;
 };
+
+export const clearToken = () => {
+  localStorage.removeItem(TOKEN_STORAGE_KEY);
+};

--- a/tests/api_fastapi/core_api/test_security.py
+++ b/tests/api_fastapi/core_api/test_security.py
@@ -66,7 +66,7 @@ class TestFastApiSecurity:
         auth_manager.get_user_from_token.side_effect = InvalidTokenError()
         mock_get_auth_manager.return_value = auth_manager
 
-        with pytest.raises(HTTPException, match="Forbidden"):
+        with pytest.raises(HTTPException, match="Invalid JWT token"):
             await get_user(token_str)
 
         auth_manager.get_user_from_token.assert_called_once_with(token_str)


### PR DESCRIPTION
related to https://github.com/apache/airflow/pull/47791

I noticed that even though new token is present in cookies, code always tries to fetch the older one from the local storage.

added code to clear token. Not sure if this is the right approach. But, I tested it and it works