### PR TITLE
Add DatabricksSQLStatementsOperator

### DIFF
--- a/providers/databricks/docs/operators/sql_statements.rst
+++ b/providers/databricks/docs/operators/sql_statements.rst
@@ -21,7 +21,7 @@
 DatabricksSQLStatementsOperator
 ===============================
 
-Use the :class:`~airflow.providers.databricks.operators.databricks.DatabricksSQLStatementsOperator` to submits a
+Use the :class:`~airflow.providers.databricks.operators.databricks.DatabricksSQLStatementsOperator` to submit a
 Databricks SQL Statement to Databricks using the
 `Databricks SQL Statement Execution API <https://docs.databricks.com/api/workspace/statementexecution>`_.
 

--- a/providers/databricks/docs/operators/sql_statements.rst
+++ b/providers/databricks/docs/operators/sql_statements.rst
@@ -1,0 +1,57 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _howto/operator:DatabricksSQLStatementsOperator:
+
+
+DatabricksSQLStatementsOperator
+===============================
+
+Use the :class:`~airflow.providers.databricks.operators.databricks.DatabricksSQLStatementsOperator` to submits a
+Databricks SQL Statement to Databricks using the
+`Databricks SQL Statement Execution API <https://docs.databricks.com/api/workspace/statementexecution>`_.
+
+
+Using the Operator
+------------------
+
+The ``DatabricksSQLStatementsOperator`` submits SQL statements to Databricks using the
+`/api/2.0/sql/statements/ <https://docs.databricks.com/api/workspace/statementexecution/executestatement>`_ endpoint.
+It supports configurable execution parameters such as warehouse selection, catalog, schema, and parameterized queries.
+The operator can either synchronously poll for query completion or run in a deferrable mode for improved efficiency.
+
+The only required parameters for using the operator are:
+
+* ``statement`` - The SQL statement to execute. The statement can optionally be parameterized, see parameters.
+* ``warehouse_id`` - Warehouse upon which to execute a statement.
+
+All other parameters are optional and described in the documentation for ``DatabricksSQLStatementsOperator`` including
+but not limited to:
+
+* ``catalog``
+* ``schema``
+* ``parameters``
+
+Examples
+--------
+
+An example usage of the ``DatabricksSQLStatementsOperator`` is as follows:
+
+.. exampleinclude:: /../../providers/databricks/tests/system/databricks/example_databricks.py
+    :language: python
+    :start-after: [START howto_operator_sql_statements]
+    :end-before: [END howto_operator_sql_statements]

--- a/providers/databricks/docs/operators/sql_statements.rst
+++ b/providers/databricks/docs/operators/sql_statements.rst
@@ -51,7 +51,7 @@ Examples
 
 An example usage of the ``DatabricksSQLStatementsOperator`` is as follows:
 
-.. exampleinclude:: /../../providers/databricks/tests/system/databricks/example_databricks.py
+.. exampleinclude:: /../../databricks/tests/system/databricks/example_databricks.py
     :language: python
     :start-after: [START howto_operator_sql_statements]
     :end-before: [END howto_operator_sql_statements]

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -191,6 +191,7 @@ class ClusterState:
 
 class SQLStatementState:
     """Utility class for the SQL statement state concept of Databricks statements."""
+
     SQL_STATEMENT_LIFE_CYCLE_STATES = [
         "PENDING",
         "RUNNING",
@@ -200,7 +201,9 @@ class SQLStatementState:
         "CLOSED",
     ]
 
