### PR TITLE
Fix bug in getting Variable via Context

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -50,7 +50,7 @@ class Variable:
         from airflow.sdk.execution_time.context import _get_variable
 
         try:
-            return _get_variable(key, deserialize_json=deserialize_json).value
+            return _get_variable(key, deserialize_json=deserialize_json)
         except AirflowRuntimeError as e:
             if e.error.error == ErrorType.VARIABLE_NOT_FOUND and default is not NOTSET:
                 return default

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -277,10 +277,9 @@ class TestVariableAccessor:
         mock_supervisor_comms.get_message.return_value = var_result
 
         # Fetch the variable; triggers __getattr__
-        var = accessor.test_key
+        value = accessor.test_key
 
-        expected_var = Variable(key="test_key", value="test_value")
-        assert var == expected_var
+        assert value == var_result.value
 
     def test_get_method_valid_variable(self, mock_supervisor_comms):
         """Test that the get method returns the requested variable using `var.get`."""
@@ -289,20 +288,19 @@ class TestVariableAccessor:
 
         mock_supervisor_comms.get_message.return_value = var_result
 
-        var = accessor.get("test_key")
-        assert var == Variable(key="test_key", value="test_value")
+        val = accessor.get("test_key")
+        assert val == var_result.value
 
     def test_get_method_with_default(self, mock_supervisor_comms):
         """Test that the get method returns the default variable when the requested variable is not found."""
 
         accessor = VariableAccessor(deserialize_json=False)
-        default_var = {"default_key": "default_value"}
         error_response = ErrorResponse(error=ErrorType.VARIABLE_NOT_FOUND, detail={"test_key": "test_value"})
 
         mock_supervisor_comms.get_message.return_value = error_response
 
-        var = accessor.get("nonexistent_var_key", default_var=default_var)
-        assert var == default_var
+        val = accessor.get("nonexistent_var_key", default="default_value")
+        assert val == "default_value"
 
 
 class TestCurrentContext:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -58,7 +58,6 @@ from airflow.sdk.api.datamodels._generated import (
 )
 from airflow.sdk.definitions.asset import Asset, AssetAlias, Dataset, Model
 from airflow.sdk.definitions.param import DagParam
-from airflow.sdk.definitions.variable import Variable
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
     AssetEventsResult,
@@ -1217,7 +1216,7 @@ class TestRuntimeTaskInstance:
         )
         mock_supervisor_comms.get_message.assert_called_once_with()
 
-        assert var_from_context == Variable(key="test_key", value=expected_value)
+        assert var_from_context == expected_value
 
     @pytest.mark.parametrize(
         "map_indexes",


### PR DESCRIPTION
This PR makes it consistent with Airflow 2 where we get values directly instead of the Variable object.

closes https://github.com/apache/airflow/issues/48298

Example Task:

```py
task = BashOperator(
        task_id="variable_jinja",
        bash_command="echo {{ var.value.my_variable }}",
)
```

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/0a2a55c7-e870-4c12-aa1b-3bf3c095922c" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
