### PR TITLE
Speed up lowest-depenency-resolution tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
       canary-run: ${{ steps.source-run-info.outputs.canary-run }}
       chicken-egg-providers: ${{ steps.selective-checks.outputs.chicken-egg-providers }}
       ci-image-build: ${{ steps.selective-checks.outputs.ci-image-build }}
-      core-test-types-list-as-string: >-
-        ${{ steps.selective-checks.outputs.core-test-types-list-as-string }}
+      core-test-types-list-as-strings-in-json: >-
+        ${{ steps.selective-checks.outputs.core-test-types-list-as-strings-in-json }}
       debug-resources: ${{ steps.selective-checks.outputs.debug-resources }}
       default-branch: ${{ steps.selective-checks.outputs.default-branch }}
       default-constraints-branch: ${{ steps.selective-checks.outputs.default-constraints-branch }}
@@ -82,8 +82,8 @@ jobs:
       has-migrations: ${{ steps.selective-checks.outputs.has-migrations }}
       helm-test-packages: ${{ steps.selective-checks.outputs.helm-test-packages }}
       include-success-outputs: ${{ steps.selective-checks.outputs.include-success-outputs }}
-      individual-providers-test-types-list-as-string: >-
-        ${{ steps.selective-checks.outputs.individual-providers-test-types-list-as-string }}
+      individual-providers-test-types-list-as-strings-in-json: >-
+        ${{ steps.selective-checks.outputs.individual-providers-test-types-list-as-strings-in-json }}
       is-airflow-runner: ${{ steps.selective-checks.outputs.is-airflow-runner }}
       is-amd-runner: ${{ steps.selective-checks.outputs.is-amd-runner }}
       is-arm-runner: ${{ steps.selective-checks.outputs.is-arm-runner }}
@@ -108,9 +108,10 @@ jobs:
       postgres-versions: ${{ steps.selective-checks.outputs.postgres-versions }}
       prod-image-build: ${{ steps.selective-checks.outputs.prod-image-build }}
       # yamllint disable rule:line-length
-      providers-compatibility-tests-matrix: ${{ steps.selective-checks.outputs.providers-compatibility-tests-matrix }}
-      providers-test-types-list-as-string: >-
-        ${{ steps.selective-checks.outputs.providers-test-types-list-as-string }}
+      providers-compatibility-tests-matrix: >
+        ${{ steps.selective-checks.outputs.providers-compatibility-tests-matrix }}
+      providers-test-types-list-as-strings-in-json: >-
+        ${{ steps.selective-checks.outputs.providers-test-types-list-as-strings-in-json }}
       pull-request-labels: ${{ steps.source-run-info.outputs.pr-labels }}
       python-versions-list-as-string: ${{ steps.selective-checks.outputs.python-versions-list-as-string }}
       python-versions: ${{ steps.selective-checks.outputs.python-versions }}
@@ -312,10 +313,12 @@ jobs:
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       selected-providers-list-as-string: ${{ needs.build-info.outputs.selected-providers-list-as-string }}
       # yamllint disable rule:line-length
-      providers-compatibility-tests-matrix: ${{ needs.build-info.outputs.providers-compatibility-tests-matrix }}
+      providers-compatibility-tests-matrix: >
+        ${{ needs.build-info.outputs.providers-compatibility-tests-matrix }}
       skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       python-versions: ${{ needs.build-info.outputs.python-versions }}
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.providers-test-types-list-as-string }}
+      providers-test-types-list-as-strings-in-json: >
+        ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
 
   tests-helm:
@@ -336,8 +339,8 @@ jobs:
       needs.build-info.outputs.default-branch == 'main' &&
       needs.build-info.outputs.latest-versions-only != 'true'
 
-  tests-postgres:
-    name: "Postgres tests"
+  tests-postgres-core:
+    name: "Postgres tests: core"
     uses: ./.github/workflows/run-unit-tests.yml
     needs: [build-info, build-ci-images]
     permissions:
@@ -348,22 +351,50 @@ jobs:
       backend: "postgres"
       test-name: "Postgres"
       test-scope: "DB"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-group: "core"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       backend-versions: ${{ needs.build-info.outputs.postgres-versions }}
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
       excludes: ${{ needs.build-info.outputs.postgres-exclude }}
