### PR TITLE
Fix execution api server url in docker-compose

### DIFF
--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -61,7 +61,7 @@ x-airflow-common:
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
-    AIRFLOW__WORKERS__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
+    AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server


### PR DESCRIPTION
The existing docker-compose didn't work due to an incorrect config variable being used for the api server url. It was setting the value for the `AIRFLOW__WORKERS` section instead of the `AIRFLOW__CORE` one. 

The error being shown was:
```
 2025-03-21 13:12:00.055281 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 1st time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:01.057557 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 2nd time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:02.583487 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 3rd time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:04.290974 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 4th time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:11.584725 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 5th time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:19.831344 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 6th time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:31.526167 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 7th time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:36.431019 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 8th time calling it. [airflow.sdk.api.client]
2025-03-21 13:12:39.748808 [warning  ] Starting call to 'airflow.sdk.api.client.Client.request', this is the 9th time calling it. [airflow.sdk.api.client]
2025-03-21 13:14:06.460918 [info     ] Process exited                 [supervisor] exit_code=<Negsignal.SIGKILL: -9> pid=159 signal=SIGKILL
2025-03-21 13:14:06.466463 [error    ] Task execute_workload[20432138-e22f-4f0a-81d8-02b6c58a0243] raised unexpected: ConnectError('[Errno 111] Connection refused') [celery.app.trace]
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/airflow/.local/lib/python3.12/site-packages/httpx/_transports/default.py:69 in             │
│ map_httpcore_exceptions                                                                          │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpx/_transports/default.py:233 in            │
│ handle_request                                                                                   │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_sync/connection_pool.py:256 in       │
│ handle_request                                                                                   │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_sync/connection_pool.py:236 in       │
│ handle_request                                                                                   │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_sync/connection.py:101 in            │
│ handle_request                                                                                   │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_sync/connection.py:78 in             │
│ handle_request                                                                                   │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_sync/connection.py:124 in _connect   │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_backends/sync.py:207 in connect_tcp  │
│                                                                                                  │
│ /usr/local/lib/python3.12/contextlib.py:158 in __exit__                                          │
│                                                                                                  │
│ /home/airflow/.local/lib/python3.12/site-packages/httpcore/_exceptions.py:14 in map_exceptions   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ConnectError: [Errno 111] Connection refused```