### PR TITLE
Change default executor to LocalExecutor

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -75,7 +75,7 @@ core:
       version_added: ~
       type: string
       example: ~
-      default: "SequentialExecutor"
+      default: "LocalExecutor"
     auth_manager:
       description: |
         The auth manager class that airflow should use. Full import path to the auth manager class.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


closes: https://github.com/apache/airflow/issues/48086

related: https://github.com/apache/airflow/issues/47608


Changing the default executor for airflow to LocalExecutor as that is the minimal executor configured to work with task sdk and we have discussions to remove SE as well: https://lists.apache.org/thread/cc7wfz9w8d1npopj72nlxnh52dpzbls9 and dont want to make it compatible when it is nearing removal.

Tested using:
```
rm ~/airflow/airflow.cfg

airflow scheduler
```

Before:
```
(airflow) ➜  airflow git:(main) ✗ airflow scheduler                                  
  ____________       _____________
 ____    |__( )_________  __/__  /________      __
____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
 _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
[2025-03-22T10:31:03.489+0530] {scheduler_job_runner.py:917} INFO - Starting the scheduler
[2025-03-22T10:31:03.490+0530] {scheduler_job_runner.py:921} INFO - Processing each file at most -1 times
[2025-03-22T10:31:03.491+0530] {executor_loader.py:275} INFO - Loaded executor: :SequentialExecutor:
[2025-03-22T10:31:03.491+0530] {scheduler_job_runner.py:1893} INFO - Adopting or resetting orphaned tasks for active dag runs

```

After:
```
(airflow) ➜  airflow git:(main) ✗ airflow scheduler
  ____________       _____________
 ____    |__( )_________  __/__  /________      __
____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
 _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
[2025-03-22T10:31:56.417+0530] {scheduler_job_runner.py:917} INFO - Starting the scheduler
[2025-03-22T10:31:56.418+0530] {scheduler_job_runner.py:921} INFO - Processing each file at most -1 times
[2025-03-22T10:31:56.420+0530] {executor_loader.py:275} INFO - Loaded executor: :LocalExecutor:
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
