### PR TITLE
add nbconvert to papermill operator

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1096,6 +1096,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "ipykernel>=6.29.4",
+      "nbconvert>=7.16.1",
       "pandas>=2.1.2,<2.2",
       "papermill[all]>=2.6.0",
       "scrapbook[all]>=0.5.0"

--- a/providers/papermill/README.rst
+++ b/providers/papermill/README.rst
@@ -58,6 +58,7 @@ PIP package         Version required
 ``scrapbook[all]``  ``>=0.5.0``
 ``ipykernel``       ``>=6.29.4``
 ``pandas``          ``>=2.1.2,<2.2``
+``nbconvert``       ``>=7.16.1``
 ==================  ==================
 
 Cross provider package dependencies

--- a/providers/papermill/pyproject.toml
+++ b/providers/papermill/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "scrapbook[all]>=0.5.0",
     "ipykernel>=6.29.4",
     "pandas>=2.1.2,<2.2",
+    "nbconvert>=7.16.1",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/papermill/src/airflow/providers/papermill/get_provider_info.py
+++ b/providers/papermill/src/airflow/providers/papermill/get_provider_info.py
@@ -89,6 +89,7 @@ def get_provider_info():
             "scrapbook[all]>=0.5.0",
             "ipykernel>=6.29.4",
             "pandas>=2.1.2,<2.2",
+            "nbconvert>=7.16.1",
         ],
         "optional-dependencies": {"common.compat": ["apache-airflow-providers-common-compat"]},
         "devel-dependencies": [],


### PR DESCRIPTION
Nbconvert is quite often used after papermill from by own experience. 
I am thinking if we can add the nbconvert args in papermill operator so that we can output an HTML directly after calling the operator.

Example usage:
<img width="484" alt="Screenshot 2025-03-25 at 10 29 52 AM" src="https://github.com/user-attachments/assets/22acc279-68c1-4289-916f-457189e4f700" />



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
