### PR TITLE
handle overflow in TaskInstance next_retry_datetime fixes 47971

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1070,39 +1070,45 @@ class TaskInstance(Base, LoggingMixin):
 
         delay = self.task.retry_delay
         if self.task.retry_exponential_backoff:
-            # If the min_backoff calculation is below 1, it will be converted to 0 via int. Thus,
-            # we must round up prior to converting to an int, otherwise a divide by zero error
-            # will occur in the modded_hash calculation.
-            # this probably gives unexpected results if a task instance has previously been cleared,
-            # because try_number can increase without bound
-            min_backoff = math.ceil(delay.total_seconds() * (2 ** (self.try_number - 1)))
+            try:
+                # If the min_backoff calculation is below 1, it will be converted to 0 via int. Thus,
+                # we must round up prior to converting to an int, otherwise a divide by zero error
+                # will occur in the modded_hash calculation.
+                # this probably gives unexpected results if a task instance has previously been cleared,
+                # because try_number can increase without bound
+                min_backoff = math.ceil(delay.total_seconds() * (2 ** (self.try_number - 1)))
 
-            # In the case when delay.total_seconds() is 0, min_backoff will not be rounded up to 1.
-            # To address this, we impose a lower bound of 1 on min_backoff. This effectively makes
-            # the ceiling function unnecessary, but the ceiling function was retained to avoid
-            # introducing a breaking change.
-            if min_backoff < 1:
-                min_backoff = 1
+                # In the case when delay.total_seconds() is 0, min_backoff will not be rounded up to 1.
+                # To address this, we impose a lower bound of 1 on min_backoff. This effectively makes
+                # the ceiling function unnecessary, but the ceiling function was retained to avoid
+                # introducing a breaking change.
+                if min_backoff < 1:
+                    min_backoff = 1
 
-            # deterministic per task instance
-            ti_hash = int(
-                hashlib.sha1(
-                    f"{self.dag_id}#{self.task_id}#{self.logical_date}#{self.try_number}".encode(),
-                    usedforsecurity=False,
-                ).hexdigest(),
-                16,
-            )
-            # between 1 and 1.0 * delay * (2^retry_number)
-            modded_hash = min_backoff + ti_hash % min_backoff
-            # timedelta has a maximum representable value. The exponentiation
-            # here means this value can be exceeded after a certain number
-            # of tries (around 50 if the initial delay is 1s, even fewer if
-            # the delay is larger). Cap the value here before creating a
-            # timedelta object so the operation doesn't fail with "OverflowError".
-            delay_backoff_in_seconds = min(modded_hash, MAX_RETRY_DELAY)
-            delay = timedelta(seconds=delay_backoff_in_seconds)
-            if self.task.max_retry_delay:
-                delay = min(self.task.max_retry_delay, delay)
+                # deterministic per task instance
+                ti_hash = int(
+                    hashlib.sha1(
+                        f"{self.dag_id}#{self.task_id}#{self.logical_date}#{self.try_number}".encode(),
+                        usedforsecurity=False,
+                    ).hexdigest(),
+                    16,
+                )
+                # between 1 and 1.0 * delay * (2^retry_number)
+                modded_hash = min_backoff + ti_hash % min_backoff
+                # timedelta has a maximum representable value. The exponentiation
+                # here means this value can be exceeded after a certain number
+                # of tries (around 50 if the initial delay is 1s, even fewer if
+                # the delay is larger). Cap the value here before creating a
+                # timedelta object so the operation doesn't fail with "OverflowError".
+                delay_backoff_in_seconds = min(modded_hash, MAX_RETRY_DELAY)
+                delay = timedelta(seconds=delay_backoff_in_seconds)
+                if self.task.max_retry_delay:
+                    delay = min(self.task.max_retry_delay, delay)
+            except OverflowError:
+                if self.task.max_retry_delay:
+                    delay = self.task.max_retry_delay
+                else:
+                    delay = MAX_RETRY_DELAY
         return self.end_date + delay
 
     def ready_for_retry(self) -> bool:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1079,6 +1079,9 @@ class TaskInstance(Base, LoggingMixin):
                 min_backoff = math.ceil(delay.total_seconds() * (2 ** (self.try_number - 1)))
             except OverflowError:
                 min_backoff = MAX_RETRY_DELAY
+                self.log.warning(
+                    "OverflowError occurred while calculating min_backoff, using MAX_RETRY_DELAY for min_backoff."
+                )
 
             # In the case when delay.total_seconds() is 0, min_backoff will not be rounded up to 1.
             # To address this, we impose a lower bound of 1 on min_backoff. This effectively makes

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -648,6 +648,10 @@ class TestTaskInstance:
         date = ti.next_retry_datetime()
         assert date == ti.end_date + max_delay
 
+        ti.try_number = 50000
+        date = ti.next_retry_datetime()
+        assert date == ti.end_date + max_delay
+
     @pytest.mark.parametrize("seconds", [0, 0.5, 1])
     def test_next_retry_datetime_short_or_zero_intervals(self, dag_maker, seconds):
         delay = datetime.timedelta(seconds=seconds)

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -627,6 +627,27 @@ class TestTaskInstance:
         date = ti.next_retry_datetime()
         assert date == ti.end_date + max_delay
 
+    def test_next_retry_datetime_returns_max_for_overflow(self, dag_maker):
+        delay = datetime.timedelta(seconds=30)
+        max_delay = datetime.timedelta(minutes=60)
+
+        with dag_maker(dag_id="fail_dag"):
+            task = BashOperator(
+                task_id="task_with_exp_backoff_and_max_delay",
+                bash_command="exit 1",
+                retries=3,
+                retry_delay=delay,
+                retry_exponential_backoff=True,
+                max_retry_delay=max_delay,
+            )
+        ti = dag_maker.create_dagrun().task_instances[0]
+        ti.task = task
+        ti.end_date = pendulum.instance(timezone.utcnow())
+
+        ti.try_number = 5000
+        date = ti.next_retry_datetime()
+        assert date == ti.end_date + max_delay
+
     @pytest.mark.parametrize("seconds", [0, 0.5, 1])
     def test_next_retry_datetime_short_or_zero_intervals(self, dag_maker, seconds):
         delay = datetime.timedelta(seconds=seconds)


### PR DESCRIPTION
This handles overflow when calculating the next execution time for a task instance by falling back to the configured maximum delay. The solution uses the same strategy that tenacity uses:
https://github.com/jd/tenacity/blob/main/tenacity/wait.py#L167

An alternate solution would be the determine the maximum tries that wouldn't exceed the maximum delay and then not calculate the timeout for values larger than that.

Something like 

```
max_delay = self.task.max_retry_delay if self.task.max_retry_delay is not null else MAX_RETRY_DELAY
tries_before_max_delay = math.floor(math.log2(max_delay))
if self.try_number <= tries_before_max_delay:
     # existing logic
else:
    delay = max_delay
```

closes: https://github.com/apache/airflow/issues/47971