### PR TITLE
Fix 0 of 0 assets bug

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -56,7 +56,8 @@ export const AssetSchedule = ({ dag }: Props) => {
             nextRunEvents[0]?.uri
           ) : (
             <>
-              {pendingEvents.length} of {nextRunEvents.length} assets updated
+              {pendingEvents.length}
+              {nextRunEvents.length > 1 ? ` of ${nextRunEvents.length} ` : " "}assets updated
             </>
           )}
         </Button>


### PR DESCRIPTION
Sometimes the next run assets list is not populated. The UI should fallback to saying `0 assets updated` instead of `0 of 0 asset updated`


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
