### PR TITLE
Document working with "sqlalchemy>0.2.0" in virtualenvs and the induced side-effects

### DIFF
--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -1005,6 +1005,9 @@ The drawbacks:
   but even that library does not solve all the serialization limitations.
 * All dependencies that are not available in Airflow environment must be locally imported in the callable you
   use and the top-level Python code of your DAG should not import/use those libraries.
+* Calling a dependency which is not compatible with Airflow's own might (or not) end up with conflicts. For
+  instance, using ``"sqlalchemy>2.0.0"`` might cause havoc with Airflow's `Variable` retrieval (depending on
+  the way those were set).
 * The virtual environments are run in the same operating system, so they cannot have conflicting system-level
   dependencies (``apt`` or ``yum`` installable packages). Only Python dependencies can be independently
   installed in those environments

--- a/docs/apache-airflow/tutorial/taskflow.rst
+++ b/docs/apache-airflow/tutorial/taskflow.rst
@@ -274,6 +274,21 @@ Example (dynamically created virtualenv):
     :start-after: [START howto_operator_python_venv]
     :end-before: [END howto_operator_python_venv]
 
+.. note::
+
+   A very specific usecase is worth documenting here on the handling of ``"sqlalchemy>2.0.0"`` dependency. 
+   As of yet, this dependency (a notorious requirement for the latest versions of the ``pandas`` library, for instance)
+   is **not** compatible with Airflow itself.
+
+   In that case, you *can* set it to a virtualenv, but there **will** be side effects in Airflow.
+   Fortunately, most of the time there will be no impact on your code. Notorious side effects will be documented
+   here ; as this is kind of an off-road exploration, this cannot be an extensive documentation. If you encounter
+   other side effects, please consider adding to the present documentation.
+
+   * impact on ``airflow.models.Variables`` : you will not be able to retrieve variables set with the 
+     ``Variable.set("eggs", "spam")`` command. Instead, please commit your variables using ``os.environ["AIRFLOW_VAR_EGGS"] = "spam"``.
+
+
 Using Python environment with pre-installed dependencies
 ........................................................
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
As discussed in https://github.com/apache/airflow/discussions/46266 there are (and will be more) usecases for `sqlalchemy>0.2.0` usage. As far as I know, this will stay there untill Airflow 3 is released. Until then, (I think) there is a good point for documenting on how to deal with this, even if this is **not** intended behaviour: `pandas` for instance cannot work with Airflow as of yet.

The current PR :

* adds a general warning on using dependencies in a virtualenv which are not compatible with airflow (this subject was not documented yet I think)
* adds a note in the virtualenv tutorial listing the known side effects to using sqlalchemy>0.2.0.