-    def __init__(self, state: str = "", error_code: str = "", error_message: str = "", *args, **kwargs) -> None:
+    def __init__(
+        self, state: str = "", error_code: str = "", error_message: str = "", *args, **kwargs
+    ) -> None:
         if state not in self.SQL_STATEMENT_LIFE_CYCLE_STATES:
             raise AirflowException(
                 f"Unexpected SQL statement life cycle state: {state}: If the state has "
@@ -228,7 +231,11 @@ class SQLStatementState:
         return self.state == "SUCCEEDED"
 
     def __eq__(self, other) -> bool:
-        return self.state == other.state and self.error_code == other.error_code and self.error_message == other.error_message
+        return (
+            self.state == other.state
+            and self.error_code == other.error_code
+            and self.error_message == other.error_message
+        )
 
     def __repr__(self) -> str:
         return str(self.__dict__)
@@ -768,32 +775,35 @@ class DatabricksHook(BaseDatabricksHook):
     def get_sql_statement_state(self, statement_id: str) -> SQLStatementState:
         """
         Retrieve run state of the SQL statement.
-        :param statement_id: ID of the SQL statement
-        :return: state of the SQL statement
+
+        :param statement_id: ID of the SQL statement.
+        :return: state of the SQL statement.
         """
         get_statement_endpoint = ("GET", f"api/2.0/sql/statements/{statement_id}")
         response = self._do_api_call(get_statement_endpoint)
         state = response["status"]["state"]
-        error_code = response.get("error", {}).get("error_code", "")
-        error_message = response.get("error", {}).get("error_message", "")
+        error_code = response["status"].get("error", {}).get("error_code", "")
+        error_message = response["status"].get("error", {}).get("message", "")
         return SQLStatementState(state, error_code, error_message)
 
     async def a_get_sql_statement_state(self, statement_id: str) -> SQLStatementState:
         """
         Async version of `get_sql_statement_state`.
+
         :param statement_id: ID of the SQL statement
         :return: state of the SQL statement
         """
         get_sql_statement_endpoint = ("GET", f"api/2.0/sql/statements/{statement_id}")
         response = await self._a_do_api_call(get_sql_statement_endpoint)
         state = response["status"]["state"]
-        error_code = response.get("error", {}).get("error_code", "")
-        error_message = response.get("error", {}).get("error_message", "")
+        error_code = response["status"].get("error", {}).get("error_code", "")
+        error_message = response["status"].get("error", {}).get("message", "")
         return SQLStatementState(state, error_code, error_message)
 
     def cancel_sql_statement(self, statement_id: str) -> None:
         """
         Cancel the SQL statement.
+
         :param statement_id: ID of the SQL statement
         """
         cancel_sql_statement_endpoint = ("POST", f"api/2.0/sql/statements/{statement_id}/cancel")

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -772,6 +772,12 @@ class DatabricksHook(BaseDatabricksHook):
         return self._do_api_call(("PATCH", f"api/2.0/permissions/jobs/{job_id}"), json)
 
     def post_sql_statement(self, json: dict[str, Any]) -> str:
+        """
+        Submit a SQL statement to the Databricks SQL Statements endpoint.
+
+        :param json: The data used in the body of the request to the SQL Statements endpoint.
+        :return: The statement_id as a string.
+        """
         response = self._do_api_call(("POST", f"{SQL_STATEMENTS_ENDPOINT}"), json)
         return response["statement_id"]
 
@@ -809,6 +815,7 @@ class DatabricksHook(BaseDatabricksHook):
 
         :param statement_id: ID of the SQL statement
         """
+        self.log.info("Canceling SQL statement with ID: %s", statement_id)
         cancel_sql_statement_endpoint = ("POST", f"{SQL_STATEMENTS_ENDPOINT}/{statement_id}/cancel")
         self._do_api_call(cancel_sql_statement_endpoint)
 

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -189,6 +189,58 @@ class ClusterState:
         return ClusterState(**json.loads(data))
 
 
+class SQLStatementState:
+    """Utility class for the SQL statement state concept of Databricks statements."""
+    SQL_STATEMENT_LIFE_CYCLE_STATES = [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+        "CANCELED",
+        "CLOSED",
+    ]
+
+    def __init__(self, state: str = "", error_code: str = "", error_message: str = "", *args, **kwargs) -> None:
+        if state not in self.SQL_STATEMENT_LIFE_CYCLE_STATES:
+            raise AirflowException(
+                f"Unexpected SQL statement life cycle state: {state}: If the state has "
+                "been introduced recently, please check the Databricks user "
+                "guide for troubleshooting information"
+            )
+
+        self.state = state
+        self.error_code = error_code
+        self.error_message = error_message
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if the current state is a terminal state."""
+        return self.state in ("SUCCEEDED", "FAILED", "CANCELED", "CLOSED")
+
+    @property
+    def is_running(self) -> bool:
+        """True if the current state is running."""
+        return self.state in ("PENDING", "RUNNING")
+
+    @property
+    def is_successful(self) -> bool:
+        """True if the state is SUCCEEDED."""
+        return self.state == "SUCCEEDED"
+
+    def __eq__(self, other) -> bool:
+        return self.state == other.state and self.error_code == other.error_code and self.error_message == other.error_message
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__)
+
+    @classmethod
+    def from_json(cls, data: str) -> SQLStatementState:
+        return SQLStatementState(**json.loads(data))
+
+
 class DatabricksHook(BaseDatabricksHook):
     """
     Interact with Databricks.
@@ -708,6 +760,44 @@ class DatabricksHook(BaseDatabricksHook):
         :return: json containing permission specification
         """
         return self._do_api_call(("PATCH", f"api/2.0/permissions/jobs/{job_id}"), json)
