### PR TITLE
Explain f-string conflicts with Jinja templating

### DIFF
--- a/airflow-core/docs/core-concepts/operators.rst
+++ b/airflow-core/docs/core-concepts/operators.rst
@@ -324,7 +324,7 @@ If you need to include a Jinja template expression (e.g., ``{{ ds }}``) literall
   )
 
   python_var = "echo Data interval start:"
-  
+
   t2 = BashOperator(
       task_id="fstring_templating_simple",
       bash_command=f"{python_var} {{{{ ds }}}}",

--- a/airflow-core/docs/core-concepts/operators.rst
+++ b/airflow-core/docs/core-concepts/operators.rst
@@ -308,9 +308,9 @@ change name from ``params`` in your operators.
 Templating Conflicts with f-strings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When constructing strings for templated fields (like ``bash_command`` in ``BashOperator``) using Python f-strings, be mindful of the interaction between f-string interpolation and Jinja templating syntax. Both use curly braces (`{}`).
+When constructing strings for templated fields (like ``bash_command`` in ``BashOperator``) using Python f-strings, be mindful of the interaction between f-string interpolation and Jinja templating syntax. Both use curly braces (``{}``).
 
-Python f-strings interpret double curly braces (`{{` and `}}`) as escape sequences for literal single braces (`{` and `}`). However, Jinja uses double curly braces (`{{ variable }}`) to denote variables for templating.
+Python f-strings interpret double curly braces (``{{`` and ``}}``) as escape sequences for literal single braces (``{`` and ``}``). However, Jinja uses double curly braces (``{{ variable }}``) to denote variables for templating.
 
 If you need to include a Jinja template expression (e.g., ``{{ ds }}``) literally within a string defined using an f-string, so that Airflow's Jinja engine can process it later, you must escape the braces for the f-string by doubling them *again*. This means using **four** curly braces:
 

--- a/airflow-core/docs/core-concepts/operators.rst
+++ b/airflow-core/docs/core-concepts/operators.rst
@@ -304,3 +304,31 @@ If you upgrade your environment and get the following error:
     AttributeError: 'str' object has no attribute '__module__'
 
 change name from ``params`` in your operators.
+
+
+Templating Conflicts with f-strings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When constructing strings for templated fields (like ``bash_command`` in ``BashOperator``) using Python f-strings, be mindful of the interaction between f-string interpolation and Jinja templating syntax. Both use curly braces (`{}`).
+
+Python f-strings interpret double curly braces (`{{` and `}}`) as escape sequences for literal single braces (`{` and `}`). However, Jinja uses double curly braces (`{{ variable }}`) to denote variables for templating.
+
+If you need to include a Jinja template expression (e.g., ``{{ ds }}``) literally within a string defined using an f-string, so that Airflow's Jinja engine can process it later, you must escape the braces for the f-string by doubling them *again*. This means using **four** curly braces:
+
+.. code-block:: python
+
+  t1 = BashOperator(
+      task_id="fstring_templating_correct",
+      bash_command=f"echo Data interval start: {{{{ ds }}}}",
+      dag=dag,
+  )
+
+  python_var = "echo Data interval start:"
+  
+  t2 = BashOperator(
+      task_id="fstring_templating_simple",
+      bash_command=f"{python_var} {{{{ ds }}}}",
+      dag=dag,
+  )
+
+This ensures the f-string processing results in a string containing the literal double braces required by Jinja, which Airflow can then template correctly before execution. Failure to do this is a common issue for beginners and can lead to errors during DAG parsing or unexpected behavior at runtime when the templating does not occur as expected.

--- a/airflow-core/docs/core-concepts/operators.rst
+++ b/airflow-core/docs/core-concepts/operators.rst
@@ -305,7 +305,6 @@ If you upgrade your environment and get the following error:
 
 change name from ``params`` in your operators.
 
-
 Templating Conflicts with f-strings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Adds a documentation section detailing how Python f-strings interact with Jinja's double-brace syntax (`{{ variable }}`). Explains that to embed a literal Jinja template within an f-string for later rendering by Airflow, quadruple curly braces (`{{{{ variable }}}}`) must be used to escape the braces correctly for the initial f-string processing.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
