### PR TITLE
Fix error from BashOperator tasks from clean_in_fork

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -390,9 +390,10 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
 
     # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork
     def clean_in_fork():
-        if engine:
+        _globals = globals()
+        if engine := _globals.get("engine"):
             engine.dispose(close=False)
-        if async_engine:
+        if async_engine := _globals.get("async_engine"):
             async_engine.sync_engine.dispose(close=False)
 
     os.register_at_fork(after_in_child=clean_in_fork)


### PR DESCRIPTION
Since a bashoperator does fork+exec, the clean_in_fork process gets called
again just before bash is invoked, and it was failing if the cleanup had
already happened.

The error we saw was this:

```
{"timestamp":"2025-03-25T14:47:40.633847Z","level":"error","event":"  File \"/usr/local/lib/python3.11/site-packages/airflow/settings.py\", line 393, in clean_in_fork","chan":"stderr","logger":"task"}
{"timestamp":"2025-03-25T14:47:40.633862Z","level":"error","event":"    if engine:","chan":"stderr","logger":"task"}
{"timestamp":"2025-03-25T14:47:40.633880Z","level":"error","event":"       ^^^^^^","chan":"stderr","logger":"task"}
{"timestamp":"2025-03-25T14:47:40.633898Z","level":"error","event":"NameError: name 'engine' is not defined","chan":"stderr","logger":"task"}
```
