### PR TITLE
 docs(newsfragments): mark implemented AIR302 rules as Done

### DIFF
--- a/airflow-core/newsfragments/41368.significant.rst
+++ b/airflow-core/newsfragments/41368.significant.rst
@@ -29,29 +29,29 @@ For example, instead of ``from airflow.sensors import TimeDeltaSensor``, use ``f
     * AIR302
 
       * [x] ``airflow.sensors.base_sensor_operator.BaseSensorOperator`` → ``airflow.sdk.bases.sensor.BaseSensorOperator``
-      * [x] ``airflow.sensors.date_time_sensor.DateTimeSensor`` → ``airflow.sensors.date_time.DateTimeSensor``
       * [x] ``airflow.hooks.base_hook.BaseHook`` → ``airflow.hooks.base.BaseHook``
 
     * AIR303
 
-      * [ ] ``airflow.sensors.external_task_sensor.ExternalTaskMarker`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskMarker``
-      * [ ] ``airflow.sensors.external_task_sensor.ExternalTaskSensor`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskSensor``
-      * [ ] ``airflow.sensors.external_task_sensor.ExternalTaskSensorLink`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink``
-      * [ ] ``airflow.sensors.time_delta_sensor.TimeDeltaSensor`` → ``airflow.providers.standard.sensors.time_delta.TimeDeltaSensor``
-      * [ ] ``airflow.operators.dagrun_operator.TriggerDagRunLink`` → ``airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink``
-      * [ ] ``airflow.operators.dagrun_operator.TriggerDagRunOperator`` → ``airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator``
-      * [ ] ``airflow.operators.python_operator.BranchPythonOperator`` → ``airflow.providers.standard.operators.python.BranchPythonOperator``
-      * [ ] ``airflow.operators.python_operator.PythonOperator`` → ``airflow.providers.standard.operators.python.PythonOperator``
-      * [ ] ``airflow.operators.python_operator.PythonVirtualenvOperator`` → ``airflow.providers.standard.operators.python.PythonVirtualenvOperator``
-      * [ ] ``airflow.operators.python_operator.ShortCircuitOperator`` → ``airflow.providers.standard.operators.python.ShortCircuitOperator``
-      * [ ] ``airflow.operators.latest_only_operator.LatestOnlyOperator`` → ``airflow.providers.standard.operators.latest_only.LatestOnlyOperator``
-      * [ ] ``airflow.operators.bash_operator.BashOperator`` → ``airflow.providers.standard.operators.bash.BashOperator``
-      * [ ] ``airflow.operators.branch_operator.BaseBranchOperator`` → ``airflow.providers.standard.operators.branch.BaseBranchOperator``
-      * [ ] ``airflow.operators.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
-      * [ ] ``airflow.operators.DummyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
-      * [ ] ``airflow.operators.dummy_operator.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
-      * [ ] ``airflow.operators.dummy_operator.DummyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
-      * [ ] ``airflow.operators.email_operator.EmailOperator`` → ``airflow.providers.smtp.operators.smtp.EmailOperator``
+      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskMarker`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskMarker``
+      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskSensor`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskSensor``
+      * [x] ``airflow.sensors.external_task_sensor.ExternalTaskSensorLink`` → ``airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink``
+      * [x] ``airflow.sensors.time_delta_sensor.TimeDeltaSensor`` → ``airflow.providers.standard.sensors.time_delta.TimeDeltaSensor``
+      * [x] ``airflow.operators.dagrun_operator.TriggerDagRunLink`` → ``airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink``
+      * [x] ``airflow.operators.dagrun_operator.TriggerDagRunOperator`` → ``airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator``
+      * [x] ``airflow.operators.python_operator.BranchPythonOperator`` → ``airflow.providers.standard.operators.python.BranchPythonOperator``
+      * [x] ``airflow.operators.python_operator.PythonOperator`` → ``airflow.providers.standard.operators.python.PythonOperator``
+      * [x] ``airflow.operators.python_operator.PythonVirtualenvOperator`` → ``airflow.providers.standard.operators.python.PythonVirtualenvOperator``
+      * [x] ``airflow.operators.python_operator.ShortCircuitOperator`` → ``airflow.providers.standard.operators.python.ShortCircuitOperator``
+      * [x] ``airflow.operators.latest_only_operator.LatestOnlyOperator`` → ``airflow.providers.standard.operators.latest_only.LatestOnlyOperator``
+      * [x] ``airflow.operators.bash_operator.BashOperator`` → ``airflow.providers.standard.operators.bash.BashOperator``
+      * [x] ``airflow.operators.branch_operator.BaseBranchOperator`` → ``airflow.providers.standard.operators.branch.BaseBranchOperator``
+      * [x] ``airflow.sensors.date_time_sensor.DateTimeSensor`` → ``airflow.providers.standardi.sensors.DateTimeSensor``
+      * [x] ``airflow.operators.dumm y.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
+      * [x] ``airflow.operators.dumm y.DummyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
+      * [x] ``airflow.operators.dummy_operator.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
+      * [x] ``airflow.operators.dummy_operator.DummyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
+      * [x] ``airflow.operators.email_operator.EmailOperator`` → ``airflow.providers.smtp.operators.smtp.EmailOperator``
       * [x] ``airflow.executors.celery_executor.CeleryExecutor`` → ``airflow.providers.celery.executors.celery_executor.CeleryExecutor``
       * [x] ``airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor`` → ``airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor``
       * [x] ``airflow.executors.dask_executor.DaskExecutor`` → ``airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor``

--- a/airflow-core/newsfragments/42252.significant.rst
+++ b/airflow-core/newsfragments/42252.significant.rst
@@ -17,4 +17,4 @@ Move bash operators from airflow core to standard provider
 
     * AIR303
 
-      * [ ] ``airflow.operators.bash.BashOperator`` → ``airflow.providers.standard.operators.bash.BashOperator``
+      * [x] ``airflow.operators.bash.BashOperator`` → ``airflow.providers.standard.operators.bash.BashOperator``

--- a/airflow-core/newsfragments/46231.significant.rst
+++ b/airflow-core/newsfragments/46231.significant.rst
@@ -20,4 +20,4 @@ For new and existing DAGs, users must import ``EmptyOperator`` from ``airflow.pr
 
     * AIR303
 
-      * [ ] ``airflow.operators.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``
+      * [x] ``airflow.operators.empty.EmptyOperator`` → ``airflow.providers.standard.operators.empty.EmptyOperator``

--- a/airflow-core/newsfragments/46573.significant.rst
+++ b/airflow-core/newsfragments/46573.significant.rst
@@ -19,4 +19,4 @@ Instead, users can install ``smtp`` provider and import ``EmailOperator`` from t
 
     * AIR303
 
-      * [ ] ``airflow.operators.email`` → ``airflow.providers.smtp.operators.smtp.EmailOperator``
+      * [x] ``airflow.operators.email.EmailOperator`` → ``airflow.providers.smtp.operators.smtp.EmailOperator``


### PR DESCRIPTION
## Why

These rules have been implemented in https://github.com/astral-sh/ruff/pull/17123

## What
as title

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
