### PR TITLE
Reduce default retries to reach API server to 5

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -490,10 +490,10 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
 
 
 # Config options for SDK how retries on HTTP requests should be handled
-# Note: Given defaults make attempts after 1, 3, 7, 15, 31seconds, 1:03, 2:07, 3:37 and fails after 5:07min
+# Note: Given defaults make attempts after 1, 3, 7, 15 and fails after 31seconds
 # So far there is no other config facility in SDK we use ENV for the moment
 # TODO: Consider these env variables while handling airflow confs in task sdk
-API_RETRIES = int(os.getenv("AIRFLOW__WORKERS__API_RETRIES", 10))
+API_RETRIES = int(os.getenv("AIRFLOW__WORKERS__API_RETRIES", 5))
 API_RETRY_WAIT_MIN = float(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MIN", 1.0))
 API_RETRY_WAIT_MAX = float(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MAX", 90.0))
 

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -135,7 +135,7 @@ class TestClient:
     @mock.patch("time.sleep", return_value=None)
     def test_retry_handling_unrecoverable_error(self, mock_sleep):
         responses: list[httpx.Response] = [
-            *[httpx.Response(500, text="Internal Server Error")] * 11,
+            *[httpx.Response(500, text="Internal Server Error")] * 6,
             httpx.Response(200, json={"detail": "Recovered from error - but will fail before"}),
             httpx.Response(400, json={"detail": "Should not get here"}),
         ]
@@ -145,12 +145,12 @@ class TestClient:
             client.get("http://error")
         assert not isinstance(err.value, ServerResponseError)
         assert len(responses) == 3
-        assert mock_sleep.call_count == 9
+        assert mock_sleep.call_count == 4
 
     @mock.patch("time.sleep", return_value=None)
     def test_retry_handling_recovered(self, mock_sleep):
         responses: list[httpx.Response] = [
-            *[httpx.Response(500, text="Internal Server Error")] * 3,
+            *[httpx.Response(500, text="Internal Server Error")] * 2,
             httpx.Response(200, json={"detail": "Recovered from error"}),
             httpx.Response(400, json={"detail": "Should not get here"}),
         ]
@@ -159,7 +159,7 @@ class TestClient:
         response = client.get("http://error")
         assert response.status_code == 200
         assert len(responses) == 1
-        assert mock_sleep.call_count == 3
+        assert mock_sleep.call_count == 2
 
     @mock.patch("time.sleep", return_value=None)
     def test_retry_handling_overload(self, mock_sleep):
@@ -228,7 +228,7 @@ class TestTaskInstanceOperations:
         def handle_request(request: httpx.Request) -> httpx.Response:
             nonlocal call_count
             call_count += 1
-            if call_count < 4:
+            if call_count < 3:
                 return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
             if request.url.path == f"/task-instances/{ti_id}/run":
                 actual_body = json.loads(request.read())
@@ -244,7 +244,7 @@ class TestTaskInstanceOperations:
         client = make_client(transport=httpx.MockTransport(handle_request))
         resp = client.task_instances.start(ti_id, 100, start_date)
         assert resp == ti_context
-        assert call_count == 4
+        assert call_count == 3
 
     @pytest.mark.parametrize(
         "state", [state for state in TerminalTIState if state != TerminalTIState.SUCCESS]


### PR DESCRIPTION
10 is excessive, especially if you consider the starting with Airflow experience. A user won't wait (or is a terrible experience) for 5 minutes without seeing any task logs and not having a clue of what is happening.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
