### PR TITLE
Updating EC2 Operators and Sensors with AWS Base classes

### DIFF
--- a/providers/amazon/docs/operators/ec2.rst
+++ b/providers/amazon/docs/operators/ec2.rst
@@ -31,7 +31,7 @@ Generic Parameters
 ------------------
 
 .. include:: ../_partials/generic_parameters.rst
-    
+
 Operators
 ---------
 

--- a/providers/amazon/docs/operators/ec2.rst
+++ b/providers/amazon/docs/operators/ec2.rst
@@ -27,6 +27,11 @@ Prerequisite Tasks
 
 .. include:: ../_partials/prerequisite_tasks.rst
 
+Generic Parameters
+------------------
+
+.. include:: ../_partials/generic_parameters.rst
+    
 Operators
 ---------
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ec2.py
@@ -18,17 +18,16 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
-from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
-
 from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
 from airflow.providers.amazon.aws.links.ec2 import (
     EC2InstanceDashboardLink,
     EC2InstanceLink,
 )
+from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
+from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -106,6 +105,7 @@ class EC2StopInstanceOperator(AwsBaseOperator[EC2Hook]):
     :param check_interval: time in seconds that the job should wait in
         between each instance state checks until operation is completed
     """
+
     aws_hook_class = EC2Hook
     operator_extra_links = (EC2InstanceLink(),)
     template_fields: Sequence[str] = aws_template_fields("instance_id", "region_name")
@@ -202,10 +202,11 @@ class EC2CreateInstanceOperator(AwsBaseOperator[EC2Hook]):
         self.wait_for_completion = wait_for_completion
 
     @property
-    def _hook_parameters(self)->dict[str:any]:
+    def _hook_parameters(self) -> dict[str, Any]:
         return {**super()._hook_parameters, "api_type": "client_type"}
+
     def execute(self, context: Context):
-        instances = self.hook.conn.run_instances(        
+        instances = self.hook.conn.run_instances(
             ImageId=self.image_id,
             MinCount=self.min_count,
             MaxCount=self.max_count,
@@ -275,7 +276,9 @@ class EC2TerminateInstanceOperator(AwsBaseOperator[EC2Hook]):
     """
 
     aws_hook_class = EC2Hook
