### PR TITLE
Improve RAT licence check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -755,8 +755,7 @@ repos:
         name: Check if licenses are OK for Apache
         entry: ./scripts/ci/pre_commit/check_license.py
         language: python
-        files: ^.*LICENSE.*$|^.*LICENCE.*$
-        exclude: ^providers/.*/src/.*/LICENSE$|.*/dist/.*
+        files: ^LICENSE$
         pass_filenames: false
       - id: check-aiobotocore-optional
         name: Check if aiobotocore is an optional dependency only

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -44,6 +44,7 @@ venv
 clients/*
 files/*
 dags/*
+generated/*
 .gitmodules
 prod_image_installed_providers.txt
 airflow_pre_installed_providers.txt

--- a/scripts/ci/dockerfiles/apache-rat/Dockerfile
+++ b/scripts/ci/dockerfiles/apache-rat/Dockerfile
@@ -15,11 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM ibmjava:sfj-alpine
+FROM eclipse-temurin:21-jre-ubi9-minimal
 
 ARG AIRFLOW_APACHERAT_VERSION
 ARG APACHERAT_VERSION
-ARG APACHE_MIRROR="https://www-us.apache.org/dist"
+ARG APACHE_DOWNLOAD="https://downloads.apache.org"
+ARG COMMIT_SHA
+ENV dist_name="apache-rat-${APACHERAT_VERSION}"
+ENV rat_tgz="${dist_name}-bin.tar.gz"
 
 SHELL ["/bin/sh", "-e", "-x", "-c"]
 
@@ -29,21 +32,13 @@ SHELL ["/bin/sh", "-e", "-x", "-c"]
 # Those are build deps only but still we want the latest versions of those
 # "Pin versions in apk add" https://github.com/hadolint/hadolint/wiki/DL3018
 # hadolint ignore=DL3018
-RUN apk add -U --no-cache --virtual .build-deps \
-        gnupg \
-        unzip \
-    && wget -qT 30 "${APACHE_MIRROR}/creadur/KEYS" \
-    && gpg --import KEYS \
-    && rm KEYS \
-    && dist_name="apache-rat-${APACHERAT_VERSION}" \
-    && rat_tgz="${dist_name}-bin.tar.gz" \
-    && wget -qT 30 "${APACHE_MIRROR}/creadur/${dist_name}/${rat_tgz}.asc" \
-    && wget -qT 30 "${APACHE_MIRROR}/creadur/${dist_name}/${rat_tgz}" \
+RUN wget -qT 30 "${APACHE_DOWNLOAD}/creadur/KEYS" && gpg --import KEYS && rm KEYS \
+    && wget -qT 30 "${APACHE_DOWNLOAD}/creadur/${dist_name}/${rat_tgz}.asc" \
+    && wget -qT 30 "${APACHE_DOWNLOAD}/creadur/${dist_name}/${rat_tgz}" \
     && gpg --verify "${rat_tgz}.asc" "${rat_tgz}" \
     && tar --extract --gzip --file "${rat_tgz}" --strip-components=1 "${dist_name}/${dist_name}.jar" "${dist_name}/LICENSE" \
     && rm -vrf "${rat_tgz}" "${rat_tgz}.asc" \
     && ln -s "${dist_name}.jar" "apache-rat.jar" \
-    && apk del .build-deps \
     && rm -rf ~/.gnupg
 
 LABEL org.apache.airflow.component="apache-rat"

--- a/scripts/ci/dockerfiles/apache-rat/build_and_push.sh
+++ b/scripts/ci/dockerfiles/apache-rat/build_and_push.sh
@@ -19,10 +19,10 @@ set -euo pipefail
 GITHUB_REPOSITORY=${GITHUB_REPOSITORY:="apache/airflow"}
 readonly GITHUB_REPOSITORY
 
-APACHERAT_VERSION="0.13"
+APACHERAT_VERSION="0.16.1"
 readonly APACHERAT_VERSION
 
-AIRFLOW_APACHERAT_VERSION="2021.07.04"
+AIRFLOW_APACHERAT_VERSION="2024.03.23"
 readonly AIRFLOW_APACHERAT_VERSION
 
 COMMIT_SHA=$(git rev-parse HEAD)
@@ -33,12 +33,13 @@ cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 TAG="ghcr.io/${GITHUB_REPOSITORY}-apache-rat:${APACHERAT_VERSION}-${AIRFLOW_APACHERAT_VERSION}"
 readonly TAG
 
-docker build . \
+docker buildx build . \
     --pull \
+    --builder "airflow_cache" \
     --build-arg "APACHERAT_VERSION=${APACHERAT_VERSION}" \
     --build-arg "AIRFLOW_APACHERAT_VERSION=${AIRFLOW_APACHERAT_VERSION}" \
     --build-arg "COMMIT_SHA=${COMMIT_SHA}" \
     --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
-    --tag "${TAG}"
-
-docker push "${TAG}"
+    --platform "linux/amd64,linux/arm64" \
+    --tag "${TAG}" \
+    --push

--- a/scripts/ci/pre_commit/check_license.py
+++ b/scripts/ci/pre_commit/check_license.py
@@ -39,7 +39,7 @@ cmd = [
     "--rm",
     "--platform",
     "linux/amd64",
-    "ghcr.io/apache/airflow-apache-rat:0.13-2021.07.04",
+    "ghcr.io/apache/airflow-apache-rat:0.16.1-2024.03.23@sha256:83c4d2610ec4a439d1809a67fadbdc9a1df089ab130b32209351bdd4527a3f02",
     "-d",
     "/opt/airflow",
     "--exclude-file",


### PR DESCRIPTION
RAT licence check had not been updated for 3 years and started to show its age.

With this PR, we are upgrading RAT to latest version (0.16.1), we use non-deprecated and fresh official eclipse-temurin OpenJDK image as base and we build the image as multi-architecture image that supports both ARM and AMD64.

We also fix the check to only be run when LICENSE file is changed in the root of Airflow, which basically means that it should NEVER be run locally unless you specify `--all-files` - this way it is always run in CI but you need to use `--all-files` to trigger the check locally.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
