### PR TITLE
HdfsTaskHandler structlog rework

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -129,7 +129,7 @@ if EXTRA_LOGGER_NAMES:
 ##################
 
 REMOTE_LOGGING: bool = conf.getboolean("logging", "remote_logging")
-REMOTE_TASK_LOG: RemoteLogIO | None = None
+REMOTE_TASK_LOG: RemoteLogIO | None = None  # type: ignore
 
 if REMOTE_LOGGING:
     ELASTICSEARCH_HOST: str | None = conf.get("elasticsearch", "HOST")

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -129,7 +129,7 @@ if EXTRA_LOGGER_NAMES:
 ##################
 
 REMOTE_LOGGING: bool = conf.getboolean("logging", "remote_logging")
-REMOTE_TASK_LOG: RemoteLogIO | None = None  # type: ignore
+REMOTE_TASK_LOG: RemoteLogIO | None = None
 
 if REMOTE_LOGGING:
     ELASTICSEARCH_HOST: str | None = conf.get("elasticsearch", "HOST")

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -129,7 +129,16 @@ if EXTRA_LOGGER_NAMES:
 ##################
 
 REMOTE_LOGGING: bool = conf.getboolean("logging", "remote_logging")
-REMOTE_TASK_LOG: RemoteLogIO | None = None
+REMOTE_TASK_LOG: (
+    RemoteLogIO
+    | S3RemoteLogIO
+    | CloudWatchRemoteLogIO
+    | GCSRemoteLogIO
+    | WasbRemoteLogIO
+    | OSSRemoteLogIO
+    | HdfsRemoteLogIO
+    | None
+) = None
 
 if REMOTE_LOGGING:
     ELASTICSEARCH_HOST: str | None = conf.get("elasticsearch", "HOST")
@@ -246,15 +255,19 @@ if REMOTE_LOGGING:
         )
         remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("hdfs://"):
-        HDFS_REMOTE_HANDLERS: dict[str, dict[str, str | None]] = {
-            "task": {
-                "class": "airflow.providers.apache.hdfs.log.hdfs_task_handler.HdfsTaskHandler",
-                "formatter": "airflow",
-                "base_log_folder": BASE_LOG_FOLDER,
-                "hdfs_log_folder": remote_base_log_folder,
-            },
-        }
-        DEFAULT_LOGGING_CONFIG["handlers"].update(HDFS_REMOTE_HANDLERS)
+        from airflow.providers.apache.hdfs.log.hdfs_task_handler import HdfsRemoteLogIO
+
+        REMOTE_TASK_LOG = HdfsRemoteLogIO(
+            **(
+                {
+                    "base_log_folder": BASE_LOG_FOLDER,
+                    "remote_base": remote_base_log_folder,
+                    "delete_local_copy": delete_local_copy,
+                }
+                | remote_task_handler_kwargs
+            )
+        )
+        remote_task_handler_kwargs = {}
     elif ELASTICSEARCH_HOST:
         ELASTICSEARCH_END_OF_LOG_MARK: str = conf.get_mandatory_value("elasticsearch", "END_OF_LOG_MARK")
         ELASTICSEARCH_FRONTEND: str = conf.get_mandatory_value("elasticsearch", "frontend")

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -129,16 +129,7 @@ if EXTRA_LOGGER_NAMES:
 ##################
 
 REMOTE_LOGGING: bool = conf.getboolean("logging", "remote_logging")
-REMOTE_TASK_LOG: (
-    RemoteLogIO
-    | S3RemoteLogIO
-    | CloudWatchRemoteLogIO
-    | GCSRemoteLogIO
-    | WasbRemoteLogIO
-    | OSSRemoteLogIO
-    | HdfsRemoteLogIO
-    | None
-) = None
+REMOTE_TASK_LOG: RemoteLogIO | None = None
 
 if REMOTE_LOGGING:
     ELASTICSEARCH_HOST: str | None = conf.get("elasticsearch", "HOST")

--- a/airflow-core/tests/unit/core/test_logging_config.py
+++ b/airflow-core/tests/unit/core/test_logging_config.py
@@ -316,3 +316,22 @@ class TestLoggingSettings:
         task_log = airflow.logging_config.REMOTE_TASK_LOG
         assert isinstance(task_log, S3RemoteLogIO)
         assert getattr(task_log, "delete_local_copy") is True
