### PR TITLE
Add option in auth managers to specify DB manager

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -464,6 +464,15 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         """
         return []
 
+    @staticmethod
+    def get_db_manager() -> str | None:
+        """
+        Specify the DB manager path needed to run the auth manager.
+
+        This is optional and not all auth managers require a DB manager.
+        """
+        return None
+
     @classmethod
     @cache
     def _get_token_signer(

--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -23,6 +23,7 @@ from alembic import command
 from sqlalchemy import inspect
 
 from airflow import settings
+from airflow.api_fastapi.app import create_auth_manager
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -144,6 +145,12 @@ class RunDBManager(LoggingMixin):
         super().__init__()
         self._managers: list[BaseDBManager] = []
         managers = conf.get("database", "external_db_managers").split(",")
+
+        # Add DB manager specified by auth manager (if any)
+        auth_manager_db_manager = create_auth_manager().get_db_manager()
+        if auth_manager_db_manager and auth_manager_db_manager not in managers:
+            managers.append(auth_manager_db_manager)
+
         for module in managers:
             manager = import_string(module)
             self._managers.append(manager)

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -171,6 +171,9 @@ class TestBaseAuthManager:
     def test_get_extra_menu_items_return_empty_list(self, auth_manager):
         assert auth_manager.get_extra_menu_items(user=BaseAuthManagerUserTest(name="test")) == []
 
+    def test_get_db_manager_return_none(self, auth_manager):
+        assert auth_manager.get_db_manager() is None
+
     @patch.object(EmptyAuthManager, "filter_authorized_menu_items")
     def test_get_authorized_menu_items(self, mock_filter_authorized_menu_items, auth_manager):
         user = BaseAuthManagerUserTest(name="test")

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -521,6 +521,10 @@ class FabAuthManager(BaseAuthManager[User]):
             if self._is_authorized(method="MENU", resource_type=item["resource_type"], user=user)
         ]
 
+    @staticmethod
+    def get_db_manager() -> str | None:
+        return "airflow.providers.fab.auth_manager.models.db.FABDBManager"
+
     def _is_authorized(
         self,
         *,

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -629,3 +629,7 @@ class TestFabAuthManager:
         result = auth_manager_with_appbuilder.get_extra_menu_items(user=Mock())
         assert len(result) == 5
         assert all(item.href.startswith(AUTH_MANAGER_FASTAPI_APP_PREFIX) for item in result)
+
+    def test_get_db_manager(self, auth_manager):
+        result = auth_manager.get_db_manager()
+        assert result == "airflow.providers.fab.auth_manager.models.db.FABDBManager"


### PR DESCRIPTION
Follow of https://github.com/apache/airflow/pull/48070#pullrequestreview-2706671742.

Some auth manager require a DB manager to be used in the environment. Instead of delegating this to users to set the correct DB manager in the config, the auth manager can set it directly.

Example: if one uses FAB auth manager, `FABDBManager` needs to be configured. With this change, the user does not need to add `FABDBManager` as part of `[database] external_db_managers`, the auth manager does it automatically.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
