### PR TITLE
Fix login redirect loop if user has multiple cookies

### DIFF
--- a/airflow/ui/src/utils/tokenHandler.ts
+++ b/airflow/ui/src/utils/tokenHandler.ts
@@ -23,15 +23,13 @@ const getTokenFromCookies = (): string | undefined => {
   const cookies = document.cookie.split(";");
 
   for (const cookie of cookies) {
-    if (cookie.includes("_token=")) {
-      const [, token] = cookie.split("=");
+    const [name, token] = cookie.split("=");
 
-      if (token !== undefined) {
-        localStorage.setItem(TOKEN_STORAGE_KEY, token);
-        document.cookie = "_token=; expires=Thu, 01 Jan 2000 00:00:00 UTC; path=/;";
+    if (name?.trim() === "_token" && token !== undefined) {
+      localStorage.setItem(TOKEN_STORAGE_KEY, token);
+      document.cookie = "_token=; expires=Thu, 01 Jan 2000 00:00:00 UTC; path=/;";
 
-        return token;
-      }
+      return token;
     }
   }
 

--- a/airflow/ui/src/utils/tokenHandler.ts
+++ b/airflow/ui/src/utils/tokenHandler.ts
@@ -23,7 +23,7 @@ const getTokenFromCookies = (): string | undefined => {
   const cookies = document.cookie.split(";");
 
   for (const cookie of cookies) {
-    if (cookie.startsWith("_token=")) {
+    if (cookie.includes("_token=")) {
       const [, token] = cookie.split("=");
 
       if (token !== undefined) {


### PR DESCRIPTION
If the browser had multiple cookies, we were not fetching the auth token correctly and the user got stuck in a infinite redirect  loop.

This is because cookies are often split by `; ` not just `;`

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
