### PR TITLE
Fix k8s test: Ensure api-server healthy before any API calls

### DIFF
--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -65,12 +65,13 @@ class BaseK8STest:
         # speed up the test and make the airflow-api-server deployment more stable
         if self.set_api_server_base_url_config():
             self.rollout_restart_deployment("airflow-api-server")
-            self.ensure_deployment_health("airflow-api-server")
 
         # Replacement for unittests.TestCase.id()
         self.test_id = f"{request.node.cls.__name__}_{request.node.name}"
-        self.session = self._get_session_with_retries()
+        # Ensure the api-server deployment is healthy at kubernetes level before calling the any API
+        self.ensure_deployment_health("airflow-api-server")
         try:
+            self.session = self._get_session_with_retries()
             self._ensure_airflow_api_server_is_healthy()
             yield
         finally:


### PR DESCRIPTION

## Why  

Recently, there have been **Kubernetes test failures** in CI, for example:  
- https://github.com/apache/airflow/actions/runs/13931864434/attempts/1
- https://github.com/apache/airflow/actions/runs/13917714046/attempts/1

## What  

I found that `_get_session_with_retries` might be called **before** the API server's health check is performed.  
I hope this small adjustment will help **resolve the instability** 🙏 