### PR TITLE
Handle 404 from assets/by-XXX in runtime

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -340,14 +340,29 @@ class AssetOperations:
     def __init__(self, client: Client):
         self.client = client
 
-    def get(self, name: str | None = None, uri: str | None = None) -> AssetResponse:
+    def get(self, name: str | None = None, uri: str | None = None) -> AssetResponse | ErrorResponse:
         """Get Asset value from the API server."""
         if name:
-            resp = self.client.get("assets/by-name", params={"name": name})
+            endpoint = "assets/by-name"
+            params = {"name": name}
         elif uri:
-            resp = self.client.get("assets/by-uri", params={"uri": uri})
+            endpoint = "assets/by-uri"
+            params = {"uri": uri}
         else:
             raise ValueError("Either `name` or `uri` must be provided")
+
+        try:
+            resp = self.client.get(endpoint, params=params)
+        except ServerResponseError as e:
+            if e.response.status_code == HTTPStatus.NOT_FOUND:
+                log.error(
+                    "Asset not found",
+                    params=params,
+                    detail=e.detail,
+                    status_code=e.response.status_code,
+                )
+                return ErrorResponse(error=ErrorType.ASSET_NOT_FOUIND, detail=params)
+            raise
 
         return AssetResponse.model_validate_json(resp.read())
 

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -25,15 +25,20 @@ if TYPE_CHECKING:
 
 
 class AirflowRuntimeError(Exception):
+    """Generic Airflow arror raised by runtime functions."""
+
     def __init__(self, error: ErrorResponse):
         self.error = error
         super().__init__(f"{error.error.value}: {error.detail}")
 
 
 class ErrorType(enum.Enum):
+    """Error types used in the API client."""
+
     CONNECTION_NOT_FOUND = "CONNECTION_NOT_FOUND"
     VARIABLE_NOT_FOUND = "VARIABLE_NOT_FOUND"
     XCOM_NOT_FOUND = "XCOM_NOT_FOUND"
+    ASSET_NOT_FOUIND = "ASSET_NOT_FOUND"
     GENERIC_ERROR = "GENERIC_ERROR"
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -54,6 +54,7 @@ from pydantic import TypeAdapter
 
 from airflow.sdk.api.client import Client, ServerResponseError
 from airflow.sdk.api.datamodels._generated import (
+    AssetResponse,
     ConnectionResponse,
     IntermediateTIState,
     TaskInstance,
@@ -906,12 +907,18 @@ class ActivitySubprocess(WatchedSubprocess):
             self.client.task_instances.set_rtif(self.id, msg.rendered_fields)
         elif isinstance(msg, GetAssetByName):
             asset_resp = self.client.assets.get(name=msg.name)
-            asset_result = AssetResult.from_asset_response(asset_resp)
-            resp = asset_result.model_dump_json(exclude_unset=True).encode()
+            if isinstance(asset_resp, AssetResponse):
+                asset_result = AssetResult.from_asset_response(asset_resp)
+                resp = asset_result.model_dump_json(exclude_unset=True).encode()
+            else:
+                resp = asset_resp.model_dump_json().encode()
         elif isinstance(msg, GetAssetByUri):
             asset_resp = self.client.assets.get(uri=msg.uri)
-            asset_result = AssetResult.from_asset_response(asset_resp)
-            resp = asset_result.model_dump_json(exclude_unset=True).encode()
+            if isinstance(asset_resp, AssetResponse):
+                asset_result = AssetResult.from_asset_response(asset_resp)
+                resp = asset_result.model_dump_json(exclude_unset=True).encode()
+            else:
+                resp = asset_resp.model_dump_json().encode()
         elif isinstance(msg, GetAssetEventByAsset):
             asset_event_resp = self.client.asset_events.get(uri=msg.uri, name=msg.name)
             asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)


### PR DESCRIPTION
Second part of https://github.com/apache/airflow/issues/47832#issuecomment-2728399542

With this correct 404 handling, now a failure to fetch an asset results in a cleaner AirflowRuntimeError with some relevant information.

Now the log would look like this

```
[2025-03-17, 09:34:39] ERROR - Task failed with exception source="task" error_detail=[{"exc_type":"AirflowRuntimeError","exc_value":"ASSET_NOT_FOUND: {'name': 'bad'}","exc_notes":[],"syntax_error":null,"is_cause":false,"frames":[{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py","lineno":599,"name":"run"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py","lineno":150,"name":"get_template_context"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py","lineno":304,"name":"__init__"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py","lineno":278,"name":"_get_asset_from_db"}]}]
```

Tested by triggering this asset-dag (where `bad` references an inlet that does not exist)

```python
@asset(schedule=None)
def wrong(bad):
    pass
```