### PR TITLE
Fix python operators errors when initialising plugins in virtualenv jinja script

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -635,7 +635,9 @@ def initialize():
 
     configure_adapters()
     # The webservers import this file from models.py with the default settings.
-    configure_orm()
+
+    if not os.environ.get("PYTHON_OPERATORS_VIRTUAL_ENV_MODE", None):
+        configure_orm()
     configure_action_logging()
 
     # mask the sensitive_config_values

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -21,6 +21,10 @@ from __future__ import annotations
 import {{ pickling_library }}
 import sys
 import os
+# Setting the PYTHON_OPERATORS_VIRTUAL_ENV_MODE environment variable to 1,
+# helps to avoid the issue of re creating the orm session in the settings file, otherwise
+# it fails with airflow-db-not-allowed
+
 os.environ["PYTHON_OPERATORS_VIRTUAL_ENV_MODE"] = "1"
 {% if expect_airflow %}
  {# Check whether Airflow is available in the environment.

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 import {{ pickling_library }}
 import sys
-
+import os
+os.environ["PYTHON_OPERATORS_VIRTUAL_ENV_MODE"] = "1"
 {% if expect_airflow %}
  {# Check whether Airflow is available in the environment.
  # If it is, we'll want to ensure that we integrate any macros that are being provided


### PR DESCRIPTION
closes #47854

```
 [2025-03-14, 14:56:50] INFO -  Previous state of the Task instance: queued chan="stdout" source="task"
[2025-03-14, 14:56:50] INFO - Current task name:branching_ext_python chan="stdout" source="task"
[2025-03-14, 14:56:50] INFO - Dag name:example_branch_operator chan="stdout" source="task"
[2025-03-14, 14:56:50] INFO - Use 'pickle' as serializer. source="airflow.task.operators.airflow.providers.standard.operators.python.BranchExternalPythonOperator"
[2025-03-14, 14:56:50] INFO - Executing cmd: /usr/local/bin/python /tmp/venv-callo4834r1x/script.py /tmp/venv-callo4834r1x/script.in /tmp/venv-callo4834r1x/script.out /tmp/venv-callo4834r1x/string_args.txt /tmp/venv-callo4834r1x/termination.log /tmp/venv-callo4834r1x/airflow_context.json source="airflow.utils.process_utils"
[2025-03-14, 14:56:50] INFO - Output: source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO - Traceback (most recent call last): source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/tmp/venv-callo4834r1x/script.py", line 10, in <module> source"airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     from airflow.plugins_manager import integrate_macros_plugins source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/opt/airflow/airflow/__init__.py", line 78, in <module> source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     settings.initialize() source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/opt/airflow/airflow/settings.py", line 638, in initialize source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     configure_orm() source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/opt/airflow/airflow/settings.py", line 363, in configure_orm source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     engine = create_engine(SQL_ALCHEMY_CONN, connect_args=connect_args, **engine_args, future=True) source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "<string>", line 2, in create_engine source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/deprecations.py", line 375, in warned source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     return fn(*args, **kwargs) source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 514, in create_engine source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     u = _url.make_url(url) source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/url.py", line 738, in make_url source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     return _parse_url(name_or_url) source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/url.py", line 799, in _parse_url source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO -     raise exc.ArgumentError( source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] INFO - sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from string 'airflow-db-not-allowed:///' source="airflow.utils.process_utils"
[2025-03-14, 14:56:51] ERROR - Task failed with exception source="task" error_detail=[{"exc_type":"CalledProcessError","exc_value":"Command '['/usr/local/bin/python', '/tmp/venv-callo4834r1x/script.py', '/tmp/venv-callo4834r1x/script.in', '/tmp/venv-callo4834r1x/script.out', '/tmp/venv-callo4834r1x/string_args.txt', '/tmp/venv-callo4834r1x/termination.log', '/tmp/venv-callo4834r1x/airflow_context.json']' returned non-zero exit status 1.","exc_notes":[],"syntax_error":null,"is_cause":false,"frames":[{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py","lineno":608,"name":"run"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py","lineno":744,"name":"_execute_task"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/definitions/baseoperator.py","lineno":373,"name":"wrapper"},{"filename":"/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py","lineno":1090,"name":"execute"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/definitions/baseoperator.py","lineno":373,"name":"wrapper"},{"filename":"/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py","lineno":479,"name":"execute"},{"filename":"/opt/airflow/task-sdk/src/airflow/sdk/definitions/baseoperator.py","lineno":373,"name":"wrapper"},{"filename":"/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py","lineno":201,"name":"execute"},{"filename":"/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py","lineno":998,"name":"execute_callable"},{"filename":"/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py","lineno":555,"name":"_execute_python_callable_in_subprocess"},{"filename":"/opt/airflow/airflow/utils/process_utils.py","lineno":175,"name":"execute_in_subprocess"},{"filename":"/opt/airflow/airflow/utils/process_utils.py","lineno":198,"name":"execute_in_subprocess_with_kwargs"}]}]
[2025-03-14, 14:56:51] INFO - Task instance in failure state chan="stdout" source="task"
```

The error previously was getting, inside virtual env its trying to initialise the `configure_orm` , causing this no db access exception.




<img width="864" alt="image" src="https://github.com/user-attachments/assets/aea521ff-f396-4739-a09d-d5e150a916d2" />

<img width="1711" alt="image" src="https://github.com/user-attachments/assets/24fed25e-39af-4036-8e83-deeced3bc8be" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
