### PR TITLE
Calculate retry eligibility before task runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -36,6 +36,7 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
     TIEnterRunningPayload,
     TIHeartbeatInfo,
     TIRescheduleStatePayload,
+    TIRetryStatePayload,
     TIRunContext,
     TIRuntimeCheckPayload,
     TISkippedDownstreamTasksStatePayload,
@@ -50,7 +51,7 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
 from airflow.models.xcom import XComModel
 from airflow.utils import timezone
-from airflow.utils.state import DagRunState, TaskInstanceState, TerminalTIState
+from airflow.utils.state import DagRunState, TaskInstanceState
 
 router = VersionedAPIRouter(
     dependencies=[
@@ -136,7 +137,7 @@ def ti_run(
         ti_run_payload.pid,
     ):
         log.info("Duplicate start request received from %s ", ti_run_payload.hostname)
-    elif previous_state != TaskInstanceState.QUEUED:
+    elif previous_state not in (TaskInstanceState.QUEUED, TaskInstanceState.RESTARTING):
         log.warning(
             "Can not start Task Instance ('%s') in invalid state: %s",
             ti_id_str,
@@ -226,6 +227,7 @@ def ti_run(
             variables=[],
             connections=[],
             xcom_keys_to_clear=xcom_keys,
+            should_retry=_is_eligible_to_retry(previous_state, ti.try_number, ti.max_tries),
         )
 
         # Only set if they are non-null
@@ -289,23 +291,18 @@ def ti_update_state(
     query = update(TI).where(TI.id == ti_id_str).values(data)
 
     if isinstance(ti_patch_payload, TITerminalStatePayload):
-        query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
         updated_state = ti_patch_payload.state
-        # if we get failed, we should attempt to retry, as it is a more
-        # normal state. Tasks with retries are more frequent than without retries.
-        if ti_patch_payload.state == TerminalTIState.FAIL_WITHOUT_RETRY:
-            updated_state = TaskInstanceState.FAILED
-        elif ti_patch_payload.state == TaskInstanceState.FAILED:
-            if _is_eligible_to_retry(previous_state, try_number, max_tries):
-                from airflow.models.taskinstance import uuid7
-                from airflow.models.taskinstancehistory import TaskInstanceHistory
+        query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
+        query = query.values(state=updated_state)
+    elif isinstance(ti_patch_payload, TIRetryStatePayload):
+        from airflow.models.taskinstance import uuid7
+        from airflow.models.taskinstancehistory import TaskInstanceHistory
 
-                ti = session.get(TI, ti_id_str)
-                TaskInstanceHistory.record_ti(ti, session=session)
-                ti.try_id = uuid7()
-                updated_state = TaskInstanceState.UP_FOR_RETRY
-            else:
-                updated_state = TaskInstanceState.FAILED
+        ti = session.get(TI, ti_id_str)
+        TaskInstanceHistory.record_ti(ti, session=session)
+        ti.try_id = uuid7()
+        updated_state = ti_patch_payload.state
+        query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
         query = query.values(state=updated_state)
     elif isinstance(ti_patch_payload, TISuccessStatePayload):
         query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -888,6 +888,7 @@ def _get_template_context(
     ti_context_from_server = TIRunContext(
         dag_run=DagRunSDK.model_validate(dag_run, from_attributes=True),
         max_tries=task_instance.max_tries,
+        should_retry=task_instance.is_eligible_to_retry(),
     )
     runtime_ti = task_instance.to_runtime_ti(context_from_server=ti_context_from_server)
 
@@ -3196,7 +3197,7 @@ class TaskInstance(Base, LoggingMixin):
             fail_fast=fail_fast,
         )
 
-    def is_eligible_to_retry(self):
+    def is_eligible_to_retry(self) -> bool:
         """Is task instance is eligible for retry."""
         return _is_eligible_to_retry(task_instance=self)
 

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -39,7 +39,6 @@ class TerminalTIState(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"  # A user can raise a AirflowSkipException from a task & it will be marked as skipped
     REMOVED = "removed"
-    FAIL_WITHOUT_RETRY = "fail_without_retry"
 
     def __str__(self) -> str:
         return self.value

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
@@ -473,6 +473,7 @@ def make_ti_context() -> MakeTIContextCallable:
             ),
             task_reschedule_count=task_reschedule_count,
             max_tries=0,
+            should_retry=False,
         )
 
     return _make_context

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -904,6 +904,7 @@ class TestOpenLineageListenerAirflow3:
                 ),
                 task_reschedule_count=0,
                 max_tries=1,
+                should_retry=False,
             ),
             start_date=dt.datetime(2023, 1, 1, 13, 1, 1),
         )

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -484,6 +484,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
                     "run_after": "2021-01-01T00:00:00Z",
                 },
                 "max_tries": 0,
