### PR TITLE
Sort children when deserializing DAG

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1865,7 +1865,7 @@ class TaskGroupSerialization(BaseSerialization):
                 if _type == DAT.OP
                 else cls.deserialize_task_group(val, group, task_dict, dag=dag)
             )
-            for label, (_type, val) in encoded_group["children"].items()
+            for label, (_type, val) in sorted(encoded_group["children"].items(), key=lambda x: x[0])
         }
         group.upstream_group_ids.update(cls.deserialize(encoded_group["upstream_group_ids"]))
         group.downstream_group_ids.update(cls.deserialize(encoded_group["downstream_group_ids"]))

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1865,7 +1865,7 @@ class TaskGroupSerialization(BaseSerialization):
                 if _type == DAT.OP
                 else cls.deserialize_task_group(val, group, task_dict, dag=dag)
             )
-            for label, (_type, val) in sorted(encoded_group["children"].items(), key=lambda x: x[0])
+            for label, (_type, val) in sorted(encoded_group["children"].items())
         }
         group.upstream_group_ids.update(cls.deserialize(encoded_group["upstream_group_ids"]))
         group.downstream_group_ids.update(cls.deserialize(encoded_group["downstream_group_ids"]))

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -139,6 +139,12 @@ DAG_RUN = DagRun(
 DAG_RUN.id = 1
 
 
+# we add the tasks out of order, to ensure they are deserialized in the correct order
+DAG_WITH_TASKS = DAG(dag_id="test_dag", start_date=datetime.now())
+EmptyOperator(task_id="task2", dag=DAG_WITH_TASKS)
+EmptyOperator(task_id="task1", dag=DAG_WITH_TASKS)
+
+
 def create_outlet_event_accessors(
     key: Asset | AssetAlias, extra: dict, asset_alias_events: list[AssetAliasEvent]
 ) -> OutletEventAccessors:
@@ -302,6 +308,11 @@ class MockLazySelectSequence(LazySelectSequence):
             AirflowFailException("uuups, failed :-("),
             DAT.AIRFLOW_EXC_SER,
             equal_exception,
+        ),
+        (
+            DAG_WITH_TASKS,
+            DAT.DAG,
+            lambda _, b: list(b.task_group.children.keys()) == sorted(b.task_group.children.keys()),
         ),
     ],
 )


### PR DESCRIPTION
MySQL doesn't maintain the order of children round trip, so this keeps the deserialized DAGs consistent across db types.

e.g. MySQL:

```
MySQL [airflow]> create table foo (data json);
Query OK, 0 rows affected (0.026 sec)

MySQL [airflow]> insert into foo values ('{"hello": "world", "ab": "cb"}');
Query OK, 1 row affected (0.003 sec)

MySQL [airflow]> select * from foo;
+--------------------------------+
| data                           |
+--------------------------------+
| {"ab": "cb", "hello": "world"} |
+--------------------------------+
1 row in set (0.000 sec)
```

and PostgreSQL:

```
postgres@localhost:postgres> create table foo (data json);
CREATE TABLE
Time: 0.005s
postgres@localhost:postgres> insert into foo values ('{"hello": "world", "ab": "cb"}');
INSERT 0 1
Time: 0.003s
postgres@localhost:postgres> select * from foo;
+--------------------------------+
| data                           |
|--------------------------------|
| {"hello": "world", "ab": "cb"} |
+--------------------------------+
SELECT 1
Time: 0.010s
postgres@localhost:postgres>
```