+
+    def post_sql_statement(self, json: dict[str, Any]) -> str:
+        response = self._do_api_call(("POST", "api/2.0/sql/statements"), json)
+        return response["statement_id"]
+
+    def get_sql_statement_state(self, statement_id: str) -> SQLStatementState:
+        """
+        Retrieve run state of the SQL statement.
+        :param statement_id: ID of the SQL statement
+        :return: state of the SQL statement
+        """
+        get_statement_endpoint = ("GET", f"api/2.0/sql/statements/{statement_id}")
+        response = self._do_api_call(get_statement_endpoint)
+        state = response["status"]["state"]
+        error_code = response.get("error", {}).get("error_code", "")
+        error_message = response.get("error", {}).get("error_message", "")
+        return SQLStatementState(state, error_code, error_message)
+
+    async def a_get_sql_statement_state(self, statement_id: str) -> SQLStatementState:
+        """
+        Async version of `get_sql_statement_state`.
+        :param statement_id: ID of the SQL statement
+        :return: state of the SQL statement
+        """
+        get_sql_statement_endpoint = ("GET", f"api/2.0/sql/statements/{statement_id}")
+        response = await self._a_do_api_call(get_sql_statement_endpoint)
+        state = response["status"]["state"]
+        error_code = response.get("error", {}).get("error_code", "")
+        error_message = response.get("error", {}).get("error_message", "")
+        return SQLStatementState(state, error_code, error_message)
+
+    def cancel_sql_statement(self, statement_id: str) -> None:
+        """
+        Cancel the SQL statement.
+        :param statement_id: ID of the SQL statement
+        """
+        cancel_sql_statement_endpoint = ("POST", f"api/2.0/sql/statements/{statement_id}/cancel")
+        self._do_api_call(cancel_sql_statement_endpoint)
 
     def test_connection(self) -> tuple[bool, str]:
         """Test the Databricks connectivity from UI."""

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -983,14 +983,17 @@ class DatabricksSQLStatementsOperator(BaseOperator):
     Submits a Databricks SQL Statement to Databricks using the api/2.0/sql/statements/ API endpoint.
 
     See: https://docs.databricks.com/api/workspace/statementexecution
