### PR TITLE
Allow quick manual runs without providing a logical date

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -62,7 +62,7 @@ const TriggerDAGForm = ({ dagId, isPaused, onClose, open }: TriggerDAGFormProps)
       conf,
       dagRunId: "",
       // Default logical date to now
-      logicalDate: dayjs().format("YYYY-MM-DDThh:mm"),
+      logicalDate: dayjs().format("YYYY-MM-DDTHH:mm:ss.SSS"),
       note: "",
     },
   });


### PR DESCRIPTION
Upon a manual run when no logical date is provided the UI will use `now` the current format only goes down to the minute leading to a 409 conflict if an impatient person like me triggers the same dag twice in a minute

![image](https://github.com/user-attachments/assets/e6a85ebf-b292-40e3-a37c-051b11ea77f4)


This PR adds some seconds and milliseconds to the format. :)