### PR TITLE
Fix installing older airflow versions and current source providers

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -914,6 +914,10 @@ function determine_airflow_to_use() {
         echo
         python "${IN_CONTAINER_DIR}/install_airflow_and_providers.py"
     fi
+    if [[ "${USE_AIRFLOW_VERSION}" =~ ^2.* ]]; then
+        # Remove auth manager setting
+        unset AIRFLOW__CORE__AUTH_MANAGER
+    fi
 
     if [[ "${USE_AIRFLOW_VERSION}" =~ ^2\.2\..*|^2\.1\..*|^2\.0\..* && "${AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=}" != "" ]]; then
         # make sure old variable is used for older airflow versions

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -236,6 +236,10 @@ function determine_airflow_to_use() {
         echo
         python "${IN_CONTAINER_DIR}/install_airflow_and_providers.py"
     fi
+    if [[ "${USE_AIRFLOW_VERSION}" =~ ^2.* ]]; then
+        # Remove auth manager setting
+        unset AIRFLOW__CORE__AUTH_MANAGER
+    fi
 
     if [[ "${USE_AIRFLOW_VERSION}" =~ ^2\.2\..*|^2\.1\..*|^2\.0\..* && "${AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=}" != "" ]]; then
         # make sure old variable is used for older airflow versions

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -371,6 +371,9 @@ ALLOWED_DISTRIBUTION_FORMAT = ["wheel", "sdist", "both"]
 ALLOWED_CONSTRAINTS_MODE = ["constraints-source-providers", "constraints", "constraints-no-providers"]
 ALLOWED_MOUNT_SOURCES = ["remove", "tests", "providers-and-tests"]
 
+INIT_CONTENT = '__path__ = __import__("pkgutil").extend_path(__path__, __name__) # type: ignore'
+FUTURE_CONTENT = "from __future__ import annotations"
+
 
 @click.command()
 @click.option(
@@ -694,18 +697,44 @@ def install_airflow_and_providers(
         if spec is None or spec.origin is None:
             console.print("[red]Airflow not found - cannot mount sources")
             sys.exit(1)
-        console.print(
-            "[blue]Modifying installed airflow's providers __init__.py "
-            "in order to load providers from separate packages."
-        )
-        airflow_path = Path(spec.origin).parent
-        # Make sure old Airflow will include providers including common subfolder allow to extend loading
-        # providers from the installed separate source packages
-        airflow_providers_init_py = airflow_path / "providers" / "__init__.py"
-        airflow_providers_common_init_py = airflow_path / "providers" / "common" / "__init__.py"
-        init_content = '__path__ = __import__("pkgutil").extend_path(__path__, __name__) # type: ignore'
-        airflow_providers_init_py.write_text(init_content)
-        airflow_providers_common_init_py.write_text(init_content)
+        from packaging.version import Version
+
+        from airflow import __version__
+
+        version = Version(__version__)
+        if version.major == 2:
+            console.print(
+                "[yellow]Patching airflow 2 installation "
+                "in order to load providers from separate distributions.\n"
+            )
+            airflow_path = Path(spec.origin).parent
+            # Make sure old Airflow will include providers including common subfolder allow to extend loading
+            # providers from the installed separate source packages
+            console.print("[yellow]Uninstalling Airflow-3 only providers\n")
+            providers_to_uninstall_for_airflow_2 = [
+                "apache-airflow-providers-common-messaging",
+                "apache-airflow-providers-git",
+            ]
+            run_command(
+                ["uv", "pip", "uninstall", *providers_to_uninstall_for_airflow_2],
+                github_actions=github_actions,
+                check=False,
+            )
+            console.print("[yellow]Uninstalling Airflow-3 only providers")
+            console.print(
+                "[yellow]Patching airflow 2 __init__.py -> replacing `from future`"
+                "with legacy namespace packages.\n"
+            )
+            airflow_init_path = airflow_path / "__init__.py"
+            airflow_init_content = airflow_init_path.read_text()
+            airflow_init_path.write_text(airflow_init_content.replace(FUTURE_CONTENT, INIT_CONTENT))
+            console.print("[yellow]Creating legacy `providers.common` and `providers` namespace packages.\n")
+            airflow_providers_init_py = airflow_path / "providers" / "__init__.py"
+            airflow_providers_common_init_py = airflow_path / "providers" / "common" / "__init__.py"
+            airflow_providers_init_py.parent.mkdir(exist_ok=True)
+            airflow_providers_init_py.write_text(INIT_CONTENT + "\n")
+            airflow_providers_common_init_py.parent.mkdir(exist_ok=True)
+            airflow_providers_common_init_py.write_text(INIT_CONTENT + "\n")
 
     console.print("\n[green]Done!")
 


### PR DESCRIPTION
The source providers and old airflow did not work well together for a few reasons:

* airflow 2 did not have legacy namespace packaging specification at the top of the file
* the providers and commong __init__.py files had no legacy namespace specification
* few Airflow 3-only providers cause airflow 2 to fail when installed together from sources.
* AIRFLOW__CORE__AUTH_MANAGER was set pointing to Simple Auth Manger only used in Airflow 3

This PR fixes all issues:

* it patches installed airflow (if airflow 2 is installed) and fixes the __init__.py files
* it uninstalls the providers that are problematic
* it unsets the AIRFLOW__CORE__AUTH_MANAGER variable

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
