### PR TITLE
Do not do XcomModel.deserialize on ti.xcom_pull in models

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -550,7 +550,7 @@ def _xcom_pull(
         if first is None:  # No matching XCom at all.
             return default
         if map_indexes is not None or first.map_index < 0:
-            return XComModel.deserialize_value(first)
+            return first.value
 
         # raise RuntimeError("Nothing should hit this anymore")
 

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -351,7 +351,7 @@ class LazyXComSelectSequence(LazySelectSequence[Any]):
 
     @staticmethod
     def _process_row(row: Row) -> Any:
-        return XComModel.deserialize_value(row)
+        return row.value
 
 
 def __getattr__(name: str):

--- a/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
+++ b/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
@@ -333,6 +333,8 @@ class PlainXComArg(XComArg):
         return super().concat(*others)
 
     def resolve(self, context: Mapping[str, Any]) -> Any:
+        from airflow.serialization.serde import deserialize
+
         ti = context["ti"]
         task_id = self.operator.task_id
 
@@ -355,6 +357,7 @@ class PlainXComArg(XComArg):
                 key=self.key,
                 default=NOTSET,
             )
+        result = deserialize(result)
         if not isinstance(result, ArgNotSet):
             return result
         if self.key == XCOM_RETURN_KEY:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1689,7 +1689,7 @@ class TestTaskInstance:
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
         ti.task = task
         ti.run()
-        assert ti.xcom_pull(task_ids=task_id, key=XCOM_RETURN_KEY) == value
+        assert ti.xcom_pull(task_ids=task_id, key=XCOM_RETURN_KEY) == json.dumps(value)
 
     def test_xcom_with_multiple_outputs(self, dag_maker):
         """
@@ -1708,9 +1708,9 @@ class TestTaskInstance:
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
         ti.task = task
         ti.run()
-        assert ti.xcom_pull(task_ids=task_id, key=XCOM_RETURN_KEY) == value
-        assert ti.xcom_pull(task_ids=task_id, key="key1") == "value1"
-        assert ti.xcom_pull(task_ids=task_id, key="key2") == "value2"
+        assert ti.xcom_pull(task_ids=task_id, key=XCOM_RETURN_KEY) == json.dumps(value)
+        assert ti.xcom_pull(task_ids=task_id, key="key1") == json.dumps("value1")
+        assert ti.xcom_pull(task_ids=task_id, key="key2") == json.dumps("value2")
 
     def test_xcom_with_multiple_outputs_and_no_mapping_result(self, dag_maker):
         """


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/47907

After effect of #45481.

This is because the xcoms are now pushed as native objects to the table and trying to do a `json.loads` on those native objects causes error. We shouldn't do that and just return when used with AF3.

Seems due to this, we were running into https://github.com/apache/airflow/issues/47907. 


Tested with the same dag in the issue. 

![image](https://github.com/user-attachments/assets/0a415d23-c569-49e0-a8a1-f91711ab8022)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