+
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:DatabricksSQLStatementsOperator`
+
     :param statement: The SQL statement to execute. The statement can optionally be parameterized, see parameters.
     :param warehouse_id: Warehouse upon which to execute a statement.
     :param catalog: Sets default catalog for statement execution, similar to USE CATALOG in SQL.
     :param schema: Sets default schema for statement execution, similar to USE SCHEMA in SQL.
     :param parameters: A list of parameters to pass into a SQL statement containing parameter markers.
+
         .. seealso::
             https://docs.databricks.com/api/workspace/statementexecution/executestatement#parameters
     :param wait_for_termination: if we should wait for termination of the statement execution. ``True`` by default.

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -30,7 +30,12 @@ from typing import TYPE_CHECKING, Any
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
-from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunLifeCycleState, RunState
+from airflow.providers.databricks.hooks.databricks import (
+    DatabricksHook,
+    RunLifeCycleState,
+    RunState,
+    SQLStatementState,
+)
 from airflow.providers.databricks.operators.databricks_workflow import (
     DatabricksWorkflowTaskGroup,
     WorkflowRunMetadata,
@@ -39,7 +44,10 @@ from airflow.providers.databricks.plugins.databricks_workflow import (
     WorkflowJobRepairSingleTaskLink,
     WorkflowJobRunLink,
 )
-from airflow.providers.databricks.triggers.databricks import DatabricksExecutionTrigger
+from airflow.providers.databricks.triggers.databricks import (
+    DatabricksExecutionTrigger,
+    DatabricksSQLStatementExecutionTrigger,
+)
 from airflow.providers.databricks.utils.databricks import normalise_json_content, validate_trigger_event
 from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -59,6 +67,7 @@ DEFER_METHOD_NAME = "execute_complete"
 XCOM_RUN_ID_KEY = "run_id"
 XCOM_JOB_ID_KEY = "job_id"
 XCOM_RUN_PAGE_URL_KEY = "run_page_url"
+XCOM_STATEMENT_ID_KEY = "statement_id"
 
 
 def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
@@ -967,6 +976,175 @@ class DatabricksRunNowOperator(BaseOperator):
             )
         else:
             self.log.error("Error: Task: %s with invalid run_id was requested to be cancelled.", self.task_id)
+
+
+class DatabricksSQLStatementsOperator(BaseOperator):
+    """
+    Submits a Databricks SQL Statement to Databricks using the api/2.0/sql/statements/ API endpoint.
+    See: https://docs.databricks.com/api/workspace/statementexecution
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:DatabricksSQLStatementsOperator`
+    :param statement: The SQL statement to execute. The statement can optionally be parameterized, see parameters.
+    :param warehouse_id: Warehouse upon which to execute a statement.
+    :param catalog: Sets default catalog for statement execution, similar to USE CATALOG in SQL.
+    :param schema: Sets default schema for statement execution, similar to USE SCHEMA in SQL.
+    :param parameters: A list of parameters to pass into a SQL statement containing parameter markers.
+        .. seealso::
+            https://docs.databricks.com/api/workspace/statementexecution/executestatement#parameters
+    :param wait_for_termination: if we should wait for termination of the statement execution. ``True`` by default.
+    :param databricks_conn_id: Reference to the :ref:`Databricks connection <howto/connection:databricks>`.
+        By default and in the common case this will be ``databricks_default``. To use
+        token based authentication, provide the key ``token`` in the extra field for the
+        connection and create the key ``host`` and leave the ``host`` field empty. (templated)
+    :param polling_period_seconds: Controls the rate which we poll for the result of
+        this statement. By default the operator will poll every 30 seconds.
+    :param databricks_retry_limit: Amount of times retry if the Databricks backend is
+        unreachable. Its value must be greater than or equal to 1.
+    :param databricks_retry_delay: Number of seconds to wait between retries (it
+            might be a floating point number).
+    :param databricks_retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
+    :param do_xcom_push: Whether we should push statement_id to xcom.
+    :param deferrable: Run operator in the deferrable mode.
+    """
+
+    # Used in airflow.models.BaseOperator
+    template_fields: Sequence[str] = ("databricks_conn_id", )
+    template_ext: Sequence[str] = (".json-tpl",)
+    # Databricks brand color (blue) under white text
+    ui_color = "#1CB1C2"
+    ui_fgcolor = "#fff"
+
+    def __init__(
+        self,
+        statement: str,
+        warehouse_id: str,
+        *,
+        catalog: str | None = None,
+        schema: str | None = None,
+        parameters: list[dict[str, Any]] | None = None,
+        databricks_conn_id: str = "databricks_default",
+        polling_period_seconds: int = 30,
+        databricks_retry_limit: int = 3,
+        databricks_retry_delay: int = 1,
+        databricks_retry_args: dict[Any, Any] | None = None,
+        do_xcom_push: bool = True,
+        wait_for_termination: bool = True,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        **kwargs,
+    ) -> None:
+        """Create a new ``DatabricksSubmitRunOperator``."""
+        super().__init__(**kwargs)
+        self.statement = statement
+        self.warehouse_id = warehouse_id
+        self.catalog = catalog
+        self.schema = schema
+        self.parameters = parameters
+        self.databricks_conn_id = databricks_conn_id
+        self.polling_period_seconds = polling_period_seconds
+        self.databricks_retry_limit = databricks_retry_limit
+        self.databricks_retry_delay = databricks_retry_delay
+        self.databricks_retry_args = databricks_retry_args
+        self.wait_for_termination = wait_for_termination
+        self.deferrable = deferrable
+
+        # This variable will be used in case our task gets killed.
+        self.statement_id: str | None = None
+        self.do_xcom_push = do_xcom_push
+
+    @cached_property
+    def _hook(self):
+        return self._get_hook(caller="DatabricksSQLStatementsOperator")
+
+    def _get_hook(self, caller: str) -> DatabricksHook:
+        return DatabricksHook(
+            self.databricks_conn_id,
+            retry_limit=self.databricks_retry_limit,
+            retry_delay=self.databricks_retry_delay,
+            retry_args=self.databricks_retry_args,
+            caller=caller,
+        )
+
+    def _handle_operator_execution(self) -> None:
+        while True:
+            statement_state = self._hook.get_sql_statement_state(self.statement_id)
+            if statement_state.is_terminal:
+                if statement_state.is_successful:
+                    self.log.info("%s completed successfully.", self.task_id)
+                    return
+                error_message = (
+                    f"{self.task_id} failed with terminal state: {statement_state.state} "
+                    f"and with the error code {statement_state.error_code} "
+                    f"and error message {statement_state.error_message}"
+                )
+                raise AirflowException(error_message)
+
+            self.log.info("%s in run state: %s", self.task_id, statement_state.state)
+            self.log.info("Sleeping for %s seconds.", self.polling_period_seconds)
+            time.sleep(self.polling_period_seconds)
+
+    def _handle_deferrable_operator_execution(self) -> None:
+        statement_state = self._hook.get_sql_statement_state(self.statement_id)
+        # if not statement_state.is_terminal:
+        self.defer(
+            trigger=DatabricksSQLStatementExecutionTrigger(
+                statement_id=self.statement_id,
+                databricks_conn_id=self.databricks_conn_id,
+                polling_period_seconds=self.polling_period_seconds,
+                retry_limit=self.databricks_retry_limit,
+                retry_delay=self.databricks_retry_delay,
+                retry_args=self.databricks_retry_args,
+            ),
+            method_name=DEFER_METHOD_NAME,
+        )
+        # else:
+        #     if statement_state.is_successful:
+        #         self.log.info("%s completed successfully.", self.task_id)
+
+    def execute(self, context: Context):
+        json = {
+            "statement": self.statement,
+            "warehouse_id": self.warehouse_id,
+            "catalog": self.catalog,
+            "schema": self.schema,
+            "parameters": self.parameters,
+            # We set the wait timeout to 0s as that seems the appropriate way for our deferrable version
+            # support of the operator. For synchronous version, we still poll on the statement
+            # execution state.
+            "wait_timeout": "0s"
+        }
+        self.statement_id = self._hook.post_sql_statement(json)
+        if self.do_xcom_push and context is not None:
+            context["ti"].xcom_push(key=XCOM_STATEMENT_ID_KEY, value=self.statement_id)
+
+        self.log.info("SQL Statement submitted with statement_id: %s", self.statement_id)
+        if not self.wait_for_termination:
+            return
+        if self.deferrable:
+            self._handle_deferrable_operator_execution()
+        else:
+            self._handle_operator_execution()
+
+    def on_kill(self):
+        if self.statement_id:
+            self._hook.cancel_sql_statement(self.statement_id)
+            self.log.info(
+                "Task: %s with statement ID: %s was requested to be cancelled.", self.task_id, self.statement_id
+            )
+        else:
+            self.log.error("Error: Task: %s with invalid statement_id was requested to be cancelled.", self.task_id)
+
+    def execute_complete(self, context: dict | None, event: dict):
+        statement_state = SQLStatementState.from_json(event["state"])
+        error = event["error"]
+        statement_id = event["statement_id"]
+
+        if statement_state.is_successful:
+            self.log.info("SQL Statement with ID %s completed successfully.", statement_id)
+            return
+
+        error_message = f"SQL Statement execution failed with terminal state: {statement_state} and with the error {error}"
+        raise AirflowException(error_message)
 
 
 class DatabricksTaskBaseOperator(BaseOperator, ABC):

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -1101,6 +1101,8 @@ class DatabricksSQLStatementsOperator(BaseOperator):
         statement_state = self._hook.get_sql_statement_state(self.statement_id)
         end_time = time.time() + self.timeout
         if not statement_state.is_terminal:
+            if not self.statement_id:
+                raise AirflowException("Failed to retrieve statement_id after submitting SQL statement.")
             self.defer(
                 trigger=DatabricksSQLStatementExecutionTrigger(
                     statement_id=self.statement_id,

--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -124,6 +124,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
 class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
     """
     The trigger handles the logic of async communication with DataBricks SQL Statements API.
