### PR TITLE
Use selected try_number in dropdown if present instead of final try number during initial page load.

### DIFF
--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -89,7 +89,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
         <Select.Root
           collection={tryOptions}
           data-testid="select-task-try"
-          defaultValue={[finalTryNumber.toString()]}
+          defaultValue={[selectedTryNumber?.toString() ?? finalTryNumber.toString()]}
           onValueChange={(details) => {
             if (onSelectTryNumber) {
               onSelectTryNumber(

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -46,6 +46,7 @@ type ParseLogsProps = {
   logLevelFilters?: Array<string>;
   sourceFilters?: Array<string>;
   taskInstance?: TaskInstanceResponse;
+  tryNumber: number;
 };
 
 type RenderStructuredLogProps = {
@@ -154,7 +155,7 @@ const renderStructuredLog = ({
   );
 };
 
-const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance }: ParseLogsProps) => {
+const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance, tryNumber }: ParseLogsProps) => {
   let warning;
   let parsedLines;
   let startGroup = false;
@@ -164,7 +165,7 @@ const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance }: Parse
 
   // open the summary when hash is present since the link might have a hash linking to a line
   const open = Boolean(location.hash);
-  const logLink = taskInstance ? getTaskInstanceLink(taskInstance) : "";
+  const logLink = taskInstance ? `${getTaskInstanceLink(taskInstance)}?try_number=${tryNumber}` : "";
 
   try {
     parsedLines = data.map((datum, index) => {
@@ -261,6 +262,7 @@ export const useLogs = (
     logLevelFilters,
     sourceFilters,
     taskInstance,
+    tryNumber,
   });
 
   return { data: parsedData, ...rest };


### PR DESCRIPTION
During initial page load if there is a try number selected then the log for the try number is displayed but the selected dropdown value is always the final try number which is not correct. With this change when there is a try number in the query param then the dropdown uses that value as default instead of the final value. This is already correct in try number selector as button and the fix needs to be present only for  dropdown.

1. Run the below dag.
2. Go to the  `retry_more_than_10` task instance and select a try number,
3. Copy the URL and paste it in a different tab. Ensure the value in query parameter is same as the value in dropdown.

```python
from __future__ import annotations

from datetime import datetime, timedelta

from airflow import DAG
from airflow.decorators import task

with DAG(
    dag_id="retry_issue_dag",
    start_date=datetime(2023, 10, 10),
    catchup=False,
    schedule="@once",
) as dag:

    @task(retries=8, retry_delay=timedelta(seconds=1))
    def retry_less_than_10():
        raise Exception("fail")

    @task(retries=40, retry_delay=timedelta(seconds=1))
    def retry_more_than_10():
        raise Exception("fail")

    retry_less_than_10()
    retry_more_than_10()
```