### PR TITLE
Fix favicon and tab title

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/dev/index.html
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/dev/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <base href="{{ backend_server_base_url }}" />
-    <link rel="icon" type="image/png" href="http://localhost:5174/api/v2/pin_32.png" />
+    <link rel="icon" type="image/png" href="http://localhost:5174/pin_32.png" />
     <script type="module" src="http://localhost:5174/@vite/client"></script>
     <script type="module">
       import RefreshRuntime from "http://localhost:5174/@react-refresh";
@@ -15,7 +15,7 @@
       window.__vite_plugin_react_preamble_installed__ = true;
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Airflow 3.0</title>
+    <title>Airflow</title>
   </head>
   <body style="height: 100%">
     <div id="root" style="height: 100%"></div>

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/index.html
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/index.html
@@ -5,7 +5,7 @@
     <base href="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Airflow 3.0</title>
+    <title>Airflow</title>
   </head>
   <body style="height: 100%">
     <div id="root" style="height: 100%"></div>

--- a/airflow-core/src/airflow/ui/dev/index.html
+++ b/airflow-core/src/airflow/ui/dev/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <base href="{{ backend_server_base_url }}" />
-    <link rel="icon" type="image/png" href="http://localhost:5173/api/v2/pin_32.png" />
+    <link rel="icon" type="image/png" href="http://localhost:5173/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">
       import RefreshRuntime from "http://localhost:5173/@react-refresh";
@@ -15,7 +15,7 @@
       window.__vite_plugin_react_preamble_installed__ = true;
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Airflow 3.0</title>
+    <title>Airflow</title>
   </head>
   <body style="height: 100%">
     <div id="root" style="height: 100%"></div>

--- a/airflow-core/src/airflow/ui/index.html
+++ b/airflow-core/src/airflow/ui/index.html
@@ -5,7 +5,7 @@
     <base href="{{ backend_server_base_url }}" />
     <link rel="icon" type="image/png" href="/static/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Airflow 3.0</title>
+    <title>Airflow</title>
   </head>
   <body style="height: 100%">
     <div id="root" style="height: 100%"></div>


### PR DESCRIPTION
Looks like find+replace for the api/v2 broke our favicon links.

Also dropping `3.0` from our website titles. It was mainly for development when we were running a legacy and new UIs

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
