### PR TITLE
Fix asset task_id, use function name as task_id

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -45,7 +45,7 @@ class _AssetMainOperator(PythonOperator):
     @classmethod
     def from_definition(cls, definition: AssetDefinition | MultiAssetDefinition) -> Self:
         return cls(
-            task_id="__main__",
+            task_id=definition._function.__name__,
             inlets=[
                 Asset.ref(name=inlet_asset_name)
                 for inlet_asset_name, param in inspect.signature(definition._function).parameters.items()

--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -45,7 +45,7 @@ class _AssetMainOperator(PythonOperator):
     @classmethod
     def from_definition(cls, definition: AssetDefinition | MultiAssetDefinition) -> Self:
         return cls(
-            task_id=definition._function.__name__,
+            task_id=definition.name,
             inlets=[
                 Asset.ref(name=inlet_asset_name)
                 for inlet_asset_name, param in inspect.signature(definition._function).parameters.items()

--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -45,7 +45,7 @@ class _AssetMainOperator(PythonOperator):
     @classmethod
     def from_definition(cls, definition: AssetDefinition | MultiAssetDefinition) -> Self:
         return cls(
-            task_id=definition.name,
+            task_id=definition._function.__name__,
             inlets=[
                 Asset.ref(name=inlet_asset_name)
                 for inlet_asset_name, param in inspect.signature(definition._function).parameters.items()

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -222,7 +222,7 @@ class Test_AssetMainOperator:
             example_asset_func_with_valid_arg_as_inlet_asset_and_default
         )
         op = _AssetMainOperator.from_definition(definition)
-        assert op.task_id == "__main__"
+        assert op.task_id == "example_asset_func"
         assert op.inlets == [Asset.ref(name="inlet_asset_1")]
         assert op.outlets == [definition]
         assert op.python_callable == example_asset_func_with_valid_arg_as_inlet_asset_and_default

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -211,7 +211,7 @@ class Test_AssetMainOperator:
             example_asset_func_with_valid_arg_as_inlet_asset
         )
         op = _AssetMainOperator.from_definition(definition)
-        assert op.task_id == "__main__"
+        assert op.task_id == "example_asset_func"
         assert op.inlets == [Asset.ref(name="inlet_asset_1"), Asset.ref(name="inlet_asset_2")]
         assert op.outlets == [definition]
         assert op.python_callable == example_asset_func_with_valid_arg_as_inlet_asset
@@ -234,7 +234,7 @@ class Test_AssetMainOperator:
             outlets=[Asset(name="a"), Asset(name="b")],
         )(example_asset_func_with_valid_arg_as_inlet_asset)
         op = _AssetMainOperator.from_definition(definition)
-        assert op.task_id == "__main__"
+        assert op.task_id == "example_asset_func"
         assert op.inlets == [Asset.ref(name="inlet_asset_1"), Asset.ref(name="inlet_asset_2")]
         assert op.outlets == [Asset(name="a"), Asset(name="b")]
         assert op.python_callable == example_asset_func_with_valid_arg_as_inlet_asset
@@ -266,7 +266,7 @@ class Test_AssetMainOperator:
         }
 
         op = _AssetMainOperator(
-            task_id="__main__",
+            task_id="example_asset_func",
             inlets=[Asset.ref(name="inlet_asset_1"), Asset.ref(name="inlet_asset_2")],
             outlets=[asset_definition],
             python_callable=example_asset_func_with_valid_arg_as_inlet_asset,


### PR DESCRIPTION
closes #47829

I tried to understand the theory behind task_id as `__main__`, but not get it. hope this change is fine.


after:

![image](https://github.com/user-attachments/assets/2b439f5b-a539-4ba5-8cd6-4879dfbb7100)


![image](https://github.com/user-attachments/assets/33d125e0-e62d-49d6-95aa-8c9d54856df2)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
