### PR TITLE
Block orm access on deprecated AIRFLOW__CORE__SQL_ALCHEMY_CONN

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -272,6 +272,7 @@ def block_orm_access():
         settings.SQL_ALCHEMY_CONN_ASYNC = conn
 
     os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = conn
+    os.environ["AIRFLOW__CORE__SQL_ALCHEMY_CONN"] = conn
 
 
 def _fork_main(


### PR DESCRIPTION
Adding the deprecated config to the block. 

Testing dag (this task should fail):

```
from airflow.decorators import dag, task


@dag 
def my_test_dag():

    @task 
    def my_direct_db_access_task():
        from sqlalchemy import create_engine
        from sqlalchemy.orm import Session
        import os

        sql_alchemy_conn = os.environ["AIRFLOW__CORE__SQL_ALCHEMY_CONN"]

        conn_url = f"{sql_alchemy_conn}/postgres"

        engine = create_engine(conn_url)

        stmt = """SELECT version_num
                FROM alembic_version;"""

        with Session(engine) as session:
            result = session.execute(stmt)
            print(result.all()[0][0])

    my_direct_db_access_task()


my_test_dag()
```
