### PR TITLE
Add check to updating dag dependencies queryData

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useDependencyGraph.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDependencyGraph.ts
@@ -43,7 +43,7 @@ export const useDependencyGraph = (
     const key = UseDependenciesServiceGetDependenciesKeyFn({ nodeId: node.id });
     const queryData = queryClient.getQueryData(key);
 
-    if (!Boolean(queryData) && Boolean(query.data)) {
+    if (!Boolean(queryData)) {
       queryClient.setQueryData(key, query.data);
     }
   });

--- a/airflow-core/src/airflow/ui/src/queries/useDependencyGraph.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDependencyGraph.ts
@@ -40,7 +40,12 @@ export const useDependencyGraph = (
 
   // Update the queries for all connected assets and dags so we save an API request
   query.data?.nodes.forEach((node) => {
-    queryClient.setQueryData(UseDependenciesServiceGetDependenciesKeyFn({ nodeId: node.id }), query.data);
+    const key = UseDependenciesServiceGetDependenciesKeyFn({ nodeId: node.id });
+    const queryData = queryClient.getQueryData(key);
+
+    if (!Boolean(queryData) && Boolean(query.data)) {
+      queryClient.setQueryData(key, query.data);
+    }
   });
 
   return query;


### PR DESCRIPTION
Sometimes this got stuck in a loop. So we should only update the queryData if it we don't already have it saved and if the API actually returned a response

Fixes: https://github.com/apache/airflow/issues/48711

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
