### PR TITLE
Handle missing container_statuses in pod_manager.get_container_status

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import enum
-import itertools
 import json
 import math
 import time
@@ -119,9 +118,12 @@ class PodOperatorHookProtocol(Protocol):
 def get_container_status(pod: V1Pod, container_name: str) -> V1ContainerStatus | None:
     """Retrieve container status."""
     if pod and pod.status:
-        container_statuses = itertools.chain(
-            pod.status.container_statuses, pod.status.init_container_statuses
-        )
+        container_statuses = []
+        if pod.status.container_statuses:
+            container_statuses.extend(pod.status.container_statuses)
+        if pod.status.init_container_statuses:
+            container_statuses.extend(pod.status.init_container_statuses)
+
     else:
         container_statuses = None
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -38,6 +38,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     container_is_running,
     container_is_succeeded,
     container_is_terminated,
+    get_container_status,
 )
 from airflow.utils.timezone import utc
 
@@ -886,6 +887,12 @@ def params_for_test_container_is_succeeded():
     p = RemotePodMock()
     p.status = None
     pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status"))
+    p = RemotePodMock()
+    p.status = RemotePodMock()
+    p.status.container_statuses = None
+    p.status.init_container_statuses = []
+
+    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status.container_statuses"))
     p = RemotePodMock()
     p.status = RemotePodMock()
     p.status.container_statuses = []

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -38,7 +38,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     container_is_running,
     container_is_succeeded,
     container_is_terminated,
-    get_container_status,
 )
 from airflow.utils.timezone import utc
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


I believe there is a small bug in the cncf/kubernetes provider. Previously `get_container_status` in `pod_manager.py` would handle cases where `pod.status.container_statuses` is `None`, but after https://github.com/apache/airflow/pull/43853 it does not. This PR adds a test illustrating the issue, and fixes it. 

