### PR TITLE
Change version handling in provider documentation to packaging version

### DIFF
--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -135,6 +135,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: afd9da2026a8ef459e604a86236da3295475a883c9479a87746635b9790aa2eaa2e678aa06ea3522d9e3f93c88b172ba4914d707800c060c6d003eb68ea1e415
+Package config hash: 9d5c8788a7125a0db14fdfbe8a6a1873c4590a2b2d60ac362a6597e64b845cb033ea398cb55548d47605d4730f66aac8fba0c501c8eacf84a3cb6027a121acca
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -75,7 +75,6 @@ dependencies = [
     "restructuredtext-lint>=1.4.0",
     "rich-click>=1.7.1",
     "rich>=13.6.0",
-    "semver>=3.0.2",
     "tabulate>=0.9.0",
     "tomli>=2.0.1; python_version < '3.11'",
     "twine>=4.0.2",


### PR DESCRIPTION
We have been using SemVer to handle version updates in provider documentation breeze commands, which started to break at the moment we started to have pre-release packages - Puthon packaging follows PEP-440 and it is implemented in packaging.version module.

This module does not have all the nice features semver has (like bumping the major/minor/patchlevel versions so we had to implement it ourselves (packaging Versions are immutable and we need to recreate the version after bump.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
