### PR TITLE
Fix api server command

### DIFF
--- a/airflow-core/src/airflow/cli/commands/local_commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/local_commands/api_server_command.py
@@ -64,7 +64,7 @@ def api_server(args):
         run_args = [
             "fastapi",
             "dev",
-            "airflow/api_fastapi/main.py",
+            "airflow-core/src/airflow/api_fastapi/main.py",
             "--port",
             str(args.port),
             "--host",

--- a/airflow-core/tests/unit/cli/commands/local_commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/local_commands/test_api_server_command.py
@@ -41,7 +41,7 @@ class TestCliApiServer(_CommonCLIGunicornTestClass):
                 [
                     "fastapi",
                     "dev",
-                    "airflow/api_fastapi/main.py",
+                    "airflow-core/src/airflow/api_fastapi/main.py",
                     "--port",
                     "9092",
                     "--host",
@@ -53,7 +53,7 @@ class TestCliApiServer(_CommonCLIGunicornTestClass):
                 [
                     "fastapi",
                     "dev",
-                    "airflow/api_fastapi/main.py",
+                    "airflow-core/src/airflow/api_fastapi/main.py",
                     "--port",
                     "9092",
                     "--host",
@@ -107,7 +107,7 @@ class TestCliApiServer(_CommonCLIGunicornTestClass):
                 [
                     "fastapi",
                     "dev",
-                    "airflow/api_fastapi/main.py",
+                    "airflow-core/src/airflow/api_fastapi/main.py",
                     "--port",
                     port,
                     "--host",


### PR DESCRIPTION
the fast api apiserver command was broken


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
