### PR TITLE
Config improvments to using JWKS with the JWT code

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -58,7 +58,6 @@ def _jwt_validator():
     validator = JWTValidator(
         required_claims=required_claims,
         issuer=issuer,
-        leeway=conf.getint("api_auth", "jwt_leeway"),
         audience=conf.get_mandatory_list_value("execution_api", "jwt_audience"),
         **get_sig_validation_args(make_secret_key_if_needed=False),
     )

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1510,9 +1510,22 @@ api_auth:
 
         This value must be appropriate for the given private key type.
 
-        Default is "HS512" if ``jwt_secret`` is set, or "EdDSA" otherwise
+        If this is not specified Airflow makes some guesses as what algorithm is best based on the key type.
+
+        ("HS512" if ``jwt_secret`` is set, otherwise a key-type specific guess)
       example: '"EdDSA" or "HS512"'
       type: string
+      default: ~
+    jwt_kid:
+      version_added: 3.0.0
+      description: |
+        The Key ID to place in header when generating JWTs. Not used in the validation path.
+
+        If this is not specified the RFC7638 thumbprint of the private key will be used.
+
+        Ignored when ``jwt_secret`` is used.
+      type: string
+      example: "my-key-id"
       default: ~
     trusted_jwks_url:
       version_added: 3.0.0

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -101,6 +101,8 @@ def _fetch_logs_from_service(url, log_relative_path):
     timeout = conf.getint("webserver", "log_fetch_timeout_sec", fallback=None)
     generator = JWTGenerator(
         secret_key=get_signing_key("webserver", "secret_key"),
+        private_key=None,
+        issuer=None,
         valid_for=conf.getint("webserver", "log_request_clock_grace", fallback=30),
         audience="task-instance-logs",
     )


### PR DESCRIPTION
Previously it was hard-coded to only use the thumbprint of the privkey as the
`kid`, which is a sensible default but not the only way JWKS documents work,
and it has to match between the generator and validator.

Additionally the JWTValidator had no way of specifying the algorithm(s) to use
when using a JWKS document and it would always fail. This now respects the
same config option that the JWTGenerator looked at.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
