### PR TITLE
Add minWidth to TruncatedText component

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TruncatedText.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TruncatedText.tsx
@@ -25,6 +25,7 @@ type Props = {
 export const TruncatedText = ({ text, ...rest }: Props) => (
   <Text
     display="-webkit-box"
+    minWidth={200}
     overflow="hidden"
     style={{
       WebkitBoxOrient: "vertical",


### PR DESCRIPTION
Make task names in a table more readable by setting a default minWidth. 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
