### PR TITLE
fix pre_commit version typo

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -230,8 +230,8 @@ def assert_pre_commit_installed():
                     )
                 else:
                     get_console().print(
-                        f"\n[error]Package name pre_commit version is wrong. It should be"
-                        f"aat least {min_pre_commit_version} and is {pre_commit_version}.[/]\n\n"
+                        f"\n[error]Package name pre_commit version is wrong. It should be "
+                        f"at least {min_pre_commit_version} and is {pre_commit_version}.[/]\n\n"
                     )
                     sys.exit(1)
                 if "pre-commit-uv" not in command_result.stdout:


### PR DESCRIPTION
fix the error that appears like:
`Package name pre_commit version is wrong. It should beaat least 3.2.0 and is 2.20.0.
`