### PR TITLE
Default to the FabAuthManager in the chart

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2653,6 +2653,7 @@ config:
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" (or .Values.elasticsearch.enabled .Values.opensearch.enabled) }}'
+    auth_manager: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager"
   logging:
     remote_logging: '{{- ternary "True" "False" (or .Values.elasticsearch.enabled .Values.opensearch.enabled) }}'
     colored_console_log: 'False'


### PR DESCRIPTION
Core is going to move to the SimpleAuthManager by default, but the chart should keep using the FabAuthManager as a default instead for the time being. Users can always change this to another auth manager if they need to.