### PR TITLE
Allow enter/return button to submit login

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/LoginForm.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/LoginForm.tsx
@@ -18,50 +18,62 @@
  */
 
 import React from "react";
-import {Button, Field, Input, Stack} from "@chakra-ui/react";
-import {Controller, useForm} from "react-hook-form";
-import {LoginBody} from "./Login";
+import { Button, Field, Input, Stack } from "@chakra-ui/react";
+import { Controller, useForm } from "react-hook-form";
+import { LoginBody } from "./Login";
 
 type LoginFormProps = {
-    readonly onLogin: (loginBody: LoginBody) => string;
-    readonly isPending: boolean;
+  readonly onLogin: (loginBody: LoginBody) => string;
+  readonly isPending: boolean;
 };
 
 export const LoginForm = ({ onLogin, isPending }: LoginFormProps) => {
-    const {
-        control, handleSubmit,
-        formState: { isValid },
-    } = useForm<LoginBody>({
-        defaultValues: {
-            username: "", password: "",
-        },
-    });
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<LoginBody>({
+    defaultValues: {
+      username: "",
+      password: "",
+    },
+  });
 
-    return <Stack spacing={4}>
+  return (
+    <form onSubmit={() => void handleSubmit(onLogin)()}>
+      <Stack gap={4}>
         <Controller
-            name="username"
-            control={control}
-            render={({field, fieldState}) => (
-                <Field.Root invalid={Boolean(fieldState.error)} required>
-                    <Field.Label>Username</Field.Label>
-                    <Input {...field} />
-                </Field.Root>)}
-            rules={{required: true}}
+          name="username"
+          control={control}
+          render={({ field, fieldState }) => (
+            <Field.Root invalid={Boolean(fieldState.error)} required>
+              <Field.Label>Username</Field.Label>
+              <Input {...field} />
+            </Field.Root>
+          )}
+          rules={{ required: true }}
         />
 
         <Controller
-            name="password"
-            control={control}
-            render={({field, fieldState}) => (
-                <Field.Root invalid={Boolean(fieldState.error)} required>
-                    <Field.Label>Password</Field.Label>
-                    <Input {...field} type="password"/>
-                </Field.Root>)}
-            rules={{required: true}}
+          name="password"
+          control={control}
+          render={({ field, fieldState }) => (
+            <Field.Root invalid={Boolean(fieldState.error)} required>
+              <Field.Label>Password</Field.Label>
+              <Input {...field} type="password" />
+            </Field.Root>
+          )}
+          rules={{ required: true }}
         />
 
-        <Button disabled={!isValid || isPending} colorPalette="blue" onClick={() => void handleSubmit(onLogin)()}>
-            Sign in
+        <Button
+          disabled={!isValid || isPending}
+          colorPalette="blue"
+          type="submit"
+        >
+          Sign in
         </Button>
-    </Stack>
-}
+      </Stack>
+    </form>
+  );
+};


### PR DESCRIPTION
Since we didn't put the login form inside of an actual `<form>` element. We couldn't use common commands like "enter/return" to submit.

Also, fixed some bad formatting.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
