### PR TITLE
Ensures DatabricksWorkflowOperator updates ACL (if available) when resetting a job.

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -298,6 +298,16 @@ class DatabricksHook(BaseDatabricksHook):
 
         :param json: The data used in the new_settings of the request to the ``reset`` endpoint.
         """
+        access_control_list = json.get("access_control_list", None)
+        if access_control_list:
+            self.log.info(
+                "Updating job permission for Databricks workflow job id %s with access_control_list %s",
+                job_id,
+                access_control_list,
+            )
+            acl_json = {"access_control_list": access_control_list}
+            self.update_job_permission(job_id=int(job_id), json=acl_json)
+
         self._do_api_call(RESET_ENDPOINT, {"job_id": job_id, "new_settings": json})
 
     def update_job(self, job_id: str, json: dict) -> None:

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -398,10 +398,6 @@ class DatabricksCreateJobsOperator(BaseOperator):
         if job_id is None:
             return self._hook.create_job(self.json)
         self._hook.reset_job(str(job_id), self.json)
-        if (access_control_list := self.json.get("access_control_list")) is not None:
-            acl_json = {"access_control_list": access_control_list}
-            self._hook.update_job_permission(job_id, normalise_json_content(acl_json))
-
         return job_id
 
 

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -190,7 +190,9 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
                     self.job_name,
                     access_control_list,
                 )
-                self._hook.update_job_permission(job_id, {"access_control_list": access_control_list})
+                self._hook.update_job_permission(
+                    job_id=job_id, json={"access_control_list": access_control_list}
+                )
             self._hook.reset_job(job_id, job_spec)
 
         else:

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -183,7 +183,16 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
                 self.job_name,
                 json.dumps(job_spec, indent=2),
             )
+            access_control_list = job_spec.get("access_control_list", None)
+            if access_control_list:
+                self.log.info(
+                    "Updating job permission for Databricks workflow job %s with access_control_list %s",
+                    self.job_name,
+                    access_control_list,
+                )
+                self._hook.update_job_permission(job_id, {"access_control_list": access_control_list})
             self._hook.reset_job(job_id, job_spec)
+
         else:
             self.log.info(
                 "Creating new Databricks workflow job %s with spec %s",

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -183,18 +183,7 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
                 self.job_name,
                 json.dumps(job_spec, indent=2),
             )
-            access_control_list = job_spec.get("access_control_list", None)
-            if access_control_list:
-                self.log.info(
-                    "Updating job permission for Databricks workflow job %s with access_control_list %s",
-                    self.job_name,
-                    access_control_list,
-                )
-                self._hook.update_job_permission(
-                    job_id=job_id, json={"access_control_list": access_control_list}
-                )
             self._hook.reset_job(job_id, job_spec)
-
         else:
             self.log.info(
                 "Creating new Databricks workflow job %s with spec %s",

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -570,42 +570,6 @@ class TestDatabricksCreateJobsOperator:
         assert return_result == JOB_ID
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
-    def test_exec_update_job_permission(self, db_mock_class):
-        """
-        Test job permission update.
-        """
-        json = {
-            "name": JOB_NAME,
-            "tags": TAGS,
-            "tasks": TASKS,
-            "job_clusters": JOB_CLUSTERS,
-            "email_notifications": EMAIL_NOTIFICATIONS,
-            "webhook_notifications": WEBHOOK_NOTIFICATIONS,
-            "timeout_seconds": TIMEOUT_SECONDS,
-            "schedule": SCHEDULE,
-            "max_concurrent_runs": MAX_CONCURRENT_RUNS,
-            "git_source": GIT_SOURCE,
-            "access_control_list": ACCESS_CONTROL_LIST,
-        }
-        op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
-        db_mock = db_mock_class.return_value
-        db_mock.find_job_id_by_name.return_value = JOB_ID
-
-        op.execute({})
-
-        expected = utils.normalise_json_content({"access_control_list": ACCESS_CONTROL_LIST})
-
-        db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID,
-            retry_limit=op.databricks_retry_limit,
-            retry_delay=op.databricks_retry_delay,
-            retry_args=None,
-            caller="DatabricksCreateJobsOperator",
-        )
-
-        db_mock.update_job_permission.assert_called_once_with(JOB_ID, expected)
-
-    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_exec_update_job_permission_with_empty_acl(self, db_mock_class):
         """
         Test job permission update.

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -107,30 +107,7 @@ def test_create_or_reset_job_existing(mock_databricks_hook, context, mock_task_g
 
     job_id = operator._create_or_reset_job(context)
     assert job_id == 123
-    operator._hook.update_job_permission.assert_not_called()
     operator._hook.reset_job.assert_called_once()
-
-
-def test_create_or_reset_job_existing_with_updated_access_control_list(
-    mock_databricks_hook, context, mock_task_group
-):
-    """Test that _CreateDatabricksWorkflowOperator._create_or_reset_job resets the job if it already exists, and also updates the job permissions if access_control_list is provided."""
-    acl = {"access_control_list": [{"user_name": "test_user", "permission_level": "CAN_MANAGE"}]}
-    operator = _CreateDatabricksWorkflowOperator(
-        task_id="test_task",
-        databricks_conn_id="databricks_default",
-        extra_job_params=acl,
-    )
-    operator.task_group = mock_task_group
-    operator._hook.list_jobs.return_value = [{"job_id": 1234}]
-
-    job_id = operator._create_or_reset_job(context)
-    assert job_id == 1234
-    operator._hook.reset_job.assert_called_once()
-    operator._hook.update_job_permission.assert_called_once_with(
-        job_id=1234,
-        json=acl,
-    )
 
 
 def test_create_or_reset_job_new(mock_databricks_hook, context, mock_task_group):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -104,11 +104,33 @@ def test_create_or_reset_job_existing(mock_databricks_hook, context, mock_task_g
     operator = _CreateDatabricksWorkflowOperator(task_id="test_task", databricks_conn_id="databricks_default")
     operator.task_group = mock_task_group
     operator._hook.list_jobs.return_value = [{"job_id": 123}]
-    operator._hook.create_job.return_value = 123
 
     job_id = operator._create_or_reset_job(context)
     assert job_id == 123
+    operator._hook.update_job_permission.assert_not_called()
     operator._hook.reset_job.assert_called_once()
+
+
+def test_create_or_reset_job_existing_with_updated_access_control_list(
+    mock_databricks_hook, context, mock_task_group
+):
+    """Test that _CreateDatabricksWorkflowOperator._create_or_reset_job resets the job if it already exists, and also updates the job permissions if access_control_list is provided."""
+    acl = {"access_control_list": [{"user_name": "test_user", "permission_level": "CAN_MANAGE"}]}
+    operator = _CreateDatabricksWorkflowOperator(
+        task_id="test_task",
+        databricks_conn_id="databricks_default",
+        extra_job_params=acl,
+    )
+    operator.task_group = mock_task_group
+    operator._hook.list_jobs.return_value = [{"job_id": 1234}]
+
+    job_id = operator._create_or_reset_job(context)
+    assert job_id == 1234
+    operator._hook.reset_job.assert_called_once()
+    operator._hook.update_job_permission.assert_called_once_with(
+        job_id=1234,
+        json=acl,
+    )
 
 
 def test_create_or_reset_job_new(mock_databricks_hook, context, mock_task_group):


### PR DESCRIPTION
...
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #45738


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
