### PR TITLE
Make `sla` params no-op with deprecation warning

### DIFF
--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -1395,7 +1395,6 @@ class TestStringifiedDAGs:
             "retry_delay": timedelta(0, 300),
             "retry_exponential_backoff": False,
             "run_as_user": None,
-            "sla": None,
             "start_date": None,
             "start_from_trigger": False,
             "start_trigger_args": None,

--- a/scripts/ci/pre_commit/check_init_decorator_arguments.py
+++ b/scripts/ci/pre_commit/check_init_decorator_arguments.py
@@ -209,7 +209,9 @@ def check_dag_init_decorator_arguments() -> int:
     items_to_check = [
         (
             "DAG",
-            list(_find_cls_attrs(dag_mod, "DAG", ignore=["full_filepath", "task_group"])),
+            list(
+                _find_cls_attrs(dag_mod, "DAG", ignore=["full_filepath", "task_group", "sla_miss_callback"])
+            ),
             "dag",
             _find_dag_deco(dag_mod),
             "dag_id",

--- a/task-sdk/src/airflow/sdk/definitions/baseoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/baseoperator.py
@@ -692,17 +692,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         way to limit concurrency for certain tasks
     :param pool_slots: the number of pool slots this task should use (>= 1)
         Values less than 1 are not allowed.
-    :param sla: time by which the job is expected to succeed. Note that
-        this represents the ``timedelta`` after the period is closed. For
-        example if you set an SLA of 1 hour, the scheduler would send an email
-        soon after 1:00AM on the ``2016-01-02`` if the ``2016-01-01`` instance
-        has not succeeded yet.
-        The scheduler pays special attention for jobs with an SLA and
-        sends alert
-        emails for SLA misses. SLA misses are also recorded in the database
-        for future reference. All tasks that share the same SLA time
-        get bundled in a single email, sent soon after that time. SLA
-        notification are sent once and only once for each task instance.
+    :param sla: DEPRECATED - The SLA feature is removed in Airflow 3.0, to be replaced with a
+        new implementation in Airflow >=3.1.
     :param execution_timeout: max time allowed for the execution of
         this task instance, if it goes beyond it will raise and fail.
     :param on_failure_callback: a function or list of functions to be called when a task instance
@@ -888,7 +879,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         "depends_on_past",
         "wait_for_downstream",
         "priority_weight",
-        "sla",
         "execution_timeout",
         "on_execute_callback",
         "on_failure_callback",
@@ -1087,7 +1077,11 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if self.pool_slots < 1:
             dag_str = f" in dag {dag.dag_id}" if dag else ""
             raise ValueError(f"pool slots for {self.task_id}{dag_str} cannot be less than 1")
-        self.sla = sla
+        if sla is not None:
+            warnings.warn(
+                "The SLA feature is removed in Airflow 3.0, to be replaced with a new implementation in >=3.1",
+                stacklevel=2,
+            )
 
         if not TriggerRule.is_valid(trigger_rule):
             raise ValueError(


### PR DESCRIPTION
This will ensure that existing 2.x dags with SLAs don't break.

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/c7d886fd-aa3f-420f-afba-844e1c01f6d8" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
