### PR TITLE
[Internal API][only 2.10] Fix issue that task instance rendered_map_index field not possible to set via the internal api.

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -830,6 +830,7 @@ def _set_ti_attrs(target, source, include_dag_run=False):
     target.next_kwargs = source.next_kwargs
     if source.note and isinstance(source, TaskInstancePydantic):
         target.note = source.note
+        target.rendered_map_index = source.rendered_map_index
 
     if include_dag_run:
         target.execution_date = source.execution_date

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -5457,7 +5457,7 @@ def test_taskinstance_with_note_pydantic(create_task_instance, session):
         executor=ti.executor,
         executor_config=None,
         updated_at=timezone.utcnow(),
-        rendered_map_index=ti.rendered_map_index,
+        rendered_map_index="ti with rendered_map_index",
         external_executor_id="x",
         trigger_id=ti.trigger_id,
         trigger_timeout=timezone.utcnow(),
@@ -5484,6 +5484,9 @@ def test_taskinstance_with_note_pydantic(create_task_instance, session):
 
     ti_note: TaskInstanceNote = session.query(TaskInstanceNote).filter_by(**filter_kwargs).one()
     assert ti_note.content == "ti with note"
+
+    ti: TaskInstance = session.query(TaskInstance).filter_by(**filter_kwargs).one()
+    assert ti.rendered_map_index == "ti with rendered_map_index"
 
 
 def test__refresh_from_db_should_not_increment_try_number(dag_maker, session):


### PR DESCRIPTION
# Overview

This PR fixes the issue that it is not possible to set the task instance rendered_map_index field via the internal api. Without this the Edge worker is not able to update the rendered_map_index field of the task_instance. 
Thankfully the rendered_map_index field is already part of the TaskInstancePydantic model, so I only had to add the code to store this into the TaskInstance. This enables the Edge worker to set the rendered_map_index field of an task instance. This is pointing to only to the 2.10 test branch as the code will be complete change in Airflow 3.

# Details of change:
* Allow _set_ti_attrs function to set the rendered_map_index field of the task instance.
* Only relevant for the 2.10 versions.
* Updated the unit test.

Similar changes as this PR for the note field: https://github.com/apache/airflow/pull/47769

