### PR TITLE
Issue refreshed Execution API JWT to tasks if their current token is expiring

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -451,7 +451,7 @@ class JWTGenerator:
             del claims["aud"]
 
         if extras is not None:
-            claims.update(extras)
+            claims = extras | claims
         headers = {"alg": self.algorithm, **(headers or {})}
         if self._private_key:
             headers["kid"] = self.kid

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -30,7 +30,12 @@ from cadwyn import (
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from airflow.api_fastapi.auth.tokens import JWTValidator, get_sig_validation_args
+from airflow.api_fastapi.auth.tokens import (
+    JWTGenerator,
+    JWTValidator,
+    get_sig_validation_args,
+    get_signing_args,
+)
 
 if TYPE_CHECKING:
     import httpx
@@ -61,6 +66,20 @@ def _jwt_validator():
     return validator
 
 
+def _jwt_generator():
+    from airflow.configuration import conf
+
+    generator = JWTGenerator(
+        valid_for=conf.getint("execution_api", "jwt_expiration_time"),
+        audience=conf.get_mandatory_list_value("execution_api", "jwt_audience")[0],
+        issuer=conf.get("api_auth", "jwt_issuer", fallback=None),
+        # Since this one is used across components/server, there is no point trying to generate one, error
+        # instead
+        **get_signing_args(make_secret_key_if_needed=False),
+    )
+    return generator
+
+
 @svcs.fastapi.lifespan
 async def lifespan(app: FastAPI, registry: svcs.Registry):
     app.state.lifespan_called = True
@@ -69,8 +88,10 @@ async def lifespan(app: FastAPI, registry: svcs.Registry):
     # record this here
     app.state.svcs_registry = registry
 
+    registry.register_factory(JWTGenerator, _jwt_generator)
     # Create an app scoped validator, so that we don't have to fetch it every time
     registry.register_value(JWTValidator, _jwt_validator(), ping=JWTValidator.status)
+
     yield
 
 
@@ -181,7 +202,7 @@ class InProcessExecutionAPI:
     def app(self):
         if not self._app:
             from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
-            from airflow.api_fastapi.execution_api.deps import JWTBearerDep
+            from airflow.api_fastapi.execution_api.deps import JWTBearerDep, JWTRefresherDep
             from airflow.api_fastapi.execution_api.routes.connections import has_connection_access
             from airflow.api_fastapi.execution_api.routes.variables import has_variable_access
             from airflow.api_fastapi.execution_api.routes.xcoms import has_xcom_access
@@ -191,6 +212,7 @@ class InProcessExecutionAPI:
             async def always_allow(): ...
 
             self._app.dependency_overrides[JWTBearerDep.dependency] = always_allow
+            self._app.dependency_overrides[JWTRefresherDep.dependency] = always_allow
             self._app.dependency_overrides[has_connection_access] = always_allow
             self._app.dependency_overrides[has_variable_access] = always_allow
             self._app.dependency_overrides[has_xcom_access] = always_allow

--- a/airflow-core/src/airflow/api_fastapi/execution_api/deps.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/deps.py
@@ -18,14 +18,17 @@
 # Disable future annotations in this file to work around https://github.com/fastapi/fastapi/issues/13056
 # ruff: noqa: I002
 
+import sys
+import time
 from typing import Any, Optional
 
 import structlog
 import svcs
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, Response, status
 from fastapi.security import HTTPBearer
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from airflow.api_fastapi.auth.tokens import JWTValidator
+from airflow.api_fastapi.auth.tokens import JWTGenerator, JWTValidator
 from airflow.api_fastapi.execution_api.datamodels.token import TIToken
 
 log = structlog.get_logger(logger_name=__name__)
@@ -92,3 +95,58 @@ class JWTBearer(HTTPBearer):
 
 
 JWTBearerDep: TIToken = Depends(JWTBearer())
+
+
+class JWTReissuer:
+    """Re-issue JWTs to requests when they are about to run out."""
+
+    def __init__(self):
+        from airflow.configuration import conf
+
+        self.refresh_when_less_than = max(
+            # Issue a new token to a task when the current one is valid for only either 20% of the total validity,
+            # or 30s
+            int(conf.getint("execution_api", "jwt_expiration_time") * 0.20),
+            30,
+        )
+
+    async def __call__(
+        self,
+        response: Response,
+        token=JWTBearerDep,
+        services=DepContainer,
+    ):
+        try:
+            yield
+        finally:
+            # We want to run this even in the case of 404 errors etc
+            now = int(time.time())
+
+            try:
+                valid_left = token.claims["exp"] - now
+                if valid_left <= self.refresh_when_less_than:
+                    generator: JWTGenerator = await services.aget(JWTGenerator)
+                    new = generator.generate(token.claims)
+                    response.headers["Refreshed-API-Token"] = new
+                    log.debug(
+                        "Refreshed token issued to Task",
+                        valid_left=valid_left,
+                        refresh_when_less_than=self.refresh_when_less_than,
+                    )
+
+                    exc, val, _ = sys.exc_info()
+                    if val and isinstance(val, StarletteHTTPException):
+                        # If there is an exception thrown, we need to set the headers there instead
+                        if val.headers is None:
+                            val.headers = {}
+
+                        # Defined as a "mapping type", but 99.9% of the time it's a mutable dict. We catch
+                        # errors if not
+                        val.headers["Refreshed-API-Token"] = new  # type: ignore[index]
+
+            except Exception as e:
+                # Don't 500 if there's a problem
+                log.warning("Error refreshing Task JWT", err=f"{type(e).__name__}: {e}")
+
+
+JWTRefresherDep = Depends(JWTReissuer())

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from cadwyn import VersionedAPIRouter
 from fastapi import APIRouter
 
-from airflow.api_fastapi.execution_api.deps import JWTBearerDep
+from airflow.api_fastapi.execution_api.deps import JWTBearerDep, JWTRefresherDep
 from airflow.api_fastapi.execution_api.routes import (
     asset_events,
     assets,
@@ -35,8 +35,8 @@ from airflow.api_fastapi.execution_api.routes import (
 execution_api_router = APIRouter()
 execution_api_router.include_router(health.router, prefix="/health", tags=["Health"])
 
-# _Every_ single endpoint under here must be authenticated. Some do further checks
-authenticated_router = VersionedAPIRouter(dependencies=[JWTBearerDep])  # type: ignore[list-item]
+# _Every_ single endpoint under here must be authenticated. Some do further checks on top of these
+authenticated_router = VersionedAPIRouter(dependencies=[JWTBearerDep, JWTRefresherDep])  # type: ignore[list-item]
 
 authenticated_router.include_router(assets.router, prefix="/assets", tags=["Assets"])
 authenticated_router.include_router(asset_events.router, prefix="/asset-events", tags=["Asset Events"])

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+
+from airflow.api_fastapi.auth.tokens import JWTValidator
+from airflow.api_fastapi.execution_api.app import lifespan
+from airflow.api_fastapi.execution_api.deps import JWTRefresherDep, JWTReissuer
+
+from tests_common.test_utils.config import conf_vars
+
+
+@pytest.fixture
+def exec_app(client):
+    last_route = client.app.routes[-1]
+    assert isinstance(last_route.app, FastAPI)
+    return last_route.app
+
+
+@pytest.mark.parametrize(
+    ("age", "validity", "expect_refreshed_token"),
+    (
+        pytest.param(25, 60, False, id="25s-of-60s"),
+        pytest.param(31, 60, True, id="30s-of-60s"),
+        # Test the "20% left" behaviour for larger validities
+        pytest.param(400, 600, False, id="400s-of-600s"),
+        pytest.param(480, 600, True, id="480s-of-600s"),
+    ),
+)
+@pytest.mark.db_test
+def test_expiring_token_is_reissued(
+    client, exec_app: FastAPI, time_machine, age, validity, expect_refreshed_token
+):
+    moment = 1743451846  # A "random" unix epoch timestamp.
+    auth = AsyncMock(spec=JWTValidator)
+    auth.avalidated_claims.return_value = {
+        "sub": "edb09971-4e0e-4221-ad3f-800852d38085",
+        "exp": moment + validity,
+    }
+
+    with conf_vars({("execution_api", "jwt_expiration_time"): str(validity)}):
+        exec_app.dependency_overrides[JWTRefresherDep.dependency] = JWTReissuer()
+
+    time_machine.move_to(moment + age, tick=False)
+
+    # Inject our fake JWTValidator object. Can be over-ridden by tests if they want
+    lifespan.registry.register_value(JWTValidator, auth)
+    # In order to test this we need any endpoint to hit. The easiest one to use is variable get
+    response = client.get("/execution/variables/key1")
+
+    if expect_refreshed_token:
+        assert "Refreshed-API-Token" in response.headers
+    else:
+        assert "Refreshed-API-Token" not in response.headers

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -203,6 +203,29 @@ class TestClient:
         assert len(responses) == 1
         assert mock_sleep.call_count == 0
 
+    def test_token_renewal(self):
+        responses: list[httpx.Response] = [
+            httpx.Response(200, json={"ok": "1"}),
+            httpx.Response(404, json={"var": "not_found"}, headers={"Refreshed-API-Token": "abc"}),
+            httpx.Response(200, json={"ok": "3"}),
+        ]
+        client = make_client_w_responses(responses)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert client.auth is not None
+        assert not client.auth.token
+        with pytest.raises(ServerResponseError):
+            response = client.get("/")
+
+        # Even thought it was Not Found, we should still respect the header
+        assert client.auth is not None
+        assert client.auth.token == "abc"
+
+        # Test that the next request is made with that new auth token
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.request.headers["Authorization"] == "Bearer abc"
+
 
 class TestTaskInstanceOperations:
     """


### PR DESCRIPTION
Since they heartbeat frequently we will use this to issue them a new token if
the oney they made the request with is soon to expire.

Closes #48536
