### PR TITLE
Correctly select multiple columns with execute()

### DIFF
--- a/airflow/dag_processing/collection.py
+++ b/airflow/dag_processing/collection.py
@@ -668,7 +668,7 @@ class AssetModelOperation(NamedTuple):
         if not references:
             return
         orm_refs = set(
-            session.scalars(
+            session.execute(
                 select(model.dag_id, getattr(model, attr)).where(
                     model.dag_id.in_(dag_id for dag_id, _ in references)
                 )

--- a/devel-common/src/tests_common/test_utils/compat.py
+++ b/devel-common/src/tests_common/test_utils/compat.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
         AssetDagRunQueue,
         AssetEvent,
         AssetModel,
+        DagScheduleAssetAliasReference,
         DagScheduleAssetReference,
         TaskOutletAssetReference,
     )
@@ -78,6 +79,7 @@ else:
             AssetDagRunQueue,
             AssetEvent,
             AssetModel,
+            DagScheduleAssetAliasReference,
             DagScheduleAssetReference,
             TaskOutletAssetReference,
         )
@@ -92,7 +94,10 @@ else:
         )
 
         if AIRFLOW_V_2_10_PLUS:
-            from airflow.models.dataset import DatasetAliasModel as AssetAliasModel
+            from airflow.models.dataset import (
+                DagScheduleDatasetAliasReference as DagScheduleAssetAliasReference,
+                DatasetAliasModel as AssetAliasModel,
+            )
 
 
 def deserialize_operator(serialized_operator: dict[str, Any]) -> Operator:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -158,14 +158,22 @@ def clear_db_assets():
         session.query(DagScheduleAssetReference).delete()
         session.query(TaskOutletAssetReference).delete()
         if AIRFLOW_V_2_10_PLUS:
-            from tests_common.test_utils.compat import AssetAliasModel
+            from tests_common.test_utils.compat import AssetAliasModel, DagScheduleAssetAliasReference
 
             session.query(AssetAliasModel).delete()
+            session.query(DagScheduleAssetAliasReference).delete()
         if AIRFLOW_V_3_0_PLUS:
-            from airflow.models.asset import AssetActive, asset_trigger_association_table
+            from airflow.models.asset import (
+                AssetActive,
+                DagScheduleAssetNameReference,
+                DagScheduleAssetUriReference,
+                asset_trigger_association_table,
+            )
 
             session.query(asset_trigger_association_table).delete()
             session.query(AssetActive).delete()
+            session.query(DagScheduleAssetNameReference).delete()
+            session.query(DagScheduleAssetUriReference).delete()
 
 
 def clear_db_triggers():


### PR DESCRIPTION
Using scalars() silently drops the second object.

Fix #47872. ~~Not quite sure how to test this…~~ Tested now.