### PR TITLE
Remove `scan_stale_dag` method in DAG processor manager

### DIFF
--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -382,6 +382,10 @@ CONFIGS_CHANGES = [
         renamed_to=ConfigParameter("scheduler", "parsing_cleanup_interval"),
     ),
     ConfigChange(
+        config=ConfigParameter("scheduler", "dag_stale_not_seen_duration"),
+        was_removed=True,
+    ),
+    ConfigChange(
         config=ConfigParameter("scheduler", "statsd_on"), renamed_to=ConfigParameter("metrics", "statsd_on")
     ),
     ConfigChange(
@@ -442,7 +446,7 @@ CONFIGS_CHANGES = [
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "stale_dag_threshold"),
-        renamed_to=ConfigParameter("dag_processor", "stale_dag_threshold"),
+        was_removed=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "print_stats_interval"),

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2448,13 +2448,6 @@ scheduler:
       type: boolean
       example: ~
       default: "True"
-    dag_stale_not_seen_duration:
-      description: |
-        Time in seconds after which dags, which were not updated by Dag Processor are deactivated.
-      version_added: 2.4.0
-      type: integer
-      example: ~
-      default: "600"
     use_job_schedule:
       description: |
         Turn off scheduler use of cron intervals by setting this to ``False``.
@@ -2726,18 +2719,6 @@ dag_processor:
       type: integer
       example: ~
       default: "30"
-    stale_dag_threshold:
-      description: |
-        How long (in seconds) to wait after we have re-parsed a DAG file before deactivating stale
-        DAGs (DAGs which are no longer present in the expected files). The reason why we need
-        this threshold is to account for the time between when the file is parsed and when the
-        DAG is loaded. The absolute maximum that this could take is
-        ``[dag_processor] dag_file_processor_timeout``, but when you have a long timeout configured,
-        it results in a significant delay in the deactivation of stale dags.
-      version_added: ~
-      type: integer
-      example: ~
-      default: "50"
     dag_file_processor_timeout:
       description: |
         How long before timing out a DagFileProcessor, which processes a dag file

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -179,7 +179,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self._task_instance_heartbeat_timeout_secs = conf.getint(
             "scheduler", "task_instance_heartbeat_timeout"
         )
-        self._dag_stale_not_seen_duration = conf.getint("scheduler", "dag_stale_not_seen_duration")
         self._task_queued_timeout = conf.getfloat("scheduler", "task_queued_timeout")
         self._enable_tracemalloc = conf.getboolean("scheduler", "enable_tracemalloc")
 


### PR DESCRIPTION
This method has been replaced by `handle_removed_files` and `deactivate_deleted_dags`. Its present now causes issues as it deactivates DAGs incorrectly. `handle_removed_files` is a better method more suited to dag bundles as the file's processor is also terminated.

Also removed unused config variable in scheduler and config.yml

Closes: #47294

