### PR TITLE
Correctly serialize objects inherited from Task SDK's BaseOperator

### DIFF
--- a/airflow-core/src/airflow/models/baseoperator.py
+++ b/airflow-core/src/airflow/models/baseoperator.py
@@ -31,7 +31,6 @@ from datetime import datetime, timedelta
 from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Any
 
-import methodtools
 import pendulum
 from sqlalchemy import select
 from sqlalchemy.orm.exc import NoResultFound
@@ -321,9 +320,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
                 hello_world_task.execute(context)
     """
 
-    start_trigger_args: StartTriggerArgs | None = None
-    start_from_trigger: bool = False
-
     def __init__(self, **kwargs):
         if start_date := kwargs.get("start_date", None):
             kwargs["start_date"] = timezone.convert_to_utc(start_date)
@@ -344,14 +340,6 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
         def dag(self, val: SchedulerDAG):
             # For type checking only
             ...
-
-    @classmethod
-    @methodtools.lru_cache(maxsize=None)
-    def get_serialized_fields(cls):
-        """Stringified DAGs and operators contain exactly these fields."""
-        # TODO: this ends up caching it once per-subclass, which isn't what we want, but this class is only
-        # kept around during the development of AIP-72/TaskSDK code.
-        return TaskSDKBaseOperator.get_serialized_fields() | {"start_trigger_args", "start_from_trigger"}
 
     def get_inlet_defs(self):
         """

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -642,7 +642,7 @@ class BaseSerialization:
     @classmethod
     def serialize_to_json(
         cls,
-        object_to_serialize: BaseOperator | MappedOperator | DAG,
+        object_to_serialize: TaskSDKBaseOperator | MappedOperator | DAG,
         decorated_fields: set,
     ) -> dict[str, Any]:
         """Serialize an object to JSON."""
@@ -726,7 +726,7 @@ class BaseSerialization:
             return var.to_dict()
         elif isinstance(var, MappedOperator):
             return cls._encode(SerializedBaseOperator.serialize_mapped_operator(var), type_=DAT.OP)
-        elif isinstance(var, BaseOperator):
+        elif isinstance(var, TaskSDKBaseOperator):
             var._needs_expansion = var.get_needs_expansion()
             return cls._encode(SerializedBaseOperator.serialize_operator(var), type_=DAT.OP)
         elif isinstance(var, cls._datetime_types):
@@ -1275,11 +1275,11 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         return serialized_op
 
     @classmethod
-    def serialize_operator(cls, op: BaseOperator | MappedOperator) -> dict[str, Any]:
+    def serialize_operator(cls, op: TaskSDKBaseOperator | MappedOperator) -> dict[str, Any]:
         return cls._serialize_node(op)
 
     @classmethod
-    def _serialize_node(cls, op: BaseOperator | MappedOperator) -> dict[str, Any]:
+    def _serialize_node(cls, op: TaskSDKBaseOperator | MappedOperator) -> dict[str, Any]:
         """Serialize operator into a JSON object."""
         serialize_op = cls.serialize_to_json(op, cls._decorated_fields)
 

--- a/task-sdk/src/airflow/sdk/definitions/baseoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/baseoperator.py
@@ -83,7 +83,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.serialization.enums import DagAttributeTypes
     from airflow.task.priority_strategy import PriorityWeightStrategy
-    from airflow.triggers.base import BaseTrigger
+    from airflow.triggers.base import BaseTrigger, StartTriggerArgs
     from airflow.typing_compat import Self
     from airflow.utils.operator_resources import Resources
 
@@ -922,9 +922,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     # Set to True for an operator instantiated by a mapped operator.
     __from_mapped: bool = False
 
-    # TODO:
-    # start_trigger_args: StartTriggerArgs | None = None
-    # start_from_trigger: bool = False
+    start_trigger_args: StartTriggerArgs | None = None
+    start_from_trigger: bool = False
 
     # base list which includes all the attrs that don't need deep copy.
     _base_operator_shallow_copy_attrs: Final[tuple[str, ...]] = (


### PR DESCRIPTION
Before:

```
(Pdbr) dag.data["dag"]["tasks"][0]
'<Task(TimeDeltaSensorAsync): wait>'
```

After:

```
(Pdbr) dag.data["dag"]["tasks"][0]
    {
        '__var': {
            'start_from_trigger': False,
            'pool': 'default_pool',
            'ui_color': '#e6f1f2',
            'is_teardown': False,
            'task_id': 'wait',
            '_needs_expansion': False,
            'on_failure_fail_dagrun': False,
            'template_fields': [],
            'reschedule': False,
            'weight_rule': 'downstream',
            'template_ext': [],
            'downstream_task_ids': ['finish'],
            'is_setup': False,
            'ui_fgcolor': '#000',
            'template_fields_renderers': {},
            '_is_sensor': True,
            'task_type': 'TimeDeltaSensorAsync',
            '_task_module': 'airflow.providers.standard.sensors.time_delta',
            '_is_empty': False,
            '_can_skip_downstream': False,
            'start_trigger_args': None
        },
        '__type': 'operator'
    },
```


This would have shown up in DAG Processor logs as following:

```
[2025-03-25T14:19:20.543+0000] {dag_processor_job_runner.py:63} ERROR - Exception when executing DagProcessorJob
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/jobs/dag_processor_job_runner.py", line 61, in _execute
    self.processor.run()
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/manager.py", line 253, in run
    return self._run_parsing_loop()
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/manager.py", line 342, in _run_parsing_loop
    self._collect_results()
  File "/opt/airflow/airflow-core/src/airflow/utils/session.py", line 101, in wrapper
    return func(*args, session=session, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/manager.py", line 785, in _collect_results
    self._file_stats[file] = process_parse_results(
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/manager.py", line 1106, in process_parse_results
    update_dag_parsing_results_in_db(
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/collection.py", line 326, in update_dag_parsing_results_in_db
    for attempt in run_with_db_retries(logger=log):
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 443, in __iter__
    do = self.iter(retry_state=retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 376, in iter
    result = action(retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/collection.py", line 336, in update_dag_parsing_results_in_db
    DAG.bulk_write_to_db(bundle_name, bundle_version, dags, session=session)
  File "/opt/airflow/airflow-core/src/airflow/utils/session.py", line 98, in wrapper
    return func(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/models/dag.py", line 1872, in bulk_write_to_db
    dag_op.update_dags(orm_dags, session=session)
  File "/opt/airflow/airflow-core/src/airflow/dag_processing/collection.py", line 426, in update_dags
    dm.is_active = True
  File "/opt/airflow/airflow-core/src/airflow/serialization/serialized_objects.py", line 1966, in owner
    set(filter(None, (task[Encoding.VAR].get("owner") for task in self.data["dag"]["tasks"])))
  File "/opt/airflow/airflow-core/src/airflow/serialization/serialized_objects.py", line 1966, in <genexpr>
    set(filter(None, (task[Encoding.VAR].get("owner") for task in self.data["dag"]["tasks"])))
TypeError: string indices must be integers
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
