### PR TITLE
Add asset event extra to events list in asset details page

### DIFF
--- a/airflow/ui/src/components/Assets/AssetEvent.tsx
+++ b/airflow/ui/src/components/Assets/AssetEvent.tsx
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text, HStack } from "@chakra-ui/react";
+import { Box, Text, HStack, Code } from "@chakra-ui/react";
 import { FiDatabase } from "react-icons/fi";
-import { MdOutlineAccountTree } from "react-icons/md";
 import { Link } from "react-router-dom";
 
 import type { AssetEventResponse } from "openapi/requests/types.gen";
@@ -28,16 +27,21 @@ import { Tooltip } from "src/components/ui";
 export const AssetEvent = ({
   assetId,
   event,
+  showExtra,
 }: {
   readonly assetId?: number;
   readonly event: AssetEventResponse;
+  readonly showExtra?: boolean;
 }) => {
   const hasDagRuns = event.created_dagruns.length > 0;
   let source = "";
 
-  if (event.extra?.from_rest_api === true) {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { from_rest_api, from_trigger, ...extra } = event.extra ?? {};
+
+  if (from_rest_api === true) {
     source = "API";
-  } else if (event.extra?.from_trigger === true) {
+  } else if (from_trigger === true) {
     source = "Trigger";
   }
 
@@ -65,7 +69,7 @@ export const AssetEvent = ({
         </HStack>
       )}
       <HStack>
-        <MdOutlineAccountTree /> <Text> Source: </Text>
+        <Text>Source: </Text>
         {source === "" ? (
           <Link
             to={`/dags/${event.source_dag_id}/runs/${event.source_run_id}/tasks/${event.source_task_id}${event.source_map_index > -1 ? `/mapped/${event.source_map_index}` : ""}`}
@@ -77,7 +81,7 @@ export const AssetEvent = ({
         )}
       </HStack>
       <HStack>
-        <Text> Triggered Dag Runs: </Text>
+        <Text>Triggered Dag Runs: </Text>
         {hasDagRuns ? (
           <Link to={`/dags/${event.created_dagruns[0]?.dag_id}/runs/${event.created_dagruns[0]?.run_id}`}>
             <Text color="fg.info"> {event.created_dagruns[0]?.dag_id} </Text>
@@ -86,6 +90,7 @@ export const AssetEvent = ({
           "~"
         )}
       </HStack>
+      {showExtra ? <Code>{JSON.stringify(extra)}</Code> : undefined}
     </Box>
   );
 };

--- a/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -29,8 +29,8 @@ import { DataTable } from "../DataTable";
 import type { CardDef, TableState } from "../DataTable/types";
 import { AssetEvent } from "./AssetEvent";
 
-const cardDef = (assetId?: number): CardDef<AssetEventResponse> => ({
-  card: ({ row }) => <AssetEvent assetId={assetId} event={row} />,
+const cardDef = (assetId?: number, showExtra?: boolean): CardDef<AssetEventResponse> => ({
+  card: ({ row }) => <AssetEvent assetId={assetId} event={row} showExtra={showExtra} />,
   meta: {
     customSkeleton: <Skeleton height="120px" width="100%" />,
   },
@@ -42,6 +42,7 @@ type AssetEventProps = {
   readonly isLoading?: boolean;
   readonly setOrderBy?: (order: string) => void;
   readonly setTableUrlState?: (state: TableState) => void;
+  readonly showExtra?: boolean;
   readonly tableUrlState?: TableState;
   readonly title?: string;
 };
@@ -52,6 +53,7 @@ export const AssetEvents = ({
   isLoading,
   setOrderBy,
   setTableUrlState,
+  showExtra,
   tableUrlState,
   title,
 }: AssetEventProps) => {
@@ -98,7 +100,7 @@ export const AssetEvents = ({
         )}
       </Flex>
       <DataTable
-        cardDef={cardDef(assetId)}
+        cardDef={cardDef(assetId, showExtra)}
         columns={[]}
         data={data?.asset_events ?? []}
         displayMode="card"

--- a/airflow/ui/src/pages/Asset/Asset.tsx
+++ b/airflow/ui/src/pages/Asset/Asset.tsx
@@ -109,6 +109,7 @@ export const Asset = () => {
                 isLoading={isLoadingEvents}
                 setOrderBy={setOrderBy}
                 setTableUrlState={setTableURLState}
+                showExtra
                 tableUrlState={tableURLState}
               />
             </Box>


### PR DESCRIPTION
Show asset event extra in the Asset details -> Events list. I didn't want to add it to other pages for now and risk the asset cards from getting unwieldy. 

<img width="1310" alt="Screenshot 2025-03-18 at 5 25 04 PM" src="https://github.com/user-attachments/assets/8ff27531-d480-41c9-b6ee-a6d5ad59488e" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
