### PR TITLE
Call `init` from auth managers only once

### DIFF
--- a/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -124,7 +124,7 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
                     passwords, changed = self._get_passwords(users=users, stream=file)
                     for user in users:
                         if user["username"] not in passwords:
-                            # User dot not exist in the file, adding it
+                            # User does not exist in the file, adding it
                             passwords[user["username"]] = self._generate_password()
                             self._print_output(
                                 f"Password for user '{user['username']}': {passwords[user['username']]}"

--- a/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -17,13 +17,16 @@
 # under the License.
 from __future__ import annotations
 
+import fcntl
 import json
+import logging
 import os
 import random
 from collections import namedtuple
 from enum import Enum
+from json import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TextIO
 
 from fastapi import FastAPI
 from starlette.requests import Request
@@ -52,6 +55,8 @@ if TYPE_CHECKING:
         PoolDetails,
         VariableDetails,
     )
+
+log = logging.getLogger(__name__)
 
 
 class SimpleAuthManagerRole(namedtuple("SimpleAuthManagerRole", "name order"), Enum):
@@ -98,39 +103,44 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
 
     @staticmethod
     def get_passwords(users: list[dict[str, str]]) -> dict[str, str]:
-        user_passwords_from_file = {}
-
-        # Read passwords from file
         password_file = SimpleAuthManager.get_generated_password_file()
-        if os.path.isfile(password_file):
-            with open(password_file) as file:
-                passwords_str = file.read().strip()
-                user_passwords_from_file = json.loads(passwords_str)
-
-        usernames = {user["username"] for user in users}
-        return {
-            username: password
-            for username, password in user_passwords_from_file.items()
-            if username in usernames
-        }
+        with open(password_file, "r+") as file:
+            return SimpleAuthManager._get_passwords(users=users, stream=file)[0]
 
     def init(self) -> None:
         is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
         if is_simple_auth_manager_all_admins:
             return
         users = self.get_users()
-        passwords = self.get_passwords(users)
-        changed = False
-        for user in users:
-            if user["username"] not in passwords:
-                # User dot not exist in the file, adding it
-                passwords[user["username"]] = self._generate_password()
-                self._print_output(f"Password for user '{user['username']}': {passwords[user['username']]}")
-                changed = True
+        password_file = self.get_generated_password_file()
 
-        if changed:
-            with open(self.get_generated_password_file(), "w") as file:
-                file.write(json.dumps(passwords) + "\n")
+        try:
+            with open(password_file, "a+") as file:
+                try:
+                    # Non-blocking exclusive lock on this file
+                    # Fastapi spins up N workers, so this method is called N times in N different processes
+                    # This needs to be called only once so we use the file ``password_file`` as locking mechanism
+                    fcntl.flock(file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    passwords, changed = self._get_passwords(users=users, stream=file)
+                    for user in users:
+                        if user["username"] not in passwords:
+                            # User dot not exist in the file, adding it
+                            passwords[user["username"]] = self._generate_password()
+                            self._print_output(
+                                f"Password for user '{user['username']}': {passwords[user['username']]}"
+                            )
+                            changed = True
+
+                    if changed:
+                        file.seek(0)
+                        file.truncate()
+                        file.write(json.dumps(passwords) + "\n")
+                finally:
+                    # Release lock
+                    fcntl.flock(file, fcntl.LOCK_UN)
+        except BlockingIOError:
+            # The file is locked, another process called this method already, skipping
+            pass
 
     def get_url_login(self, **kwargs) -> str:
         """Return the login page url."""
@@ -333,6 +343,27 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         if method == "GET":
             return role.order >= allow_get_role.order
         return role.order >= allow_role.order
+
+    @staticmethod
+    def _get_passwords(users: list[dict[str, str]], stream: TextIO) -> tuple[dict[str, str], bool]:
+        try:
+            # Read passwords from file
+            stream.seek(0)
+            content = stream.read().strip() or "{}"
+            user_passwords_from_file = json.loads(content)
+        except JSONDecodeError:
+            log.error("Error decoding JSON from file %s", stream.name)
+            raise
+
+        usernames = {user["username"] for user in users}
+        changed = bool(user_passwords_from_file.keys() - usernames)
+        user_passwords_from_file = {
+            username: password
+            for username, password in user_passwords_from_file.items()
+            if username in usernames
+        }
+
+        return user_passwords_from_file, changed
 
     @staticmethod
     def _generate_password() -> str:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -176,10 +176,8 @@ class FabAuthManager(BaseAuthManager[User]):
 
     appbuilder: AirflowAppBuilder | None = None
 
-    def init(self) -> None:
-        """Run operations when Airflow is initializing."""
-        if self.appbuilder:
-            self._sync_appbuilder_roles()
+    def init_flask_resources(self) -> None:
+        self._sync_appbuilder_roles()
 
     @cached_property
     def apiserver_endpoint(self) -> str:

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
@@ -198,7 +198,8 @@ class AirflowAppBuilder:
         self.session = session
         auth_manager = create_auth_manager()
         auth_manager.appbuilder = self
-        auth_manager.init()
+        if hasattr(auth_manager, "init_flask_resources"):
+            auth_manager.init_flask_resources()
         if hasattr(auth_manager, "security_manager"):
             self.sm = auth_manager.security_manager
         else:


### PR DESCRIPTION
The method `init` from auth managers is called multiples times for two reasons:

- The method `init` is also called in the Flask applications. This is only needed for fab auth manager. Thus, I created a method specific `init_flask_resources` in FAB auth manager that I call in the Flask applications
- `fastapi` spins up multiple workers (4 by default), therefore `init` is called 4 times. I updated the init function of simple auth manager to be called only once

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
