### PR TITLE
Tell mypy that pymssql.BINARY, etc have a .value

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -104,9 +104,9 @@ class MsSqlToHiveOperator(BaseOperator):
     def type_map(cls, mssql_type: int) -> str:
         """Map MsSQL type to Hive type."""
         map_dict = {
-            pymssql.BINARY.value: "INT",
-            pymssql.DECIMAL.value: "FLOAT",
-            pymssql.NUMBER.value: "INT",
+            pymssql.BINARY.value: "INT",  # type:ignore[attr-defined]
+            pymssql.DECIMAL.value: "FLOAT",  # type:ignore[attr-defined]
+            pymssql.NUMBER.value: "INT",  # type:ignore[attr-defined]
         }
         return map_dict.get(mssql_type, "STRING")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Saw this error in https://github.com/apache/airflow/actions/runs/14216382230/job/39834390290?pr=48666 recently.


```
providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py:107: error:
"int" has no attribute "value"  [attr-defined]
                pymssql.BINARY.value: "INT",
                ^~~~~~~~~~~~~~~~~~~~
providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py:108: error:
"int" has no attribute "value"  [attr-defined]
                pymssql.DECIMAL.value: "FLOAT",
                ^~~~~~~~~~~~~~~~~~~~~
providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py:109: error:
"int" has no attribute "value"  [attr-defined]
                pymssql.NUMBER.value: "INT",
```

pymssql 2.3.4 was installed which likely had some updates in the types due to which mypy complains. I investigated with both the versions and that part hasnt changed.

```
root@6df56b1b55c6:/opt/airflow# python
Python 3.9.21 (main, Mar 18 2025, 00:53:02)
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pymssql
>>> print(type(pymssql.BINARY.value))
<class 'int'>
>>>
>>>
>>>
>>> import pymssql
KeyboardInterrupt
>>> from enum import Enum
>>>
>>>
>>> print(isinstance(pymssql.BINARY, Enum))
False
>>> print(type(pymssql.BINARY))
<class 'pymssql._pymssql.DBAPIType'>
>>>
>>>
>>> print(hasattr(pymssql.BINARY, "value"))
True
>>>
>>>
>>> exit()
root@6df56b1b55c6:/opt/airflow# pip install pymssql==2.3.4
Collecting pymssql==2.3.4
  Using cached pymssql-2.3.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (4.5 kB)
Using cached pymssql-2.3.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (3.9 MB)
Installing collected packages: pymssql
  Attempting uninstall: pymssql
    Found existing installation: pymssql 2.3.2
    Uninstalling pymssql-2.3.2:
      Successfully uninstalled pymssql-2.3.2
Successfully installed pymssql-2.3.4
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
root@6df56b1b55c6:/opt/airflow# python
Python 3.9.21 (main, Mar 18 2025, 00:53:02)
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pymssql
>>> print(hasattr(pymssql.BINARY, "value"))
True
>>> print(type(pymssql.BINARY.value))
<class 'int'>
```

Telling mypy to ignore it.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
