### PR TITLE
Checking modification timestamps only when `newer_than` is present

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/sensors/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/sensors/sftp.py
@@ -95,18 +95,24 @@ class SFTPSensor(BaseSensorOperator):
             else:
                 return False
         else:
-            actual_files_to_check = [self.path]
-
-        for actual_file_to_check in actual_files_to_check:
             try:
-                mod_time = self.hook.get_mod_time(actual_file_to_check)
-                self.log.info("Found File %s last modified: %s", actual_file_to_check, mod_time)
+                self.hook.isfile(self.path)
+                actual_files_to_check = [self.path]
             except OSError as e:
                 if e.errno != SFTP_NO_SUCH_FILE:
                     raise AirflowException from e
-                continue
+                actual_files_to_check = []
 
-            if self.newer_than:
+        if self.newer_than:
+            for actual_file_to_check in actual_files_to_check:
+                try:
+                    mod_time = self.hook.get_mod_time(actual_file_to_check)
+                    self.log.info("Found File %s last modified: %s", actual_file_to_check, mod_time)
+                except OSError as e:
+                    if e.errno != SFTP_NO_SUCH_FILE:
+                        raise AirflowException from e
+                    continue
+
                 if isinstance(self.newer_than, str):
                     self.newer_than = parse(self.newer_than)
                 _mod_time = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
@@ -126,8 +132,8 @@ class SFTPSensor(BaseSensorOperator):
                         str(_mod_time),
                         str(_newer_than),
                     )
-            else:
-                files_found.append(actual_file_to_check)
+        else:
+            files_found = actual_files_to_check
 
         if not len(files_found):
             return False


### PR DESCRIPTION
…esent

Checking modification timestamps has sagnificant impact on performance of sensors in ase of large amount of files.
This whole block of code do not need to be executed, when `newer_than=None`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
