### PR TITLE
AIP-72: Move logic to load Secrets backend on Workers

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -112,12 +112,12 @@ def _convert_variable_result_to_variable(var_result: VariableResult, deserialize
 
 
 def _get_connection(conn_id: str) -> Connection:
-    from airflow.sdk.execution_time.supervisor import SECRETS_BACKEND
+    from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
     # TODO: check cache first
     # enabled only if SecretCache.init() has been called first
 
     # iterate over configured backends if not in cache (or expired)
-    for secrets_backend in SECRETS_BACKEND:
+    for secrets_backend in ensure_secrets_backend_loaded():
         try:
             conn = secrets_backend.get_connection(conn_id=conn_id)
             if conn:
@@ -155,11 +155,11 @@ def _get_connection(conn_id: str) -> Connection:
 def _get_variable(key: str, deserialize_json: bool) -> Any:
     # TODO: check cache first
     # enabled only if SecretCache.init() has been called first
-    from airflow.sdk.execution_time.supervisor import SECRETS_BACKEND
+    from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
 
     var_val = None
     # iterate over backends if not in cache (or expired)
-    for secrets_backend in SECRETS_BACKEND:
+    for secrets_backend in ensure_secrets_backend_loaded():
         try:
             var_val = secrets_backend.get_variable(key=key)  # type: ignore[assignment]
             if var_val is not None:

--- a/task-sdk/tests/task_sdk/definitions/test_connections.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connections.py
@@ -25,7 +25,6 @@ from airflow.configuration import initialize_secrets_backends
 from airflow.exceptions import AirflowException
 from airflow.sdk import Connection
 from airflow.sdk.execution_time.comms import ConnectionResult
-from airflow.sdk.execution_time.supervisor import initialize_secrets_backend_on_workers
 from airflow.secrets import DEFAULT_SECRETS_SEARCH_PATH_WORKERS
 
 from tests_common.test_utils.config import conf_vars
@@ -112,7 +111,6 @@ class TestConnectionsFromSecrets:
                 ("workers", "secrets_backend_kwargs"): f'{{"connections_file_path": "{path}"}}',
             }
         ):
-            initialize_secrets_backend_on_workers()
             retrieved_conn = Connection.get(conn_id="CONN_A")
             assert retrieved_conn is not None
             assert retrieved_conn.conn_id == "CONN_A"
@@ -120,7 +118,6 @@ class TestConnectionsFromSecrets:
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_connection")
     def test_get_connection_env_var(self, mock_env_get, mock_supervisor_comms):
         """Tests getting a connection from environment variable."""
-        initialize_secrets_backend_on_workers()
         mock_env_get.return_value = Connection(conn_id="something", conn_type="some-type")  # return None
         Connection.get("something")
         mock_env_get.assert_called_once_with(conn_id="something")
@@ -135,7 +132,6 @@ class TestConnectionsFromSecrets:
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_connection")
     def test_backend_fallback_to_env_var(self, mock_get_connection, mock_env_get, mock_supervisor_comms):
         """Tests if connection retrieval falls back to environment variable backend if not found in secrets backend."""
-        initialize_secrets_backend_on_workers()
         mock_get_connection.return_value = None
         mock_env_get.return_value = Connection(conn_id="something", conn_type="some-type")
 

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -24,7 +24,6 @@ import pytest
 from airflow.configuration import initialize_secrets_backends
 from airflow.sdk import Variable
 from airflow.sdk.execution_time.comms import VariableResult
-from airflow.sdk.execution_time.supervisor import initialize_secrets_backend_on_workers
 from airflow.secrets import DEFAULT_SECRETS_SEARCH_PATH_WORKERS
 
 from tests_common.test_utils.config import conf_vars
@@ -72,7 +71,6 @@ class TestVariableFromSecrets:
                 ("workers", "secrets_backend_kwargs"): f'{{"variables_file_path": "{path}"}}',
             }
         ):
-            initialize_secrets_backend_on_workers()
             retrieved_var = Variable.get(key="VAR_A")
             assert retrieved_var is not None
             assert retrieved_var == "some_value"
@@ -80,7 +78,6 @@ class TestVariableFromSecrets:
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_variable")
     def test_get_variable_env_var(self, mock_env_get, mock_supervisor_comms):
         """Tests getting a variable from environment variable."""
-        initialize_secrets_backend_on_workers()
         mock_env_get.return_value = "fake_value"
         Variable.get(key="fake_var_key")
         mock_env_get.assert_called_once_with(key="fake_var_key")
@@ -97,7 +94,6 @@ class TestVariableFromSecrets:
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_variable")
     def test_backend_fallback_to_env_var(self, mock_get_variable, mock_env_get, mock_supervisor_comms):
         """Tests if variable retrieval falls back to environment variable backend if not found in secrets backend."""
-        initialize_secrets_backend_on_workers()
         mock_get_variable.return_value = None
         mock_env_get.return_value = "fake_value"
 


### PR DESCRIPTION
Currently, even the default backend is only loaded when the supervise process is called via initialize_secrets_backend_on_workers. This makes it difficult to test any operator without calling that function.

The changes in this commit unifies how we handle it to the 2.x side and on the API-server side.

https://github.com/apache/airflow/blob/2.10.5/airflow/models/connection.py#L524-L536

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
