### PR TITLE
Fix bug in fallback logic with Secrets Backend on the workers

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -2061,8 +2061,12 @@ def get_custom_secret_backend(worker_mode: bool = False) -> BaseSecretsBackend |
         if worker_mode:
             # if we find no secrets backend for worker, return that of secrets backend
             secrets_backend_cls = conf.getimport(section="secrets", key="backend")
+            if not secrets_backend_cls:
+                return None
+            # When falling back to secrets backend, use its kwargs
             kwargs_key = "backend_kwargs"
-        if not secrets_backend_cls:
+            section = "secrets"
+        else:
             return None
 
     try:

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -960,7 +960,7 @@ key7 =
                 "airflow.secrets.local_filesystem.LocalFilesystemBackend",
                 '{"connections_file_path": "/files/conn.json", "variables_file_path": "/files/var.json"}',
                 "airflow.secrets.local_filesystem.LocalFilesystemBackend",
-                {"connections_file_path": "/files/conn.json", "variables_file_path": "/files/var.json"},
+                {"connections_file": "/files/conn.json", "variables_file": "/files/var.json"},
                 id="worker-backend-and-kwargs-not-defined",
             ),
         ],
@@ -996,7 +996,10 @@ key7 =
             backends = ensure_secrets_loaded(DEFAULT_SECRETS_SEARCH_PATH_WORKERS)
             secrets_backend = backends[0]
             assert secrets_backend.__class__.__name__ in expected_backend
-            all(secrets_backend.__dict__.get(k) == v for k, v in expected_backend_kwargs.items())
+
+            # Verify kwargs are properly applied to the backend instance
+            for key, value in expected_backend_kwargs.items():
+                assert getattr(secrets_backend, key) == value
 
 
 @mock.patch.dict(


### PR DESCRIPTION
The logic in the code and test both needed fixing since we weren't testing the right thing.

This ensure the fallback works as expected.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
