### PR TITLE
AIP-38 Fix safari login loop for non ssl

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -69,7 +69,9 @@ class FabIndexView(IndexView):
         if g.user is not None and g.user.is_authenticated:
             token = get_auth_manager().generate_jwt(g.user)
             response = make_response(redirect(f"{conf.get('api', 'base_url')}", code=302))
-            response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=True)
+
+            secure = bool(conf.get("api", "ssl_cert"))
+            response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
 
             return response
         else:


### PR DESCRIPTION
Safari has a stricter policy when it comes to secure cookies. I will not allow `localhost` to use such cookies (https is always required), which is not the case for other browser.

This will at least fix the case for the development mode. i.e safari will work in `--dev-mode` in breeze or by specifying the env variable and running the api_server.

> It will still not work in `non dev-mode` via breeze though.

There is no issue for real development mode as long as people are using https to connect to their instance.