### PR TITLE
fix: remove use of get_inlet_defs and get_outlet_defs from OpenLineage

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/extractors/manager.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/extractors/manager.py
@@ -134,7 +134,7 @@ class ExtractorManager(LoggingMixin):
                             task_metadata.inputs = inputs
                             task_metadata.outputs = outputs
                         else:
-                            self.extract_inlets_and_outlets(task_metadata, task.inlets, task.outlets)
+                            self.extract_inlets_and_outlets(task_metadata, task)
                     return task_metadata
 
             except Exception as e:
@@ -156,9 +156,7 @@ class ExtractorManager(LoggingMixin):
             task_metadata = OperatorLineage(
                 run_facets=get_unknown_source_attribute_run_facet(task=task),
             )
-            inlets = task.get_inlet_defs()
-            outlets = task.get_outlet_defs()
-            self.extract_inlets_and_outlets(task_metadata, inlets, outlets)
+            self.extract_inlets_and_outlets(task_metadata, task)
             return task_metadata
 
         return OperatorLineage()
@@ -183,19 +181,14 @@ class ExtractorManager(LoggingMixin):
             return extractor(task)
         return None
 
-    def extract_inlets_and_outlets(
-        self,
-        task_metadata: OperatorLineage,
-        inlets: list,
-        outlets: list,
-    ):
-        if inlets or outlets:
+    def extract_inlets_and_outlets(self, task_metadata: OperatorLineage, task) -> None:
+        if task.inlets or task.outlets:
             self.log.debug("Manually extracting lineage metadata from inlets and outlets")
-        for i in inlets:
+        for i in task.inlets:
             d = self.convert_to_ol_dataset(i)
             if d:
                 task_metadata.inputs.append(d)
-        for o in outlets:
+        for o in task.outlets:
             d = self.convert_to_ol_dataset(o)
             if d:
                 task_metadata.outputs.append(d)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In Task SDK for AF3, [BaseOperator](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/bases/operator.py#L1132) only has self.inlets and self.outlets, without the "helper" methods that we used in OL (`get_inlet_defs()`, `get_outlet_defs()`). These methods are added in `airflow.models.baseoperator.BaseOperator` but they are not added for BaseSensor in `airflow.sdk.bases.sensor.BaseSensorOperator` so the OL extraction breaks for sensors.

This already caused problems f.e. when running sensors on AF3:
![image](https://github.com/user-attachments/assets/cb847d14-df4a-4827-94e6-c8b697b2e7e8)
``

This PR switches the OL provider to use inlets and outlets directly so that it always works.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
