### PR TITLE
fix(asset): allow extra in Metadata to be optional

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/metadata.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/metadata.py
@@ -32,5 +32,5 @@ class Metadata:
     """Metadata to attach to an AssetEvent."""
 
     asset: Asset
-    extra: dict[str, Any]
+    extra: dict[str, Any] = attrs.field(factory=dict)
     alias: AssetAlias | None = None

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2404,6 +2404,14 @@ class TestTaskInstance:
                 post_execute=_write2_post_execute,
             )
 
+            @task(outlets=Asset("test_outlet_asset_extra_3"))
+            def write3():
+                result = "write_3 result"
+                yield Metadata(Asset(name="test_outlet_asset_extra_3"))
+                return result
+
+            write3()
+
         dr: DagRun = dag_maker.create_dagrun()
         for ti in dr.get_task_instances(session=session):
             ti.run(session=session)
@@ -2416,7 +2424,7 @@ class TestTaskInstance:
         assert xcom.value == json.dumps("write_1 result")
 
         events = dict(iter(session.execute(select(AssetEvent.source_task_id, AssetEvent))))
-        assert set(events) == {"write1", "write2"}
+        assert set(events) == {"write1", "write2", "write3"}
 
         assert events["write1"].source_dag_id == dr.dag_id
         assert events["write1"].source_run_id == dr.run_id
@@ -2431,6 +2439,13 @@ class TestTaskInstance:
         assert events["write2"].asset.uri == "test://asset-2/"
         assert events["write2"].asset.name == "test_outlet_asset_extra_2"
         assert events["write2"].extra == {"x": 1}
+
+        assert events["write3"].source_dag_id == dr.dag_id
+        assert events["write3"].source_run_id == dr.run_id
+        assert events["write3"].source_task_id == "write3"
+        assert events["write3"].asset.uri == "test_outlet_asset_extra_3"
+        assert events["write3"].asset.name == "test_outlet_asset_extra_3"
+        assert events["write3"].extra == {}
 
     @pytest.mark.want_activate_assets(True)
     def test_outlet_asset_alias(self, dag_maker, session):


### PR DESCRIPTION
## Why
close: #47779

## What
default Metadata to extra to `dict` if no provided

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
