### PR TITLE
Fix code blocks in extra packages reference docs

### DIFF
--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -85,7 +85,7 @@ python dependencies for the provided package.
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 | uv                  | ``pip install 'apache-airflow[uv]'``                | Install uv - fast, Rust-based package installer (experimental)             |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
-| cloudpickle         | pip install apache-airflow[cloudpickle]             | Cloudpickle hooks and operators                                            |
+| cloudpickle         | ``pip install apache-airflow[cloudpickle]``         | Cloudpickle hooks and operators                                            |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 
 

--- a/scripts/ci/pre_commit/check_extra_packages_ref.py
+++ b/scripts/ci/pre_commit/check_extra_packages_ref.py
@@ -59,7 +59,7 @@ for dependency in ALL_DYNAMIC_EXTRAS:
             suggestions_devel.append(
                 (
                     dependency,
-                    f"pip install -e '.[{dependency}]'",
+                    f"``pip install -e '.[{dependency}]'``",
                     f"Adds all test libraries needed to test {short_dep}",
                 )
             )
@@ -67,7 +67,7 @@ for dependency in ALL_DYNAMIC_EXTRAS:
             suggestions.append(
                 (
                     dependency,
-                    f"pip install apache-airflow[{dependency}]",
+                    f"``pip install apache-airflow[{dependency}]``",
                     f"{dependency.capitalize()} hooks and operators",
                 )
             )


### PR DESCRIPTION
I noticed the precommit didn't include the code block ticks, and we had one extra that was missing it in the docs.