### PR TITLE
Fix local running of backcompat tests after we switched to UV

### DIFF
--- a/scripts/ci/docker-compose/providers-and-tests-sources.yml
+++ b/scripts/ci/docker-compose/providers-and-tests-sources.yml
@@ -29,11 +29,13 @@ services:
       # Remove airflow sources from container
       - ../../../empty:/opt/airflow/airflow-core/src
       # But keep airflow/__init__.py to make hatchling happy when building empty package
-      - ../../../airflow-core/src/airflow/__init__.py:/opt/airflow/airflow-core/src/airflow/__init__.py
+      - /dev/null:/opt/airflow/airflow-core/src/airflow/__init__.py
       # Remove task-sdk sources from container
       - ../../../empty:/opt/airflow/task-sdk/src
       # But keep task-sdk/a__init__.py to make hatchling happy when building empty package
-      - ../../../task-sdk/src/airflow/sdk/__init__.py:/opt/airflow/task-sdk/src/airflow/sdk/__init__.py
+      - /dev/null:/opt/airflow/task-sdk/src/airflow/sdk/__init__.py
+
+      - ../../../devel-common:/opt/airflow/devel-common
       # And keep tests
       - ../../../airflow-core/tests/:/opt/airflow/airflow-core/tests:cached
       # Mount providers to make sure that we have the latest providers - both tests and sources

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -795,6 +795,8 @@ def install_airflow_and_providers(
                 "apache-airflow-providers-common-messaging",
                 "apache-airflow-providers-git",
             ]
+            if version.minor < 10:
+                providers_to_uninstall_for_airflow_2.append("apache-airflow-providers-edge")
             run_command(
                 ["uv", "pip", "uninstall", *providers_to_uninstall_for_airflow_2],
                 github_actions=github_actions,


### PR DESCRIPTION
We were including a real `airflow/__init__.py` which has the unfortunate
side-effect of making `AIRFLOW_V_3_0_PLUS` find 3.0.0dev0 as the version!
Oops. The fix for that is to mount an empyt init file instead (we need a file
to keep the uv build etc happy)

Also uninstall edge provider for 2.9, as that needs 2.10.

Oh and volume mount devel-common as that is part of test code.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
