### PR TITLE
docs(newsfragments): migration rules format/content fix

### DIFF
--- a/newsfragments/47761.significant.rst
+++ b/newsfragments/47761.significant.rst
@@ -25,6 +25,9 @@ If you have these configuration options in your ``airflow.cfg`` file, you need t
   * [ ] Code interface changes
 
 * Migration rules needed
+
+  * ``airflow config lint``
+
     * [ ] Remove ``[core] hostname`` configuration option from config if value is ``:``
     * [ ] Remove ``[email] email_backend`` configuration option from config if value is ``airflow.contrib.utils.sendgrid.send_email``
     * [ ] Remove ``[logging] log_filename_template`` configuration option from config if value is ``{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log``

--- a/newsfragments/aip-72.significant.rst
+++ b/newsfragments/aip-72.significant.rst
@@ -105,4 +105,4 @@ As part of this change the following breaking changes have occurred:
 
     * AIR302
 
-      * [ ] ``airflow.models.baseoperatorlink`` → ``airflow.sdk``
+      * [ ] ``airflow.models.baseoperatorlink.BaseOperatorLink`` → ``airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink``

--- a/newsfragments/api-38.significant.rst
+++ b/newsfragments/api-38.significant.rst
@@ -18,12 +18,12 @@
 
 * Migration rules needed
 
+  * ``airflow config lint``
+
+    * [ ] ``core.dag_default_view``
+    * [ ] ``core.dag_orientation``
+
   * ruff
-
-    * ``airflow config lint``
-
-      * [ ] ``core.dag_default_view``
-      * [ ] ``core.dag_orientation``
 
     * AIR302
 


### PR DESCRIPTION
## Why
Some content is missing, or the format is incorrect for these news fragments.

## What
fix the format and content

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