+
+    def test_loading_remote_logging_with_hdfs_handler(self):
+        """Test if logging can be configured successfully for HDFS"""
+        pytest.importorskip("airflow.providers.apache.hdfs", reason="'apache.hdfs' provider not installed")
+        import airflow.logging_config
+        from airflow.config_templates import airflow_local_settings
+        from airflow.providers.apache.hdfs.log.hdfs_task_handler import HdfsRemoteLogIO
+
+        with conf_vars(
+            {
+                ("logging", "remote_logging"): "True",
+                ("logging", "remote_log_conn_id"): "some_hdfs",
+                ("logging", "remote_base_log_folder"): "hdfs://some-folder",
+            }
+        ):
+            importlib.reload(airflow_local_settings)
+            airflow.logging_config.configure_logging()
+
+        assert isinstance(airflow.logging_config.REMOTE_TASK_LOG, HdfsRemoteLogIO)

--- a/providers/apache/hdfs/src/airflow/providers/apache/hdfs/log/hdfs_task_handler.py
+++ b/providers/apache/hdfs/src/airflow/providers/apache/hdfs/log/hdfs_task_handler.py
@@ -17,43 +17,98 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 import os
-import pathlib
 import shutil
 from functools import cached_property
+from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
+
+import attrs
 
 from airflow.configuration import conf
 from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
 
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.utils.log.file_task_handler import LogMessages, LogSourceInfo
 
-class HdfsTaskHandler(FileTaskHandler, LoggingMixin):
-    """Logging handler to upload and read from HDFS."""
 
-    def __init__(self, base_log_folder: str, hdfs_log_folder: str, **kwargs):
-        super().__init__(base_log_folder)
-        self.remote_base = urlsplit(hdfs_log_folder).path
-        self.log_relative_path = ""
-        self._hook = None
-        self.closed = False
-        self.upload_on_close = True
-        self.delete_local_copy = kwargs.get(
-            "delete_local_copy", conf.getboolean("logging", "delete_local_logs")
-        )
+@attrs.define(kw_only=True)
+class HdfsRemoteLogIO(LoggingMixin):  # noqa: D101
+    remote_base: str
+    base_log_folder: Path = attrs.field(converter=Path)
+    delete_local_copy: bool
+
+    processors = ()
+
+    def upload(self, path: os.PathLike | str):
+        """Upload the given log path to the remote storage."""
+        path = Path(path)
+        if path.is_absolute():
+            local_loc = path
+            remote_loc = os.path.join(self.remote_base, path.relative_to(self.base_log_folder))
+        else:
+            local_loc = self.base_log_folder.joinpath(path)
+            remote_loc = os.path.join(self.remote_base, path)
+
+        if local_loc.is_file():
+            self.hook.load_file(local_loc, remote_loc)
+            if self.delete_local_copy:
+                shutil.rmtree(os.path.dirname(local_loc))
 
     @cached_property
     def hook(self):
         """Returns WebHDFSHook."""
         return WebHDFSHook(webhdfs_conn_id=conf.get("logging", "REMOTE_LOG_CONN_ID"))
 
-    def set_context(self, ti):
+    def read(self, relative_path: str, ti: TaskInstance) -> tuple[LogSourceInfo, LogMessages]:
+        logs = []
+        messages = []
+        file_path = os.path.join(self.remote_base, relative_path)
+        if self.hook.check_for_path(file_path):
+            logs.append(self.hook.read_file(file_path).decode("utf-8"))
+        else:
+            messages.append(f"No logs found on hdfs for ti={ti}")
+        return messages, logs
+
+
+class HdfsTaskHandler(FileTaskHandler, LoggingMixin):
+    """
+    HdfsTaskHandler is a Python logging handler that handles and reads task instance logs.
+
+    It extends airflow FileTaskHandler and uploads to and reads from HDFS.
+    """
+
+    def __init__(self, base_log_folder: str, hdfs_log_folder: str, **kwargs):
+        super().__init__(base_log_folder)
+        self.handler: logging.FileHandler | None = None
+        self.remote_base = urlsplit(hdfs_log_folder).path
+        self.log_relative_path = ""
+        self._hook = None
+        self.closed = False
+        self.upload_on_close = True
+
+        self.io = HdfsRemoteLogIO(
+            remote_base=hdfs_log_folder,
+            base_log_folder=base_log_folder,
+            delete_local_copy=kwargs.get(
+                "delete_local_copy", conf.getboolean("logging", "delete_local_logs")
+            ),
+        )
+
+    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:
         super().set_context(ti)
         # Local location and remote location is needed to open and
         # upload local log file to HDFS storage.
+        if TYPE_CHECKING:
+            assert self.handler is not None
+
         full_path = self.handler.baseFilename
