### PR TITLE
Enhance Variable set method to use upsert instead of delsert

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -236,8 +236,7 @@ class Variable(Base, LoggingMixin):
             existing_variable = session.query(Variable).filter(Variable.key == key).first()
             if existing_variable:
                 existing_variable.val = stored_value
-                if description is not None:
-                    existing_variable.description = description
+                existing_variable.description = description
             else:
                 session.add(Variable(key=key, val=stored_value, description=description))
 

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -121,6 +121,22 @@ class TestVariable:
             "EnvironmentVariablesBackend"
         )
 
+    def test_variable_set_update_existing(self, session):
+        Variable.set(key="test_key", value="initial_value", session=session)
+
+        initial_var = session.query(Variable).filter(Variable.key == "test_key").one()
+        initial_id = initial_var.id
+
+        Variable.set(key="test_key", value="updated_value", session=session)
+
+        updated_var = session.query(Variable).filter(Variable.key == "test_key").one()
+
+        # 1. The ID remains the same (no delete-insert)
+        assert updated_var.id == initial_id, "Variable ID should remain the same after update"
+
+        # 2. The value is updated to the new value
+        assert updated_var.val == "updated_value", "Variable value should be updated to the new value"
+
     @mock.patch("airflow.models.variable.ensure_secrets_loaded")
     def test_variable_set_with_extra_secret_backend(self, mock_ensure_secrets, caplog, session):
         caplog.set_level(logging.WARNING, logger=variable.log.name)

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -127,6 +127,11 @@ class TestVariable:
         initial_var = session.query(Variable).filter(Variable.key == "test_key").one()
         initial_id = initial_var.id
 
+        # Need to expire session cache to fetch fresh data from db on next query
+        # Without this, SQLAlchemy will return the cached object with old values
+        # instead of querying the database again for the updated values
+        session.expire(initial_var)
+
         Variable.set(key="test_key", value="updated_value", session=session)
 
         updated_var = session.query(Variable).filter(Variable.key == "test_key").one()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## Refactor Variable.set Method to Use Upsert Instead of Delsert

This pull request refactors the `Variable.set` method to replace the current delsert pattern (delete followed by insert) with an upsert approach, addressing key reliability and efficiency issues.

### Key Changes:

#### 1. Preventing Unique Constraint Errors

When `set` is called repeatedly within a single process, the existing delsert pattern can trigger `UNIQUE constraint` violations. This occurs when a `DELETE` operation has not been flushed or committed before a subsequent `INSERT` is attempted — even within the same session — leading to conflicts.

Example error message:
```
 sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "variable_key_key"
DETAIL:  Key (key)=(dummy_variable_key_for_test) already exists.
[SQL: INSERT INTO variable (key, val, description, is_encrypted) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s) RETURNING variable.id]
[parameters: {'key': 'dummy_variable_key_for_test', 'val': 'dummy_variable_value_for_test', 'description': None, 'is_encrypted': True}]
(Background on this error at: https://sqlalche.me/e/14/gkpj)
```
<img width="1740" alt="image" src="https://github.com/user-attachments/assets/8bdec103-6037-47cb-9817-9beb0e5f5979" />

#### 2. Reducing Unnecessary Transactions

The previous delsert pattern always executed both a DELETE and an INSERT, even when the variable already existed. This introduced unnecessary write operations and transactional overhead.
By switching to an update-or-insert approach, the common case — where a variable already exists — now results in a single UPDATE instead of a full row replacement. This reduces the number of write operations and improves overall efficiency without changing behavior.




Please review the changes and let me know if there are any questions or further improvements needed.
Feel free to adjust the wording to better fit your style, or let me know if you'd like me to make any changes.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
