### PR TITLE
add kalyan in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,8 +22,8 @@
 /docs/helm-chart @dstandish @jedcunningham
 
 # API
-/airflow/api/ @ephraimbuddy @pierrejeambrun
-/airflow/api_fastapi/ @ephraimbuddy @pierrejeambrun
+/airflow/api/ @ephraimbuddy @pierrejeambrun @rawwar
+/airflow/api_fastapi/ @ephraimbuddy @pierrejeambrun @rawwar
 
 # UI
 /airflow/ui/ @bbovenzi @pierrejeambrun @ryanahamilton @jscheffl


### PR DESCRIPTION
Updating CODEOWNERS so that I get notified of changes related to `airflow/api` and `airflow/api_fastapi`