### PR TITLE
Fix check for asset expression in Schedule component

### DIFF
--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -30,13 +30,13 @@ type Props = {
 
 export const Schedule = ({ dag }: Props) =>
   Boolean(dag.timetable_summary) ? (
-    dag.asset_expression === null ? (
+    Boolean(dag.asset_expression) ? (
+      <AssetSchedule dag={dag} />
+    ) : (
       <Tooltip content={dag.timetable_description}>
         <Text fontSize="sm">
           <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}
         </Text>
       </Tooltip>
-    ) : (
-      <AssetSchedule dag={dag} />
     )
   ) : undefined;


### PR DESCRIPTION
Switch the asset_expression check to `Boolean()` to also catch undefined


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
