### PR TITLE
Default logical date in dag run trigger form

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Input, Button, Box, Spacer, HStack, Field, Stack } from "@chakra-ui/react";
+import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { FiPlay } from "react-icons/fi";
@@ -60,7 +61,8 @@ const TriggerDAGForm = ({ dagId, isPaused, onClose, open }: TriggerDAGFormProps)
     defaultValues: {
       conf,
       dagRunId: "",
-      logicalDate: "",
+      // Default logical date to now
+      logicalDate: dayjs().format("YYYY-MM-DDThh:mm"),
       note: "",
     },
   });
@@ -142,13 +144,7 @@ const TriggerDAGForm = ({ dagId, isPaused, onClose, open }: TriggerDAGFormProps)
                       </Field.Label>
                     </Stack>
                     <Stack css={{ flexBasis: "70%" }}>
-                      <Input
-                        {...field}
-                        onBlur={resetDateError}
-                        placeholder="yyyy-mm-ddThh:mm"
-                        size="sm"
-                        type="datetime-local"
-                      />
+                      <Input {...field} onBlur={resetDateError} size="sm" type="datetime-local" />
                     </Stack>
                   </Field.Root>
                 )}


### PR DESCRIPTION
Default the logical date to the time the dag run trigger modal was opened. A user can still click "Clear" to set it to null

UI part of https://github.com/apache/airflow/issues/48412

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
