### PR TITLE
Fix support for a path in `[api] base_url`

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -67,7 +68,7 @@ def create_app(apps: str = "all") -> FastAPI:
     fastapi_base_url = conf.get("api", "base_url", fallback="")
     if fastapi_base_url and not fastapi_base_url.endswith("/"):
         fastapi_base_url += "/"
-        conf.set("api", "base_url", fastapi_base_url)
+        os.environ["AIRFLOW__API__BASE_URL"] = fastapi_base_url
 
     root_path = urlsplit(fastapi_base_url).path.removesuffix("/")
 

--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -41,8 +41,14 @@ from airflow.exceptions import AirflowConfigException
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
 
-# Define the path in which the potential auth manager fastapi is mounted
-AUTH_MANAGER_FASTAPI_APP_PREFIX = "/auth"
+API_BASE_URL = conf.get("api", "base_url")
+if API_BASE_URL and not API_BASE_URL.endswith("/"):
+    API_BASE_URL += "/"
+    os.environ["AIRFLOW__API__BASE_URL"] = API_BASE_URL
+API_ROOT_PATH = urlsplit(API_BASE_URL).path
+
+# Define the full path on which the potential auth manager fastapi is mounted
+AUTH_MANAGER_FASTAPI_APP_PREFIX = f"{API_ROOT_PATH}auth"
 
 log = logging.getLogger(__name__)
 
@@ -65,20 +71,13 @@ async def lifespan(app: FastAPI):
 def create_app(apps: str = "all") -> FastAPI:
     apps_list = apps.split(",") if apps else ["all"]
 
-    fastapi_base_url = conf.get("api", "base_url", fallback="")
-    if fastapi_base_url and not fastapi_base_url.endswith("/"):
-        fastapi_base_url += "/"
-        os.environ["AIRFLOW__API__BASE_URL"] = fastapi_base_url
-
-    root_path = urlsplit(fastapi_base_url).path.removesuffix("/")
-
     app = FastAPI(
         title="Airflow API",
         description="Airflow API. All endpoints located under ``/public`` can be used safely, are stable and backward compatible. "
         "Endpoints located under ``/ui`` are dedicated to the UI and are subject to breaking change "
         "depending on the need of the frontend. Users should not rely on those but use the public ones instead.",
         lifespan=lifespan,
-        root_path=root_path,
+        root_path=API_ROOT_PATH.removesuffix("/"),
     )
 
     if "execution" in apps_list or "all" in apps_list:
@@ -145,7 +144,7 @@ def init_auth_manager(app: FastAPI | None = None) -> BaseAuthManager:
     am.init()
 
     if app and (auth_manager_fastapi_app := am.get_fastapi_app()):
-        app.mount(AUTH_MANAGER_FASTAPI_APP_PREFIX, auth_manager_fastapi_app)
+        app.mount("/auth", auth_manager_fastapi_app)
         app.state.auth_manager = am
 
     return am

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -44,7 +44,10 @@ axios.interceptors.response.use(
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);
-      globalThis.location.replace(`/public/auth/login?${params.toString()}`);
+      const baseUrl = document.querySelector("head>base")?.getAttribute("href") ?? "";
+      const loginPath = new URL("public/auth/login", baseUrl).pathname;
+
+      globalThis.location.replace(`${loginPath}?${params.toString()}`);
     }
 
     return Promise.reject(error);

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -99,7 +99,7 @@ class TestDagRunOperator:
 
         if AIRFLOW_V_3_0_PLUS:
             base_url = conf.get_mandatory_value("api", "base_url").lower()
-            expected_url = f"{base_url}/dags/{triggered_dag_run.dag_id}/runs/{triggered_dag_run.run_id}"
+            expected_url = f"{base_url}dags/{triggered_dag_run.dag_id}/runs/{triggered_dag_run.run_id}"
 
             link = triggering_task.operator_extra_links[0].get_link(
                 operator=triggering_task, ti_key=triggering_ti.key


### PR DESCRIPTION
This PR fixes support for a path in `[api] base_url`. There were a few things wrong:

- If base_url was set via env var, and did not have a trailing slash, we did not add one properly, resulting in the base href missing a trailing slash, leading to the JS not being loaded.
- When the UI redirects to `public/auth/login`, so browser can redirect to the auth manager login url, we weren't taking the path in base_url into account.
- The global var auth managers use to know what path they are mounted on wasn't taking the path in the base_url into account.

More on the trailing slash problem (the first bullet):
When `[api] base_url` does not have a trailing slash configured, we update it to have one. However, this was done with `conf.set`, which does _not_ actually take precedence over the original value if it was configured with an env var. So, instead, we will set the fixed value in an env var.

This doesn't completely fix supporting an arbitrary path in the base_url, but it at least the first problem.

Here is an example that demonstrates conf.set's behavior:

```
$ AIRFLOW__API__BASE_URL=hello python3
Python 3.12.9 (main, Feb 12 2025, 15:09:19) [Clang 19.1.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.configuration import conf
>>> conf.get("api", "base_url")
'hello'
>>> conf.set("api", "base_url", "world")
>>> conf.get("api", "base_url")
'hello'
>>> import os
>>> del os.environ["AIRFLOW__API__BASE_URL"]
>>> conf.get("api", "base_url")
'world'
```