### PR TITLE
Fix Worker crash on API Server Error

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -598,6 +598,10 @@ class ServerResponseError(httpx.HTTPStatusError):
 
     detail: list[RemoteValidationError] | str | dict[str, Any] | None
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        # Needed because https://github.com/encode/httpx/pull/3108 isn't merged yet.
+        return Exception.__new__, (type(self),) + self.args, self.__dict__
+
     @classmethod
     def from_response(cls, response: httpx.Response) -> ServerResponseError | None:
         if response.is_success:

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import json
+import pickle
 from unittest import mock
 
 import httpx
@@ -107,6 +108,29 @@ class TestClient:
             client.get("http://error")
         assert err.value.args == ("Not found",)
         assert err.value.detail is None
+
+    def test_server_response_error_pickling(self):
+        responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
+        client = make_client_w_responses(responses)
+
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.get("http://error")
+
+        err = exc_info.value
+        assert err.args == ("Server returned error",)
+        assert err.detail == {"detail": {"message": "Invalid input"}}
+
+        # Check that the error is picklable
+        pickled = pickle.dumps(err)
+        unpickled = pickle.loads(pickled)
+
+        assert isinstance(unpickled, ServerResponseError)
+
+        # Test that unpickled error has the same attributes as the original
+        assert unpickled.response.json() == {"detail": {"message": "Invalid input"}}
+        assert unpickled.detail == {"detail": {"message": "Invalid input"}}
+        assert unpickled.response.status_code == 404
+        assert unpickled.request.url == "http://error"
 
     @mock.patch("time.sleep", return_value=None)
     def test_retry_handling_unrecoverable_error(self, mock_sleep):
@@ -865,3 +889,33 @@ class TestTaskRescheduleOperations:
 
         assert isinstance(result, TaskRescheduleStartDate)
         assert result.start_date == "2024-01-01T00:00:00Z"
+
+
+# def test_server_response_error_pickling():
+#     """Test that ServerResponseError can be pickled and unpickled."""
+#     def handle_request(request: httpx.Request) -> httpx.Response:
+#         return httpx.Response(
+#             status_code=400,
+#             request=request,
+#             json={"detail": {"message": "Invalid input"}},
+#         )
+#
+#     client = make_client(transport=httpx.MockTransport(handle_request))
+#
+#     # Create an error by making a request that will fail
+#     with pytest.raises(ServerResponseError) as exc_info:
+#         client.get("http://fake-url-for-testing")
+#
+#     err = exc_info.value
+#
+#     # Pickle and unpickle
+#     pickled = pickle.dumps(err)
+#     unpickled = pickle.loads(pickled)
+#
+#     assert isinstance(unpickled, ServerResponseError)
+#
+#     # Error message from response
+#     assert unpickled.response.json() == {"detail": {"message": "Invalid input"}}
+#     assert unpickled.detail == {"detail": {"message": "Invalid input"}}
+#     assert unpickled.response.status_code == 400
+#     assert unpickled.request.url == "http://fake-url-for-testing"


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/47873

closes https://github.com/apache/airflow/issues/48503


The error comes from `LocalExecutor`, specifically the following block:

 https://github.com/apache/airflow/blob/831f12ad7e2cff25c8007583521d664a5e9f21e6/airflow-core/src/airflow/executors/local_executor.py#L91-L97


When a task fails with an exception, the exception is put into the `result_queue` as part of a tuple with the task key and state.

Later, in _read_results, the executor tries to read from this queue, and it fails!!:

https://github.com/apache/airflow/blob/831f12ad7e2cff25c8007583521d664a5e9f21e6/airflow-core/src/airflow/executors/local_executor.py#L208-L210


**Before**:

The scheduler with `LocalExecutor` fails and exits with the following error. This was because `ServerResponseError` isn't picklable and `httpx` maintainers haven't merged https://github.com/encode/httpx/pull/3108.

The task stays in `running` state
:

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/b9675d98-6f0d-4710-867e-173f845e1c9f" />

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/4911950b-11c0-4d2e-ba90-87ab355988b4" />

<img width="764" alt="image" src="https://github.com/user-attachments/assets/c2f988cc-385e-4255-918a-0fa853a422b5" />

