### PR TITLE
Attempting to fix CI by restricting setuptools

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -94,6 +94,7 @@ dependencies = [
     "types-redis>=4.6.0.20240425",
     "types-requests>=2.31.0.6",
     "types-setuptools>=69.5.0.20240423",
+    "setuptools>=76.0.0,!=77.0.1",
     "types-tabulate>=0.9.0.20240106",
     "types-toml>=0.10.8.20240310",
     "ipdb>=0.13.13",

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -94,7 +94,6 @@ dependencies = [
     "types-redis>=4.6.0.20240425",
     "types-requests>=2.31.0.6",
     "types-setuptools>=69.5.0.20240423",
-    "setuptools>=76.0.0,!=77.0.1",
     "types-tabulate>=0.9.0.20240106",
     "types-toml>=0.10.8.20240310",
     "ipdb>=0.13.13",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -857,7 +857,8 @@
       "msgraph-core>=1.0.0,!=1.1.8"
     ],
     "devel-deps": [
-      "pywinrm>=0.4"
+      "pywinrm>=0.4",
+      "setuptools>=76.0.0,!=77.0.1"
     ],
     "plugins": [],
     "cross-providers-deps": [
@@ -901,7 +902,9 @@
       "apache-airflow>=2.9.0",
       "pywinrm>=0.4"
     ],
-    "devel-deps": [],
+    "devel-deps": [
+      "setuptools>=76.0.0,!=77.0.1"
+    ],
     "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],

--- a/providers/microsoft/azure/pyproject.toml
+++ b/providers/microsoft/azure/pyproject.toml
@@ -120,6 +120,7 @@ dev = [
     "apache-airflow-providers-sftp",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "pywinrm>=0.4",
+    "setuptools>=76.0.0,!=77.0.1",
 ]
 
 [tool.uv.sources]

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
@@ -493,5 +493,5 @@ def get_provider_info():
             "oracle": ["apache-airflow-providers-oracle"],
             "sftp": ["apache-airflow-providers-sftp"],
         },
-        "devel-dependencies": ["pywinrm>=0.4"],
+        "devel-dependencies": ["pywinrm>=0.4", "setuptools>=76.0.0,!=77.0.1"],
     }

--- a/providers/microsoft/winrm/pyproject.toml
+++ b/providers/microsoft/winrm/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
+    "setuptools>=76.0.0,!=77.0.1",
 ]
 
 [tool.uv.sources]

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
@@ -77,5 +77,5 @@ def get_provider_info():
             }
         ],
         "dependencies": ["apache-airflow>=2.9.0", "pywinrm>=0.4"],
-        "devel-dependencies": [],
+        "devel-dependencies": ["setuptools>=76.0.0,!=77.0.1"],
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Related to https://github.com/apache/airflow/pull/47985.

Facing these issues in tests:
```
_ ERROR collecting providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py _
ImportError while importing test module '/opt/airflow/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py:26: in <module>
    from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py:25: in <module>
    from winrm.exceptions import WinRMOperationTimeoutError
/usr/local/lib/python3.12/site-packages/winrm/__init__.py:6: in <module>
    from winrm.protocol import Protocol
/usr/local/lib/python3.12/site-packages/winrm/protocol.py:11: in <module>
    from winrm.transport import Transport
/usr/local/lib/python3.12/site-packages/winrm/transport.py:9: in <module>
    from distutils.util import strtobool
E   ModuleNotFoundError: No module named 'distutils'
------------------------------- Captured stderr --------------------------------
/usr/local/lib/python3.12/site-packages/winrm/__init__.py:107 SyntaxWarning: invalid escape sequence '\d'
- generated xml file: /files/test_result-providers_microsoft_winrm-postgres.xml -
=========================== short test summary info ============================
ERROR providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 warning, 1 error in 5.92s ==========================
```

Example https://github.com/apache/airflow/actions/runs/13960392547

This is caused by setuptools 77.0.1

Trying to fix by adding restriction on setuptools to MS tests.

Doubted using `uv pip tree > a.txt`