+                "should_retry": False,
             },
         )
     return httpx.Response(200, json={"text": "Hello, world!"})

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -195,6 +195,18 @@ class TIRescheduleStatePayload(BaseModel):
     end_date: Annotated[datetime, Field(title="End Date")]
 
 
+class TIRetryStatePayload(BaseModel):
+    """
+    Schema for updating TaskInstance to up_for_retry.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    state: Annotated[Literal["up_for_retry"] | None, Field(title="State")] = "up_for_retry"
+    end_date: Annotated[datetime, Field(title="End Date")]
+
+
 class TIRuntimeCheckPayload(BaseModel):
     """
     Payload for performing Runtime checks on the TaskInstance model as requested by the SDK.
@@ -247,7 +259,6 @@ class TerminalStateNonSuccess(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"
-    FAIL_WITHOUT_RETRY = "fail_without_retry"
 
 
 class TriggerDAGRunPayload(BaseModel):
@@ -333,7 +344,6 @@ class TerminalTIState(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"
-    FAIL_WITHOUT_RETRY = "fail_without_retry"
 
 
 class AssetEventResponse(BaseModel):
@@ -399,6 +409,7 @@ class TIRunContext(BaseModel):
     next_method: Annotated[str | None, Field(title="Next Method")] = None
     next_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Next Kwargs")] = None
     xcom_keys_to_clear: Annotated[list[str] | None, Field(title="Xcom Keys To Clear")] = None
+    should_retry: Annotated[bool, Field(title="Should Retry")]
 
 
 class TITerminalStatePayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -61,6 +61,7 @@ from airflow.sdk.api.datamodels._generated import (
     TerminalTIState,
     TIDeferredStatePayload,
     TIRescheduleStatePayload,
+    TIRetryStatePayload,
     TIRunContext,
     TIRuntimeCheckPayload,
     TISkippedDownstreamTasksStatePayload,
@@ -257,7 +258,6 @@ class TaskState(BaseModel):
         TerminalTIState.FAILED,
         TerminalTIState.SKIPPED,
         TerminalTIState.REMOVED,
-        TerminalTIState.FAIL_WITHOUT_RETRY,
     ]
     end_date: datetime | None = None
     type: Literal["TaskState"] = "TaskState"
@@ -286,6 +286,12 @@ class DeferTask(TIDeferredStatePayload):
             # Already encoded.
             return val
         return BaseSerialization.serialize(val or {})
+
+
+class RetryTask(TIRetryStatePayload):
+    """Update a task instance state to up_for_retry."""
+
+    type: Literal["RetryTask"] = "RetryTask"
 
 
 class RescheduleTask(TIRescheduleStatePayload):
@@ -445,6 +451,7 @@ ToSupervisor = Annotated[
         GetXComCount,
         PutVariable,
         RescheduleTask,
+        RetryTask,
         SkipDownstreamTasks,
         SetRenderedFields,
         SetXCom,

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -60,6 +60,7 @@ from airflow.sdk.execution_time.comms import (
     GetDagRunState,
     OKResponse,
     RescheduleTask,
+    RetryTask,
     RuntimeCheckOnTask,
     SetRenderedFields,
     SkipDownstreamTasks,
@@ -655,19 +656,15 @@ def run(
         # TODO: Handle fail_stop here: https://github.com/apache/airflow/issues/44951
         # TODO: Handle addition to Log table: https://github.com/apache/airflow/issues/44952
         msg = TaskState(
-            state=TerminalTIState.FAIL_WITHOUT_RETRY,
-            end_date=datetime.now(tz=timezone.utc),
-        )
-        state = TerminalTIState.FAIL_WITHOUT_RETRY
-        error = e
-    except (AirflowTaskTimeout, AirflowException) as e:
-        # We should allow retries if the task has defined it.
-        log.exception("Task failed with exception")
-        msg = TaskState(
             state=TerminalTIState.FAILED,
             end_date=datetime.now(tz=timezone.utc),
         )
         state = TerminalTIState.FAILED
+        error = e
+    except (AirflowTaskTimeout, AirflowException) as e:
+        # We should allow retries if the task has defined it.
+        log.exception("Task failed with exception")
+        msg, state = _handle_current_task_failed(ti)
         error = e
     except AirflowTaskTerminated as e:
         # External state updates are already handled with `ti_heartbeat` and will be
@@ -675,24 +672,19 @@ def run(
         # If these are thrown, we should mark the TI state as failed.
         log.exception("Task failed with exception")
         msg = TaskState(
-            state=TerminalTIState.FAIL_WITHOUT_RETRY,
-            end_date=datetime.now(tz=timezone.utc),
-        )
-        state = TerminalTIState.FAIL_WITHOUT_RETRY
-        error = e
-    except SystemExit as e:
-        # SystemExit needs to be retried if they are eligible.
-        log.exception("Task failed with exception")
-        msg = TaskState(
             state=TerminalTIState.FAILED,
             end_date=datetime.now(tz=timezone.utc),
         )
         state = TerminalTIState.FAILED
         error = e
+    except SystemExit as e:
+        # SystemExit needs to be retried if they are eligible.
+        log.exception("Task failed with exception")
+        msg, state = _handle_current_task_failed(ti)
+        error = e
     except BaseException as e:
         log.exception("Task failed with exception")
-        msg = TaskState(state=TerminalTIState.FAILED, end_date=datetime.now(tz=timezone.utc))
-        state = TerminalTIState.FAILED
+        msg, state = _handle_current_task_failed(ti)
         error = e
     finally:
         if msg:
@@ -701,7 +693,10 @@ def run(
     return state, msg, error
 
 
-def _handle_current_task_success(context: Context, ti: RuntimeTaskInstance):
+def _handle_current_task_success(
+    context: Context,
+    ti: RuntimeTaskInstance,
+) -> tuple[SucceedTask, TerminalTIState]:
     task_outlets = list(_build_asset_profiles(ti.task.outlets))
     outlet_events = list(_serialize_outlet_events(context["outlet_events"]))
     msg = SucceedTask(
@@ -712,9 +707,18 @@ def _handle_current_task_success(context: Context, ti: RuntimeTaskInstance):
     return msg, TerminalTIState.SUCCESS
 
 
+def _handle_current_task_failed(
+    ti: RuntimeTaskInstance,
+) -> tuple[RetryTask, IntermediateTIState] | tuple[TaskState, TerminalTIState]:
+    end_date = datetime.now(tz=timezone.utc)
+    if ti._ti_context_from_server and ti._ti_context_from_server.should_retry:
+        return RetryTask(end_date=end_date), IntermediateTIState.UP_FOR_RETRY
+    return TaskState(state=TerminalTIState.FAILED, end_date=end_date), TerminalTIState.FAILED
+
+
 def _handle_trigger_dag_run(
     drte: DagRunTriggerException, context: Context, ti: RuntimeTaskInstance, log: Logger
-):
+) -> tuple[ToSupervisor, TerminalTIState]:
     """Handle exception from TriggerDagRunOperator."""
     log.info("Triggering Dag Run.", trigger_dag_id=drte.trigger_dag_id)
     SUPERVISOR_COMMS.send_request(
@@ -784,9 +788,7 @@ def _handle_trigger_dag_run(
                 state=comms_msg.state,
             )
 
-    msg, state = _handle_current_task_success(context, ti)
-
-    return msg, state
+    return _handle_current_task_success(context, ti)
 
 
 def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
@@ -881,7 +883,10 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
 
 
 def finalize(
-    ti: RuntimeTaskInstance, state: TerminalTIState, log: Logger, error: BaseException | None = None
+    ti: RuntimeTaskInstance,
+    state: IntermediateTIState | TerminalTIState,
+    log: Logger,
+    error: BaseException | None = None,
 ):
     # Pushing xcom for each operator extra links defined on the operator only.
     for oe in ti.task.operator_extra_links:
@@ -890,12 +895,17 @@ def finalize(
         _xcom_push(ti, key=xcom_key, value=link)
 
     log.debug("Running finalizers", ti=ti)
-    if state in [TerminalTIState.SUCCESS]:
+    if state == TerminalTIState.SUCCESS:
         get_listener_manager().hook.on_task_instance_success(
             previous_state=TaskInstanceState.RUNNING, task_instance=ti
         )
         # TODO: Run task success callbacks here
-    if state in [TerminalTIState.FAILED, TerminalTIState.FAIL_WITHOUT_RETRY]:
+    elif state == IntermediateTIState.UP_FOR_RETRY:
+        get_listener_manager().hook.on_task_instance_failed(
+            previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
+        )
+        # TODO: Run task retry callbacks here
+    elif state == TerminalTIState.FAILED:
         get_listener_manager().hook.on_task_instance_failed(
             previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
         )

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -220,6 +220,7 @@ def make_ti_context() -> MakeTIContextCallable:
             ),
             task_reschedule_count=task_reschedule_count,
             max_tries=0,
+            should_retry=False,
         )
 
     return _make_context

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -56,6 +56,7 @@ class TestClient:
                         "run_after": "2021-01-01T00:00:00Z",
                     },
                     "max_tries": 0,
+                    "should_retry": False,
                 },
             ),
         ],

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -728,23 +728,16 @@ class TestListenerOvertime:
 
         if expected_timeout:
             assert any(
-                [
-                    event["event"] == "Workload success overtime reached; terminating process"
-                    for event in captured_logs
-                ]
+                event["event"] == "Workload success overtime reached; terminating process"
+                for event in captured_logs
             )
             assert any(
-                [
-                    event["event"] == "Process exited" and event["signal"] == "SIGTERM"
-                    for event in captured_logs
-                ]
+                event["event"] == "Process exited" and event["signal"] == "SIGTERM" for event in captured_logs
             )
         else:
             assert all(
-                [
-                    event["event"] != "Workload success overtime reached; terminating process"
-                    for event in captured_logs
-                ]
+                event["event"] != "Workload success overtime reached; terminating process"
+                for event in captured_logs
             )
 
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -140,7 +140,7 @@ class TestCommsDecoder:
             b'"dag_id": "c"}, "ti_context":{"dag_run":{"dag_id":"c","run_id":"b","logical_date":"2024-12-01T01:00:00Z",'
             b'"data_interval_start":"2024-12-01T00:00:00Z","data_interval_end":"2024-12-01T01:00:00Z",'
             b'"start_date":"2024-12-01T01:00:00Z","run_after":"2024-12-01T01:00:00Z","end_date":null,"run_type":"manual","conf":null},'
-            b'"max_tries":0,"variables":null,"connections":null},"file": "/dev/null",'
+            b'"max_tries":0,"should_retry":false,"variables":null,"connections":null},"file": "/dev/null",'
             b'"start_date":"2024-12-01T01:00:00Z", "dag_rel_path": "/dev/null", "bundle_info": {"name": '
             b'"any-name", "version": "any-version"}, "requests_fd": '
             + str(w2.fileno()).encode("ascii")
@@ -670,7 +670,7 @@ def test_run_basic_failed(
     run(ti, log=mock.MagicMock())
 
     mock_supervisor_comms.send_request.assert_called_once_with(
-        msg=TaskState(state=TerminalTIState.FAIL_WITHOUT_RETRY, end_date=instant), log=mock.ANY
+        msg=TaskState(state=TerminalTIState.FAILED, end_date=instant), log=mock.ANY
     )
 
 


### PR DESCRIPTION
The task needs this information to know whether it should run the retry or failed callback if the task fails, so we calculate it eagerly and pass it to the runner, instead of lazily only after the task has failed.

~~When a task fails, it uses this information to decide whether it should go directly into FAIL_WITHOUT_RETRY, so the server does not need to calculate this again.~~

~~This makes the TITerminalState a bit wonky. Now the FAILED state actually makes the server always retry the task, and should probably be renamed to RETRY or something...? And FAIL_WITHOUT_RETRY can actually just be called FAILED since there's no other kind of failed. A simple rename causes a lot of things to change though since the enum is reused in a lot of places. So I decided to leave the names be for now.~~

The information is used by the task runner to decide what state to set the ti to when an error happens. If the task is eligible for retry, the next state is set to UP_FOR_RETRY; otherwise it's FAILED. This is then handled accordingly in the API.

The FAIL_WITHOUT_RETRY state has been removed from the code base since it is no longer needed. The state was introduced in #45106 to tell the API server to not check retry eligibility on certain failure cases, but now that eligibility is always checked and used in the task runner, the API server no longer needs this information; a request to update to FAILED always set the TI to FAILED.