### PR TITLE
Disallowing kylinpy 2.7.0 as it contains invalid pypi metadata

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -235,7 +235,7 @@
   "apache.kylin": {
     "deps": [
       "apache-airflow>=2.9.0",
-      "kylinpy>=2.7.0"
+      "kylinpy>2.7.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/apache/kylin/README.rst
+++ b/providers/apache/kylin/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.9.0``
-``kylinpy``         ``>=2.7.0``
+``kylinpy``         ``>2.7.0``
 ==================  ==================
 
 The changelog for the provider package can be found in the

--- a/providers/apache/kylin/pyproject.toml
+++ b/providers/apache/kylin/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.9.0",
-    "kylinpy>=2.7.0",
+    "kylinpy>2.7.0",
 ]
 
 [dependency-groups]

--- a/providers/apache/kylin/src/airflow/providers/apache/kylin/get_provider_info.py
+++ b/providers/apache/kylin/src/airflow/providers/apache/kylin/get_provider_info.py
@@ -76,6 +76,6 @@ def get_provider_info():
                 "connection-type": "kylin",
             }
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "kylinpy>=2.7.0"],
+        "dependencies": ["apache-airflow>=2.9.0", "kylinpy>2.7.0"],
         "devel-dependencies": [],
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

kylinpy 2.7.0 has a bad metadata on pypi as reported here: https://github.com/apache/airflow/actions/runs/14044194114/job/39321485583

Diasllowing that version. I also wonder if we need to bump since this version was from May 2020.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
