### PR TITLE
feat: Add helper for any provider version check

### DIFF
--- a/providers/common/compat/src/airflow/providers/common/compat/check.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/check.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import functools
+import importlib
+from importlib import metadata
+
+from packaging.version import Version
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+
+
+def require_provider_version(provider_name: str, provider_min_version: str):
+    """
+    Enforce minimum version requirement for a specific provider.
+
+    Some providers, do not explicitly require other provider packages but may offer optional features
+    that depend on it. These features are generally available starting from a specific version of such
+    provider. This decorator helps ensure compatibility, preventing import errors and providing clear
+    logs about version requirements.
+
+    Args:
+        provider_name: Name of the provider e.g., apache-airflow-providers-openlineage
+        provider_min_version: Optional minimum version requirement e.g., 1.0.1
+
+    Raises:
+        ValueError: If neither `provider_name` nor `provider_min_version` is provided.
+        ValueError: If full provider name (e.g., apache-airflow-providers-openlineage) is not provided.
+        TypeError: If the decorator is used without parentheses (e.g., `@require_provider_version`).
+    """
+    err_msg = (
+        "`require_provider_version` decorator must be used with two arguments: "
+        "'provider_name' and 'provider_min_version', "
+        'e.g., @require_provider_version(provider_name="apache-airflow-providers-openlineage", '
+        'provider_min_version="1.0.0")'
+    )
+    # Detect if decorator is mistakenly used without arguments
+    if callable(provider_name) and not provider_min_version:
+        raise TypeError(err_msg)
+
+    # Ensure both arguments are provided and not empty
+    if not provider_name or not provider_min_version:
+        raise ValueError(err_msg)
+
+    # Ensure full provider name is passed
+    if not provider_name.startswith("apache-airflow-providers-"):
+        raise ValueError(
+            f"Full `provider_name` must be provided starting with 'apache-airflow-providers-', "
+            f"got `{provider_name}`."
+        )
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                provider_version: str = metadata.version(provider_name)
+            except metadata.PackageNotFoundError:
+                try:
+                    # Try dynamically importing the provider module based on the provider name
+                    import_provider_name = provider_name.replace("apache-airflow-providers-", "").replace(
+                        "-", "."
+                    )
+                    provider_module = importlib.import_module(f"airflow.providers.{import_provider_name}")
+
+                    provider_version = getattr(provider_module, "__version__")
+
+                except (ImportError, AttributeError, ModuleNotFoundError):
+                    raise AirflowOptionalProviderFeatureException(
+                        f"Provider `{provider_name}` not found or has no version, "
+                        f"skipping function `{func.__name__}` execution"
+                    )
+
+            if provider_version and Version(provider_version) < Version(provider_min_version):
+                raise AirflowOptionalProviderFeatureException(
+                    f"Provider's `{provider_name}` version `{provider_version}` is lower than required "
+                    f"`{provider_min_version}`, skipping function `{func.__name__}` execution"
+                )
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/providers/common/compat/src/airflow/providers/common/compat/openlineage/check.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/openlineage/check.py
@@ -23,6 +23,8 @@ from importlib import metadata
 
 from packaging.version import Version
 
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+
 log = logging.getLogger(__name__)
 
 
