### PR TITLE
Update code to use flask_session 0.8.0

### DIFF
--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -73,8 +73,6 @@ dependencies = [
     # In particular, make sure any breaking changes, for example any new methods, are accounted for.
     "flask-appbuilder==4.5.3",
     "flask-login>=0.6.2",
-    # Flask-Session 0.6 add new arguments into the SqlAlchemySessionInterface constructor as well as
-    # all parameters now are mandatory which make AirflowDatabaseSessionInterface incompatible with this version.
     "flask-session>=0.8.0,<0.9",
     "flask-wtf>=1.1.0",
     "connexion[flask]>=2.14.2,<3.0",

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "flask-login>=0.6.2",
     # Flask-Session 0.6 add new arguments into the SqlAlchemySessionInterface constructor as well as
     # all parameters now are mandatory which make AirflowDatabaseSessionInterface incompatible with this version.
-    "flask-session>=0.4.0,<0.6",
+    "flask-session>=0.8.0,<0.9",
     "flask-wtf>=1.1.0",
     "connexion[flask]>=2.14.2,<3.0",
     "jmespath>=0.7.0",

--- a/providers/fab/src/airflow/providers/fab/auth_manager/models/db.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/models/db.py
@@ -41,7 +41,7 @@ def _get_flask_db(sql_database_uri):
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = sql_database_uri
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     db = SQLAlchemy(flask_app)
-    AirflowDatabaseSessionInterface(app=flask_app, db=db, table="session", key_prefix="")
+    AirflowDatabaseSessionInterface(app=flask_app, client=db, table="session", key_prefix="")
     return db
 
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -539,7 +539,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             FabAirflowDatabaseSessionInterface,
         ):
             interface = self.appbuilder.get_app.session_interface
-            session = interface.db.session
+            session = interface.client.session
             user_session_model = interface.sql_session_model
             num_sessions = session.query(user_session_model).count()
             if num_sessions > MAX_NUM_DATABASE_USER_SESSIONS:
@@ -556,7 +556,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 )
             else:
                 for s in session.query(user_session_model):
-                    session_details = interface.serializer.loads(want_bytes(s.data))
+                    session_details = interface.serializer.decode(want_bytes(s.data))
                     if session_details.get("_user_id") == user.id:
                         session.delete(s)
                 session.commit()

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_session.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_session.py
@@ -55,6 +55,7 @@ def init_airflow_session_interface(app):
             table="session",
             key_prefix="",
             use_signer=True,
+            cleanup_n_requests=5,
         )
     else:
         raise AirflowConfigException(

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_session.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_session.py
@@ -47,7 +47,7 @@ def init_airflow_session_interface(app):
     elif selected_backend == "database":
         app.session_interface = AirflowDatabaseSessionInterface(
             app=app,
-            db=None,
+            client=None,
             permanent=permanent_cookie,
             # Typically these would be configurable with Flask-Session,
             # but we will set them explicitly instead as they don't make

--- a/providers/fab/src/airflow/providers/fab/www/session.py
+++ b/providers/fab/src/airflow/providers/fab/www/session.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from flask import request
 from flask.sessions import SecureCookieSessionInterface
-from flask_session.sessions import SqlAlchemySessionInterface
+from flask_session.sqlalchemy import SqlAlchemySessionInterface
 
 
 class SessionExemptMixin:


### PR DESCRIPTION
Our code has been using flask_session 0.5.0 but recent update has us use 0.8.0 and main is failing cause of this change. This PR updates the fab db code to use flask_session 0.8.0

closes: https://github.com/apache/airflow/issues/36897
