### PR TITLE
Fix mapped task xcom push

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_dynamic_task_mapping.py
+++ b/airflow-core/src/airflow/example_dags/example_dynamic_task_mapping.py
@@ -38,7 +38,9 @@ with DAG(dag_id="example_dynamic_task_mapping", schedule=None, start_date=dateti
     added_values = add_one.expand(x=[1, 2, 3])
     sum_it(added_values)
 
-with DAG(dag_id="example_task_mapping_second_order", schedule=None, start_date=datetime(2022, 3, 4)):
+with DAG(
+    dag_id="example_task_mapping_second_order", schedule=None, catchup=False, start_date=datetime(2022, 3, 4)
+) as dag2:
 
     @task
     def get_nums():

--- a/airflow-core/src/airflow/example_dags/example_dynamic_task_mapping.py
+++ b/airflow-core/src/airflow/example_dags/example_dynamic_task_mapping.py
@@ -37,3 +37,21 @@ with DAG(dag_id="example_dynamic_task_mapping", schedule=None, start_date=dateti
 
     added_values = add_one.expand(x=[1, 2, 3])
     sum_it(added_values)
+
+with DAG(dag_id="example_task_mapping_second_order", schedule=None, start_date=datetime(2022, 3, 4)):
+
+    @task
+    def get_nums():
+        return [1, 2, 3]
+
+    @task
+    def times_2(num):
+        return num * 2
+
+    @task
+    def add_10(num):
+        return num + 10
+
+    _get_nums = get_nums()
+    _times_2 = times_2.expand(num=_get_nums)
+    add_10.expand(num=_times_2)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1841,6 +1841,8 @@ class TaskInstance(Base, LoggingMixin):
     def to_runtime_ti(self, context_from_server) -> RuntimeTaskInstanceProtocol:
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
+        if TYPE_CHECKING:
+            assert self.task
         runtime_ti = RuntimeTaskInstance.model_construct(
             id=self.id,
             task_id=self.task_id,
@@ -1851,6 +1853,7 @@ class TaskInstance(Base, LoggingMixin):
             task=self.task,
             max_tries=self.max_tries,
             hostname=self.hostname,
+            is_mapped=self.task.is_mapped,
             _ti_context_from_server=context_from_server,
             start_date=self.start_date,
         )

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1841,8 +1841,6 @@ class TaskInstance(Base, LoggingMixin):
     def to_runtime_ti(self, context_from_server) -> RuntimeTaskInstanceProtocol:
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
-        if TYPE_CHECKING:
-            assert self.task
         runtime_ti = RuntimeTaskInstance.model_construct(
             id=self.id,
             task_id=self.task_id,
@@ -1853,7 +1851,6 @@ class TaskInstance(Base, LoggingMixin):
             task=self.task,
             max_tries=self.max_tries,
             hostname=self.hostname,
-            is_mapped=self.task.is_mapped,
             _ti_context_from_server=context_from_server,
             start_date=self.start_date,
         )

--- a/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes_tests/test_kubernetes_executor.py
@@ -50,6 +50,30 @@ class TestKubernetesExecutor(BaseK8STest):
             timeout=300,
         )
 
+    @pytest.mark.execution_timeout(300)
+    def test_integration_run_dag_task_mapping(self):
+        dag_id = "example_task_mapping_second_order"
+        dag_run_id, logical_date = self.start_job_in_kubernetes(dag_id, self.host)
+        print(f"Found the job with logical_date {logical_date}")
+
+        # Wait some time for the operator to complete
+        self.monitor_task(
+            host=self.host,
+            dag_run_id=dag_run_id,
+            dag_id=dag_id,
+            task_id="start_task",
+            expected_final_state="success",
+            timeout=300,
+        )
+
+        self.ensure_dag_expected_state(
+            host=self.host,
+            logical_date=logical_date,
+            dag_id=dag_id,
+            expected_final_state="success",
+            timeout=300,
+        )
+
     @pytest.mark.execution_timeout(500)
     def test_integration_run_dag_with_scheduler_failure(self):
         dag_id = "example_kubernetes_executor"

--- a/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes_tests/test_kubernetes_executor.py
@@ -61,7 +61,7 @@ class TestKubernetesExecutor(BaseK8STest):
             host=self.host,
             dag_run_id=dag_run_id,
             dag_id=dag_id,
-            task_id="start_task",
+            task_id="get_nums",
             expected_final_state="success",
             timeout=300,
         )

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -118,7 +118,7 @@ class RuntimeTaskInstance(TaskInstance):
     start_date: datetime
     """Start date of the task instance."""
 