-      core-test-types-list-as-string: ${{ needs.build-info.outputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-migration-tests: "true"
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: needs.build-info.outputs.run-tests == 'true'
 
-  tests-mysql:
-    name: "MySQL tests"
+  tests-postgres-providers:
+    name: "Postgres tests: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, build-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
+      backend: "postgres"
+      test-name: "Postgres"
+      test-scope: "DB"
+      test-group: "providers"
+      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      backend-versions: ${{ needs.build-info.outputs.postgres-versions }}
+      excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
+      excludes: ${{ needs.build-info.outputs.postgres-exclude }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      run-migration-tests: "true"
+      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
+      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
+      use-uv: ${{ needs.build-info.outputs.use-uv }}
+    if: needs.build-info.outputs.run-tests == 'true'
+
+  tests-mysql-core:
+    name: "MySQL tests: core"
     uses: ./.github/workflows/run-unit-tests.yml
     needs: [build-info, build-ci-images]
     permissions:
@@ -374,22 +405,51 @@ jobs:
       backend: "mysql"
       test-name: "MySQL"
       test-scope: "DB"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-group: "core"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       backend-versions: ${{ needs.build-info.outputs.mysql-versions }}
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
       excludes: ${{ needs.build-info.outputs.mysql-exclude }}
-      core-test-types-list-as-string: ${{ needs.build-info.outputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       run-migration-tests: "true"
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: needs.build-info.outputs.run-tests == 'true'
 
-  tests-sqlite:
-    name: "Sqlite tests"
+  tests-mysql-providers:
+    name: "MySQL tests: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, build-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
+      backend: "mysql"
+      test-name: "MySQL"
+      test-scope: "DB"
+      test-group: "providers"
+      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      backend-versions: ${{ needs.build-info.outputs.mysql-versions }}
+      excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
+      excludes: ${{ needs.build-info.outputs.mysql-exclude }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
+      run-migration-tests: "true"
+      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
+      use-uv: ${{ needs.build-info.outputs.use-uv }}
+    if: needs.build-info.outputs.run-tests == 'true'
+
+
+  tests-sqlite-core:
+    name: "Sqlite tests: core"
     uses: ./.github/workflows/run-unit-tests.yml
     needs: [build-info, build-ci-images]
     permissions:
@@ -401,23 +461,54 @@ jobs:
       test-name: "Sqlite"
       test-name-separator: ""
       test-scope: "DB"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-group: "core"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       # No versions for sqlite
       backend-versions: "['']"
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
       excludes: ${{ needs.build-info.outputs.sqlite-exclude }}
-      core-test-types-list-as-string: ${{ needs.build-info.outputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       run-migration-tests: "true"
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: needs.build-info.outputs.run-tests == 'true'
 
-  tests-non-db:
-    name: "Non-DB tests"
+  tests-sqlite-providers:
+    name: "Sqlite tests: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, build-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
+      backend: "sqlite"
+      test-name: "Sqlite"
+      test-name-separator: ""
+      test-scope: "DB"
+      test-group: "providers"
+      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      # No versions for sqlite
+      backend-versions: "['']"
+      excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
+      excludes: ${{ needs.build-info.outputs.sqlite-exclude }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
+      run-migration-tests: "true"
+      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
+      use-uv: ${{ needs.build-info.outputs.use-uv }}
+    if: needs.build-info.outputs.run-tests == 'true'
+
+
+  tests-non-db-core:
+    name: "Non-DB tests: core"
     uses: ./.github/workflows/run-unit-tests.yml
     needs: [build-info, build-ci-images]
     permissions:
@@ -429,17 +520,46 @@ jobs:
       test-name: ""
       test-name-separator: ""
       test-scope: "Non-DB"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-group: "core"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       # No versions for non-db
       backend-versions: "['']"
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
       excludes: ${{ needs.build-info.outputs.sqlite-exclude }}
-      core-test-types-list-as-string: ${{ needs.build-info.outputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
+      use-uv: ${{ needs.build-info.outputs.use-uv }}
+    if: needs.build-info.outputs.run-tests == 'true'
+
+  tests-non-db-providers:
+    name: "Non-DB tests: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, build-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
+      backend: "sqlite"
+      test-name: ""
+      test-name-separator: ""
+      test-scope: "Non-DB"
+      test-group: "providers"
+      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      # No versions for non-db
+      backend-versions: "['']"
+      excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
+      excludes: ${{ needs.build-info.outputs.sqlite-exclude }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
+      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: needs.build-info.outputs.run-tests == 'true'
 
@@ -459,8 +579,10 @@ jobs:
       test-groups: ${{ needs.build-info.outputs.test-groups }}
       default-branch: ${{ needs.build-info.outputs.default-branch }}
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
-      core-test-types-list-as-string: ${{ needs.build-info.outputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.providers-test-types-list-as-string }}
+      core-test-types-list-as-strings-in-json: >
+        ${{ needs.build-info.outputs.core-test-types-list-as-strings-in-json }}
+      providers-test-types-list-as-strings-in-json: >
+        ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
       python-versions: ${{ needs.build-info.outputs.python-versions }}
@@ -469,6 +591,7 @@ jobs:
       canary-run: ${{ needs.build-info.outputs.canary-run }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
 
@@ -487,14 +610,14 @@ jobs:
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
       default-postgres-version: ${{ needs.build-info.outputs.default-postgres-version }}
       default-mysql-version: ${{ needs.build-info.outputs.default-mysql-version }}
-      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: needs.build-info.outputs.run-tests == 'true'
 
-  tests-with-lowest-direct-resolution:
-    name: "Lowest direct dependency tests"
+  tests-with-lowest-direct-resolution-core:
+    name: "Low dep tests:core"
     needs: [build-info, build-ci-images]
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
@@ -507,19 +630,47 @@ jobs:
       test-name: "LowestDeps"
       force-lowest-dependencies: "true"
       test-scope: "All"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-group: "core"
+      backend: "sqlite"
+      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      backend-versions: "['${{ needs.build-info.outputs.default-postgres-version }}']"
+      excluded-providers-as-string: ""
+      excludes: "[]"
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.core-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
+      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      monitor-delay-time-in-seconds: 120
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
+      use-uv: ${{ needs.build-info.outputs.use-uv }}
+
+  tests-with-lowest-direct-resolution-providers:
+    name: "Low dep tests: providers"
+    needs: [build-info, build-ci-images]
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    if: needs.build-info.outputs.run-tests == 'true'
+    with:
+      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
+      test-name: "LowestDeps"
+      force-lowest-dependencies: "true"
+      test-scope: "All"
+      test-group: "providers"
       backend: "sqlite"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       backend-versions: "['${{ needs.build-info.outputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ needs.build-info.outputs.core-test-types-list-as-string }}
-      # yamllint disable rule:line-length
-      providers-test-types-list-as-string: ${{ needs.build-info.outputs.individual-providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: >
+        ${{ needs.build-info.outputs.individual-providers-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
       monitor-delay-time-in-seconds: 120
+      skip-providers-tests: ${{ needs.build-info.outputs.skip-providers-tests }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
 
   build-prod-images:
@@ -637,10 +788,14 @@ jobs:
       - build-info
       - generate-constraints
       - ci-image-checks
-      - tests-sqlite
-      - tests-mysql
-      - tests-postgres
-      - tests-non-db
+      - tests-sqlite-core
+      - tests-sqlite-providers
+      - tests-mysql-core
+      - tests-mysql-providers
+      - tests-postgres-core
+      - tests-postgres-providers
+      - tests-non-db-core
+      - tests-non-db-providers
       - tests-integration-system
       - build-prod-images
     uses: ./.github/workflows/finalize-tests.yml
@@ -668,7 +823,8 @@ jobs:
       - providers
       - tests-helm
       - tests-special
-      - tests-with-lowest-direct-resolution
+      - tests-with-lowest-direct-resolution-core
+      - tests-with-lowest-direct-resolution-providers
       - additional-prod-image-tests
       - tests-kubernetes
       - tests-task-sdk

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -24,8 +24,12 @@ on:  # yamllint disable-line rule:truthy
         description: "The array of labels (in json form) determining default runner used for the build."
         required: true
         type: string
-      test-groups:
-        description: "The json representing list of test test groups to run"
+      test-group:
+        description: "Test group to run: ('core', 'providers')"
+        required: true
+        type: string
+      test-types-as-strings-in-json:
+        description: "The list of list of test types to run (types in item are separated by spaces) as json"
         required: true
         type: string
       backend:
@@ -59,14 +63,6 @@ on:  # yamllint disable-line rule:truthy
         type: string
       excludes:
         description: "Excluded combos (stringified JSON array of python-version/backend-version dicts)"
-        required: true
-        type: string
-      core-test-types-list-as-string:
-        description: "The list of core test types to run separated by spaces"
-        required: true
-        type: string
-      providers-test-types-list-as-string:
-        description: "The list of providers test types to run separated by spaces"
         required: true
         type: string
       run-migration-tests:
@@ -112,6 +108,10 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 20
         type: number
+      skip-providers-tests:
+        description: "Whether to skip providers tests or not (true/false)"
+        required: true
+        type: string
       use-uv:
         description: "Whether to use uv"
         required: true
@@ -122,17 +122,17 @@ jobs:
   tests:
     timeout-minutes: 120
     name: "\
-      ${{ inputs.test-scope }}-${{ matrix.test-group }}:\
+      ${{ inputs.test-scope }}-${{ inputs.test-group }}:\
       ${{ inputs.test-name }}${{ inputs.test-name-separator }}${{ matrix.backend-version }}:\
-      ${{matrix.python-version}}"
+      ${{ matrix.python-version}}:${{ matrix.test-types.description }}"
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-default) }}
     strategy:
       fail-fast: false
       matrix:
         python-version: "${{fromJSON(inputs.python-versions)}}"
         backend-version: "${{fromJSON(inputs.backend-versions)}}"
+        test-types: ${{ fromJSON(inputs.test-types-as-strings-in-json) }}
         exclude: "${{fromJSON(inputs.excludes)}}"
-        test-group: "${{fromJSON(inputs.test-groups)}}"
     env:
       BACKEND: "${{ inputs.backend }}"
       BACKEND_VERSION: "${{ matrix.backend-version }}"
@@ -148,14 +148,15 @@ jobs:
       GITHUB_USERNAME: ${{ github.actor }}
       INCLUDE_SUCCESS_OUTPUTS: ${{ inputs.include-success-outputs }}
       # yamllint disable rule:line-length
-      JOB_ID: "${{ matrix.test-group }}-${{ inputs.test-scope }}-${{ inputs.test-name }}-${{inputs.backend}}-${{ matrix.backend-version }}-${{ matrix.python-version }}"
+      JOB_ID: "${{ inputs.test-group }}-${{ matrix.test-types.description }}-${{ inputs.test-scope }}-${{ inputs.test-name }}-${{inputs.backend}}-${{ matrix.backend-version }}-${{ matrix.python-version }}"
       MOUNT_SOURCES: "skip"
       # yamllint disable rule:line-length
-      PARALLEL_TEST_TYPES: ${{ matrix.test-group == 'core' && inputs.core-test-types-list-as-string || inputs.providers-test-types-list-as-string }}
+      PARALLEL_TEST_TYPES: ${{ matrix.test-types.test_types }}
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
       UPGRADE_BOTO: "${{ inputs.upgrade-boto }}"
       AIRFLOW_MONITOR_DELAY_TIME_IN_SECONDS: "${{inputs.monitor-delay-time-in-seconds}}"
       VERBOSE: "true"
+    if: inputs.test-group == 'core' || inputs.skip-providers-tests != 'true'
     steps:
       - name: "Cleanup repo"
         shell: bash
@@ -173,12 +174,12 @@ jobs:
       - name: >
           Migration Tests: ${{ matrix.python-version }}:${{ env.PARALLEL_TEST_TYPES }}
         uses: ./.github/actions/migration_tests
-        if: inputs.run-migration-tests == 'true' && matrix.test-group == 'core'
+        if: inputs.run-migration-tests == 'true' && inputs.test-group == 'core'
       - name: >
-          ${{ matrix.test-group}}:${{ inputs.test-scope }} Tests ${{ inputs.test-name }} ${{ matrix.backend-version }}
+          ${{ inputs.test-group }}:${{ inputs.test-scope }} Tests ${{ inputs.test-name }} ${{ matrix.backend-version }}
           Py${{ matrix.python-version }}:${{ env.PARALLEL_TEST_TYPES }}
         env:
-          TEST_GROUP: "${{ matrix.test-group }}"
+          TEST_GROUP: "${{ inputs.test-group }}"
           TEST_SCOPE: "${{ inputs.test-scope }}"
         run: ./scripts/ci/testing/run_unit_tests.sh "${TEST_GROUP}" "${TEST_SCOPE}"
       - name: "Post Tests success"

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -32,11 +32,11 @@ on:  # yamllint disable-line rule:truthy
         description: "The json representing list of test test groups to run"
         required: true
         type: string
-      core-test-types-list-as-string:
+      core-test-types-list-as-strings-in-json:
         description: "The list of core test types to run separated by spaces"
         required: true
         type: string
-      providers-test-types-list-as-string:
+      providers-test-types-list-as-strings-in-json:
         description: "The list of providers test types to run separated by spaces"
         required: true
         type: string
@@ -76,6 +76,10 @@ on:  # yamllint disable-line rule:truthy
         description: "Whether to debug resources or not (true/false)"
         required: true
         type: string
+      skip-providers-tests:
+        description: "Whether to skip providers tests or not (true/false)"
+        required: true
+        type: string
       use-uv:
         description: "Whether to use uv or not (true/false)"
         required: true
@@ -84,7 +88,7 @@ permissions:
   contents: read
 jobs:
   tests-min-sqlalchemy:
-    name: "Min SQLAlchemy test"
+    name: "Min SQLAlchemy test: core"
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
       contents: read
@@ -94,20 +98,43 @@ jobs:
       downgrade-sqlalchemy: "true"
       test-name: "MinSQLAlchemy-Postgres"
       test-scope: "DB"
-      test-groups: ${{ inputs.test-groups }}
+      test-group: "core"
       backend: "postgres"
       python-versions: "['${{ inputs.default-python-version }}']"
       backend-versions: "['${{ inputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}
 
-  tests-boto:
-    name: "Latest Boto test"
+  tests-min-sqlalchemy-providers:
+    name: "Min SQLAlchemy test: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      downgrade-sqlalchemy: "true"
+      test-name: "MinSQLAlchemy-Postgres"
+      test-scope: "DB"
+      test-group: "providers"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.providers-test-types-list-as-strings-in-json }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+
+  tests-boto-core:
+    name: "Latest Boto test: core"
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
       contents: read
@@ -117,21 +144,46 @@ jobs:
       upgrade-boto: "true"
       test-name: "LatestBoto-Postgres"
       test-scope: "All"
-      test-groups: ${{ inputs.test-groups }}
+      test-group: "core"
       backend: "postgres"
       python-versions: "['${{ inputs.default-python-version }}']"
       backend-versions: "['${{ inputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}
 
-  tests-pendulum-2:
-    name: "Pendulum2 test"
+  tests-boto-providers:
+    name: "Latest Boto test: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      upgrade-boto: "true"
+      test-name: "LatestBoto-Postgres"
+      test-scope: "All"
+      test-group: "providers"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+
+
+  tests-pendulum-2-core:
+    name: "Pendulum2 test: core"
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
       contents: read
@@ -141,21 +193,45 @@ jobs:
       downgrade-pendulum: "true"
       test-name: "Pendulum2-Postgres"
       test-scope: "All"
-      test-groups: ${{ inputs.test-groups }}
+      test-group: "core"
       backend: "postgres"
       python-versions: "['${{ inputs.default-python-version }}']"
       backend-versions: "['${{ inputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}
 
-  tests-quarantined:
-    name: "Quarantined test"
+  tests-pendulum-2-providers:
+    name: "Pendulum2 test: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      downgrade-pendulum: "true"
+      test-name: "Pendulum2-Postgres"
+      test-scope: "All"
+      test-group: "providers"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+
+  tests-quarantined-core:
+    name: "Quarantined test: core"
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
       contents: read
@@ -164,21 +240,45 @@ jobs:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "Postgres"
       test-scope: "Quarantined"
-      test-groups: ${{ inputs.test-groups }}
+      test-group: "core"
       backend: "postgres"
       python-versions: "['${{ inputs.default-python-version }}']"
       backend-versions: "['${{ inputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}
 
-  tests-arm-collection:
-    name: "ARM Collection test"
+  tests-quarantined-providers:
+    name: "Quarantined test: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      test-name: "Postgres"
+      test-scope: "Quarantined"
+      test-group: "providers"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.providers-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+
+
+  tests-arm-collection-core:
+    name: "ARM Collection test: core"
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
       contents: read
@@ -187,22 +287,46 @@ jobs:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "Postgres"
       test-scope: "ARM collection"
-      test-groups: ${{ inputs.test-groups }}
+      test-group: "core"
       backend: "postgres"
       python-versions: "['${{ inputs.default-python-version }}']"
       backend-versions: "['${{ inputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}
     if: ${{ inputs.default-branch == 'main' }}
 
-  # matrix.test-group comes from run-unit-tests.yml
-  tests-system:
+  tests-arm-collection-providers:
+    name: "ARM Collection test: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      test-name: "Postgres"
+      test-scope: "ARM collection"
+      test-group: "providers"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+    if: ${{ inputs.default-branch == 'main' }}
+
+
+  tests-system-core:
     name: "System test: ${{ matrix.test-group }}"
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
@@ -212,15 +336,15 @@ jobs:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "SystemTest"
       test-scope: "System"
-      test-groups: "['core']"
+      test-group: "core"
       backend: "postgres"
       python-versions: "['${{ inputs.default-python-version }}']"
       backend-versions: "['${{ inputs.default-postgres-version }}']"
       excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
       excludes: "[]"
-      core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
-      providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
       include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}

--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -46,7 +46,7 @@ on:  # yamllint disable-line rule:truthy
           (airflow-version, python-versions, remove-providers, run-tests)
         required: true
         type: string
-      providers-test-types-list-as-string:
+      providers-test-types-list-as-strings-in-json:
         description: "List of parallel provider test types as string"
         required: true
         type: string
@@ -161,18 +161,20 @@ jobs:
   # All matrix parameters are passed as JSON string in the input variable providers-compatibility-tests-matrix
   providers-compatibility-tests-matrix:
     timeout-minutes: 80
-    name: Compat ${{ matrix.airflow-version }}:P${{ matrix.python-version }} providers test
+    # yamllint disable rule:line-length
+    name: Compat ${{ matrix.compat.airflow-version }}:P${{ matrix.compat.python-version }}:${{ matrix.compat.test-types.description }}
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-default) }}
     strategy:
       fail-fast: false
       matrix:
-        include: ${{fromJSON(inputs.providers-compatibility-tests-matrix)}}
+        compat: ${{fromJSON(inputs.providers-compatibility-tests-matrix)}}
+        test-types: ${{ fromJSON(inputs.providers-test-types-list-as-strings-in-json) }}
     env:
       GITHUB_REPOSITORY: ${{ github.repository }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}
       INCLUDE_NOT_READY_PROVIDERS: "true"
-      PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
+      PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.compat.python-version }}"
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       VERBOSE: "true"
       CLEAN_AIRFLOW_INSTALLATION: "true"
@@ -185,11 +187,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: "Prepare breeze & CI image: ${{ matrix.python-version }}"
+      - name: "Prepare breeze & CI image: ${{ matrix.compat.python-version }}"
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: "linux/amd64"
-          python: ${{ matrix.python-version }}
+          python: ${{ matrix.compat.python-version }}
           use-uv: ${{ inputs.use-uv }}
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*
@@ -197,28 +199,27 @@ jobs:
         run: >
           breeze release-management prepare-provider-distributions --include-not-ready-providers
           --distribution-format wheel
-      - name: >
-          Remove incompatible Airflow
-          ${{ matrix.airflow-version }}:Python ${{ matrix.python-version }} provider distributions
+      # yamllint disable rule:line-length
+      - name: Remove incompatible Airflow ${{ matrix.compat.airflow-version }}:Python ${{ matrix.compat.python-version }} provider distributions
         env:
-          REMOVE_PROVIDERS: ${{ matrix.remove-providers }}
+          REMOVE_PROVIDERS: ${{ matrix.compat.remove-providers }}
         run: |
           for provider in ${REMOVE_PROVIDERS}; do
             echo "Removing incompatible provider: ${provider}"
             rm -vf dist/apache_airflow_providers_${provider/./_}-*
           done
-        if: matrix.remove-providers != ''
+        if: matrix.compat.remove-providers != ''
       - name: "Download airflow package: wheel"
         run: |
-          pip download "apache-airflow==${{ matrix.airflow-version }}" -d dist --no-deps
+          pip download "apache-airflow==${{ matrix.compat.airflow-version }}" -d dist --no-deps
       - name: >
           Install and verify all provider distributions and airflow on
-          Airflow ${{ matrix.airflow-version }}:Python ${{ matrix.python-version }}
+          Airflow ${{ matrix.compat.airflow-version }}:Python ${{ matrix.compat.python-version }}
         # We do not need to run import check if we run tests, the tests should cover all the import checks
         # automatically
-        if: matrix.run-tests != 'true'
+        if: matrix.compat.run-tests != 'true'
         env:
-          AIRFLOW_VERSION: "${{ matrix.airflow-version }}"
+          AIRFLOW_VERSION: "${{ matrix.compat.airflow-version }}"
         run: >
           breeze release-management verify-provider-distributions
           --use-distributions-from-dist
@@ -231,13 +232,13 @@ jobs:
         run: df -H
         shell: bash
       - name: >
-          Run provider unit tests on
-          Airflow ${{ matrix.airflow-version }}:Python ${{ matrix.python-version }}
-        if: matrix.run-tests == 'true'
+          Run provider unit tests on Airflow ${{ matrix.compat.airflow-version }}:Python
+          ${{ matrix.compat.python-version }}:${{ matrix.test-types.description }}
+        if: matrix.compat.run-tests == 'true'
         env:
-          PROVIDERS_TEST_TYPES: "${{ inputs.providers-test-types-list-as-string }}"
-          AIRFLOW_VERSION: "${{ matrix.airflow-version }}"
-          REMOVE_PROVIDERS: "${{ matrix.remove-providers }}"
+          PROVIDERS_TEST_TYPES: "${{ matrix.test-types.test_types }}"
+          AIRFLOW_VERSION: "${{ matrix.compat.airflow-version }}"
+          REMOVE_PROVIDERS: "${{ matrix.compat.remove-providers }}"
         run: >
           breeze testing providers-tests --run-in-parallel
           --parallel-test-types "${PROVIDERS_TEST_TYPES}"

--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -173,7 +173,7 @@ GitHub Actions to pass the list of parameters to a command to execute
 | build_system_changed_in_pyproject_toml         | When builds system dependencies changed in pyproject.toml changed in the PR.                           | false                                   |      |
 | chicken-egg-providers                          | List of providers that should be considered as "chicken-egg" - expecting development Airflow version   |                                         |      |
 | ci-image-build                                 | Whether CI image build is needed                                                                       | true                                    |      |
-| core-test-types-list-as-string                 | Which test types should be run for unit tests for core                                                 | API Always Providers                    | *    |
+| core-test-types-list-as-strings-in-json                 | Which test types should be run for unit tests for core                                                 | API Always Providers                    | *    |
 | debug-resources                                | Whether resources usage should be printed during parallel job execution ("true"/ "false")              | false                                   |      |
 | default-branch                                 | Which branch is default for the build ("main" for main branch, "v2-4-test" for 2.4 line etc.)          | main                                    |      |
 | default-constraints-branch                     | Which branch is default for the build ("constraints-main" for main branch, "constraints-2-4" etc.)     | constraints-main                        |      |
@@ -196,7 +196,7 @@ GitHub Actions to pass the list of parameters to a command to execute
 | helm-test-packages-list-as-string              | List of helm packages to test as JSON array                                                            | \["airflow_aux", "airflow_core"\]       | *    |
 | helm-version                                   | Which Helm version to use for tests                                                                    | v3.15.3                                 |      |
 | include-success-outputs                        | Whether to include outputs of successful parallel tests ("true"/"false")                               | false                                   |      |
-| individual-providers-test-types-list-as-string | Which test types should be run for unit tests for providers (individually listed)                      | Providers[\amazon\] Providers\[google\] | *    |
+| individual-providers-test-types-list-as-strings-in-json | Which test types should be run for unit tests for providers (individually listed)                      | Providers[\amazon\] Providers\[google\] | *    |
 | is-airflow-runner                              | Whether runner used is an airflow or infrastructure runner (true if airflow/false if infrastructure)   | false                                   |      |
 | is-amd-runner                                  | Whether runner used is an AMD one                                                                      | true                                    |      |
 | is-arm-runner                                  | Whether runner used is an ARM one                                                                      | false                                   |      |
@@ -224,7 +224,7 @@ GitHub Actions to pass the list of parameters to a command to execute
 | postgres-versions                              | Which versions of Postgres to use for tests as JSON array                                              | \['12'\]                                |      |
 | prod-image-build                               | Whether PROD image build is needed                                                                     | true                                    |      |
 | providers-compatibility-tests-matrix           | Matrix of providers compatibility tests: (python_version, airflow_version, removed_providers)          | \[{}\]                                  |      |
-| providers-test-types-list-as-string            | Which test types should be run for unit tests for providers                                            | Providers Providers\[-google\]          | *    |
+| providers-test-types-list-as-strings-in-json            | Which test types should be run for unit tests for providers                                            | Providers Providers\[-google\]          | *    |
 | pyproject-toml-changed                         | When pyproject.toml changed in the PR.                                                                 | false                                   |      |
 | python-versions                                | List of python versions to use for that build                                                          | \['3.9'\]                               |      |
 | python-versions-list-as-string                 | Which versions of MySQL to use for tests as space-separated string                                     | 3.9                                     | *    |

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -34,8 +34,9 @@ from airflow_breeze.utils.functools_cache import clearable_cache
 from airflow_breeze.utils.packages import get_available_distributions
 from airflow_breeze.utils.selective_checks import (
     ALL_CI_SELECTIVE_TEST_TYPES,
-    ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
     SelectiveChecks,
+    _get_test_list_as_json,
+    _split_list,
 )
 
 ANSI_COLORS_MATCHER = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
@@ -43,8 +44,29 @@ ANSI_COLORS_MATCHER = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
 
 ALL_DOCS_SELECTED_FOR_BUILD = ""
 ALL_PROVIDERS_AFFECTED = ""
-LIST_OF_ALL_PROVIDER_TESTS = " ".join(
+
+ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON = json.dumps(
+    [
+        {"description": "API...Serialization", "test_types": ALL_CI_SELECTIVE_TEST_TYPES},
+    ]
+)
+
+ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON = json.dumps(
+    [
+        {
+            "description": "-amazon,googl...standard",
+            "test_types": "Providers[-amazon,google,standard] "
+            "Providers[amazon] Providers[google] Providers[standard]",
+        }
+    ]
+)
+
+LIST_OF_ALL_PROVIDER_TESTS = [
     f"Providers[{provider}]" for provider in get_available_distributions(include_not_ready=True)
+]
+
+LIST_OF_ALL_PROVIDER_TESTS_AS_JSON = json.dumps(
+    _get_test_list_as_json(_split_list(sorted(LIST_OF_ALL_PROVIDER_TESTS), 5))
 )
 
 ALL_MYPY_CHECKS_ARRAY = [
@@ -139,9 +161,13 @@ def print_in_color(s: Any = ""):
     get_rich_console().print(s)
 
 
-def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
+def get_outputs_from_stderr(stderr: str) -> dict[str, str]:
     escaped_stderr = escape_ansi_colors(stderr)
-    received_output_as_dict = dict(line.split("=", 1) for line in escaped_stderr.splitlines() if "=" in line)
+    return dict(line.split("=", 1) for line in escaped_stderr.splitlines() if "=" in line)
+
+
+def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
+    received_output_as_dict = get_outputs_from_stderr(stderr)
     for expected_key, expected_value in expected_outputs.items():
         if expected_value is None:
             if expected_key in received_output_as_dict:
@@ -196,9 +222,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "false",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_ON_NO_CI_IMAGE,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": None,
-                    "providers-test-types-list-as-string": None,
-                    "individual-providers-test-types-list-as-string": None,
+                    "core-test-types-list-as-strings-in-json": None,
+                    "providers-test-types-list-as-strings-in-json": None,
+                    "individual-providers-test-types-list-as-strings-in-json": None,
                     "needs-mypy": "false",
                     "mypy-checks": "[]",
                 },
@@ -230,9 +256,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
-                    "individual-providers-test-types-list-as-string": LIST_OF_ALL_PROVIDER_TESTS,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "individual-providers-test-types-list-as-strings-in-json": LIST_OF_ALL_PROVIDER_TESTS_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -255,9 +281,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
-                    "individual-providers-test-types-list-as-string": LIST_OF_ALL_PROVIDER_TESTS,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "individual-providers-test-types-list-as-strings-in-json": LIST_OF_ALL_PROVIDER_TESTS_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -280,9 +306,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
-                    "individual-providers-test-types-list-as-string": LIST_OF_ALL_PROVIDER_TESTS,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "individual-providers-test-types-list-as-strings-in-json": LIST_OF_ALL_PROVIDER_TESTS_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -306,9 +332,25 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[common.compat] Providers[standard]",
-                    "individual-providers-test-types-list-as-string": "Providers[common.compat] Providers[standard]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "common.compat...standard",
+                                "test_types": "Providers[common.compat] Providers[standard]",
+                            }
+                        ]
+                    ),
+                    "individual-providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "common.compat...standard",
+                                "test_types": "Providers[common.compat] Providers[standard]",
+                            }
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                 },
@@ -332,11 +374,14 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_PROVIDERS_UI_AND_HELM_TESTS,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always Serialization",
-                    "providers-test-types-list-as-string": "",
-                    "individual-providers-test-types-list-as-string": "",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always...Serialization", "test_types": "Always Serialization"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": None,
+                    "individual-providers-test-types-list-as-strings-in-json": None,
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-airflow-core']",
+                    "skip-providers-tests": "true",
                 },
                 id="Only Serialization tests",
             )
@@ -361,9 +406,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "docs-build": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
-                    "individual-providers-test-types-list-as-string": LIST_OF_ALL_PROVIDER_TESTS,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "individual-providers-test-types-list-as-strings-in-json": LIST_OF_ALL_PROVIDER_TESTS_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -388,9 +433,26 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                     "run-kubernetes-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[apache.beam,common.compat] Providers[google]",
-                    "individual-providers-test-types-list-as-string": "Providers[apache.beam] Providers[common.compat] Providers[google]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam,c...google",
+                                "test_types": "Providers[apache.beam,common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
+                    "individual-providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam...google",
+                                "test_types": "Providers[apache.beam] "
+                                "Providers[common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                 },
@@ -415,9 +477,26 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                     "run-kubernetes-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[apache.beam,common.compat] Providers[google]",
-                    "individual-providers-test-types-list-as-string": "Providers[apache.beam] Providers[common.compat] Providers[google]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam,c...google",
+                                "test_types": "Providers[apache.beam,common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
+                    "individual-providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam...google",
+                                "test_types": "Providers[apache.beam] "
+                                "Providers[common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                     "skip-providers-tests": "false",
@@ -446,9 +525,26 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                     "run-kubernetes-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[apache.beam,common.compat] Providers[google]",
-                    "individual-providers-test-types-list-as-string": "Providers[apache.beam] Providers[common.compat] Providers[google]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam,c...google",
+                                "test_types": "Providers[apache.beam,common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
+                    "individual-providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam...google",
+                                "test_types": "Providers[apache.beam] "
+                                "Providers[common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                     "skip-providers-tests": "false",
@@ -477,14 +573,32 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                     "run-kubernetes-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[apache.beam,common.compat] Providers[google]",
-                    "individual-providers-test-types-list-as-string": "Providers[apache.beam] Providers[common.compat] Providers[google]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam,c...google",
+                                "test_types": "Providers[apache.beam,common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
+                    "individual-providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "apache.beam...google",
+                                "test_types": "Providers[apache.beam] "
+                                "Providers[common.compat] Providers[google]",
+                            }
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                     "skip-providers-tests": "false",
                 },
