### PR TITLE
Improve css for selecting a node in the graph

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -33,7 +33,7 @@ export const TaskNode = ({
   data: {
     childCount,
     depth,
-    height,
+    height = 0,
     isGroup,
     isMapped,
     isOpen,
@@ -42,7 +42,7 @@ export const TaskNode = ({
     operator,
     setupTeardownType,
     taskInstance,
-    width,
+    width = 0,
   },
   id,
 }: NodeProps<NodeType<CustomNodeProps, "task">>) => {
@@ -71,11 +71,11 @@ export const TaskNode = ({
             }
             borderRadius={5}
             borderWidth={isSelected ? 6 : 2}
-            height={`${height}px`}
+            height={`${height + (isSelected ? 4 : 0)}px`}
             justifyContent="space-between"
-            px={3}
+            px={isSelected ? 1 : 2}
             py={isSelected ? 0 : 1}
-            width={`${width}px`}
+            width={`${width + (isSelected ? 4 : 0)}px`}
           >
             <Box>
               <TaskLink
@@ -127,7 +127,7 @@ export const TaskNode = ({
               borderLeftWidth={1}
               borderRightWidth={1}
               height={1}
-              width={`${(width ?? 0) - 10}px`}
+              width={`${width - 10}px`}
             />
             <Box
               bg="bg.subtle"
@@ -138,7 +138,7 @@ export const TaskNode = ({
               borderLeftWidth={1}
               borderRightWidth={1}
               height={1}
-              width={`${(width ?? 0) - 20}px`}
+              width={`${width - 20}px`}
             />
           </>
         ) : undefined}


### PR DESCRIPTION
Adjust the node padding and size to adjust to the border radius change when a task is selected.

Before:
<img width="622" alt="Screenshot 2025-03-26 at 2 32 25 PM" src="https://github.com/user-attachments/assets/051fd574-ef32-4266-b4a1-a5b1e132bdb7" />

After:
<img width="689" alt="Screenshot 2025-03-26 at 2 32 19 PM" src="https://github.com/user-attachments/assets/37acd16f-9d25-43b8-a9a1-8891dcec319c" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
