### PR TITLE
docs: fix typo in breeze shell command

### DIFF
--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1248,7 +1248,7 @@ running the tests from there:
 
 .. code-block:: bash
 
-    breeze shell --force-lowest-dependencies --test-type "Core"
+    breeze shell --force-lowest-dependencies
 
 
 The way it works - when you run the breeze with ``--force-lowest-dependencies`` flag, breeze will use
@@ -1283,7 +1283,7 @@ running the tests from there:
 
 .. code-block:: bash
 
-    breeze shell --force-lowest-dependencies --test-type "Providers[PROVIDER_ID]"
+    breeze shell --force-lowest-dependencies
 
 Similarly as in case of "Core" tests, the dependencies will be downgraded to the lowest version that is
 compatible with the dependencies specified in the provider dependencies and you will see the list of


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When trying to follow the docs and run the lowest dependency tests for both core and providers I encountered an error:
<img width="754" alt="image" src="https://github.com/user-attachments/assets/3b8696ce-3165-420b-9c9c-287453f5edab" />

I think the `--test-type` should not be there and maybe is a result of copying the command from above that runs tests. I checked other flags with `breeze shell --help` and I could not find something with similar functionality (not sure what it should even do when entering the shell).


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
