### PR TITLE
feat: Added files to introduce exasol connection and do some chores

### DIFF
--- a/providers/amazon/docs/transfer/exasol_to_s3.rst
+++ b/providers/amazon/docs/transfer/exasol_to_s3.rst
@@ -1,0 +1,59 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements. See the NOTICE file
+   distributed with this work for additional details regarding 
+   copyright ownership. The ASF licenses this file under the 
+   Apache License, Version 2.0 (the "License"); you may not use 
+   this file except in compliance with the License. 
+
+   You may obtain a copy of the License at:
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, 
+   software distributed under the License is provided on an 
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+   either express or implied. See the License for the specific 
+   language governing permissions and limitations under the License.
+
+==================================
+Exasol to Amazon S3 Transfer
+==================================
+
+The ``ExasolToS3Operator`` allows you to transfer data from an Exasol database 
+to an Amazon Simple Storage Service (S3) file.
+
+Prerequisite Tasks
+------------------
+
+.. include:: ../_partials/prerequisite_tasks.rst
+
+For more information about exasol connection in the Airflow, see :ref:`howto/connection:exasol`.
+
+Operators
+---------
+
+.. _howto/operator:ExasolToS3Operator:
+
+Exasol to Amazon S3 Transfer Operator
+=====================================
+
+This operator extracts query results from an Exasol database and saves them as a file in an Amazon S3 bucket.
+
+For more details about this operator, refer to:
+:class:`~airflow.providers.amazon.aws.transfers.exasol_to_s3.ExasolToS3Operator`
+
+Example Usage
+-------------
+
+The following example demonstrates how to use ``ExasolToS3Operator``:
+
+.. exampleinclude:: /../../providers/amazon/tests/system/amazon/aws/example_exasol_to_s3.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_transfer_exasol_to_s3]
+    :end-before: [END howto_transfer_exasol_to_s3]
+
+Reference
+---------
+
+* `AWS Boto3 documentation for Amazon S3 <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html>`__

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/exasol_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/exasol_to_s3.py
@@ -108,4 +108,3 @@ class ExasolToS3Operator(BaseOperator):
                 gzip=self.gzip,
                 acl_policy=self.acl_policy,
             )
-        self.log.info("Data uploaded")

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/exasol_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/exasol_to_s3.py
@@ -109,4 +109,3 @@ class ExasolToS3Operator(BaseOperator):
                 acl_policy=self.acl_policy,
             )
         self.log.info("Data uploaded")
-        return self.key

