### PR TITLE
Add a CLI command `airflow config update` to update the config changes from airflow 2.x to 3. 

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1657,6 +1657,7 @@ CONFIG_COMMANDS = (
             ARG_UPDATE_CONFIG_OPTION,
             ARG_UPDATE_CONFIG_IGNORE_SECTION,
             ARG_UPDATE_CONFIG_IGNORE_OPTION,
+            ARG_DRY_RUN,
             ARG_VERBOSE,
         ),
     ),

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -791,6 +791,28 @@ ARG_OPTIONAL_SECTION = Arg(
     help="The section name",
 )
 
+# config update
+ARG_UPDATE_CONFIG_SECTION = Arg(
+    ("--section",),
+    help="The section name(s) to update in the airflow config.",
+    type=string_list_type,
+)
+ARG_UPDATE_CONFIG_OPTION = Arg(
+    ("--option",),
+    help="The option name(s) to update in the airflow config.",
+    type=string_list_type,
+)
+ARG_UPDATE_CONFIG_IGNORE_SECTION = Arg(
+    ("--ignore-section",),
+    help="The section name(s) to ignore to update in the airflow config.",
+    type=string_list_type,
+)
+ARG_UPDATE_CONFIG_IGNORE_OPTION = Arg(
+    ("--ignore-option",),
+    help="The option name(s) to ignore to update in the airflow config.",
+    type=string_list_type,
+)
+
 # jobs check
 ARG_JOB_TYPE_FILTER = Arg(
     ("--job-type",),
@@ -1623,6 +1645,18 @@ CONFIG_COMMANDS = (
             ARG_LINT_CONFIG_OPTION,
             ARG_LINT_CONFIG_IGNORE_SECTION,
             ARG_LINT_CONFIG_IGNORE_OPTION,
+            ARG_VERBOSE,
+        ),
+    ),
+    ActionCommand(
+        name="update",
+        help="update options for the configuration changes while migrating from Airflow 2.x to Airflow 3.0",
+        func=lazy_load_command("airflow.cli.commands.config_command.update_config"),
+        args=(
+            ARG_UPDATE_CONFIG_SECTION,
+            ARG_UPDATE_CONFIG_OPTION,
+            ARG_UPDATE_CONFIG_IGNORE_SECTION,
+            ARG_UPDATE_CONFIG_IGNORE_OPTION,
             ARG_VERBOSE,
         ),
     ),

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -729,7 +729,7 @@ def update_config(args) -> None:
 
     This command scans the current configuration file for parameters that have been renamed,
     removed, or had their default values changed in Airflow 3.0, and automatically updates
-    the configuration file.
+    the configuration file. This command cleans up the existing comments in airflow.cfg
 
     CLI Arguments:
         --dry-run: flag (optional)
@@ -753,7 +753,7 @@ def update_config(args) -> None:
             Example: --ignore-option check_slas
 
     Examples:
-        1. Dry-run mode (print the changes without modifying airflow.cfg):
+        1. Dry-run mode (print the changes in modified airflow.cfg):
             airflow config update --dry-run
 
         2. Update the entire configuration file:

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -834,7 +834,7 @@ def update_config(args) -> None:
         console.print(f"Failed to create backup: {e}")
         raise AirflowConfigException("Backup creation failed. Aborting update_config operation.")
 
