### PR TITLE
Smaller distribution files

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -272,7 +272,8 @@ include = [
     "NOTICE"
 ]
 exclude = [
-    "src/airflow/ui/node_modules/"
+    "src/airflow/ui/node_modules/",
+    "src/airflow/api_fastapi/auth/managers/simple/ui/node_modules",
 ]
 
 [tool.hatch.build.targets.custom]
@@ -291,6 +292,10 @@ artifacts = [
     "airflow/ui/dist/",
     "airflow/api_fastapi/auth/managers/simple/ui/dist/",
     "airflow/git_version"
+]
+exclude = [
+    "src/airflow/ui/node_modules/",
+    "src/airflow/api_fastapi/auth/managers/simple/ui/node_modules",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ path = "./hatch_build.py"
 path = "./hatch_build.py"
 
 [tool.hatch.build.targets.sdist]
+exclude = ["*"]
 
 [tool.hatch.build.targets.wheel]
 bypass-selection = true


### PR DESCRIPTION
We are now including node_modules into our wheel/sdist files, which makes them rather large. This brings them back down.

This was a regression with the core move.

Before:

```
11K   apache_airflow-3.0.0.dev0-py3-none-any.whl
688M  apache_airflow-3.0.0.dev0.tar.gz
212M  apache_airflow_core-3.0.0.dev0-py3-none-any.whl
63M   apache_airflow_core-3.0.0.dev0.tar.gz
```

After:

```
11K   apache_airflow-3.0.0.dev0-py3-none-any.whl
26K   apache_airflow-3.0.0.dev0.tar.gz
3.4M  apache_airflow_core-3.0.0.dev0-py3-none-any.whl
2.6M  apache_airflow_core-3.0.0.dev0.tar.gz
```