### PR TITLE
Use dag details response for schedule since recent dagruns returns empty response for dag with no dagrun

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -24,6 +24,7 @@ import { RiArrowGoBackFill } from "react-icons/ri";
 import { useParams } from "react-router-dom";
 
 import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { TaskIcon } from "src/assets/TaskIcon";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
@@ -68,7 +69,14 @@ export const Dag = () => {
         : false,
   });
 
-  const dagWithRuns = runsData?.dags.find((recentDag) => recentDag.dag_id === dagId);
+  let dagWithRuns = runsData?.dags.find((recentDag) => recentDag.dag_id === dagId);
+
+  if (dagWithRuns === undefined && Boolean(dag)) {
+    dagWithRuns = {
+      latest_dag_runs: [],
+      ...dag,
+    } as DAGWithLatestDagRunsResponse;
+  }
 
   return (
     <ReactFlowProvider>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -71,11 +71,11 @@ export const Dag = () => {
 
   let dagWithRuns = runsData?.dags.find((recentDag) => recentDag.dag_id === dagId);
 
-  if (dagWithRuns === undefined && Boolean(dag)) {
+  if (dagWithRuns === undefined && dag !== undefined) {
     dagWithRuns = {
       latest_dag_runs: [],
       ...dag,
-    } as DAGWithLatestDagRunsResponse;
+    } satisfies DAGWithLatestDagRunsResponse;
   }
 
   return (


### PR DESCRIPTION
Closes #48191

When there are no dagruns then the recent dag runs endpoint returns empty list for the dag details which causes the `Schedule` and `Next Run` to be empty. Though the details header displays empty values the dags list page displays the value so use the dag runs endpoint if present and fallback to dag details if there is no dagrun. Similar to what is done in `useDag` implementation used in dags list page.

1. Visit a dag with schedule but no dagrun yet. E.g. http://localhost:8000/dags/tutorial
2. The schedule and next run are present in dags list page but not dag page. After PR dag page will also display the values.

https://github.com/apache/airflow/blob/ba0d3cd77331d27f39d7e69748c8a0865daf9b87/airflow-core/src/airflow/ui/src/queries/useDags.tsx#L67-L80