### PR TITLE
Correctly handle callback args in mapped operator

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -331,6 +331,9 @@ else:
         )
         partial_kwargs.setdefault("executor_config", {})
 
+        for k in ("execute", "failure", "success", "retry", "skipped"):
+            partial_kwargs[attr] = _collect_callbacks(partial_kwargs.get(attr := f"on_{k}_callback"))
+
         return OperatorPartial(
             operator_class=operator_class,
             kwargs=partial_kwargs,

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -576,43 +576,43 @@ class MappedOperator(AbstractOperator):
 
     @property
     def on_execute_callback(self) -> TaskStateChangeCallbackAttrType:
-        return self.partial_kwargs.get("on_execute_callback")
+        return self.partial_kwargs.get("on_execute_callback") or []
 
     @on_execute_callback.setter
     def on_execute_callback(self, value: TaskStateChangeCallbackAttrType) -> None:
-        self.partial_kwargs["on_execute_callback"] = value
+        self.partial_kwargs["on_execute_callback"] = value or []
 
     @property
     def on_failure_callback(self) -> TaskStateChangeCallbackAttrType:
-        return self.partial_kwargs.get("on_failure_callback")
+        return self.partial_kwargs.get("on_failure_callback") or []
 
     @on_failure_callback.setter
     def on_failure_callback(self, value: TaskStateChangeCallbackAttrType) -> None:
-        self.partial_kwargs["on_failure_callback"] = value
+        self.partial_kwargs["on_failure_callback"] = value or []
 
     @property
     def on_retry_callback(self) -> TaskStateChangeCallbackAttrType:
-        return self.partial_kwargs.get("on_retry_callback")
+        return self.partial_kwargs.get("on_retry_callback") or []
 
     @on_retry_callback.setter
     def on_retry_callback(self, value: TaskStateChangeCallbackAttrType) -> None:
-        self.partial_kwargs["on_retry_callback"] = value
+        self.partial_kwargs["on_retry_callback"] = value or []
 
     @property
     def on_success_callback(self) -> TaskStateChangeCallbackAttrType:
-        return self.partial_kwargs.get("on_success_callback")
+        return self.partial_kwargs.get("on_success_callback") or []
 
     @on_success_callback.setter
     def on_success_callback(self, value: TaskStateChangeCallbackAttrType) -> None:
-        self.partial_kwargs["on_success_callback"] = value
+        self.partial_kwargs["on_success_callback"] = value or []
 
     @property
     def on_skipped_callback(self) -> TaskStateChangeCallbackAttrType:
-        return self.partial_kwargs.get("on_skipped_callback")
+        return self.partial_kwargs.get("on_skipped_callback") or []
 
     @on_skipped_callback.setter
     def on_skipped_callback(self, value: TaskStateChangeCallbackAttrType) -> None:
-        self.partial_kwargs["on_skipped_callback"] = value
+        self.partial_kwargs["on_skipped_callback"] = value or []
 
     @property
     def run_as_user(self) -> str | None:

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -131,9 +131,15 @@ def test_partial_on_instance() -> None:
 
 def test_partial_on_class() -> None:
     # Test that we accept args for superclasses too
-    op = MockOperator.partial(task_id="a", arg1="a", trigger_rule=TriggerRule.ONE_FAILED)
+    op = MockOperator.partial(
+        task_id="a",
+        arg1="a",
+        trigger_rule=TriggerRule.ONE_FAILED,
+        on_execute_callback=id,
+    )
     assert op.kwargs["arg1"] == "a"
     assert op.kwargs["trigger_rule"] == TriggerRule.ONE_FAILED
+    assert op.kwargs["on_execute_callback"] == [id]
 
 
 def test_partial_on_class_invalid_ctor_args() -> None:
@@ -155,12 +161,17 @@ def test_partial_on_invalid_pool_slots_raises() -> None:
 
 
 def test_mapped_task_applies_default_args_classic():
-    with DAG("test", default_args={"execution_timeout": timedelta(minutes=30)}) as dag:
+    with DAG(
+        dag_id="test",
+        default_args={"execution_timeout": timedelta(minutes=30), "on_failure_callback": str},
+    ) as dag:
         MockOperator(task_id="simple", arg1=None, arg2=0)
         MockOperator.partial(task_id="mapped").expand(arg1=[1], arg2=[2, 3])
 
     assert dag.get_task("simple").execution_timeout == timedelta(minutes=30)
     assert dag.get_task("mapped").execution_timeout == timedelta(minutes=30)
+    assert dag.get_task("simple").on_failure_callback == [str]
+    assert dag.get_task("mapped").on_failure_callback == [str]
 
 
 def test_mapped_task_applies_default_args_taskflow():
@@ -179,6 +190,8 @@ def test_mapped_task_applies_default_args_taskflow():
 
     assert dag.get_task("simple").execution_timeout == timedelta(minutes=30)
     assert dag.get_task("mapped").execution_timeout == timedelta(minutes=30)
+    assert dag.get_task("simple").on_success_callback == []
+    assert dag.get_task("mapped").on_success_callback == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We need to convert them to sequences internally.

Fix #48621.