### PR TITLE
AIP-72: Port Variable.set From TaskSDK to Models

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -215,12 +215,13 @@ class Variable(Base, LoggingMixin):
             # check if the secret exists in the custom secrets' backend.
             # passing the secrets backend initialized on the worker side
             Variable.check_for_write_conflict(key=key, secrets_backends=SECRETS_BACKEND)
-            return TaskSDKVariable.set(
+            TaskSDKVariable.set(
                 key=key,
                 value=value,
                 description=description,
                 serialize_json=serialize_json,
             )
+            return
         # check if the secret exists in the custom secrets' backend.
         Variable.check_for_write_conflict(key=key)
         if serialize_json:
@@ -283,9 +284,7 @@ class Variable(Base, LoggingMixin):
             self._val = fernet.rotate(self._val.encode("utf-8")).decode()
 
     @staticmethod
-    def check_for_write_conflict(
-        key: str, secrets_backends: list[BaseSecretsBackend] = ensure_secrets_loaded()
-    ) -> None:
+    def check_for_write_conflict(key: str, secrets_backends: list[BaseSecretsBackend] | None = None) -> None:
         """
         Log a warning if a variable exists outside the metastore.
 
@@ -295,6 +294,8 @@ class Variable(Base, LoggingMixin):
 
         :param key: Variable Key
         """
+        if secrets_backends is None:
+            secrets_backends = ensure_secrets_loaded()
         for secrets_backend in secrets_backends:
             if not isinstance(secrets_backend, MetastoreBackend):
                 try:

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -210,11 +210,10 @@ class Variable(Base, LoggingMixin):
                 stacklevel=1,
             )
             from airflow.sdk import Variable as TaskSDKVariable
-            from airflow.sdk.execution_time.supervisor import SECRETS_BACKEND
 
             # check if the secret exists in the custom secrets' backend.
             # passing the secrets backend initialized on the worker side
-            Variable.check_for_write_conflict(key=key, secrets_backends=SECRETS_BACKEND)
+            Variable.check_for_write_conflict(key=key)
             TaskSDKVariable.set(
                 key=key,
                 value=value,

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -181,9 +181,7 @@ class TestDagFileProcessor:
         if result.import_errors:
             assert "VARIABLE_NOT_FOUND" in next(iter(result.import_errors.values()))
 
-    def test_top_level_variable_set(
-        self, spy_agency: SpyAgency, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_top_level_variable_set(self, spy_agency: SpyAgency, tmp_path: pathlib.Path):
         logger_filehandle = MagicMock()
 
         def dag_in_a_fn():
@@ -195,7 +193,6 @@ class TestDagFileProcessor:
 
         path = write_dag_in_a_fn_to_file(dag_in_a_fn, tmp_path)
 
-        monkeypatch.setenv("AIRFLOW_VAR_MYVAR", "abc")
         proc = DagFileProcessorProcess.start(
             id=1, path=path, bundle_path=tmp_path, callbacks=[], logger_filehandle=logger_filehandle
         )

--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -55,3 +55,9 @@ class Variable:
             if e.error.error == ErrorType.VARIABLE_NOT_FOUND and default is not NOTSET:
                 return default
             raise
+
+    @classmethod
+    def set(cls, key: str, value: Any, description: str | None = None, serialize_json: bool = False):
+        from airflow.sdk.execution_time.context import _set_variable
+
+        _set_variable(key, value, description=description, serialize_json=serialize_json)

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -25,7 +25,6 @@ import pytest
 from airflow.configuration import initialize_secrets_backends
 from airflow.sdk import Variable
 from airflow.sdk.execution_time.comms import PutVariable, VariableResult
-from airflow.sdk.execution_time.supervisor import initialize_secrets_backend_on_workers
 from airflow.secrets import DEFAULT_SECRETS_SEARCH_PATH_WORKERS
 
 from tests_common.test_utils.config import conf_vars


### PR DESCRIPTION
closes: #47920

## Why 

Setting a variable in Dag is failing due to 'Direct database access via the ORM is not allowed in Airflow 3.0' ( details in issue context )

```python
from datetime import datetime

from airflow.models import Variable
from airflow import DAG

my_var = Variable.set("param_variable", 10)
```

## What

Port `Variable.set` from TaskSDK to `airflow.models.Variable.set`