### PR TITLE
change statsd mapping rules ended with dag_id

### DIFF
--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -58,17 +58,20 @@ mappings:
       dag_id: "$1"
       task_id: "$2"
 
-  - match: airflow.dagrun.duration.success.*
+  - match: airflow.dagrun.duration.success.([a-zA-Z0-9_\-\.]*)$
+    match_type: regex
     name: "airflow_dagrun_duration"
     labels:
       dag_id: "$1"
 
-  - match: airflow.dagrun.duration.failed.*
+  - match: airflow.dagrun.duration.failed.([a-zA-Z0-9_\-\.]*)$
+    match_type: regex
     name: "airflow_dagrun_failed"
     labels:
       dag_id: "$1"
 
-  - match: airflow.dagrun.schedule_delay.*
+  - match: airflow.dagrun.schedule_delay.([a-zA-Z0-9_\-\.]*)$
+    match_type: regex
     name: "airflow_dagrun_schedule_delay"
     labels:
       dag_id: "$1"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
According to the airflow document, alphanumeric characters, dashes, dots and underscores are allowed for dag_id.
(https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dag/index.html#airflow.models.dag.DAG)
When a dag_id has dots, some statsd mapping rules don't work properly because they assume that dag_id can't contain dots.
This PR fixes some of the rules ended with dag_id.
We need some more improvement for other rules like this one below, but I was not able to find exact rule of task_id.
```
  - match: airflow.dag.*.*.duration
    name: "airflow_task_duration"
    labels:
      dag_id: "$1"
      task_id: "$2"
```

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
