### PR TITLE
Add missing clear to clear_all

### DIFF
--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -335,7 +335,6 @@ def clear_dag_specific_permissions():
 
 def clear_all():
     clear_db_runs()
-    clear_db_backfills()
     clear_db_assets()
     clear_db_triggers()
     clear_db_dags()
@@ -354,5 +353,7 @@ def clear_all():
     clear_db_connections(add_default_connections_back=True)
     clear_db_deadline()
     clear_dag_specific_permissions()
-    clear_db_dag_parsing_requests()
-    clear_db_dag_bundles()
+    if AIRFLOW_V_3_0_PLUS:
+        clear_db_backfills()
+        clear_db_dag_bundles()
+        clear_db_dag_parsing_requests()

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -335,7 +335,9 @@ def clear_dag_specific_permissions():
 
 def clear_all():
     clear_db_runs()
+    clear_db_backfills()
     clear_db_assets()
+    clear_db_triggers()
     clear_db_dags()
     clear_db_serialized_dags()
     clear_db_dag_code()
@@ -352,5 +354,5 @@ def clear_all():
     clear_db_connections(add_default_connections_back=True)
     clear_db_deadline()
     clear_dag_specific_permissions()
-    if AIRFLOW_V_3_0_PLUS:
-        clear_db_dag_bundles()
+    clear_db_dag_parsing_requests()
+    clear_db_dag_bundles()


### PR DESCRIPTION
Some tables are not cleared on `clear_all` which I find confusing and could introduce tests side effects.