### PR TITLE
Make zIndex of select to be greater than modal in fullscreen mode to display options.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -32,6 +32,7 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
 import { Button, Select } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { system } from "src/theme";
 import { type LogLevel, logLevelColorMapping, logLevelOptions } from "src/utils/logs";
 
 type Props = {
@@ -59,6 +60,12 @@ export const TaskLogHeader = ({
   const sources = searchParams.getAll(SearchParamsKeys.SOURCE);
   const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
   const hasLogLevels = logLevels.length > 0;
+
+  // Have select zIndex greater than modal zIndex in fullscreen so that
+  // select options are displayed.
+  const zIndex = isFullscreen
+    ? Number(system.tokens.categoryMap.get("zIndex")?.get("modal")?.value ?? 1400) + 1
+    : undefined;
 
   const sourceOptionList = createListCollection<{
     label: string;
@@ -117,6 +124,7 @@ export const TaskLogHeader = ({
         <Select.Root
           collection={logLevelOptions}
           maxW="250px"
+          minW={isFullscreen ? "150px" : undefined}
           multiple
           onValueChange={handleLevelChange}
           value={hasLogLevels ? logLevels : ["all"]}
@@ -138,7 +146,7 @@ export const TaskLogHeader = ({
               }
             </Select.ValueText>
           </Select.Trigger>
-          <Select.Content>
+          <Select.Content zIndex={zIndex}>
             {logLevelOptions.items.map((option) => (
               <Select.Item item={option} key={option.label}>
                 {option.value === "all" ? (


### PR DESCRIPTION
Closes #48661 

dropdown has 1000 as zIndex value with modal as 1400 . This causes the dropdown options to be not displayed in fullscreen mode though displayed in normal mode. Also noticed that the dropdown is very short so made `minW` as "150px" in fullscreen mode.

In main

![image](https://github.com/user-attachments/assets/40d9e901-dab7-48b9-981d-cc3aed17fb76)

With PR

![image](https://github.com/user-attachments/assets/d52995c2-15a8-46a0-ba83-7fedef4bdb23)


https://chakra-ui.com/docs/theming/z-index