### PR TITLE
Update EKS Operators and Sensors to inherit AWS base classes

### DIFF
--- a/providers/amazon/docs/operators/eks.rst
+++ b/providers/amazon/docs/operators/eks.rst
@@ -31,10 +31,10 @@ Prerequisite Tasks
 
 .. include:: ../_partials/prerequisite_tasks.rst
 
- Generic Parameters
- ------------------
+Generic Parameters
+------------------
 
- .. include:: ../_partials/generic_parameters.rst
+.. include:: ../_partials/generic_parameters.rst
 
 Operators
 ---------

--- a/providers/amazon/docs/operators/eks.rst
+++ b/providers/amazon/docs/operators/eks.rst
@@ -31,6 +31,11 @@ Prerequisite Tasks
 
 .. include:: ../_partials/prerequisite_tasks.rst
 
+ Generic Parameters
+ ------------------
+
+ .. include:: ../_partials/generic_parameters.rst
+
 Operators
 ---------
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -177,6 +177,7 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
     :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
     :param verify: Whether or not to verify SSL certificates. See:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+
     If compute is assigned the value of 'nodegroup':
 
     :param nodegroup_name: *REQUIRED* The unique name to give your Amazon EKS managed node group. (templated)

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -216,7 +216,6 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         "create_fargate_profile_kwargs",
         "wait_for_completion",
         "aws_conn_id",
-        "region",
         "region_name",
     )
 
@@ -234,7 +233,6 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         fargate_pod_execution_role_arn: str | None = None,
         fargate_selectors: list | None = None,
         create_fargate_profile_kwargs: dict | None = None,
-        region: str | None = None,
         wait_for_completion: bool = False,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         waiter_delay: int = 30,
@@ -259,14 +257,9 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         self.fargate_selectors = fargate_selectors or [{"namespace": DEFAULT_NAMESPACE_NAME}]
         self.fargate_profile_name = fargate_profile_name
         self.deferrable = deferrable
-        self.region = region  # for templated field
         super().__init__(
             **kwargs,
         )
-
-    """ @cached_property
-    def hook(self) -> EksHook:
-        return EksHook(aws_conn_id=self.aws_conn_id, region_name=self.region) """
 
     def execute(self, context: Context):
         if self.compute:
@@ -465,7 +458,6 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         "create_nodegroup_kwargs",
         "wait_for_completion",
         "aws_conn_id",
-        "region",
         "region_name",
     )
 
@@ -477,7 +469,6 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         nodegroup_name: str = DEFAULT_NODEGROUP_NAME,
         create_nodegroup_kwargs: dict | None = None,
         wait_for_completion: bool = False,
-        region: str | None = None,
         waiter_delay: int = 30,
         waiter_max_attempts: int = 80,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
@@ -492,7 +483,6 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         if deferrable:
             wait_for_completion = False
         self.wait_for_completion = wait_for_completion
-        self.region = region
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
@@ -566,7 +556,6 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
     :param create_fargate_profile_kwargs: Optional parameters to pass to the CreateFargate Profile API
      (templated)
     :param wait_for_completion: If True, waits for operator to complete. (default: False) (templated)
-
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
@@ -591,7 +580,6 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
         "create_fargate_profile_kwargs",
         "wait_for_completion",
         "aws_conn_id",
-        "region",
         "region_name",
     )
 
@@ -603,7 +591,6 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
         fargate_profile_name: str = DEFAULT_FARGATE_PROFILE_NAME,
         create_fargate_profile_kwargs: dict | None = None,
         wait_for_completion: bool = False,
-        region: str | None = None,
         waiter_delay: int = 10,
         waiter_max_attempts: int = 60,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
@@ -617,7 +604,6 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
         if deferrable:
             wait_for_completion = False
         self.wait_for_completion = wait_for_completion
-        self.region = region
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
@@ -648,7 +634,7 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
                     aws_conn_id=self.aws_conn_id,
                     waiter_delay=self.waiter_delay,
                     waiter_max_attempts=self.waiter_max_attempts,
-                    region_name=self.region,
+                    region_name=self.region_name,
                 ),
                 method_name="execute_complete",
                 # timeout is set to ensure that if a trigger dies, the timeout does not restart
