### PR TITLE
Move graph display options into an accordion

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagVersionSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagVersionSelect.tsx
@@ -30,7 +30,13 @@ import { SearchParamsKeys } from "src/constants/searchParams";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
 import type { Option } from "src/utils/option";
 
-const DagVersionSelect = ({ disabled = false }: { readonly disabled?: boolean }) => {
+const DagVersionSelect = ({
+  disabled = false,
+  showLabel = true,
+}: {
+  readonly disabled?: boolean;
+  readonly showLabel?: boolean;
+}) => {
   const queryClient = useQueryClient();
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -76,7 +82,8 @@ const DagVersionSelect = ({ disabled = false }: { readonly disabled?: boolean })
   );
 
   return (
-    <Field.Root bg="bg" disabled={disabled} width="fit-content">
+    <Field.Root disabled={disabled} width="fit-content">
+      {showLabel ? <Field.Label fontSize="xs">Dag Version</Field.Label> : undefined}
       <AsyncSelect
         defaultOptions
         filterOption={undefined}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagRunSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagRunSelect.tsx
@@ -58,7 +58,6 @@ export const DagRunSelect = forwardRef<HTMLDivElement, DagRunSelectProps>(({ lim
 
   return (
     <Select.Root
-      bg="bg"
       collection={runOptions}
       data-testid="dag-run-select"
       disabled={isLoading}
@@ -67,6 +66,7 @@ export const DagRunSelect = forwardRef<HTMLDivElement, DagRunSelectProps>(({ lim
       value={runId === undefined ? [] : [runId]}
       width="250px"
     >
+      <Select.Label fontSize="xs">Dag Run</Select.Label>
       <Select.Trigger clearable>
         <Select.ValueText placeholder="All Runs">
           {(items: Array<DagRunSelected>) => (

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -24,6 +24,8 @@ import {
   Stack,
   createListCollection,
   type SelectValueChangeDetails,
+  Accordion,
+  Text,
 } from "@chakra-ui/react";
 import { FiGrid } from "react-icons/fi";
 import { MdOutlineAccountTree } from "react-icons/md";
@@ -99,6 +101,7 @@ export const PanelButtons = ({ dagView, limit, setDagView, setLimit, ...rest }: 
       alignItems="flex-start"
       justifyContent="space-between"
       position="absolute"
+      pr={3}
       top={0}
       width="100%"
       zIndex={1}
@@ -124,75 +127,84 @@ export const PanelButtons = ({ dagView, limit, setDagView, setLimit, ...rest }: 
           <MdOutlineAccountTree />
         </IconButton>
       </ButtonGroup>
-      <Stack alignItems="flex-end" gap={1} mr={2}>
-        <HStack>
-          <DagVersionSelect disabled={dagView !== "graph"} />
-          <Select.Root
-            bg="bg"
-            collection={displayRunOptions}
-            data-testid="display-dag-run-options"
-            onValueChange={handleLimitChange}
-            size="sm"
-            value={[limit.toString()]}
-            width="70px"
-          >
-            <Select.Trigger>
-              <Select.ValueText />
-            </Select.Trigger>
-            <Select.Content>
-              {displayRunOptions.items.map((option) => (
-                <Select.Item item={option} key={option.value}>
-                  {option.label}
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select.Root>
-        </HStack>
-        {dagView === "graph" ? (
-          <>
-            <Select.Root
-              bg="bg"
-              collection={directionOptions}
-              onValueChange={handleDirectionUpdate}
-              size="sm"
-              value={[direction]}
-              width="150px"
-            >
-              <Select.Trigger>
-                <Select.ValueText />
-              </Select.Trigger>
-              <Select.Content>
-                {directionOptions.items.map((option) => (
-                  <Select.Item item={option} key={option.value}>
-                    {option.label}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select.Root>
-            <Select.Root
-              bg="bg"
-              collection={options}
-              data-testid="filter-duration"
-              onValueChange={handleDepsChange}
-              size="sm"
-              value={[dependencies]}
-              width="210px"
-            >
-              <Select.Trigger>
-                <Select.ValueText placeholder="Dependencies" />
-              </Select.Trigger>
-              <Select.Content>
-                {options.items.map((option) => (
-                  <Select.Item item={option} key={option.value}>
-                    {option.label}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select.Root>
-            <DagRunSelect limit={limit} />
-          </>
-        ) : undefined}
-      </Stack>
+      <Accordion.Root collapsible>
+        <Accordion.Item borderBottomWidth={0} value="1">
+          <Accordion.ItemTrigger justifyContent="flex-end">
+            <Text fontSize="sm">Options</Text>
+            <Accordion.ItemIndicator />
+          </Accordion.ItemTrigger>
+          <Accordion.ItemContent display="flex" justifyContent="flex-end">
+            <Accordion.ItemBody bg="bg.muted" p={2} width="fit-content">
+              <Stack gap={1} mr={2}>
+                <DagVersionSelect disabled={dagView !== "graph"} />
+                {dagView === "graph" ? (
+                  <>
+                    <DagRunSelect limit={limit} />
+                    <Select.Root
+                      collection={options}
+                      data-testid="filter-duration"
+                      onValueChange={handleDepsChange}
+                      size="sm"
+                      value={[dependencies]}
+                    >
+                      <Select.Label fontSize="xs">Dependencies</Select.Label>
+                      <Select.Trigger>
+                        <Select.ValueText placeholder="Dependencies" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {options.items.map((option) => (
+                          <Select.Item item={option} key={option.value}>
+                            {option.label}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select.Root>
+                    <Select.Root
+                      collection={directionOptions}
+                      onValueChange={handleDirectionUpdate}
+                      size="sm"
+                      value={[direction]}
+                    >
+                      <Select.Label fontSize="xs">Graph Direction</Select.Label>
+                      <Select.Trigger>
+                        <Select.ValueText />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {directionOptions.items.map((option) => (
+                          <Select.Item item={option} key={option.value}>
+                            {option.label}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select.Root>
+                  </>
+                ) : (
+                  <Select.Root
+                    collection={displayRunOptions}
+                    data-testid="display-dag-run-options"
+                    onValueChange={handleLimitChange}
+                    size="sm"
+                    value={[limit.toString()]}
+                  >
+                    <Select.Label>Number of Dag Runs</Select.Label>
+                    <Select.Trigger>
+                      {}
+                      <Select.ValueText />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {displayRunOptions.items.map((option) => (
+                        <Select.Item item={option} key={option.value}>
+                          {option.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Root>
+                )}
+              </Stack>
+            </Accordion.ItemBody>
+          </Accordion.ItemContent>
+        </Accordion.Item>
+      </Accordion.Root>
     </HStack>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -117,7 +117,7 @@ export const Code = () => {
           }
         </HStack>
         <HStack>
-          <DagVersionSelect />
+          <DagVersionSelect showLabel={false} />
           <ClipboardRoot value={code?.content ?? ""}>
             <ClipboardButton />
           </ClipboardRoot>


### PR DESCRIPTION
We started accumulating a lot of select dropdowns to change the grid and graph views. It was getting unwieldy displaying them all the time. Now they're moved to an accordion to show/hide them, defaulting to hidden.

Also, none of the dropdowns had labels, and with so many it became confusing as to what each did.


<img width="424" alt="Screenshot 2025-03-27 at 9 56 23 AM" src="https://github.com/user-attachments/assets/7ebe604f-a087-46da-b961-9b6db6030291" />
<img width="842" alt="Screenshot 2025-03-27 at 9 56 29 AM" src="https://github.com/user-attachments/assets/3dae0e9c-8464-4c9e-872f-64ed6ba23ea2" />
<img width="422" alt="Screenshot 2025-03-27 at 9 56 16 AM" src="https://github.com/user-attachments/assets/3087a75a-15e3-454b-a154-b03ec35d189f" />
<img width="420" alt="Screenshot 2025-03-27 at 9 56 09 AM" src="https://github.com/user-attachments/assets/8bc73e22-09ec-4f9e-8d76-0424e67d8055" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