+
     :param statement_id: ID of the SQL statement.
     :param databricks_conn_id: Reference to the :ref:`Databricks connection <howto/connection:databricks>`.
     :param polling_period_seconds: Controls the rate of the poll for the result of this run.
@@ -189,7 +190,7 @@ class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
                 if statement_state.error_code:
                     error = {
                         "error_code": statement_state.error_code,
-                        "error_message": statement_state.error_message
+                        "error_message": statement_state.error_message,
                     }
                 yield TriggerEvent(
                     {

--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -119,3 +119,83 @@ class DatabricksExecutionTrigger(BaseTrigger):
                     }
                 )
                 return
+
+
+class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
+    """
+    The trigger handles the logic of async communication with DataBricks SQL Statements API.
+    :param statement_id: ID of the SQL statement.
+    :param databricks_conn_id: Reference to the :ref:`Databricks connection <howto/connection:databricks>`.
+    :param polling_period_seconds: Controls the rate of the poll for the result of this run.
+        By default, the trigger will poll every 30 seconds.
+    :param retry_limit: The number of times to retry the connection in case of service outages.
+    :param retry_delay: The number of seconds to wait between retries.
+    :param retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
+    """
+
+    def __init__(
+        self,
+        statement_id: str,
+        databricks_conn_id: str,
+        polling_period_seconds: int = 30,
+        retry_limit: int = 3,
+        retry_delay: int = 10,
+        retry_args: dict[Any, Any] | None = None,
+        caller: str = "DatabricksSQLStatementExecutionTrigger",
+    ) -> None:
+        super().__init__()
+        self.statement_id = statement_id
+        self.databricks_conn_id = databricks_conn_id
+        self.polling_period_seconds = polling_period_seconds
+        self.retry_limit = retry_limit
+        self.retry_delay = retry_delay
+        self.retry_args = retry_args
+        self.hook = DatabricksHook(
+            databricks_conn_id,
+            retry_limit=self.retry_limit,
+            retry_delay=self.retry_delay,
+            retry_args=retry_args,
+            caller=caller,
+        )
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.databricks.triggers.databricks.DatabricksSQLStatementExecutionTrigger",
+            {
+                "statement_id": self.statement_id,
+                "databricks_conn_id": self.databricks_conn_id,
+                "polling_period_seconds": self.polling_period_seconds,
+                "retry_limit": self.retry_limit,
+                "retry_delay": self.retry_delay,
+                "retry_args": self.retry_args,
+            },
+        )
+
+    async def run(self):
+        async with self.hook:
+            while True:
+                statement_state = await self.hook.a_get_sql_statement_state(self.statement_id)
+                if not statement_state.is_terminal:
+                    self.log.info(
+                        "Statement ID %s is in state %s. sleeping for %s seconds",
+                        self.statement_id,
+                        statement_state,
+                        self.polling_period_seconds,
+                    )
+                    await asyncio.sleep(self.polling_period_seconds)
+                    continue
+
+                error = {}
+                if statement_state.error_code:
+                    error = {
+                        "error_code": statement_state.error_code,
+                        "error_message": statement_state.error_message
+                    }
+                yield TriggerEvent(
+                    {
+                        "statement_id": self.statement_id,
+                        "state": statement_state.to_json(),
+                        "error": error,
+                    }
+                )
+                return

