### PR TITLE
Ensure a WatchedSubprocess redacts only its values and not parent processes'

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -233,6 +233,10 @@ class DagFileProcessorManager(LoggingMixin):
         By processing them in separate processes, we can get parallelism and isolation
         from potentially harmful user code.
         """
+        from airflow.sdk.execution_time.secrets_masker import reset_secrets_masker
+
+        reset_secrets_masker()
+
         self.register_exit_signals()
 
         self.log.info("Processing files using up to %s processes at a time ", self._parallelism)

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -316,6 +316,10 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
     def run(self) -> None:
         """Run synchronously and handle all database reads/writes."""
+        from airflow.sdk.execution_time.secrets_masker import reset_secrets_masker
+
+        reset_secrets_masker()
+
         while not self.stop:
             if not self.is_alive():
                 log.error("Trigger runner process has died! Exiting.")

--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -131,6 +131,15 @@ def _secrets_masker() -> SecretsMasker:
 
 
 def reset_secrets_masker() -> None:
+    """
+    Reset the secrets masker to clear existing patterns and replacer.
+
+    This utility ensures that an execution environment starts with a fresh masker,
+    preventing any carry over of patterns or replacer from previous execution or parent processes.
+
+    New processor types should invoke this method when setting up their own masking to avoid
+    inheriting masking rules from existing execution environments.
+    """
     _secrets_masker().reset_masker()
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -130,6 +130,10 @@ def _secrets_masker() -> SecretsMasker:
     )
 
 
+def reset_secrets_masker() -> None:
+    _secrets_masker().reset_masker()
+
+
 @cache
 def _get_v1_env_var_type() -> type:
     try:
@@ -350,6 +354,11 @@ class SecretsMasker(logging.Filter):
         elif isinstance(secret, collections.abc.Iterable):
             for v in secret:
                 self.add_mask(v, name)
+
+    def reset_masker(self):
+        """Reset the patterns and the replacer in the masker instance."""
+        self.patterns = set()
+        self.replacer = None
 
 
 class RedactedIO(TextIO):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1076,14 +1076,6 @@ def ensure_secrets_backend_loaded() -> list[BaseSecretsBackend]:
     return ensure_secrets_loaded(default_backends=DEFAULT_SECRETS_SEARCH_PATH_WORKERS)
 
 
-def register_secrets_masker():
-    """Register the secrets masker to mask task logs."""
-    from airflow.sdk.execution_time.secrets_masker import get_sensitive_variables_fields, mask_secret
-
-    for field in get_sensitive_variables_fields():
-        mask_secret(field)
-
-
 def supervise(
     *,
     ti: TaskInstance,
@@ -1143,7 +1135,9 @@ def supervise(
 
     ensure_secrets_backend_loaded()
 
-    register_secrets_masker()
+    from airflow.sdk.execution_time.secrets_masker import reset_secrets_masker
+
+    reset_secrets_masker()
 
     process = ActivitySubprocess.start(
         dag_rel_path=dag_rel_path,

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1103,6 +1103,8 @@ def supervise(
     :return: Exit code of the process.
     """
     # One or the other
+    from airflow.sdk.execution_time.secrets_masker import reset_secrets_masker
+
     if not client and ((not server) ^ dry_run):
         raise ValueError(f"Can only specify one of {server=} or {dry_run=}")
 
