### PR TITLE
Update S3 system test

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3.py
@@ -34,7 +34,6 @@ from airflow.providers.amazon.aws.operators.s3 import (
     S3PutBucketTaggingOperator,
 )
 from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor, S3KeysUnchangedSensor
-from airflow.providers.standard.operators.python import BranchPythonOperator
 from airflow.utils.trigger_rule import TriggerRule
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 
@@ -253,12 +252,6 @@ with DAG(
     )
     # [END howto_operator_s3_file_transform]
 
-    # This task skips the `sensor_keys_unchanged` task because the S3KeysUnchangedSensor
-    # runs in poke mode only, which is not supported by the DebugExecutor, causing system tests to fail.
-    branching = BranchPythonOperator(
-        task_id="branch_to_delete_objects", python_callable=lambda: "delete_objects"
-    )
-
     # [START howto_sensor_s3_keys_unchanged]
     sensor_keys_unchanged = S3KeysUnchangedSensor(
         task_id="sensor_keys_unchanged",
@@ -315,7 +308,6 @@ with DAG(
         ],
         copy_object,
         file_transform,
-        branching,
         sensor_keys_unchanged,
         # TEST TEARDOWN
         delete_objects,


### PR DESCRIPTION
A Sensor was being skipped for a reason that is no longer true, so we may as well stop skipping it.

This passes when I test it locally, should be good to go on the CI as well.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
