### PR TITLE
Adding a backcompat shim for baseoperatorlink

### DIFF
--- a/airflow-core/src/airflow/models/baseoperatorlink.py
+++ b/airflow-core/src/airflow/models/baseoperatorlink.py
@@ -19,6 +19,4 @@
 
 from __future__ import annotations
 
-from airflow.sdk.definitions.baseoperatorlink import BaseOperatorLink
-
-__all__ = ["BaseOperatorLink"]
+from airflow.sdk.definitions.baseoperatorlink import BaseOperatorLink as BaseOperatorLink

--- a/airflow-core/src/airflow/models/baseoperatorlink.py
+++ b/airflow-core/src/airflow/models/baseoperatorlink.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Re exporting the new baseoperatorlink module from Task SDK for backward compatibility."""
+
+from __future__ import annotations
+
+from airflow.sdk.definitions.baseoperatorlink import BaseOperatorLink
+
+__all__ = ["BaseOperatorLink"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Users could've written plugins historically before AF3 using `airflow.models.baseoperatorlink`
Example:
```
from airflow.plugins_manager import AirflowPlugin
from airflow.models.baseoperatorlink import BaseOperatorLink
from airflow.providers.standard.operators.python import PythonOperator


# define the extra link
class HTTPDocsLink(BaseOperatorLink):
    # name the link button in the UI
    name = "HTTP docs"

    # add the button to one or more operators
    operators = [PythonOperator]

    # provide the link
    def get_link(self, operator, *, ti_key=None):
        return "https://developer.mozilla.org/en-US/docs/Web/HTTP"

# define the plugin class
class AirflowExtraLinkPlugin(AirflowPlugin):
    name = "extra_link_plugin"
    operator_extra_links = [
        HTTPDocsLink(),
    ]

```

Now this has been moved to `airflow.sdk`, so their plugins would complain of:
![image](https://github.com/user-attachments/assets/af493bfa-f989-47fb-8cfa-efa18a376e4e)


Adding a backcompat shim that imports and re-exports the baseoperatorlink from sdk would do a good job at handling this.


After:

![image](https://github.com/user-attachments/assets/088cf000-2fdf-4353-8678-a4c54e820d31)

![image](https://github.com/user-attachments/assets/fac4f310-382b-4c6e-b7aa-081007183f64)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