-    template_fields: Sequence[str] = aws_template_fields("instance_ids", "region_name", "aws_conn_id", "wait_for_completion")
+    template_fields: Sequence[str] = aws_template_fields(
+        "instance_ids", "region_name", "aws_conn_id", "wait_for_completion"
+    )
 
     def __init__(
         self,
@@ -292,9 +295,9 @@ class EC2TerminateInstanceOperator(AwsBaseOperator[EC2Hook]):
         self.wait_for_completion = wait_for_completion
 
     @property
-    def _hook_parameters(self)->dict[str:any]:
+    def _hook_parameters(self) -> dict[str, Any]:
         return {**super()._hook_parameters, "api_type": "client_type"}
-    
+
     def execute(self, context: Context):
         if isinstance(self.instance_ids, str):
             self.instance_ids = [self.instance_ids]
@@ -357,7 +360,7 @@ class EC2RebootInstanceOperator(AwsBaseOperator[EC2Hook]):
         self.wait_for_completion = wait_for_completion
 
     @property
-    def _hook_parameters(self)->dict[str:any]:
+    def _hook_parameters(self) -> dict[str, Any]:
         return {**super()._hook_parameters, "api_type": "client_type"}
 
     def execute(self, context: Context):
@@ -406,6 +409,7 @@ class EC2HibernateInstanceOperator(AwsBaseOperator[EC2Hook]):
     :param wait_for_completion: If True, the operator will wait for the instance to be
         in the `stopped` state before returning.
     """
+
     aws_hook_class = EC2Hook
     operator_extra_links = (EC2InstanceDashboardLink(),)
     template_fields: Sequence[str] = aws_template_fields("instance_ids", "region_name")
@@ -428,9 +432,9 @@ class EC2HibernateInstanceOperator(AwsBaseOperator[EC2Hook]):
         self.wait_for_completion = wait_for_completion
 
     @property
-    def _hook_parameters(self)->dict[str:any]:
+    def _hook_parameters(self) -> dict[str, Any]:
         return {**super()._hook_parameters, "api_type": "client_type"}
-    
+
     def execute(self, context: Context):
         if isinstance(self.instance_ids, str):
             self.instance_ids = [self.instance_ids]

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ec2.py
@@ -42,12 +42,14 @@ class EC2StartInstanceOperator(AwsBaseOperator[EC2Hook]):
         :ref:`howto/operator:EC2StartInstanceOperator`
 
     :param instance_id: id of the AWS EC2 instance
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region_name: (optional) aws region name associated with the client
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param check_interval: time in seconds that the job should wait in
         between each instance state checks until operation is completed
     """
@@ -97,11 +99,13 @@ class EC2StopInstanceOperator(AwsBaseOperator[EC2Hook]):
 
     :param instance_id: id of the AWS EC2 instance
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region_name: (optional) aws region name associated with the client
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param check_interval: time in seconds that the job should wait in
         between each instance state checks until operation is completed
     """
@@ -154,11 +158,13 @@ class EC2CreateInstanceOperator(AwsBaseOperator[EC2Hook]):
     :param max_count: Maximum number of instances to launch. Defaults to 1.
     :param min_count: Minimum number of instances to launch. Defaults to 1.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region_name: AWS region name associated with the client.
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param poll_interval: Number of seconds to wait before attempting to
         check state of instance. Only used if wait_for_completion is True. Default is 20.
     :param max_attempts: Maximum number of attempts when checking state of instance.
@@ -262,11 +268,13 @@ class EC2TerminateInstanceOperator(AwsBaseOperator[EC2Hook]):
 
     :param instance_id: ID of the instance to be terminated.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region_name: AWS region name associated with the client.
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param poll_interval: Number of seconds to wait before attempting to
         check state of instance. Only used if wait_for_completion is True. Default is 20.
     :param max_attempts: Maximum number of attempts when checking state of instance.
@@ -325,11 +333,13 @@ class EC2RebootInstanceOperator(AwsBaseOperator[EC2Hook]):
 
     :param instance_ids: ID of the instance(s) to be rebooted.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region_name: AWS region name associated with the client.
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param poll_interval: Number of seconds to wait before attempting to
         check state of instance. Only used if wait_for_completion is True. Default is 20.
     :param max_attempts: Maximum number of attempts when checking state of instance.
@@ -397,11 +407,13 @@ class EC2HibernateInstanceOperator(AwsBaseOperator[EC2Hook]):
 
     :param instance_ids: ID of the instance(s) to be hibernated.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region_name: AWS region name associated with the client.
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param poll_interval: Number of seconds to wait before attempting to
         check state of instance. Only used if wait_for_completion is True. Default is 20.
     :param max_attempts: Maximum number of attempts when checking state of instance.

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/ec2.py
@@ -23,16 +23,18 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
 from airflow.providers.amazon.aws.triggers.ec2 import EC2StateSensorTrigger
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
+from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class EC2InstanceStateSensor(BaseSensorOperator):
+class EC2InstanceStateSensor(AwsBaseSensor[EC2Hook]):
     """
     Poll the state of the AWS EC2 instance until the instance reaches the target state.
 
@@ -45,8 +47,8 @@ class EC2InstanceStateSensor(BaseSensorOperator):
     :param region_name: (optional) aws region name associated with the client
     :param deferrable: if True, the sensor will run in deferrable mode
     """
-
-    template_fields: Sequence[str] = ("target_state", "instance_id", "region_name")
+    aws_hook_class = EC2Hook
+    template_fields: Sequence[str] = aws_template_fields("target_state", "instance_id", "region_name")
     ui_color = "#cc8811"
     ui_fgcolor = "#ffffff"
     valid_states = ["running", "stopped", "terminated"]
@@ -56,8 +58,6 @@ class EC2InstanceStateSensor(BaseSensorOperator):
         *,
         target_state: str,
         instance_id: str,
-        aws_conn_id: str | None = "aws_default",
-        region_name: str | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ):
@@ -66,8 +66,6 @@ class EC2InstanceStateSensor(BaseSensorOperator):
         super().__init__(**kwargs)
         self.target_state = target_state
         self.instance_id = instance_id
-        self.aws_conn_id = aws_conn_id
-        self.region_name = region_name
         self.deferrable = deferrable
 
     def execute(self, context: Context) -> Any:
@@ -85,9 +83,6 @@ class EC2InstanceStateSensor(BaseSensorOperator):
         else:
             super().execute(context=context)
 
-    @cached_property
-    def hook(self):
-        return EC2Hook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
 
     def poke(self, context: Context):
         instance_state = self.hook.get_instance_state(instance_id=self.instance_id)

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/ec2.py
@@ -18,17 +18,15 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
+from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.triggers.ec2 import EC2StateSensorTrigger
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
-from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -47,6 +45,7 @@ class EC2InstanceStateSensor(AwsBaseSensor[EC2Hook]):
     :param region_name: (optional) aws region name associated with the client
     :param deferrable: if True, the sensor will run in deferrable mode
     """
+
     aws_hook_class = EC2Hook
     template_fields: Sequence[str] = aws_template_fields("target_state", "instance_id", "region_name")
     ui_color = "#cc8811"
@@ -82,7 +81,6 @@ class EC2InstanceStateSensor(AwsBaseSensor[EC2Hook]):
             )
         else:
             super().execute(context=context)
-
 
     def poke(self, context: Context):
         instance_state = self.hook.get_instance_state(instance_id=self.instance_id)


### PR DESCRIPTION

---
Updated EC2 Operators to inherit base AWS Operator, and updated Sensors to inherit Base AWS Sensor. I did not update the Trigger, as it wasn't using the standard waiter.

Partially address #35278