### PR TITLE
Implement on_execute_callback in task sdk

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -339,7 +339,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
     start_trigger_args: StartTriggerArgs | None = None
     start_from_trigger: bool = False
 
-    on_execute_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
     on_failure_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
     on_success_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
     on_retry_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
@@ -349,7 +348,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
         self,
         pre_execute=None,
         post_execute=None,
-        on_execute_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
         on_failure_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
         on_success_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
         on_retry_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
@@ -364,7 +362,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
         super().__init__(**kwargs)
         self._pre_execute_hook = pre_execute
         self._post_execute_hook = post_execute
-        self.on_execute_callback = on_execute_callback
         self.on_failure_callback = on_failure_callback
         self.on_success_callback = on_success_callback
         self.on_skipped_callback = on_skipped_callback
@@ -393,7 +390,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
         return TaskSDKBaseOperator.get_serialized_fields() | {
             "start_trigger_args",
             "start_from_trigger",
-            "on_execute_callback",
             "on_failure_callback",
             "on_success_callback",
             "on_retry_callback",

--- a/task-sdk/src/airflow/sdk/definitions/baseoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/baseoperator.py
@@ -69,6 +69,7 @@ from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import db_safe_priority
 
+C = TypeVar("C", bound=Callable)
 T = TypeVar("T", bound=FunctionType)
 
 if TYPE_CHECKING:
@@ -380,6 +381,12 @@ if "airflow.configuration" in sys.modules:
     from airflow.configuration import conf
 
     ExecutorSafeguard.test_mode = conf.getboolean("core", "unit_test_mode")
+
+
+def _collect_callbacks(callbacks: C | Collection[C]) -> list[C]:
+    if isinstance(callbacks, Collection):
+        return list(callbacks)
+    return [callbacks]
 
 
 class BaseOperatorMeta(abc.ABCMeta):
@@ -805,7 +812,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     pool: str = DEFAULT_POOL_NAME
     pool_slots: int = DEFAULT_POOL_SLOTS
     execution_timeout: timedelta | None = DEFAULT_TASK_EXECUTION_TIMEOUT
-    # on_execute_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
+    on_execute_callback: Sequence[TaskStateChangeCallback] = ()
     # on_failure_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
     # on_success_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
     # on_retry_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None
@@ -959,7 +966,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         pool_slots: int = DEFAULT_POOL_SLOTS,
         sla: timedelta | None = None,
         execution_timeout: timedelta | None = DEFAULT_TASK_EXECUTION_TIMEOUT,
-        # on_execute_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
+        on_execute_callback: TaskStateChangeCallback | Collection[TaskStateChangeCallback] = (),
         # on_failure_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
         # on_success_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
         # on_retry_callback: None | TaskStateChangeCallback | list[TaskStateChangeCallback] = None,
@@ -1037,7 +1044,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.execution_timeout = execution_timeout
 
         # TODO:
-        # self.on_execute_callback = on_execute_callback
+        self.on_execute_callback = _collect_callbacks(on_execute_callback)
         # self.on_failure_callback = on_failure_callback
         # self.on_success_callback = on_success_callback
         # self.on_retry_callback = on_retry_callback

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1357,7 +1357,7 @@ class TestStringifiedDAGs:
             "max_active_tis_per_dag": None,
             "max_active_tis_per_dagrun": None,
             "max_retry_delay": None,
-            "on_execute_callback": None,
+            "on_execute_callback": [],
             "on_failure_fail_dagrun": False,
             "on_failure_callback": None,
             "on_retry_callback": None,


### PR DESCRIPTION
The callable is run *outside* of the timeout block. Failures calling any callback functions are simply logged without failing the entire task. This matches Airflow 2's behavior.

Submitting this first to get feedback. Other callbacks will be implemented in later PRs if I'm on the right track.

First part of #45424.