### PR TITLE
Implement triggering_asset_events in task sdk

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -243,6 +243,33 @@ class TaskInstance(StrictBaseModel):
     hostname: str | None = None
 
 
+class AssetReferenceAssetEventDagRun(StrictBaseModel):
+    """Schema for AssetModel used in AssetEventDagRunReference."""
+
+    name: str
+    uri: str
+    extra: dict
+
+
+class AssetAliasReferenceAssetEventDagRun(StrictBaseModel):
+    """Schema for AssetAliasModel used in AssetEventDagRunReference."""
+
+    name: str
+
+
+class AssetEventDagRunReference(StrictBaseModel):
+    """Schema for AssetEvent model used in DagRun."""
+
+    asset: AssetReferenceAssetEventDagRun
+    extra: dict
+    source_task_id: str | None
+    source_dag_id: str | None
+    source_run_id: str | None
+    source_map_index: int | None
+    source_aliases: list[AssetAliasReferenceAssetEventDagRun]
+    timestamp: UtcDateTime
+
+
 class DagRun(StrictBaseModel):
     """Schema for DagRun model with minimal required fields needed for Runtime."""
 
@@ -261,6 +288,7 @@ class DagRun(StrictBaseModel):
     clear_number: int = 0
     run_type: DagRunType
     conf: Annotated[dict[str, Any], Field(default_factory=dict)]
+    consumed_asset_events: list[AssetEventDagRunReference]
 
 
 class TIRunContext(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -27,6 +27,7 @@ from fastapi import Body, Depends, HTTPException, status
 from pydantic import JsonValue
 from sqlalchemy import func, tuple_, update
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
 from airflow.api_fastapi.common.db.common import SessionDep
@@ -173,21 +174,15 @@ def ti_run(
         result = session.execute(query)
         log.info("TI %s state updated: %s row(s) affected", ti_id_str, result.rowcount)
 
-        dr = session.execute(
-            select(
-                DR.run_id,
-                DR.dag_id,
-                DR.data_interval_start,
-                DR.data_interval_end,
-                DR.run_after,
-                DR.start_date,
-                DR.end_date,
-                DR.clear_number,
-                DR.run_type,
-                DR.conf,
-                DR.logical_date,
-            ).filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
-        ).one_or_none()
+        dr = (
+            session.scalars(
+                select(DR)
+                .filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
+                .options(joinedload(DR.consumed_asset_events))
+            )
+            .unique()
+            .one_or_none()
+        )
 
         if not dr:
             raise ValueError(f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.")
@@ -236,8 +231,8 @@ def ti_run(
             context.next_kwargs = ti.next_kwargs
 
         return context
-    except SQLAlchemyError as e:
-        log.error("Error marking Task Instance state as running: %s", e)
+    except SQLAlchemyError:
+        log.exception("Error marking Task Instance state as running")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
         )

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -739,16 +739,16 @@ class AssetEvent(Base):
     )
 
     @property
-    def uri(self):
+    def name(self) -> str:
+        return self.asset.name
+
+    @property
+    def uri(self) -> str:
         return self.asset.uri
 
     @property
-    def group(self):
+    def group(self) -> str:
         return self.asset.group
-
-    @property
-    def name(self):
-        return self.asset.name
 
     def __repr__(self) -> str:
         args = []

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -174,6 +174,7 @@ class TestTIRunState:
                 "end_date": None,
                 "run_type": "manual",
                 "conf": {},
+                "consumed_asset_events": [],
             },
             "task_reschedule_count": 0,
             "max_tries": max_tries,

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -2078,6 +2078,7 @@ def create_runtime_ti(mocked_parse):
                 run_type=run_type,  # type: ignore
                 run_after=run_after,  # type: ignore
                 conf=conf,
+                consumed_asset_events=[],
             ),
             task_reschedule_count=task_reschedule_count,
             max_tries=task_retries if max_tries is None else max_tries,

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
@@ -45,8 +45,10 @@ from tests_common.test_utils.compat import PythonOperator
 from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     try:
