### PR TITLE
Remove side-effects from test_sqlalchemy_config

### DIFF
--- a/airflow-core/tests/unit/core/test_sqlalchemy_config.py
+++ b/airflow-core/tests/unit/core/test_sqlalchemy_config.py
@@ -33,16 +33,13 @@ pytestmark = pytest.mark.db_test
 
 
 class TestSqlAlchemySettings:
-    def setup_method(self):
-        self.old_engine = settings.engine
-        self.old_session = settings.Session
-        self.old_conn = settings.SQL_ALCHEMY_CONN
+    @pytest.fixture(autouse=True, scope="class")
+    def reset(self):
         settings.SQL_ALCHEMY_CONN = "mysql+foobar://user:pass@host/dbname?inline=param&another=param"
-
-    def teardown_method(self):
-        settings.engine = self.old_engine
-        settings.Session = self.old_session
-        settings.SQL_ALCHEMY_CONN = self.old_conn
+        try:
+            yield
+        finally:
+            settings.configure_orm()
 
     @patch("airflow.settings.setup_event_handlers")
     @patch("airflow.settings.scoped_session")


### PR DESCRIPTION
The SQLA global variables we create and set up has grown over time, and in
debugging another test issue I noticed that this test was causing side effects
in another PR

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
