### PR TITLE
Run Dependabot also for NPM as well as v2 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ version: 2
 updates:
   - package-ecosystem: pip
     directories:
+      - /airflow-core
+      - /airflow-ctl
       - /clients/python
       - /dev/breeze
       - /docker_tests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,21 +51,9 @@ updates:
       - /clients/python
       - /dev/breeze
       - /docker_tests
-      - /task-sdk
       - /
     schedule:
       interval: daily
-    target-branch: v2-10-test
-
-  - package-ecosystem: pip
-    directories:
-      - /providers/*/
-    schedule:
-      interval: daily
-    groups:
-      provider-dependencies:
-        patterns:
-          - "*"
     target-branch: v2-10-test
 
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,43 @@ updates:
       provider-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: npm
+    directories:
+      - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
+      - /airflow-core/src/airflow/ui
+      - /providers/fab/src/airflow/providers/fab/www
+    schedule:
+      interval: daily
+
+  # Repeat dependency updates on 2.10 branch as well
+  - package-ecosystem: pip
+    directories:
+      - /clients/python
+      - /dev/breeze
+      - /docker_tests
+      - /task-sdk
+      - /
+    schedule:
+      interval: daily
+    target-branch: v2-10-test
+
+  - package-ecosystem: pip
+    directories:
+      - /providers/*/
+    schedule:
+      interval: daily
+    groups:
+      provider-dependencies:
+        patterns:
+          - "*"
+    target-branch: v2-10-test
+
+  - package-ecosystem: npm
+    directories:
+      - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
+      - /airflow-core/src/airflow/ui
+      - /providers/fab/src/airflow/providers/fab/www
+    schedule:
+      interval: daily
+    target-branch: v2-10-test


### PR DESCRIPTION
I noticed that we do not run dependabot explicitly on NPM... so
as well as thought that it might be good as we have derivated v2 from v3 as of the new UI to run dependabot also on the v2-10-test branch for maintenance.