--- a/providers/databricks/tests/system/databricks/example_databricks.py
+++ b/providers/databricks/tests/system/databricks/example_databricks.py
@@ -41,6 +41,7 @@ from airflow.providers.databricks.operators.databricks import (
     DatabricksCreateJobsOperator,
     DatabricksNotebookOperator,
     DatabricksRunNowOperator,
+    DatabricksSQLStatementsOperator,
     DatabricksSubmitRunOperator,
     DatabricksTaskOperator,
 )
@@ -151,6 +152,16 @@ with DAG(
     )
     # [END howto_operator_databricks_named]
     notebook_task >> spark_jar_task
+
+    # [START howto_operator_sql_statements]
+    sql_statement = DatabricksSQLStatementsOperator(
+        task_id="sql_statement",
+        databricks_conn_id="databricks_default",
+        statement="select * from default.my_airflow_table",
+        warehouse_id=WAREHOUSE_ID,
+        # deferrable=True, # For using the operator in deferrable mode
+    )
+    # [END howto_operator_sql_statements]
 
     # [START howto_operator_databricks_notebook_new_cluster]
     new_cluster_spec = {

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -27,16 +27,20 @@ import pytest
 
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models import DAG
-from airflow.providers.databricks.hooks.databricks import RunState
+from airflow.providers.databricks.hooks.databricks import RunState, SQLStatementState
 from airflow.providers.databricks.operators.databricks import (
     DatabricksCreateJobsOperator,
     DatabricksNotebookOperator,
     DatabricksRunNowOperator,
+    DatabricksSQLStatementsOperator,
     DatabricksSubmitRunOperator,
     DatabricksTaskBaseOperator,
     DatabricksTaskOperator,
 )
-from airflow.providers.databricks.triggers.databricks import DatabricksExecutionTrigger
+from airflow.providers.databricks.triggers.databricks import (
+    DatabricksExecutionTrigger,
+    DatabricksSQLStatementExecutionTrigger,
+)
 from airflow.providers.databricks.utils import databricks as utils
 
 pytestmark = pytest.mark.db_test
@@ -64,6 +68,8 @@ EXISTING_CLUSTER_ID = "existing-cluster-id"
 RUN_NAME = "run-name"
 RUN_ID = 1
 RUN_PAGE_URL = "run-page-url"
+STATEMENT_ID = "statement_id"
+WAREHOUSE_ID = "warehouse_id"
 JOB_ID = "42"
 JOB_NAME = "job-name"
 JOB_DESCRIPTION = "job-description"
@@ -1946,6 +1952,171 @@ class TestDatabricksRunNowOperator:
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         assert op.run_id == RUN_ID
         assert not mock_defer.called
+
+
+class TestDatabricksSQLStatementsOperator:
+    def test_init(self):
+        """
+        Test the initializer.
+        """
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID, statement="select * from test.test;", warehouse_id=WAREHOUSE_ID
+        )
+
+        assert op.statement == "select * from test.test;"
+        assert op.warehouse_id == WAREHOUSE_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_exec_success(self, db_mock_class):
+        """
+        Test the execute function in case where the statement is successful.
+        """
+        expected_json = {
+            "statement": "select * from test.test;",
+            "warehouse_id": WAREHOUSE_ID,
+            "catalog": None,
+            "schema": None,
+            "parameters": None,
+            "wait_timeout": "0s",
+        }
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID, statement="select * from test.test;", warehouse_id=WAREHOUSE_ID
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+
+        op.execute(None)
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksSQLStatementsOperator",
+        )
+
+        db_mock.post_sql_statement.assert_called_once_with(expected_json)
+        db_mock.get_sql_statement_state.assert_called_once_with(STATEMENT_ID)
+        assert op.statement_id == STATEMENT_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_exec_failure(self, db_mock_class):
+        """
+        Test the execute function in case where the statement failed.
+        """
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID, statement="select * from test.test;", warehouse_id=WAREHOUSE_ID
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.return_value = SQLStatementState(
+            state="FAILED", error_code="500", error_message="Something went wrong"
+        )
+
+        with pytest.raises(AirflowException):
+            op.execute(None)
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksSQLStatementsOperator",
+        )
+        db_mock.get_sql_statement_state.assert_called_once_with(STATEMENT_ID)
+        assert op.statement_id == STATEMENT_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_on_kill(self, db_mock_class):
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID, statement="select * from test.test;", warehouse_id=WAREHOUSE_ID
+        )
+        db_mock = db_mock_class.return_value
+        op.statement_id = STATEMENT_ID
+
+        op.on_kill()
+
+        db_mock.cancel_sql_statement.assert_called_once_with(STATEMENT_ID)
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_wait_for_termination_is_default(self, db_mock_class):
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID, statement="select * from test.test;", warehouse_id=WAREHOUSE_ID
+        )
+
+        assert op.wait_for_termination
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_no_wait_for_termination(self, db_mock_class):
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement="select * from test.test;",
+            warehouse_id=WAREHOUSE_ID,
+            wait_for_termination=False,
+        )
+        db_mock = db_mock_class.return_value
+
+        assert not op.wait_for_termination
+
+        op.execute(None)
+
+        db_mock.get_sql_statement_state.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_execute_task_deferred(self, db_mock_class):
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement="select * from test.test;",
+            warehouse_id=WAREHOUSE_ID,
+            deferrable=True,
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.get_sql_statement_state.return_value = SQLStatementState("RUNNING")
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(None)
+        assert isinstance(exc.value.trigger, DatabricksSQLStatementExecutionTrigger)
+        assert exc.value.method_name == "execute_complete"
+
+    def test_execute_complete_success(self):
+        """
+        Test `execute_complete` function in case the Trigger has returned a successful completion event.
+        """
+        event = {
+            "statement_id": STATEMENT_ID,
+            "state": SQLStatementState("SUCCEEDED").to_json(),
+            "error": {},
+        }
+
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement="select * from test.test;",
+            warehouse_id=WAREHOUSE_ID,
+            deferrable=True,
+        )
+        assert op.execute_complete(context=None, event=event) is None
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_execute_complete_failure(self, db_mock_class):
+        """
+        Test `execute_complete` function in case the Trigger has returned a failure completion event.
+        """
+        event = {
+            "statement_id": STATEMENT_ID,
+            "state": SQLStatementState("FAILED").to_json(),
+            "error": SQLStatementState(
+                state="FAILED", error_code="500", error_message="Something Went Wrong"
+            ).to_json(),
+        }
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement="select * from test.test;",
+            warehouse_id=WAREHOUSE_ID,
+            deferrable=True,
+        )
+
+        with pytest.raises(AirflowException, match="^SQL Statement execution failed with terminal state: .*"):
+            op.execute_complete(context=None, event=event)
 
 
 class TestDatabricksNotebookOperator:

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -22,8 +22,11 @@ from unittest import mock
 import pytest
 
 from airflow.models import Connection
