### PR TITLE
Fix docstyle  PT007

### DIFF
--- a/task-sdk/tests/task_sdk/definitions/_internal/test_templater.py
+++ b/task-sdk/tests/task_sdk/definitions/_internal/test_templater.py
@@ -114,13 +114,13 @@ def test_private_access(env):
 
 @pytest.mark.parametrize(
     ["name", "expected"],
-    (
+    [
         ("ds", "2012-07-24"),
         ("ds_nodash", "20120724"),
         ("ts", "2012-07-24T03:04:52+00:00"),
         ("ts_nodash", "20120724T030452"),
         ("ts_nodash_with_tz", "20120724T030452+0000"),
-    ),
+    ],
 )
 def test_filters(env, name, expected):
     when = datetime(2012, 7, 24, 3, 4, 52, tzinfo=timezone.utc)

--- a/task-sdk/tests/task_sdk/definitions/test_asset.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset.py
@@ -384,21 +384,21 @@ class TestAssetAlias:
 
 
 class TestAssetSubclasses:
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize("subcls, group", [(Model, "model"), (Dataset, "dataset")])
     def test_only_name(self, subcls, group):
         obj = subcls(name="foobar")
         assert obj.name == "foobar"
         assert obj.uri == "foobar"
         assert obj.group == group
 
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize("subcls, group", [(Model, "model"), (Dataset, "dataset")])
     def test_only_uri(self, subcls, group):
         obj = subcls(uri="s3://bucket/key/path")
         assert obj.name == "s3://bucket/key/path"
         assert obj.uri == "s3://bucket/key/path"
         assert obj.group == group
 
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize("subcls, group", [(Model, "model"), (Dataset, "dataset")])
     def test_both_name_and_uri(self, subcls, group):
         obj = subcls("foobar", "s3://bucket/key/path")
         assert obj.name == "foobar"
@@ -406,7 +406,7 @@ class TestAssetSubclasses:
         assert obj.group == group
 
     @pytest.mark.parametrize("arg", ["foobar", "s3://bucket/key/path"])
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize("subcls, group", [(Model, "model"), (Dataset, "dataset")])
     def test_only_posarg(self, subcls, group, arg):
         obj = subcls(arg)
         assert obj.name == arg

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -113,7 +113,7 @@ class TestAssetDecorator:
 
         assert err.value.args[0] == "nested function not supported"
 
-    @pytest.mark.parametrize("example_asset_func", ("self", "context"), indirect=True)
+    @pytest.mark.parametrize("example_asset_func", ["self", "context"], indirect=True)
     def test_with_invalid_asset_name(self, example_asset_func):
         with pytest.raises(ValueError) as err:
             asset(schedule=None)(example_asset_func)

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -346,7 +346,7 @@ class TestCurrentContext:
 class TestOutletEventAccessor:
     @pytest.mark.parametrize(
         "key, asset_alias_events",
-        (
+        [
             (AssetUniqueKey.from_asset(Asset("test_uri")), []),
             (
                 AssetAliasUniqueKey.from_asset_alias(AssetAlias("test_alias")),
@@ -358,7 +358,7 @@ class TestOutletEventAccessor:
                     )
                 ],
             ),
-        ),
+        ],
     )
     def test_add(self, key, asset_alias_events, mock_supervisor_comms):
         asset = Asset("test_uri")
@@ -370,7 +370,7 @@ class TestOutletEventAccessor:
 
     @pytest.mark.parametrize(
         "key, asset_alias_events",
-        (
+        [
             (AssetUniqueKey.from_asset(Asset("test_uri")), []),
             (
                 AssetAliasUniqueKey.from_asset_alias(AssetAlias("test_alias")),
@@ -382,7 +382,7 @@ class TestOutletEventAccessor:
                     )
                 ],
             ),
-        ),
+        ],
     )
     def test_add_with_db(self, key, asset_alias_events, mock_supervisor_comms):
         asset = Asset(uri="test://asset-uri", name="test-asset")
@@ -396,14 +396,14 @@ class TestOutletEventAccessor:
 class TestOutletEventAccessors:
     @pytest.mark.parametrize(
         "access_key, internal_key",
-        (
+        [
             (Asset("test"), AssetUniqueKey.from_asset(Asset("test"))),
             (
                 Asset(name="test", uri="test://asset"),
                 AssetUniqueKey.from_asset(Asset(name="test", uri="test://asset")),
             ),
             (AssetAlias("test_alias"), AssetAliasUniqueKey.from_asset_alias(AssetAlias("test_alias"))),
-        ),
+        ],
     )
     def test__get_item__dict_key_not_exists(self, access_key, internal_key):
         outlet_event_accessors = OutletEventAccessors()
@@ -415,11 +415,11 @@ class TestOutletEventAccessors:
 
     @pytest.mark.parametrize(
         ["access_key", "asset"],
-        (
+        [
             (Asset.ref(name="test"), Asset(name="test")),
             (Asset.ref(name="test1"), Asset(name="test1", uri="test://asset-uri")),
             (Asset.ref(uri="test://asset-uri"), Asset(uri="test://asset-uri")),
-        ),
+        ],
     )
     def test__get_item__asset_ref(self, access_key, asset, mock_supervisor_comms):
         """Test accessing OutletEventAccessors with AssetRef resolves to correct Asset."""

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1323,10 +1323,10 @@ class TestRuntimeTaskInstance:
 
     @pytest.mark.parametrize(
         ("logical_date", "check"),
-        (
+        [
             pytest.param(None, pytest.raises(KeyError), id="no-logical-date"),
             pytest.param(timezone.datetime(2024, 12, 3), contextlib.nullcontext(), id="with-logical-date"),
-        ),
+        ],
     )
     def test_no_logical_date_key_error(
         self, mocked_parse, make_ti_context, mock_supervisor_comms, create_runtime_ti, logical_date, check


### PR DESCRIPTION
Fixes PT007 docstyle in task-sdk folder 
Contributes towards issue #40567 

[PT007](https://docs.astral.sh/ruff/rules/pytest-parametrize-values-wrong-type/) 
Rows of test values should follow a consistent format  - Top level list instead of tuple