### PR TITLE
Fix spacing and naming in AssetNode

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/AssetNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/AssetNode.tsx
@@ -44,7 +44,7 @@ export const AssetNode = ({
     { enabled: Boolean(dagId) && Boolean(runId) },
   );
 
-  const datasetEvent = [
+  const assetEvent = [
     ...(upstreamEventsData?.asset_events ?? []),
     ...(downstreamEventsData?.asset_events ?? []),
   ].find((event) => event.name === label);
@@ -69,18 +69,18 @@ export const AssetNode = ({
           <Heading ml={-2} size="sm">
             <FiDatabase />
           </Heading>
-          <Link asChild color="fg.info" mb={2}>
+          <Link asChild color="fg.info">
             <RouterLink to={`/assets/${assetId}`}>{label}</RouterLink>
           </Link>
         </HStack>
-        {datasetEvent === undefined ? undefined : (
+        {assetEvent === undefined ? undefined : (
           <>
             <Text color="fg.muted">
-              <Time datetime={datasetEvent.timestamp} />
+              <Time datetime={assetEvent.timestamp} />
             </Text>
-            {datasetEvent.created_dagruns.length && datasetEvent.created_dagruns.length > 1 ? (
+            {assetEvent.created_dagruns.length && assetEvent.created_dagruns.length > 1 ? (
               <Text color="fg.muted" fontSize="sm">
-                +{pluralize("other Dag Run", datasetEvent.created_dagruns.length)}
+                +{pluralize("other Dag Run", assetEvent.created_dagruns.length)}
               </Text>
             ) : undefined}
           </>


### PR DESCRIPTION

<img width="917" alt="Screenshot 2025-04-02 at 2 08 51 PM" src="https://github.com/user-attachments/assets/bf48e865-9cb9-4a00-908c-e0f3bd05e64b" />

Remove the margin so any event information is better located on a asset node. And remove reference to "dataset"



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