@@ -1134,8 +1136,6 @@ def supervise(
         logger = structlog.wrap_logger(underlying_logger, processors=processors, logger_name="task").bind()
 
     ensure_secrets_backend_loaded()
-
-    from airflow.sdk.execution_time.secrets_masker import reset_secrets_masker
 
     reset_secrets_masker()
 

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -133,9 +133,7 @@ class StdBinaryStreamHandler(logging.StreamHandler):
 
 
 @cache
-def logging_processors(
-    enable_pretty_log: bool,
-):
+def logging_processors(enable_pretty_log: bool, mask_secrets: bool = True):
     if enable_pretty_log:
         timestamper = structlog.processors.MaybeTimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f")
     else:
@@ -148,9 +146,11 @@ def logging_processors(
         structlog.stdlib.PositionalArgumentsFormatter(),
         logger_name,
         redact_jwt,
-        mask_logs,
         structlog.processors.StackInfoRenderer(),
     ]
+
+    if mask_secrets:
+        processors.append(mask_logs)
 
     # Imports to suppress showing code from these modules. We need the import to get the filepath for
     # structlog to ignore.
@@ -255,7 +255,7 @@ def configure_logging(
         formatter = "colored"
     else:
         formatter = "plain"
-    processors, named = logging_processors(enable_pretty_log)
+    processors, named = logging_processors(enable_pretty_log, mask_secrets=not sending_to_supervisor)
     timestamper = named["timestamper"]
 
     pre_chain: list[structlog.typing.Processor] = [

--- a/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
+++ b/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
@@ -35,6 +35,7 @@ from airflow.sdk.execution_time.secrets_masker import (
     SecretsMasker,
     mask_secret,
     redact,
+    reset_secrets_masker,
     should_hide_value_for_key,
 )
 from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
@@ -356,6 +357,27 @@ class TestSecretsMasker:
             conn = Connection(**test_conn_attributes)
             logger.info(conn.get_uri())
             assert "should_be_hidden" not in caplog.text
+
+    def test_reset_secrets_masker(
+        self,
+    ):
+        secrets_masker = SecretsMasker()
+        secrets_masker.add_mask("mask_this")
+        secrets_masker.add_mask("and_this")
+        secrets_masker.add_mask("maybe_this_too")
+
+        val = ["mask_this", "and_this", "maybe_this_too"]
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            print(secrets_masker.patterns, secrets_masker.replacer)
+
+            got = redact(val)
+            assert got == ["***"] * 3
+
+            reset_secrets_masker()
+
+            got = redact(val)
+            assert got == val
 
 
 class TestShouldHideValueForKey:

--- a/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
+++ b/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
@@ -369,8 +369,6 @@ class TestSecretsMasker:
         val = ["mask_this", "and_this", "maybe_this_too"]
 
         with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
-            print(secrets_masker.patterns, secrets_masker.replacer)
-
             got = redact(val)
             assert got == ["***"] * 3
 


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Problem

If you have noticed some of the recent logs by running tasks from the latest main, branch they somewhat look like:
```
[2025-03-26, 17:24:08] ERROR - Task failed with exception: source="task"
KeyError: 'logical_date'
File "/opt/***/task-sdk/src/***/sdk/execution_time/task_runner.py", line 646 in run

File "/opt/***/task-sdk/src/***/sdk/execution_time/task_runner.py", line 892 in _execute_task

File "/opt/***/task-sdk/src/***/sdk/definitions/baseoperator.py", line 380 in wrapper

File "/opt/***/***-core/src/***/decorators/base.py", line 252 in execute

File "/opt/***/task-sdk/src/***/sdk/definitions/baseoperator.py", line 380 in wrapper

File "/opt/***/providers/standard/src/***/providers/standard/operators/python.py", line 212 in execute

File "/opt/***/providers/standard/src/***/providers/standard/operators/python.py", line 235 in execute_callable

File "/opt/***/task-sdk/src/***/sdk/execution_time/callback_runner.py", line 81 in run

File "/files/dags/context_test.py", line 18 in access_context_task
```

This problem is because we mask the "password" of SQLA when running in breeze (which is `airflow`), here: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/settings.py#L372

Although this might seem like a trivial problem for breeze, it isn't. There is a bigger problem here because we SHOULDNT be redacting the SQLA stuff at all for the "subprocess" that task sdk supervisor launches, and the reason for that is the subprocess has not access to the DB at ALL!! 

## Solution

- Solving this by introducing a new "reset" method on secrets masker that will reset the current patterns and replacer in it
- What that does basically is it treats the masker as a new instance, which is what i want: https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py#L330-L352
 

- Adding a condition while adding the `mask_logs` log processor to the logger. We control that using the `sending_to_supervisor` flag now. If we are sending to supervisor, then DO NOT add the `mask_logs` as it will be already masked by the supervisor and no need to remask it.

- This will not impact any existing behaviour as you might think because all calls will still go through: https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py#L83-L94
- This same functionality needs to be extended to the dag processor as well as triggerer which use the task sdk supervisor now. The subprocess shan't have access to the parent process' masking.


## Testing

### Scenario 1: Retrieving a conneciton inside a task and trying to print its password, which is "password"

Connection:

![image](https://github.com/user-attachments/assets/e0e04592-a9a1-465b-a698-758851a8f7e5)


DAG:
```
import structlog

from airflow import DAG

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Connection


def print_sensitive():
    log = structlog.get_logger()

    c = Connection.get("teradata_default")
    log.info("Retrieved connection", password=c.password)


with DAG(
    dag_id="print_sensitive_data",
    schedule=None,
) as dag:

    print_sensitive_task = PythonOperator(
        task_id="print_sensitive_task",
        python_callable=print_sensitive,
    )
```

![image](https://github.com/user-attachments/assets/bdc836dd-6158-4739-a1ab-4fcc89aea228)


### Scenario 2: Trying to do the same with conneciton but at global level

DAG:
```
import structlog

from airflow import DAG

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Connection

log = structlog.get_logger()
c = Connection.get("teradata_default")
log.info("At the top level is", password=c.password)

def print_sensitive():
    log.info("Retrieved connection and printing in task", password=c.password)

with DAG(
    dag_id="print_sensitive_data_top_level",
    schedule=None,
) as dag:

    print_sensitive_task = PythonOperator(
        task_id="print_sensitive_task",
        python_callable=print_sensitive,
    )

```

![image](https://github.com/user-attachments/assets/efa2ff14-a7a4-47cc-9814-f67be631f996)





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