-from airflow.providers.databricks.hooks.databricks import RunState
-from airflow.providers.databricks.triggers.databricks import DatabricksExecutionTrigger
+from airflow.providers.databricks.hooks.databricks import RunState, SQLStatementState
+from airflow.providers.databricks.triggers.databricks import (
+    DatabricksExecutionTrigger,
+    DatabricksSQLStatementExecutionTrigger,
+)
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import provide_session
 
@@ -38,6 +41,7 @@ POLLING_INTERVAL_SECONDS = 30
 RETRY_DELAY = 10
 RETRY_LIMIT = 3
 RUN_ID = 1
+STATEMENT_ID = "statement_id"
 TASK_RUN_ID1 = 11
 TASK_RUN_ID1_KEY = "first_task"
 TASK_RUN_ID2 = 22
@@ -246,6 +250,102 @@ class TestDatabricksExecutionTrigger:
                     "run_page_url": RUN_PAGE_URL,
                     "repair_run": False,
                     "errors": [],
+                }
+            )
+        mock_sleep.assert_called_once()
+        mock_sleep.assert_called_with(POLLING_INTERVAL_SECONDS)
+
+
+class TestDatabricksSQLStatementExecutionTrigger:
+    @provide_session
+    def setup_method(self, method, session=None):
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.host = HOST
+        conn.login = LOGIN
+        conn.password = PASSWORD
+        conn.extra = None
+        session.commit()
+
+        self.trigger = DatabricksSQLStatementExecutionTrigger(
+            statement_id=STATEMENT_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
+            polling_period_seconds=POLLING_INTERVAL_SECONDS,
+        )
+
+    def test_serialize(self):
+        assert self.trigger.serialize() == (
+            "airflow.providers.databricks.triggers.databricks.DatabricksSQLStatementExecutionTrigger",
+            {
+                "statement_id": STATEMENT_ID,
+                "databricks_conn_id": DEFAULT_CONN_ID,
+                "polling_period_seconds": POLLING_INTERVAL_SECONDS,
+                "retry_delay": 10,
+                "retry_limit": 3,
+                "retry_args": None,
+            },
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_sql_statement_state")
+    async def test_run_return_success(self, mock_a_get_sql_statement_state):
+        mock_a_get_sql_statement_state.return_value = SQLStatementState(state="SUCCEEDED")
+
+        trigger_event = self.trigger.run()
+        async for event in trigger_event:
+            assert event == TriggerEvent(
+                {
+                    "statement_id": STATEMENT_ID,
+                    "state": SQLStatementState(state="SUCCEEDED").to_json(),
+                    "error": {},
+                }
+            )
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_sql_statement_state")
+    async def test_run_return_failure(self, mock_a_get_sql_statement_state):
+        mock_a_get_sql_statement_state.return_value = SQLStatementState(
+            state="FAILED",
+            error_code="500",
+            error_message="Something went wrong",
+        )
+
+        trigger_event = self.trigger.run()
+        async for event in trigger_event:
+            assert event == TriggerEvent(
+                {
+                    "statement_id": STATEMENT_ID,
+                    "state": SQLStatementState(
+                        state="FAILED",
+                        error_code="500",
+                        error_message="Something went wrong",
+                    ).to_json(),
+                    "error": {
+                        "error_code": "500",
+                        "error_message": "Something went wrong",
+                    },
+                }
+            )
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.triggers.databricks.asyncio.sleep")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_sql_statement_state")
+    async def test_sleep_between_retries(self, mock_a_get_sql_statement_state, mock_sleep):
+        mock_a_get_sql_statement_state.side_effect = [
+            SQLStatementState(
+                state="PENDING",
+            ),
+            SQLStatementState(
+                state="SUCCEEDED",
+            ),
+        ]
+
+        trigger_event = self.trigger.run()
+        async for event in trigger_event:
+            assert event == TriggerEvent(
+                {
+                    "statement_id": STATEMENT_ID,
+                    "state": SQLStatementState(state="SUCCEEDED").to_json(),
+                    "error": {},
                 }
             )
         mock_sleep.assert_called_once()

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import time
 from unittest import mock
 
 import pytest
