### PR TITLE
Clarifying 47354.significant.rst (catchup_by_default config change)

### DIFF
--- a/airflow-core/newsfragments/47354.significant.rst
+++ b/airflow-core/newsfragments/47354.significant.rst
@@ -1,4 +1,4 @@
-The catchup_by_default configuration is now False by default. This means dags which do not expclitely define `catchup` will not display catchup behavior. 
+The catchup_by_default configuration is now False by default. This means dags which do not expclitely define `catchup` will not display catchup behavior.
 
 * Types of change
 

--- a/airflow-core/newsfragments/47354.significant.rst
+++ b/airflow-core/newsfragments/47354.significant.rst
@@ -1,4 +1,4 @@
-Catchup is now disabled by default.
+The catchup_by_default configuration is now False by default. This means dags which do not expclitely define `catchup` will not display catchup behavior. 
 
 * Types of change
 
@@ -10,3 +10,10 @@ Catchup is now disabled by default.
   * [ ] Plugin changes
   * [ ] Dependency changes
   * [ ] Code interface changes
+
+
+* Migration rules needed
+
+  * ``airflow config lint``
+
+    * [x] ``scheduler.catchup_by_default`` default change from ``True`` to ``False``.

--- a/airflow-core/newsfragments/47354.significant.rst
+++ b/airflow-core/newsfragments/47354.significant.rst
@@ -1,4 +1,4 @@
-The catchup_by_default configuration is now False by default. This means dags which do not expclitely define `catchup` will not display catchup behavior.
+The ``catchup_by_default`` configuration is now ``False`` by default. This means dags which do not explicitly define ``catchup`` will not display catchup behavior.
 
 * Types of change
 


### PR DESCRIPTION
That one is on me 😅 The existing newsfragment is ambiguous about whether the config or the dag-level default was changed. Fixed that and added that it is covered in airflow config lint.