### PR TITLE
Fix deepcopy of read-only properties in BaseOperator

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -1246,6 +1246,10 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         shallow_copy = tuple(cls.shallow_copy_attrs) + cls._base_operator_shallow_copy_attrs
 
         for k, v in self.__dict__.items():
+            class_attr = inspect.getattr_static(cls, k, None)
+            if isinstance(class_attr, property) and class_attr.fset is None:
+                # Skip read-only properties such as "is_mapped".
+                continue
             if k not in shallow_copy:
                 v = copy.deepcopy(v, memo)
             else:

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -1246,10 +1246,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         shallow_copy = tuple(cls.shallow_copy_attrs) + cls._base_operator_shallow_copy_attrs
 
         for k, v in self.__dict__.items():
-            class_attr = inspect.getattr_static(cls, k, None)
-            if isinstance(class_attr, property) and class_attr.fset is None:
-                # Skip read-only properties such as "is_mapped".
-                continue
             if k not in shallow_copy:
                 v = copy.deepcopy(v, memo)
             else:
@@ -1257,7 +1253,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
             # Bypass any setters, and set it on the object directly. This works since we are cloning ourself so
             # we know the type is already fine
-            object.__setattr__(result, k, v)
+            result.__dict__[k] = v
         return result
 
     def __getstate__(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
The root cause of the [47274](https://github.com/apache/airflow/issues/47274) is that when Airflow serializes (deep-copies) an operator, the `__deepcopy__` method iterates over `self.__dict__` and sets every key using `object.__setattr__(result, k, copy.deepcopy(v, memo))`. This causes an AttributeError for read-only properties like "is_mapped" which have no setter. This PR modifies `__deepcopy__` to use `inspect.getattr_static` to detect and skip read-only properties, ensuring that `"is_mapped"` is not copied and preventing serialization errors.

I have tested this with the same DAG and setup mentioned in the issue:
<img width="1722" alt="Screenshot 2025-04-03 at 4 43 44 AM" src="https://github.com/user-attachments/assets/b7169e47-15dd-42ed-8a34-134e157ab1f3" />
<img width="1728" alt="Screenshot 2025-04-03 at 4 44 01 AM" src="https://github.com/user-attachments/assets/92aa75bb-b7e8-4848-9b98-a96c7e5de9ae" />



closes: [47274](https://github.com/apache/airflow/issues/47274)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
