### PR TITLE
Make updated pyproject.toml output only on verbose/dry_run and fold

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -428,9 +428,11 @@ def update_version_suffix_in_pyproject_toml(version_suffix: str, pyproject_toml_
         updated_lines.append(line)
     new_content = "\n".join(updated_lines) + "\n"
     get_console().print(f"[info]Writing updated content to {pyproject_toml_path}.\n")
-    # Format the content to make it more readable with rich
-    syntax = Syntax(new_content, "toml", theme="ansi_dark", line_numbers=True)
-    get_console().print(syntax)
+    if get_verbose() or get_dry_run():
+        with ci_group(f"Updated {pyproject_toml_path} content", message_type=MessageType.INFO):
+            # Format the content to make it more readable with rich
+            syntax = Syntax(new_content, "toml", theme="ansi_dark", line_numbers=True)
+            get_console().print(syntax)
     pyproject_toml_path.write_text(new_content)
 
 


### PR DESCRIPTION
The output of the dynamically modified pyproject.toml when you add suffix is useful for deugging but it should only be shown when `--verbose` flag is passed (or `--dry-run`). Also in CI (which is always run in verbose mode) we should fold the output so that it does not clutter the output and need unfolding to see the content.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
