### PR TITLE
test: k8s set [api/base_url] with Helm in Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -982,6 +982,10 @@ def configure_cluster(
         sys.exit(return_code)
 
 
+CLUSTER_FORWARDED_PORT = os.environ.get("CLUSTER_FORWARDED_PORT") or "8080"
+KUBERNETES_HOST_PORT = (os.environ.get("CLUSTER_HOST") or "localhost") + ":" + CLUSTER_FORWARDED_PORT
+
+
 def _deploy_helm_chart(
     python: str,
     upgrade: bool,
@@ -1034,6 +1038,8 @@ def _deploy_helm_chart(
             "config.api_auth.jwt_secret=foo",
             "--set",
             "config.core.auth_manager=airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+            "--set",
+            f"config.api.base_url=http://{KUBERNETES_HOST_PORT}",
         ]
         if multi_namespace_mode:
             helm_command.extend(["--set", "multiNamespaceMode=true"])

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -65,6 +65,7 @@ from airflow_breeze.utils.kubernetes_utils import (
     get_kind_cluster_name,
     get_kubeconfig_file,
     get_kubectl_cluster_name,
+    get_kubernetes_port_numbers,
     get_kubernetes_python_combos,
     make_sure_kubernetes_tools_are_installed,
     print_cluster_urls,
@@ -982,12 +983,6 @@ def configure_cluster(
         sys.exit(return_code)
 
 
-def _get_airflow_api_host_with_forwarded_port() -> str:
-    cluster_forwarded_port = os.getenv("CLUSTER_FORWARDED_PORT") or "8080"
-    kubernetes_cluster_host = os.getenv("CLUSTER_HOST") or "localhost"
-    return f"{kubernetes_cluster_host}:{cluster_forwarded_port}"
-
-
 def _deploy_helm_chart(
     python: str,
     upgrade: bool,
@@ -999,6 +994,7 @@ def _deploy_helm_chart(
     multi_namespace_mode: bool = False,
 ) -> RunCommandResult:
     cluster_name = get_kubectl_cluster_name(python=python, kubernetes_version=kubernetes_version)
+    _, api_server_port = get_kubernetes_port_numbers(python=python, kubernetes_version=kubernetes_version)
     action = "Deploying" if not upgrade else "Upgrading"
     get_console(output=output).print(f"[info]{action} {cluster_name} with airflow Helm Chart.")
     with tempfile.TemporaryDirectory(prefix="chart_") as tmp_dir:
@@ -1041,7 +1037,7 @@ def _deploy_helm_chart(
             "--set",
             "config.core.auth_manager=airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
             "--set",
-            f"config.api.base_url=http://{_get_airflow_api_host_with_forwarded_port()}",
+            f"config.api.base_url=http://localhost:{api_server_port}",
         ]
         if multi_namespace_mode:
             helm_command.extend(["--set", "multiNamespaceMode=true"])

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -982,8 +982,10 @@ def configure_cluster(
         sys.exit(return_code)
 
 
-CLUSTER_FORWARDED_PORT = os.environ.get("CLUSTER_FORWARDED_PORT") or "8080"
-KUBERNETES_HOST_PORT = (os.environ.get("CLUSTER_HOST") or "localhost") + ":" + CLUSTER_FORWARDED_PORT
+def _get_airflow_api_host_with_forwarded_port() -> str:
+    cluster_forwarded_port = os.getenv("CLUSTER_FORWARDED_PORT") or "8080"
+    kubernetes_cluster_host = os.getenv("CLUSTER_HOST") or "localhost"
+    return f"{kubernetes_cluster_host}:{cluster_forwarded_port}"
 
 
 def _deploy_helm_chart(
@@ -1039,7 +1041,7 @@ def _deploy_helm_chart(
             "--set",
             "config.core.auth_manager=airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
             "--set",
-            f"config.api.base_url=http://{KUBERNETES_HOST_PORT}",
+            f"config.api.base_url=http://{_get_airflow_api_host_with_forwarded_port()}",
         ]
         if multi_namespace_mode:
             helm_command.extend(["--set", "multiNamespaceMode=true"])

--- a/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
@@ -470,7 +470,7 @@ def get_k8s_env(python: str, kubernetes_version: str, executor: str | None = Non
     new_env["KINDCONFIG"] = str(
         get_kind_cluster_config_path(python=python, kubernetes_version=kubernetes_version)
     )
-    _, api_server_port = _get_kubernetes_port_numbers(python=python, kubernetes_version=kubernetes_version)
+    _, api_server_port = get_kubernetes_port_numbers(python=python, kubernetes_version=kubernetes_version)
     new_env["CLUSTER_FORWARDED_PORT"] = str(api_server_port)
     kubectl_cluster_name = get_kubectl_cluster_name(python=python, kubernetes_version=kubernetes_version)
     if executor:
@@ -501,13 +501,14 @@ def _get_free_port() -> int:
 
 
 def _get_kind_cluster_config_content(python: str, kubernetes_version: str) -> dict[str, Any] | None:
-    if not get_kind_cluster_config_path(python=python, kubernetes_version=kubernetes_version).exists():
+    config_path = get_kind_cluster_config_path(python=python, kubernetes_version=kubernetes_version)
+    if not config_path.exists():
+        get_console().print(f"[warning]The kind cluster config file {config_path} does not exist!")
         return None
+
     import yaml
 
-    return yaml.safe_load(
-        get_kind_cluster_config_path(python=python, kubernetes_version=kubernetes_version).read_text()
-    )
+    return yaml.safe_load(config_path.read_text())
 
 
 def set_random_cluster_ports(python: str, kubernetes_version: str, output: Output | None) -> None:
@@ -533,9 +534,9 @@ def set_random_cluster_ports(python: str, kubernetes_version: str, output: Outpu
     get_console(output=output).print("\n")
 
 
-def _get_kubernetes_port_numbers(python: str, kubernetes_version: str) -> tuple[int, int]:
+def get_kubernetes_port_numbers(python: str, kubernetes_version: str) -> tuple[int, int]:
     conf = _get_kind_cluster_config_content(python=python, kubernetes_version=kubernetes_version)
-    if conf is None:
+    if not conf:
         return 0, 0
     k8s_api_server_port = conf["networking"]["apiServerPort"]
     api_server_port = conf["nodes"][1]["extraPortMappings"][0]["hostPort"]
@@ -582,7 +583,7 @@ def _attempt_to_connect(port_number: int, output: Output | None, wait_seconds: i
 def print_cluster_urls(
     python: str, kubernetes_version: str, output: Output | None, wait_time_in_seconds: int = 0
 ):
-    k8s_api_server_port, api_server_port = _get_kubernetes_port_numbers(
+    k8s_api_server_port, api_server_port = get_kubernetes_port_numbers(
         python=python, kubernetes_version=kubernetes_version
     )
     get_console(output=output).print(

--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import json
 import os
 import re
 import subprocess
@@ -61,11 +60,6 @@ class BaseK8STest:
 
     @pytest.fixture(autouse=True)
     def base_tests_setup(self, request):
-        # only restart the deployment if the configmap was updated
-        # speed up the test and make the airflow-api-server deployment more stable
-        if self.set_api_server_base_url_config():
-            self.rollout_restart_deployment("airflow-api-server")
-
         # Replacement for unittests.TestCase.id()
         self.test_id = f"{request.node.cls.__name__}_{request.node.name}"
         # Ensure the api-server deployment is healthy at kubernetes level before calling the any API
@@ -275,23 +269,6 @@ class BaseK8STest:
         ).decode()
         assert "successfully rolled out" in deployment_rollout_status
 
-    @staticmethod
-    def rollout_restart_deployment(deployment_name: str, namespace: str = "airflow"):
-        """Rollout restart the deployment."""
-        check_call(["kubectl", "rollout", "restart", "deployment", deployment_name, "-n", namespace])
-
-    def _parse_airflow_cfg_as_dict(self, airflow_cfg: str) -> dict[str, dict[str, str]]:
-        """Parse the airflow.cfg file as a dictionary."""
-        parsed_airflow_cfg: dict[str, dict[str, str]] = {}
-        for line in airflow_cfg.splitlines():
-            if line.startswith("["):
-                section = line[1:-1]
-                parsed_airflow_cfg[section] = {}
-            elif "=" in line:
-                key, value = line.split("=", 1)
-                parsed_airflow_cfg[section][key.strip()] = value.strip()
-        return parsed_airflow_cfg
-
     def _parse_airflow_cfg_dict_as_escaped_toml(self, airflow_cfg_dict: dict) -> str:
         """Parse the airflow.cfg dictionary as a toml string."""
         airflow_cfg_str = ""
@@ -302,50 +279,6 @@ class BaseK8STest:
             airflow_cfg_str += "\n"
         # escape newlines and double quotes
         return airflow_cfg_str.replace("\n", "\\n").replace('"', '\\"')
-
-    def set_airflow_cfg_in_kubernetes_configmap(self, section: str, key: str, value: str) -> bool:
-        """Set [section/key] with `value` in airflow.cfg in k8s configmap.
-
-        :return: True if the configmap was updated successfully, False otherwise
-        """
-        original_configmap_json_str = check_output(
-            ["kubectl", "get", "configmap", CONFIG_MAP_NAME, "-n", "airflow", "-o", "json"]
-        ).decode()
-        original_config_map = json.loads(original_configmap_json_str)
-        original_airflow_cfg = original_config_map["data"][CONFIG_MAP_KEY]
-        # set [section/key] with `value` in airflow.cfg
-        # The airflow.cfg is toml format, so we need to convert it to json
-        airflow_cfg_dict = self._parse_airflow_cfg_as_dict(original_airflow_cfg)
-        if section not in airflow_cfg_dict:
-            airflow_cfg_dict[section] = {}
-        airflow_cfg_dict[section][key] = value
-        # update the configmap with the new airflow.cfg
-        patch_configmap_result = check_output(
-            [
-                "kubectl",
-                "patch",
-                "configmap",
-                CONFIG_MAP_NAME,
-                "-n",
-                "airflow",
-                "--type",
-                "merge",
-                "-p",
-                f'{{"data": {{"{CONFIG_MAP_KEY}": "{self._parse_airflow_cfg_dict_as_escaped_toml(airflow_cfg_dict)}"}}}}',
-            ]
-        ).decode()
-        if "(no change)" in patch_configmap_result:
-            return False
-        return True
-
-    def set_api_server_base_url_config(self) -> bool:
-        """Set [api/base_url] with `f"http://{KUBERNETES_HOST_PORT}"` as env in k8s configmap.
-
-        :return: True if the configmap was updated successfully, False otherwise
-        """
-        return self.set_airflow_cfg_in_kubernetes_configmap(
-            "api", "base_url", f"http://{KUBERNETES_HOST_PORT}"
-        )
 
     def ensure_dag_expected_state(self, host, logical_date, dag_id, expected_final_state, timeout):
         tries = 0

--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -269,17 +269,6 @@ class BaseK8STest:
         ).decode()
         assert "successfully rolled out" in deployment_rollout_status
 
-    def _parse_airflow_cfg_dict_as_escaped_toml(self, airflow_cfg_dict: dict) -> str:
-        """Parse the airflow.cfg dictionary as a toml string."""
-        airflow_cfg_str = ""
-        for section, section_dict in airflow_cfg_dict.items():
-            airflow_cfg_str += f"[{section}]\n"
-            for key, value in section_dict.items():
-                airflow_cfg_str += f"{key} = {value}\n"
-            airflow_cfg_str += "\n"
-        # escape newlines and double quotes
-        return airflow_cfg_str.replace("\n", "\\n").replace('"', '\\"')
-
     def ensure_dag_expected_state(self, host, logical_date, dag_id, expected_final_state, timeout):
         tries = 0
         state = ""


### PR DESCRIPTION
- Removing setup part in base k8s test class which runs rollout restart on deployment for the kubernetes host setup and related methods
- Set the `[api/base_url]` via parameter from helm chart

closes: #47939 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
