### PR TITLE
Bump cadwyn min version to 5.1.3

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     # Blinker use for signals in Flask, this is an optional dependency in Flask 2.2 and lower.
     # In Flask 2.3 it becomes a mandatory dependency, and flask signals are always available.
     "blinker>=1.6.2",
-    "cadwyn>=5.1.2",
+    "cadwyn>=5.1.3",
     "colorlog>=6.8.2",
     "configupdater>=3.1.1",
     "cron-descriptor>=1.2.24",

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -97,6 +97,14 @@ class DagRunAssetReference(BaseModel):
 
 
 class DagRunState(str, Enum):
+    """
+    All possible states that a DagRun can be in.
+
+    These are "shared" with TaskInstanceState in some parts of the code,
+    so please ensure that their values always match the ones with the
+    same name in TaskInstanceState.
+    """
+
     QUEUED = "queued"
     RUNNING = "running"
     SUCCESS = "success"
@@ -112,6 +120,10 @@ class DagRunStateResponse(BaseModel):
 
 
 class DagRunType(str, Enum):
+    """
+    Class with DagRun types.
+    """
+
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
@@ -119,6 +131,10 @@ class DagRunType(str, Enum):
 
 
 class IntermediateTIState(str, Enum):
+    """
+    States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
+    """
+
     SCHEDULED = "scheduled"
     QUEUED = "queued"
     RESTARTING = "restarting"
@@ -256,6 +272,10 @@ class TITargetStatePayload(BaseModel):
 
 
 class TerminalStateNonSuccess(str, Enum):
+    """
+    TaskInstance states that can be reported without extra information.
+    """
+
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"


### PR DESCRIPTION
This fixes static checks on main, and ensures when we generate consistent datamodels.