### PR TITLE
add baseurl to docs link

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -24,6 +24,8 @@ import { useConfig } from "src/queries/useConfig";
 
 import { NavButton } from "./NavButton";
 
+const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
+
 const links = [
   {
     href: "https://airflow.apache.org/docs/",
@@ -34,7 +36,7 @@ const links = [
     title: "GitHub Repo",
   },
   {
-    href: "/docs",
+    href: new URL("docs", baseUrl).href,
     title: "REST API Reference",
   },
 ];


### PR DESCRIPTION
If you customized the baseurl, the docs link would break. Instead we should use the baseurl in the docs link.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
