### PR TITLE
Update create token apis in simple auth manager

### DIFF
--- a/airflow-core/docs/security/api.rst
+++ b/airflow-core/docs/security/api.rst
@@ -56,7 +56,7 @@ Response
 .. code-block:: json
 
   {
-    "jwt_token": "<JWT-TOKEN>"
+    "access_token": "<JWT-TOKEN>"
   }
 
 Use the JWT token to call Airflow public API

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/datamodels/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/datamodels/login.py
@@ -25,7 +25,7 @@ from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 class LoginResponse(BaseModel):
     """Login serializer for responses."""
 
-    jwt_token: str
+    access_token: str
 
 
 class LoginBody(StrictBaseModel):

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/openapi/v1-generated.yaml
@@ -15,11 +15,12 @@ paths:
         is True.
       operationId: create_token_all_admins
       responses:
-        '307':
+        '201':
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
         '403':
           description: Forbidden
           content:
@@ -63,6 +64,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /auth/token/login:
+    get:
+      tags:
+      - SimpleAuthManagerLogin
+      summary: Login All Admins
+      description: Login the user with no credentials.
+      operationId: login_all_admins
+      responses:
+        '307':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
   /auth/token/cli:
     post:
       tags:
@@ -142,12 +162,12 @@ components:
       description: Login serializer for post bodies.
     LoginResponse:
       properties:
-        jwt_token:
+        access_token:
           type: string
-          title: Jwt Token
+          title: Access Token
       type: object
       required:
-      - jwt_token
+      - access_token
       title: LoginResponse
       description: Login serializer for responses.
     ValidationError:

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -17,14 +17,12 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
+from fastapi import status
 from starlette.responses import RedirectResponse
 
-from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody, LoginResponse
 from airflow.api_fastapi.auth.managers.simple.services.login import SimpleAuthManagerLogin
-from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.configuration import conf
@@ -41,33 +39,31 @@ def create_token(
     body: LoginBody,
 ) -> LoginResponse:
     """Authenticate the user."""
-    return SimpleAuthManagerLogin.create_token(body=body)
+    return LoginResponse(access_token=SimpleAuthManagerLogin.create_token(body=body))
 
 
 @login_router.get(
     "/token",
+    status_code=status.HTTP_201_CREATED,
+    responses=create_openapi_http_exception_doc([status.HTTP_403_FORBIDDEN]),
+)
+def create_token_all_admins() -> LoginResponse:
+    """Create a token with no credentials only if ``simple_auth_manager_all_admins`` is True."""
+    return LoginResponse(access_token=SimpleAuthManagerLogin.create_token_all_admins())
+
+
+@login_router.get(
+    "/token/login",
     status_code=status.HTTP_307_TEMPORARY_REDIRECT,
     responses=create_openapi_http_exception_doc([status.HTTP_403_FORBIDDEN]),
 )
-def create_token_all_admins() -> RedirectResponse:
-    """Create a token with no credentials only if ``simple_auth_manager_all_admins`` is True."""
-    is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
-    if not is_simple_auth_manager_all_admins:
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            "This method is only allowed if ``[core] simple_auth_manager_all_admins`` is True",
-        )
-    user = SimpleAuthManagerUser(
-        username="Anonymous",
-        role="ADMIN",
-    )
-
+def login_all_admins() -> RedirectResponse:
+    """Login the user with no credentials."""
     response = RedirectResponse(url=conf.get("api", "base_url"))
-
     secure = conf.has_option("api", "ssl_cert")
     response.set_cookie(
         COOKIE_NAME_JWT_TOKEN,
-        get_auth_manager().generate_jwt(user),
+        SimpleAuthManagerLogin.create_token_all_admins(),
         secure=secure,
     )
     return response
@@ -82,6 +78,8 @@ def create_token_cli(
     body: LoginBody,
 ) -> LoginResponse:
     """Authenticate the user for the CLI."""
