### PR TITLE
Allow using dag decorator without arguments

### DIFF
--- a/airflow/example_dags/example_simplest_dag.py
+++ b/airflow/example_dags/example_simplest_dag.py
@@ -14,24 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Example DAG demonstrating the simplest use of the `@dag` decorator."""
 
 from __future__ import annotations
 
-import datetime
-
-from airflow.providers.standard.sensors.date_time import DateTimeSensorAsync
-from airflow.sdk.definitions.dag import dag
-from airflow.utils import timezone
+from airflow.decorators import dag, task
 
 
 @dag
-def super_basic_deferred_run():
-    DateTimeSensorAsync(
-        task_id="async",
-        target_time=timezone.utcnow() + datetime.timedelta(seconds=3),
-        poke_interval=60,
-        timeout=600,
-    )
+def example_simplest_dag():
+    @task
+    def my_task():
+        pass
+
+    my_task()
 
 
-super_basic_deferred_run()
+example_simplest_dag()

--- a/scripts/ci/pre_commit/sync_init_decorator.py
+++ b/scripts/ci/pre_commit/sync_init_decorator.py
@@ -90,7 +90,8 @@ def _find_dag_deco(mod: ast.Module) -> ast.FunctionDef:
     return next(
         n
         for n in itertools.chain.from_iterable(map(ast.iter_child_nodes, type_checking_blocks))
-        if isinstance(n, ast.FunctionDef) and n.name == "dag"
+        if isinstance(n, ast.FunctionDef) and n.name == "dag" and n.args.args[0].arg != "func"
+        # Ignore overload from `dag` decorator with `func` as first arg
     )
 
 

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -35,6 +35,7 @@ from typing import (
     ClassVar,
     Union,
     cast,
+    overload,
 )
 from urllib.parse import urlsplit
 
@@ -1045,6 +1046,7 @@ DAG._DAG__serialized_fields = frozenset(a.name for a in attrs.fields(DAG)) - {  
 if TYPE_CHECKING:
     # NOTE: Please keep the list of arguments in sync with DAG.__init__.
     # Only exception: dag_id here should have a default value, but not in DAG.
+    @overload
     def dag(
         dag_id: str = "",
         *,
@@ -1085,48 +1087,57 @@ if TYPE_CHECKING:
         :param dag_args: Arguments for DAG object
         :param dag_kwargs: Kwargs for DAG object.
         """
-else:
 
-    def dag(dag_id="", __DAG_class=DAG, __warnings_stacklevel_delta=2, **decorator_kwargs):
-        # TODO: Task-SDK: remove __DAG_class
-        # __DAG_class is a temporary hack to allow the dag decorator in airflow.models.dag to continue to
-        # return SchedulerDag objects
-        DAG = __DAG_class
+    @overload
+    def dag(func: Callable[..., DAG]) -> Callable[..., DAG]:
+        """Python dag decorator to use without any arguments."""
 
-        def wrapper(f: Callable) -> Callable[..., DAG]:
-            @functools.wraps(f)
-            def factory(*args, **kwargs):
-                # Generate signature for decorated function and bind the arguments when called
-                # we do this to extract parameters, so we can annotate them on the DAG object.
-                # In addition, this fails if we are missing any args/kwargs with TypeError as expected.
-                f_sig = signature(f).bind(*args, **kwargs)
-                # Apply defaults to capture default values if set.
-                f_sig.apply_defaults()
 
-                # Initialize DAG with bound arguments
-                with DAG(dag_id or f.__name__, **decorator_kwargs) as dag_obj:
-                    # Set DAG documentation from function documentation if it exists and doc_md is not set.
-                    if f.__doc__ and not dag_obj.doc_md:
-                        dag_obj.doc_md = f.__doc__
+def dag(dag_id_or_func=None, __DAG_class=DAG, __warnings_stacklevel_delta=2, **decorator_kwargs):
+    # TODO: Task-SDK: remove __DAG_class
+    # __DAG_class is a temporary hack to allow the dag decorator in airflow.models.dag to continue to
+    # return SchedulerDag objects
+    DAG = __DAG_class
 
