### PR TITLE
Fix css warnings and rearrange backfills column order

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, Table, Box } from "@chakra-ui/react";
+import { Button, Table } from "@chakra-ui/react";
 import { flexRender, type Row, type Table as TanStackTable } from "@tanstack/react-table";
 import React, { Fragment } from "react";
 import { TiArrowSortedDown, TiArrowSortedUp, TiArrowUnsorted } from "react-icons/ti";
@@ -34,11 +34,13 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
     <Table.Header bg="chakra-body-bg" position="sticky" top={0} zIndex={1}>
       {table.getHeaderGroups().map((headerGroup) => (
         <Table.Row key={headerGroup.id}>
-          {headerGroup.headers.map(({ colSpan, column, getContext, id, isPlaceholder }) => {
+          {headerGroup.headers.map(({ colSpan, column, getContext, id, isPlaceholder }, index) => {
             const sort = column.getIsSorted();
             const canSort = column.getCanSort();
             const text = flexRender(column.columnDef.header, getContext());
             let rightIcon;
+
+            const showFilters = allowFiltering && index === headerGroup.headers.length - 1;
 
             if (canSort) {
               if (sort === "desc") {
@@ -62,6 +64,7 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
                       {rightIcon}
                     </Button>
                   )}
+                  {showFilters ? <FilterMenuButton table={table} /> : undefined}
                 </Table.ColumnHeader>
               );
             }
@@ -69,16 +72,12 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
             return (
               <Table.ColumnHeader colSpan={colSpan} key={id} whiteSpace="nowrap">
                 {isPlaceholder ? undefined : text}
+                {showFilters ? <FilterMenuButton table={table} /> : undefined}
               </Table.ColumnHeader>
             );
           })}
         </Table.Row>
       ))}
-      {allowFiltering ? (
-        <Box position="absolute" right={0} top={2}>
-          <FilterMenuButton table={table} />
-        </Box>
-      ) : undefined}
     </Table.Header>
     <Table.Body>
       {table.getRowModel().rows.map((row) => (

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link } from "@chakra-ui/react";
+import { Box, Link } from "@chakra-ui/react";
 import { FiChevronRight } from "react-icons/fi";
 import { LuPlug } from "react-icons/lu";
 
@@ -55,7 +55,7 @@ export const PluginMenus = () => {
   return (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger>
-        <NavButton icon={<LuPlug />} title="Plugins" />
+        <NavButton as={Box} icon={<LuPlug />} title="Plugins" />
       </Menu.Trigger>
       <Menu.Content>
         {buttons.map(({ href, name }) =>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -31,6 +31,26 @@ import { getDuration, pluralize } from "src/utils";
 
 const columns: Array<ColumnDef<BackfillResponse>> = [
   {
+    accessorKey: "date_from",
+    cell: ({ row }) => (
+      <Text>
+        <Time datetime={row.original.from_date} />
+      </Text>
+    ),
+    enableSorting: false,
+    header: "From",
+  },
+  {
+    accessorKey: "date_to",
+    cell: ({ row }) => (
+      <Text>
+        <Time datetime={row.original.to_date} />
+      </Text>
+    ),
+    enableSorting: false,
+    header: "To",
+  },
+  {
     accessorKey: "reprocess_behavior",
     cell: ({ row }) => (
       <Text>
@@ -42,11 +62,6 @@ const columns: Array<ColumnDef<BackfillResponse>> = [
     ),
     enableSorting: false,
     header: "Reprocess Behavior",
-  },
-  {
-    accessorKey: "max_active_runs",
-    enableSorting: false,
-    header: "Max Active Runs",
   },
   {
     accessorKey: "created_at",
@@ -69,26 +84,6 @@ const columns: Array<ColumnDef<BackfillResponse>> = [
     header: "Completed at",
   },
   {
-    accessorKey: "date_from",
-    cell: ({ row }) => (
-      <Text>
-        <Time datetime={row.original.from_date} />
-      </Text>
-    ),
-    enableSorting: false,
-    header: "From",
-  },
-  {
-    accessorKey: "date_to",
-    cell: ({ row }) => (
-      <Text>
-        <Time datetime={row.original.to_date} />
-      </Text>
-    ),
-    enableSorting: false,
-    header: "To",
-  },
-  {
     accessorKey: "duration",
     cell: ({ row }) => (
       <Text>
@@ -99,6 +94,11 @@ const columns: Array<ColumnDef<BackfillResponse>> = [
     ),
     enableSorting: false,
     header: "Duration",
+  },
+  {
+    accessorKey: "max_active_runs",
+    enableSorting: false,
+    header: "Max Active Runs",
   },
 ];
 


### PR DESCRIPTION
We had two css errors with improperly nested html elements.

Also, the filter columns button still got in the way sometimes. Now it is always just added to the last column.

Rearranged the backfills column ordering a bit. Figured the date ranges are most important.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
