### PR TITLE
Improve DatabricksRunNowOperator docs and document job parameter support

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -650,9 +650,9 @@ class DatabricksSubmitRunOperator(BaseOperator):
 
 class DatabricksRunNowOperator(BaseOperator):
     """
-    Runs an existing Spark job run to Databricks using the api/2.1/jobs/run-now API endpoint.
+    Runs an existing job in Databricks using the api/2.1/jobs/run-now API endpoint.
 
-    See: https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow
+    See: https://docs.databricks.com/api/workspace/jobs_21/runnow
 
     There are two ways to instantiate this operator.
 
@@ -675,23 +675,11 @@ class DatabricksRunNowOperator(BaseOperator):
 
         job_id = 42
 
-        dbt_commands = ["dbt deps", "dbt seed", "dbt run"]
+        job_parameters = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 
-        notebook_params = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
-
-        python_params = ["douglas adams", "42"]
-
-        jar_params = ["douglas adams", "42"]
-
-        spark_submit_params = ["--class", "org.apache.spark.examples.SparkPi"]
-
-        notebook_run = DatabricksRunNowOperator(
+        job_run = DatabricksRunNowOperator(
             job_id=job_id,
-            dbt_commands=dbt_commands,
-            notebook_params=notebook_params,
-            python_params=python_params,
-            jar_params=jar_params,
-            spark_submit_params=spark_submit_params,
+            job_parameters=job_parameters,
         )
 
     In the case where both the json parameter **AND** the named parameters


### PR DESCRIPTION
Improve the documentation of the `DatabricksRunNowOperator` based on feedback from users. Notably, show that `job_parameters` has first-class support and is the recommended and supported way to parameterize job runs.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
