### PR TITLE
Fix serialization inconsistency in classic Operators

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1235,7 +1235,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
     def operator_name(self) -> str:
         # Overwrites operator_name of BaseOperator to use _operator_name instead of
         # __class__.operator_name.
-        return self._operator_name
+        return self._operator_name or self.task_type
 
     @operator_name.setter
     def operator_name(self, operator_name: str):

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1284,8 +1284,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         serialize_op["task_type"] = getattr(op, "task_type", type(op).__name__)
         serialize_op["_task_module"] = getattr(op, "_task_module", type(op).__module__)
-        if op.operator_name and op.operator_name != serialize_op["task_type"]:
-            # op.operator_name can be None. See self._operator_name
+        if op.operator_name != serialize_op["task_type"]:
             serialize_op["_operator_name"] = op.operator_name
 
         # Used to determine if an Operator is inherited from EmptyOperator

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -48,7 +48,7 @@ def task_group_to_dict(task_item_or_group):
         if isinstance(task, MappedOperator):
             is_mapped["is_mapped"] = True
         if isinstance(task, BaseOperator) or isinstance(task, MappedOperator):
-            node_operator["operator"] = task.operator_name or task.task_type
+            node_operator["operator"] = task.operator_name
 
         return {
             "id": task.task_id,

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -48,7 +48,7 @@ def task_group_to_dict(task_item_or_group):
         if isinstance(task, MappedOperator):
             is_mapped["is_mapped"] = True
         if isinstance(task, BaseOperator) or isinstance(task, MappedOperator):
-            node_operator["operator"] = task.operator_name
+            node_operator["operator"] = task.operator_name or task.task_type
 
         return {
             "id": task.task_id,

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -422,7 +422,7 @@ def test_roundtrip_exceptions():
     assert deser.timeout == timedelta(seconds=30)
 
 
-def test_serialized_dag_to_dict_and_from_dict_gives_same_result_in_tasks(dag_maker, session):
+def test_serialized_dag_to_dict_and_from_dict_gives_same_result_in_tasks(dag_maker):
     with dag_maker() as dag:
         BashOperator(task_id="task1", bash_command="echo 1")
 

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -39,6 +39,7 @@ from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
 from airflow.models.xcom_arg import XComArg
+from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.triggers.file import FileDeleteTrigger
@@ -46,7 +47,7 @@ from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAliasEvent, As
 from airflow.sdk.definitions.param import Param
 from airflow.sdk.execution_time.context import OutletEventAccessor, OutletEventAccessors
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
-from airflow.serialization.serialized_objects import BaseSerialization
+from airflow.serialization.serialized_objects import BaseSerialization, SerializedDAG
 from airflow.triggers.base import BaseTrigger
 from airflow.utils import timezone
 from airflow.utils.db import LazySelectSequence
@@ -419,3 +420,14 @@ def test_roundtrip_exceptions():
     assert deser.method_name == "meth_name"
     assert deser.kwargs == {"have": "pie"}
     assert deser.timeout == timedelta(seconds=30)
+
+
+def test_serialized_dag_to_dict_and_from_dict_gives_same_result_in_tasks(dag_maker, session):
+    with dag_maker() as dag:
+        BashOperator(task_id="task1", bash_command="echo 1")
+
+    dag1 = SerializedDAG.to_dict(dag)
+    from_dict = SerializedDAG.from_dict(dag1)
+    dag2 = SerializedDAG.to_dict(from_dict)
+
+    assert dag2["dag"]["tasks"][0]["__var"].keys() == dag1["dag"]["tasks"][0]["__var"].keys()

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -422,6 +422,7 @@ def test_roundtrip_exceptions():
     assert deser.timeout == timedelta(seconds=30)
 
 
+@pytest.mark.db_test
 def test_serialized_dag_to_dict_and_from_dict_gives_same_result_in_tasks(dag_maker):
     with dag_maker() as dag:
         BashOperator(task_id="task1", bash_command="echo 1")


### PR DESCRIPTION
Fix inconsistent serialization in classic Operators

Problem:
- Classic operators serialization was inconsistently including `_operator_name` and `label` keys
- This inconsistency caused unnecessary versioning due to dictionary key differences
- The dag processor uses LazyDeserializedDAG, where the serialization process went through SerializedDAG.from_dict before creating the versioning hash. This is where the _operator_name and label are added for classic operators.
- Other times, SerializedDag.to_dict is used in SerializedDagModel init to create versioning hash. In this case, the label and _operator_name are not included.

Changes:
- Removed automatic addition of `label` during deserialization (legacy field for pre-TaskGroup data)
- Initialized _operator_name to None in SerializedBaseOperator constructor
- Added null check before comparing operator_name with task_type in _serialize_node to avoid having None as operator_name in classic operator serialization. The task_type and operator_name is always the same so we chose to keep the task_type.
- Improved SerializedBaseOperator.operator_name to return task_type if operator_name is null
- Added test to verify serialization consistency between to_dict and from_dict operations

This change helps stabilize versioning of classic operators by removing unnecessary fields from the serialized representation.

