### PR TITLE
fix: set explicit separator for isoformat when serializing EventsTimetable

### DIFF
--- a/airflow-core/src/airflow/timetables/events.py
+++ b/airflow-core/src/airflow/timetables/events.py
@@ -122,7 +122,7 @@ class EventsTimetable(Timetable):
 
     def serialize(self):
         return {
-            "event_dates": [str(x) for x in self.event_dates],
+            "event_dates": [x.isoformat(sep="T") for x in self.event_dates],
             "restrict_to_events": self.restrict_to_events,
         }
 

--- a/airflow-core/tests/unit/timetables/test_events_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_events_timetable.py
@@ -176,3 +176,18 @@ def test_empty_timetable_manual_run() -> None:
     empty_timetable = EventsTimetable(event_dates=[])
     manual_run_data_interval = empty_timetable.infer_manual_data_interval(run_after=START_DATE)
     assert manual_run_data_interval == DataInterval(start=START_DATE, end=START_DATE)
+
+
+def test_serialize(unrestricted_timetable: Timetable):
+    serialized = unrestricted_timetable.serialize()
+    assert serialized == {
+        "event_dates": [
+            "2021-09-06T00:00:00+00:00",
+            "2021-09-07T00:00:00+00:00",
+            "2021-09-08T00:00:00+00:00",
+            "2021-09-08T00:00:00+00:00",
+            "2021-09-10T00:00:00+00:00",
+            "2021-10-09T00:00:00+00:00",
+        ],
+        "restrict_to_events": False,
+    }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When working on #47915 I noticed that dates in EventTimetable are being serialized in a different way, depending on whether tests are run on lowest dependencies or not.

The reasons it that 
pendulum==2.1.2 implements `T` as separator for isoformat():
```
def __str__(self):
    return self.isoformat("T")
``` 
while pendulum==3.0.0 implements ` ` as separator for isoformat():
```
def __str__(self) -> str:
    return self.isoformat(" ")
```
and we are just using `str()` when serializing:
```
"event_dates": [str(x) for x in self.event_dates],
```


I think we should stick to using `T` as separator, so I've updated the `serialize()` method on the EventsTimetable to explicitly use isoformat with `T` as separator.
```
"event_dates": [x.isoformat(sep="T") for x in self.event_dates],
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