-    return SimpleAuthManagerLogin.create_token(
-        body=body, expiration_time_in_sec=conf.getint("api_auth", "jwt_cli_expiration_time")
+    return LoginResponse(
+        access_token=SimpleAuthManagerLogin.create_token(
+            body=body, expiration_time_in_seconds=conf.getint("api_auth", "jwt_cli_expiration_time")
+        )
     )

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from fastapi import HTTPException, status
 
 from airflow.api_fastapi.app import get_auth_manager
-from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody, LoginResponse
+from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody
 from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.configuration import conf
@@ -29,18 +29,22 @@ from airflow.configuration import conf
 class SimpleAuthManagerLogin:
     """Service for login."""
 
-    @classmethod
+    @staticmethod
     def create_token(
-        cls, body: LoginBody, expiration_time_in_sec: int = conf.getint("api_auth", "jwt_expiration_time")
-    ) -> LoginResponse:
+        body: LoginBody, expiration_time_in_seconds: int = conf.getint("api_auth", "jwt_expiration_time")
+    ) -> str:
         """
         Authenticate user with given configuration.
 
         :param body: LoginBody should include username and password
-        :param expiration_time_in_sec: int expiration time in seconds
-
-        :return: LoginResponse
+        :param expiration_time_in_seconds: int expiration time in seconds
         """
+        is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
+        if is_simple_auth_manager_all_admins:
+            return SimpleAuthManagerLogin._create_anonymous_admin_user(
+                expiration_time_in_seconds=expiration_time_in_seconds
+            )
+
         if not body.username or not body.password:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -66,8 +70,33 @@ class SimpleAuthManagerLogin:
             role=found_users[0]["role"],
         )
 
-        return LoginResponse(
-            jwt_token=get_auth_manager().generate_jwt(
-                user=user, expiration_time_in_seconds=expiration_time_in_sec
+        return get_auth_manager().generate_jwt(
+            user=user, expiration_time_in_seconds=expiration_time_in_seconds
+        )
+
+    @staticmethod
+    def create_token_all_admins(
+        expiration_time_in_seconds: int = conf.getint("api_auth", "jwt_expiration_time"),
+    ) -> str:
+        is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
+        if not is_simple_auth_manager_all_admins:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "This method is only allowed if ``[core] simple_auth_manager_all_admins`` is True",
             )
+
+        return SimpleAuthManagerLogin._create_anonymous_admin_user(
+            expiration_time_in_seconds=expiration_time_in_seconds
+        )
+
+    @staticmethod
+    def _create_anonymous_admin_user(
+        expiration_time_in_seconds: int = conf.getint("api_auth", "jwt_expiration_time"),
+    ) -> str:
+        user = SimpleAuthManagerUser(
+            username="Anonymous",
+            role="ADMIN",
+        )
+        return get_auth_manager().generate_jwt(
+            user=user, expiration_time_in_seconds=expiration_time_in_seconds
         )

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -146,7 +146,7 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         """Return the login page url."""
         is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
         if is_simple_auth_manager_all_admins:
-            return AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token"
+            return AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token/login"
 
         return AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login"
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
@@ -46,7 +46,7 @@ export const Login = () => {
     // Redirect to appropriate page with the token
     const next = searchParams.get("next")
 
-    setCookie('_token', data.jwt_token, {path: "/", secure: globalThis.location.protocol !== "http:"})
+    setCookie('_token', data.access_token, {path: "/", secure: globalThis.location.protocol !== "http:"})
 
     globalThis.location.replace(`${next ?? ""}`);
   }

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
@@ -22,8 +22,6 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginResponse
-
 from tests_common.test_utils.config import conf_vars
 
 TEST_USER_1 = "test1"
@@ -40,14 +38,14 @@ class TestLogin:
     )
     @patch("airflow.api_fastapi.auth.managers.simple.routes.login.SimpleAuthManagerLogin")
     def test_create_token(self, mock_simple_auth_manager_login, test_client, auth_manager, test_user):
-        mock_simple_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
+        mock_simple_auth_manager_login.create_token.return_value = "DUMMY_TOKEN"
 
         response = test_client.post(
             "/auth/token",
             json={"username": test_user, "password": "DUMMY_PASS"},
         )
         assert response.status_code == 201
