### PR TITLE
Fix Cloudwatch remote logging

### DIFF
--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -496,26 +496,32 @@ def load_remote_log_handler() -> RemoteLogIO | None:
     return airflow.logging_config.REMOTE_TASK_LOG
 
 
-def upload_to_remote(logger: FilteringBoundLogger):
-    from airflow.configuration import conf
-
-    raw_logger = getattr(logger, "_logger")
-
-    if not raw_logger or not hasattr(raw_logger, "_file"):
+def relative_path_from_logger(logger) -> Path | None:
+    if not logger:
+        return None
+    if not hasattr(logger, "_file"):
         logger.warning("Unable to find log file, logger was of unexpected type", type=type(logger))
-        return
+        return None
 
-    fh = raw_logger._file
+    fh = logger._file
     fname = fh.name
 
     if fh.fileno() == 1 or not isinstance(fname, str):
         # Logging to stdout, or something odd about this logger, don't try to upload!
-        return
+        return None
+    from airflow.configuration import conf
+
     base_log_folder = conf.get("logging", "base_log_folder")
-    relative_path = Path(fname).relative_to(base_log_folder)
+    return Path(fname).relative_to(base_log_folder)
+
+
+def upload_to_remote(logger: FilteringBoundLogger):
+    raw_logger = getattr(logger, "_logger")
+
+    relative_path = relative_path_from_logger(raw_logger)
 
     handler = load_remote_log_handler()
-    if not handler:
+    if not handler or not relative_path:
         return
 
     log_relative_path = relative_path.as_posix()


### PR DESCRIPTION
There were three main issues:

1) A circular loop that eventually fails due to call depth exceeded. This is because the handler was lazily initted during the first log emission. But when the handler is created some code down stream tries to log, and since there is no handler yet (because we're in the middle of creating it), it tries to create another one, and we were spinning ad infinitum.
2) The stream name is not set on read, because we don't call set_context anywhere in the SDK path, and the processor doesn't have access to the TI anyway (which is used for the stream name). So a 0 byte stream name was being used and was causing a failure in Watchtower.
3) read is also failing because it is using the relative_path as the stream name, which is almost right,  but the name isn't sanitized (there are some characters that cloudwatch doesn't allow in a stream name). set_context used to sanitize the name and set it, but it isn't called in the SDK path.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