-                id="Selected Providers and docs should run when both system tests and tests are modified for more than one provider",
+                id="Selected Providers and docs should run when both system "
+                "tests and tests are modified for more than one provider",
             )
         ),
         (
@@ -505,8 +619,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_ON_NO_CI_IMAGE,
                     "run-kubernetes-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": None,
-                    "providers-test-types-list-as-string": None,
+                    "core-test-types-list-as-strings-in-json": None,
+                    "providers-test-types-list-as-strings-in-json": None,
                     "needs-mypy": "false",
                     "mypy-checks": "[]",
                 },
@@ -533,8 +647,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_PROVIDERS_UI_AND_HELM_TESTS,
                     "skip-providers-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ("API Always CLI Core Other Serialization"),
-                    "providers-test-types-list-as-string": "Providers[-amazon,google,standard] Providers[amazon] Providers[google] Providers[standard]",
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers', 'mypy-task-sdk']",
                 },
@@ -548,7 +662,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "providers/postgres/tests/unit/postgres/file.py",
                 ),
                 {
-                    "selected-providers-list-as-string": "amazon common.sql google openlineage pgvector postgres",
+                    "selected-providers-list-as-string": "amazon common.sql google "
+                    "openlineage pgvector postgres",
                     "all-python-versions": "['3.9']",
                     "all-python-versions-list-as-string": "3.9",
                     "python-versions": "['3.9']",
@@ -562,9 +677,19 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI,
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[amazon] "
-                    "Providers[common.sql,openlineage,pgvector,postgres] Providers[google]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "amazon...google",
+                                "test_types": "Providers[amazon] "
+                                "Providers[common.sql,openlineage,pgvector,postgres] "
+                                "Providers[google]",
+                            }
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                 },
@@ -594,11 +719,29 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI,
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[amazon] Providers[apache.livy,dbt.cloud,dingding,discord,http]",
-                    "individual-providers-test-types-list-as-string": "Providers[amazon] "
-                    "Providers[apache.livy] Providers[dbt.cloud] "
-                    "Providers[dingding] Providers[discord] Providers[http]",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "amazon...apache.livy,d",
+                                "test_types": "Providers[amazon] Providers[apache.livy,dbt.cloud,dingding,discord,http]",
+                            }
+                        ]
+                    ),
+                    "individual-providers-test-types-list-as-strings-in-json": json.dumps(
+                        [
+                            {
+                                "description": "amazon...apache.livy",
+                                "test_types": "Providers[amazon] Providers[apache.livy]",
+                            },
+                            {"description": "dbt.cloud", "test_types": "Providers[dbt.cloud]"},
+                            {"description": "dingding", "test_types": "Providers[dingding]"},
+                            {"description": "discord", "test_types": "Providers[discord]"},
+                            {"description": "http", "test_types": "Providers[http]"},
+                        ]
+                    ),
                     "needs-mypy": "true",
                     "mypy-checks": "['mypy-providers']",
                 },
