### PR TITLE
Correct status code validation in `ServerResponseError.from_response`

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -609,7 +609,7 @@ class ServerResponseError(httpx.HTTPStatusError):
         if response.is_success:
             return None
         # 4xx or 5xx error?
-        if 400 < (response.status_code // 100) >= 600:
+        if not (400 <= response.status_code < 600):
             return None
 
         if response.headers.get("content-type") != "application/json":

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -226,6 +226,19 @@ class TestClient:
         assert response.status_code == 200
         assert response.request.headers["Authorization"] == "Bearer abc"
 
+    @pytest.mark.parametrize(
+        ["status_code", "description"],
+        [
+            (399, "status code < 400"),
+            (301, "3xx redirect status code"),
+            (600, "status code >= 600"),
+        ],
+    )
+    def test_server_response_error_invalid_status_codes(self, status_code, description):
+        """Test that ServerResponseError.from_response returns None for invalid status codes."""
+        response = httpx.Response(status_code, json={"detail": f"Test {description}"})
+        assert ServerResponseError.from_response(response) is None
+
 
 class TestTaskInstanceOperations:
     """


### PR DESCRIPTION
The original condition `if 400 < (response.status_code // 100) >= 600` was logically incorrect and would never evaluate to True. This meant the method would never return `None` for status codes outside the 4xx/5xx range, which is the intended behavior.

The fix changes the condition to properly handle status codes:
- Returns None for status codes < 400 and >= 600
- Creates ServerResponseError for 4xx/5xx status codes

## Why
The original condition `if 400 < (response.status_code // 100) >= 600` was logically incorrect and would never evaluate to True. This meant the method would never return `None` for status codes outside the 4xx/5xx range, which is the intended behavior.

### Why wasn't this causing issues?
The bug wasn't causing issues in production because:

1. The condition would always evaluate to `False` due to its logical structure:
   - For any status code, `response.status_code // 100` will be a number between 0 and 6
   - The condition `400 < (response.status_code // 100) >= 600` is equivalent to:
     ```python
     (400 < (response.status_code // 100)) and ((response.status_code // 100) >= 600)
     ```
   - This is impossible to satisfy because no number can be both greater than 400 AND greater than or equal to 600

2. Since the condition was always `False`, the code would continue to the next check:
   ```python
   if response.headers.get("content-type") != "application/json":
       return None
   ```
   - For JSON responses with 4xx/5xx status codes, it would create and return a `ServerResponseError`
   - This was the correct behavior we wanted

3. The error handling chain would still work as expected:
   - For JSON responses with 4xx/5xx status codes: `ServerResponseError` would be created
   - For non-JSON responses: `None` would be returned
   - For successful responses: `None` would be returned

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
