### PR TITLE
Implementing masking for task SDK logs

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1079,6 +1079,14 @@ def initialize_secrets_backend_on_workers():
     log.debug("Initialized secrets backend on workers", secrets_backend=SECRETS_BACKEND)
 
 
+def register_secrets_masker():
+    """Register the secrets masker to mask task logs."""
+    from airflow.sdk.execution_time.secrets_masker import get_sensitive_variables_fields, mask_secret
+
+    for field in get_sensitive_variables_fields():
+        mask_secret(field)
+
+
 def supervise(
     *,
     ti: TaskInstance,
@@ -1137,6 +1145,8 @@ def supervise(
         logger = structlog.wrap_logger(underlying_logger, processors=processors, logger_name="task").bind()
 
     initialize_secrets_backend_on_workers()
+
+    register_secrets_masker()
 
     process = ActivitySubprocess.start(
         dag_rel_path=dag_rel_path,

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -99,7 +99,7 @@ def redact_jwt(logger: Any, method_name: str, event_dict: EventDict) -> EventDic
 def mask_logs(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
     from airflow.sdk.execution_time.secrets_masker import redact
 
-    event_dict["event"] = redact(event_dict["event"])
+    event_dict = redact(event_dict)
     return event_dict
 
 

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -96,6 +96,13 @@ def redact_jwt(logger: Any, method_name: str, event_dict: EventDict) -> EventDic
     return event_dict
 
 
+def mask_logs(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
+    from airflow.sdk.execution_time.secrets_masker import redact
+
+    event_dict["event"] = redact(event_dict["event"])
+    return event_dict
+
+
 def drop_positional_args(logger: Any, method_name: Any, event_dict: EventDict) -> EventDict:
     event_dict.pop("positional_args", None)
     return event_dict
@@ -141,6 +148,7 @@ def logging_processors(
         structlog.stdlib.PositionalArgumentsFormatter(),
         logger_name,
         redact_jwt,
+        mask_logs,
         structlog.processors.StackInfoRenderer(),
     ]
 

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -99,7 +99,7 @@ def redact_jwt(logger: Any, method_name: str, event_dict: EventDict) -> EventDic
 def mask_logs(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
     from airflow.sdk.execution_time.secrets_masker import redact
 
-    event_dict = redact(event_dict)
+    event_dict = redact(event_dict)  # type: ignore[assignment]
     return event_dict
 
 

--- a/task-sdk/tests/task_sdk/log/test_log.py
+++ b/task-sdk/tests/task_sdk/log/test_log.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 import json
 import logging
 import unittest.mock
+from unittest import mock
 
 import pytest
 import structlog
 from uuid6 import UUID
 
 from airflow.sdk.api.datamodels._generated import TaskInstance
+from airflow.sdk.execution_time.secrets_masker import SecretsMasker
 
 
 @pytest.mark.parametrize(
@@ -36,21 +38,76 @@ def test_json_rendering(captured_logs):
     Test that the JSON formatter renders correctly.
     """
     logger = structlog.get_logger()
-    logger.info(
-        "A test message with a Pydantic class",
-        pydantic_class=TaskInstance(
-            id=UUID("ffec3c8e-2898-46f8-b7d5-3cc571577368"),
-            dag_id="test_dag",
-            task_id="test_task",
-            run_id="test_run",
-            try_number=1,
-        ),
-    )
+
+    secrets_masker = SecretsMasker()
+
+    with mock.patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+        logger.info(
+            "A test message with a Pydantic class",
+            pydantic_class=TaskInstance(
+                id=UUID("ffec3c8e-2898-46f8-b7d5-3cc571577368"),
+                dag_id="test_dag",
+                task_id="test_task",
+                run_id="test_run",
+                try_number=1,
+            ),
+        )
+        assert captured_logs
+        assert isinstance(captured_logs[0], bytes)
+        assert json.loads(captured_logs[0]) == {
+            "event": "A test message with a Pydantic class",
+            "pydantic_class": "TaskInstance(id=UUID('ffec3c8e-2898-46f8-b7d5-3cc571577368'), task_id='test_task', dag_id='test_dag', run_id='test_run', try_number=1, map_index=-1, hostname=None)",
+            "timestamp": unittest.mock.ANY,
+            "level": "info",
+        }
+
+
+@pytest.mark.parametrize(
+    "captured_logs", [(logging.INFO, "json")], indirect=True, ids=["log_level=info,formatter=json"]
+)
+def test_logs_are_masked(captured_logs):
+    """
+    Test that JSON logs are masked.
+    """
+    logger = structlog.get_logger()
+    secrets_masker = SecretsMasker()
+    secrets_masker.add_mask("password")
+    with mock.patch(
+        "airflow.sdk.execution_time.secrets_masker.redact",
+        side_effect=lambda event: {
+            "event": "Connection *** is ***",
+            "level": "info",
+            "pydantic_class": TaskInstance(
+                id=UUID("ffec3c8e-2898-46f8-b7d5-3cc571577368"),
+                task_id="test_task",
+                dag_id="test_dag",
+                run_id="test_run",
+                try_number=1,
+                map_index=-1,
+                hostname=None,
+            ),
+            "timestamp": "2025-03-25T05:13:27.073918Z",
+        },
+    ):
+        logger.info(
+            "Connection password is password123",
+            pydantic_class=TaskInstance(
+                id=UUID("ffec3c8e-2898-46f8-b7d5-3cc571577368"),
+                dag_id="test_dag",
+                task_id="test_task",
+                run_id="test_run",
+                try_number=1,
+            ),
+        )
     assert captured_logs
     assert isinstance(captured_logs[0], bytes)
-    assert json.loads(captured_logs[0]) == {
-        "event": "A test message with a Pydantic class",
-        "pydantic_class": "TaskInstance(id=UUID('ffec3c8e-2898-46f8-b7d5-3cc571577368'), task_id='test_task', dag_id='test_dag', run_id='test_run', try_number=1, map_index=-1, hostname=None)",
-        "timestamp": unittest.mock.ANY,
+
+    log_entry = json.loads(captured_logs[0])
+    assert log_entry == {
+        "event": "Connection *** is ***",
         "level": "info",
+        "pydantic_class": "TaskInstance(id=UUID('ffec3c8e-2898-46f8-b7d5-3cc571577368'), "
+        "task_id='test_task', dag_id='test_dag', run_id='test_run', "
+        "try_number=1, map_index=-1, hostname=None)",
+        "timestamp": "2025-03-25T05:13:27.073918Z",
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #47845 

We need the ability to mask secrets in logs generated by tasks as they can log stuff in the logs which we do not want to display in the task logs.

Example of such a badly written DAG:
```
from airflow import DAG

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Connection


def print_sensitive():
    c = Connection.get("teradata_default")
    print("Connection is", c.password)

with DAG(
    dag_id="print_sensitive_data",
    schedule=None,
) as dag:

    print_sensitive_task = PythonOperator(
        task_id="print_sensitive_task",
        python_callable=print_sensitive,
    )

```


- I am registering a new processor in the task sdk's configure_logging that will handle the log masking in the dict
- Decided to not redact every extra field. We need to worry about "event" field in event_dict as its generated by user tasks. Example of a event_dict:
```
{'chan': 'stdout', 'event': 'Connection is password', 'timestamp': '2025-03-24T08:49:41.302433Z', 'level': 'info', 'logger': 'task'}
```

- Added the registration of sensitive values in supervise() as this will ensure that every time a worker starts, it will register the masking.
- Tested with LocalExecutor, CeleryExecutor.

Before changes, logs:
<img width="1636" alt="image" src="https://github.com/user-attachments/assets/d300cb7d-f023-450f-93a4-942b0776960b" />



After changes, logs:
<img width="1636" alt="image" src="https://github.com/user-attachments/assets/98e63e88-645a-41c7-8bd5-ae1513308d44" />






<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