```
2025-03-28 22:31:18 [warning  ] Server error                   [airflow.sdk.api.client] detail={'message': 'Internal server error', 'correlation-id': '0195dee1-8af3-7cd2-9c14-e54b668c31bf'}
[2025-03-28T22:31:18.924+0000] {local_executor.py:96} ERROR - uhoh
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 92, in _run_worker
    _execute_work(log, workload)
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 113, in _execute_work
    supervise(
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 1159, in supervise
    exit_code = process.wait()
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 730, in wait
    self._monitor_subprocess()
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 788, in _monitor_subprocess
    alive = self._service_subprocess(max_wait_time=max_wait_time) is None
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 625, in _service_subprocess
    need_more = socket_handler(key.fileobj)
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 1010, in cb
    gen.send(line)
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 514, in handle_requests
    self._handle_request(msg, log)
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 948, in _handle_request
    dagrun_resp = self.client.task_instances.get_previous_successful_dagrun(self.id)
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 195, in get_previous_successful_dagrun
    resp = self.client.get(f"task-instances/{id}/previous-successful-dagrun")
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 1054, in get
    return self.request(
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 336, in wrapped_f
    return copy(f, *args, **kw)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 475, in __call__
    do = self.iter(retry_state=retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 376, in iter
    result = action(retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 418, in exc_check
    raise retry_exc.reraise()
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 185, in reraise
    raise self.last_attempt.result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 478, in __call__
    result = fn(*args, **kwargs)
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 538, in request
    return super().request(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 827, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 914, in send
    response = self._send_handling_auth(
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 942, in _send_handling_auth
    response = self._send_handling_redirects(
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 999, in _send_handling_redirects
    raise exc
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 982, in _send_handling_redirects
    hook(response)
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 107, in raise_on_4xx_5xx
    return get_json_error(response) or response.raise_for_status()
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 103, in get_json_error
    raise err
airflow.sdk.api.client.ServerResponseError: Server returned error
[2025-03-28T22:31:19.022+0000] {scheduler_job_runner.py:938} ERROR - Exception when executing SchedulerJob._run_scheduler_loop
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 934, in _execute
    self._run_scheduler_loop()
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 1073, in _run_scheduler_loop
    executor.heartbeat()
  File "/opt/airflow/airflow-core/src/airflow/traces/tracer.py", line 54, in wrapper
    return func(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/executors/base_executor.py", line 280, in heartbeat
    self.sync()
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 205, in sync
    self._read_results()
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 210, in _read_results
    key, state, exc = self.result_queue.get()
  File "/usr/local/lib/python3.10/multiprocessing/queues.py", line 367, in get
    return _ForkingPickler.loads(res)
TypeError: ServerResponseError.__init__() missing 2 required keyword-only arguments: 'request' and 'response'
[2025-03-28T22:31:19.023+0000] {local_executor.py:216} INFO - Shutting down LocalExecutor; waiting for running tasks to finish.  Signal again if you don't want to wait.
[2025-03-28T22:31:19.027+0000] {scheduler_job_runner.py:950} INFO - Exited execute loop
[2025-03-28 22:31:19 +0000] [341] [INFO] Handling signal: term
[2025-03-28 22:31:19 +0000] [342] [INFO] Worker exiting (pid: 342)
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 10, in <module>
    sys.exit(main())
  File "/opt/airflow/airflow-core/src/airflow/__main__.py", line 58, in main
    args.func(args)
  File "/opt/airflow/airflow-core/src/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/utils/cli.py", line 111, in wrapper
    return f(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/cli/commands/scheduler_command.py", line 52, in scheduler
    run_command_with_daemon_option(
  File "/opt/airflow/airflow-core/src/airflow/cli/commands/daemon_utils.py", line 86, in run_command_with_daemon_option
    callback()
  File "/opt/airflow/airflow-core/src/airflow/cli/commands/scheduler_command.py", line 55, in <lambda>
    callback=lambda: _run_scheduler_job(args),
  File "/opt/airflow/airflow-core/src/airflow/cli/commands/scheduler_command.py", line 43, in _run_scheduler_job
    run_job(job=job_runner.job, execute_callable=job_runner._execute)
  File "/opt/airflow/airflow-core/src/airflow/utils/session.py", line 101, in wrapper
    return func(*args, session=session, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/jobs/job.py", line 348, in run_job
    return execute_job(job, execute_callable=execute_callable)
  File "/opt/airflow/airflow-core/src/airflow/jobs/job.py", line 377, in execute_job
    ret = execute_callable()
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 934, in _execute
    self._run_scheduler_loop()
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 1073, in _run_scheduler_loop
    executor.heartbeat()
  File "/opt/airflow/airflow-core/src/airflow/traces/tracer.py", line 54, in wrapper
    return func(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/executors/base_executor.py", line 280, in heartbeat
    self.sync()
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 205, in sync
    self._read_results()
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 210, in _read_results
    key, state, exc = self.result_queue.get()
  File "/usr/local/lib/python3.10/multiprocessing/queues.py", line 367, in get
    return _ForkingPickler.loads(res)
TypeError: ServerResponseError.__init__() missing 2 required keyword-only arguments: 'request' and 'response'
[2025-03-28 22:31:19 +0000] [343] [INFO] Worker exiting (pid: 343)
[2025-03-28 22:31:19 +0000] [341] [INFO] Shutting down: Master
```

