### PR TITLE
Disallowing types-protobuf 5.29.1.20250402 for google to fix mypy

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -740,7 +740,8 @@
       "python-slugify>=7.0.0",
       "sqlalchemy-bigquery>=1.2.1",
       "sqlalchemy-spanner>=1.6.2",
-      "tenacity>=8.1.0"
+      "tenacity>=8.1.0",
+      "types-protobuf!=5.29.1.20250402"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -127,6 +127,7 @@ PIP package                                 Version required
 ``sqlalchemy-spanner``                      ``>=1.6.2``
 ``tenacity``                                ``>=8.1.0``
 ``immutabledict``                           ``>=4.2.0``
+``types-protobuf``                          ``!=5.29.1.20250402``
 ==========================================  ======================================
 
 Cross provider package dependencies

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -139,6 +139,8 @@ dependencies = [
     "sqlalchemy-spanner>=1.6.2",
     "tenacity>=8.1.0",
     "immutabledict>=4.2.0",
+    # types-protobuf 5.29.1.20250402 is a partial stub package, leading to mypy complaining
+    "types-protobuf!=5.29.1.20250402",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1652,6 +1652,7 @@ def get_provider_info():
             "sqlalchemy-spanner>=1.6.2",
             "tenacity>=8.1.0",
             "immutabledict>=4.2.0",
+            "types-protobuf!=5.29.1.20250402",
         ],
         "optional-dependencies": {
             "apache.beam": [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

types-protobuf 5.29.1.20250402 was released today and it seems that this one is a partial stub package. https://peps.python.org/pep-0561/#partial-stub-packages.

Due to this, mypy complains of `[import-untyped]` which basically means type annotations arent present.

Disallowing this version for google provider. Google provider depends on devel-common so in conjunction the right version will be picked imo.

Example failure:
```
providers/google/src/airflow/providers/google/cloud/hooks/dataproc.py:60: error:
Library stubs not installed for "google.protobuf.field_mask_pb2" 
[import-untyped]
        from google.protobuf.field_mask_pb2 import FieldMask
    ^
providers/google/src/airflow/providers/google/cloud/hooks/cloud_memorystore.py:53: error:
Library stubs not installed for "google.protobuf.field_mask_pb2" 
[import-untyped]
        from google.protobuf.field_mask_pb2 import FieldMask
```

https://github.com/apache/airflow/actions/runs/14214004343/job/39826852033

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
