### PR TITLE
Don't add auth token to git bundle view urls

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -223,6 +223,11 @@ class GitDagBundle(BaseDagBundle):
         host = parsed_url.hostname
         if not host:
             return None
+        if parsed_url.username or parsed_url.password:
+            new_netloc = host
+            if parsed_url.port:
+                new_netloc += f":{parsed_url.port}"
+            url = parsed_url._replace(netloc=new_netloc).geturl()
         host_patterns = {
             "github.com": f"{url}/tree/{version}",
             "gitlab.com": f"{url}/-/tree/{version}",


### PR DESCRIPTION
We definitely do not want to show auth tokens in the view urls generated by the git bundle. We strip them if they are present now.