### PR TITLE
Fix new import paths in Newsfragment

### DIFF
--- a/airflow-core/newsfragments/41368.significant.rst
+++ b/airflow-core/newsfragments/41368.significant.rst
@@ -28,27 +28,27 @@ For example, instead of ``from airflow.sensors import TimeDeltaSensor``, use ``f
 
     * AIR302
 
-      * [ ] ``airflow.operators.bash_operator.BashOperator`` → ``airflow.sdk.bases.operator.BashOperator``
+      * [ ] ``airflow.operators.bash_operator.BashOperator`` → ``airflow.providers.standard.operators.bash.BashOperator``
       * [ ] ``airflow.operators.branch_operator.BaseBranchOperator`` → ``airflow.providers.standard.operators.branch.BaseBranchOperator``
       * [ ] ``airflow.operators.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
       * [ ] ``airflow.operators.DummyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
       * [ ] ``airflow.operators.dummy_operator.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
       * [ ] ``airflow.operators.dummy_operator.DummyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
       * [ ] ``airflow.operators.email_operator.EmailOperator`` → ``airflow.operators.email.EmailOperator``
-      * [ ] ``airflow.sensors.base_sensor_operator.BaseSensorOperator`` → ``airflow.sdk.bases.sensor.BashOperator``
+      * [ ] ``airflow.sensors.base_sensor_operator.BaseSensorOperator`` → ``airflow.sdk.bases.sensor.BaseSensorOperator``
       * [x] ``airflow.sensors.date_time_sensor.DateTimeSensor`` → ``airflow.sensors.date_time.DateTimeSensor``
-      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskMarker`` → ``airflow.sensors.external_task.ExternalTaskMarker``
-      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskSensor`` → ``airflow.sensors.external_task.ExternalTaskSensor``
-      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskSensorLink`` → ``airflow.sensors.external_task.ExternalTaskSensorLink``
-      * [x] ``airflow.sensors.time_delta_sensor.TimeDeltaSensor`` → ``airflow.sensors.time_delta.TimeDeltaSensor``
+      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskMarker`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskMarker``
+      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskSensor`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskSensor``
+      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskSensorLink`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink``
+      * [x] ``airflow.sensors.time_delta_sensor.TimeDeltaSensor`` → ``airflow.providers.standard.sensors.time_delta.TimeDeltaSensor``
       * [x] ``airflow.hooks.base_hook.BaseHook`` → ``airflow.hooks.base.BaseHook``
-      * [x] ``airflow.operators.dagrun_operator.TriggerDagRunLink`` → ``airflow.operators.trigger_dagrun.TriggerDagRunLink``
-      * [x] ``airflow.operators.dagrun_operator.TriggerDagRunOperator`` → ``airflow.operators.trigger_dagrun.TriggerDagRunOperator``
-      * [x] ``airflow.operators.python_operator.BranchPythonOperator`` → ``airflow.operators.python.BranchPythonOperator``
-      * [x] ``airflow.operators.python_operator.PythonOperator`` → ``airflow.operators.python.PythonOperator``
-      * [x] ``airflow.operators.python_operator.PythonVirtualenvOperator`` → ``airflow.operators.python.PythonVirtualenvOperator``
-      * [x] ``airflow.operators.python_operator.ShortCircuitOperator`` → ``airflow.operators.python.ShortCircuitOperator``
-      * [x] ``airflow.operators.latest_only_operator.LatestOnlyOperator`` → ``airflow.operators.latest_only.LatestOnlyOperator``
+      * [x] ``airflow.operators.dagrun_operator.TriggerDagRunLink`` → ``airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink``
+      * [x] ``airflow.operators.dagrun_operator.TriggerDagRunOperator`` → ``airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator``
+      * [x] ``airflow.operators.python_operator.BranchPythonOperator`` → ``airflow.providers.standard.operators.python.BranchPythonOperator``
+      * [x] ``airflow.operators.python_operator.PythonOperator`` → ``airflow.providers.standard.operators.python.PythonOperator``
+      * [x] ``airflow.operators.python_operator.PythonVirtualenvOperator`` → ``airflow.providers.standard.operators.python.PythonVirtualenvOperator``
+      * [x] ``airflow.operators.python_operator.ShortCircuitOperator`` → ``airflow.providers.standard.operators.python.ShortCircuitOperator``
+      * [x] ``airflow.operators.latest_only_operator.LatestOnlyOperator`` → ``airflow.providers.standard.operators.latest_only.LatestOnlyOperator``
 
     * AIR303
 


### PR DESCRIPTION
Some of the paths were incorrect.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
