### PR TITLE
Add condition to check dag version is undefined or not

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -144,7 +144,7 @@ const taskInstanceColumns = (
   },
   {
     accessorKey: "dag_version",
-    cell: ({ row: { original } }) => 
+    cell: ({ row: { original } }) =>
       original.dag_version?.version_number === undefined ? "" : `v${original.dag_version.version_number}`,
     enableSorting: false,
     header: "Dag Version",

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -144,7 +144,7 @@ const taskInstanceColumns = (
   },
   {
     accessorKey: "dag_version",
-    cell: ({ row: { original } }) => `v${original.dag_version?.version_number}`,
+    cell: ({ row: { original } }) => original.dag_version?.version_number === undefined ? "" : `v${original.dag_version.version_number}`,
     enableSorting: false,
     header: "Dag Version",
   },

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -144,7 +144,8 @@ const taskInstanceColumns = (
   },
   {
     accessorKey: "dag_version",
-    cell: ({ row: { original } }) => original.dag_version?.version_number === undefined ? "" : `v${original.dag_version.version_number}`,
+    cell: ({ row: { original } }) => 
+        original.dag_version?.version_number === undefined ? "" : `v${original.dag_version.version_number}`,
     enableSorting: false,
     header: "Dag Version",
   },

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -145,7 +145,7 @@ const taskInstanceColumns = (
   {
     accessorKey: "dag_version",
     cell: ({ row: { original } }) => 
-        original.dag_version?.version_number === undefined ? "" : `v${original.dag_version.version_number}`,
+      original.dag_version?.version_number === undefined ? "" : `v${original.dag_version.version_number}`,
     enableSorting: false,
     header: "Dag Version",
   },


### PR DESCRIPTION
Added a condition to check if dag version is undefined If version is undefined making it as empty else with the dag version similar to Dag/Header.tsx#L84-87

Dag version is being shown as vundefined in the task instance table in UI if version is undefined
