### PR TITLE
Next run date should not be updated by backfills

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1419,8 +1419,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # If last_dag_run is defined, the update was triggered by a scheduling decision in this DAG run.
         # In such case, schedule next only if last_dag_run is finished and was an automated run.
         if last_dag_run and not (
-            last_dag_run.state in State.finished_dr_states
-            and last_dag_run.run_type in [DagRunType.SCHEDULED, DagRunType.BACKFILL_JOB]
+            last_dag_run.state in State.finished_dr_states and last_dag_run.run_type == DagRunType.SCHEDULED
         ):
             return False
         # If the DAG never schedules skip save runtime

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3675,37 +3675,6 @@ class TestSchedulerJob:
         assert "Marked 1 SchedulerJob instances as failed" in caplog.messages
 
     @pytest.mark.parametrize(
-        "run_type,expected",
-        [
-            (DagRunType.BACKFILL_JOB, False),
-            (DagRunType.SCHEDULED, True),
-        ],
-    )
-    def test_should_update_dag_next_dagruns_no_backfill(self, run_type, expected, session, dag_maker):
-        """Test if really required to update next dagrun or possible to save run time"""
-        with dag_maker(schedule="@daily") as dag:
-            EmptyOperator(task_id="dummy")
-
-        dr = dag_maker.create_dagrun(
-            run_id="some-run",
-            logical_date=DEFAULT_DATE,
-            start_date=timezone.utcnow(),
-            state=State.SUCCESS,
-            run_type=run_type,
-            session=session,
-        )
-        scheduler_job = Job(executor=self.null_exec)
-        runner = SchedulerJobRunner(job=scheduler_job)
-        actual = runner._should_update_dag_next_dagruns(
-            dag=dag,
-            dag_model=dag_maker.dag_model,
-            active_non_backfill_runs=0,
-            last_dag_run=dr,
-            session=session,
-        )
-        assert actual == expected
-
-    @pytest.mark.parametrize(
         "kwargs",
         [
             param(
@@ -3810,7 +3779,7 @@ class TestSchedulerJob:
         [
             (DagRunType.MANUAL, False),
             (DagRunType.SCHEDULED, True),
-            (DagRunType.BACKFILL_JOB, True),
+            (DagRunType.BACKFILL_JOB, False),
             (DagRunType.ASSET_TRIGGERED, False),
         ],
         ids=[

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3675,6 +3675,37 @@ class TestSchedulerJob:
         assert "Marked 1 SchedulerJob instances as failed" in caplog.messages
 
     @pytest.mark.parametrize(
+        "run_type,expected",
+        [
+            (DagRunType.BACKFILL_JOB, False),
+            (DagRunType.SCHEDULED, True),
+        ],
+    )
+    def test_should_update_dag_next_dagruns_no_backfill(self, run_type, expected, session, dag_maker):
+        """Test if really required to update next dagrun or possible to save run time"""
+        with dag_maker(schedule="@daily") as dag:
+            EmptyOperator(task_id="dummy")
+
+        dr = dag_maker.create_dagrun(
+            run_id="some-run",
+            logical_date=DEFAULT_DATE,
+            start_date=timezone.utcnow(),
+            state=State.SUCCESS,
+            run_type=run_type,
+            session=session,
+        )
+        scheduler_job = Job(executor=self.null_exec)
+        runner = SchedulerJobRunner(job=scheduler_job)
+        actual = runner._should_update_dag_next_dagruns(
+            dag=dag,
+            dag_model=dag_maker.dag_model,
+            active_non_backfill_runs=0,
+            last_dag_run=dr,
+            session=session,
+        )
+        assert actual == expected
+
+    @pytest.mark.parametrize(
         "kwargs",
         [
             param(


### PR DESCRIPTION
If we update next run after a backfill, for a dag with catchup enabled, the scheduler may create old runs that are before start date (in the period between the last backfill run and the start date of the dag).

resolves https://github.com/apache/airflow/issues/47886