### PR TITLE
Fix providers common missing

### DIFF
--- a/providers/common/messaging/src/airflow/providers/common/__init__.py
+++ b/providers/common/messaging/src/airflow/providers/common/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -793,6 +793,7 @@ dev = [
     "apache-airflow-devel-common",
 ]
 
+
 [tool.uv]
 required-version = ">=0.6.3"
 no-build-isolation-package = ["sphinx-redoc"]

--- a/scripts/ci/pre_commit/check_providers_subpackages_all_have_init.py
+++ b/scripts/ci/pre_commit/check_providers_subpackages_all_have_init.py
@@ -124,8 +124,8 @@ def check_dir_init_src_folders(folders: list[Path]) -> None:
             need_path_extension = (
                 root_path == providers_base_folder
                 or len(relative_root_path.parts) == 2
-                and relative_root_path.parts[0] in KNOWN_SECOND_LEVEL_PATHS
-                and relative_root_path.parts[1] == "providers"
+                and relative_root_path.parts[1] in KNOWN_SECOND_LEVEL_PATHS
+                and relative_root_path.parts[0] == "providers"
             )
             print("Needs path extension: ", need_path_extension)
             _determine_init_py_action(need_path_extension, root_path)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