-        self.log_relative_path = pathlib.Path(full_path).relative_to(self.local_base).as_posix()
+        self.log_relative_path = Path(full_path).relative_to(self.local_base).as_posix()
         is_trigger_log_context = getattr(ti, "is_trigger_log_context", False)
         self.upload_on_close = is_trigger_log_context or not ti.raw
         # Clear the file first so that duplicate data is not uploaded
@@ -76,28 +131,15 @@ class HdfsTaskHandler(FileTaskHandler, LoggingMixin):
         if not self.upload_on_close:
             return
 
-        local_loc = os.path.join(self.local_base, self.log_relative_path)
-        remote_loc = os.path.join(self.remote_base, self.log_relative_path)
-        if os.path.exists(local_loc) and os.path.isfile(local_loc):
-            self.hook.load_file(local_loc, remote_loc)
-            if self.delete_local_copy:
-                shutil.rmtree(os.path.dirname(local_loc))
+        self.io.upload(self.log_relative_path)
 
         # Mark closed so we don't double write if close is called twice
         self.closed = True
 
-    def _read_remote_logs(self, ti, try_number, metadata=None):
+    def _read_remote_logs(self, ti, try_number, metadata=None) -> tuple[LogSourceInfo, LogMessages]:
         # Explicitly getting log relative path is necessary as the given
         # task instance might be different from task instance passed
         # in set_context method.
         worker_log_rel_path = self._render_filename(ti, try_number)
-
-        logs = []
-        messages = []
-        file_path = os.path.join(self.remote_base, worker_log_rel_path)
-        if self.hook.check_for_path(file_path):
-            logs.append(self.hook.read_file(file_path).decode("utf-8"))
-        else:
-            messages.append(f"No logs found on hdfs for ti={ti}")
-
+        messages, logs = self.io.read(worker_log_rel_path, ti)
         return messages, logs

--- a/providers/apache/hdfs/tests/unit/apache/hdfs/log/__init__.py
+++ b/providers/apache/hdfs/tests/unit/apache/hdfs/log/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/apache/hdfs/tests/unit/apache/hdfs/log/test_hdfs_task_handler.py
+++ b/providers/apache/hdfs/tests/unit/apache/hdfs/log/test_hdfs_task_handler.py
@@ -115,7 +115,7 @@ class TestHdfsTaskHandler:
         assert logs == []
 
     @mock.patch("shutil.rmtree")
-    def test_upload_absolute_path(self, mock_rmtree):
+    def test_upload_absolute_path(self, mock_rmtree, ti):
         base_path = Path(self.local_log_location)
         base_path.mkdir(parents=True, exist_ok=True)
         test_file = base_path / "test.log"
@@ -126,12 +126,12 @@ class TestHdfsTaskHandler:
 
         self.hdfs_task_handler.io.hook = mock.MagicMock(spec=WebHDFSHook)
         self.hdfs_task_handler.io.hook.load_file = mock.MagicMock()
-        self.hdfs_task_handler.io.upload(absolute_path)
+        self.hdfs_task_handler.io.upload(absolute_path, ti)
         self.hdfs_task_handler.io.hook.load_file.assert_called_once_with(test_file, expected_remote_loc)
         mock_rmtree.assert_called_once_with(os.path.dirname(str(test_file)))
 
     @mock.patch("shutil.rmtree")
-    def test_upload_relative_path(self, mock_rmtree):
+    def test_upload_relative_path(self, mock_rmtree, ti):
         base_path = Path(self.local_log_location)
         base_path.mkdir(parents=True, exist_ok=True)
         test_file = base_path / "relative.log"
@@ -140,7 +140,7 @@ class TestHdfsTaskHandler:
         expected_remote_loc = os.path.join(self.hdfs_task_handler.io.remote_base, relative_path)
         self.hdfs_task_handler.io.hook = mock.MagicMock(spec=WebHDFSHook)
         self.hdfs_task_handler.io.hook.load_file = mock.MagicMock()
-        self.hdfs_task_handler.io.upload(relative_path)
+        self.hdfs_task_handler.io.upload(relative_path, ti)
         self.hdfs_task_handler.io.hook.load_file.assert_called_once_with(test_file, expected_remote_loc)
         mock_rmtree.assert_called_once_with(os.path.dirname(str(test_file)))
 
@@ -148,7 +148,7 @@ class TestHdfsTaskHandler:
         self.hdfs_task_handler.set_context(ti)
         self.hdfs_task_handler.io.upload = mock.MagicMock()
         self.hdfs_task_handler.close()
-        self.hdfs_task_handler.io.upload.assert_called_once_with(self.hdfs_task_handler.log_relative_path)
+        self.hdfs_task_handler.io.upload.assert_called_once_with(self.hdfs_task_handler.log_relative_path, ti)
 
         self.hdfs_task_handler.io.upload.reset_mock()
         self.hdfs_task_handler.close()

