### PR TITLE
Cookies in non TLS mode

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -145,7 +145,9 @@ delete the cookie.
     from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 
     response = RedirectResponse(url="/")
-    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=True)
+
+    secure = conf.getboolean("api", "ssl_cert")
+    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
     return response
 
 .. note::

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -63,10 +63,12 @@ def create_token_all_admins() -> RedirectResponse:
     )
 
     response = RedirectResponse(url=conf.get("api", "base_url"))
+
+    secure = conf.getboolean("api", "ssl_cert")
     response.set_cookie(
         COOKIE_NAME_JWT_TOKEN,
         get_auth_manager().generate_jwt(user),
-        secure=True,
+        secure=secure,
     )
     return response
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
@@ -43,7 +43,7 @@ export const Login = () => {
         // Redirect to appropriate page with the token
         const next = searchParams.get("next")
 
-        setCookie('_token', data.jwt_token, {path: "/", secure: true});
+        setCookie('_token', data.jwt_token, {path: "/", secure: globalThis.location.protocol !== "http:"});
 
         globalThis.location.replace(`${next ?? ""}`);
     }

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
@@ -58,7 +58,7 @@ class TestLogin:
         assert response.json()["detail"] == "Invalid credentials"
 
     def test_create_token_all_admins(self, test_client):
-        with conf_vars({("core", "simple_auth_manager_all_admins"): "true"}):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true", ("api", "ssl_cert"): "false"}):
             response = test_client.get("/auth/token", follow_redirects=False)
             assert response.status_code == 307
             assert "location" in response.headers

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
@@ -83,7 +83,9 @@ def login_callback(request: Request):
     url = conf.get("api", "base_url")
     token = get_auth_manager().generate_jwt(user)
     response = RedirectResponse(url=url, status_code=303)
-    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=True)
+
+    secure = conf.getboolean("api", "ssl_cert")
+    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
     return response
 
 

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/router/test_login.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/router/test_login.py
@@ -90,6 +90,7 @@ class TestLoginRouter:
                     "auth_manager",
                 ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
                 ("aws_auth_manager", "saml_metadata_url"): SAML_METADATA_URL,
+                ("api", "ssl_cert"): "false",
             }
         ):
             with (

--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -70,7 +70,7 @@ class FabIndexView(IndexView):
             token = get_auth_manager().generate_jwt(g.user)
             response = make_response(redirect(f"{conf.get('api', 'base_url')}", code=302))
 
-            secure = bool(conf.get("api", "ssl_cert"))
+            secure = conf.getboolean("api", "ssl_cert")
             response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
 
             return response


### PR DESCRIPTION
Continuation of https://github.com/apache/airflow/pull/47859 to extend it to all auth managers.

Cookies shouldn't have the attribute secure if the cluster is not using https