### PR TITLE
AIP-38 Fix log warnings

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -126,12 +126,9 @@ export const renderStructuredLog = ({
   if (errorDetail !== undefined) {
     details = (errorDetail as Array<ErrorDetail>).map((error) => {
       const errorLines = error.frames.map((frame) => (
-        <chakra.p key="test">
-          File{" "}
-          <chakra.span color="fg.info" key="test">
-            {JSON.stringify(frame.filename)}
-          </chakra.span>
-          , line {frame.lineno} in {frame.name}
+        <chakra.p key={`frame-${frame.name}-${frame.filename}-${frame.lineno}`}>
+          File <chakra.span color="fg.info">{JSON.stringify(frame.filename)}</chakra.span>, line{" "}
+          {frame.lineno} in {frame.name}
         </chakra.p>
       ));
 
@@ -172,8 +169,8 @@ export const renderStructuredLog = ({
   );
 
   return (
-    <chakra.p key={index} lineHeight={1.5}>
+    <chakra.div key={index} lineHeight={1.5}>
       {elements}
-    </chakra.p>
+    </chakra.div>
   );
 };


### PR DESCRIPTION
Fix log warnings cause by duplicated keys on elements as well as wrong nesting on the error section. (`<p> inside <p>, <details> inside <p>` etc.)

### Before
![Screenshot 2025-03-28 at 11 53 10](https://github.com/user-attachments/assets/1c358b56-e2db-4545-8599-da6ee4626d35)
![Screenshot 2025-03-28 at 11 53 21](https://github.com/user-attachments/assets/eaf72274-0c96-408a-af15-ef3b5b840b15)

### After
![Screenshot 2025-03-28 at 11 51 26](https://github.com/user-attachments/assets/0bcc1655-254f-4d9e-a465-aada87dfbe6b)
