### PR TITLE
Fix broken task mapping due to XCom refactor

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -344,7 +344,7 @@ def _xcom_push(ti: RuntimeTaskInstance, key: str, value: Any, mapped_length: int
         task_id=ti.task_id,
         run_id=ti.run_id,
         map_index=ti.map_index,
-        mapped_length=mapped_length,
+        _mapped_length=mapped_length,
     )
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -343,6 +343,8 @@ def _xcom_push(ti: RuntimeTaskInstance, key: str, value: Any, mapped_length: int
         dag_id=ti.dag_id,
         task_id=ti.task_id,
         run_id=ti.run_id,
+        map_index=ti.map_index,
+        mapped_length=mapped_length,
     )
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/xcom.py
+++ b/task-sdk/src/airflow/sdk/execution_time/xcom.py
@@ -40,6 +40,7 @@ class BaseXCom:
         task_id: str,
         run_id: str,
         map_index: int = -1,
+        mapped_length: int | None = None,
     ) -> None:
         """
         Store an XCom value.
@@ -51,6 +52,7 @@ class BaseXCom:
         :param run_id: DAG run ID for the task.
         :param map_index: Optional map index to assign XCom for a mapped task.
             The default is ``-1`` (set for a non-mapped task).
+        :param mapped_length: Optional map length to assign XCom for a mapped task.
         """
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
@@ -72,6 +74,7 @@ class BaseXCom:
                 task_id=task_id,
                 run_id=run_id,
                 map_index=map_index,
+                mapped_length=mapped_length,
             ),
         )
 

--- a/task-sdk/src/airflow/sdk/execution_time/xcom.py
+++ b/task-sdk/src/airflow/sdk/execution_time/xcom.py
@@ -40,7 +40,7 @@ class BaseXCom:
         task_id: str,
         run_id: str,
         map_index: int = -1,
-        mapped_length: int | None = None,
+        _mapped_length: int | None = None,
     ) -> None:
         """
         Store an XCom value.
@@ -52,7 +52,6 @@ class BaseXCom:
         :param run_id: DAG run ID for the task.
         :param map_index: Optional map index to assign XCom for a mapped task.
             The default is ``-1`` (set for a non-mapped task).
-        :param mapped_length: Optional map length to assign XCom for a mapped task.
         """
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
@@ -74,7 +73,7 @@ class BaseXCom:
                 task_id=task_id,
                 run_id=run_id,
                 map_index=map_index,
-                mapped_length=mapped_length,
+                mapped_length=_mapped_length,
             ),
         )
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1495,7 +1495,7 @@ class TestXComAfterTaskExecution:
             task_id="pull_task",
             run_id="test_run",
             map_index=-1,
-            mapped_length=None,
+            _mapped_length=None,
         )
 
         # assert that we didn't call the API when XCom backend is configured

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -33,7 +33,6 @@ import pytest
 from task_sdk import FAKE_BUNDLE
 from uuid6 import uuid7
 
-import airflow.sdk.execution_time.xcom
 from airflow.decorators import task as task_decorator
 from airflow.exceptions import (
     AirflowException,
@@ -95,6 +94,7 @@ from airflow.sdk.execution_time.task_runner import (
     run,
     startup,
 )
+from airflow.sdk.execution_time.xcom import XCom
 from airflow.utils import timezone
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.types import NOTSET, ArgNotSet
@@ -1418,7 +1418,7 @@ class TestXComAfterTaskExecution:
 
         runtime_ti = create_runtime_ti(task=task)
 
-        with mock.patch.object(airflow.sdk.execution_time.xcom.XCom, "set") as mock_xcom_set:
+        with mock.patch.object(XCom, "set") as mock_xcom_set:
             _xcom_push(runtime_ti, "return_value", result, 7)
             mock_xcom_set.assert_called_once_with(
                 key="return_value",
@@ -1494,6 +1494,8 @@ class TestXComAfterTaskExecution:
             dag_id="test_dag",
             task_id="pull_task",
             run_id="test_run",
+            map_index=-1,
+            mapped_length=None,
         )
 
         # assert that we didn't call the API when XCom backend is configured

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1427,7 +1427,7 @@ class TestXComAfterTaskExecution:
                 task_id=runtime_ti.task_id,
                 run_id=runtime_ti.run_id,
                 map_index=runtime_ti.map_index,
-                mapped_length=7,
+                _mapped_length=7,
             )
 
     def test_xcom_with_multiple_outputs_and_no_mapping_result(self, create_runtime_ti, spy_agency):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/47929

Recent Xcom refactor broke this part, fixing dynamic task mapping.

Tested this with 2 dags:

```
from datetime import datetime

from airflow.decorators import task
from airflow.models.dag import DAG

with DAG(dag_id="example_dynamic_task_mapping", schedule=None, start_date=datetime(2022, 3, 4)) as dag:

    @task
    def add_one(x: int):
        return x + 1

    @task
    def sum_it(values):
        total = sum(values)
        print(f"Total was {total}")

    added_values = add_one.expand(x=[1, 2, 3])
    sum_it(added_values)
```

<img width="875" alt="image" src="https://github.com/user-attachments/assets/e878f97a-e521-46a7-b0c2-967ec85b2fc9" />


```
from datetime import datetime, timedelta

from airflow import DAG
from airflow.decorators import task
from airflow.models.taskinstance import TaskInstance

delays = [30, 60, 90]
l = [5, 10]


@task
def get_delays():
    return delays

@task
def get_delays2():
    return l

@task
def get_wakes(delay, delay2, **context):
    "Wake {delay} seconds after the task starts"
    ti: TaskInstance = context["ti"]
    return [delay, delay2]


with DAG(
    dag_id="mapping_with_xcom",
    start_date=datetime(1970, 1, 1),
    schedule=None,
    tags=["taskmap"]
) as dag:
    wake_times = get_wakes.expand(delay=get_delays(), delay2=get_delays2())
```

<img width="875" alt="image" src="https://github.com/user-attachments/assets/04122c75-eaef-43ac-a0ae-0816a4955eeb" />


```
from airflow import DAG
from airflow.decorators import task, task_group
from datetime import datetime

# Track the results for verification (only for testing purposes)
results = {}

# Expected values for reference
expected_values = {
    ("tg.t1", 0): ["a", "b"],
    ("tg.t1", 1): [4],
    ("tg.t1", 2): ["z"],
    ("tg.t2", 0): ["a", "b"],
    ("tg.t2", 1): [4],
    ("tg.t2", 2): ["z"],
    ("t3", None): [["a", "b"], [4], ["z"]],
}

# Define the DAG
with DAG(
    dag_id="tg_dag",
    start_date=datetime(2025, 1, 1),
    schedule=None,
    catchup=False,
) as dag:
    @task
    def t(value, ti=None):
        # Store results for verification
        global results
        results[(ti.task_id, ti.map_index)] = value

        print("Value is", value)

        return value

    @task
    def t(value, ti=None):
        # Store results for verification
        global results
        results[(ti.task_id, ti.map_index)] = value

        print("Value is", value)

        return value

    @task_group
    def tg(va):
        # Each expanded group has one t1 and t2 each.
        t1 = t.override(task_id="t1")(va)
        t2 = t.override(task_id="t2")(t1)
        return t2

    t2 = tg.expand(va=[["a", "b"], [4], ["z"]])

    t3 = t.override(task_id="t3")(t2)
```

<img width="875" alt="image" src="https://github.com/user-attachments/assets/7fe2182a-1e70-4bd2-acb3-c1d8088655f3" />




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
