### PR TITLE
Disallow platformdirs: 4.3.7 to limit setuptools 77.0.1 that breaks CI

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -236,7 +236,9 @@ DEPENDENCIES = [
     "opentelemetry-exporter-otlp>=1.24.0",
     "packaging>=23.2",
     "pathspec>=0.9.0",
-    "platformdirs>=4.3.6",
+    # platformdirs installs setuptools 77.0.1 which seems to break distutils
+    # excluding that version for now, remove this comment and limitation if new version is installed and fixes it
+    "platformdirs>=4.3.6,!=4.3.7",
     'pendulum>=2.1.2,<4.0;python_version<"3.12"',
     'pendulum>=3.0.0,<4.0;python_version>="3.12"',
     "pluggy>=1.5.0",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Facing these issues in tests:
```
_ ERROR collecting providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py _
ImportError while importing test module '/opt/airflow/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py:26: in <module>
    from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py:25: in <module>
    from winrm.exceptions import WinRMOperationTimeoutError
/usr/local/lib/python3.12/site-packages/winrm/__init__.py:6: in <module>
    from winrm.protocol import Protocol
/usr/local/lib/python3.12/site-packages/winrm/protocol.py:11: in <module>
    from winrm.transport import Transport
/usr/local/lib/python3.12/site-packages/winrm/transport.py:9: in <module>
    from distutils.util import strtobool
E   ModuleNotFoundError: No module named 'distutils'
------------------------------- Captured stderr --------------------------------
/usr/local/lib/python3.12/site-packages/winrm/__init__.py:107 SyntaxWarning: invalid escape sequence '\d'
- generated xml file: /files/test_result-providers_microsoft_winrm-postgres.xml -
=========================== short test summary info ============================
ERROR providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 warning, 1 error in 5.92s ==========================
```

Example https://github.com/apache/airflow/actions/runs/13960392547

This is caused by setuptools 77.0.1 (which is the way to access distutils in PY3.12: https://github.com/python/cpython/issues/92584) which is installed by platformdirs latest version https://pypi.org/project/platformdirs/4.3.7/


Limiting the version of platformdirs in attempt to fix this.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
