### PR TITLE
Fix tests in test_dag to account for month change

### DIFF
--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -848,7 +848,9 @@ class TestDag:
 
             # Verify it's not using the old DEFAULT_DATE from 2016
             assert model.next_dagrun.year == current_time.year
-            assert model.next_dagrun.month == current_time.month
+
+            # Ideally should be 24 hrs but can be a little more, so keeping an hours window
+            assert (current_time - model.next_dagrun) <= timedelta(hours=30)
 
             # Verify the date is within a reasonable range of the current date
             # (allowing for timezone differences and scheduling details)
@@ -2002,7 +2004,10 @@ my_postgres_conn:
         # With catchup=False, next_dagrun should be based on the current date
         # Verify it's not using the old start_date
         assert next_info.logical_date.year == current_time.year
-        assert next_info.logical_date.month == current_time.month
+
+        # Ideally should be 24 hrs but can be a little more, so keeping an hours window
+        assert (current_time - next_info.logical_date) <= timedelta(hours=30)
+
         # Verify it's following the cron schedule pattern (4 5 * * *)
         assert next_info.logical_date.hour == 5
         assert next_info.logical_date.minute == 4
@@ -2020,7 +2025,8 @@ my_postgres_conn:
         # With catchup=False, next_dagrun should be based on the current date
         # Verify it's not using the old start_date
         assert next_info.logical_date.year == current_time.year
-        assert next_info.logical_date.month == current_time.month
+        # This will cover cases when the month changes
+        assert next_info.logical_date.diff(current_time).days <= 1
         # Verify it's following the cron schedule pattern (10 10 * * *)
         assert next_info.logical_date.hour == 10
         assert next_info.logical_date.minute == 10

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -1988,7 +1988,6 @@ my_postgres_conn:
         assert next_info.logical_date == timezone.datetime(2016, 1, 1, 10, 10)
 
         # Test catchup=False scenario (using current dates)
-        current_time = timezone.utcnow()
         start_date = timezone.datetime(2016, 1, 1, 10, 10, 0)
         dag = DAG(
             dag_id="test_scheduler_auto_align_3",
@@ -2009,9 +2008,10 @@ my_postgres_conn:
         assert next_info.logical_date.hour == 5
         assert next_info.logical_date.minute == 4
 
+        start_date = timezone.datetime(2016, 1, 1, 10, 10, 0)
         dag = DAG(
             dag_id="test_scheduler_auto_align_4",
-            start_date=timezone.datetime(2016, 1, 1, 10, 10, 0),
+            start_date=start_date,
             schedule="10 10 * * *",
             catchup=False,
         )
@@ -2021,9 +2021,8 @@ my_postgres_conn:
         assert next_info
         # With catchup=False, next_dagrun should be based on the current date
         # Verify it's not using the old start_date
-        assert next_info.logical_date.year == current_time.year
-        # This will cover cases when the month changes
-        assert next_info.logical_date.diff(current_time).days <= 1
+        assert next_info.logical_date.year >= start_date.year
+        assert next_info.logical_date.month >= start_date.month
         # Verify it's following the cron schedule pattern (10 10 * * *)
         assert next_info.logical_date.hour == 10
         assert next_info.logical_date.minute == 10

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -849,7 +849,7 @@ class TestDag:
             # Verify it's not using the old DEFAULT_DATE from 2016
             assert model.next_dagrun.year == current_time.year
 
-            # Ideally should be 24 hrs but can be a little more, so keeping an hours window
+            # Ideally should be 24 hrs but can be a little more, so keeping some window
             assert (current_time - model.next_dagrun) <= timedelta(hours=30)
 
             # Verify the date is within a reasonable range of the current date
@@ -2005,7 +2005,7 @@ my_postgres_conn:
         # Verify it's not using the old start_date
         assert next_info.logical_date.year == current_time.year
 
-        # Ideally should be 24 hrs but can be a little more, so keeping an hours window
+        # Ideally should be 24 hrs but can be a little more, so keeping some window
         assert (current_time - next_info.logical_date) <= timedelta(hours=30)
 
         # Verify it's following the cron schedule pattern (4 5 * * *)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Example failure https://github.com/apache/airflow/actions/runs/14187319355/job/39745074487?pr=48528

Tests in test_dag are failing in main with the below error:


```
=========================== short test summary info ============================
FAILED airflow-core/tests/unit/models/test_dag.py::TestDag::test_bulk_write_to_db_max_active_runs[running-False-None] - AssertionError: assert 3 == 4
 +  where 3 = datetime.datetime(2025, 3, 31, 0, 0, tzinfo=Timezone('UTC')).month
 +    where datetime.datetime(2025, 3, 31, 0, 0, tzinfo=Timezone('UTC')) = <DAG: test_scheduler_verify_max_active_runs>.next_dagrun
 +  and   4 = datetime.datetime(2025, 4, 1, 4, 49, 35, 966138, tzinfo=Timezone('UTC')).month
FAILED airflow-core/tests/unit/models/test_dag.py::TestDag::test_bulk_write_to_db_max_active_runs[queued-False-None] - AssertionError: assert 3 == 4
 +  where 3 = datetime.datetime(2025, 3, 31, 0, 0, tzinfo=Timezone('UTC')).month
 +    where datetime.datetime(2025, 3, 31, 0, 0, tzinfo=Timezone('UTC')) = <DAG: test_scheduler_verify_max_active_runs>.next_dagrun
 +  and   4 = datetime.datetime(2025, 4, 1, 4, 49, 37, 274971, tzinfo=Timezone('UTC')).month
FAILED airflow-core/tests/unit/models/test_dag.py::TestDag::test_next_dagrun_after_auto_align - AssertionError: assert 3 == 4
 +  where 3 = DateTime(2025, 3, 30, 5, 4, 0, tzinfo=Timezone('UTC')).month
 +    where DateTime(2025, 3, 30, 5, 4, 0, tzinfo=Timezone('UTC')) = DagRunInfo(run_after=DateTime(2025, 3, 31, 5, 4, 0, tzinfo=Timezone('UTC')), data_interval=DataInterval(start=DateTime(2025, 3, 30, 5, 4, 0, tzinfo=Timezone('UTC')), end=DateTime(2025, 3, 31, 5, 4, 0, tzinfo=Timezone('UTC')))).logical_date
 +  and   4 = datetime.datetime(2025, 4, 1, 4, 49, 42, 601908, tzinfo=Timezone('UTC')).month
= 3 failed, 2349 passed, 30 skipped, 1 xfailed, 1 warning in 432.46s (0:07:12) =
Exporter already shutdown, ignoring call
Exporter already shutdown, ignoring call
Exporter already shutdown, ignoring call
```

This is because the tests arent accounting for change in month. Today is 1st April!!

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
