### PR TITLE
fix: compat test test_provider_not_installed failing on main

### DIFF
--- a/providers/common/compat/tests/unit/common/compat/test_check.py
+++ b/providers/common/compat/tests/unit/common/compat/test_check.py
@@ -56,34 +56,35 @@ def test_invalid_provider_name():
 
 @patch("importlib.metadata.version", return_value="0.9.9")
 def test_provider_version_lower_than_required(mock_version):
-    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    @require_provider_version("apache-airflow-providers-nonexistingprovidermock", "1.0.0")
     def dummy_function():
         return "Function Executed"
 
     with pytest.raises(
         AirflowOptionalProviderFeatureException,
-        match=r"Provider's `apache-airflow-providers-mockprovider` version `0.9.9` is lower than required `1.0.0`",
+        match=r"Provider's `apache-airflow-providers-nonexistingprovidermock` "
+        r"version `0.9.9` is lower than required `1.0.0`",
     ):
         dummy_function()
 
 
+@patch("importlib.import_module", side_effect=ImportError)
 @patch("importlib.metadata.version", side_effect=metadata.PackageNotFoundError)
-@patch("importlib.import_module", side_effect=ModuleNotFoundError)
-def test_provider_not_installed(mock_import, mock_version):
-    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+def test_provider_not_installed(mock_version, mock_import):
+    @require_provider_version("apache-airflow-providers-nonexistingprovidermock", "1.0.0")
     def dummy_function():
         return "Function Executed"
 
     with pytest.raises(
         AirflowOptionalProviderFeatureException,
-        match=r"Provider `apache-airflow-providers-mockprovider` not found or has no version",
+        match=r"Provider `apache-airflow-providers-nonexistingprovidermock` not found or has no version",
     ):
         dummy_function()
 
 
 @patch("importlib.metadata.version", return_value="2.0.0")
 def test_provider_version_ok(mock_version):
-    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    @require_provider_version("apache-airflow-providers-nonexistingprovidermock", "1.0.0")
     def dummy_function():
         return "Function Executed"
 
@@ -94,7 +95,7 @@ def test_provider_version_ok(mock_version):
 @patch("importlib.import_module", return_value=type("module", (), {"__version__": "1.5.0"}))
 @patch("importlib.metadata.version", side_effect=metadata.PackageNotFoundError)
 def test_provider_dynamic_import(mock_version, mock_import):
-    @require_provider_version("apache-airflow-providers-mockprovider", "1.0.0")
+    @require_provider_version("apache-airflow-providers-nonexistingprovidermock", "1.0.0")
     def dummy_function():
         return "Function Executed"
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
After #47909 merged, the test `test_provider_not_installed` seems to be failing on main. I think i got the order of mocking wrong. What's interesting, it's only failing for python 3.11 and 3.12 images. [Logs](https://github.com/apache/airflow/actions/runs/13969794160/job/39109477446?pr=47736) of failed CI run.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