-                    # Generate DAGParam for each function arg/kwarg and replace it for calling the function.
-                    # All args/kwargs for function will be DAGParam object and replaced on execution time.
-                    f_kwargs = {}
-                    for name, value in f_sig.arguments.items():
-                        f_kwargs[name] = dag_obj.param(name, value)
+    def wrapper(f: Callable) -> Callable[..., DAG]:
+        dag_id = dag_id_or_func if isinstance(dag_id_or_func, str) and dag_id_or_func.strip() else f.__name__
 
-                    # set file location to caller source path
-                    back = sys._getframe().f_back
-                    dag_obj.fileloc = back.f_code.co_filename if back else ""
+        @functools.wraps(f)
+        def factory(*args, **kwargs):
+            # Generate signature for decorated function and bind the arguments when called
+            # we do this to extract parameters, so we can annotate them on the DAG object.
+            # In addition, this fails if we are missing any args/kwargs with TypeError as expected.
+            f_sig = signature(f).bind(*args, **kwargs)
+            # Apply defaults to capture default values if set.
+            f_sig.apply_defaults()
 
-                    # Invoke function to create operators in the DAG scope.
-                    f(**f_kwargs)
+            # Initialize DAG with bound arguments
+            with DAG(dag_id, **decorator_kwargs) as dag_obj:
+                # Set DAG documentation from function documentation if it exists and doc_md is not set.
+                if f.__doc__ and not dag_obj.doc_md:
+                    dag_obj.doc_md = f.__doc__
 
-                # Return dag object such that it's accessible in Globals.
-                return dag_obj
+                # Generate DAGParam for each function arg/kwarg and replace it for calling the function.
+                # All args/kwargs for function will be DAGParam object and replaced on execution time.
+                f_kwargs = {}
+                for name, value in f_sig.arguments.items():
+                    f_kwargs[name] = dag_obj.param(name, value)
 
-            # Ensure that warnings from inside DAG() are emitted from the caller, not here
-            fixup_decorator_warning_stack(factory)
-            return factory
+                # set file location to caller source path
+                back = sys._getframe().f_back
+                dag_obj.fileloc = back.f_code.co_filename if back else ""
 
-        return wrapper
+                # Invoke function to create operators in the DAG scope.
+                f(**f_kwargs)
+
+            # Return dag object such that it's accessible in Globals.
+            return dag_obj
+
+        # Ensure that warnings from inside DAG() are emitted from the caller, not here
+        fixup_decorator_warning_stack(factory)
+        return factory
+
+    if callable(dag_id_or_func) and not isinstance(dag_id_or_func, str):
+        return wrapper(dag_id_or_func)
+
+    return wrapper

--- a/task-sdk/tests/task_sdk/dags/super_basic.py
+++ b/task-sdk/tests/task_sdk/dags/super_basic.py
@@ -21,7 +21,7 @@ from airflow.sdk.definitions.baseoperator import BaseOperator
 from airflow.sdk.definitions.dag import dag
 
 
-@dag()
+@dag
 def super_basic():
     BaseOperator(task_id="a")
 

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -367,6 +367,15 @@ class TestDagDecorator:
     }
     VALUE = 42
 
+    def test_dag_decorator_without_args(self):
+        """Test that @dag can be used without any arguments."""
+
+        @dag_decorator
+        def noop_pipeline(): ...
+
+        dag = noop_pipeline()
+        assert dag.dag_id == "noop_pipeline"
+
     def test_fileloc(self):
         @dag_decorator(schedule=None, default_args=self.DEFAULT_ARGS)
         def noop_pipeline(): ...


### PR DESCRIPTION
This allow using:

```python
@dag
def my_dag(): ...
```

Currently it fails with:

```
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/tamara.fingerlin/airflow/dags_manning/syntax_examples/dependencies_examples.py", line 29, in <module>
    dependency_syntax()
TypeError: dag.<locals>.wrapper() missing 1 required positional argument: 'f'
```

so currently we need to use:

```python
@dag()
def my_dag(): ...
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
