### PR TITLE
fix: add explicit requirement for OpenLineage provider>=2.0.0 on OL function

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -495,6 +495,7 @@
   "dbt.cloud": {
     "deps": [
       "aiohttp>=3.9.2",
+      "apache-airflow-providers-common-compat>=1.6.0",
       "apache-airflow-providers-http",
       "apache-airflow>=2.9.0",
       "asgiref>=2.3.0"

--- a/providers/dbt/cloud/README.rst
+++ b/providers/dbt/cloud/README.rst
@@ -50,14 +50,15 @@ The package supports the following python versions: 3.9,3.10,3.11,3.12
 Requirements
 ------------
 
-=================================  ==================
-PIP package                        Version required
-=================================  ==================
-``apache-airflow``                 ``>=2.9.0``
+==========================================  ==================
+PIP package                                 Version required
+==========================================  ==================
+``apache-airflow``                          ``>=2.9.0``
+``apache-airflow-providers-common-compat``  ``>=1.6.0``
 ``apache-airflow-providers-http``
-``asgiref``                        ``>=2.3.0``
-``aiohttp``                        ``>=3.9.2``
-=================================  ==================
+``asgiref``                                 ``>=2.3.0``
+``aiohttp``                                 ``>=3.9.2``
+==========================================  ==================
 
 Cross provider package dependencies
 -----------------------------------

--- a/providers/dbt/cloud/pyproject.toml
+++ b/providers/dbt/cloud/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.9.0",
+    "apache-airflow-providers-common-compat>=1.6.0",
     "apache-airflow-providers-http",
     "asgiref>=2.3.0",
     "aiohttp>=3.9.2",
@@ -68,10 +69,7 @@ dependencies = [
 [project.optional-dependencies]
 # pip install apache-airflow-providers-dbt-cloud[openlineage]
 "openlineage" = [
-    "apache-airflow-providers-openlineage>=1.7.0",
-]
-"common.compat" = [
-    "apache-airflow-providers-common-compat"
+    "apache-airflow-providers-openlineage>=2.0.0",
 ]
 
 [dependency-groups]

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/get_provider_info.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/get_provider_info.py
@@ -96,13 +96,11 @@ def get_provider_info():
         "extra-links": ["airflow.providers.dbt.cloud.operators.dbt.DbtCloudRunJobOperatorLink"],
         "dependencies": [
             "apache-airflow>=2.9.0",
+            "apache-airflow-providers-common-compat>=1.6.0",
             "apache-airflow-providers-http",
             "asgiref>=2.3.0",
             "aiohttp>=3.9.2",
         ],
-        "optional-dependencies": {
-            "openlineage": ["apache-airflow-providers-openlineage>=1.7.0"],
-            "common.compat": ["apache-airflow-providers-common-compat"],
-        },
+        "optional-dependencies": {"openlineage": ["apache-airflow-providers-openlineage>=2.0.0"]},
         "devel-dependencies": [],
     }

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py
@@ -21,6 +21,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+from airflow.providers.common.compat.openlineage.check import require_openlineage_version
 from airflow.providers.dbt.cloud.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
@@ -54,6 +55,7 @@ def _get_try_number(val):
     return val.try_number - 1
 
 
+@require_openlineage_version(provider_min_version="2.0.0")
 def generate_openlineage_events_from_dbt_cloud_run(
     operator: DbtCloudRunJobOperator | DbtCloudJobRunSensor, task_instance: TaskInstance
 ) -> OperatorLineage:
@@ -73,14 +75,7 @@ def generate_openlineage_events_from_dbt_cloud_run(
     """
     from openlineage.common.provider.dbt import DbtCloudArtifactProcessor, ParentRunMetadata
 
-    try:
-        from airflow.providers.openlineage.conf import namespace
-    except ModuleNotFoundError as e:
-        from airflow.exceptions import AirflowOptionalProviderFeatureException
-
-        msg = "Please install `apache-airflow-providers-openlineage>=1.7.0`"
-        raise AirflowOptionalProviderFeatureException(e, msg)
-
+    from airflow.providers.openlineage.conf import namespace
     from airflow.providers.openlineage.extractors import OperatorLineage
     from airflow.providers.openlineage.plugins.adapter import (
         _PRODUCER,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
`generate_openlineage_events_from_dbt_cloud_run` assumed the OL provider has some features that were introduced in 2.0.0 version. Added an explicit requirement on the function, so that it throws `AirflowOptionalProviderFeatureException` if the OL provider version is not enough.

As the function checking the provider version is in common.compat, I needed to add compat provider as requirement for DBT cloud provider.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
