### PR TITLE
Add dark/light mode to simple auth manager

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
@@ -15,11 +15,12 @@
     "@chakra-ui/react": "^3.1.1",
     "@tanstack/react-query": "^5.52.1",
     "axios": "^1.8.2",
+    "next-themes": "^0.4.6",
     "react": "^18.3.1",
+    "react-cookie": "^7.0.0",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.20.0",
-    "react-router-dom": "^6.26.2",
-    "react-cookie": "^7.0.0"
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@7nohe/openapi-react-query-codegen": "^1.6.0",

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/pnpm-lock.yaml
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       axios:
         specifier: ^1.8.2
         version: 1.8.2
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1588,6 +1591,12 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
@@ -3834,6 +3843,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   node-fetch-native@1.6.4: {}
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/main.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/main.tsx
@@ -18,6 +18,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { createRoot } from "react-dom/client";
+import { ThemeProvider } from "next-themes";
 import { RouterProvider } from "react-router-dom";
 import { router } from "src/router";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -25,8 +26,10 @@ import { queryClient } from "./queryClient";
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <ChakraProvider value={defaultSystem}>
+    <ThemeProvider attribute="class" disableTransitionOnChange>
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
       </QueryClientProvider>
+    </ThemeProvider>
   </ChakraProvider>
 );


### PR DESCRIPTION
Add a theme provider to have the auth page match the main app's color mode:


<img width="1125" alt="Screenshot 2025-03-21 at 12 19 15 PM" src="https://github.com/user-attachments/assets/018fe987-7039-4169-bf3a-b866cd865f2b" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
