### PR TITLE
AIP-38 Fix SimpleAuthManager prefix

### DIFF
--- a/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -306,7 +306,11 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
 
         @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
         def webapp(request: Request, rest_of_path: str):
-            return templates.TemplateResponse("/index.html", {"request": request}, media_type="text/html")
+            return templates.TemplateResponse(
+                "/index.html",
+                {"request": request, "backend_server_base_url": conf.get("api", "base_url")},
+                media_type="text/html",
+            )
 
         return app
 

--- a/airflow/api_fastapi/auth/managers/simple/ui/dev/index.html
+++ b/airflow/api_fastapi/auth/managers/simple/ui/dev/index.html
@@ -3,6 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
+    <base href="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="http://localhost:5174/api/v2/pin_32.png" />
     <script type="module" src="http://localhost:5174/@vite/client"></script>
     <script type="module">

--- a/airflow/api_fastapi/auth/managers/simple/ui/index.html
+++ b/airflow/api_fastapi/auth/managers/simple/ui/index.html
@@ -2,6 +2,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
+    <base href="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Airflow 3.0</title>

--- a/airflow/api_fastapi/auth/managers/simple/ui/src/queryClient.ts
+++ b/airflow/api_fastapi/auth/managers/simple/ui/src/queryClient.ts
@@ -17,6 +17,13 @@
  * under the License.
  */
 import { QueryClient } from "@tanstack/react-query";
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
+
+// Dynamically set the base URL for XHR requests based on the meta tag.
+OpenAPI.BASE = document.querySelector("head>base")?.getAttribute("href") ?? "";
+if (OpenAPI.BASE.endsWith("/")) {
+  OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
+}
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/airflow/api_fastapi/auth/managers/simple/ui/src/router.tsx
+++ b/airflow/api_fastapi/auth/managers/simple/ui/src/router.tsx
@@ -19,19 +19,19 @@
 import { createBrowserRouter } from "react-router-dom";
 import { Login } from "src/login/Login";
 
-export const router = createBrowserRouter(
-  [
-    {
-      children: [
-        {
-          element: <Login />,
-          path: "login",
-        },
-      ],
-      path: "/",
-    },
-  ],
+export const routerConfig = [
   {
-    basename: "/auth",
+    children: [
+      {
+        element: <Login />,
+        path: "login",
+      },
+    ],
+    path: "/",
   },
-);
+];
+const baseUrl =
+  document.querySelector("base")?.href ?? "http://localhost:8080/";
+const basename = new URL(`${baseUrl}auth`).pathname;
+
+export const router = createBrowserRouter(routerConfig, { basename });

--- a/airflow/api_fastapi/auth/managers/simple/ui/vite.config.ts
+++ b/airflow/api_fastapi/auth/managers/simple/ui/vite.config.ts
@@ -22,6 +22,7 @@ import { defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "./",
   build: { chunkSizeWarningLimit: 1600, manifest: true },
   plugins: [
     react(),
@@ -29,7 +30,9 @@ export default defineConfig({
     {
       name: "transform-url-src",
       transformIndexHtml: (html) =>
-        html.replace(`src="/assets/`, `src="/auth/static/assets/`).replace(`href="/`, `href="/auth/`),
+        html
+          .replace(`src="./assets/`, `src="./auth/static/assets/`)
+          .replace(`href="/`, `href="./auth/`),
     },
     cssInjectedByJsPlugin(),
   ],


### PR DESCRIPTION
We missed to update the SimpleAuthManager to handle url prefix. Now that the SimpleAuthManager is the default auth manager, it's better if it can also support prefix so we don't have to disrupt our local environment when using prefix.

(I always work with a url prefix to ensure that this is still working as expected, this is how I noticed the SimpleAuthManager was not supporting that)

Tested the setup both:
- with prefix (dev-mode and non dev-mode)
- without prefix (dev-mode and non dev-mode)