-        assert response.json()["jwt_token"]
+        assert response.json()["access_token"]
 
     def test_create_token_invalid_user_password(self, test_client):
         response = test_client.post(
@@ -58,14 +56,23 @@ class TestLogin:
         assert response.json()["detail"] == "Invalid credentials"
 
     def test_create_token_all_admins(self, test_client):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true"}):
+            response = test_client.get("/auth/token")
+            assert response.status_code == 201
+
+    def test_create_token_all_admins_config_disabled(self, test_client):
+        response = test_client.get("/auth/token")
+        assert response.status_code == 403
+
+    def test_login_all_admins(self, test_client):
         with conf_vars({("core", "simple_auth_manager_all_admins"): "true", ("api", "ssl_cert"): "false"}):
-            response = test_client.get("/auth/token", follow_redirects=False)
+            response = test_client.get("/auth/token/login", follow_redirects=False)
             assert response.status_code == 307
             assert "location" in response.headers
             assert response.cookies.get("_token") is not None
 
-    def test_create_token_all_admins_config_disabled(self, test_client):
-        response = test_client.get("/auth/token")
+    def test_login_all_admins_config_disabled(self, test_client):
+        response = test_client.get("/auth/token/login", follow_redirects=False)
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
@@ -77,14 +84,14 @@ class TestLogin:
     )
     @patch("airflow.api_fastapi.auth.managers.simple.routes.login.SimpleAuthManagerLogin")
     def test_create_token_cli(self, mock_simple_auth_manager_login, test_client, auth_manager, test_user):
-        mock_simple_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
+        mock_simple_auth_manager_login.create_token.return_value = "DUMMY_TOKEN"
 
         response = test_client.post(
             "/auth/token/cli",
             json={"username": test_user, "password": "DUMMY_PASS"},
         )
         assert response.status_code == 201
-        assert response.json()["jwt_token"]
+        assert response.json()["access_token"]
 
     def test_create_token_invalid_user_password_cli(self, test_client):
         response = test_client.post(

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -118,7 +118,7 @@ class TestSimpleAuthManager:
     def test_get_url_login_with_all_admins(self, auth_manager):
         with conf_vars({("core", "simple_auth_manager_all_admins"): "true"}):
             result = auth_manager.get_url_login()
-            assert result == AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token"
+            assert result == AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token/login"
 
     def test_deserialize_user(self, auth_manager):
         result = auth_manager.deserialize_user({"sub": "test", "role": "admin"})

--- a/clients/python/test_python_client.py
+++ b/clients/python/test_python_client.py
@@ -71,7 +71,7 @@ auth_manager = cast("get_auth_manager()", SimpleAuthManager)
 users = auth_manager.get_users()
 passwords = auth_manager.get_passwords(users)
 username, password = next(iter(passwords.items()))
-access_token = SimpleAuthManagerLogin.create_token(LoginBody(username=username, password=password)).jwt_token
+access_token = SimpleAuthManagerLogin.create_token(LoginBody(username=username, password=password))
 configuration = airflow_client.client.Configuration(
     host="http://localhost:8080/api/v2",
 )

--- a/docker_tests/test_docker_compose_quick_start.py
+++ b/docker_tests/test_docker_compose_quick_start.py
@@ -67,7 +67,7 @@ def get_jwt_token() -> str:
             "password": AIRFLOW_WWW_USER_PASSWORD,
         },
     )
-    jwt_token = login_response.json().get("jwt_token")
+    jwt_token = login_response.json().get("access_token")
 
     assert jwt_token, f"Failed to get JWT token from redirect url {url} with status code {login_response}"
     return jwt_token

--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -156,7 +156,7 @@ class BaseK8STest:
             url,
             json={"username": username, "password": password},
         )
-        jwt_token = login_response.json().get("jwt_token")
+        jwt_token = login_response.json().get("access_token")
 
         assert jwt_token, f"Failed to get JWT token from redirect url {url} with status code {login_response}"
         return jwt_token

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/login.py
@@ -22,7 +22,7 @@ from airflow.api_fastapi.core_api.base import BaseModel
 class LoginResponse(BaseModel):
     """API Token serializer for responses."""
 
-    jwt_token: str
+    access_token: str
 
 
 class LoginBody(BaseModel):

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v1-generated.yaml
@@ -122,12 +122,12 @@ components:
       description: API Token serializer for requests.
     LoginResponse:
       properties:
-        jwt_token:
+        access_token:
           type: string
-          title: Jwt Token
+          title: Access Token
       type: object
       required:
