### PR TITLE
Handle none logical date and show dependency check for the relevant state

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
@@ -29,7 +29,7 @@ class ExecDateAfterStartDateDep(BaseTIDep):
 
     @provide_session
     def _get_dep_statuses(self, ti, session, dep_context):
-        if ti.task.start_date and ti.logical_date < ti.task.start_date:
+        if ti.task.start_date and ti.logical_date and ti.logical_date < ti.task.start_date:
             yield self._failing_status(
                 reason=(
                     f"The logical date is {ti.logical_date.isoformat()} but this is before "
@@ -37,7 +37,12 @@ class ExecDateAfterStartDateDep(BaseTIDep):
                 )
             )
 
-        if ti.task.dag and ti.task.dag.start_date and ti.logical_date < ti.task.dag.start_date:
+        if (
+            ti.task.dag
+            and ti.task.dag.start_date
+            and ti.logical_date
+            and ti.logical_date < ti.task.dag.start_date
+        ):
             yield self._failing_status(
                 reason=(
                     f"The logical date is {ti.logical_date.isoformat()} but this is "

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/BlockingDeps.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/BlockingDeps.tsx
@@ -41,8 +41,8 @@ export const BlockingDeps = ({ taskInstance }: { readonly taskInstance: TaskInst
       <Table.Root striped>
         <Table.Body>
           <Table.Row>
-            <Table.Header>Dependency</Table.Header>
-            <Table.Header>Reason</Table.Header>
+            <Table.ColumnHeader>Dependency</Table.ColumnHeader>
+            <Table.ColumnHeader>Reason</Table.ColumnHeader>
           </Table.Row>
           {data.dependencies.map((dep) => (
             <Table.Row key={dep.name}>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -106,7 +106,7 @@ export const Details = () => {
       <ExtraLinks />
       {taskInstance === undefined ||
       // eslint-disable-next-line unicorn/no-null
-      [null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
+      ![null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
         <BlockingDeps taskInstance={taskInstance} />
       )}
       {taskInstance !== undefined && (taskInstance.trigger ?? taskInstance.triggerer_job) ? (


### PR DESCRIPTION
1. When logical date is None for the task instance checking for the task instance logical date with task's start date throws below error.
2. Deps should use `ColumnHeader` since normal `Header` shows both the headers as different rows.
3. Deps should not be shown (undefined) when the state is not null, queued or scheduled instead of opposite way since the task in running state won't have any blocking deps.

Before fix : 

![image](https://github.com/user-attachments/assets/6e103517-b2e5-4283-a280-4a95fb403b64)

After fix : 

![image](https://github.com/user-attachments/assets/73d1f5ce-03d7-4efc-9467-1617c3ad8d21)


Stack trace : 

```
Traceback (most recent call last):
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/gzip.py", line 29, in __call__
    await responder(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/gzip.py", line 126, in __call__
    await super().__call__(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/gzip.py", line 46, in __call__
    await self.app(scope, receive, self.send_with_compression)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/cors.py", line 85, in __call__
    await self.app(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 173, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 175, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/api_fastapi/core_api/middleware.py", line 28, in dispatch
    response = await call_next(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 153, in call_next
    raise app_exc
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 140, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 214, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/starlette/concurrency.py", line 37, in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 2470, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 967, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py", line 261, in get_task_instance_dependencies
    [
  File "/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py", line 261, in <listcomp>
    [
  File "/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/models/taskinstance.py", line 2326, in get_failed_dep_statuses
    for dep_status in dep.get_dep_statuses(self, session, dep_context):
  File "/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/ti_deps/deps/base_ti_dep.py", line 116, in get_dep_statuses
    yield from self._get_dep_statuses(ti, session, cxt)
  File "/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/ti_deps/deps/exec_date_after_start_date_dep.py", line 32, in _get_dep_statuses
    if ti.task.start_date and ti.logical_date < ti.task.start_date:
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'DateTime'
```