### PR TITLE
Swap DAG Version details table to show id vs number

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagVersionDetails.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagVersionDetails.tsx
@@ -30,8 +30,8 @@ export const DagVersionDetails = ({ dagVersion }: { readonly dagVersion?: DagVer
     <Table.Root striped>
       <Table.Body>
         <Table.Row>
-          <Table.Cell>Version Number</Table.Cell>
-          <Table.Cell>{dagVersion.version_number ? `v${dagVersion.version_number}` : "unknown"}</Table.Cell>
+          <Table.Cell>Version ID</Table.Cell>
+          <Table.Cell>{dagVersion.id}</Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.Cell>Bundle Name</Table.Cell>


### PR DESCRIPTION
We will be going through and replacing the number with either created_at and/or id, based on user feedback we've received. This is the first one to switch.

![Screenshot 2025-03-28 at 2 42 36 PM](https://github.com/user-attachments/assets/227f19c0-d8ca-44fb-9696-3676e5d1cc0e)
