### PR TITLE
Bump min version of aiobotocore

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -141,7 +141,7 @@ dependencies = [
 # TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
 # boto3 have native aync support and we move away from aio aiobotocore
 "aiobotocore" =  [
-    "aiobotocore>=2.9.0",
+    "aiobotocore>=2.13.0",
 ]
 "async" = [
     "eventlet>=0.33.3",


### PR DESCRIPTION
fixing https://github.com/apache/airflow/actions/runs/14054019633

The issue seems to come from backtracking of aiobotocore due to install of Airflow aiobotocore extra

` pip install --root-user-action ignore 'apache-airflow[aiobotocore,amazon,...]`
 The minimal version in this extra is 2.9.0 

```
 Downloading aioitertools-0.12.0-py3-none-any.whl.metadata (3.8 kB)
  #61 42.21 INFO: pip is looking at multiple versions of aiobotocore to determine which version is compatible with other requirements. This could take a while.
  #61 42.22 Collecting aiobotocore>=2.9.0 (from apache-airflow-core@ file:///docker-context-files/apache_airflow_core-3.0.0.dev0-py3-none-any.whl)
  #61 42.23   Downloading aiobotocore-2.21.0-py3-none-any.whl.metadata (24 kB)
  #61 42.25   Downloading aiobotocore-2.20.0-py3-none-any.whl.metadata (23 kB)
  #61 42.42   Downloading aiobotocore-2.19.0-py3-none-any.whl.metadata (23 kB)
  #61 42.60   Downloading aiobotocore-2.18.0-py3-none-any.whl.metadata (23 kB)
  #61 42.80   Downloading aiobotocore-2.17.0-py3-none-any.whl.metadata (23 kB)
  #61 42.98   Downloading aiobotocore-2.16.1-py3-none-any.whl.metadata (23 kB)
  #61 43.19   Downloading aiobotocore-2.16.0-py3-none-any.whl.metadata (23 kB)
  #61 43.36 INFO: pip is still looking at multiple versions of aiobotocore to determine which version is compatible with other requirements. This could take a while.
  #61 43.37   Downloading aiobotocore-2.15.2-py3-none-any.whl.metadata (23 kB)
  #61 43.59   Downloading aiobotocore-2.15.1-py3-none-any.whl.metadata (23 kB)
  #61 43.81   Downloading aiobotocore-2.15.0-py3-none-any.whl.metadata (23 kB)
  #61 44.03   Downloading aiobotocore-2.14.0-py3-none-any.whl.metadata (23 kB)
  #61 44.22   Downloading aiobotocore-2.13.3-py3-none-any.whl.metadata (22 kB)
  #61 44.42 INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See 
https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
```


I bumped min version of this extra to 2.13.0 to match the version in Amazon provider.
Larger question is: why do we keep this extra in Airflow 3?