@@ -696,7 +682,7 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "force_delete_compute", "wait_for_completion", "aws_conn_id", "region", "region_name"
+        "cluster_name", "force_delete_compute", "wait_for_completion", "aws_conn_id", "region_name"
     )
 
     def __init__(
@@ -704,7 +690,6 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
         cluster_name: str,
         force_delete_compute: bool = False,
         wait_for_completion: bool = False,
-        region: str | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         waiter_delay: int = 30,
         waiter_max_attempts: int = 40,
@@ -715,7 +700,6 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
         if deferrable:
             wait_for_completion = False
         self.wait_for_completion = wait_for_completion
-        self.region = region
         self.deferrable = deferrable
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
@@ -729,7 +713,7 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
                     waiter_delay=self.waiter_delay,
                     waiter_max_attempts=self.waiter_max_attempts,
                     aws_conn_id=self.aws_conn_id,
-                    region_name=self.region,
+                    region_name=self.region_name,
                     force_delete_compute=self.force_delete_compute,
                 ),
                 method_name="execute_complete",
@@ -806,7 +790,7 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
          running Airflow in a distributed manner and aws_conn_id is None or
          empty, then the default boto3 configuration would be used (and must be
          maintained on each worker node).
-    :param region: Which AWS region the connection should use. (templated)
+    :param region_name: Which AWS region the connection should use. (templated)
         If this is None or empty then the default boto3 behaviour is used.
     :param verify: Whether or not to verify SSL certificates. See:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
@@ -820,7 +804,7 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "nodegroup_name", "wait_for_completion", "aws_conn_id", "region", "region_name"
+        "cluster_name", "nodegroup_name", "wait_for_completion", "aws_conn_id", "region_name"
     )
 
     def __init__(
@@ -828,7 +812,6 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
         cluster_name: str,
         nodegroup_name: str,
         wait_for_completion: bool = False,
-        region: str | None = None,
         waiter_delay: int = 30,
         waiter_max_attempts: int = 40,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
@@ -837,7 +820,6 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
         self.cluster_name = cluster_name
         self.nodegroup_name = nodegroup_name
         self.wait_for_completion = wait_for_completion
-        self.region = region
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
@@ -889,7 +871,7 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
          running Airflow in a distributed manner and aws_conn_id is None or
          empty, then the default boto3 configuration would be used (and must be
          maintained on each worker node).
-    :param region: Which AWS region the connection should use. (templated)
+    :param region_name: Which AWS region the connection should use. (templated)
         If this is None or empty then the default boto3 behaviour is used.
     :param verify: Whether or not to verify SSL certificates. See:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
@@ -902,7 +884,7 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "fargate_profile_name", "wait_for_completion", "aws_conn_id", "region", "region_name"
+        "cluster_name", "fargate_profile_name", "wait_for_completion", "aws_conn_id", "region_name"
     )
 
     def __init__(
@@ -910,7 +892,6 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
         cluster_name: str,
         fargate_profile_name: str,
         wait_for_completion: bool = False,
-        region: str | None = None,
         waiter_delay: int = 30,
         waiter_max_attempts: int = 60,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
@@ -920,7 +901,6 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
         self.cluster_name = cluster_name
         self.fargate_profile_name = fargate_profile_name
         self.wait_for_completion = wait_for_completion
-        self.region = region
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -264,6 +264,7 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         )
 
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -499,6 +500,7 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         super().__init__(**kwargs)
 
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -630,6 +632,7 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
             **kwargs,
         )
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -732,6 +735,7 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
         super().__init__(**kwargs)
 
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -861,6 +865,7 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
         super().__init__(**kwargs)
 
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -949,6 +954,7 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
         self.deferrable = deferrable
         self.region = region
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -215,8 +215,6 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         "fargate_selectors",
         "create_fargate_profile_kwargs",
         "wait_for_completion",