@@ -628,10 +771,12 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI,
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "Providers[airbyte]",
-                    "needs-mypy": "true",
-                    "mypy-checks": "['mypy-providers']",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "airbyte", "test_types": "Providers[airbyte]"}]
+                    ),
                 },
                 id="Helm tests, airbyte providers, kubernetes tests and "
                 "docs should run even if unimportant files were added",
@@ -659,8 +804,10 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "run-amazon-tests": "false",
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "Always",
-                    "providers-test-types-list-as-string": "",
+                    "core-test-types-list-as-strings-in-json": json.dumps(
+                        [{"description": "Always", "test_types": "Always"}]
+                    ),
+                    "providers-test-types-list-as-strings-in-json": None,
                     "needs-mypy": "false",
                     "mypy-checks": "[]",
                 },
@@ -686,8 +833,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "true",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -713,8 +860,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "true",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -740,8 +887,20 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
                 "run-amazon-tests": "true",
-                "core-test-types-list-as-string": "Always",
-                "providers-test-types-list-as-string": "Providers[amazon] Providers[apache.hive,cncf.kubernetes,common.compat,common.messaging,common.sql,exasol,ftp,http,imap,microsoft.azure,mongo,mysql,openlineage,postgres,salesforce,ssh,teradata] Providers[google]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "amazon...google",
+                            "test_types": "Providers[amazon] Providers[apache.hive,cncf.kubernetes,"
+                            "common.compat,common.messaging,common.sql,exasol,ftp,http,imap,"
+                            "microsoft.azure,mongo,mysql,openlineage,postgres,salesforce,ssh,teradata] "
+                            "Providers[google]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-providers']",
             },
