### PR TITLE
Bump helm version in docs due to break statement

### DIFF
--- a/chart/docs/index.rst
+++ b/chart/docs/index.rst
@@ -60,7 +60,7 @@ Requirements
 ------------
 
 -  Kubernetes 1.29+ cluster
--  Helm 3.0+
+-  Helm 3.10+
 -  PV provisioner support in the underlying infrastructure (optionally)
 
 Features


### PR DESCRIPTION
## Bump Helm Version Requirement to 3.10+

### Description
This PR updates the required Helm version for deploying Apache Airflow from `3.0+` to `3.10+`. The change aligns with the minimum version needed for compatibility with newer Helm features used in the Helm chart, particularly the `break` statement introduced in 972714e (in airflow/templates/rbac/pod-launcher-rolebinding.yaml:66)

### Related Issues
N/A

### Changes Made
- Updated Helm version requirement in relevant documentation and configurations.

### Testing
- No functional changes were introduced.
- Verified that Helm 3.10+ works as expected with the deployment.

### Checklist
- [ ] My PR includes unit tests / doc updates if applicable.
- [x] My PR follows the project's coding style and best practices.
- [x] I have run `pre-commit` locally to validate formatting and linting.
- [x] My PR is focused on a single change and does not introduce unrelated modifications.
- [x] I have rebased my branch onto the latest `main`.
- [x] All CI checks have passed.