```
apache-airflow-devel-common v0.1.0
├── aioresponses v0.7.8
│   ├── aiohttp v3.11.13
│   │   ├── aiohappyeyeballs v2.6.1
│   │   ├── aiosignal v1.3.2
│   │   │   └── frozenlist v1.5.0
│   │   ├── attrs v25.3.0
│   │   ├── frozenlist v1.5.0
│   │   ├── multidict v6.1.0
│   │   ├── propcache v0.3.0
│   │   └── yarl v1.18.3
│   │       ├── idna v3.10
│   │       ├── multidict v6.1.0
│   │       └── propcache v0.3.0
│   └── packaging v24.2
├── beautifulsoup4 v4.13.3
│   ├── soupsieve v2.6
│   └── typing-extensions v4.12.2
├── black v25.1.0
│   ├── click v8.1.8
│   ├── mypy-extensions v1.0.0
│   ├── packaging v24.2
│   ├── pathspec v0.12.1
│   └── platformdirs v4.3.6
├── blinker v1.9.0
├── click v8.1.8
├── coverage v7.6.12
├── deepdiff v8.3.0
│   └── orderly-set v5.3.0
├── duckdb v1.2.1
├── gitpython v3.1.44
│   └── gitdb v4.0.12
│       └── smmap v5.0.2
├── incremental v24.7.2
│   └── setuptools v76.0.0
├── ipdb v0.13.13
│   ├── decorator v5.2.1
│   └── ipython v9.0.2
│       ├── decorator v5.2.1
│       ├── ipython-pygments-lexers v1.1.1
│       │   └── pygments v2.19.1
│       ├── jedi v0.19.2
│       │   └── parso v0.8.4
│       ├── matplotlib-inline v0.1.7
│       │   └── traitlets v5.14.3
│       ├── pexpect v4.9.0
│       │   └── ptyprocess v0.7.0
│       ├── prompt-toolkit v3.0.50
│       │   └── wcwidth v0.2.13
│       ├── pygments v2.19.1
│       ├── stack-data v0.6.3
│       │   ├── asttokens v3.0.0
│       │   ├── executing v2.2.0
│       │   └── pure-eval v0.2.3
│       └── traitlets v5.14.3
├── ipdb v0.13.13 (*)
├── jmespath v1.0.1
├── kgb v7.2
├── mypy v1.9.0
│   ├── mypy-extensions v1.0.0
│   └── typing-extensions v4.12.2
├── pdbr v0.9.0
│   └── rich v13.9.4
│       ├── markdown-it-py v3.0.0
│       │   └── mdurl v0.1.2
│       └── pygments v2.19.1
├── pdbr v0.9.0 (*)
├── pipdeptree v2.25.1
│   ├── packaging v24.2
│   └── pip v25.0.1
├── pygithub v2.6.1
│   ├── deprecated v1.2.18
│   │   └── wrapt v1.17.2
│   ├── pyjwt v2.10.1
│   ├── pynacl v1.5.0
│   │   └── cffi v1.17.1
│   │       └── pycparser v2.22
│   ├── requests v2.32.3
│   │   ├── certifi v2025.1.31
│   │   ├── charset-normalizer v3.4.1
│   │   ├── idna v3.10
│   │   └── urllib3 v2.3.0
│   ├── typing-extensions v4.12.2
│   └── urllib3 v2.3.0
├── pytest v8.3.5
│   ├── iniconfig v2.0.0
│   ├── packaging v24.2
│   └── pluggy v1.5.0
├── pytest-asyncio v0.25.0
│   └── pytest v8.3.5 (*)
├── pytest-cov v6.0.0
│   ├── coverage v7.6.12
│   └── pytest v8.3.5 (*)
├── pytest-custom-exit-code v0.3.0
│   └── pytest v8.3.5 (*)
├── pytest-icdiff v0.9
│   ├── icdiff v2.0.7
│   ├── pprintpp v0.4.0
│   └── pytest v8.3.5 (*)
├── pytest-instafail v0.5.0
│   └── pytest v8.3.5 (*)
├── pytest-mock v3.14.0
│   └── pytest v8.3.5 (*)
├── pytest-rerunfailures v15.0
│   ├── packaging v24.2
│   └── pytest v8.3.5 (*)
├── pytest-timeouts v1.2.1
│   └── pytest v8.3.5 (*)
├── pytest-unordered v0.6.1
│   └── pytest v8.3.5 (*)
├── pytest-xdist v3.6.1
│   ├── execnet v2.1.1
│   └── pytest v8.3.5 (*)
├── requests-mock v1.12.1
│   └── requests v2.32.3 (*)
├── restructuredtext-lint v1.4.0
│   └── docutils v0.21.2
├── rich-click v1.8.8
│   ├── click v8.1.8
│   ├── rich v13.9.4 (*)
│   └── typing-extensions v4.12.2
├── ruff v0.8.1
├── semver v3.0.4
├── semver v3.0.4
├── time-machine v2.16.0
│   └── python-dateutil v2.9.0.post0
│       └── six v1.17.0
├── towncrier v24.8.0
│   ├── click v8.1.8
│   └── jinja2 v3.1.6
│       └── markupsafe v3.0.2
├── twine v6.1.0
│   ├── id v1.5.0
│   │   └── requests v2.32.3 (*)
│   ├── keyring v25.6.0
│   │   ├── jaraco-classes v3.4.0
│   │   │   └── more-itertools v10.6.0
│   │   ├── jaraco-context v6.0.1
│   │   └── jaraco-functools v4.1.0
│   │       └── more-itertools v10.6.0
│   ├── packaging v24.2
│   ├── readme-renderer v44.0
│   │   ├── docutils v0.21.2
│   │   ├── nh3 v0.2.21
│   │   └── pygments v2.19.1
│   ├── requests v2.32.3 (*)
│   ├── requests-toolbelt v1.0.0
│   │   └── requests v2.32.3 (*)
│   ├── rfc3986 v2.0.0
│   ├── rich v13.9.4 (*)
│   └── urllib3 v2.3.0
├── types-aiofiles v24.1.0.20241221
├── types-certifi v2021.10.8.3
├── types-croniter v5.0.1.20241205
├── types-deprecated v1.2.15.20250304
├── types-docutils v0.21.0.20241128
├── types-markdown v3.7.0.20241204
├── types-paramiko v3.5.0.20240928
│   └── cryptography v44.0.2
│       └── cffi v1.17.1 (*)
├── types-protobuf v5.29.1.20250208
├── types-pymysql v1.1.0.20241103
├── types-python-dateutil v2.9.0.20241206
├── types-python-slugify v8.0.2.20240310
├── types-pytz v2025.1.0.20250204
├── types-pyyaml v6.0.12.20241230
├── types-redis v4.6.0.20241004
│   ├── cryptography v44.0.2 (*)
│   └── types-pyopenssl v24.1.0.20240722
│       ├── cryptography v44.0.2 (*)
│       └── types-cffi v1.16.0.20250307
│           └── types-setuptools v75.8.2.20250305
│               └── setuptools v76.0.0
├── types-requests v2.32.0.20250306
│   └── urllib3 v2.3.0
├── types-setuptools v75.8.2.20250305 (*)
├── types-tabulate v0.9.0.20241207
├── types-toml v0.10.8.20240310
├── wheel v0.45.1
└── yamllint v1.36.0
    ├── pathspec v0.12.1
    └── pyyaml v6.0.2
apache-airflow-providers-amazon v9.5.0
├── apache-airflow v3.0.0.dev0
│   ├── a2wsgi v1.10.8
│   ├── a2wsgi v1.10.8
│   ├── alembic v1.15.1
│   │   ├── mako v1.3.9
│   │   │   └── markupsafe v3.0.2
│   │   ├── sqlalchemy v1.4.54
│   │   └── typing-extensions v4.12.2
│   ├── alembic v1.15.1 (*)
│   ├── apache-airflow-providers-common-compat v1.5.1
│   │   └── apache-airflow v3.0.0.dev0 (*)
│   ├── apache-airflow-providers-common-io v1.5.1
│   │   └── apache-airflow v3.0.0.dev0 (*)
│   ├── apache-airflow-providers-common-sql v1.24.0
│   │   ├── apache-airflow v3.0.0.dev0 (*)
│   │   ├── methodtools v0.4.7
│   │   │   └── wirerope v1.0.0
│   │   │       └── six v1.17.0
│   │   ├── more-itertools v10.6.0
│   │   └── sqlparse v0.5.3
│   ├── apache-airflow-providers-smtp v2.0.1
│   │   └── apache-airflow v3.0.0.dev0 (*)
│   ├── apache-airflow-providers-sqlite v4.0.1
│   │   ├── aiosqlite v0.21.0
│   │   │   └── typing-extensions v4.12.2
│   │   ├── apache-airflow v3.0.0.dev0 (*)
│   │   └── apache-airflow-providers-common-sql v1.24.0 (*)
│   ├── apache-airflow-providers-standard v0.1.1
│   │   └── apache-airflow v3.0.0.dev0 (*)
│   ├── argcomplete v3.6.0
│   ├── argcomplete v3.6.0
│   ├── asgiref v3.8.1
│   ├── asgiref v3.8.1
│   ├── attrs v25.3.0
│   ├── attrs v25.3.0
│   ├── blinker v1.9.0
│   ├── blinker v1.9.0
│   ├── colorlog v6.9.0
│   ├── colorlog v6.9.0
│   ├── configupdater v3.2
│   ├── configupdater v3.2
│   ├── cron-descriptor v1.4.5
│   ├── cron-descriptor v1.4.5
│   ├── croniter v6.0.0
│   │   ├── python-dateutil v2.9.0.post0 (*)
│   │   └── pytz v2025.1
│   ├── croniter v6.0.0 (*)
│   ├── cryptography v44.0.2 (*)
│   ├── cryptography v44.0.2 (*)
│   ├── deprecated v1.2.18 (*)
│   ├── deprecated v1.2.18 (*)
│   ├── dill v0.3.9
│   ├── dill v0.3.9
│   ├── fastapi v0.115.11
│   │   ├── pydantic v2.10.6
│   │   │   ├── annotated-types v0.7.0
│   │   │   ├── pydantic-core v2.27.2
│   │   │   │   └── typing-extensions v4.12.2
│   │   │   └── typing-extensions v4.12.2
│   │   ├── starlette v0.46.1
│   │   │   └── anyio v4.9.0
│   │   │       ├── idna v3.10
│   │   │       ├── sniffio v1.3.1
│   │   │       └── typing-extensions v4.12.2
│   │   └── typing-extensions v4.12.2
│   ├── fastapi v0.115.11 (*)
│   ├── flask v2.2.5
│   │   ├── click v8.1.8
│   │   ├── itsdangerous v2.2.0
│   │   ├── jinja2 v3.1.6 (*)
│   │   └── werkzeug v2.3.8
│   │       └── markupsafe v3.0.2
│   ├── flask v2.2.5 (*)
│   ├── flask-caching v2.3.1
│   │   ├── cachelib v0.13.0
│   │   └── flask v2.2.5 (*)
│   ├── flask-caching v2.3.1 (*)
│   ├── flask-session v0.5.0
│   │   ├── cachelib v0.13.0
│   │   └── flask v2.2.5 (*)
│   ├── flask-session v0.5.0 (*)
│   ├── flask-wtf v1.2.2
│   │   ├── flask v2.2.5 (*)
│   │   ├── itsdangerous v2.2.0
│   │   └── wtforms v3.2.1
│   │       └── markupsafe v3.0.2
│   ├── flask-wtf v1.2.2 (*)
│   ├── fsspec v2025.3.0
│   ├── fsspec v2025.3.0
│   ├── gitpython v3.1.44 (*)
│   ├── gitpython v3.1.44 (*)
│   ├── gunicorn v23.0.0
│   │   └── packaging v24.2
│   ├── gunicorn v23.0.0 (*)
│   ├── httpx v0.28.1
│   │   ├── anyio v4.9.0 (*)
│   │   ├── certifi v2025.1.31
│   │   ├── httpcore v1.0.7
│   │   │   ├── certifi v2025.1.31
│   │   │   └── h11 v0.14.0
│   │   └── idna v3.10
│   ├── httpx v0.28.1 (*)
│   ├── itsdangerous v2.2.0
│   ├── itsdangerous v2.2.0
│   ├── jinja2 v3.1.6 (*)
│   ├── jinja2 v3.1.6 (*)
│   ├── jsonschema v4.23.0
│   │   ├── attrs v25.3.0
│   │   ├── jsonschema-specifications v2024.10.1
│   │   │   └── referencing v0.36.2
│   │   │       ├── attrs v25.3.0
│   │   │       ├── rpds-py v0.23.1
│   │   │       └── typing-extensions v4.12.2
│   │   ├── referencing v0.36.2 (*)
│   │   └── rpds-py v0.23.1
│   ├── jsonschema v4.23.0 (*)
│   ├── keyring v25.6.0 (*)
│   ├── keyring v25.6.0 (*)
│   ├── lazy-object-proxy v1.10.0
│   ├── lazy-object-proxy v1.10.0
│   ├── libcst v1.7.0
│   │   └── pyyaml v6.0.2
│   ├── libcst v1.7.0 (*)
│   ├── linkify-it-py v2.0.3
│   │   └── uc-micro-py v1.0.3
│   ├── linkify-it-py v2.0.3 (*)
│   ├── lockfile v0.12.2
│   ├── lockfile v0.12.2
│   ├── markdown-it-py v3.0.0 (*)
│   ├── markdown-it-py v3.0.0 (*)
│   ├── markupsafe v3.0.2
│   ├── markupsafe v3.0.2
│   ├── marshmallow-oneofschema v3.1.1
│   │   └── marshmallow v3.26.1
│   │       └── packaging v24.2
│   ├── marshmallow-oneofschema v3.1.1 (*)
│   ├── mdit-py-plugins v0.4.2
│   │   └── markdown-it-py v3.0.0 (*)
│   ├── mdit-py-plugins v0.4.2 (*)
│   ├── methodtools v0.4.7 (*)
│   ├── methodtools v0.4.7 (*)
│   ├── opentelemetry-api v1.31.0
│   │   ├── deprecated v1.2.18 (*)
│   │   └── importlib-metadata v8.6.1
│   │       └── zipp v3.21.0
│   ├── opentelemetry-api v1.31.0 (*)
│   ├── opentelemetry-exporter-otlp v1.31.0
│   │   ├── opentelemetry-exporter-otlp-proto-grpc v1.31.0
│   │   │   ├── deprecated v1.2.18 (*)
│   │   │   ├── googleapis-common-protos v1.69.2
│   │   │   │   └── protobuf v5.29.4
│   │   │   ├── grpcio v1.71.0
│   │   │   ├── opentelemetry-api v1.31.0 (*)
│   │   │   ├── opentelemetry-exporter-otlp-proto-common v1.31.0
│   │   │   │   └── opentelemetry-proto v1.31.0
│   │   │   │       └── protobuf v5.29.4
│   │   │   ├── opentelemetry-proto v1.31.0 (*)
│   │   │   └── opentelemetry-sdk v1.31.0
│   │   │       ├── opentelemetry-api v1.31.0 (*)
│   │   │       ├── opentelemetry-semantic-conventions v0.52b0
│   │   │       │   ├── deprecated v1.2.18 (*)
│   │   │       │   └── opentelemetry-api v1.31.0 (*)
│   │   │       └── typing-extensions v4.12.2
│   │   └── opentelemetry-exporter-otlp-proto-http v1.31.0
│   │       ├── deprecated v1.2.18 (*)
│   │       ├── googleapis-common-protos v1.69.2 (*)
│   │       ├── opentelemetry-api v1.31.0 (*)
│   │       ├── opentelemetry-exporter-otlp-proto-common v1.31.0 (*)
│   │       ├── opentelemetry-proto v1.31.0 (*)
│   │       ├── opentelemetry-sdk v1.31.0 (*)
│   │       └── requests v2.32.3 (*)
│   ├── opentelemetry-exporter-otlp v1.31.0 (*)
│   ├── packaging v24.2
│   ├── packaging v24.2
│   ├── pathspec v0.12.1
│   ├── pathspec v0.12.1
│   ├── pendulum v3.0.0
│   │   ├── python-dateutil v2.9.0.post0 (*)
│   │   ├── time-machine v2.16.0 (*)
│   │   └── tzdata v2025.1
│   ├── pendulum v3.0.0 (*)
│   ├── platformdirs v4.3.6
│   ├── platformdirs v4.3.6
│   ├── pluggy v1.5.0
│   ├── pluggy v1.5.0
│   ├── psutil v7.0.0
│   ├── psutil v7.0.0
│   ├── pydantic v2.10.6 (*)
│   ├── pydantic v2.10.6 (*)
│   ├── pygments v2.19.1
│   ├── pygments v2.19.1
│   ├── pyjwt v2.10.1
│   ├── pyjwt v2.10.1
│   ├── python-daemon v3.1.2
│   │   └── lockfile v0.12.2
│   ├── python-daemon v3.1.2 (*)
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── python-nvd3 v0.16.0
│   │   ├── jinja2 v3.1.6 (*)
│   │   └── python-slugify v8.0.4
│   │       └── text-unidecode v1.3
│   ├── python-nvd3 v0.16.0 (*)
│   ├── python-slugify v8.0.4 (*)
│   ├── python-slugify v8.0.4 (*)
│   ├── requests v2.32.3 (*)
│   ├── requests v2.32.3 (*)
│   ├── requests-toolbelt v1.0.0 (*)
│   ├── requests-toolbelt v1.0.0 (*)
│   ├── rfc3339-validator v0.1.4
│   │   └── six v1.17.0
│   ├── rfc3339-validator v0.1.4 (*)
│   ├── rich v13.9.4 (*)
│   ├── rich v13.9.4 (*)
│   ├── rich-argparse v1.7.0
│   │   └── rich v13.9.4 (*)
│   ├── rich-argparse v1.7.0 (*)
│   ├── setproctitle v1.3.5
│   ├── setproctitle v1.3.5
│   ├── sqlalchemy v1.4.54
│   ├── sqlalchemy v1.4.54
│   ├── sqlalchemy-jsonfield v1.0.2
│   │   └── sqlalchemy v1.4.54
│   ├── sqlalchemy-jsonfield v1.0.2 (*)
│   ├── sqlalchemy-utils v0.41.2
│   │   └── sqlalchemy v1.4.54
│   ├── sqlalchemy-utils v0.41.2 (*)
│   ├── svcs v25.1.0
│   │   └── attrs v25.3.0
│   ├── svcs v25.1.0 (*)
│   ├── tabulate v0.9.0
│   ├── tabulate v0.9.0
│   ├── tenacity v9.0.0
│   ├── tenacity v9.0.0
│   ├── termcolor v2.5.0
│   ├── termcolor v2.5.0
│   ├── universal-pathlib v0.2.6
│   │   └── fsspec v2025.3.0
│   ├── universal-pathlib v0.2.6 (*)
│   ├── uuid6 v2024.7.10
│   ├── uuid6 v2024.7.10
│   ├── werkzeug v2.3.8 (*)
│   └── werkzeug v2.3.8 (*)
├── apache-airflow-providers-common-compat v1.5.1 (*)
├── apache-airflow-providers-common-sql v1.24.0 (*)
├── apache-airflow-providers-http v5.2.1
│   ├── aiohttp v3.11.13 (*)
│   ├── apache-airflow v3.0.0.dev0 (*)
│   ├── asgiref v3.8.1
│   ├── requests v2.32.3 (*)
│   └── requests-toolbelt v1.0.0 (*)
├── asgiref v3.8.1
├── boto3 v1.37.11
│   ├── botocore v1.37.11
│   │   ├── jmespath v1.0.1
│   │   ├── python-dateutil v2.9.0.post0 (*)
│   │   └── urllib3 v2.3.0
│   ├── jmespath v1.0.1
│   └── s3transfer v0.11.4
│       └── botocore v1.37.11 (*)
├── botocore v1.37.11 (*)
├── inflection v0.5.1
├── jmespath v1.0.1
├── jsonpath-ng v1.7.0
│   └── ply v3.11
├── pyathena v3.12.2
│   ├── boto3 v1.37.11 (*)
│   ├── botocore v1.37.11 (*)
│   ├── fsspec v2025.3.0
│   ├── python-dateutil v2.9.0.post0 (*)
│   └── tenacity v9.0.0
├── python3-saml v1.16.0
│   ├── isodate v0.7.2
│   ├── lxml v5.3.1
│   └── xmlsec v1.3.14
│       └── lxml v5.3.1
├── redshift-connector v2.1.5
│   ├── beautifulsoup4 v4.13.3 (*)
│   ├── boto3 v1.37.11 (*)
│   ├── botocore v1.37.11 (*)
│   ├── lxml v5.3.1
│   ├── packaging v24.2
│   ├── pytz v2025.1
│   ├── requests v2.32.3 (*)
│   ├── scramp v1.4.5
│   │   └── asn1crypto v1.5.1
│   └── setuptools v76.0.0
├── sagemaker-studio v1.0.9
│   ├── boto3 v1.37.11 (*)
│   ├── botocore v1.37.11 (*)
│   ├── packaging v24.2
│   ├── psutil v7.0.0
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── requests v2.32.3 (*)
│   ├── setuptools v76.0.0
│   └── urllib3 v2.3.0
├── watchtower v3.4.0
│   └── boto3 v1.37.11 (*)
└── xmlsec v1.3.14 (*)
apache-airflow-providers-cncf-kubernetes v10.3.1
├── aiofiles v23.2.1
├── apache-airflow v3.0.0.dev0 (*)
├── asgiref v3.8.1
├── cryptography v44.0.2 (*)
├── kubernetes v31.0.0
│   ├── certifi v2025.1.31
│   ├── durationpy v0.9
│   ├── google-auth v2.38.0
│   │   ├── cachetools v5.5.2
│   │   ├── pyasn1-modules v0.4.0
│   │   │   └── pyasn1 v0.6.1
│   │   └── rsa v4.9
│   │       └── pyasn1 v0.6.1
│   ├── oauthlib v3.2.2
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── pyyaml v6.0.2
│   ├── requests v2.32.3 (*)
│   ├── requests-oauthlib v2.0.0
│   │   ├── oauthlib v3.2.2
│   │   └── requests v2.32.3 (*)
│   ├── six v1.17.0
│   ├── urllib3 v2.3.0
│   └── websocket-client v1.8.0
└── kubernetes-asyncio v30.3.1
    ├── aiohttp v3.11.13 (*)
    ├── certifi v2025.1.31
    ├── python-dateutil v2.9.0.post0 (*)
    ├── pyyaml v6.0.2
    ├── six v1.17.0
    └── urllib3 v2.3.0
apache-airflow-providers-dbt-cloud v4.2.1
├── aiohttp v3.11.13 (*)
├── apache-airflow v3.0.0.dev0 (*)
├── apache-airflow-providers-http v5.2.1 (*)
└── asgiref v3.8.1
apache-airflow-providers-fab v2.0.0
├── apache-airflow v3.0.0.dev0 (*)
├── apache-airflow-providers-common-compat v1.5.1 (*)
├── connexion v2.14.2
│   ├── clickclick v20.10.2
│   │   ├── click v8.1.8
│   │   └── pyyaml v6.0.2
│   ├── flask v2.2.5 (*)
│   ├── inflection v0.5.1
│   ├── itsdangerous v2.2.0
│   ├── jsonschema v4.23.0 (*)
│   ├── packaging v24.2
│   ├── pyyaml v6.0.2
│   └── requests v2.32.3 (*)
├── flask v2.2.5 (*)
├── flask-appbuilder v4.5.3
│   ├── apispec v6.8.1
│   │   └── packaging v24.2
│   ├── click v8.1.8
│   ├── colorama v0.4.6
│   ├── email-validator v2.2.0
│   │   ├── dnspython v2.7.0
│   │   └── idna v3.10
│   ├── flask v2.2.5 (*)
│   ├── flask-babel v2.0.0
│   │   ├── babel v2.17.0
│   │   ├── flask v2.2.5 (*)
│   │   ├── jinja2 v3.1.6 (*)
│   │   └── pytz v2025.1
│   ├── flask-jwt-extended v4.7.1
│   │   ├── flask v2.2.5 (*)
│   │   ├── pyjwt v2.10.1
│   │   └── werkzeug v2.3.8 (*)
│   ├── flask-limiter v3.11.0
│   │   ├── flask v2.2.5 (*)
│   │   ├── limits v4.2
│   │   │   ├── deprecated v1.2.18 (*)
│   │   │   ├── packaging v24.2
│   │   │   └── typing-extensions v4.12.2
│   │   ├── ordered-set v4.1.0
│   │   ├── rich v13.9.4 (*)
│   │   └── typing-extensions v4.12.2
│   ├── flask-login v0.6.3
│   │   ├── flask v2.2.5 (*)
│   │   └── werkzeug v2.3.8 (*)
│   ├── flask-sqlalchemy v2.5.1
│   │   ├── flask v2.2.5 (*)
│   │   └── sqlalchemy v1.4.54
│   ├── flask-wtf v1.2.2 (*)
│   ├── jsonschema v4.23.0 (*)
│   ├── marshmallow v3.26.1 (*)
│   ├── marshmallow-sqlalchemy v0.28.2
│   │   ├── marshmallow v3.26.1 (*)
│   │   ├── packaging v24.2
│   │   └── sqlalchemy v1.4.54
│   ├── prison v0.2.1
│   │   └── six v1.17.0
│   ├── pyjwt v2.10.1
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── sqlalchemy v1.4.54
│   ├── sqlalchemy-utils v0.41.2 (*)
│   ├── werkzeug v2.3.8 (*)
│   └── wtforms v3.2.1 (*)
├── flask-login v0.6.3 (*)
└── jmespath v1.0.1
apache-airflow-providers-ftp v3.12.3
└── apache-airflow v3.0.0.dev0 (*)
apache-airflow-providers-google v14.0.0
├── apache-airflow v3.0.0.dev0 (*)
├── apache-airflow-providers-common-compat v1.5.1 (*)
├── apache-airflow-providers-common-sql v1.24.0 (*)
├── asgiref v3.8.1
├── dill v0.3.9
├── gcloud-aio-auth v5.3.2
│   ├── aiohttp v3.11.13 (*)
│   ├── backoff v2.2.1
│   ├── chardet v5.2.0
│   ├── cryptography v44.0.2 (*)
│   └── pyjwt v2.10.1
├── gcloud-aio-bigquery v7.1.0
│   └── gcloud-aio-auth v5.3.2 (*)
├── gcloud-aio-storage v9.3.0
│   ├── aiofiles v23.2.1
│   ├── gcloud-aio-auth v5.3.2 (*)
│   ├── pyasn1-modules v0.4.0 (*)
│   └── rsa v4.9 (*)
├── gcsfs v2025.3.0
│   ├── aiohttp v3.11.13 (*)
│   ├── decorator v5.2.1
│   ├── fsspec v2025.3.0
│   ├── google-auth v2.38.0 (*)
│   ├── google-auth-oauthlib v1.2.1
│   │   ├── google-auth v2.38.0 (*)
│   │   └── requests-oauthlib v2.0.0 (*)
│   ├── google-cloud-storage v2.19.0
│   │   ├── google-api-core v2.24.2
│   │   │   ├── google-auth v2.38.0 (*)
│   │   │   ├── googleapis-common-protos v1.69.2 (*)
│   │   │   ├── proto-plus v1.26.1
│   │   │   │   └── protobuf v5.29.4
│   │   │   ├── protobuf v5.29.4
│   │   │   └── requests v2.32.3 (*)
│   │   ├── google-auth v2.38.0 (*)
│   │   ├── google-cloud-core v2.4.3
│   │   │   ├── google-api-core v2.24.2 (*)
│   │   │   └── google-auth v2.38.0 (*)
│   │   ├── google-crc32c v1.6.0
│   │   ├── google-resumable-media v2.7.2
│   │   │   └── google-crc32c v1.6.0
│   │   └── requests v2.32.3 (*)
│   └── requests v2.32.3 (*)
├── google-ads v26.0.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth-oauthlib v1.2.1 (*)
│   ├── googleapis-common-protos v1.69.2 (*)
│   ├── grpcio v1.71.0
│   ├── grpcio-status v1.71.0
│   │   ├── googleapis-common-protos v1.69.2 (*)
│   │   ├── grpcio v1.71.0
│   │   └── protobuf v5.29.4
│   ├── proto-plus v1.26.1 (*)
│   ├── protobuf v5.29.4
│   └── pyyaml v6.0.2
├── google-analytics-admin v0.23.5
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-api-core v2.24.2 (*)
├── google-api-python-client v2.164.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-auth-httplib2 v0.2.0
│   │   ├── google-auth v2.38.0 (*)
│   │   └── httplib2 v0.22.0
│   │       └── pyparsing v3.2.1
│   ├── httplib2 v0.22.0 (*)
│   └── uritemplate v4.1.1
├── google-auth v2.38.0 (*)
├── google-auth-httplib2 v0.2.0 (*)
├── google-cloud-aiplatform v1.84.0
│   ├── docstring-parser v0.16
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-cloud-bigquery v3.30.0
│   │   ├── google-api-core v2.24.2 (*)
│   │   ├── google-auth v2.38.0 (*)
│   │   ├── google-cloud-core v2.4.3 (*)
│   │   ├── google-resumable-media v2.7.2 (*)
│   │   ├── packaging v24.2
│   │   ├── python-dateutil v2.9.0.post0 (*)
│   │   └── requests v2.32.3 (*)
│   ├── google-cloud-resource-manager v1.14.1
│   │   ├── google-api-core v2.24.2 (*)
│   │   ├── google-auth v2.38.0 (*)
│   │   ├── grpc-google-iam-v1 v0.14.1
│   │   │   ├── googleapis-common-protos v1.69.2 (*)
│   │   │   ├── grpcio v1.71.0
│   │   │   └── protobuf v5.29.4
│   │   ├── proto-plus v1.26.1 (*)
│   │   └── protobuf v5.29.4
│   ├── google-cloud-storage v2.19.0 (*)
│   ├── packaging v24.2
│   ├── proto-plus v1.26.1 (*)
│   ├── protobuf v5.29.4
│   ├── pydantic v2.10.6 (*)
│   ├── shapely v2.0.7
│   │   └── numpy v1.26.4
│   └── typing-extensions v4.12.2
├── google-cloud-alloydb v0.4.3
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-automl v2.16.2
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-batch v0.17.34
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-bigquery v3.30.0 (*)
├── google-cloud-bigquery-datatransfer v3.19.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-bigtable v2.29.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-cloud-core v2.4.3 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-build v3.31.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-compute v1.26.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-container v2.56.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-datacatalog v3.25.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-dataflow-client v0.8.16
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-dataform v0.6.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-dataplex v2.7.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-dataproc v5.18.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-dataproc-metastore v1.18.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-dlp v3.28.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-kms v3.4.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-language v2.17.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-logging v3.11.4
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-cloud-appengine-logging v1.6.0
│   │   ├── google-api-core v2.24.2 (*)
│   │   ├── google-auth v2.38.0 (*)
│   │   ├── proto-plus v1.26.1 (*)
│   │   └── protobuf v5.29.4
│   ├── google-cloud-audit-log v0.3.1
│   │   ├── googleapis-common-protos v1.69.2 (*)
│   │   └── protobuf v5.29.4
│   ├── google-cloud-core v2.4.3 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── opentelemetry-api v1.31.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-managedkafka v0.1.7
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-memcache v1.12.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-monitoring v2.27.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-orchestration-airflow v1.17.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-os-login v2.17.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-pubsub v2.28.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── grpcio v1.71.0
│   ├── grpcio-status v1.71.0 (*)
│   ├── opentelemetry-api v1.31.0 (*)
│   ├── opentelemetry-sdk v1.31.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-redis v2.18.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-run v0.10.16
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-secret-manager v2.23.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-spanner v3.52.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-cloud-core v2.4.3 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── grpc-interceptor v0.15.4
│   │   └── grpcio v1.71.0
│   ├── proto-plus v1.26.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   ├── protobuf v5.29.4
│   └── sqlparse v0.5.3
├── google-cloud-speech v2.31.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-storage v2.19.0 (*)
├── google-cloud-storage-transfer v1.16.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-tasks v2.19.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-texttospeech v2.25.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-translate v3.20.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-cloud-core v2.4.3 (*)
│   ├── grpc-google-iam-v1 v0.14.1 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-videointelligence v2.16.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-vision v3.10.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── google-cloud-workflows v1.17.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── proto-plus v1.26.1 (*)
│   └── protobuf v5.29.4
├── grpcio-gcp v0.2.2
│   └── grpcio v1.71.0
├── httpx v0.28.1 (*)
├── immutabledict v4.2.1
├── json-merge-patch v0.2
├── looker-sdk v25.4.0
│   ├── attrs v25.3.0
│   ├── cattrs v24.1.2
│   │   └── attrs v25.3.0
│   ├── requests v2.32.3 (*)
│   └── typing-extensions v4.12.2
├── pandas v2.1.4
│   ├── numpy v1.26.4
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── pytz v2025.1
│   └── tzdata v2025.1
├── pandas-gbq v0.28.0
│   ├── db-dtypes v1.4.2
│   │   ├── numpy v1.26.4
│   │   ├── packaging v24.2
│   │   ├── pandas v2.1.4 (*)
│   │   └── pyarrow v19.0.1
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-auth-oauthlib v1.2.1 (*)
│   ├── google-cloud-bigquery v3.30.0 (*)
│   ├── numpy v1.26.4
│   ├── packaging v24.2
│   ├── pandas v2.1.4 (*)
│   ├── pyarrow v19.0.1
│   ├── pydata-google-auth v1.9.1
│   │   ├── google-auth v2.38.0 (*)
│   │   ├── google-auth-oauthlib v1.2.1 (*)
│   │   └── setuptools v76.0.0
│   └── setuptools v76.0.0
├── proto-plus v1.26.1 (*)
├── pyarrow v19.0.1
├── pyopenssl v25.0.0
│   ├── cryptography v44.0.2 (*)
│   └── typing-extensions v4.12.2
├── python-slugify v8.0.4 (*)
├── sqlalchemy-bigquery v1.13.0
│   ├── google-api-core v2.24.2 (*)
│   ├── google-auth v2.38.0 (*)
│   ├── google-cloud-bigquery v3.30.0 (*)
│   ├── packaging v24.2
│   └── sqlalchemy v1.4.54
├── sqlalchemy-spanner v1.9.0
│   ├── alembic v1.15.1 (*)
│   ├── google-cloud-spanner v3.52.0 (*)
│   └── sqlalchemy v1.4.54
└── tenacity v9.0.0
apache-airflow-providers-imap v3.8.3
└── apache-airflow v3.0.0.dev0 (*)
apache-airflow-providers-microsoft-azure v12.2.1
├── adal v1.2.7
│   ├── cryptography v44.0.2 (*)
│   ├── pyjwt v2.10.1
│   ├── python-dateutil v2.9.0.post0 (*)
│   └── requests v2.32.3 (*)
├── adlfs v2024.12.0
│   ├── aiohttp v3.11.13 (*)
│   ├── azure-core v1.32.0
│   │   ├── requests v2.32.3 (*)
│   │   ├── six v1.17.0
│   │   └── typing-extensions v4.12.2
│   ├── azure-datalake-store v0.0.53
│   │   ├── cffi v1.17.1 (*)
│   │   ├── msal v1.32.0
│   │   │   ├── cryptography v44.0.2 (*)
│   │   │   ├── pyjwt v2.10.1
│   │   │   └── requests v2.32.3 (*)
│   │   └── requests v2.32.3 (*)
│   ├── azure-identity v1.21.0
│   │   ├── azure-core v1.32.0 (*)
│   │   ├── cryptography v44.0.2 (*)
│   │   ├── msal v1.32.0 (*)
│   │   ├── msal-extensions v1.2.0
│   │   │   ├── msal v1.32.0 (*)
│   │   │   └── portalocker v2.10.1
│   │   └── typing-extensions v4.12.2
│   ├── azure-storage-blob v12.25.0
│   │   ├── azure-core v1.32.0 (*)
│   │   ├── cryptography v44.0.2 (*)
│   │   ├── isodate v0.7.2
│   │   └── typing-extensions v4.12.2
│   └── fsspec v2025.3.0
├── apache-airflow v3.0.0.dev0 (*)
├── azure-batch v14.2.0
│   ├── azure-common v1.1.28
│   └── msrestazure v0.6.4.post1
│       ├── adal v1.2.7 (*)
│       ├── msrest v0.7.1
│       │   ├── azure-core v1.32.0 (*)
│       │   ├── certifi v2025.1.31
│       │   ├── isodate v0.7.2
│       │   ├── requests v2.32.3 (*)
│       │   └── requests-oauthlib v2.0.0 (*)
│       └── six v1.17.0
├── azure-cosmos v4.9.0
│   ├── azure-core v1.32.0 (*)
│   └── typing-extensions v4.12.2
├── azure-datalake-store v0.0.53 (*)
├── azure-identity v1.21.0 (*)
├── azure-keyvault-secrets v4.9.0
│   ├── azure-core v1.32.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-kusto-data v5.0.1
│   ├── azure-core v1.32.0 (*)
│   ├── azure-identity v1.21.0 (*)
│   ├── ijson v3.3.0
│   ├── msal v1.32.0 (*)
│   ├── python-dateutil v2.9.0.post0 (*)
│   └── requests v2.32.3 (*)
├── azure-mgmt-containerinstance v10.1.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0
│   │   └── azure-core v1.32.0 (*)
│   └── isodate v0.7.2
├── azure-mgmt-containerregistry v12.0.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-mgmt-cosmosdb v9.7.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-mgmt-datafactory v9.1.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-mgmt-datalake-store v0.5.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-datalake-nspkg v3.0.1
│   │   └── azure-mgmt-nspkg v3.0.2
│   │       └── azure-nspkg v3.0.2
│   └── msrestazure v0.6.4.post1 (*)
├── azure-mgmt-resource v23.3.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-mgmt-storage v22.1.1
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-servicebus v7.14.1
│   ├── azure-core v1.32.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-storage-blob v12.25.0 (*)
├── azure-storage-file-datalake v12.19.0
│   ├── azure-core v1.32.0 (*)
│   ├── azure-storage-blob v12.25.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-storage-file-share v12.21.0
│   ├── azure-core v1.32.0 (*)
│   ├── cryptography v44.0.2 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-synapse-artifacts v0.20.0
│   ├── azure-common v1.1.28
│   ├── azure-mgmt-core v1.5.0 (*)
│   ├── isodate v0.7.2
│   └── typing-extensions v4.12.2
├── azure-synapse-spark v0.7.0
│   ├── azure-common v1.1.28
│   ├── azure-core v1.32.0 (*)
│   └── msrest v0.7.1 (*)
├── microsoft-kiota-abstractions v1.3.3
│   ├── opentelemetry-api v1.31.0 (*)
│   ├── opentelemetry-sdk v1.31.0 (*)
│   └── std-uritemplate v2.0.3
├── microsoft-kiota-http v1.3.3
│   ├── httpx v0.28.1 (*)
│   ├── microsoft-kiota-abstractions v1.3.3 (*)
│   ├── opentelemetry-api v1.31.0 (*)
│   └── opentelemetry-sdk v1.31.0 (*)
├── microsoft-kiota-serialization-json v1.0.0
│   ├── microsoft-kiota-abstractions v1.3.3 (*)
│   └── pendulum v3.0.0 (*)
├── microsoft-kiota-serialization-text v1.0.0
│   ├── microsoft-kiota-abstractions v1.3.3 (*)
│   └── python-dateutil v2.9.0.post0 (*)
└── msgraph-core v1.2.1
    ├── httpx v0.28.1 (*)
    ├── microsoft-kiota-abstractions v1.3.3 (*)
    ├── microsoft-kiota-authentication-azure v1.1.0
    │   ├── aiohttp v3.11.13 (*)
    │   ├── azure-core v1.32.0 (*)
    │   ├── microsoft-kiota-abstractions v1.3.3 (*)
    │   ├── opentelemetry-api v1.31.0 (*)
    │   └── opentelemetry-sdk v1.31.0 (*)
    └── microsoft-kiota-http v1.3.3 (*)
apache-airflow-providers-microsoft-winrm v3.9.1
├── apache-airflow v3.0.0.dev0 (*)
└── pywinrm v0.5.0
    ├── requests v2.32.3 (*)
    ├── requests-ntlm v1.3.0
    │   ├── cryptography v44.0.2 (*)
    │   ├── pyspnego v0.11.2
    │   │   └── cryptography v44.0.2 (*)
    │   └── requests v2.32.3 (*)
    └── xmltodict v0.14.2
apache-airflow-providers-mysql v6.2.0
├── aiomysql v0.2.0
│   └── pymysql v1.1.1
├── apache-airflow v3.0.0.dev0 (*)
├── apache-airflow-providers-common-sql v1.24.0 (*)
└── mysql-connector-python v9.2.0
apache-airflow-providers-openlineage v2.1.1
├── apache-airflow v3.0.0.dev0 (*)
├── apache-airflow-providers-common-compat v1.5.1 (*)
├── apache-airflow-providers-common-sql v1.24.0 (*)
├── attrs v25.3.0
├── openlineage-integration-common v1.29.0
│   ├── attrs v25.3.0
│   ├── openlineage-python v1.29.0
│   │   ├── attrs v25.3.0
│   │   ├── packaging v24.2
│   │   ├── python-dateutil v2.9.0.post0 (*)
│   │   ├── pyyaml v6.0.2
│   │   └── requests v2.32.3 (*)
│   └── openlineage-sql v1.29.0
└── openlineage-python v1.29.0 (*)
apache-airflow-providers-postgres v6.1.1
├── apache-airflow v3.0.0.dev0 (*)
├── apache-airflow-providers-common-sql v1.24.0 (*)
├── asyncpg v0.30.0
└── psycopg2-binary v2.9.10
apache-airflow-providers-sqlite v4.0.1 (*)
apache-airflow-task-sdk v1.0.0a1
├── httpx v0.28.1 (*)
├── jinja2 v3.1.6 (*)
├── methodtools v0.4.7 (*)
├── msgspec v0.19.0
├── pendulum v3.0.0 (*)
├── psutil v7.0.0
├── python-dateutil v2.9.0.post0 (*)
├── retryhttp v1.3.1
│   ├── httpx v0.28.1 (*)
│   ├── pydantic v2.10.6 (*)
│   ├── requests v2.32.3 (*)
│   ├── tenacity v9.0.0
│   └── types-requests v2.32.0.20250306 (*)
└── structlog v25.2.0
fastapi-cli v0.0.7
├── rich-toolkit v0.13.2
│   ├── click v8.1.8
│   ├── rich v13.9.4 (*)
│   └── typing-extensions v4.12.2
├── typer v0.15.2
│   ├── click v8.1.8
│   ├── rich v13.9.4 (*)
│   ├── shellingham v1.5.4
│   └── typing-extensions v4.12.2
└── uvicorn v0.34.0
    ├── click v8.1.8
    └── h11 v0.14.0
h2 v4.2.0
├── hpack v4.1.0
└── hyperframe v6.1.0
httptools v0.6.4
python-dotenv v1.0.1
python-multipart v0.0.20
scikit-learn v1.6.1
├── joblib v1.4.2
├── numpy v1.26.4
├── scipy v1.15.2
│   └── numpy v1.26.4
└── threadpoolctl v3.5.0
tqdm v4.67.1
uvloop v0.21.0
watchfiles v1.0.4
└── anyio v4.9.0 (*)
websockets v15.0.1
(*) Package tree already displayed

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
