### PR TITLE
Add vertical scrolling to Grid container

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -71,7 +71,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
       <Box flex={1} minH={0}>
         <PanelGroup autoSaveId={dagId} direction="horizontal">
           <Panel defaultSize={dagView === "graph" ? 70 : 20} minSize={6}>
-            <Box height="100%" position="relative" pr={2}>
+            <Box height="100%" overflowY="auto" position="relative" pr={2}>
               <PanelButtons dagView={dagView} limit={limit} setDagView={setDagView} setLimit={setLimit} />
               {dagView === "graph" ? <Graph /> : <Grid limit={limit} />}
             </Box>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -71,7 +71,7 @@ export const Grid = ({ limit }: Props) => {
   );
 
   return (
-    <Flex justifyContent="flex-end" mr={3} position="relative" pt={50} width="100%">
+    <Flex justifyContent="flex-end" position="relative" pt={50} width="100%">
       <Box position="absolute" top="150px" width="100%">
         <TaskNames nodes={flatNodes} />
       </Box>


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/48681

Just adds a scrollable 'auto' on the left pane. This has no effect on the Grid because it takes only 100% of the vertical space. (no scroll)

![Screenshot 2025-04-02 at 16 38 49](https://github.com/user-attachments/assets/3a28d427-84e6-4c85-84c9-0c980995f602)
![Screenshot 2025-04-02 at 16 40 54](https://github.com/user-attachments/assets/03638630-26cf-41b6-9374-a5182752ef19)
