### PR TITLE
Fixing CI in main due to failing generate sdk datamodels

### DIFF
--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -97,6 +97,14 @@ class DagRunAssetReference(BaseModel):
 
 
 class DagRunState(str, Enum):
+    """
+    All possible states that a DagRun can be in.
+
+    These are "shared" with TaskInstanceState in some parts of the code,
+    so please ensure that their values always match the ones with the
+    same name in TaskInstanceState.
+    """
+
     QUEUED = "queued"
     RUNNING = "running"
     SUCCESS = "success"
@@ -112,6 +120,10 @@ class DagRunStateResponse(BaseModel):
 
 
 class DagRunType(str, Enum):
+    """
+    Class with DagRun types.
+    """
+
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
@@ -119,6 +131,10 @@ class DagRunType(str, Enum):
 
 
 class IntermediateTIState(str, Enum):
+    """
+    States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
+    """
+
     SCHEDULED = "scheduled"
     QUEUED = "queued"
     RESTARTING = "restarting"
@@ -256,6 +272,10 @@ class TITargetStatePayload(BaseModel):
 
 
 class TerminalStateNonSuccess(str, Enum):
+    """
+    TaskInstance states that can be reported without extra information.
+    """
+
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Example failure:
```
pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
index 0ed6fc9..2fb9295 100644
--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -97,6 +97,14 @@ class DagRunAssetReference(BaseModel):
 
 
 class DagRunState(str, Enum):
+    """
+    All possible states that a DagRun can be in.
+
+    These are "shared" with TaskInstanceState in some parts of the code,
+    so please ensure that their values always match the ones with the
+    same name in TaskInstanceState.
+    """
+
     QUEUED = "queued"
     RUNNING = "running"
     SUCCESS = "success"
@@ -112,6 +120,10 @@ class DagRunStateResponse(BaseModel):
 
 
 class DagRunType(str, Enum):
+    """
+    Class with DagRun types.
+    """
+
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
@@ -119,6 +131,10 @@ class DagRunType(str, Enum):
 
 
 class IntermediateTIState(str, Enum):
+    """
+    States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
+    """
+
     SCHEDULED = "scheduled"
     QUEUED = "queued"
     RESTARTING = "restarting"
@@ -[256](https://github.com/apache/airflow/actions/runs/14004064574/job/39216142215#step:6:257),6 +272,10 @@ class TITargetStatePayload(BaseModel):
 
 
 class TerminalStateNonSuccess(str, Enum):
+    """
+    TaskInstance states that can be reported without extra information.
+    """
+
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"

This error means that you have to fix the issues listed above:
```

 http://github.com/apache/airflow/actions/runs/14004064574/job/39216142215


This was done so that cadwyn had 5.1.2 issues and 5.1.3 seems to have fixed it: https://github.com/zmievsa/cadwyn


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
