### PR TITLE
Cleanup of the updated test-type workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,6 @@ jobs:
       skip-providers-tests: ${{ steps.selective-checks.outputs.skip-providers-tests }}
       source-head-repo: ${{ steps.source-run-info.outputs.source-head-repo }}
       sqlite-exclude: ${{ steps.selective-checks.outputs.sqlite-exclude }}
-      test-groups: ${{ steps.selective-checks.outputs.test-groups }}
       testable-core-integrations: ${{ steps.selective-checks.outputs.testable-core-integrations }}
       testable-providers-integrations: ${{ steps.selective-checks.outputs.testable-providers-integrations }}
       use-uv: ${{ steps.selective-checks.outputs.force-pip == 'true' && 'false' || 'true' }}
@@ -576,7 +575,6 @@ jobs:
        needs.build-info.outputs.upgrade-to-newer-dependencies != 'false' ||
        needs.build-info.outputs.full-tests-needed == 'true')
     with:
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
       default-branch: ${{ needs.build-info.outputs.default-branch }}
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
       core-test-types-list-as-strings-in-json: >

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -28,10 +28,6 @@ on:  # yamllint disable-line rule:truthy
         description: "The default branch for the repository"
         required: true
         type: string
-      test-groups:
-        description: "The json representing list of test test groups to run"
-        required: true
-        type: string
       core-test-types-list-as-strings-in-json:
         description: "The list of core test types to run separated by spaces"
         required: true

--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -244,7 +244,6 @@ GitHub Actions to pass the list of parameters to a command to execute
 | skip-pre-commits                               | Which pre-commits should be skipped during the static-checks run                                       | flynt,identity                          |      |
 | skip-providers-tests                           | When provider tests should be skipped (on non-main branch or when no provider changes detected)        | true                                    |      |
 | sqlite-exclude                                 | Which versions of Sqlite to exclude for tests as JSON array                                            | []                                      |      |
-| test-groups                                    | List of test groups that are valid for this run                                                        | \['core', 'providers'\]                 |      |
 | testable-core-integrations                     | List of core integrations that are testable in the build as JSON array                                 | \['celery', 'kerberos'\]                |      |
 | testable-providers-integrations                | List of core integrations that are testable in the build as JSON array                                 | \['mongo', 'kafka'\]                    |      |
 | upgrade-to-newer-dependencies                  | Whether the image build should attempt to upgrade all dependencies (true/false or commit hash)         | false                                   |      |

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -652,6 +652,9 @@ PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
     },
 ]
 
+# Number of slices for low dep tests
+NUMBER_OF_LOW_DEP_SLICES = 5
+
 
 class GithubEvents(Enum):
     PULL_REQUEST = "pull_request"

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -45,6 +45,7 @@ from airflow_breeze.global_constants import (
     DISABLE_TESTABLE_INTEGRATIONS_FROM_CI,
     HELM_VERSION,
     KIND_VERSION,
+    NUMBER_OF_LOW_DEP_SLICES,
     PROVIDERS_COMPATIBILITY_TESTS_MATRIX,
     RUNS_ON_PUBLIC_RUNNER,
     RUNS_ON_SELF_HOSTED_ASF_RUNNER,
@@ -988,9 +989,9 @@ class SelectiveChecks:
         # We are hard-coding the number of lists as reasonable starting point to split the
         # list of test types - and we can modify it in the future
         # TODO: In Python 3.12 we will be able to use itertools.batched
-        if len(current_test_types) < 5:
+        if len(current_test_types) < NUMBER_OF_LOW_DEP_SLICES:
             return json.dumps(_get_test_list_as_json([current_test_types]))
-        list_of_list_of_types = _split_list(current_test_types, 5)
+        list_of_list_of_types = _split_list(current_test_types, NUMBER_OF_LOW_DEP_SLICES)
         return json.dumps(_get_test_list_as_json(list_of_list_of_types))
 
     @cached_property
@@ -1211,16 +1212,6 @@ class SelectiveChecks:
         if self._get_providers_test_types_to_run():
             return False
         return True
-
-    @cached_property
-    def test_groups(self):
-        if self.skip_providers_tests:
-            if self.run_tests:
-                return "['core']"
-        else:
-            if self.run_tests:
-                return "['core', 'providers']"
-        return "[]"
 
     @cached_property
     def docker_cache(self) -> str:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -27,6 +27,7 @@ from rich.console import Console
 from airflow_breeze.global_constants import (
     COMMITTERS,
     DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
+    NUMBER_OF_LOW_DEP_SLICES,
     PROVIDERS_COMPATIBILITY_TESTS_MATRIX,
     GithubEvents,
 )
@@ -1224,7 +1225,7 @@ def test_list_splitting():
         list_of_types["test_types"].split(" ")
         for list_of_types in individual_providers_test_types_list_as_string
     ]
