### PR TITLE
Update taskflow.rst

### DIFF
--- a/airflow-core/docs/core-concepts/taskflow.rst
+++ b/airflow-core/docs/core-concepts/taskflow.rst
@@ -129,10 +129,10 @@ a ``Asset``, which is ``@attr.define`` decorated, together with TaskFlow.
             return data["data"]
 
         @task()
-        def to_fahrenheit(temps: dict[int, float]) -> dict[int, float]:
+        def to_fahrenheit(temps: dict[int, dict[str, float]]) -> dict[int, float]:
             ret: dict[int, float] = {}
-            for year, celsius in temps.items():
-                ret[year] = float(celsius) * 1.8 + 32
+            for year, info in temps.items():
+                ret[year] = float(info["anomaly"]) * 1.8 + 32
 
             return ret
 


### PR DESCRIPTION
Fix data mismatch in "Passing Arbitrary Objects As Arguments" section

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

The example URL (https://www.ncei.noaa.gov/access/monitoring/climate-at-a-glance/global/time-series/globe/land_ocean/ytd/12/1880-2022.json) returns a data structure that is incompatible with `to_fahrenheit`. The original code attempts to operate on a `dict` as if it were a numeric datatype, causing an error and preventing the example from being executed.
