### PR TITLE
Move column filters button back to table header

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, Spacer, Text } from "@chakra-ui/react";
+import { HStack, Text } from "@chakra-ui/react";
 import {
   getCoreRowModel,
   getExpandedRowModel,
@@ -32,7 +32,6 @@ import {
 import React, { type ReactNode, useCallback, useRef, useState } from "react";
 
 import { CardList } from "src/components/DataTable/CardList";
-import FilterMenuButton from "src/components/DataTable/FilterMenuButton";
 import { TableList } from "src/components/DataTable/TableList";
 import { createSkeletonMock } from "src/components/DataTable/skeleton";
 import type { CardDef, MetaColumn, TableState } from "src/components/DataTable/types";
@@ -133,12 +132,10 @@ export const DataTable = <TData,>({
     <>
       <ProgressBar size="xs" visibility={Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"} />
       <Toaster />
-      <HStack>
-        <Spacer display="flow" />
-        {allowFiltering && hasRows && display === "table" ? <FilterMenuButton table={table} /> : undefined}
-      </HStack>
       {errorMessage}
-      {hasRows && display === "table" ? <TableList table={table} /> : undefined}
+      {hasRows && display === "table" ? (
+        <TableList allowFiltering={allowFiltering} table={table} />
+      ) : undefined}
       {hasRows && display === "card" && cardDef !== undefined ? (
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
       ) : undefined}

--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -59,7 +59,7 @@ type DataTableProps<TData> = {
 const defaultGetRowCanExpand = () => false;
 
 export const DataTable = <TData,>({
-  allowFiltering = true,
+  allowFiltering,
   cardDef,
   columns,
   data,
@@ -128,13 +128,16 @@ export const DataTable = <TData,>({
     (table.getState().pagination.pageIndex !== 0 ||
       (table.getState().pagination.pageIndex === 0 && rows.length !== total));
 
+  // Default to show columns filter only if there are actually many columns displayed
+  const showColumnsFilter = allowFiltering ?? columns.length > 5;
+
   return (
     <>
       <ProgressBar size="xs" visibility={Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"} />
       <Toaster />
       {errorMessage}
       {hasRows && display === "table" ? (
-        <TableList allowFiltering={allowFiltering} table={table} />
+        <TableList allowFiltering={showColumnsFilter} table={table} />
       ) : undefined}
       {hasRows && display === "card" && cardDef !== undefined ? (
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />

--- a/airflow-core/src/airflow/ui/src/components/DataTable/FilterMenuButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/FilterMenuButton.tsx
@@ -35,7 +35,7 @@ const FilterMenuButton = <TData,>({ table }: Props<TData>) => (
         margin={1}
         padding={0}
         title="Filter table columns"
-        variant="plain"
+        variant="ghost"
       >
         <MdFilterList size="1" />
       </IconButton>

--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -16,17 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, Table } from "@chakra-ui/react";
+import { Button, Table, Box } from "@chakra-ui/react";
 import { flexRender, type Row, type Table as TanStackTable } from "@tanstack/react-table";
 import React, { Fragment } from "react";
 import { TiArrowSortedDown, TiArrowSortedUp, TiArrowUnsorted } from "react-icons/ti";
 
+import FilterMenuButton from "./FilterMenuButton";
+
 type DataTableProps<TData> = {
+  readonly allowFiltering: boolean;
   readonly renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
   readonly table: TanStackTable<TData>;
 };
 
-export const TableList = <TData,>({ renderSubComponent, table }: DataTableProps<TData>) => (
+export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }: DataTableProps<TData>) => (
   <Table.Root data-testid="table-list" striped>
     <Table.Header bg="chakra-body-bg" position="sticky" top={0} zIndex={1}>
       {table.getHeaderGroups().map((headerGroup) => (
@@ -71,6 +74,11 @@ export const TableList = <TData,>({ renderSubComponent, table }: DataTableProps<
           })}
         </Table.Row>
       ))}
+      {allowFiltering ? (
+        <Box position="absolute" right={0} top={2}>
+          <FilterMenuButton table={table} />
+        </Box>
+      ) : undefined}
     </Table.Header>
     <Table.Body>
       {table.getRowModel().rows.map((row) => (


### PR DESCRIPTION
The Filter Columns button was given its own row which created a lot of excess whitespace on the page. Instead it can just be positioned at the end of the table header. Since column headers are left-aligned. We should avoid overlapping.

Also, we defaulted to always showing the column filter button. Instead, we show it if there are more than 5 columns

<img width="1665" alt="Screenshot 2025-03-27 at 10 44 27 AM" src="https://github.com/user-attachments/assets/5fa700cf-79c1-4f4a-8cf0-40fa2a4ebe26" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
