### PR TITLE
Disable starting a mapped task from trigger

### DIFF
--- a/airflow-core/docs/core-concepts/overview.rst
+++ b/airflow-core/docs/core-concepts/overview.rst
@@ -165,7 +165,7 @@ dags and tasks, but cannot author dags.
 
 The *DAG files* need to be synchronized between all the components that use them - *scheduler*,
 *triggerer* and *workers*. The *DAG files* can be synchronized by various mechanisms - typical
-ways how dags can be synchronized are described in :doc:`helm-chart:manage-dag-files` of our
+ways how dags can be synchronized are described in :doc:`manage-dag-files` of our
 Helm Chart documentation. Helm chart is one of the ways how to deploy Airflow in K8S cluster.
 
 .. image:: ../img/diagram_distributed_airflow_architecture.png

--- a/airflow-core/docs/core-concepts/overview.rst
+++ b/airflow-core/docs/core-concepts/overview.rst
@@ -165,7 +165,7 @@ dags and tasks, but cannot author dags.
 
 The *DAG files* need to be synchronized between all the components that use them - *scheduler*,
 *triggerer* and *workers*. The *DAG files* can be synchronized by various mechanisms - typical
-ways how dags can be synchronized are described in :doc:`manage-dag-files` of our
+ways how dags can be synchronized are described in :doc:`helm-chart:manage-dag-files` of our
 Helm Chart documentation. Helm chart is one of the ways how to deploy Airflow in K8S cluster.
 
 .. image:: ../img/diagram_distributed_airflow_architecture.png

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -60,11 +60,12 @@ class MappedOperator(TaskSDKMappedOperator, AbstractOperator):  # type: ignore[m
 
         :meta private:
         """
-        log.warning(
-            "Starting a mapped task from triggerer is currently unsupported",
-            task_id=self.task_id,
-            dag_id=self.dag_id,
-        )
+        if self.partial_kwargs.get("start_from_trigger", self.start_from_trigger):
+            log.warning(
+                "Starting a mapped task from triggerer is currently unsupported",
+                task_id=self.task_id,
+                dag_id=self.dag_id,
+            )
         return False
         # start_from_trigger only makes sense when start_trigger_args exists.
         if not self.start_trigger_args:

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import attrs
+import structlog
 
 from airflow.models.abstractoperator import AbstractOperator
 from airflow.sdk.definitions.mappedoperator import MappedOperator as TaskSDKMappedOperator
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
     from airflow.sdk.definitions.context import Context
+
+log = structlog.get_logger()
 
 
 @attrs.define(
@@ -57,6 +60,12 @@ class MappedOperator(TaskSDKMappedOperator, AbstractOperator):  # type: ignore[m
 
         :meta private:
         """
+        log.warning(
+            "Starting a mapped task from triggerer is currently unsupported",
+            task_id=self.task_id,
+            dag_id=self.dag_id,
+        )
+        return False
         # start_from_trigger only makes sense when start_trigger_args exists.
         if not self.start_trigger_args:
             return False


### PR DESCRIPTION
The scheduler versions of "ExpandInput" classes don't have a "resolve" method anymore so scheduler crashes when trying to expand_start_from_trigger.  To keep the scheduler running, for now we disable the feature.

Related to https://github.com/apache/airflow/issues/47735