### PR TITLE
Fix clearing of mapped task run

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -237,7 +237,7 @@ def set_xcom(
                     "message": "pushed value is too large to map as a downstream's dependency",
                 },
             )
-        session.add(task_map)
+        session.merge(task_map)
 
     # else:
     # TODO: Can/should we check if a client _hasn't_ provided this for an upstream of a mapped task? That


### PR DESCRIPTION
When clearing a dag run with mapped tasks, previously we got PK error.  That's because we were unconditionally inserting, when we needed to merge.

Resolves https://github.com/apache/airflow/issues/48538