### PR TITLE
Create Mock object with resource id as an attribute instead of passing a string

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from tableauserverclient.models import TaskItem
+
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.tableau.hooks.tableau import (
@@ -120,7 +122,8 @@ class TableauOperator(BaseOperator):
 
             resource_id = self._get_resource_id(tableau_hook)
 
-            response = method(resource_id)
+            task_item = TaskItem(id_=resource_id, task_type=TaskItem.Type.ExtractRefresh, priority=0)
+            response = method(task_item)
 
             job_id = response.id
 

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -195,3 +195,12 @@ class TestTableauOperator:
         resource_id = "res_id"
         operator = TableauOperator(resource="task", find=resource_id, method="run", task_id="t", dag=None)
         assert operator._get_resource_id(resource_id) == resource_id
+
+    def test_execute_resource_tasks(self):
+        """
+        Test execute of resource tasks
+        """
+        operator = TableauOperator(resource="tasks", method="run", **self.kwargs)
+
+        with pytest.raises(AirflowException):
+            operator.execute({})


### PR DESCRIPTION
This closes: #42248 and is based on work that was previously done for the ticket here: https://github.com/apache/airflow/pull/43854, additionally a unit test has been added to test the new code change as suggested in the linked pull request.