### PR TITLE
Fixing DatabricksNotebookOperator invalid dependency graph issue

### DIFF
--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -2385,8 +2385,9 @@ class TestDatabricksNotebookOperator:
         operator.task_id = "test_task"
         operator.upstream_task_ids = ["upstream_task"]
         relevant_upstreams = [MagicMock(task_id="upstream_task")]
+        task_dict = {"upstream_task": MagicMock(task_id="upstream_task")}
 
-        task_json = operator._convert_to_databricks_workflow_task(relevant_upstreams)
+        task_json = operator._convert_to_databricks_workflow_task(relevant_upstreams, task_dict)
 
         task_key = hashlib.md5(b"example_dag__test_task").hexdigest()
         expected_json = {
@@ -2423,12 +2424,13 @@ class TestDatabricksNotebookOperator:
         )
         operator.task_group = None
         relevant_upstreams = [MagicMock(task_id="upstream_task")]
+        task_dict = {"upstream_task": MagicMock(task_id="upstream_task")}
 
         with pytest.raises(
             AirflowException,
             match="Calling `_convert_to_databricks_workflow_task` without a parent TaskGroup.",
         ):
-            operator._convert_to_databricks_workflow_task(relevant_upstreams)
+            operator._convert_to_databricks_workflow_task(relevant_upstreams, task_dict)
 
     def test_convert_to_databricks_workflow_task_cluster_conflict(self):
         """Test that an error is raised if both `existing_cluster_id` and `job_cluster_key` are set."""
@@ -2446,12 +2448,13 @@ class TestDatabricksNotebookOperator:
         operator.job_cluster_key = "job-cluster-key"
         operator.task_group = databricks_workflow_task_group
         relevant_upstreams = [MagicMock(task_id="upstream_task")]
+        task_dict = {"upstream_task": MagicMock(task_id="upstream_task")}
 
         with pytest.raises(
             ValueError,
             match="Both existing_cluster_id and job_cluster_key are set. Only one can be set per task.",
         ):
-            operator._convert_to_databricks_workflow_task(relevant_upstreams)
+            operator._convert_to_databricks_workflow_task(relevant_upstreams, task_dict)
 
 
 class TestDatabricksTaskOperator:

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -83,9 +83,9 @@ def test_create_workflow_json(mock_databricks_hook, context, mock_task_group):
     )
     operator.task_group = mock_task_group
 
-    task = MagicMock(spec=BaseOperator)
+    task = MagicMock(spec=BaseOperator, task_id="task_1")
     task._convert_to_databricks_workflow_task = MagicMock(return_value={})
-    operator.add_task(task)
+    operator.add_task(task.task_id, task)
 
     workflow_json = operator.create_workflow_json(context=context)
 
@@ -150,9 +150,9 @@ def test_execute(mock_databricks_hook, context, mock_task_group):
         life_cycle_state=RunLifeCycleState.RUNNING.value
     )
 
-    task = MagicMock(spec=BaseOperator)
+    task = MagicMock(spec=BaseOperator, task_id="task_1")
     task._convert_to_databricks_workflow_task = MagicMock(return_value={})
-    operator.add_task(task)
+    operator.add_task(task.task_id, task)
 
     result = operator.execute(context)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixing the DatabricksNotebookOperator invalid dependency graph issue, this comes when dependencies are defined in DatabricksWorkflowTaskGroup. Issue is child task DatabricksNotebookOperator and DatabricksTaskOperator task referencing itself. Issue in `_generate_databricks_task_key ` function which is incorrectly generating `depends_on` task value. 

closes: #47983


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
