### PR TITLE
Unify the usage of structlog.get_logger in the codebase

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -74,7 +74,7 @@ from airflow.models.dag_version import DagVersion
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
 
 dag_run_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}/dagRuns")
 

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
 
 
 class AssetManager(LoggingMixin):

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -36,7 +36,7 @@ __all__ = [
     "ExecuteTask",
 ]
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
 
 
 class BaseWorkload(BaseModel):

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
     from airflow.sdk.definitions.context import Context
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
 
 
 @attrs.define(

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -30,7 +30,7 @@ from airflow.dag_processing.bundles.base import (
 from airflow.exceptions import AirflowException
 from airflow.providers.git.hooks.git import GitHook
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
 
 
 class GitDagBundle(BaseDagBundle):

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -466,7 +466,7 @@ def init_log_file(local_relative_path: str) -> Path:
     try:
         full_path.touch(new_file_permissions)
     except OSError as e:
-        log = structlog.get_logger()
+        log = structlog.get_logger(__name__)
         log.warning("OSError while changing ownership of the log file. %s", e)
 
     return full_path

--- a/task-sdk/tests/task_sdk/definitions/conftest.py
+++ b/task-sdk/tests/task_sdk/definitions/conftest.py
@@ -34,7 +34,7 @@ def run_ti(create_runtime_ti, mock_supervisor_comms):
         """Run the task and return the state that the SDK sent as the result for easier asserts"""
         from airflow.sdk.execution_time.task_runner import run
 
-        log = structlog.get_logger()
+        log = structlog.get_logger(__name__)
 
         mock_supervisor_comms.send_request.reset_mock()
         ti = create_runtime_ti(dag.task_dict[task_id], map_index=map_index)

--- a/task-sdk/tests/task_sdk/definitions/test_baseoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_baseoperator.py
@@ -822,7 +822,7 @@ def test_render_template_fields_logging(
 
 
 class HelloWorldOperator(BaseOperator):
-    log = structlog.get_logger()
+    log = structlog.get_logger(__name__)
 
     def execute(self, context):
         return f"Hello {self.owner}!"

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -29,7 +29,7 @@ from airflow.sdk.api.datamodels._generated import TerminalTIState
 from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.execution_time.comms import GetXCom, XComResult
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
 
 RunTI = Callable[[DAG, str, int], TerminalTIState]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Related discussion: https://github.com/apache/airflow/pull/48427#discussion_r2015671369

TLDR: Associating the logger with the module provides only benefits like better debugging and filtering since it is now contextual logging. Adding the __name__ while initialising the logger is also a best practice mentioned herE: https://www.structlog.org/en/stable

> If you prefer to name your standard library loggers explicitly, a positional argument to [get_logger()](https://www.structlog.org/en/17.1.0/api.html#structlog.get_logger) gets passed to the factory and used as the name.

Most of our codebase uses `structlog.get_logger(__name__)` while these instances dont. Unifying those.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
