### PR TITLE
Add Task Instance clear for mapped task summaries

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
@@ -28,7 +28,7 @@ import { columns } from "./columns";
 
 type Props = {
   readonly affectedTasks?: TaskInstanceCollectionResponse;
-  readonly note: DAGRunResponse["note"];
+  readonly note?: DAGRunResponse["note"];
   readonly setNote: (value: string) => void;
 };
 
@@ -62,40 +62,42 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
           </Accordion.ItemContent>
         </Accordion.Item>
       ) : undefined}
-      <Accordion.Item key="note" value="note">
-        <Accordion.ItemTrigger>
-          <Text fontWeight="bold">Note</Text>
-        </Accordion.ItemTrigger>
-        <Accordion.ItemContent>
-          <Editable.Root
-            onChange={(event: ChangeEvent<HTMLInputElement>) => setNote(event.target.value)}
-            value={note ?? ""}
-          >
-            <Editable.Preview
-              _hover={{ backgroundColor: "transparent" }}
-              alignItems="flex-start"
-              as={VStack}
-              gap="0"
-              height="200px"
-              overflowY="auto"
-              width="100%"
+      {note === undefined ? undefined : (
+        <Accordion.Item key="note" value="note">
+          <Accordion.ItemTrigger>
+            <Text fontWeight="bold">Note</Text>
+          </Accordion.ItemTrigger>
+          <Accordion.ItemContent>
+            <Editable.Root
+              onChange={(event: ChangeEvent<HTMLInputElement>) => setNote(event.target.value)}
+              value={note ?? ""}
             >
-              {Boolean(note) ? (
-                <ReactMarkdown>{note}</ReactMarkdown>
-              ) : (
-                <Text color="fg.subtle">Add a note...</Text>
-              )}
-            </Editable.Preview>
-            <Editable.Textarea
-              data-testid="notes-input"
-              height="200px"
-              overflowY="auto"
-              placeholder="Add a note..."
-              resize="none"
-            />
-          </Editable.Root>
-        </Accordion.ItemContent>
-      </Accordion.Item>
+              <Editable.Preview
+                _hover={{ backgroundColor: "transparent" }}
+                alignItems="flex-start"
+                as={VStack}
+                gap="0"
+                height="200px"
+                overflowY="auto"
+                width="100%"
+              >
+                {Boolean(note) ? (
+                  <ReactMarkdown>{note}</ReactMarkdown>
+                ) : (
+                  <Text color="fg.subtle">Add a note...</Text>
+                )}
+              </Editable.Preview>
+              <Editable.Textarea
+                data-testid="notes-input"
+                height="200px"
+                overflowY="auto"
+                placeholder="Add a note..."
+                resize="none"
+              />
+            </Editable.Root>
+          </Accordion.ItemContent>
+        </Accordion.Item>
+      )}
     </Accordion.Root>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -19,17 +19,17 @@
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { CgRedo } from "react-icons/cg";
 
-import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import type { TaskActionProps } from "src/components/MarkAs/utils";
 import ActionButton from "src/components/ui/ActionButton";
 
-import ClearTaskInstanceDialog from "./ClearTaskInstanceDialog";
+import { ClearTaskInstanceDialog } from "./ClearTaskInstanceDialog";
 
 type Props = {
-  readonly taskInstance: TaskInstanceResponse;
+  readonly taskActionProps: TaskActionProps;
   readonly withText?: boolean;
 };
 