@@ -764,8 +923,12 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always",
-                "providers-test-types-list-as-string": "Providers[airbyte]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "airbyte", "test_types": "Providers[airbyte]"}]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-providers']",
             },
@@ -790,8 +953,20 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always",
-                "providers-test-types-list-as-string": "Providers[amazon] Providers[apache.hive,cncf.kubernetes,common.compat,common.messaging,common.sql,exasol,ftp,http,imap,microsoft.azure,mongo,mysql,openlineage,postgres,salesforce,ssh,teradata] Providers[google]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "amazon...google",
+                            "test_types": "Providers[amazon] Providers[apache.hive,cncf.kubernetes,"
+                            "common.compat,common.messaging,common.sql,exasol,ftp,http,imap,"
+                            "microsoft.azure,mongo,mysql,openlineage,postgres,salesforce,ssh,teradata] "
+                            "Providers[google]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-providers']",
             },
@@ -818,8 +993,17 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "run-kubernetes-tests": "false",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always",
-                "providers-test-types-list-as-string": "Providers[common.compat,common.io,openlineage]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "common.compat,common.io,openl",
+                            "test_types": "Providers[common.compat,common.io,openlineage]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-airflow-core', 'mypy-providers']",
             },
@@ -842,8 +1026,17 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "run-kubernetes-tests": "false",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always Core Serialization",
-                "providers-test-types-list-as-string": "Providers[common.compat] Providers[standard]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always...Serialization", "test_types": "Always Core Serialization"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "common.compat...standard",
+                            "test_types": "Providers[common.compat] Providers[standard]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-providers']",
             },
