### PR TITLE
Auth Manager should raise an invalid token error when the payload cann…

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -101,10 +101,15 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         """Verify the JWT token is valid and create a user object from it if valid."""
         try:
             payload: dict[str, Any] = await self._get_token_validator().avalidated_claims(token)
-            return self.deserialize_user(payload)
         except InvalidTokenError as e:
             log.error("JWT token is not valid: %s", e)
             raise e
+
+        try:
+            return self.deserialize_user(payload)
+        except (ValueError, KeyError) as e:
+            log.error("Couldn't deserialize user from token, JWT token is not valid: %s", e)
+            raise InvalidTokenError(str(e))
 
     def generate_jwt(
         self, user: T, *, expiration_time_in_seconds: int = conf.getint("api_auth", "jwt_expiration_time")

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -179,16 +179,19 @@ class TestBaseAuthManager:
         mock_filter_authorized_menu_items.assert_called_once_with(list(MenuItem), user=user)
         assert results == []
 
-    @patch("airflow.api_fastapi.auth.managers.base_auth_manager.JWTValidator", autospec=True)
+    @patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager._get_token_validator",
+        autospec=True,
+    )
     @patch.object(EmptyAuthManager, "deserialize_user")
     @pytest.mark.asyncio
-    async def test_get_user_from_token(self, mock_deserialize_user, mock_jwt_validator, auth_manager):
+    async def test_get_user_from_token(self, mock_deserialize_user, mock__get_token_validator, auth_manager):
         token = "token"
         payload = {}
         user = BaseAuthManagerUserTest(name="test")
         signer = AsyncMock(spec=JWTValidator)
         signer.avalidated_claims.return_value = payload
-        mock_jwt_validator.return_value = signer
+        mock__get_token_validator.return_value = signer
         mock_deserialize_user.return_value = user
 
         result = await auth_manager.get_user_from_token(token)
@@ -197,22 +200,26 @@ class TestBaseAuthManager:
         signer.avalidated_claims.assert_called_once_with(token)
         assert result == user
 
-    @patch("airflow.api_fastapi.auth.managers.base_auth_manager.JWTValidator", autospec=True)
+    @patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager._get_token_validator",
+        autospec=True,
+    )
     @patch.object(EmptyAuthManager, "deserialize_user")
     @pytest.mark.asyncio
     async def test_get_user_from_token_invalid_token_payload(
-        self, mock_deserialize_user, mock_jwt_validator, auth_manager
+        self, mock_deserialize_user, mock__get_token_validator, auth_manager
     ):
         token = "token"
         payload = {}
         signer = AsyncMock(spec=JWTValidator)
         signer.avalidated_claims.return_value = payload
-        mock_jwt_validator.return_value = signer
+        mock__get_token_validator.return_value = signer
         mock_deserialize_user.side_effect = ValueError("Some error deserializing the user")
 
         with pytest.raises(InvalidTokenError, match="Some error deserializing the user"):
             await auth_manager.get_user_from_token(token)
         mock_deserialize_user.assert_called_once_with(payload)
+        signer.avalidated_claims.assert_called_once_with(token)
 
     @patch("airflow.api_fastapi.auth.managers.base_auth_manager.JWTGenerator", autospec=True)
     @patch.object(EmptyAuthManager, "serialize_user")


### PR DESCRIPTION
…ot be deserialize

closes: https://github.com/apache/airflow/issues/48044

If the payload cannot be deserialized into a user (missing keys, value errors etc.) we shouldn't get a 500 internal error. This is now an `InvalidTokenError` and will be handled in the same flow. (403 -> token invalid -> clearing user browser -> redirect to login form)

That could currently happen if you were switching auth managers from breeze. (For instance you would still have a token stored in your browser for the SimpleAuthManager, but after the breeze restart switching to FabAuthManager the payload does not have the appropriate structure and will raise ValueErrors when trying to deserialize the user)