### PR TITLE
feat(secrets_masker): add minimum secret length and skip masking for common terms

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -892,6 +892,14 @@ logging:
       type: string
       default: ""
       example: "urllib.parse.quote"
+    min_length_masked_secret:
+      description: |
+        The minimum length of a secret to be masked in log messages.
+        Secrets shorter than this length will not be masked.
+      version_added: 3.0.0
+      type: integer
+      default: "5"
+      example: ~
     task_log_prefix_template:
       description: |
         Specify prefix pattern like mentioned below with stream handler ``TaskHandlerWithCustomFormatter``

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -170,6 +170,22 @@ class TestGetConnection(TestConnectionEndpoint):
         assert body["conn_type"] == TEST_CONN_TYPE
         assert body["extra"] == '{"password": "***"}'
 
+    @pytest.mark.enable_redact
+    def test_get_should_not_overmask_short_password_value_in_extra(self, test_client, session):
+        connection = Connection(
+            conn_id=TEST_CONN_ID, conn_type="generic", login="a", password="a", extra='{"key": "value"}'
+        )
+        session.add(connection)
+        session.commit()
+
+        response = test_client.get(f"/connections/{TEST_CONN_ID}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["connection_id"] == TEST_CONN_ID
+        assert body["conn_type"] == "generic"
+        assert body["login"] == "a"
+        assert body["extra"] == '{"key": "value"}'
+
 
 class TestGetConnections(TestConnectionEndpoint):
     @pytest.mark.parametrize(

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
@@ -485,7 +485,10 @@ class TestDbApiHook:
             )
         )
         assert self.db_hook.placeholder == "?"
-        assert not caplog.messages
+        filtered_messages = [
+            msg for msg in caplog.messages if "Skipping masking for a secret as it's too short" not in msg
+        ]
+        assert not filtered_messages
 
     def test_placeholder_with_invalid_placeholder_in_extra(self, caplog):
         self.db_hook.get_connection = mock.MagicMock(


### PR DESCRIPTION
closes: #48105

feat(secrets_masker): add minimum secret length and skip masking for common terms

Introduce a minimum secret length (MIN_SECRET_LENGTH) to avoid masking short strings that are unlikely to be sensitive. Add a list of common terms (SECRETS_TO_SKIP_MASKING) that should be excluded from masking in production.