### PR TITLE
Ensure `dagbag.sync_to_db` always operates on SerializedDAGs

### DIFF
--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -645,12 +645,21 @@ class DagBag(LoggingMixin):
     @provide_session
     def sync_to_db(self, bundle_name: str, bundle_version: str | None, session: Session = NEW_SESSION):
         """Save attributes about list of DAG to the DB."""
+        import airflow.models.dag
         from airflow.dag_processing.collection import update_dag_parsing_results_in_db
+        from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
+
+        dags = [
+            dag
+            if isinstance(dag, airflow.models.dag.DAG)
+            else LazyDeserializedDAG(data=SerializedDAG.to_dict(dag))
+            for dag in self.dags.values()
+        ]
 
         update_dag_parsing_results_in_db(
             bundle_name,
             bundle_version,
-            self.dags.values(),  # type: ignore[arg-type]  # We should create a proto for DAG|LazySerializedDAG
+            dags,
             self.import_errors,
             self.dag_warnings,
             session=session,


### PR DESCRIPTION
This is needed now as the process of creating and updating the Dag Model
tables needs the "scheduler DAG" functions which, from the split to out of the
Task SDK, only exist on the SerializedDag class.

There are no tests directly of this, but this should make #48014 pass (so will
be tested there) and fixes #48420, fixes #48402.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