-    if getattr(args, "dry_run", False):
+    if args.dry_run:
         console.print("[blue]Dry-run mode enabled. No changes will be written to airflow.cfg.[/blue]")
         with StringIO() as config_output:
             conf.write_custom_config(

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-import os
+import shutil
 from dataclasses import dataclass
 from io import StringIO
 from typing import Any, NamedTuple
@@ -27,7 +27,7 @@ import pygments
 from pygments.lexers.configs import IniLexer
 
 from airflow.cli.simple_table import AirflowConsole
-from airflow.configuration import AIRFLOW_CONFIG, ENV_VAR_PREFIX, conf
+from airflow.configuration import AIRFLOW_CONFIG, conf
 from airflow.exceptions import AirflowConfigException
 from airflow.utils.cli import should_use_colors
 from airflow.utils.code_utils import get_terminal_formatter
@@ -729,7 +729,7 @@ def update_config(args) -> None:
 
     This command scans the current configuration file for parameters that have been renamed,
     removed, or had their default values changed in Airflow 3.0, and automatically updates
-    both the configuration file and relevant environment variables accordingly.
+    the configuration file.
 
     CLI Arguments:
         --section: str (optional)
@@ -812,48 +812,22 @@ def update_config(args) -> None:
             conf.remove_option(conf_section, conf_option)
             changes_applied.append(f"Removed '{conf_section}/{conf_option}' from configuration.")
 
-    for change in CONFIGS_CHANGES:
-        conf_section = change.config.section
-        conf_option = change.config.option
-
-        if update_sections is not None and conf_section not in update_sections:
-            continue
-        if update_options is not None and conf_option not in update_options:
-            continue
-        if conf_section in ignore_sections or conf_option in ignore_options:
-            continue
-
-        old_env = f"{ENV_VAR_PREFIX}{conf_section.upper()}__{conf_option.upper()}"
-        if old_env in os.environ:
-            os.environ.pop(old_env)
-            if change.renamed_to:
-                new_env = (
-                    f"{ENV_VAR_PREFIX}{change.renamed_to.section.upper()}__{change.renamed_to.option.upper()}"
-                )
-                new_value = conf.get(change.renamed_to.section, change.renamed_to.option)
-                os.environ[new_env] = new_value
-                changes_applied.append(f"Updated environment variable: renamed '{old_env}' to '{new_env}'.")
-            else:
-                changes_applied.append(f"Removed environment variable '{old_env}'.")
-
     backup_path = AIRFLOW_CONFIG + ".bak"
     try:
-        with open(AIRFLOW_CONFIG) as original:
-            content = original.read()
-        with open(backup_path, "w") as backup:
-            backup.write(content)
+        shutil.copy2(AIRFLOW_CONFIG, backup_path)
         console.print(f"Backup saved as '{backup_path}'.")
     except Exception as e:
         console.print(f"Failed to create backup: {e}")
+        raise AirflowConfigException("Backup creation failed. Aborting update_config operation.")
 
     with open(AIRFLOW_CONFIG, "w") as config_file:
         conf.write(
-            config_file,
+            file=config_file,
             include_sources=False,
             include_env_vars=True,
             include_providers=True,
             comment_out_everything=False,
-            only_defaults=False,
+            only_defaults=True,
         )
 
     if changes_applied:

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -73,6 +73,30 @@ ConfigSourcesType = dict[str, ConfigSectionSourcesType]
 ENV_VAR_PREFIX = "AIRFLOW__"
 
 
+class ConfigModifications:
+    """
+    Holds modifications to be applied when writing out the config.
+
+    :param rename: Mapping from (old_section, old_option) to (new_section, new_option)
+    :param remove: Set of (section, option) to remove
+    :param default_updates: Mapping from (section, option) to new default value
+    """
+
+    def __init__(self) -> None:
+        self.rename: dict[tuple[str, str], tuple[str, str]] = {}
+        self.remove: set[tuple[str, str]] = set()
+        self.default_updates: dict[tuple[str, str], str] = {}
+
+    def add_rename(self, old_section: str, old_option: str, new_section: str, new_option: str) -> None:
+        self.rename[(old_section, old_option)] = (new_section, new_option)
+
+    def add_remove(self, section: str, option: str) -> None:
+        self.remove.add((section, option))
+
+    def add_default_update(self, section: str, option: str, new_default: str) -> None:
+        self.default_updates[(section, option)] = new_default
+
+
 def _parse_sqlite_version(s: str) -> tuple[int, ...]:
     match = _SQLITE3_VERSION_PATTERN.match(s)
     if match is None:
@@ -548,6 +572,88 @@ class AirflowConfigParser(ConfigParser):
                 file.write(f"{option} = {value}\n")
         if needs_separation:
             file.write("\n")
+
+    def write_custom_config(
+        self,
+        file: IO[str],
+        comment_out_defaults: bool = True,
+        include_descriptions: bool = True,
+        extra_spacing: bool = True,
+        modifications: ConfigModifications | None = None,
+    ) -> None:
+        """
+        Write a configuration file using a ConfigModifications object.
+
+        This method includes only options from the current airflow.cfg. For each option:
+          - If it's marked for removal, omit it.
+          - If renamed, output it under its new name and add a comment indicating its original location.
+          - If a default update is specified, apply the new default and output the option as a commented line.
+          - Otherwise, if the current value equals the default and comment_out_defaults is True, output it as a comment.
+        Options absent from the current airflow.cfg are omitted.
+
+        :param file: File to write the configuration.
+        :param comment_out_defaults: If True, options whose value equals the default are written as comments.
+        :param include_descriptions: Whether to include section descriptions.
+        :param extra_spacing: Whether to insert an extra blank line after each option.
+        :param modifications: ConfigModifications instance with rename, remove, and default updates.
+        """
+        modifications = modifications or ConfigModifications()
+        output: dict[str, list[tuple[str, str, bool, str]]] = {}
+
+        for section in self._sections:  # type: ignore[attr-defined]  # accessing _sections from ConfigParser
+            for option, orig_value in self._sections[section].items():  # type: ignore[attr-defined]
+                key = (section.lower(), option.lower())
+                if key in modifications.remove:
+                    continue
+
+                mod_comment = ""
+                if key in modifications.rename:
+                    new_sec, new_opt = modifications.rename[key]
+                    effective_section = new_sec
+                    effective_option = new_opt
+                    mod_comment += f"# Renamed from {section}.{option}\n"
+                else:
+                    effective_section = section
+                    effective_option = option
+
+                value = orig_value
+                if key in modifications.default_updates:
+                    mod_comment += (
+                        f"# Default updated from {orig_value} to {modifications.default_updates[key]}\n"
+                    )
+                    value = modifications.default_updates[key]
+
+                default_value = self.get_default_value(effective_section, effective_option, fallback="")
+                is_default = str(value) == str(default_value)
+                output.setdefault(effective_section.lower(), []).append(
+                    (effective_option, str(value), is_default, mod_comment)
+                )
+
+        for section, options in output.items():
+            section_buffer = StringIO()
+            section_buffer.write(f"[{section}]\n")
+            if include_descriptions:
+                description = self.configuration_description.get(section, {}).get("description", "")
+                if description:
+                    for line in description.splitlines():
+                        section_buffer.write(f"# {line}\n")
+                    section_buffer.write("\n")
+            for option, value_str, is_default, mod_comment in options:
+                key = (section.lower(), option.lower())
+                if key in modifications.default_updates and comment_out_defaults:
+                    section_buffer.write(f"# {option} = {value_str}\n")
+                else:
+                    if mod_comment:
+                        section_buffer.write(mod_comment)
+                    if is_default and comment_out_defaults:
+                        section_buffer.write(f"# {option} = {value_str}\n")
+                    else:
+                        section_buffer.write(f"{option} = {value_str}\n")
+                if extra_spacing:
+                    section_buffer.write("\n")
+            content = section_buffer.getvalue().strip()
+            if content:
+                file.write(content + "\n\n")
 
     def write(  # type: ignore[override]
         self,

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -653,7 +653,7 @@ class AirflowConfigParser(ConfigParser):
                     section_buffer.write("\n")
             content = section_buffer.getvalue().strip()
             if content:
-                file.write(content + "\n\n")
+                file.write(f"{content}\n\n")
 
     def write(  # type: ignore[override]
         self,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This PR introduces the `airflow config update` CLI command to help users transition smoothly from Airflow 2.x to 3. This command scans the current `airflow.cfg file` , then updates configuration parameters that have been removed, renamed, or had their default values changed. In addition, it cleans out deprecated configuration values (as updated in [#47761](https://github.com/apache/airflow/pull/47761/files) that have been emitting warnings in Airflow 2.x. For each such `section-option`:

- **Renamed:** Options that have been renamed (or moved across sections) are written under their new names with a comment indicating their original location.
- **Removed Options:** Deprecated options are omitted from the updated file.
- **Default Value Updates:** When an option’s value is updated to a new default (or if the effective value equals the default), the option is written as a commented line. A comment is added - for example:
  
```
  # Default updated from OldDefault to NewDefault
  # default_key = NewDefault
  ```  


In addition, a backup of the original `airflow.cfg` is created before updating.

**Examples:**

- **Renamed Option:**  
  A legacy key from the `[admin]` section:  
  ```ini
  hide_sensitive_variable_fields = True
  ```  
  is moved and renamed to `core` section:  
  ```ini
  # Renamed from admin.hide_sensitive_variable_fields
  # hide_sensitive_var_conn_fields = True
  ```  
  in the `[core]` section.

- **Removed Option:**  
  Deprecated options such as  
  ```ini
  check_slas = True
  ```  
  in `[core]` are omitted entirely from the new configuration.

- **Default Value Update:**  
  If an option in `[core]` is set to “OldDefault” (e.g. `default_key = OldDefault`) and the new default is “NewDefault”, the updated file will show as comment:  
  ```ini
  [core]
  # Default updated from OldDefault to NewDefault
  # default_key = NewDefault
  ```  

**Usage Examples:**

- **Update the Entire Configuration:**  
  ```bash
  airflow config update
  ```

- **Update Specific Sections:**  
  ```bash
  airflow config update --section core,database
  ```

- **Update Specific Options:**  
  ```bash
  airflow config update --option sql_alchemy_conn,catchup_by_default
  ```

- **Ignore Specific Sections/Options:**  
  ```bash
  airflow config update --ignore-section webserver --ignore-option check_slas
  ```

- **Dry run for dummy detailed output:**  
  ```bash
  airflow config update --dry-run
  ```

closes: [[#48376](https://github.com/apache/airflow/issues/48376)]

Tested locally:
- old `airflow.cfg`
<img width="821" alt="Screenshot 2025-03-27 at 5 03 40 PM" src="https://github.com/user-attachments/assets/5030482c-8a46-47e9-9436-6c05ae49e616" />

- After running `airflow config update`:
<img width="774" alt="Screenshot 2025-03-27 at 5 03 57 PM" src="https://github.com/user-attachments/assets/c03f883d-99be-4096-a616-a9c7a5963861" />

<img width="849" alt="Screenshot 2025-03-27 at 5 34 16 PM" src="https://github.com/user-attachments/assets/24064302-ab4b-4b3a-9aa6-f6a03f4c87df" />


- Also added the option to dry run:
<img width="851" alt="Screenshot 2025-03-27 at 7 28 39 PM" src="https://github.com/user-attachments/assets/7a596108-5097-46dc-ad97-841a6b2a8c4f" />

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
