### PR TITLE
Add documentation on handling PGBouncer with separate Schema

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -231,6 +231,12 @@ For more information regarding setup of the PostgreSQL connection, see `PostgreS
    PGBouncer instance with flipping a boolean flag. You can take a look at the approach we have taken there and use it as
    an inspiration, when you prepare your own Deployment, even if you do not use the Official Helm Chart.
 
+   Note that PGBouncer is currently **not** handling a ``search_path`` set in the sqlalchemy connection string : therefore, the previous
+   configuration set in :ref:`Other configuration options` should not work. To keep a distinct schema, you will need :
+   1. to create a specific user;
+   2. register the ``search_path`` for this user (see just above);
+   3. set the sqlalchemy connection string with this user.
+
    See also :ref:`Helm Chart production guide <production-guide:pgbouncer>`
 
 
@@ -357,6 +363,10 @@ For instance, you can specify a database schema where Airflow will create its re
     export AIRFLOW__DATABASE__SQL_ALCHEMY_SCHEMA="airflow"
 
 Note the ``search_path`` at the end of the ``SQL_ALCHEMY_CONN`` database URL.
+
+.. note::
+
+   If you are using a PostgreSQL Database in production with PGBouncer in between, setting the ``search_path`` in the sqlalchemy connection string might not be supported. Please have a look at :ref:`Setting up a PostgreSQL Database`.
 
 
 Initialize the database


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
While setting airflow in production with a PGBouncer/PostgreSQL database, I've encountered errors regarding the `search_path` method for a custom schema : it seems PGBouncer doesn't allow the `search_path` in the sqlalchemy connection string (which is the current method stated in airflow's documentation).

This documentation details steps for a workaround.
