### PR TITLE
Allow bundle_name and relative_fileloc to be None API response

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -61,8 +61,8 @@ class DAGResponse(BaseModel):
     is_active: bool
     last_parsed_time: datetime | None
     last_expired: datetime | None
-    bundle_name: str
-    relative_fileloc: str
+    bundle_name: str | None
+    relative_fileloc: str | None
     fileloc: str
     description: str | None
     timetable_summary: str | None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -8531,10 +8531,14 @@ components:
           - type: 'null'
           title: Last Expired
         bundle_name:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Bundle Name
         relative_fileloc:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Relative Fileloc
         fileloc:
           type: string
@@ -8765,10 +8769,14 @@ components:
           - type: 'null'
           title: Last Expired
         bundle_name:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Bundle Name
         relative_fileloc:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Relative Fileloc
         fileloc:
           type: string
@@ -9286,10 +9294,14 @@ components:
           - type: 'null'
           title: Last Expired
         bundle_name:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Bundle Name
         relative_fileloc:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Relative Fileloc
         fileloc:
           type: string

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1722,11 +1722,25 @@ export const $DAGDetailsResponse = {
       title: "Last Expired",
     },
     bundle_name: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Bundle Name",
     },
     relative_fileloc: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Relative Fileloc",
     },
     fileloc: {
@@ -2109,11 +2123,25 @@ export const $DAGResponse = {
       title: "Last Expired",
     },
     bundle_name: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Bundle Name",
     },
     relative_fileloc: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Relative Fileloc",
     },
     fileloc: {
@@ -2915,11 +2943,25 @@ export const $DAGWithLatestDagRunsResponse = {
       title: "Last Expired",
     },
     bundle_name: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Bundle Name",
     },
     relative_fileloc: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Relative Fileloc",
     },
     fileloc: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -535,8 +535,8 @@ export type DAGDetailsResponse = {
   is_active: boolean;
   last_parsed_time: string | null;
   last_expired: string | null;
-  bundle_name: string;
-  relative_fileloc: string;
+  bundle_name: string | null;
+  relative_fileloc: string | null;
   fileloc: string;
   description: string | null;
   timetable_summary: string | null;
@@ -599,8 +599,8 @@ export type DAGResponse = {
   is_active: boolean;
   last_parsed_time: string | null;
   last_expired: string | null;
-  bundle_name: string;
-  relative_fileloc: string;
+  bundle_name: string | null;
+  relative_fileloc: string | null;
   fileloc: string;
   description: string | null;
   timetable_summary: string | null;
@@ -775,8 +775,8 @@ export type DAGWithLatestDagRunsResponse = {
   is_active: boolean;
   last_parsed_time: string | null;
   last_expired: string | null;
-  bundle_name: string;
-  relative_fileloc: string;
+  bundle_name: string | null;
+  relative_fileloc: string | null;
   fileloc: string;
   description: string | null;
   timetable_summary: string | null;


### PR DESCRIPTION
This is necessary because, in practice, they are null in the db.  And, it does not make much sense to correct this at upgrade time because, they're not necessarily even defined in dags anymore, and we don't know which bundle they'd be a part of post upgrade.  So, let's just leave it null, and it will be resolved by dag processor or through `airflow dags reserialize`.
