### PR TITLE
feat: Add test analytics 

### DIFF
--- a/.github/actions/post_tests_success/action.yml
+++ b/.github/actions/post_tests_success/action.yml
@@ -45,9 +45,10 @@ runs:
         mv ./files/coverage*.xml ./files/coverage-reports/ || true
     - name: "Upload test results to Codecov"
       uses: codecov/test-results-action@v1
+      env:
+        CODECOV_TOKEN: ${{ inputs.codecov-token }}
       if: env.ENABLE_COVERAGE == 'true' && env.TEST_TYPES != 'Helm' && inputs.python-version != '3.12'
       with:
-        token: ${{ inputs.codecov-token }}
         file: ./files/test_result-*.xml
     - name: "Upload all coverage reports to codecov"
       uses: codecov/codecov-action@v4

--- a/.github/actions/post_tests_success/action.yml
+++ b/.github/actions/post_tests_success/action.yml
@@ -45,6 +45,7 @@ runs:
         mv ./files/coverage*.xml ./files/coverage-reports/ || true
     - name: "Upload test results to Codecov"
       uses: codecov/test-results-action@v1
+      if: env.ENABLE_COVERAGE == 'true' && env.TEST_TYPES != 'Helm' && inputs.python-version != '3.12'
       with:
         token: ${{ inputs.codecov-token }}
         file: ./files/test_result-*.xml

--- a/.github/actions/post_tests_success/action.yml
+++ b/.github/actions/post_tests_success/action.yml
@@ -43,6 +43,11 @@ runs:
       run: |
         mkdir ./files/coverage-reports
         mv ./files/coverage*.xml ./files/coverage-reports/ || true
+    - name: "Upload test results to Codecov"
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ inputs.codecov-token }}
+        file: ./files/test_result-*.xml
     - name: "Upload all coverage reports to codecov"
       uses: codecov/codecov-action@v4
       env:

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -361,6 +361,7 @@ def generate_args_for_pytest(
             "--maxfail=50",
             "--color=yes",
             f"--junitxml={result_log_file}",
+            "-o", "junit_family=legacy",
             # timeouts in seconds for individual tests
             "--timeouts-order=moi",
             f"--setup-timeout={test_timeout}",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->


<!-- Please keep an empty line above the dashes. -->

---
This PR sets up Codecov [Test Analytics](https://docs.codecov.com/docs/test-analytics), which enhances this project's existing Codecov coverage PR notification with details about failing, flaky, and slow tests.

# Enable Codecov Test Analytics

This PR sets up Codecov Test Analytics, which enhances this project's existing Codecov coverage PR notification with details about failing, flaky, and slow tests.

## The PR proposes the following edits:

1. The JUnit XML file generation is already configured in `dev/breeze/src/airflow_breeze/utils/run_tests.py`:
```python
args.extend([
    f"--junitxml={result_log_file}",
    "-o", "junit_family=legacy",  # Added for nicer formatting in Codecov UI
])
```

2. The test results upload is configured in `.github/actions/post_tests_success/action.yml` using the same conditions as coverage upload:
```yaml
- name: "Upload test results to Codecov"
  uses: codecov/test-results-action@v1
  if: env.ENABLE_COVERAGE == 'true' && env.TEST_TYPES != 'Helm' && inputs.python-version != '3.12'
  with:
    token: ${{ inputs.codecov-token }}
    file: ./files/test_result-*.xml
```

3. The test results files are generated as `/files/test_result-{test_type}-{backend}.xml`, which follows Codecov's requirement that files with XML test results should be parseable by the Test Analytics tool.

4. The upload step is integrated into the existing GitHub Actions workflow, reusing the same conditions as coverage upload:
   - Only runs on main branch pushes to apache/airflow
   - Skips for Python 3.12 and Helm tests
   - Uses the same Codecov token as coverage uploads

## Expected Results

When this PR is merged:
- "Tests" tab will show tests results in Codecov's UI
- Test analytics will provide insights about:
  - Failing tests
  - Flaky tests
  - Slow tests
- Results will be available for all test types (core, providers, system)

**Permission to test this update to the workflow is awaiting approval.**

Look forward to any feedback!