### PR TITLE
Fix typo in 42953.significant.rst (max_active_runs -> max_active_tasks)

### DIFF
--- a/airflow-core/newsfragments/42953.significant.rst
+++ b/airflow-core/newsfragments/42953.significant.rst
@@ -1,4 +1,4 @@
-``DAG.max_active_runs`` is now evaluated per-run
+``DAG.max_active_tasks`` is now evaluated per-run
 
 Previously, this was evaluated across all runs of the dag. This behavior change was passed by lazy consensus.
 Vote thread: https://lists.apache.org/thread/9o84d3yn934m32gtlpokpwtbbmtxj47l.


### PR DESCRIPTION
Noticed a typo in the newsfragment 

the PR says:
> Pursuant to mailing list vote, this PR changes meaning of DAG.max_active_tasks from "per dag" to "per dag run"

max_active_runs is the parameter limiting concurrent dag runs.

Related question for @dstandish: Was the `AIRFLOW__CORE__MAX_ACTIVE_TASKS_PER_DAG` config changed as well? I don't think from reading #42953 , but I might be missing another PR, just asking because
he [draft docs](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/stable/configurations-ref.html#max-active-tasks-per-dag) still say the config is per dag, not per dag run and I think there should be parity between the config and the dag-level param if possible :) 