### PR TITLE
Fetch dagrun in graph page only when runId is valid.

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -77,7 +77,7 @@ const edgeTypes = { custom: Edge };
 
 export const Graph = () => {
   const { colorMode = "light" } = useColorMode();
-  const { dagId = "", runId, taskId } = useParams();
+  const { dagId = "", runId = "", taskId } = useParams();
 
   const selectedVersion = useSelectedVersion();
 
@@ -112,7 +112,7 @@ export const Graph = () => {
   const { data: dagRun } = useDagRunServiceGetDagRun(
     {
       dagId,
-      dagRunId: runId ?? "",
+      dagRunId: runId,
     },
     undefined,
     { enabled: runId !== "" },


### PR DESCRIPTION
Loading graph for a dag without dagrun causes the call to be still fetched resulting in 404 error. Another approach would be `enabled: Boolean(runId)` and skip "" as default value for runId.

To reproduce

1. Visit a dag page like `http://localhost:8000/dags/example_xcom_args` and select graph.
2. In the console see 404 errors trying to fetch dagrun though there is no dagrun in the params and no dagrun is passed to the API URL.