### PR TITLE
Revert change to unit test mode conf get

### DIFF
--- a/airflow-core/src/airflow/models/dagcode.py
+++ b/airflow-core/src/airflow/models/dagcode.py
@@ -120,7 +120,7 @@ class DagCode(Base):
                 code = f.read()
             return code
         except FileNotFoundError:
-            test_mode = conf.getboolean("core", "unit_test_mode")
+            test_mode = conf.get("core", "unit_test_mode")
             if test_mode:
                 return "source_code"
             raise


### PR DESCRIPTION
Previously it was always evaluating to True because the setting retrieved with `get` came out as string, and it was truthy evaluation.

It makes sense to correct it -- clearly it's not doing what was intended.  But, correcting it has broken some other processes, and we need to revert for now while we figure out better solution.
