### PR TITLE
Move newsfragment about secret backends on workers to AIP-72 one

### DIFF
--- a/newsfragments/47946.feature.rst
+++ b/newsfragments/47946.feature.rst
@@ -1,1 +1,0 @@
-A new config "workers secrets_backend[kwargs]" has been introduced to configure secrets backend on the workers directly to allow reducing the round trip to the API server and also to allow configuring a different secrets backend. Priority defined as workers backend > workers env > secrets backend on API server > API server env > metadata DB.

--- a/newsfragments/aip-72.significant.rst
+++ b/newsfragments/aip-72.significant.rst
@@ -83,6 +83,12 @@ As part of this change the following breaking changes have occurred:
 
 - The ``SkipMixin` class has been removed as a parent class from ``BaseSensorOperator``.
 
+- A new config ``[workers] secrets_backend[kwargs]`` & ``[workers] secrets_backend_kwargs``  has been introduced to configure secrets backend on the
+  workers directly to allow reducing the round trip to the API server and also to allow configuring a
+  different secrets backend.
+  Priority defined as workers backend > workers env > secrets backend on API server > API server env > metadata DB.
+
+
 * Types of change
 
   * [x] Dag changes


### PR DESCRIPTION
So that all AIP-72 ones remain on the same place.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