--- a/providers/amazon/tests/system/amazon/aws/example_exasol_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_exasol_to_s3.py
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG to test Exasol connection and S3 upload in Apache Airflow.
+
+This DAG uses the ExasolToS3Operator to execute a simple SQL query on Exasol and
+upload the result file to S3. It verifies that both the Exasol connection (`exasol_default`)
+and S3 credential settings (`aws_default`) are working correctly.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.models.baseoperator import chain
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.s3 import S3CreateBucketOperator, S3DeleteBucketOperator
+from airflow.providers.amazon.aws.transfers.exasol_to_s3 import ExasolToS3Operator
+from airflow.utils.trigger_rule import TriggerRule
+from system.amazon.aws.utils import SystemTestContextBuilder
+
+sys_test_context_task = SystemTestContextBuilder().build()
+
+DAG_ID = "example_exasol_to_s3"
+
+with DAG(
+    dag_id=DAG_ID,
+    start_date=datetime(2025, 3, 11),
+    schedule="@once",
+    catchup=False,
+    tags=["exasol", "s3", "test"],
+) as dag:
+
+    test_context = sys_test_context_task()
+    env_id = test_context["ENV_ID"]
+    s3_bucket_name = f"{env_id}-bucket"
+    s3_key = f"{env_id}/files/exasol-output.csv"
+
+    create_s3_bucket = S3CreateBucketOperator(
+        task_id="create_s3_bucket",
+        bucket_name=s3_bucket_name,
+    )
+
+    # [START howto_transfer_exasol_to_s3]
+    exasol_to_s3 = ExasolToS3Operator(
+        task_id="exasol_to_s3",
+        query_or_table="SELECT 1 AS val",
+        key=s3_key,
+        bucket_name=s3_bucket_name
+    )
+    # [END howto_transfer_exasol_to_s3]
+    
+    delete_s3_bucket = S3DeleteBucketOperator(
+        task_id="delete_s3_bucket",
+        bucket_name=s3_bucket_name,
+        force_delete=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    chain(
+        # TEST SETUP
+        test_context,
+        create_s3_bucket,
+        # TEST BODY
+        exasol_to_s3,
+        # TEST TEARDOWN
+        delete_s3_bucket
+        )
+
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "tearDown" task with trigger rule is part of the DAG
+    from tests_common.test_utils.watcher import watcher
+    list(dag.tasks) >> watcher()
+
+from tests_common.test_utils.system_tests import get_test_run
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_exasol_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_exasol_to_s3.py
@@ -21,6 +21,12 @@ Example DAG to test Exasol connection and S3 upload in Apache Airflow.
 This DAG uses the ExasolToS3Operator to execute a simple SQL query on Exasol and
 upload the result file to S3. It verifies that both the Exasol connection (`exasol_default`)
 and S3 credential settings (`aws_default`) are working correctly.
+
+Note:
+This test assumes you have a working Exasol connection (`exasol_default`) and
+AWS credentials (`aws_default`) already configured. If not, the task will fail at runtime.
+Please refer to the documentation for setup instructions:
+<intro-url>
 """
 from __future__ import annotations
 

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_exasol_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_exasol_to_s3.py
@@ -61,7 +61,7 @@ class TestExasolToS3Operator:
 
         mock_fh.flush.assert_called_once_with()
 
-        mock_s3_hook.return_value.load_file(
+        mock_s3_hook.return_value.load_file.assert_called_once_with(
             key="key",
             bucket_name="bucket_name",
             replace=False,

--- a/providers/exasol/README.rst
+++ b/providers/exasol/README.rst
@@ -46,7 +46,7 @@ for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-exasol``
 
 The package supports the following python versions: 3.9,3.10,3.11,3.12
-
+ 
 Requirements
 ------------
 

--- a/providers/exasol/docs/connections/exasol.rst
+++ b/providers/exasol/docs/connections/exasol.rst
@@ -1,0 +1,63 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements. See the NOTICE file
+   distributed with this work for additional details regarding 
+   copyright ownership. The ASF licenses this file under the 
+   Apache License, Version 2.0 (the "License"); you may not use 
+   this file except in compliance with the License. 
+
+   You may obtain a copy of the License at:
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, 
+   software distributed under the License is provided on an 
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+   either express or implied. See the License for the specific 
+   language governing permissions and limitations under the License.
+
+.. _howto/connection:exasol:
+
+Exasol Connection
+=================
+
+The Exasol connection type allows Apache Airflow to connect to an Exasol database 
+for querying and data extraction.
+
+.. note::
+   This connection type is designed for use with ``ExasolHook``.
+
+Authenticating to Exasol
+------------------------
+
+Airflow supports authentication to Exasol via the standard connection mechanism.
+
+Default Connection IDs
+----------------------
+
+The default connection ID is ``exasol_default``.
+
+Configuring the Connection
+--------------------------
+
+Host
+  The hostname or IP address of the Exasol database.
+
+Port (optional)
+  The port to connect to Exasol (default: ``8563``).
+
+Schema (optional)
+  The Exasol schema to be used.
+
+Login (optional)
+  The username for authentication.
+
+Password (optional)
+  The password for authentication.
+
+Extra
+  Specify additional parameters (as JSON dictionary) to be used in the Exasol connection.
+
+  * ``encryption``: Whether to use encryption (default: true).
+  * ``compression``: Whether to enable compression (default: true).
+
+For a full setup guide, see: :ref:`howto/connection:exasol_ce_setup`

--- a/providers/exasol/docs/exasol_ce_setup.rst
+++ b/providers/exasol/docs/exasol_ce_setup.rst
@@ -1,0 +1,125 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership. The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License. You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. _howto/connection:exasol_ce_setup:
+
+########################################
+Exasol Connection Setup for Apache Airflow
+########################################
+
+This guide provides a step-by-step approach to configuring an Exasol connection in Apache Airflow. The setup enables data extraction from an Exasol database using the ``ExasolToS3Operator``.
+
+Prerequisites
+#############
+- **Docker** installed on the local machine
+- **Apache Airflow** installed and running
+- **Exasol Database** running in a Docker container
+- **Exasol Python Client (`pyexasol`)** installed
+
+Setting Up Exasol in Docker
+#############################
+To start an Exasol instance locally using Docker:
+
+.. code-block:: sh
+
+   docker run --name <EXASOL_CONTAINER_NAME> --privileged -d -p 8563:8563 -p 2580:2580 exasol/docker-db:latest
+
+This command runs Exasol on ``localhost:8563``.
+
+**Parameters:**
+- ``<EXASOL_CONTAINER_NAME>``: Custom name for the Exasol container.
+
+Verifying the Container
+#######################
+
+After launching the container, check its status:
+
+.. code-block:: sh
+
+   docker ps  # Retrieve CONTAINER_ID
+   docker exec -it <CONTAINER_ID> /bin/bash  # Access Exasol container
+
+Inside the container, locate and use the Exasol client:
+
+.. code-block:: sh
+
+   find / -name "exaplus" 2>/dev/null  # Identify the Exasol client path
+   <path-to-exaplus> -c 127.0.0.1:8563 -u sys -p exasol
+
+   # If using TCP, use:
+   <path-to-exaplus> -c 127.0.0.1/<FINGERPRINT>:8563 -u sys -p exasol
+
+**Definitions:**
+- ``<CONTAINER_ID>``: ID of the running Exasol container.
+- ``<FINGERPRINT>``: Optional identifier for secure TCP connections.
+
+Connecting Exasol to Airflow's Network
+######################################
+
+To ensure Airflow can communicate with Exasol, connect the container to the ``breeze_default`` network:
+
+.. code-block:: sh
+
+   docker network connect breeze_default <EXASOL_CONTAINER_NAME>
+
+Connecting to Exasol via Python
+################################
+
+Once the container is running, test the connection using ``pyexasol``:
+
+.. code-block:: python
+
+   import pyexasol
+
+   conn = pyexasol.connect(dsn="<EXASOL_CONTAINER_NAME>:8563", user="SYS", password="exasol")
+   result = conn.execute("SELECT CURRENT_USER, CURRENT_SCHEMA").fetchall()
+   print(result)
+
+Ensure that the connection is established successfully before proceeding.
+
+Configuring Airflow Connection to Exasol
+########################################
+
+To integrate Apache Airflow with Exasol, define an Airflow connection. This allows Airflow to interact with Exasol for data extraction and processing.
+
+Using the Airflow CLI:
+
+.. code-block:: sh
+
+   airflow connections add 'exasol_default' \
+       --conn-type 'exasol' \
+       --conn-host '<EXASOL_HOST>' \
+       --conn-port '8563' \
+       --conn-schema '<EXASOL_SCHEMA>' \
+       --conn-login 'SYS' \
+       --conn-password 'exasol' \
+       --conn-extra '{"encryption": true}'
+
+**Parameter Details:**
+- ``<EXASOL_HOST>``: The hostname or IP address of the Exasol instance. If running in a Docker container using the ``bridge`` network, use the container's name (e.g., ``exasol-db``) instead of ``localhost``.
+- ``<EXASOL_SCHEMA>``: The schema to execute queries in Exasol.
+
+Verifying the Connection
+#########################
+
+Once the connection is configured, check if it was successfully added:
+
+.. code-block:: sh
+
+   airflow connections get exasol_default
+
+This command displays the connection details, ensuring Airflow can communicate with Exasol.


### PR DESCRIPTION
Summary
Adds documentation for ExasolToS3Operator to enhance clarity and usability.

Changes Introduced

- Added `exasol.rst`, `exasol_to_s3.rst`, `exasol_ce_setup.rst` to introduce exasol connection
- Removed `return self.key` from ExasolToS3Operator execute method
- Added `example_exasol_to_s3.py` to test exasol in DAG
- Used `assert_called_once_with` for stricter verification

Related Issues
related: https://github.com/apache/airflow/pull/47478