-        from airflow.sdk.api.datamodels._generated import TIRunContext
+        from airflow.sdk.api.datamodels._generated import AssetEventDagRunReference, TIRunContext
         from airflow.sdk.definitions.context import Context
 
     except ImportError:
@@ -54,7 +56,7 @@ if TYPE_CHECKING:
         # TIRunContext is only used in Airflow 3 tests
         from airflow.utils.context import Context
 
-        TIRunContext = Any  # type: ignore[misc, assignment]
+        AssetEventDagRunReference = TIRunContext = Any  # type: ignore[misc, assignment]
 
 
 if AIRFLOW_V_2_10_PLUS:
@@ -438,6 +440,7 @@ class MakeTIContextCallable(Protocol):
         run_type: str = ...,
         task_reschedule_count: int = ...,
         conf: dict[str, Any] | None = ...,
+        consumed_asset_events: Sequence[AssetEventDagRunReference] = ...,
     ) -> TIRunContext: ...
 
 
@@ -459,6 +462,7 @@ def make_ti_context() -> MakeTIContextCallable:
         run_type: str = "manual",
         task_reschedule_count: int = 0,
         conf=None,
+        consumed_asset_events: Sequence[AssetEventDagRunReference] = (),
     ) -> TIRunContext:
         return TIRunContext(
             dag_run=DagRun(
@@ -472,6 +476,7 @@ def make_ti_context() -> MakeTIContextCallable:
                 run_type=run_type,  # type: ignore
                 run_after=run_after,  # type: ignore
                 conf=conf,  # type: ignore
+                consumed_asset_events=list(consumed_asset_events),
             ),
             task_reschedule_count=task_reschedule_count,
             max_tries=0,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -900,6 +900,7 @@ class TestOpenLineageListenerAirflow3:
                     run_type=DagRunType.MANUAL,
                     run_after=timezone.datetime(2023, 1, 3, 13, 1, 1),
                     conf=None,
+                    consumed_asset_events=[],
                 ),
                 task_reschedule_count=0,
                 max_tries=1,

--- a/scripts/ci/pre_commit/check_template_context_variable_in_sync.py
+++ b/scripts/ci/pre_commit/check_template_context_variable_in_sync.py
@@ -91,14 +91,9 @@ def _iter_template_context_keys_from_original_return() -> typing.Iterator[str]:
         raise ValueError("'context' is not assigned a dictionary literal")
     yield from extract_keys_from_dict(context_assignment.value)
 
-    # Handle keys added conditionally in `if x := self._ti_context_from_server`
+    # Handle keys added conditionally in `if from_server`
     for stmt in fn_get_template_context.body:
-        if (
-            isinstance(stmt, ast.If)
-            and isinstance(stmt.test, ast.NamedExpr)
-            and isinstance(stmt.test.value, ast.Attribute)
-            and stmt.test.value.attr == "_ti_context_from_server"
-        ):
+        if isinstance(stmt, ast.If) and isinstance(stmt.test, ast.Name) and stmt.test.id == "from_server":
             for sub_stmt in stmt.body:
                 # Get keys from `context_from_server` assignment
                 if (

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -481,6 +481,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
                     "start_date": "2021-01-01T00:00:00Z",
                     "run_type": DagRunType.MANUAL,
                     "run_after": "2021-01-01T00:00:00Z",
+                    "consumed_asset_events": [],
                 },
                 "max_tries": 0,
                 "should_retry": False,

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -30,6 +30,17 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue
 API_VERSION: Final[str] = "2025-03-26"
 
 
+class AssetAliasReferenceAssetEventDagRun(BaseModel):
+    """
+    Schema for AssetAliasModel used in AssetEventDagRunReference.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    name: Annotated[str, Field(title="Name")]
+
+
 class AssetProfile(BaseModel):
     """
     Profile of an asset-like object.
@@ -50,6 +61,19 @@ class AssetProfile(BaseModel):
     name: Annotated[str | None, Field(title="Name")] = None
     uri: Annotated[str | None, Field(title="Uri")] = None
     type: Annotated[str, Field(title="Type")]