@@ -866,8 +1059,17 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "run-kubernetes-tests": "false",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always Core Serialization",
-                "providers-test-types-list-as-string": "Providers[common.compat] Providers[standard]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always...Serialization", "test_types": "Always Core Serialization"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "common.compat...standard",
+                            "test_types": "Providers[common.compat] Providers[standard]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-providers']",
             },
@@ -891,8 +1093,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -917,10 +1119,11 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "testable-core-integrations": "['celery', 'kerberos']",
-                    "testable-providers-integrations": "['cassandra', 'drill', 'kafka', 'mongo', 'pinot', 'qdrant', 'redis', 'trino', 'ydb']",
+                    "testable-providers-integrations": "['cassandra', 'drill', 'kafka', 'mongo', "
+                    "'pinot', 'qdrant', 'redis', 'trino', 'ydb']",
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1008,18 +1211,22 @@ def test_full_test_needed_when_pyproject_toml_changes(
     assert_outputs_are_printed(expected_outputs, str(stderr))
 
 
-def test_hatch_build_py_changes():
+def test_list_splitting():
     stderr = SelectiveChecks(
-        files=("hatch_build.py",),
-        github_event=GithubEvents.PULL_REQUEST,
+        pr_labels=("full tests needed",),
         default_branch="main",
     )
-    assert_outputs_are_printed(
-        {
-            "full-tests-needed": "true",
-            "all-versions": "true",
-        },
-        str(stderr),
+    output_dict = get_outputs_from_stderr(str(stderr))
+    individual_providers_test_types_list_as_string = json.loads(
+        output_dict["individual-providers-test-types-list-as-strings-in-json"]
+    )
+    all_providers_in_sub_lists = [
+        list_of_types["test_types"].split(" ")
+        for list_of_types in individual_providers_test_types_list_as_string
+    ]
+    assert len(all_providers_in_sub_lists) == 5
+    assert sum([len(list_of_types) for list_of_types in all_providers_in_sub_lists]) == len(
+        LIST_OF_ALL_PROVIDER_TESTS
     )
 
 
@@ -1118,8 +1325,8 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1154,8 +1361,8 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1190,8 +1397,8 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1227,8 +1434,8 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1264,8 +1471,8 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1298,9 +1505,9 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
-                    "providers-test-types-list-as-string": ALL_PROVIDERS_SELECTIVE_TEST_TYPES,
-                    "individual-providers-test-types-list-as-string": LIST_OF_ALL_PROVIDER_TESTS,
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "individual-providers-test-types-list-as-strings-in-json": LIST_OF_ALL_PROVIDER_TESTS_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
                 },
@@ -1332,7 +1539,7 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "full-tests-needed": "true",
                     "skip-pre-commits": All_SKIPPED_COMMITS_IF_NON_MAIN_BRANCH,
                     "upgrade-to-newer-dependencies": "false",
-                    "core-test-types-list-as-string": "API Always CLI Core Other Serialization",
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                     "needs-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS_EXCEPT_PROVIDERS,
                 },
