### PR TITLE
Fix artifacts path for builds.

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -254,18 +254,18 @@ exclude = [
 path = "./hatch_build_airflow_core.py"
 
 artifacts = [
-    "airflow/ui/dist/",
-    "airflow/api_fastapi/auth/managers/simple/ui/dist/",
-    "airflow/git_version",
+    "src/airflow/ui/dist/",
+    "src/airflow/api_fastapi/auth/managers/simple/ui/dist/",
+    "src/airflow/git_version",
     "generated/",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ['src/airflow']
 artifacts = [
-    "airflow/ui/dist/",
-    "airflow/api_fastapi/auth/managers/simple/ui/dist/",
-    "airflow/git_version"
+    "src/airflow/ui/dist/",
+    "src/airflow/api_fastapi/auth/managers/simple/ui/dist/",
+    "src/airflow/git_version"
 ]
 exclude = [
     "src/airflow/ui/node_modules/",


### PR DESCRIPTION
It seems artifacts value is missing "src" in their path due to which the artifacts like UI build files are not getting included in the wheel builds. "src" is present in excluded list. The UI dist folders were included in beta4 and not in main. With the PR they are included.

Locally using main

```
unzip -l dist/apache_airflow_core-3.0.0.dev0-py3-none-any.whl | grep -i 'ui/dist'
```

After PR

```
      510  2020-02-02 00:00   airflow/api_fastapi/auth/managers/simple/ui/dist/index.html
      131  2020-02-02 00:00   airflow/api_fastapi/auth/managers/simple/ui/dist/.vite/manifest.json
   633445  2020-02-02 00:00   airflow/api_fastapi/auth/managers/simple/ui/dist/assets/index-D-Eul43E.js
      512  2020-02-02 00:00   airflow/ui/dist/index.html
     1201  2020-02-02 00:00   airflow/ui/dist/pin_32.png
      451  2020-02-02 00:00   airflow/ui/dist/.vite/manifest.json
     1472  2020-02-02 00:00   airflow/ui/dist/assets/FailedLogs-u5-_VlqR.js
  4122748  2020-02-02 00:00   airflow/ui/dist/assets/index-BVSsJR78.js
```

Beta 4 wheel file

```
unzip -l  ~/Downloads/apache_airflow-3.0.0b4-py3-none-any.whl | grep -i 'ui/dist'
      462  2025-03-20 17:49   airflow/api_fastapi/auth/managers/simple/ui/dist/index.html
      131  2025-03-20 17:49   airflow/api_fastapi/auth/managers/simple/ui/dist/.vite/manifest.json
   568153  2025-03-20 17:49   airflow/api_fastapi/auth/managers/simple/ui/dist/assets/index-DnXVQYs3.js
      516  2025-03-20 17:49   airflow/ui/dist/index.html
     1201  2025-03-20 17:49   airflow/ui/dist/pin_32.png
      451  2025-03-20 17:49   airflow/ui/dist/.vite/manifest.json
     1472  2025-03-20 17:49   airflow/ui/dist/assets/FailedLogs-BhhMEN0w.js
  4111255  2025-03-20 17:49   airflow/ui/dist/assets/index-B9H4E3td.js
```