-      - jwt_token
+      - access_token
       title: LoginResponse
       description: API Token serializer for responses.
     ValidationError:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -47,5 +47,5 @@ def create_token(body: LoginBody) -> LoginResponse:
 def create_token_cli(body: LoginBody) -> LoginResponse:
     """Generate a new CLI API token."""
     return FABAuthManagerLogin.create_token(
-        body=body, expiration_time_in_sec=conf.getint("api_auth", "jwt_cli_expiration_time")
+        body=body, expiration_time_in_seconds=conf.getint("api_auth", "jwt_cli_expiration_time")
     )

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
@@ -35,7 +35,7 @@ class FABAuthManagerLogin:
 
     @classmethod
     def create_token(
-        cls, body: LoginBody, expiration_time_in_sec: int = conf.getint("api_auth", "jwt_expiration_time")
+        cls, body: LoginBody, expiration_time_in_seconds: int = conf.getint("api_auth", "jwt_expiration_time")
     ) -> LoginResponse:
         """Create a new token."""
         if not body.username or not body.password:
@@ -50,8 +50,8 @@ class FABAuthManagerLogin:
 
         if auth_manager.security_manager.check_password(username=body.username, password=body.password):
             return LoginResponse(
-                jwt_token=auth_manager.generate_jwt(
-                    user=user, expiration_time_in_seconds=expiration_time_in_sec
+                access_token=auth_manager.generate_jwt(
+                    user=user, expiration_time_in_seconds=expiration_time_in_seconds
                 )
             )
         else:

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -27,7 +27,7 @@ from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import Logi
 @pytest.mark.db_test
 class TestLogin:
     dummy_login_body = LoginBody(username="dummy", password="dummy")
-    dummy_token = LoginResponse(jwt_token="DUMMY_TOKEN")
+    dummy_token = LoginResponse(access_token="DUMMY_TOKEN")
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
     def test_create_token(self, mock_fab_auth_manager_login, test_client):
@@ -38,15 +38,15 @@ class TestLogin:
             json=self.dummy_login_body.model_dump(),
         )
         assert response.status_code == 201
-        assert response.json()["jwt_token"] == self.dummy_token.jwt_token
+        assert response.json()["access_token"] == self.dummy_token.access_token
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.FABAuthManagerLogin")
     def test_create_token_cli(self, mock_fab_auth_manager_login, test_client):
-        mock_fab_auth_manager_login.create_token.return_value = LoginResponse(jwt_token="DUMMY_TOKEN")
+        mock_fab_auth_manager_login.create_token.return_value = LoginResponse(access_token="DUMMY_TOKEN")
 
         response = test_client.post(
             "/token/cli",
             json=self.dummy_login_body.model_dump(),
         )
         assert response.status_code == 201
-        assert response.json()["jwt_token"] == self.dummy_token.jwt_token
+        assert response.json()["access_token"] == self.dummy_token.access_token

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -55,9 +55,9 @@ class TestLogin:
 
         login_response: LoginResponse = FABAuthManagerLogin.create_token(
             body=self.dummy_login_body,
-            expiration_time_in_sec=1,
+            expiration_time_in_seconds=1,
         )
-        assert login_response.jwt_token == self.dummy_token
+        assert login_response.access_token == self.dummy_token
 
     def test_create_token_invalid_username(self, get_auth_manager):
         get_auth_manager.return_value = self.dummy_auth_manager
@@ -68,7 +68,7 @@ class TestLogin:
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(
                 body=self.dummy_login_body,
-                expiration_time_in_sec=1,
+                expiration_time_in_seconds=1,
             )
         assert ex.value.status_code == 401
         assert ex.value.detail == "Invalid username"
@@ -83,7 +83,7 @@ class TestLogin:
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(
                 body=self.dummy_login_body,
-                expiration_time_in_sec=1,
+                expiration_time_in_seconds=1,
             )
         assert ex.value.status_code == 401
         assert ex.value.detail == "Invalid password"
@@ -99,7 +99,7 @@ class TestLogin:
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(
                 body=self.dummy_login_body,
-                expiration_time_in_sec=1,
+                expiration_time_in_seconds=1,
             )
         assert ex.value.status_code == 400
         assert ex.value.detail == "Username and password must be provided"


### PR DESCRIPTION
While working on the documentation I realized something was missing in simple auth manager. We need to have an API to generate a token when `[core] simple_auth_manager_all_admins` is `True`. The route `GET /auth/token` in simple auth manager currently logs in the user but we need to have both:
- An api to generate the token so that users can generate a JWT token to access Airflow API
- A route to log in the user when the option is enabled

I also renamed `jwt_token` key from the API responses to `access_token` to follow standards.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
