### PR TITLE
Fix `conf.get_boolean("api", "ssl_cert")`

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -146,7 +146,7 @@ delete the cookie.
 
     response = RedirectResponse(url="/")
 
-    secure = conf.getboolean("api", "ssl_cert")
+    secure = conf.has_option("api", "ssl_cert")
     response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
     return response
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -64,7 +64,7 @@ def create_token_all_admins() -> RedirectResponse:
 
     response = RedirectResponse(url=conf.get("api", "base_url"))
 
-    secure = conf.getboolean("api", "ssl_cert")
+    secure = conf.has_option("api", "ssl_cert")
     response.set_cookie(
         COOKIE_NAME_JWT_TOKEN,
         get_auth_manager().generate_jwt(user),

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
@@ -84,7 +84,7 @@ def login_callback(request: Request):
     token = get_auth_manager().generate_jwt(user)
     response = RedirectResponse(url=url, status_code=303)
 
-    secure = conf.getboolean("api", "ssl_cert")
+    secure = conf.has_option("api", "ssl_cert")
     response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
     return response
 

--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -70,7 +70,7 @@ class FabIndexView(IndexView):
             token = get_auth_manager().generate_jwt(g.user)
             response = make_response(redirect(f"{conf.get('api', 'base_url')}", code=302))
 
-            secure = conf.getboolean("api", "ssl_cert")
+            secure = conf.has_option("api", "ssl_cert")
             response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
 
             return response


### PR DESCRIPTION
`[api] ssl_cert` is not a boolean, thus `conf.get_boolean("api", "ssl_cert")` raises an error. Using `has_option` instead.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
