### PR TITLE
Set dag version on expanded tis

### DIFF
--- a/airflow/ui/src/components/DagVersionDetails.tsx
+++ b/airflow/ui/src/components/DagVersionDetails.tsx
@@ -31,7 +31,7 @@ export const DagVersionDetails = ({ dagVersion }: { readonly dagVersion?: DagVer
       <Table.Body>
         <Table.Row>
           <Table.Cell>Version Number</Table.Cell>
-          <Table.Cell>v{dagVersion.version_number}</Table.Cell>
+          <Table.Cell>{dagVersion.version_number ? "v{dagVersion.version_number}" : "unknown"}</Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.Cell>Bundle Name</Table.Cell>


### PR DESCRIPTION
The version is set to the unmapped ti's if available, latest otherwise.

Fix #47687.

I’m setting the text in UI “unknown” when a dag version is not available. This should not happen; it’s a bug if it is shown to a normal user.