-    assert len(all_providers_in_sub_lists) == 5
+    assert len(all_providers_in_sub_lists) == NUMBER_OF_LOW_DEP_SLICES
     assert sum([len(list_of_types) for list_of_types in all_providers_in_sub_lists]) == len(
         LIST_OF_ALL_PROVIDER_TESTS
     )
@@ -1319,7 +1320,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "false",
-                    "test-groups": "['core', 'providers']",
                     "docs-build": "true",
                     "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                     "full-tests-needed": "true",
@@ -1355,7 +1355,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "false",
-                    "test-groups": "['core', 'providers']",
                     "docs-build": "true",
                     "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                     "full-tests-needed": "true",
@@ -1391,7 +1390,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "false",
-                    "test-groups": "['core', 'providers']",
                     "docs-build": "true",
                     "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                     "full-tests-needed": "true",
@@ -1428,7 +1426,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "false",
-                    "test-groups": "['core', 'providers']",
                     "docs-build": "true",
                     "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                     "full-tests-needed": "true",
@@ -1465,7 +1462,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "false",
-                    "test-groups": "['core', 'providers']",
                     "docs-build": "true",
                     "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                     "full-tests-needed": "true",
@@ -1499,7 +1495,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "false",
-                    "test-groups": "['core', 'providers']",
                     "docs-build": "true",
                     "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                     "full-tests-needed": "true",
@@ -1533,7 +1528,6 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "prod-image-build": "true",
                     "run-tests": "true",
                     "skip-providers-tests": "true",
-                    "test-groups": "['core']",
                     "docs-build": "true",
                     "docs-list-as-string": "apache-airflow docker-stack",
                     "full-tests-needed": "true",
@@ -1578,7 +1572,6 @@ def test_expected_output_full_tests_needed(
                 "needs-helm-tests": "false",
                 "run-tests": "false",
                 "skip-providers-tests": "true",
-                "test-groups": "[]",
                 "docs-build": "false",
                 "docs-list-as-string": None,
                 "full-tests-needed": "false",
@@ -1602,7 +1595,6 @@ def test_expected_output_full_tests_needed(
                 "prod-image-build": "true",
                 "run-tests": "true",
                 "skip-providers-tests": "true",
-                "test-groups": "['core']",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow docker-stack",
                 "full-tests-needed": "false",
@@ -1631,7 +1623,6 @@ def test_expected_output_full_tests_needed(
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "skip-providers-tests": "true",
-                "test-groups": "['core']",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow docker-stack",
                 "full-tests-needed": "false",
@@ -1658,7 +1649,6 @@ def test_expected_output_full_tests_needed(
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "skip-providers-tests": "true",
-                "test-groups": "['core']",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow docker-stack",
                 "full-tests-needed": "false",
@@ -1787,7 +1777,6 @@ def test_expected_output_push(
                 "needs-helm-tests": "false",
                 "run-tests": "false",
                 "skip-providers-tests": "true",
-                "test-groups": "[]",
                 "docs-build": "false",
                 "docs-list-as-string": None,
                 "upgrade-to-newer-dependencies": "false",
@@ -1809,7 +1798,6 @@ def test_expected_output_push(
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "skip-providers-tests": "true",
-                "test-groups": "['core']",
                 "docs-build": "true",
                 "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_PROVIDERS,
@@ -1840,7 +1828,6 @@ def test_expected_output_push(
                 "needs-helm-tests": "true",
                 "run-tests": "true",
                 "skip-providers-tests": "false",
-                "test-groups": "['core', 'providers']",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow helm-chart amazon apache.beam apache.cassandra "
                 "apache.kafka cncf.kubernetes common.compat common.sql facebook google hashicorp microsoft.azure "
@@ -1880,7 +1867,6 @@ def test_expected_output_push(
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "skip-providers-tests": "true",
-                "test-groups": "['core']",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_IF_NO_PROVIDERS_UI_AND_HELM_TESTS,
@@ -1902,7 +1888,6 @@ def test_expected_output_push(
                 "needs-helm-tests": "true",
                 "run-tests": "true",
                 "skip-providers-tests": "false",
-                "test-groups": "['core', 'providers']",
                 "docs-build": "true",
                 "docs-list-as-string": "",
                 "upgrade-to-newer-dependencies": "false",
@@ -1931,7 +1916,6 @@ def test_expected_output_push(
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "skip-providers-tests": "false",
-                "test-groups": "['core', 'providers']",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow amazon common.compat common.io common.sql "
                 "dbt.cloud ftp google microsoft.mssql mysql "


### PR DESCRIPTION
Follow up after #48696. After we added more parallelism options for low-dep tests we also had to use a separate `test-group` rather than matrix of `test-groups` before and duplicate workflow "calls". It turned out that we can remove `test-groups` altogether.

Also the number of slices in the low-dep workflow has been extracted to a constant.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