-    is_mapped: bool | None
+    is_mapped: bool | None = None
     """True if the original task was mapped."""
 
     def __rich_repr__(self):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -118,7 +118,7 @@ class RuntimeTaskInstance(TaskInstance):
     start_date: datetime
     """Start date of the task instance."""
 
-    is_mapped: bool
+    is_mapped: bool | None = None
     """True if the original task was mapped."""
 
     def __rich_repr__(self):
@@ -254,6 +254,7 @@ class RuntimeTaskInstance(TaskInstance):
         # MappedOperator is useless for template rendering, and we need to be
         # able to access the unmapped task instead.
         self.task.render_template_fields(context, jinja_env)
+        self.is_mapped = original_task.is_mapped
         return original_task
 
     def xcom_pull(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -118,7 +118,7 @@ class RuntimeTaskInstance(TaskInstance):
     start_date: datetime
     """Start date of the task instance."""
 
-    is_mapped: bool | None = None
+    is_mapped: bool
     """True if the original task was mapped."""
 
     def __rich_repr__(self):
@@ -254,7 +254,6 @@ class RuntimeTaskInstance(TaskInstance):
         # MappedOperator is useless for template rendering, and we need to be
         # able to access the unmapped task instead.
         self.task.render_template_fields(context, jinja_env)
-        self.is_mapped = original_task.is_mapped
         return original_task
 
     def xcom_pull(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -927,10 +927,8 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
         xcom_value = None
 
     has_mapped_dep = next(ti.task.iter_mapped_dependants(), None) is not None
-    is_mapped = ti.is_mapped
-    log.info("running through xcom checks", is_mapped=is_mapped, has_mapped_dep=has_mapped_dep)
     if xcom_value is None:
-        if not is_mapped and has_mapped_dep:
+        if not ti.is_mapped and has_mapped_dep:
             # Uhoh, a downstream mapped task depends on us to push something to map over
             from airflow.sdk.exceptions import XComForMappingNotPushed
 
@@ -938,7 +936,7 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
         return
 
     mapped_length: int | None = None
-    if not is_mapped and has_mapped_dep:
+    if not ti.is_mapped and has_mapped_dep:
         from airflow.sdk.definitions.mappedoperator import is_mappable_value
         from airflow.sdk.exceptions import UnmappableXComTypePushed
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -118,6 +118,9 @@ class RuntimeTaskInstance(TaskInstance):
     start_date: datetime
     """Start date of the task instance."""
 
+    is_mapped: bool | None
+    """True if the original task was mapped."""
+
     def __rich_repr__(self):
         yield "id", self.id
         yield "task_id", self.task_id
@@ -251,7 +254,7 @@ class RuntimeTaskInstance(TaskInstance):
         # MappedOperator is useless for template rendering, and we need to be
         # able to access the unmapped task instead.
         self.task.render_template_fields(context, jinja_env)
-
+        self.is_mapped = original_task.is_mapped
         return original_task
 
     def xcom_pull(
@@ -923,10 +926,11 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
     else:
         xcom_value = None
 
-    is_mapped = next(ti.task.iter_mapped_dependants(), None) is not None or ti.task.is_mapped
-
+    has_mapped_dep = next(ti.task.iter_mapped_dependants(), None) is not None
+    is_mapped = ti.is_mapped
+    log.info("running through xcom checks", is_mapped=is_mapped, has_mapped_dep=has_mapped_dep)
     if xcom_value is None:
-        if is_mapped:
+        if not is_mapped and has_mapped_dep:
             # Uhoh, a downstream mapped task depends on us to push something to map over
             from airflow.sdk.exceptions import XComForMappingNotPushed
 
@@ -934,7 +938,7 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
         return
 
     mapped_length: int | None = None
-    if is_mapped:
+    if not is_mapped and has_mapped_dep:
         from airflow.sdk.definitions.mappedoperator import is_mappable_value
         from airflow.sdk.exceptions import UnmappableXComTypePushed
 


### PR DESCRIPTION
Previously, likely from https://github.com/apache/airflow/pull/46319, we got error when mapped task returned xcom of type that is not mappable. See issue https://github.com/apache/airflow/issues/48433 for some more details.