@@ -1376,7 +1583,7 @@ def test_expected_output_full_tests_needed(
                 "docs-list-as-string": None,
                 "full-tests-needed": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": None,
+                "core-test-types-list-as-strings-in-json": None,
                 "needs-mypy": "false",
                 "mypy-checks": "[]",
             },
@@ -1401,7 +1608,9 @@ def test_expected_output_full_tests_needed(
                 "full-tests-needed": "false",
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
                 "needs-mypy": "false",
                 "mypy-checks": "[]",
             },
@@ -1428,7 +1637,9 @@ def test_expected_output_full_tests_needed(
                 "full-tests-needed": "false",
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always CLI",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always...CLI", "test_types": "Always CLI"}]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-airflow-core']",
             },
@@ -1453,7 +1664,7 @@ def test_expected_output_full_tests_needed(
                 "full-tests-needed": "false",
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "API Always CLI Core Other Serialization",
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-airflow-core']",
             },
@@ -1495,7 +1706,7 @@ def test_expected_output_pull_request_v2_7(
                 "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                 "upgrade-to-newer-dependencies": "true",
-                "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "needs-mypy": "true",
                 "mypy-checks": ALL_MYPY_CHECKS,
             },
@@ -1516,7 +1727,7 @@ def test_expected_output_pull_request_v2_7(
                 "skip-pre-commits": All_SKIPPED_COMMITS_IF_NON_MAIN_BRANCH,
                 "docs-list-as-string": "apache-airflow docker-stack",
                 "upgrade-to-newer-dependencies": "true",
-                "core-test-types-list-as-string": "API Always CLI Core Other Serialization",
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "needs-mypy": "true",
                 "mypy-checks": ALL_MYPY_CHECKS_EXCEPT_PROVIDERS,
             },
