### PR TITLE
AIP-38 Improve handling of mapped task group

### DIFF
--- a/airflow/ui/src/components/TaskName.tsx
+++ b/airflow/ui/src/components/TaskName.tsx
@@ -51,6 +51,7 @@ export const TaskName = ({
     return (
       <Text fontSize="md" fontWeight="bold" {...rest}>
         {label}
+        {isMapped ? " [ ]" : undefined}
       </Text>
     );
   }


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/47784

Propagate down `is_mapped` to child tasks of `mapped task groups`. Adjust the UI to take this into consideration.


![Screenshot 2025-03-20 at 14 41 19](https://github.com/user-attachments/assets/f4955dd9-f8da-434c-9bb1-8c1e4b120193)
