### PR TITLE
Fix: Handle Invalid --conn-uri Gracefully in CLI

### DIFF
--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -174,6 +174,7 @@ def _build_metrics(func_name, namespace):
         uri_index = full_command.index("--conn-uri") + 1
         conn_uri = full_command[uri_index]
         parsed_uri = urlparse(conn_uri)
+        netloc = parsed_uri.netloc
         if parsed_uri.password:
             password = "*" * 8
             netloc = f"{parsed_uri.username}:{password}@{parsed_uri.hostname}"

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -334,7 +334,6 @@ class TestCliExportConnections:
 
 
 TEST_URL = "postgresql://airflow:airflow@host:5432/airflow"
-INVALID_TEST_URL = "postgresql"
 TEST_JSON = json.dumps(
     {
         "conn_type": "postgres",

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -334,6 +334,7 @@ class TestCliExportConnections:
 
 
 TEST_URL = "postgresql://airflow:airflow@host:5432/airflow"
+INVALID_TEST_URL = "postgresql"
 TEST_JSON = json.dumps(
     {
         "conn_type": "postgres",
@@ -554,10 +555,23 @@ class TestCliAddConnections:
                 },
                 id="uri-with-@-instead-authority-and-host-blocks",
             ),
+            pytest.param(
+                ["connections", "add", "invalid-uri-test", "--conn-uri", "invalid_uri"],
+                "The URI provided to --conn-uri is invalid: invalid_uri",
+                None,  # No connection should be created
+                id="invalid-uri",
+            ),
         ],
     )
     @pytest.mark.execution_timeout(120)
     def test_cli_connection_add(self, cmd, expected_output, expected_conn, session):
+        if "invalid-uri-test" in cmd:
+            with pytest.raises(SystemExit) as exc_info:
+                connection_command.connections_add(self.parser.parse_args(cmd))
+
+            assert str(exc_info.value) == expected_output
+            return
+
         with redirect_stdout(StringIO()) as stdout:
             connection_command.connections_add(self.parser.parse_args(cmd))
 


### PR DESCRIPTION
This PR improves the handling of invalid --conn-uri values in the Airflow CLI. Previously, providing an invalid URI (e.g., testing) would cause a failure due to netloc being unset.

closes: [#ISSUE](https://github.com/apache/airflow/issues/48390)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