+
+
+class AssetReferenceAssetEventDagRun(BaseModel):
+    """
+    Schema for AssetModel used in AssetEventDagRunReference.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    name: Annotated[str, Field(title="Name")]
+    uri: Annotated[str, Field(title="Uri")]
+    extra: Annotated[dict[str, Any], Field(title="Extra")]
 
 
 class AssetResponse(BaseModel):
@@ -354,6 +378,24 @@ class TerminalTIState(str, Enum):
     REMOVED = "removed"
 
 
+class AssetEventDagRunReference(BaseModel):
+    """
+    Schema for AssetEvent model used in DagRun.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    asset: AssetReferenceAssetEventDagRun
+    extra: Annotated[dict[str, Any], Field(title="Extra")]
+    source_task_id: Annotated[str | None, Field(title="Source Task Id")] = None
+    source_dag_id: Annotated[str | None, Field(title="Source Dag Id")] = None
+    source_run_id: Annotated[str | None, Field(title="Source Run Id")] = None
+    source_map_index: Annotated[int | None, Field(title="Source Map Index")] = None
+    source_aliases: Annotated[list[AssetAliasReferenceAssetEventDagRun], Field(title="Source Aliases")]
+    timestamp: Annotated[AwareDatetime, Field(title="Timestamp")]
+
+
 class AssetEventResponse(BaseModel):
     """
     Asset event schema with fields that are needed for Runtime.
@@ -397,6 +439,7 @@ class DagRun(BaseModel):
     clear_number: Annotated[int | None, Field(title="Clear Number")] = 0
     run_type: DagRunType
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
+    consumed_asset_events: Annotated[list[AssetEventDagRunReference], Field(title="Consumed Asset Events")]
 
 
 class HTTPValidationError(BaseModel):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -78,6 +78,7 @@ from airflow.sdk.execution_time.context import (
     InletEventsAccessors,
     MacrosAccessor,
     OutletEventAccessors,
+    TriggeringAssetEventsAccessor,
     VariableAccessor,
     context_get_outlet_events,
     context_to_airflow_vars,
@@ -139,13 +140,9 @@ class RuntimeTaskInstance(TaskInstance):
         # TODO: Move this to `airflow.sdk.execution_time.context`
         #   once we port the entire context logic from airflow/utils/context.py ?
 
-        dag_run_conf = None
-        if (
-            self._ti_context_from_server
-            and self._ti_context_from_server.dag_run
-            and self._ti_context_from_server.dag_run.conf
-        ):
-            dag_run_conf = self._ti_context_from_server.dag_run.conf
+        dag_run_conf: dict[str, Any] | None = None
+        if from_server := self._ti_context_from_server:
+            dag_run_conf = from_server.dag_run.conf or dag_run_conf
 
         validated_params = process_params(self.task.dag, self.task, dag_run_conf, suppress_exception=False)
 
@@ -174,14 +171,14 @@ class RuntimeTaskInstance(TaskInstance):
             },
             "conn": ConnectionAccessor(),
         }
-        if from_server := self._ti_context_from_server:
+        if from_server:
             dag_run = from_server.dag_run
-
             context_from_server: Context = {
                 # TODO: Assess if we need to pass these through timezone.coerce_datetime
                 "dag_run": dag_run,  # type: ignore[typeddict-item]  # Removable after #46522
+                "triggering_asset_events": TriggeringAssetEventsAccessor.build(dag_run.consumed_asset_events),
                 "task_instance_key_str": f"{self.task.dag_id}__{self.task.task_id}__{dag_run.run_id}",
-                "task_reschedule_count": self._ti_context_from_server.task_reschedule_count or 0,
+                "task_reschedule_count": from_server.task_reschedule_count or 0,
                 "prev_start_date_success": lazy_object_proxy.Proxy(
                     lambda: coerce_datetime(get_previous_dagrun_success(self.id).start_date)
                 ),

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -61,6 +61,7 @@ class TestClient:
                         "start_date": "2021-01-01T00:00:00Z",
                         "run_type": "manual",
                         "run_after": "2021-01-01T00:00:00Z",
+                        "consumed_asset_events": [],
                     },
                     "max_tries": 0,
                     "should_retry": False,

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -24,7 +24,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.sdk import get_current_context
-from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
+from airflow.sdk.api.datamodels._generated import (
+    AssetEventDagRunReference,
+    AssetEventResponse,
+    AssetResponse,
+)
 from airflow.sdk.definitions.asset import (
     Asset,
     AssetAlias,
@@ -40,6 +44,8 @@ from airflow.sdk.execution_time.comms import (
     AssetResult,
     ConnectionResult,
     ErrorResponse,
+    GetAssetByName,
+    GetAssetByUri,
     VariableResult,
 )
 from airflow.sdk.execution_time.context import (
@@ -47,7 +53,9 @@ from airflow.sdk.execution_time.context import (
     InletEventsAccessors,
     OutletEventAccessor,
     OutletEventAccessors,
+    TriggeringAssetEventsAccessor,
     VariableAccessor,
+    _AssetRefResolutionMixin,
     _convert_connection_result_conn,
     _convert_variable_result_to_variable,
     context_to_airflow_vars,
@@ -390,6 +398,129 @@ class TestOutletEventAccessor:
         outlet_event_accessor = OutletEventAccessor(key=key, extra={"not": ""})
         outlet_event_accessor.add(asset, extra={})
         assert outlet_event_accessor.asset_alias_events == asset_alias_events
+
+
+class TestTriggeringAssetEventsAccessor:
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        _AssetRefResolutionMixin._asset_ref_cache = {}
+        yield
+        _AssetRefResolutionMixin._asset_ref_cache = {}
+
+    @pytest.fixture
+    def event_data(self):
+        return [
+            {
+                "asset": {
+                    "name": "1",
+                    "uri": "1",
+                    "extra": {},
+                },
+                "extra": {},
+                "source_task_id": "t1",
+                "source_dag_id": "d1",
+                "source_run_id": "r1",
+                "source_map_index": -1,
+                "source_aliases": [],
+                "timestamp": "2025-01-01T00:00:12Z",
+            },
+            {
+                "asset": {
+                    "name": "1",
+                    "uri": "1",
+                    "extra": {},
+                },
+                "extra": {},
+                "source_task_id": "t2",
+                "source_dag_id": "d1",
+                "source_run_id": "r1",
+                "source_map_index": -1,
+                "source_aliases": [
+                    {"name": "a"},
+                    {"name": "b"},
+                ],
+                "timestamp": "2025-01-01T00:05:43Z",
+            },
+            {
+                "asset": {
+                    "name": "2",
+                    "uri": "2",
+                    "extra": {},
+                },
+                "extra": {},
+                "source_task_id": "t2",
+                "source_dag_id": "d1",
+                "source_run_id": "r1",
+                "source_map_index": -1,
+                "source_aliases": [],
+                "timestamp": "2025-01-01T00:06:07Z",
+            },
+        ]
+
+    @pytest.fixture
+    def accessor(self, event_data):
+        return TriggeringAssetEventsAccessor.build(
+            [AssetEventDagRunReference.model_validate(d) for d in event_data],
+        )
+
+    @pytest.mark.parametrize(
+        "key, result_indexes",
+        [
+            (Asset("1"), [0, 1]),
+            (Asset("2"), [2]),
+            (AssetAlias("a"), [1]),
+            (AssetAlias("b"), [1]),
+        ],
+    )
+    def test_getitem(self, event_data, accessor, key, result_indexes):
+        expected = [AssetEventDagRunReference.model_validate(event_data[index]) for index in result_indexes]
+        assert accessor[key] == expected
+
+    @pytest.mark.parametrize(
+        "name, resolved_asset, result_indexes",
+        [
+            ("1", AssetResult(name="1", uri="1", group="whatever"), [0, 1]),
+            ("2", AssetResult(name="2", uri="2", group="whatever"), [2]),
+        ],
+    )
+    def test_getitem_name_ref(
+        self,
+        mock_supervisor_comms,
+        event_data,
+        accessor,
+        name,
+        resolved_asset,
+        result_indexes,
+    ):
+        mock_supervisor_comms.get_message.return_value = resolved_asset
+        expected = [AssetEventDagRunReference.model_validate(event_data[index]) for index in result_indexes]
+        assert accessor[Asset.ref(name=name)] == expected
+        assert len(mock_supervisor_comms.send_request.mock_calls) == 1
+        assert mock_supervisor_comms.send_request.mock_calls[0].kwargs["msg"] == GetAssetByName(name=name)
+        assert _AssetRefResolutionMixin._asset_ref_cache
+
+    @pytest.mark.parametrize(
+        "uri, resolved_asset, result_indexes",
+        [
+            ("1", AssetResult(name="1", uri="1", group="whatever"), [0, 1]),
+            ("2", AssetResult(name="2", uri="2", group="whatever"), [2]),
+        ],
+    )
+    def test_getitem_uri_ref(
+        self,
+        mock_supervisor_comms,
+        event_data,
+        accessor,
+        uri,
+        resolved_asset,
+        result_indexes,
+    ):
+        mock_supervisor_comms.get_message.return_value = resolved_asset
+        expected = [AssetEventDagRunReference.model_validate(event_data[index]) for index in result_indexes]
+        assert accessor[Asset.ref(uri=uri)] == expected
+        assert len(mock_supervisor_comms.send_request.mock_calls) == 1
+        assert mock_supervisor_comms.send_request.mock_calls[0].kwargs["msg"] == GetAssetByUri(uri=uri)
+        assert _AssetRefResolutionMixin._asset_ref_cache
 
 
 class TestOutletEventAccessors:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -90,6 +90,7 @@ from airflow.sdk.execution_time.context import (
     InletEventsAccessors,
     MacrosAccessor,
     OutletEventAccessors,
+    TriggeringAssetEventsAccessor,
     VariableAccessor,
 )
 from airflow.sdk.execution_time.task_runner import (
@@ -140,9 +141,11 @@ class TestCommsDecoder:
         w.makefile("wb").write(
             b'{"type":"StartupDetails", "ti": {'
             b'"id": "4d828a62-a417-4936-a7a6-2b3fabacecab", "task_id": "a", "try_number": 1, "run_id": "b", '
-            b'"dag_id": "c"}, "ti_context":{"dag_run":{"dag_id":"c","run_id":"b","logical_date":"2024-12-01T01:00:00Z",'
+            b'"dag_id": "c"}, "ti_context":{"dag_run":{"dag_id":"c","run_id":"b",'
+            b'"logical_date":"2024-12-01T01:00:00Z",'
             b'"data_interval_start":"2024-12-01T00:00:00Z","data_interval_end":"2024-12-01T01:00:00Z",'
-            b'"start_date":"2024-12-01T01:00:00Z","run_after":"2024-12-01T01:00:00Z","end_date":null,"run_type":"manual","conf":null},'
+            b'"start_date":"2024-12-01T01:00:00Z","run_after":"2024-12-01T01:00:00Z","end_date":null,'
+            b'"run_type":"manual","conf":null,"consumed_asset_events":[]},'
             b'"max_tries":0,"should_retry":false,"variables":null,"connections":null},"file": "/dev/null",'
             b'"start_date":"2024-12-01T01:00:00Z", "dag_rel_path": "/dev/null", "bundle_info": {"name": '
             b'"any-name", "version": "any-version"}, "requests_fd": '
@@ -979,6 +982,7 @@ class TestRuntimeTaskInstance:
             "data_interval_start": timezone.datetime(2024, 12, 1, 1, 0, 0),
             "logical_date": timezone.datetime(2024, 12, 1, 1, 0, 0),
             "task_reschedule_count": 0,
+            "triggering_asset_events": TriggeringAssetEventsAccessor.build(dr.consumed_asset_events),
             "ds": "2024-12-01",
             "ds_nodash": "20241201",
             "task_instance_key_str": "basic_task__hello__20241201",


### PR DESCRIPTION
This is done by adding consumed_asset_events to the initial triggering
body, and processing the content in the execution context.

The value to the key is now implemented as a mapping accessor to support
more key types, including AssetRef and AssetAlias.

Close #47133. Close #47282.