### PR TITLE
Make triggered_by nullable 

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -72,7 +72,7 @@ class DAGRunResponse(BaseModel):
     last_scheduling_decision: datetime | None
     run_type: DagRunType
     state: DagRunState
-    triggered_by: DagRunTriggeredByType
+    triggered_by: DagRunTriggeredByType | None
     conf: dict
     note: str | None
     dag_versions: list[DagVersionResponse]

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -8985,7 +8985,9 @@ components:
         state:
           $ref: '#/components/schemas/DagRunState'
         triggered_by:
-          $ref: '#/components/schemas/DagRunTriggeredByType'
+          anyOf:
+          - $ref: '#/components/schemas/DagRunTriggeredByType'
+          - type: 'null'
         conf:
           additionalProperties: true
           type: object

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2463,7 +2463,14 @@ export const $DAGRunResponse = {
       $ref: "#/components/schemas/DagRunState",
     },
     triggered_by: {
-      $ref: "#/components/schemas/DagRunTriggeredByType",
+      anyOf: [
+        {
+          $ref: "#/components/schemas/DagRunTriggeredByType",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     conf: {
       additionalProperties: true,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -667,7 +667,7 @@ export type DAGRunResponse = {
   last_scheduling_decision: string | null;
   run_type: DagRunType;
   state: DagRunState;
-  triggered_by: DagRunTriggeredByType;
+  triggered_by: DagRunTriggeredByType | null;
   conf: {
     [key: string]: unknown;
   };


### PR DESCRIPTION
This PR modifies the triggered_by in DAGRunResponse to nullable and respecting what we have in database.

related: https://github.com/apache/airflow/issues/48630

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
