### PR TITLE
Document that the triggerer does not load dag bundles

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/deferring.rst
+++ b/airflow-core/docs/authoring-and-scheduling/deferring.rst
@@ -147,6 +147,7 @@ There's some design constraints to be aware of when writing your own trigger:
 * If your trigger is designed to emit more than one event (not currently supported), then each emitted event *must* contain a payload that can be used to deduplicate events if the trigger is running in multiple places. If you only fire one event and don't need to pass information back to the operator, you can just set the payload to ``None``.
 * A trigger can suddenly be removed from one triggerer service and started on a new one. For example, if subnets are changed and a network partition results or if there is a deployment. If desired, you can implement the ``cleanup`` method, which is always called after ``run``, whether the trigger exits cleanly or otherwise.
 * In order for any changes to a trigger to be reflected, the *triggerer* needs to be restarted whenever the trigger is modified.
+* Your trigger must not come from a dag bundle - anywhere else on ``sys.path`` is fine. The triggerer does not initialize any bundles when running a trigger.
 
 .. note::
 

--- a/airflow-core/newsfragments/aip-66.significant.rst
+++ b/airflow-core/newsfragments/aip-66.significant.rst
@@ -31,6 +31,10 @@ The ``--subdir`` option has been removed from the following commands:
 * ``airflow dags trigger``
 * ``airflow dags unpause``
 
+Dag bundles are not initialized in the triggerer. In practice, this means that triggers cannot come from a dag bundle.
+This is because the triggerer does not deal with changes in trigger code over time, as everything happens in the main process.
+Triggers can come from anywhere else on ``sys.path`` instead.
+
 .. Provide additional contextual information
 
 .. Check the type of change that applies to this change


### PR DESCRIPTION
This never really worked *well*, as the triggerer is unable to account for changes without having a restart. This just formalizes that it's best practice to have triggers come from elsewhere on `sys.path` instead to avoid that problem.