@@ -259,6 +260,7 @@ class TestDatabricksExecutionTrigger:
 class TestDatabricksSQLStatementExecutionTrigger:
     @provide_session
     def setup_method(self, method, session=None):
+        self.end_time = time.time() + 60
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
         conn.host = HOST
         conn.login = LOGIN
@@ -270,6 +272,7 @@ class TestDatabricksSQLStatementExecutionTrigger:
             statement_id=STATEMENT_ID,
             databricks_conn_id=DEFAULT_CONN_ID,
             polling_period_seconds=POLLING_INTERVAL_SECONDS,
+            end_time=self.end_time,
         )
 
     def test_serialize(self):
@@ -278,6 +281,7 @@ class TestDatabricksSQLStatementExecutionTrigger:
             {
                 "statement_id": STATEMENT_ID,
                 "databricks_conn_id": DEFAULT_CONN_ID,
+                "end_time": self.end_time,
                 "polling_period_seconds": POLLING_INTERVAL_SECONDS,
                 "retry_delay": 10,
                 "retry_limit": 3,


### PR DESCRIPTION
This PR introduces the DatabricksSQLStatementsOperator to the Databricks provider, enabling the submission of dynamic SQL statements and polling their execution status. Additionally, it includes support for deferrable mode.

The operator utilises the [Databricks Statement Execution API](https://docs.databricks.com/api/workspace/statementexecution), allowing SQL submission via the [POST](https://docs.databricks.com/api/workspace/statementexecution/executestatement) endpoint and subsequent polling using the `statement ID` (returned by the POST endpoint) through the [GET](https://docs.databricks.com/api/workspace/statementexecution/getstatement) endpoint.

closes: #46549

