### PR TITLE
Add lower-binding for microsoft azure/winrm providers

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -854,10 +854,11 @@
       "microsoft-kiota-http>=1.3.0,!=1.3.4",
       "microsoft-kiota-serialization-json==1.0.0",
       "microsoft-kiota-serialization-text==1.0.0",
+      "msal-extensions>=1.1.0",
       "msgraph-core>=1.0.0,!=1.1.8"
     ],
     "devel-deps": [
-      "pywinrm>=0.4"
+      "pywinrm>=0.5.0"
     ],
     "plugins": [],
     "cross-providers-deps": [
@@ -899,7 +900,7 @@
   "microsoft.winrm": {
     "deps": [
       "apache-airflow>=2.9.0",
-      "pywinrm>=0.4"
+      "pywinrm>=0.5.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/microsoft/azure/README.rst
+++ b/providers/microsoft/azure/README.rst
@@ -80,6 +80,7 @@ PIP package                             Version required
 ``microsoft-kiota-serialization-json``  ``==1.0.0``
 ``microsoft-kiota-serialization-text``  ``==1.0.0``
 ``microsoft-kiota-abstractions``        ``<1.4.0``
+``msal-extensions``                     ``>=1.1.0``
 ======================================  ===================
 
 Cross provider package dependencies

--- a/providers/microsoft/azure/pyproject.toml
+++ b/providers/microsoft/azure/pyproject.toml
@@ -91,6 +91,7 @@ dependencies = [
     # microsoft-kiota-abstractions 1.4.0 breaks MyPy static checks on main
     # see https://github.com/apache/airflow/issues/43036
     "microsoft-kiota-abstractions<1.4.0",
+    "msal-extensions>=1.1.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file
@@ -119,7 +120,7 @@ dev = [
     "apache-airflow-providers-oracle",
     "apache-airflow-providers-sftp",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    "pywinrm>=0.4",
+    "pywinrm>=0.5.0",
 ]
 
 [tool.uv.sources]

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
@@ -486,6 +486,7 @@ def get_provider_info():
             "microsoft-kiota-serialization-json==1.0.0",
             "microsoft-kiota-serialization-text==1.0.0",
             "microsoft-kiota-abstractions<1.4.0",
+            "msal-extensions>=1.1.0",
         ],
         "optional-dependencies": {
             "amazon": ["apache-airflow-providers-amazon"],
@@ -493,5 +494,5 @@ def get_provider_info():
             "oracle": ["apache-airflow-providers-oracle"],
             "sftp": ["apache-airflow-providers-sftp"],
         },
-        "devel-dependencies": ["pywinrm>=0.4"],
+        "devel-dependencies": ["pywinrm>=0.5.0"],
     }

--- a/providers/microsoft/winrm/README.rst
+++ b/providers/microsoft/winrm/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.9.0``
-``pywinrm``         ``>=0.4``
+``pywinrm``         ``>=0.5.0``
 ==================  ==================
 
 The changelog for the provider package can be found in the

--- a/providers/microsoft/winrm/pyproject.toml
+++ b/providers/microsoft/winrm/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.9.0",
-    "pywinrm>=0.4",
+    "pywinrm>=0.5.0",
 ]
 
 [dependency-groups]

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
@@ -76,6 +76,6 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.microsoft.winrm.hooks.winrm"],
             }
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "pywinrm>=0.4"],
+        "dependencies": ["apache-airflow>=2.9.0", "pywinrm>=0.5.0"],
         "devel-dependencies": [],
     }


### PR DESCRIPTION
For Python 3.12 removal of distutils causes older versions of microsoft libraries to fail when trying to import it when lowest bound versions of msal-extensions and pywirm are used. Adding lower binding for msal-extensions and pywinrm should avoid that.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