-        "aws_conn_id",
-        "region_name",
     )
 
     def __init__(
@@ -457,8 +455,6 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         "nodegroup_name",
         "create_nodegroup_kwargs",
         "wait_for_completion",
-        "aws_conn_id",
-        "region_name",
     )
 
     def __init__(
@@ -579,8 +575,6 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
         "fargate_profile_name",
         "create_fargate_profile_kwargs",
         "wait_for_completion",
-        "aws_conn_id",
-        "region_name",
     )
 
     def __init__(
@@ -682,7 +676,7 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "force_delete_compute", "wait_for_completion", "aws_conn_id", "region_name"
+        "cluster_name", "force_delete_compute", "wait_for_completion"
     )
 
     def __init__(
@@ -804,7 +798,7 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "nodegroup_name", "wait_for_completion", "aws_conn_id", "region_name"
+        "cluster_name", "nodegroup_name", "wait_for_completion"
     )
 
     def __init__(
@@ -884,7 +878,7 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "fargate_profile_name", "wait_for_completion", "aws_conn_id", "region_name"
+        "cluster_name", "fargate_profile_name", "wait_for_completion"
     )
 
     def __init__(

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
@@ -146,6 +146,7 @@ class EksClusterStateSensor(EksBaseSensor):
     ):
         super().__init__(target_state=target_state, target_state_type=ClusterStates, **kwargs)
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -198,6 +199,7 @@ class EksFargateProfileStateSensor(EksBaseSensor):
         self.fargate_profile_name = fargate_profile_name
         self.region = region
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
@@ -252,6 +254,7 @@ class EksNodegroupStateSensor(EksBaseSensor):
         self.region = region
         self.nodegroup_name = nodegroup_name
         if region is not None:
+            self.region_name = region
             warnings.warn(
                 message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
@@ -18,11 +18,12 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.eks import (
     ClusterStates,
     EksHook,
@@ -132,7 +133,7 @@ class EksClusterStateSensor(EksBaseSensor):
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
 
-    template_fields: Sequence[str] = aws_template_fields("cluster_name", "target_state")
+    template_fields: Sequence[str] = aws_template_fields("cluster_name", "target_state", "region")
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
 
@@ -140,9 +141,16 @@ class EksClusterStateSensor(EksBaseSensor):
         self,
         *,
         target_state: ClusterStates = ClusterStates.ACTIVE,
+        region: str | None = None,
         **kwargs,
     ):
         super().__init__(target_state=target_state, target_state_type=ClusterStates, **kwargs)
+        if region is not None:
+            warnings.warn(
+                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                category=AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
 
     def get_state(self) -> ClusterStates:
         return self.hook.get_cluster_state(clusterName=self.cluster_name)
@@ -173,9 +181,7 @@ class EksFargateProfileStateSensor(EksBaseSensor):
     """
 
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name",
-        "fargate_profile_name",
-        "target_state",
+        "cluster_name", "fargate_profile_name", "target_state", "region"
     )
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
@@ -184,11 +190,19 @@ class EksFargateProfileStateSensor(EksBaseSensor):
         self,
         *,
         fargate_profile_name: str,
+        region: str | None = None,
         target_state: FargateProfileStates = FargateProfileStates.ACTIVE,
         **kwargs,
     ):
         super().__init__(target_state=target_state, target_state_type=FargateProfileStates, **kwargs)
         self.fargate_profile_name = fargate_profile_name
+        self.region = region
+        if region is not None:
+            warnings.warn(
+                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                category=AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
 
     def get_state(self) -> FargateProfileStates:
         return self.hook.get_fargate_profile_state(
@@ -221,9 +235,7 @@ class EksNodegroupStateSensor(EksBaseSensor):
     """
 
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name",
-        "nodegroup_name",
-        "target_state",
+        "cluster_name", "nodegroup_name", "target_state", "region"
     )
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
@@ -233,10 +245,18 @@ class EksNodegroupStateSensor(EksBaseSensor):
         *,
         nodegroup_name: str,
         target_state: NodegroupStates = NodegroupStates.ACTIVE,
+        region: str | None = None,
         **kwargs,
     ):
         super().__init__(target_state=target_state, target_state_type=NodegroupStates, **kwargs)
+        self.region = region
         self.nodegroup_name = nodegroup_name
