### PR TITLE
Fix case when no suffix is passed when building packages

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -401,6 +401,8 @@ def set_package_version(version: str, init_file_path: Path, extra_text: str) -> 
 
 
 def update_version_suffix_in_pyproject_toml(version_suffix: str, pyproject_toml_path: Path):
+    if not version_suffix:
+        return
     get_console().print(f"[info]Updating version suffix to {version_suffix} for {pyproject_toml_path}.\n")
     lines = pyproject_toml_path.read_text().splitlines()
     updated_lines = []
@@ -438,34 +440,33 @@ def update_version_suffix_in_pyproject_toml(version_suffix: str, pyproject_toml_
 def package_version(
     version_suffix: str, package_path: Path, init_file_path: Path, pyproject_toml_paths: list[Path]
 ) -> Generator:
-    from packaging.version import Version
-
     release_version_matcher = re.compile(r"^\d+\.\d+\.\d+$")
     original_package_version = get_current_package_version(package_path)
     original_contents = []
     for pyproject_toml_path in pyproject_toml_paths:
         original_contents.append(pyproject_toml_path.read_text())
     update_version_in__init_py = False
+    base_package_version = original_package_version
     if version_suffix:
         if original_package_version.endswith(f".{version_suffix}"):
             get_console().print(
                 f"[info]The {original_package_version} already has suffix {version_suffix}. Not updating it.\n"
             )
-            package_version = original_package_version
         elif not release_version_matcher.match(original_package_version):
             get_console().print(
                 f"[warning]Normally you should only pass version suffix if package version "
                 f"does not have suffix in code (it is  {original_package_version} now).\n"
                 f"Overriding the version in code with the {version_suffix}."
             )
-            package_version = Version(original_package_version).base_version
             update_version_in__init_py = True
         else:
-            package_version = original_package_version
+            base_package_version = original_package_version
             update_version_in__init_py = True
     if update_version_in__init_py:
         set_package_version(
-            f"{package_version}.{version_suffix}", init_file_path=init_file_path, extra_text="temporarily"
+            f"{base_package_version}.{version_suffix}",
+            init_file_path=init_file_path,
+            extra_text="temporarily",
         )
     for pyproject_toml_path in pyproject_toml_paths:
         update_version_suffix_in_pyproject_toml(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
