### PR TITLE
Fix clearing dag run endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -252,13 +252,10 @@ def clear_dag_run(
         )
 
     dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
-    start_date = dag_run.logical_date
-    end_date = dag_run.logical_date
 
     if body.dry_run:
         task_instances = dag.clear(
-            start_date=start_date,
-            end_date=end_date,
+            run_id=dag_run_id,
             task_ids=None,
             only_failed=body.only_failed,
             dry_run=True,
@@ -271,8 +268,7 @@ def clear_dag_run(
         )
     else:
         dag.clear(
-            start_date=start_date,
-            end_date=end_date,
+            run_id=dag_run_id,
             task_ids=None,
             only_failed=body.only_failed,
             session=session,

--- a/airflow/ui/src/queries/useClearDagRunDryRun.ts
+++ b/airflow/ui/src/queries/useClearDagRunDryRun.ts
@@ -47,5 +47,5 @@ export const useClearDagRunDryRun = <TData = TaskInstanceCollectionResponse, TEr
           ...requestBody,
         },
       }) as TData,
-    queryKey: [useClearDagRunDryRunKey, dagId, { only_failed: requestBody.only_failed }],
+    queryKey: [useClearDagRunDryRunKey, dagId, dagRunId, { only_failed: requestBody.only_failed }],
   });


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/47450#issuecomment-2729135545


This was a side effect of AIP-83 amendment where `logical_date` can be None, therefore no filtering on `start_date/end_date` whould happen and TI outside the dag_run considered would be cleared.

This removes the `start_date/end_date` and use the `run_id` parameter to clear a dag_run.