**After**:

The worker continues execution and marks the current task as failed.

<img width="1715" alt="image" src="https://github.com/user-attachments/assets/5ea583bb-5b45-42ad-b990-591aa194db86" />

```
[2025-03-28T22:27:44.731+0000] {_client.py:1026} INFO - HTTP Request: GET http://localhost:8080/execution/task-instances/0195dedc-dd4e-7b99-a42f-6c46a55e8ebd/previous-successful-dagrun "HTTP/1.1 500 Internal Server Error"
2025-03-28 22:27:44 [warning  ] Server error                   [airflow.sdk.api.client] detail={'message': 'Internal server error', 'correlation-id': '0195dede-4676-7de6-b57f-b65c2d632deb'}
[2025-03-28T22:27:44.732+0000] {local_executor.py:96} ERROR - uhoh
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 92, in _run_worker
    _execute_work(log, workload)
  File "/opt/airflow/airflow-core/src/airflow/executors/local_executor.py", line 113, in _execute_work
    supervise(
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 1159, in supervise
    exit_code = process.wait()
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 730, in wait
    self._monitor_subprocess()
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 788, in _monitor_subprocess
    alive = self._service_subprocess(max_wait_time=max_wait_time) is None
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 625, in _service_subprocess
    need_more = socket_handler(key.fileobj)
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 1010, in cb
    gen.send(line)
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 514, in handle_requests
    self._handle_request(msg, log)
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 948, in _handle_request
    dagrun_resp = self.client.task_instances.get_previous_successful_dagrun(self.id)
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 195, in get_previous_successful_dagrun
    resp = self.client.get(f"task-instances/{id}/previous-successful-dagrun")
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 1054, in get
    return self.request(
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 336, in wrapped_f
    return copy(f, *args, **kw)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 475, in __call__
    do = self.iter(retry_state=retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 376, in iter
    result = action(retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 418, in exc_check
    raise retry_exc.reraise()
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 185, in reraise
    raise self.last_attempt.result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 478, in __call__
    result = fn(*args, **kwargs)
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 538, in request
    return super().request(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 827, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 914, in send
    response = self._send_handling_auth(
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 942, in _send_handling_auth
    response = self._send_handling_redirects(
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 999, in _send_handling_redirects
    raise exc
  File "/usr/local/lib/python3.10/site-packages/httpx/_client.py", line 982, in _send_handling_redirects
    hook(response)
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 107, in raise_on_4xx_5xx
    return get_json_error(response) or response.raise_for_status()
  File "/opt/airflow/task-sdk/src/airflow/sdk/api/client.py", line 103, in get_json_error
    raise err
airflow.sdk.api.client.ServerResponseError: Server returned error
[2025-03-28T22:27:45.740+0000] {scheduler_job_runner.py:752} INFO - Received executor event with state failed for task instance TaskInstanceKey(dag_id='context_full_test_dag', task_id='print_context', run_id='manual__2025-03-28T22:26:11.395841+00:00_mw5XAc9F', try_number=2, map_index=-1)
[2025-03-28T22:27:45.747+0000] {scheduler_job_runner.py:794} INFO - TaskInstance Finished: dag_id=context_full_test_dag, task_id=print_context, run_id=manual__2025-03-28T22:26:11.395841+00:00_mw5XAc9F, map_index=-1, run_start_date=2025-03-28 22:27:39.943960+00:00, run_end_date=None, run_duration=None, state=running, executor=LocalExecutor(parallelism=32), executor_state=failed, try_number=2, max_tries=0, pool=default_pool, queue=default, priority_weight=1, operator=_PythonDecoratedOperator, queued_dttm=2025-03-28 22:27:39.682231+00:00, scheduled_dttm=2025-03-28 22:27:39.666751+00:00,queued_by_job_id=368, pid=301
[2025-03-28T22:27:45.751+0000] {taskinstance.py:3095} ERROR - Executor LocalExecutor(parallelism=32) reported that the task instance <TaskInstance: context_full_test_dag.print_context manual__2025-03-28T22:26:11.395841+00:00_mw5XAc9F [running]> finished with state failed, but the task instance's state attribute is running. Learn more: https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#task-state-changed-externally
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
