### PR TITLE
Remove experiment part from resolve all conversations requirement for PRs

### DIFF
--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -48,8 +48,7 @@ these guidelines:
 -   Maintainers will not merge a PR that regresses linting or does not pass CI tests (unless you have good
     justification that it a transient error or something that is being fixed in other PR).
 
--   Maintainers will not merge PRs that have unresolved conversation. Note! This is experimental - to be
-    assessed at the end of January 2024 if we want to continue it.
+-   Maintainers will not merge PRs that have unresolved conversation.
 
 -   We prefer that you ``rebase`` your PR (and do it quite often) rather than merge. It leads to
     easier reviews and cleaner changes where you know exactly what changes you've done. You can learn more
@@ -101,23 +100,20 @@ these guidelines:
 -   Adhere to guidelines for commit messages described in this `article <https://cbea.ms/git-commit/>`__.
     This makes the lives of those who come after you (and your future self) a lot easier.
 
-Experimental Requirement to resolve all conversations
------------------------------------------------------
+Requirement to resolve all conversations
+----------------------------------------
 
-In December 2023 we enabled - experimentally - the requirement to resolve all the open conversations in a
+We have decided to enable the requirement to resolve all the open conversations in a
 PR in order to make it merge-able. You will see in the status of the PR that it needs to have all the
 conversations resolved before it can be merged.
 
-This is an experiment and we will evaluate by the end of January 2024. If it turns out to be a good idea,
-we will keep it enabled in the future.
-
-The goal of this experiment is to make it easier to see when there are some conversations that are not
+The goal is to make it easier to see when there are some conversations that are not
 resolved for everyone involved in the PR - author, reviewers and maintainers who try to figure out if
 the PR is ready to merge and - eventually - merge it. The goal is also to use conversations more as a "soft" way
 to request changes and limit the use of ``Request changes`` status to only those cases when the maintainer
-is sure that the PR should not be merged in the current state. That should lead to faster review/merge
+is sure that the PR should not be merged in the current state. This leads to faster review/merge
 cycle and less problems with stalled PRs that have ``Request changes`` status but all the issues are
-already solved (assuming that maintainers will start treating the conversations this way).
+already solved.
 
 .. _coding_style:
 


### PR DESCRIPTION
This PR is an initial part of taking the LAZY CONSENSUS decision on approving and accepting the results of the "Requirement to resolve all conversations" experiment mentioned in the pull requests contributing docs.

Removing all the "experiment" parts from rational about this requirement.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
