### PR TITLE
fix PosixPath not working with file create_asset

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1494,7 +1494,9 @@ class S3Hook(AwsBaseHook):
             get_hook_lineage_collector().add_output_asset(
                 context=self,
                 scheme="file",
-                asset_kwargs={"path": file_path if file_path.is_absolute() else file_path.absolute()},
+                asset_kwargs={
+                    "path": str(file_path) if file_path.is_absolute() else str(file_path.absolute())
+                },
             )
             file = open(file_path, "wb")
         else:

--- a/providers/common/io/src/airflow/providers/common/io/assets/file.py
+++ b/providers/common/io/src/airflow/providers/common/io/assets/file.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import urllib.parse
+from pathlib import PosixPath
 from typing import TYPE_CHECKING
 
 from airflow.providers.common.io.version_compat import AIRFLOW_V_3_0_PLUS
@@ -32,9 +33,18 @@ if TYPE_CHECKING:
     from airflow.providers.common.compat.openlineage.facet import Dataset as OpenLineageDataset
 
 
-def create_asset(*, path: str, extra=None) -> Asset:
+def create_asset(*, path: str | PosixPath, extra=None) -> Asset:
+    if isinstance(path, PosixPath):
+        path = str(path)
+
     if path.startswith("file://"):
         path = path[len("file://") :]
+    elif path.startswith("file:"):
+        path = path[5:]
+        while path.startswith("/"):
+            path = path[1:]
+        path = "/" + path
+
     return Asset(uri=f"file://{path}", extra=extra)
 
 

--- a/providers/common/io/tests/unit/common/io/assets/test_file.py
+++ b/providers/common/io/tests/unit/common/io/assets/test_file.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from pathlib import PosixPath
 from urllib.parse import urlsplit, urlunsplit
 
 import pytest
@@ -54,6 +55,9 @@ def test_sanitize_uri_invalid(uri):
         ("file:///asdf/fdsa", "file:///asdf/fdsa"),
         ("file://asdf/fdsa", "file://asdf/fdsa"),
         ("file://127.0.0.1:8080/dir/file.csv", "file://127.0.0.1:8080/dir/file.csv"),
+        (PosixPath("file:///tmpdir/some-path.csv"), "file:///tmpdir/some-path.csv"),
+        ("file:/tmpdir/some-path.csv", "file:///tmpdir/some-path.csv"),
+        ("file:tmpdir/some-path.csv", "file:///tmpdir/some-path.csv"),
     ),
 )
 def test_file_asset(path, uri):
@@ -71,6 +75,12 @@ def test_file_asset(path, uri):
         ("file:///C://dir/file", OpenLineageDataset(namespace="file", name="/C://dir/file")),
         ("file://asdf.pdf", OpenLineageDataset(namespace="file", name="/asdf.pdf")),
         ("file:///asdf.pdf", OpenLineageDataset(namespace="file", name="/asdf.pdf")),
+        (
+            PosixPath("file:///tmp/pytest/test.log"),
+            OpenLineageDataset(namespace="file", name="/tmp/pytest/test.log"),
+        ),
+        ("file:/tmp/pytest/test.log", OpenLineageDataset(namespace="file", name="/tmp/pytest/test.log")),
+        ("file:tmp/pytest/test.log", OpenLineageDataset(namespace="file", name="/tmp/pytest/test.log")),
     ),
 )
 def test_convert_asset_to_openlineage(path, ol_dataset):


### PR DESCRIPTION
Handle PosixPath in `common.io` file `create_asset` handler. 