### PR TITLE
feat: Add fail_when_dag_is_paused param to TriggerDagRunOperator

### DIFF
--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -246,6 +246,17 @@ class AirflowTimetableInvalid(AirflowException):
     """Raise when a DAG has an invalid timetable."""
 
 
+class DagIsPaused(AirflowException):
+    """Raise when a DAG is paused and something tries to run it."""
+
+    def __init__(self, dag_id: str) -> None:
+        super().__init__(dag_id)
+        self.dag_id = dag_id
+
+    def __str__(self) -> str:
+        return f"DAG {self.dag_id} is paused"
+
+
 class DagNotFound(AirflowNotFoundException):
     """Raise when a DAG is not available in the system."""
 

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -247,14 +247,14 @@ class AirflowTimetableInvalid(AirflowException):
 
 
 class DagIsPaused(AirflowException):
-    """Raise when a DAG is paused and something tries to run it."""
+    """Raise when a dag is paused and something tries to run it."""
 
     def __init__(self, dag_id: str) -> None:
         super().__init__(dag_id)
         self.dag_id = dag_id
 
     def __str__(self) -> str:
-        return f"DAG {self.dag_id} is paused"
+        return f"Dag {self.dag_id} is paused"
 
 
 class DagNotFound(AirflowNotFoundException):

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -31,6 +31,7 @@ from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
     AirflowSkipException,
+    DagIsPaused,
     DagNotFound,
     DagRunAlreadyExists,
 )
@@ -131,7 +132,7 @@ class TriggerDagRunOperator(BaseOperator):
         Default is ``[DagRunState.FAILED]``.
     :param skip_when_already_exists: Set to true to mark the task as SKIPPED if a DAG run of the triggered
         DAG for the same logical date already exists.
-    :param fail_when_dag_is_paused: If the DAG to trigger is paused, fail the task.
+    :param fail_when_dag_is_paused: If the dag to trigger is paused, DagIsPaused will be raised.
     :param deferrable: If waiting for completion, whether or not to defer the task until done,
         default is ``False``.
     """
@@ -222,7 +223,7 @@ class TriggerDagRunOperator(BaseOperator):
         if self.fail_when_dag_is_paused:
             dag_model = DagModel.get_current(self.trigger_dag_id)
             if dag_model.is_paused:
-                raise AirflowException(f"Dag id {self.trigger_dag_id} is paused")
+                raise DagIsPaused(dag_id=self.trigger_dag_id)
 
         if AIRFLOW_V_3_0_PLUS:
             self._trigger_dag_af_3(context=context, run_id=run_id, parsed_logical_date=parsed_logical_date)

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -25,7 +25,7 @@ import pytest
 import time_machine
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, DagRunAlreadyExists, TaskDeferred
+from airflow.exceptions import AirflowException, DagIsPaused, DagRunAlreadyExists, TaskDeferred
 from airflow.models.dag import DagModel
 from airflow.models.dagrun import DagRun
 from airflow.models.log import Log
@@ -751,5 +751,5 @@ class TestDagRunOperatorAF2:
                 fail_when_dag_is_paused=True,
             )
         dag_maker.create_dagrun()
-        with pytest.raises(AirflowException, match=f"^Dag id {TRIGGERED_DAG_ID} is paused$"):
+        with pytest.raises(DagIsPaused, match=f"^DAG {TRIGGERED_DAG_ID} is paused$"):
             task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -737,7 +737,7 @@ class TestDagRunOperatorAF2:
         assert mock_task_defer.call_args_list[1].kwargs["trigger"].run_ids == [run_id]
 
     def test_trigger_dagrun_with_fail_when_dag_is_paused(self, dag_maker):
-        """Test TriggerDagRunOperator with skip_when_already_exists."""
+        """Test TriggerDagRunOperator with fail_when_dag_is_paused set to True."""
         self.dag_model.set_is_paused(True)
 
         with dag_maker(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

---
Add an optional parameter to `TriggerDagRunOperator` to allow it to check if the triggered DAG is in a Paused state, and if so then fail the task.

