### PR TITLE
Fix: JWT token auth in Airflow 3 beta as JWT mechanism changed

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -23,7 +23,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.20.0pre0``
+Release: ``0.20.1pre0``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -36,7 +36,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1pre0/>`_.
 
 Installation
 ------------
@@ -78,4 +78,4 @@ Dependent package                                                               
 ==============================================================================================  =======
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1pre0/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.20.1pre0
+..........
+
+Fix
+~~~
+
+* ``Fix JWT token auth in Airflow 3 beta as JWT mechanism changed.``
+
+
 0.20.0pre0
 ..........
 

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1741121867
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.20.0pre0
+  - 0.20.1pre0
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.20.0pre0"
+version = "0.20.1pre0"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -89,8 +89,8 @@ apache-airflow-providers-fab = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.0pre0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1pre0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1pre0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.20.0pre0"
+__version__ = "0.20.1pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1741121867,
-        "versions": ["0.20.0pre0"],
+        "versions": ["0.20.1pre0"],
         "plugins": [
             {
                 "name": "edge_executor",

--- a/providers/edge/src/airflow/providers/edge/worker_api/auth.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/auth.py
@@ -57,8 +57,6 @@ if AIRFLOW_V_3_0_PLUS:
     def jwt_validate(authorization: str) -> dict:
         return jwt_validator().validated_claims(authorization)
 
-    JWT_METHOD_FIELD = "sub"
-
 else:
     # Airflow 2.10 compatibility
     from airflow.utils.jwt_signer import JWTSigner  # type: ignore
@@ -76,8 +74,6 @@ else:
     def jwt_validate(authorization: str) -> dict:
         return jwt_signer().verify_token(authorization)
 
-    JWT_METHOD_FIELD = "method"
-
 
 def _forbidden_response(message: str):
     """Log the error and return the response anonymized."""
@@ -93,7 +89,7 @@ def jwt_token_authorization(method: str, authorization: str):
     """Check if the JWT token is correct."""
     try:
         payload = jwt_validate(authorization)
-        signed_method = payload.get(JWT_METHOD_FIELD)
+        signed_method = payload.get("method")
         if not signed_method or signed_method != method:
             _forbidden_response(
                 "Invalid method in token authorization. "


### PR DESCRIPTION
Unfortunately I needed to notice that the recent changes in JWT token generation/validation broke the Edge Worker API calls in main. Just a small adjustment needed which even reduces a diff between 2.10 and 3.0 line.

This also (again) triggers me that I need to find time to add a Edge Worker test into CI...

How to test?
- Start via `breeze start-airflow --python 3.12 --load-example-dags --backend postgres --executor EdgeExecutor --answer y` and see that EdgeWorker comes-up and reports no task. Before this PR on main it failed authentication and got a 403 error.