### PR TITLE
Add mapped task count to graph task node

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -79,6 +79,7 @@ export const TaskNode = ({
           >
             <Box>
               <TaskLink
+                childCount={taskInstance?.task_count}
                 id={id}
                 isGroup={isGroup}
                 isMapped={isMapped}

--- a/airflow-core/src/airflow/ui/src/components/TaskName.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskName.tsx
@@ -23,6 +23,7 @@ import { FiArrowUpRight, FiArrowDownRight } from "react-icons/fi";
 import type { NodeResponse } from "openapi/requests/types.gen";
 
 export type TaskNameProps = {
+  readonly childCount?: number;
   readonly isGroup?: boolean;
   readonly isMapped?: boolean;
   readonly isOpen?: boolean;
@@ -38,6 +39,7 @@ const iconStyle: CSSProperties = {
 };
 
 export const TaskName = ({
+  childCount,
   isGroup = false,
   isMapped = false,
   isOpen = false,
@@ -59,7 +61,7 @@ export const TaskName = ({
   return (
     <Text fontSize={isZoomedOut ? "lg" : "md"} fontWeight="bold" {...rest}>
       {label}
-      {isMapped ? " [ ]" : undefined}
+      {isMapped ? ` [${childCount ?? " "}]` : undefined}
       {setupTeardownType === "setup" && <FiArrowUpRight size={isZoomedOut ? 24 : 15} style={iconStyle} />}
       {setupTeardownType === "teardown" && (
         <FiArrowDownRight size={isZoomedOut ? 24 : 15} style={iconStyle} />


### PR DESCRIPTION
Show the number of mapped tasks in the graph when possible:

Task Instance is available:
<img width="528" alt="Screenshot 2025-03-27 at 11 00 36 AM" src="https://github.com/user-attachments/assets/dc61b8c3-0648-427f-8cd9-333a3e46d221" />

Nothing is selected so we can't know how many mapped tasks there are:
<img width="513" alt="Screenshot 2025-03-27 at 11 00 47 AM" src="https://github.com/user-attachments/assets/dbe5adfe-53c7-42a7-910c-a9e68b95e85c" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