+        if region is not None:
+            warnings.warn(
+                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                category=AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
 
     def get_state(self) -> NodegroupStates:
         return self.hook.get_nodegroup_state(clusterName=self.cluster_name, nodegroupName=self.nodegroup_name)

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Sequence
-from functools import cached_property
 from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowException
@@ -30,7 +29,8 @@ from airflow.providers.amazon.aws.hooks.eks import (
     FargateProfileStates,
     NodegroupStates,
 )
-from airflow.sensors.base import BaseSensorOperator
+from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
+from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -57,7 +57,7 @@ NODEGROUP_TERMINAL_STATES = frozenset(
 )
 
 
-class EksBaseSensor(BaseSensorOperator):
+class EksBaseSensor(AwsBaseSensor):
     """
     Base class to check various EKS states.
 
@@ -68,13 +68,16 @@ class EksBaseSensor(BaseSensorOperator):
     :param target_state_type: The enum containing the states,
         will be used to convert the target state if it has to be converted from a string
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
-        empty, then the default boto3 configuration would be used (and must be
+        empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-    :param region: Which AWS region the connection should use.
-        If this is None or empty then the default boto3 behaviour is used.
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
+
+    aws_hook_class = EksHook
 
     def __init__(
         self,
@@ -82,25 +85,14 @@ class EksBaseSensor(BaseSensorOperator):
         cluster_name: str,
         target_state: ClusterStates | NodegroupStates | FargateProfileStates,
         target_state_type: type,
-        aws_conn_id: str | None = DEFAULT_CONN_ID,
-        region: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cluster_name = cluster_name
-        self.aws_conn_id = aws_conn_id
-        self.region = region
         self.target_state = (
             target_state
             if isinstance(target_state, target_state_type)
             else target_state_type(str(target_state).upper())
-        )
-
-    @cached_property
-    def hook(self) -> EksHook:
-        return EksHook(
-            aws_conn_id=self.aws_conn_id,
-            region_name=self.region,
         )
 
     def poke(self, context: Context) -> bool:
@@ -130,16 +122,17 @@ class EksClusterStateSensor(EksBaseSensor):
 
     :param cluster_name: The name of the Cluster to watch. (templated)
     :param target_state: Target state of the Cluster. (templated)
-    :param region: Which AWS region the connection should use. (templated)
-        If this is None or empty then the default boto3 behaviour is used.
-    :param aws_conn_id: The Airflow connection used for AWS credentials. (templated)
-         If this is None or empty then the default boto3 behaviour is used. If
-         running Airflow in a distributed manner and aws_conn_id is None or
-         empty, then the default boto3 configuration would be used (and must be
-         maintained on each worker node).
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
 
-    template_fields: Sequence[str] = ("cluster_name", "target_state", "aws_conn_id", "region")
+    template_fields: Sequence[str] = aws_template_fields("cluster_name", "target_state")
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
 
@@ -169,21 +162,20 @@ class EksFargateProfileStateSensor(EksBaseSensor):
     :param cluster_name: The name of the Cluster which the AWS Fargate profile is attached to. (templated)
     :param fargate_profile_name: The name of the Fargate profile to watch. (templated)
     :param target_state: Target state of the Fargate profile. (templated)
-    :param region: Which AWS region the connection should use. (templated)
-        If this is None or empty then the default boto3 behaviour is used.
-    :param aws_conn_id: The Airflow connection used for AWS credentials. (templated)
-         If this is None or empty then the default boto3 behaviour is used. If
-         running Airflow in a distributed manner and aws_conn_id is None or
-         empty, then the default boto3 configuration would be used (and must be
-         maintained on each worker node).
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
 
-    template_fields: Sequence[str] = (
+    template_fields: Sequence[str] = aws_template_fields(
         "cluster_name",
         "fargate_profile_name",
         "target_state",
-        "aws_conn_id",
-        "region",
     )
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
@@ -218,21 +210,20 @@ class EksNodegroupStateSensor(EksBaseSensor):
     :param cluster_name: The name of the Cluster which the Nodegroup is attached to. (templated)
     :param nodegroup_name: The name of the Nodegroup to watch. (templated)
     :param target_state: Target state of the Nodegroup. (templated)
-    :param region: Which AWS region the connection should use. (templated)
-        If this is None or empty then the default boto3 behaviour is used.
-    :param aws_conn_id: The Airflow connection used for AWS credentials. (templated)
-         If this is None or empty then the default boto3 behaviour is used. If
-         running Airflow in a distributed manner and aws_conn_id is None or
-         empty, then the default boto3 configuration would be used (and must be
-         maintained on each worker node).
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
 
-    template_fields: Sequence[str] = (
+    template_fields: Sequence[str] = aws_template_fields(
         "cluster_name",
         "nodegroup_name",
         "target_state",
-        "aws_conn_id",
-        "region",
     )
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
@@ -368,7 +368,7 @@ class TestEksCreateClusterOperator:
 
     def test_template_fields(self):
         op = EksCreateClusterOperator(
-            task_id=TASK_ID, **self.create_cluster_params, compute="fargate", region="us-east-1"
+            task_id=TASK_ID, **self.create_cluster_params, compute="fargate", region_name="us-east-1"
         )
 
         validate_template_fields(op)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
@@ -368,9 +368,7 @@ class TestEksCreateClusterOperator:
 
     def test_template_fields(self):
         op = EksCreateClusterOperator(
-            task_id=TASK_ID,
-            **self.create_cluster_params,
-            compute="fargate",
+            task_id=TASK_ID, **self.create_cluster_params, compute="fargate", region="us-east-1"
         )
 
         validate_template_fields(op)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
@@ -23,7 +23,7 @@ from unittest import mock
 import pytest
 from botocore.waiter import Waiter
 
-from airflow.exceptions import TaskDeferred
+from airflow.exceptions import AirflowProviderDeprecationWarning, TaskDeferred
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EksHook
 from airflow.providers.amazon.aws.operators.eks import (
     EksCreateClusterOperator,
@@ -338,6 +338,16 @@ class TestEksCreateClusterOperator:
         ):
             missing_fargate_pod_execution_role_arn.execute({})
 
+    def test_init_with_region(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+            m.operator = EksCreateClusterOperator(
+                task_id=TASK_ID,
+                **self.create_cluster_params,
+                compute=None,
+                region="us-east-2",
+            )
+        assert m.operator.region_name == "us-east-2"
+
     @mock.patch.object(EksHook, "create_cluster")
     def test_eks_create_cluster_short_circuit_early(self, mock_create_cluster, caplog):
         mock_create_cluster.return_value = None
@@ -458,6 +468,15 @@ class TestEksCreateFargateProfileOperator:
 
         validate_template_fields(op)
 
+    def test_init_with_region(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+            m.operator = EksCreateFargateProfileOperator(
+                task_id=TASK_ID,
+                **self.create_fargate_profile_params,
+                region="us-east-2",
+            )
+        assert m.operator.region_name == "us-east-2"
+
 
 class TestEksCreateNodegroupOperator:
     def setup_method(self) -> None:
@@ -555,6 +574,17 @@ class TestEksCreateNodegroupOperator:
 
         validate_template_fields(op)
 
+    def test_init_with_region(self):
+        op_kwargs = {**self.create_nodegroup_params}
+
+        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+            m.operator = EksCreateNodegroupOperator(
+                task_id=TASK_ID,
+                **op_kwargs,
+                region="us-east-2",
+            )
+        assert m.operator.region_name == "us-east-2"
+
 
 class TestEksDeleteClusterOperator:
     def setup_method(self) -> None:
@@ -597,6 +627,13 @@ class TestEksDeleteClusterOperator:
     def test_template_fields(self):
         validate_template_fields(self.delete_cluster_operator)
 
+    def test_init_with_region(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+            m.operator = EksDeleteClusterOperator(
+                task_id=TASK_ID, cluster_name=self.cluster_name, region="us-east-2"
+            )
+        assert m.operator.region_name == "us-east-2"
+
 
 class TestEksDeleteNodegroupOperator:
     def setup_method(self) -> None:
@@ -632,6 +669,16 @@ class TestEksDeleteNodegroupOperator:
 
     def test_template_fields(self):
         validate_template_fields(self.delete_nodegroup_operator)
+
+    def test_init_with_region(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+            m.operator = EksDeleteNodegroupOperator(
+                task_id=TASK_ID,
+                cluster_name=self.cluster_name,
+                nodegroup_name=self.nodegroup_name,
+                region="us-east-2",
+            )
+        assert m.operator.region_name == "us-east-2"
 
 
 class TestEksDeleteFargateProfileOperator:
@@ -683,6 +730,16 @@ class TestEksDeleteFargateProfileOperator:
 
     def test_template_fields(self):
         validate_template_fields(self.delete_fargate_profile_operator)
+
+    def test_init_with_region(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+            m.operator = EksDeleteFargateProfileOperator(
+                task_id=TASK_ID,
+                cluster_name=self.cluster_name,
+                fargate_profile_name=self.fargate_profile_name,
+                region="us-east-2",
+            )
+        assert m.operator.region_name == "us-east-2"
 
 
 class TestEksPodOperator:

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_eks.py
@@ -105,6 +105,7 @@ class TestEksClusterStateSensor:
         assert str(raised_exception.value) == expected_message
         mock_get_cluster_state.assert_called_once_with(clusterName=CLUSTER_NAME)
 
+    @pytest.mark.db_test
     def test_region_argument(self):
         with pytest.warns(AirflowProviderDeprecationWarning) as w:
             w.sensor = EksClusterStateSensor(
@@ -128,6 +129,7 @@ class TestEksFargateProfileStateSensor:
             target_state=self.target_state,
         )
 
+    @pytest.mark.db_test
     def test_region_argument(self):
         with pytest.warns(AirflowProviderDeprecationWarning) as w:
             w.sensor = EksFargateProfileStateSensor(
@@ -187,6 +189,7 @@ class TestEksNodegroupStateSensor:
             target_state=self.target_state,
         )
 
+    @pytest.mark.db_test
     def test_region_argument(self):
         with pytest.warns(AirflowProviderDeprecationWarning) as w:
             w.sensor = EksNodegroupStateSensor(

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_eks.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.eks import (
     ClusterStates,
     EksHook,
@@ -105,6 +105,17 @@ class TestEksClusterStateSensor:
         assert str(raised_exception.value) == expected_message
         mock_get_cluster_state.assert_called_once_with(clusterName=CLUSTER_NAME)
 
+    def test_region_argument(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as w:
+            w.sensor = EksClusterStateSensor(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                target_state=self.target_state,
+                aws_conn_id="test_conn_id",
+                region="us-east-1",
+            )
+        assert w.sensor.hook.region_name == "us-east-1"
+
 
 class TestEksFargateProfileStateSensor:
     @pytest.fixture(autouse=True)
@@ -116,6 +127,17 @@ class TestEksFargateProfileStateSensor:
             fargate_profile_name=FARGATE_PROFILE_NAME,
             target_state=self.target_state,
         )
+
+    def test_region_argument(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as w:
+            w.sensor = EksFargateProfileStateSensor(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                fargate_profile_name=FARGATE_PROFILE_NAME,
+                target_state=self.target_state,
+                region="us-east-2",
+            )
+        assert w.sensor.region_name == "us-east-2"
 
     @mock.patch.object(EksHook, "get_fargate_profile_state", return_value=FargateProfileStates.ACTIVE)
     def test_poke_reached_target_state(self, mock_get_fargate_profile_state):
@@ -164,6 +186,17 @@ class TestEksNodegroupStateSensor:
             nodegroup_name=NODEGROUP_NAME,
             target_state=self.target_state,
         )
+
+    def test_region_argument(self):
+        with pytest.warns(AirflowProviderDeprecationWarning) as w:
+            w.sensor = EksNodegroupStateSensor(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                nodegroup_name=NODEGROUP_NAME,
+                target_state=self.target_state,
+                region="us-east-2",
+            )
+        assert w.sensor.region_name == "us-east-2"
 
     @mock.patch.object(EksHook, "get_nodegroup_state", return_value=NodegroupStates.ACTIVE)
     def test_poke_reached_target_state(self, mock_get_nodegroup_state):


### PR DESCRIPTION

---
Updated EKS operators and sensors to inherit AWS base classes. Not, the existing operators allowed `region` as a template field. This is now changed to `region_name`.

Partially address #35278 