### PR TITLE
Connections API is able to patch all fields correctly

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -44,7 +44,10 @@ from airflow.api_fastapi.core_api.datamodels.connections import (
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_access_connection
-from airflow.api_fastapi.core_api.services.public.connections import BulkConnectionService
+from airflow.api_fastapi.core_api.services.public.connections import (
+    BulkConnectionService,
+    update_orm_from_pydantic,
+)
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.configuration import conf
 from airflow.models import Connection
@@ -200,23 +203,7 @@ def patch_connection(
         raise RequestValidationError(errors=e.errors())
 
     # Not all fields match and some need setters, therefore copy manually
-    if not update_mask or "conn_type" in update_mask:
-        connection.conn_type = patch_body.conn_type
-    if not update_mask or "description" in update_mask:
-        connection.description = patch_body.description
-    if not update_mask or "host" in update_mask:
-        connection.host = patch_body.host
-    if not update_mask or "schema" in update_mask:
-        connection.schema = patch_body.schema_
-    if not update_mask or "login" in update_mask:
-        connection.login = patch_body.login
-    if not update_mask or "password" in update_mask:
-        connection.set_password(patch_body.password)
-    if not update_mask or "port" in update_mask:
-        connection.port = patch_body.port
-    if not update_mask or "extra" in update_mask:
-        connection.set_extra(patch_body.extra)
-
+    update_orm_from_pydantic(connection, patch_body, update_mask)
     return connection
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -202,7 +202,6 @@ def patch_connection(
     except ValidationError as e:
         raise RequestValidationError(errors=e.errors())
 
-    # Not all fields match and some need setters, therefore copy manually
     update_orm_from_pydantic(connection, patch_body, update_mask)
     return connection
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -199,7 +199,7 @@ def patch_connection(
     except ValidationError as e:
         raise RequestValidationError(errors=e.errors())
 
-    # Not all fields match, therefore copy manually
+    # Not all fields match and some need setters, therefore copy manually
     if not update_mask or "conn_type" in update_mask:
         connection.conn_type = patch_body.conn_type
     if not update_mask or "description" in update_mask:
@@ -211,11 +211,11 @@ def patch_connection(
     if not update_mask or "login" in update_mask:
         connection.login = patch_body.login
     if not update_mask or "password" in update_mask:
-        connection._password = patch_body.password
+        connection.set_password(patch_body.password)
     if not update_mask or "port" in update_mask:
         connection.port = patch_body.port
     if not update_mask or "extra" in update_mask:
-        connection._extra = patch_body.extra
+        connection.set_extra(patch_body.extra)
 
     return connection
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
@@ -41,12 +41,13 @@ def update_orm_from_pydantic(
     # Not all fields match and some need setters, therefore copy partly manually via setters
     non_update_fields = {"connection_id", "conn_id"}
     setter_fields = {"password", "extra"}
-    fields_to_update = pydantic_conn.model_fields_set - non_update_fields - setter_fields
+    fields_to_update = set(pydantic_conn.model_dump(by_alias=True).keys()) - non_update_fields - setter_fields
     if update_mask:
         fields_to_update = fields_to_update.intersection(update_mask)
-    conn_data = pydantic_conn.model_dump(include=fields_to_update, by_alias=True)
+    conn_data = pydantic_conn.model_dump(by_alias=True)
     for key, val in conn_data.items():
-        setattr(orm_conn, key, val)
+        if key in fields_to_update:
+            setattr(orm_conn, key, val)
 
     if not update_mask or "password" in update_mask:
         orm_conn.set_password(pydantic_conn.password)

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
@@ -36,7 +36,7 @@ from airflow.models.connection import Connection
 
 def update_orm_from_pydantic(
     orm_conn: Connection, pydantic_conn: ConnectionBody, update_mask: list[str] | None = None
-):
+) -> None:
     """Update ORM object from Pydantic object."""
     # Not all fields match and some need setters, therefore copy partly manually via setters
     non_update_fields = {"connection_id", "conn_id"}

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -353,7 +353,7 @@ class Connection(Base, LoggingMixin):
             self._validate_extra(extra_val, self.conn_id)
         return extra_val
 
-    def set_extra(self, value: str):
+    def set_extra(self, value: str | None):
         """Encrypt extra-data and save in object attribute to object."""
         if value:
             self._validate_extra(value, self.conn_id)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -468,6 +468,30 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "schema": "http_patch",
                 },
             ),
+            (
+                {  # Explicitly test that None is applied compared to if not provided
+                    "conn_type": TEST_CONN_TYPE,
+                    "connection_id": TEST_CONN_ID,
+                    "description": None,
+                    "extra": None,
+                    "host": None,
+                    "login": None,
+                    "password": None,
+                    "port": None,
+                    "schema": None,
+                },
+                {
+                    "conn_type": TEST_CONN_TYPE,
+                    "connection_id": TEST_CONN_ID,
+                    "description": None,
+                    "extra": None,
+                    "host": None,
+                    "login": None,
+                    "password": None,
+                    "port": None,
+                    "schema": None,
+                },
+            ),
         ],
     )
     @provide_session


### PR DESCRIPTION
During implementation of #48102 we saw that the patch API for connections is not working correctly.

This PR fixes the problem - reason is that pydantic fields to not map 1:1 to API fields - as well as extends pytests to cover the difference