### PR TITLE
[Edge] Edge worker reports hostname as task runner

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -23,7 +23,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.20.1b1``
+Release: ``0.20.2b1``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -36,7 +36,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1b1/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1/>`_.
 
 Installation
 ------------
@@ -78,4 +78,4 @@ Dependent package                                                               
 ==============================================================================================  =======
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1b1/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.20.2b1
+..........
+
+Fix
+~~~
+
+* ``Fix hostname reporting - worker will consistently report defined hostname as task runner.``
+
+
 0.20.1pre0
 ..........
 

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1741121867
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.20.1b1
+  - 0.20.2b1
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.20.1b1"
+version = "0.20.2b1"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -89,8 +89,8 @@ apache-airflow-providers-fab = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1b1"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.1b1/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.20.1b1"
+__version__ = "0.20.2b1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/edge/src/airflow/providers/edge/cli/edge_command.py
@@ -156,6 +156,11 @@ def _write_pid_to_pidfile(pid_file_path: str):
     write_pid_to_pidfile(pid_file_path)
 
 
+def _edge_hostname() -> str:
+    """Get the hostname of the edge worker that should be reported by tasks."""
+    return os.environ.get("HOSTNAME", _hostname())
+
+
 class _EdgeWorkerCli:
     """Runner instance which executes the Edge Worker."""
 
@@ -341,6 +346,8 @@ class _EdgeWorkerCli:
         signal.signal(signal.SIGINT, _EdgeWorkerCli.signal_handler)
         signal.signal(SIG_STATUS, _EdgeWorkerCli.signal_handler)
         signal.signal(signal.SIGTERM, self.shutdown_handler)
+        os.environ["HOSTNAME"] = self.hostname
+        os.environ["AIRFLOW__CORE__HOSTNAME_CALLABLE"] = f"{_edge_hostname.__module__}._edge_hostname"
         try:
             self.worker_state_changed = self.heartbeat()
             self.last_hb = datetime.now()

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1741121867,
-        "versions": ["0.20.1b1"],
+        "versions": ["0.20.2b1"],
         "plugins": [
             {
                 "name": "edge_executor",


### PR DESCRIPTION
Overview

Issue is that sometimes only the IP address of the host is reported as the hostname which executed the task. With that it is not possible to see which worker produced which task. This PR sets the hostname so that the right name is consistently reported as a task runner.
