### PR TITLE
Only return active assets in API by default

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -622,6 +622,13 @@ paths:
           items:
             type: string
           title: Dag Ids
+      - name: only_active
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: true
+          title: Only Active
       - name: order_by
         in: query
         required: false

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -75,6 +75,7 @@ export const UseAssetServiceGetAssetsKeyFn = (
     limit,
     namePattern,
     offset,
+    onlyActive,
     orderBy,
     uriPattern,
   }: {
@@ -82,13 +83,14 @@ export const UseAssetServiceGetAssetsKeyFn = (
     limit?: number;
     namePattern?: string;
     offset?: number;
+    onlyActive?: boolean;
     orderBy?: string;
     uriPattern?: string;
   } = {},
   queryKey?: Array<unknown>,
 ) => [
   useAssetServiceGetAssetsKey,
-  ...(queryKey ?? [{ dagIds, limit, namePattern, offset, orderBy, uriPattern }]),
+  ...(queryKey ?? [{ dagIds, limit, namePattern, offset, onlyActive, orderBy, uriPattern }]),
 ];
 export type AssetServiceGetAssetAliasesDefaultResponse = Awaited<
   ReturnType<typeof AssetService.getAssetAliases>

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -75,6 +75,7 @@ export const prefetchUseAssetServiceNextRunAssets = (
  * @param data.namePattern
  * @param data.uriPattern
  * @param data.dagIds
+ * @param data.onlyActive
  * @param data.orderBy
  * @returns AssetCollectionResponse Successful Response
  * @throws ApiError
@@ -86,6 +87,7 @@ export const prefetchUseAssetServiceGetAssets = (
     limit,
     namePattern,
     offset,
+    onlyActive,
     orderBy,
     uriPattern,
   }: {
@@ -93,6 +95,7 @@ export const prefetchUseAssetServiceGetAssets = (
     limit?: number;
     namePattern?: string;
     offset?: number;
+    onlyActive?: boolean;
     orderBy?: string;
     uriPattern?: string;
   } = {},
@@ -103,10 +106,12 @@ export const prefetchUseAssetServiceGetAssets = (
       limit,
       namePattern,
       offset,
+      onlyActive,
       orderBy,
       uriPattern,
     }),
-    queryFn: () => AssetService.getAssets({ dagIds, limit, namePattern, offset, orderBy, uriPattern }),
+    queryFn: () =>
+      AssetService.getAssets({ dagIds, limit, namePattern, offset, onlyActive, orderBy, uriPattern }),
   });
 /**
  * Get Asset Aliases

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -112,6 +112,7 @@ export const useAssetServiceNextRunAssets = <
  * @param data.namePattern
  * @param data.uriPattern
  * @param data.dagIds
+ * @param data.onlyActive
  * @param data.orderBy
  * @returns AssetCollectionResponse Successful Response
  * @throws ApiError
@@ -126,6 +127,7 @@ export const useAssetServiceGetAssets = <
     limit,
     namePattern,
     offset,
+    onlyActive,
     orderBy,
     uriPattern,
   }: {
@@ -133,6 +135,7 @@ export const useAssetServiceGetAssets = <
     limit?: number;
     namePattern?: string;
     offset?: number;
+    onlyActive?: boolean;
     orderBy?: string;
     uriPattern?: string;
   } = {},
@@ -141,11 +144,19 @@ export const useAssetServiceGetAssets = <
 ) =>
   useQuery<TData, TError>({
     queryKey: Common.UseAssetServiceGetAssetsKeyFn(
-      { dagIds, limit, namePattern, offset, orderBy, uriPattern },
+      { dagIds, limit, namePattern, offset, onlyActive, orderBy, uriPattern },
       queryKey,
     ),
     queryFn: () =>
-      AssetService.getAssets({ dagIds, limit, namePattern, offset, orderBy, uriPattern }) as TData,
+      AssetService.getAssets({
+        dagIds,
+        limit,
+        namePattern,
+        offset,
+        onlyActive,
+        orderBy,
+        uriPattern,
+      }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -89,6 +89,7 @@ export const useAssetServiceNextRunAssetsSuspense = <
  * @param data.namePattern
  * @param data.uriPattern
  * @param data.dagIds
+ * @param data.onlyActive
  * @param data.orderBy
  * @returns AssetCollectionResponse Successful Response
  * @throws ApiError
@@ -103,6 +104,7 @@ export const useAssetServiceGetAssetsSuspense = <
     limit,
     namePattern,
     offset,
+    onlyActive,
     orderBy,
     uriPattern,
   }: {
@@ -110,6 +112,7 @@ export const useAssetServiceGetAssetsSuspense = <
     limit?: number;
     namePattern?: string;
     offset?: number;
+    onlyActive?: boolean;
     orderBy?: string;
     uriPattern?: string;
   } = {},
@@ -118,11 +121,19 @@ export const useAssetServiceGetAssetsSuspense = <
 ) =>
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseAssetServiceGetAssetsKeyFn(
-      { dagIds, limit, namePattern, offset, orderBy, uriPattern },
+      { dagIds, limit, namePattern, offset, onlyActive, orderBy, uriPattern },
       queryKey,
     ),
     queryFn: () =>
-      AssetService.getAssets({ dagIds, limit, namePattern, offset, orderBy, uriPattern }) as TData,
+      AssetService.getAssets({
+        dagIds,
+        limit,
+        namePattern,
+        offset,
+        onlyActive,
+        orderBy,
+        uriPattern,
+      }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -261,6 +261,7 @@ export class AssetService {
    * @param data.namePattern
    * @param data.uriPattern
    * @param data.dagIds
+   * @param data.onlyActive
    * @param data.orderBy
    * @returns AssetCollectionResponse Successful Response
    * @throws ApiError
@@ -275,6 +276,7 @@ export class AssetService {
         name_pattern: data.namePattern,
         uri_pattern: data.uriPattern,
         dag_ids: data.dagIds,
+        only_active: data.onlyActive,
         order_by: data.orderBy,
       },
       errors: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1681,6 +1681,7 @@ export type GetAssetsData = {
   limit?: number;
   namePattern?: string | null;
   offset?: number;
+  onlyActive?: boolean;
   orderBy?: string;
   uriPattern?: string | null;
 };


### PR DESCRIPTION
Similar to the list dags endpoint, the list assets endpoint now has a query param 'only_active' that defaults to true (i.e. only show active assets). You can set this to false for the endpoint to also show inactive (deleted from code) assets.

Fix #47810
Fix #47830 since only one asset with the same URI would show in the UI now

Sorry @tyrellcurry for stealing this, I want to get this in for 3.0.0b4 scheduled for tomorrow.