### PR TITLE
Update 41520.significant.rst with airflow.sdk imports

### DIFF
--- a/airflow-core/newsfragments/41520.significant.rst
+++ b/airflow-core/newsfragments/41520.significant.rst
@@ -2,8 +2,8 @@ Removed deprecated methods in ``airflow/utils/helpers.py``
 
 * Methods removed:
 
-  * ``chain`` (Use ``airflow.models.baseoperator.chain``)
-  * ``cross_downstream`` (Use ``airflow.models.baseoperator.cross_downstream``)
+  * ``chain`` (Use ``airflow.sdk.chain``)
+  * ``cross_downstream`` (Use ``airflow.sdk.cross_downstream``)
 
 * Types of change
 
@@ -22,5 +22,5 @@ Removed deprecated methods in ``airflow/utils/helpers.py``
 
     * AIR302
 
-      * [x] ``airflow.utils.helpers.chain`` → ``airflow.models.baseoperator.chain``
-      * [x] ``airflow.utils.helpers.cross_downstream`` → ``airflow.models.baseoperator.cross_downstream``
+      * [x] ``airflow.utils.helpers.chain`` → ``airflow.sdk.chain``
+      * [x] ``airflow.utils.helpers.cross_downstream`` → ``airflow.sdk.cross_downstream``


### PR DESCRIPTION
The best practice imports for these functions has been moved to airflow.sdk.

https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/__init__.py 