### PR TITLE
Display API Sever errors in task logs & fail task on error

### DIFF
--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -41,6 +41,7 @@ class ErrorType(enum.Enum):
     ASSET_NOT_FOUND = "ASSET_NOT_FOUND"
     DAGRUN_ALREADY_EXISTS = "DAGRUN_ALREADY_EXISTS"
     GENERIC_ERROR = "GENERIC_ERROR"
+    API_SERVER_ERROR = "API_SERVER_ERROR"
 
 
 class XComForMappingNotPushed(TypeError):

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -52,7 +52,7 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstance,
     TerminalTIState,
 )
-from airflow.sdk.exceptions import ErrorType
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 from airflow.sdk.execution_time.comms import (
     AssetEventsResult,
     AssetResult,
@@ -1404,3 +1404,42 @@ class TestHandleRequest:
             input_stream = BytesIO(val)
             decoder = CommsDecoder(input=input_stream)
             assert decoder.get_message() == mock_response
+
+    def test_handle_requests_api_server_error(self, watched_subprocess, mocker):
+        """Test that API server errors are properly handled and sent back to the task."""
+        error = ServerResponseError(
+            message="API Server Error",
+            request=httpx.Request("GET", "http://test"),
+            response=httpx.Response(500, json={"detail": "Internal Server Error"}),
+        )
+
+        mock_client_method = mocker.Mock(side_effect=error)
+        watched_subprocess.client.task_instances.succeed = mock_client_method
+
+        # Simulate the generator
+        generator = watched_subprocess.handle_requests(log=mocker.Mock())
+
+        next(generator)
+        msg = SucceedTask(end_date=timezone.parse("2024-10-31T12:00:00Z")).model_dump_json().encode() + b"\n"
+        generator.send(msg)
+
+        # Verify the error was sent back to the task
+        val = watched_subprocess.stdin.getvalue()
+
+        assert val == (
+            b'{"error":"API_SERVER_ERROR","detail":{"status_code":500,"message":"API Server Error",'
+            b'"detail":{"detail":"Internal Server Error"}},"type":"ErrorResponse"}\n'
+        )
+
+        # Verify the error can be decoded correctly
+        input_stream = BytesIO(val)
+        decoder = CommsDecoder(input=input_stream)
+        with pytest.raises(AirflowRuntimeError) as exc_info:
+            decoder.get_message()
+
+        assert exc_info.value.error.error == ErrorType.API_SERVER_ERROR
+        assert exc_info.value.error.detail == {
+            "status_code": error.response.status_code,
+            "message": str(error),
+            "detail": error.response.json(),
+        }


### PR DESCRIPTION
Follow-up of https://github.com/apache/airflow/pull/48517

Currently, when a task fails due to API Server error, the task logs shows nothing, and the task continues running.

It also leads to the pickling issue on LocalExecutor that was fixed by https://github.com/apache/airflow/pull/48517.

This PR improves upon it and propogates the API server error in the task UI and fails the task.

<img width="1712" alt="image" src="https://github.com/user-attachments/assets/5e91c1ec-4497-4b16-9ca4-c54c8da7e545" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