@@ -1539,7 +1750,7 @@ def test_expected_output_pull_request_v2_7(
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
                 "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                 "upgrade-to-newer-dependencies": "true",
-                "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "needs-mypy": "true",
                 "mypy-checks": ALL_MYPY_CHECKS,
             },
@@ -1581,7 +1792,7 @@ def test_expected_output_push(
                 "docs-list-as-string": None,
                 "upgrade-to-newer-dependencies": "false",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NOT_IMPORTANT_FILES_CHANGED,
-                "core-test-types-list-as-string": None,
+                "core-test-types-list-as-strings-in-json": None,
                 "needs-mypy": "false",
                 "mypy-checks": "[]",
             },
@@ -1603,7 +1814,9 @@ def test_expected_output_push(
                 "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_PROVIDERS,
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-airflow-core']",
             },
@@ -1636,10 +1849,21 @@ def test_expected_output_push(
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_UI,
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "Always CLI",
-                "providers-test-types-list-as-string": "Providers[amazon] Providers[apache.beam,apache.cassandra,apache.kafka,cncf.kubernetes,common.compat,common.sql,facebook,"
-                "hashicorp,microsoft.azure,microsoft.mssql,mysql,openlineage,oracle,postgres,presto,"
-                "salesforce,samba,sftp,ssh,trino] Providers[google]",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always...CLI", "test_types": "Always CLI"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "amazon...google",
+                            "test_types": "Providers[amazon] Providers[apache.beam,apache.cassandra,"
+                            "apache.kafka,cncf.kubernetes,common.compat,common.sql,facebook,"
+                            "hashicorp,microsoft.azure,microsoft.mssql,mysql,"
+                            "openlineage,oracle,postgres,presto,salesforce,samba,sftp,ssh,trino] "
+                            "Providers[google]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-airflow-core', 'mypy-providers']",
             },
@@ -1662,7 +1886,7 @@ def test_expected_output_push(
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_PROVIDERS_UI_AND_HELM_TESTS,
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "needs-mypy": "true",
                 "mypy-checks": "['mypy-airflow-core']",
             },
@@ -1683,7 +1907,7 @@ def test_expected_output_push(
                 "docs-list-as-string": "",
                 "upgrade-to-newer-dependencies": "false",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
-                "core-test-types-list-as-string": "API Always CLI Core Other Serialization",
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "needs-mypy": "true",
                 "mypy-checks": ALL_MYPY_CHECKS,
             },
@@ -1697,7 +1921,9 @@ def test_expected_output_push(
                 "airflow-core/src/airflow/datasets/",
             ),
             {
-                "selected-providers-list-as-string": "amazon common.compat common.io common.sql dbt.cloud ftp google microsoft.mssql mysql openlineage postgres sftp snowflake trino",
+                "selected-providers-list-as-string": "amazon common.compat common.io common.sql "
+                "dbt.cloud ftp google microsoft.mssql mysql "
+                "openlineage postgres sftp snowflake trino",
                 "all-python-versions": "['3.9']",
                 "all-python-versions-list-as-string": "3.9",
                 "ci-image-build": "true",
@@ -1707,12 +1933,23 @@ def test_expected_output_push(
                 "skip-providers-tests": "false",
                 "test-groups": "['core', 'providers']",
                 "docs-build": "true",
-                "docs-list-as-string": "apache-airflow amazon common.compat common.io common.sql dbt.cloud ftp google microsoft.mssql mysql openlineage postgres sftp snowflake trino",
+                "docs-list-as-string": "apache-airflow amazon common.compat common.io common.sql "
+                "dbt.cloud ftp google microsoft.mssql mysql "
+                "openlineage postgres sftp snowflake trino",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_ON_NO_CI_IMAGE,
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "core-test-types-list-as-string": "API Always CLI Core Other Serialization",
-                "providers-test-types-list-as-string": "Providers[amazon] Providers[common.compat,common.io,common.sql,dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,postgres,sftp,snowflake,trino] Providers[google]",
+                "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "amazon...google",
+                            "test_types": "Providers[amazon] Providers[common.compat,common.io,common.sql,"
+                            "dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,"
+                            "postgres,sftp,snowflake,trino] Providers[google]",
+                        }
+                    ]
+                ),
                 "needs-mypy": "false",
                 "mypy-checks": "[]",
             },
@@ -1765,7 +2002,7 @@ def test_no_commit_provided_trigger_full_build_for_any_event_type(github_event):
             "upgrade-to-newer-dependencies": (
                 "true" if github_event in [GithubEvents.PUSH, GithubEvents.SCHEDULE] else "false"
             ),
-            "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
+            "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
             "needs-mypy": "true",
             "mypy-checks": ALL_MYPY_CHECKS,
         },
@@ -1804,7 +2041,7 @@ def test_files_provided_trigger_full_build_for_any_event_type(github_event):
             "upgrade-to-newer-dependencies": (
                 "true" if github_event in [GithubEvents.PUSH, GithubEvents.SCHEDULE] else "false"
             ),
-            "core-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
+            "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
             "needs-mypy": "true",
             "mypy-checks": ALL_MYPY_CHECKS,
         },


### PR DESCRIPTION
With `uv sync` lowest dependency test take longer, because it takes 20-30 seconds for each test to just perform the lowest resolution so for the provider tests it adds up if we run them mostly sequentially.

We do not want those tests to run one job per-provider, so we want to slice the list of providers into n parallel jobs.

This PR rewrites unit tests actions to allow this to happen.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
