### PR TITLE
Change last week to last 48 hours since weekly queries will be expensive.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TimeRangeSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TimeRangeSelector.tsx
@@ -38,7 +38,7 @@ const defaultTimeOptions = createListCollection({
     { label: "Last 1 hour", value: "1" },
     { label: "Last 12 hours", value: "12" },
     { label: "Last 24 hours", value: "24" },
-    { label: "Past week", value: "168" },
+    { label: "Last 48 hours", value: "48" },
   ],
 });
 


### PR DESCRIPTION
Last week was used during development as default and got changed to last 24 hours. The last week option is expensive in large environments and might take a long time to return the results. Replace it with "last 48 hours" which is a better option.