-const ClearTaskInstanceButton = ({ taskInstance, withText = true }: Props) => {
+const ClearTaskInstanceButton = ({ taskActionProps, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   return (
@@ -43,7 +43,7 @@ const ClearTaskInstanceButton = ({ taskInstance, withText = true }: Props) => {
       />
 
       {open ? (
-        <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
+        <ClearTaskInstanceDialog onClose={onClose} open={open} taskActionProps={taskActionProps} />
       ) : undefined}
     </Box>
   );

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -20,7 +20,8 @@ import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
 import { MdArrowDropDown } from "react-icons/md";
 
-import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
+import type { TaskInstanceState } from "openapi/requests/types.gen";
+import type { TaskActionProps } from "src/components/MarkAs/utils";
 import { StateBadge } from "src/components/StateBadge";
 import { Menu } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
@@ -29,11 +30,12 @@ import { allowedStates } from "../utils";
 import MarkTaskInstanceAsDialog from "./MarkTaskInstanceAsDialog";
 
 type Props = {
-  readonly taskInstance: TaskInstanceResponse;
+  readonly state?: TaskInstanceState | null;
+  readonly taskActionProps: TaskActionProps;
   readonly withText?: boolean;
 };
 
-const MarkTaskInstanceAsButton = ({ taskInstance, withText = true }: Props) => {
+const MarkTaskInstanceAsButton = ({ state: taskState, taskActionProps, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   const [state, setState] = useState<TaskInstanceState>("success");
@@ -54,10 +56,10 @@ const MarkTaskInstanceAsButton = ({ taskInstance, withText = true }: Props) => {
           {allowedStates.map((menuState) => (
             <Menu.Item
               asChild
-              disabled={taskInstance.state === menuState}
+              disabled={taskState === menuState}
               key={menuState}
               onClick={() => {
-                if (taskInstance.state !== menuState) {
+                if (taskState !== menuState) {
                   setState(menuState);
                   onOpen();
                 }
@@ -73,7 +75,12 @@ const MarkTaskInstanceAsButton = ({ taskInstance, withText = true }: Props) => {
       </Menu.Root>
 
       {open ? (
-        <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
+        <MarkTaskInstanceAsDialog
+          onClose={onClose}
+          open={open}
+          state={state}
+          taskActionProps={taskActionProps}
+        />
       ) : undefined}
     </Box>
   );

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/utils.ts
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/utils.ts
@@ -19,3 +19,14 @@
 import type { DAGRunPatchStates } from "openapi/requests/types.gen";
 
 export const allowedStates: Array<DAGRunPatchStates> = ["success", "failed"];
+
+export type TaskActionProps = {
+  dagId: string;
+  dagRunId: string;
+  logicalDate?: string | null;
+  mapIndex?: number;
+  note?: string | null;
+  startDate: string | null;
+  taskDisplayName?: string;
+  taskId: string;
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -56,7 +56,18 @@ export const TaskLogPreview = ({
           <Time datetime={taskInstance.run_after} ml={1} />
         </Box>
         <Flex gap={1}>
-          <ClearTaskInstanceButton taskInstance={taskInstance} withText={false} />
+          <ClearTaskInstanceButton
+            taskActionProps={{
+              dagId: taskInstance.dag_id,
+              dagRunId: taskInstance.dag_run_id,
+              mapIndex: taskInstance.map_index,
+              note: taskInstance.note,
+              startDate: taskInstance.start_date,
+              taskDisplayName: taskInstance.task_display_name,
+              taskId: taskInstance.task_id,
+            }}
+            withText={false}
+          />
           <Link asChild color="fg.info" fontSize="sm">
             <RouterLink to={getTaskInstanceLink(taskInstance)}>View full logs</RouterLink>
           </Link>

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -19,8 +19,10 @@
 import { Box } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { MdOutlineTask } from "react-icons/md";
+import { useParams } from "react-router-dom";
 
 import type { GridTaskInstanceSummary } from "openapi/requests/types.gen";
+import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
@@ -32,6 +34,7 @@ export const Header = ({
   readonly isRefreshing?: boolean;
   readonly taskInstance: GridTaskInstanceSummary;
 }) => {
+  const { dagId = "", runId = "" } = useParams();
   const entries: Array<{ label: string; value: number | ReactNode | string }> = [];
 
   if (taskInstance.child_states !== null) {
@@ -54,6 +57,27 @@ export const Header = ({
   return (
     <Box>
       <HeaderCard
+        actions={
+          <>
+            <ClearTaskInstanceButton
+              taskActionProps={{
+                dagId,
+                dagRunId: runId,
+                startDate: taskInstance.start_date,
+                taskId: taskInstance.task_id,
+              }}
+            />
+            {/* Looks like the API does not support this yet. TODO: Uncomment when it does */}
+            {/* <MarkTaskInstanceAsButton
+              taskActionProps={{
+                dagId,
+                dagRunId: runId,
+                startDate: taskInstance.start_date,
+                taskId: taskInstance.task_id,
+              }}
+            /> */}
+          </>
+        }
         icon={<MdOutlineTask />}
         isRefreshing={isRefreshing}
         state={taskInstance.state}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -84,6 +84,16 @@ export const Header = ({
     }
   }, [dagId, dagRunId, mapIndex, mutate, note, taskId, taskInstance.note]);
 
+  const taskActionProps = {
+    dagId: taskInstance.dag_id,
+    dagRunId: taskInstance.dag_run_id,
+    mapIndex: taskInstance.map_index,
+    note: taskInstance.note,
+    startDate: taskInstance.start_date,
+    taskDisplayName: taskInstance.task_display_name,
+    taskId: taskInstance.task_id,
+  };
+
   return (
     <Box ref={containerRef}>
       <HeaderCard
@@ -100,8 +110,12 @@ export const Header = ({
               text={Boolean(taskInstance.note) ? "Note" : "Add a note"}
               withText={containerWidth > 700}
             />
-            <ClearTaskInstanceButton taskInstance={taskInstance} withText={containerWidth > 700} />
-            <MarkTaskInstanceAsButton taskInstance={taskInstance} withText={containerWidth > 700} />
+            <ClearTaskInstanceButton taskActionProps={taskActionProps} withText={containerWidth > 700} />
+            <MarkTaskInstanceAsButton
+              state={taskInstance.state}
+              taskActionProps={taskActionProps}
+              withText={containerWidth > 700}
+            />
           </>
         }
         icon={<MdOutlineTask />}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -151,12 +151,28 @@ const taskInstanceColumns = (
   },
   {
     accessorKey: "actions",
-    cell: ({ row }) => (
-      <Flex justifyContent="end">
-        <ClearTaskInstanceButton taskInstance={row.original} withText={false} />
-        <MarkTaskInstanceAsButton taskInstance={row.original} withText={false} />
-      </Flex>
-    ),
+    cell: ({ row: { original } }) => {
+      const taskActionProps = {
+        dagId: original.dag_id,
+        dagRunId: original.dag_run_id,
+        mapIndex: original.map_index,
+        note: original.note,
+        startDate: original.start_date,
+        taskDisplayName: original.task_display_name,
+        taskId: original.task_id,
+      };
+
+      return (
+        <Flex justifyContent="end">
+          <ClearTaskInstanceButton taskActionProps={taskActionProps} withText={false} />
+          <MarkTaskInstanceAsButton
+            state={original.state}
+            taskActionProps={taskActionProps}
+            withText={false}
+          />
+        </Flex>
+      );
+    },
     enableSorting: false,
     header: "",
     meta: {

--- a/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
@@ -23,6 +23,7 @@ import {
   useDagRunServiceGetDagRunsKey,
   UseGridServiceGridDataKeyFn,
   UseTaskInstanceServiceGetMappedTaskInstanceKeyFn,
+  UseTaskInstanceServiceGetTaskInstancesKeyFn,
   useTaskInstanceServicePostClearTaskInstances,
 } from "openapi/queries";
 import type { ClearTaskInstancesBody, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
@@ -79,6 +80,8 @@ export const useClearTaskInstances = ({
     const queryKeys = [
       ...taskInstanceKeys,
       UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
+      UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId }, [{ dagId, dagRunId }]),
+      [useClearTaskInstancesDryRunKey],
       [useDagRunServiceGetDagRunsKey],
       [useClearTaskInstancesDryRunKey, dagId],
       [usePatchTaskInstanceDryRunKey, dagId, dagRunId],


### PR DESCRIPTION
On the Mapped Task Summary details page, add a Clear button to clear all the mapped tasks at once.

This PR also updated the Mark As button too, but there seems to be an API issue that prevents bulk marking state from working so the button is commented out with a TODO


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