--- a/providers/apache/hdfs/tests/unit/apache/hdfs/log/test_hdfs_task_handler.py
+++ b/providers/apache/hdfs/tests/unit/apache/hdfs/log/test_hdfs_task_handler.py
@@ -1,0 +1,196 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+from unittest.mock import PropertyMock
+
+import pytest
+
+from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
+from airflow.providers.apache.hdfs.log.hdfs_task_handler import HdfsTaskHandler
+from airflow.utils.state import TaskInstanceState
+from airflow.utils.timezone import datetime
+
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+
+pytestmark = pytest.mark.db_test
+
+DEFAULT_DATE = datetime(2020, 8, 10)
+
+
+class TestHdfsTaskHandler:
+    @pytest.fixture(autouse=True)
+    def ti(self, create_task_instance, create_log_template):
+        create_log_template("{try_number}.log")
+        ti = create_task_instance(
+            dag_id="dag_for_testing_hdfs_task_handler",
+            task_id="task_for_testing_hdfs_log_handler",
+            logical_date=DEFAULT_DATE,
+            start_date=DEFAULT_DATE,
+            dagrun_state=TaskInstanceState.RUNNING,
+            state=TaskInstanceState.RUNNING,
+        )
+        ti.try_number = 1
+        ti.hostname = "localhost"
+        ti.raw = False
+        yield ti
+        clear_db_runs()
+        clear_db_dags()
+
+    def setup_method(self):
+        self.hdfs_log_folder = "hdfs://namenode/remote/log/location"
+        self.remote_log_location = "remote/log/location/1.log"
+        self.local_log_location = str(Path(tempfile.gettempdir()) / "local/log/location")
+        self.hdfs_task_handler = HdfsTaskHandler(
+            base_log_folder=self.local_log_location,
+            hdfs_log_folder=self.hdfs_log_folder,
+            delete_local_copy=True,
+        )
+
+    def test_hook(self):
+        assert isinstance(self.hdfs_task_handler.io.hook, WebHDFSHook)
+
+    def test_set_context_raw(self, ti):
+        ti.raw = True
+        mock_open = mock.mock_open()
+        with mock.patch("airflow.providers.apache.hdfs.log.hdfs_task_handler.open", mock_open):
+            self.hdfs_task_handler.set_context(ti)
+
+        assert self.hdfs_task_handler.upload_on_close is False
+        mock_open.assert_not_called()
+
+    def test_set_context_not_raw(self, ti):
+        mock_open = mock.mock_open()
+        with mock.patch("airflow.providers.apache.hdfs.log.hdfs_task_handler.open", mock_open):
+            self.hdfs_task_handler.io.upload = mock.MagicMock()
+            self.hdfs_task_handler.set_context(ti)
+
+        assert self.hdfs_task_handler.upload_on_close is True
+        mock_open.assert_called_once_with(self.hdfs_task_handler.handler.baseFilename, "w")
+        mock_open().write.assert_not_called()
+
+    @mock.patch(
+        "airflow.providers.apache.hdfs.log.hdfs_task_handler.HdfsRemoteLogIO.hook", new_callable=PropertyMock
+    )
+    def test_hdfs_read(self, mock_hook):
+        expected_file_path = os.path.join(self.hdfs_task_handler.io.remote_base, "1.log")
+        mock_hook.return_value.check_for_path.return_value = True
+        mock_hook.return_value.read_file.return_value = b"mock_content"
+        dummy_ti = "dummy_ti"
+        messages, logs = self.hdfs_task_handler.io.read("1.log", dummy_ti)
+        mock_hook.return_value.check_for_path.assert_called_once_with(expected_file_path)
+        mock_hook.return_value.read_file.assert_called_once_with(expected_file_path)
+        assert messages == []
+        assert logs == ["mock_content"]
+
+    @mock.patch(
+        "airflow.providers.apache.hdfs.log.hdfs_task_handler.HdfsRemoteLogIO.hook", new_callable=PropertyMock
+    )
+    def test_hdfs_read_not_exists(self, mock_hook):
+        expected_file_path = os.path.join(self.hdfs_task_handler.io.remote_base, "1.log")
+        mock_hook.return_value.check_for_path.return_value = False
+        dummy_ti = "dummy_ti"
+        messages, logs = self.hdfs_task_handler.io.read("1.log", dummy_ti)
+        mock_hook.return_value.check_for_path.assert_called_once_with(expected_file_path)
+        assert messages == [f"No logs found on hdfs for ti={dummy_ti}"]
+        assert logs == []
+
+    @mock.patch("shutil.rmtree")
+    def test_upload_absolute_path(self, mock_rmtree):
+        base_path = Path(self.local_log_location)
+        base_path.mkdir(parents=True, exist_ok=True)
+        test_file = base_path / "test.log"
+        test_file.write_text("log content")
+        absolute_path = str(test_file.resolve())
+        relative_path = test_file.relative_to(base_path)
+        expected_remote_loc = os.path.join(self.hdfs_task_handler.io.remote_base, str(relative_path))
+
+        self.hdfs_task_handler.io.hook = mock.MagicMock(spec=WebHDFSHook)
+        self.hdfs_task_handler.io.hook.load_file = mock.MagicMock()
+        self.hdfs_task_handler.io.upload(absolute_path)
+        self.hdfs_task_handler.io.hook.load_file.assert_called_once_with(test_file, expected_remote_loc)
+        mock_rmtree.assert_called_once_with(os.path.dirname(str(test_file)))
+
+    @mock.patch("shutil.rmtree")
+    def test_upload_relative_path(self, mock_rmtree):
+        base_path = Path(self.local_log_location)
+        base_path.mkdir(parents=True, exist_ok=True)
+        test_file = base_path / "relative.log"
+        test_file.write_text("relative log content")
+        relative_path = "relative.log"
+        expected_remote_loc = os.path.join(self.hdfs_task_handler.io.remote_base, relative_path)
+        self.hdfs_task_handler.io.hook = mock.MagicMock(spec=WebHDFSHook)
+        self.hdfs_task_handler.io.hook.load_file = mock.MagicMock()
+        self.hdfs_task_handler.io.upload(relative_path)
+        self.hdfs_task_handler.io.hook.load_file.assert_called_once_with(test_file, expected_remote_loc)
+        mock_rmtree.assert_called_once_with(os.path.dirname(str(test_file)))
+
+    def test_close_uploads_once(self, ti):
+        self.hdfs_task_handler.set_context(ti)
+        self.hdfs_task_handler.io.upload = mock.MagicMock()
+        self.hdfs_task_handler.close()
+        self.hdfs_task_handler.io.upload.assert_called_once_with(self.hdfs_task_handler.log_relative_path)
+
+        self.hdfs_task_handler.io.upload.reset_mock()
+        self.hdfs_task_handler.close()
+        self.hdfs_task_handler.io.upload.assert_not_called()
+
+    def test_read_remote_logs_found(self, ti):
+        self.hdfs_task_handler._render_filename = lambda ti, try_number: "dummy.log"
+        self.hdfs_task_handler.io.read = mock.MagicMock(return_value=([], ["dummy log"]))
+        messages, logs = self.hdfs_task_handler._read_remote_logs(ti, try_number=1)
+        assert messages == []
+        assert logs == ["dummy log"]
+
+    def test_read_remote_logs_not_found(self, ti):
+        self.hdfs_task_handler._render_filename = lambda ti, try_number: "dummy.log"
+        self.hdfs_task_handler.io.read = mock.MagicMock(
+            return_value=([f"No logs found on hdfs for ti={ti}"], [])
+        )
+        messages, logs = self.hdfs_task_handler._read_remote_logs(ti, try_number=1)
+        assert [f"No logs found on hdfs for ti={ti}"]
+        assert logs == []
+
+    @pytest.mark.parametrize(
+        "delete_local_copy, expected_existence_of_local_copy",
+        [(True, False), (False, True)],
+    )
+    def test_close_with_delete_local_logs_conf(
+        self, ti, tmp_path_factory, delete_local_copy, expected_existence_of_local_copy
+    ):
+        local_log_dir = tmp_path_factory.mktemp("local-hdfs-log-location")
+        local_log_file = local_log_dir / "1.log"
+        local_log_file.write_text("test")
+        with conf_vars({("logging", "delete_local_logs"): str(delete_local_copy)}):
+            handler = HdfsTaskHandler(
+                base_log_folder=str(local_log_dir),
+                hdfs_log_folder=self.hdfs_log_folder,
+                delete_local_copy=delete_local_copy,
+            )
+        handler.log.info("test")
+        handler.local_base = local_log_dir
+        with mock.patch.object(handler.io, "hook") as mock_hook:
+            mock_hook.load_file.return_value = None
+            handler.set_context(ti)
+            assert handler.upload_on_close
+            handler.close()
+        assert os.path.exists(handler.handler.baseFilename) == expected_existence_of_local_copy


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Closes: #48685

Also, unit tests for hdfs logging (`HdfsTaskHandler`) were added.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
