### PR TITLE
Minor cleanup on grid endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -186,7 +186,7 @@ def grid_data(
     )
     # Create the Task Instance Summaries to be used in the Grid Response
     task_instance_summaries: dict[str, list] = {
-        run_id: [] for (_, run_id), _ in itertools.chain(parent_tis.items(), all_tis.items())
+        run_id: [] for _, run_id in itertools.chain(parent_tis, all_tis)
     }
 
     # Fill the Task Instance Summaries for the Parent and Grouped Task Instances.
@@ -220,9 +220,7 @@ def grid_data(
             data_interval_end=dag_run.data_interval_end,
             version_number=dag_run.version_number,
             note=dag_run.note,
-            task_instances=(
-                task_instance_summaries[dag_run.run_id] if dag_run.run_id in task_instance_summaries else []
-            ),
+            task_instances=task_instance_summaries.get(dag_run.run_id, []),
         )
         for dag_run in dag_runs
     ]

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -381,6 +381,7 @@ class AirflowConfigParser(ConfigParser):
         # celery_logging_level can be empty, which uses logging_level as fallback
         ("logging", "celery_logging_level"): [*_available_logging_levels, ""],
         ("webserver", "analytical_tool"): ["google_analytics", "metarouter", "segment", "matomo", ""],
+        ("webserver", "grid_view_sorting_order"): ["topological", "hierarchical_alphabetical"],
     }
 
     upgraded_values: dict[tuple[str, str], str]


### PR DESCRIPTION
This just cleans up some code in the grid endpoint - no real changes.

- this uses a proper config enum for the grid view sort order config - fails at startup, not throwing a 500 in responses
- removes unnecessary fallback
- count child nodes directly - no need to sort then iterate through then count
- simplifies some other code too