### PR TITLE
Fix git has_version check

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -172,7 +172,7 @@ class GitDagBundle(BaseDagBundle):
         try:
             repo.commit(version)
             return True
-        except BadName:
+        except (BadName, ValueError):
             return False
 
     def _fetch_bare_repo(self):


### PR DESCRIPTION
It was not catching ValueError, but that is sometimes thrown from git/cmd.py.