@@ -68,36 +70,32 @@ def require_openlineage_version(
                     try:
                         from airflow.providers.openlineage import __version__ as provider_version
                     except (ImportError, AttributeError, ModuleNotFoundError):
-                        log.info(
-                            "OpenLineage provider not found or has no version, skipping function `%s` execution",
-                            func.__name__,
+                        raise AirflowOptionalProviderFeatureException(
+                            "OpenLineage provider not found or has no version, "
+                            f"skipping function `{func.__name__}` execution"
                         )
-                        return None
 
                 if provider_version and Version(provider_version) < Version(provider_min_version):
-                    log.info(
-                        "OpenLineage provider version `%s` is lower than required `%s`, skipping function `%s` execution",
-                        provider_version,
-                        provider_min_version,
-                        func.__name__,
+                    raise AirflowOptionalProviderFeatureException(
+                        f"OpenLineage provider version `{provider_version}` "
+                        f"is lower than required `{provider_min_version}`, "
+                        f"skipping function `{func.__name__}` execution"
                     )
-                    return None
 
             if client_min_version:
                 try:
                     client_version: str = metadata.version("openlineage-python")
                 except metadata.PackageNotFoundError:
-                    log.info("OpenLineage client not found, skipping function `%s` execution", func.__name__)
-                    return None
+                    raise AirflowOptionalProviderFeatureException(
+                        f"OpenLineage client not found, skipping function `{func.__name__}` execution"
+                    )
 
                 if client_version and Version(client_version) < Version(client_min_version):
-                    log.info(
-                        "OpenLineage client version `%s` is lower than required `%s`, skipping function `%s` execution",
-                        client_version,
-                        client_min_version,
-                        func.__name__,
+                    raise AirflowOptionalProviderFeatureException(
+                        f"OpenLineage client version `{client_version}` "
+                        f"is lower than required `{client_min_version}`, "
+                        f"skipping function `{func.__name__}` execution"
                     )
-                    return None
 
             return func(*args, **kwargs)
 

--- a/providers/common/compat/tests/unit/common/compat/test_check.py
+++ b/providers/common/compat/tests/unit/common/compat/test_check.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from importlib import metadata
+from unittest.mock import patch
+
+import pytest
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+from airflow.providers.common.compat.check import require_provider_version
+
+
+def test_decorator_usage_without_parentheses():
+    with pytest.raises(TypeError):
+
+        @require_provider_version
+        def dummy_function():
+            pass
+
+
+def test_empty_provider_name_and_version():
+    with pytest.raises(ValueError, match="decorator must be used with two arguments"):
+
+        @require_provider_version("", "")
+        def dummy_function():
+            pass
+
+
+def test_invalid_provider_name():
+    expected_error = (
+        "Full `provider_name` must be provided starting with 'apache-airflow-providers-', "
+        "got `invalid-provider-name`."
+    )
+    with pytest.raises(ValueError, match=expected_error):
+
+        @require_provider_version("invalid-provider-name", "1.0.0")
+        def dummy_function():
+            pass
+
+
+@patch("importlib.metadata.version", return_value="0.9.9")
+def test_provider_version_lower_than_required(mock_version):
+    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    def dummy_function():
+        return "Function Executed"
+
+    with pytest.raises(
+        AirflowOptionalProviderFeatureException,
+        match=r"Provider's `apache-airflow-providers-mockprovider` version `0.9.9` is lower than required `1.0.0`",
+    ):
+        dummy_function()
+
+
+@patch("importlib.metadata.version", side_effect=metadata.PackageNotFoundError)
+@patch("importlib.import_module", side_effect=ModuleNotFoundError)
+def test_provider_not_installed(mock_import, mock_version):
+    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    def dummy_function():
+        return "Function Executed"
+
+    with pytest.raises(
+        AirflowOptionalProviderFeatureException,
+        match=r"Provider `apache-airflow-providers-mockprovider` not found or has no version",
+    ):
+        dummy_function()
+
+
+@patch("importlib.metadata.version", return_value="2.0.0")
+def test_provider_version_ok(mock_version):
+    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    def dummy_function():
+        return "Function Executed"
+
+    result = dummy_function()
+    assert result == "Function Executed"
+
+
+@patch("importlib.import_module", return_value=type("module", (), {"__version__": "1.5.0"}))
+@patch("importlib.metadata.version", side_effect=metadata.PackageNotFoundError)
+def test_provider_dynamic_import(mock_version, mock_import):
+    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    def dummy_function():
+        return "Function Executed"
+
+    result = dummy_function()
+    assert result == "Function Executed"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Followup to #47897, adding more general decorator that will work for any provider.

Also as @eladkal pointed, we should be raising `AirflowOptionalProviderFeatureException` and not returning silently, so I also adjusted that.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
