### PR TITLE
Bump minimum boto3 version to 1.37.0

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -31,7 +31,7 @@
       "apache-airflow-providers-http",
       "apache-airflow>=2.9.0",
       "asgiref>=2.3.0",
-      "boto3>=1.34.90",
+      "boto3>=1.37.0",
       "botocore>=1.34.90",
       "inflection>=0.5.1",
       "jmespath>=0.7.0",

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -57,7 +57,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.3.0``
 ``apache-airflow-providers-common-sql``     ``>=1.20.0``
 ``apache-airflow-providers-http``
-``boto3``                                   ``>=1.34.90``
+``boto3``                                   ``>=1.37.0``
 ``botocore``                                ``>=1.34.90``
 ``inflection``                              ``>=0.5.1``
 ``watchtower``                              ``>=3.0.0,!=3.3.0,<4``

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     # We should update minimum version of boto3 and here regularly to avoid `pip` backtracking with the number
     # of candidates to consider. Make sure to configure boto3 version here as well as in all the tools below
     # in the `devel-dependencies` section to be the same minimum version.
-    "boto3>=1.34.90",
+    "boto3>=1.37.0",
     "botocore>=1.34.90",
     "inflection>=0.5.1",
     # Allow a wider range of watchtower versions for flexibility among users

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1375,7 +1375,7 @@ def get_provider_info():
             "apache-airflow-providers-common-compat>=1.3.0",
             "apache-airflow-providers-common-sql>=1.20.0",
             "apache-airflow-providers-http",
-            "boto3>=1.34.90",
+            "boto3>=1.37.0",
             "botocore>=1.34.90",
             "inflection>=0.5.1",
             "watchtower>=3.0.0,!=3.3.0,<4",


### PR DESCRIPTION
following https://github.com/apache/airflow/pull/48236
the underlying issue is that boto3 has 150+ releases since 1.34.90 so we need to bump min version to avoid `ResolutionTooDeep` errors like:
`pip._vendor.resolvelib.resolvers.ResolutionTooDeep: 200000`in the cases pip backtrack to find matching versions