### PR TITLE
Vertical Align Alert Icon

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ui/Alert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/Alert.tsx
@@ -34,7 +34,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
   const { children, closable, endElement, icon, onClose, startElement, title, ...rest } = props;
 
   return (
-    <ChakraAlert.Root ref={ref} {...rest}>
+    <ChakraAlert.Root ref={ref} {...rest} alignItems="center">
       {startElement ?? <ChakraAlert.Indicator>{icon}</ChakraAlert.Indicator>}
       {Boolean(children) ? (
         <ChakraAlert.Content>


### PR DESCRIPTION
Vertically align alert icon.

When there is only one or two lines to the alert, icon placement looks very weird, it looks like it's miss aligned.

### Before
![Screenshot 2025-03-31 at 16 01 50](https://github.com/user-attachments/assets/a8397bfc-a4c3-4c8c-bd0e-9f20b591aceb)
![Screenshot 2025-03-31 at 16 02 03](https://github.com/user-attachments/assets/771c55af-b691-48ad-bad8-c04b09994754)
Or from this PR https://github.com/apache/airflow/pull/48450
![Screenshot 2025-03-31 at 16 02 17](https://github.com/user-attachments/assets/454a45b9-d3bc-40f0-9af0-feb632b17109)


### After 
![Screenshot 2025-03-31 at 16 00 50](https://github.com/user-attachments/assets/ed60fa26-347a-4a9d-bed8-65f72873651e)
![Screenshot 2025-03-31 at 16 01 17](https://github.com/user-attachments/assets/f91f81a3-9ac5-4e77-ad4b-0819cce5e3d1)

