### PR TITLE
Allow bundle_name to be None API response

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/import_error.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/import_error.py
@@ -29,7 +29,7 @@ class ImportErrorResponse(BaseModel):
     id: int = Field(alias="import_error_id")
     timestamp: datetime
     filename: str
-    bundle_name: str
+    bundle_name: str | None
     stacktrace: str = Field(alias="stack_trace")
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -10074,7 +10074,9 @@ components:
           type: string
           title: Filename
         bundle_name:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Bundle Name
         stack_trace:
           type: string

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4098,7 +4098,14 @@ export const $ImportErrorResponse = {
       title: "Filename",
     },
     bundle_name: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Bundle Name",
     },
     stack_trace: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1082,7 +1082,7 @@ export type ImportErrorResponse = {
   import_error_id: number;
   timestamp: string;
   filename: string;
-  bundle_name: string;
+  bundle_name: string | null;
   stack_trace: string;
 };
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
@@ -82,12 +82,13 @@ def clear_db():
 def import_errors(session: Session = NEW_SESSION) -> list[ParseImportError]:
     _import_errors = [
         ParseImportError(
-            bundle_name=BUNDLE_NAME,
+            bundle_name=bundle,
             filename=filename,
             stacktrace=stacktrace,
             timestamp=timestamp,
         )
-        for filename, stacktrace, timestamp in zip(
+        for bundle, filename, stacktrace, timestamp in zip(
+            (BUNDLE_NAME, BUNDLE_NAME, None),
             (FILENAME1, FILENAME2, FILENAME3),
             (STACKTRACE1, STACKTRACE2, STACKTRACE3),
             (TIMESTAMP1, TIMESTAMP2, TIMESTAMP3),
@@ -146,6 +147,16 @@ class TestGetImportError:
                     "filename": FILENAME2,
                     "stack_trace": STACKTRACE2,
                     "bundle_name": BUNDLE_NAME,
+                },
+            ),
+            (
+                2,
+                200,
+                {
+                    "timestamp": from_datetime_to_zulu_without_ms(TIMESTAMP3),
+                    "filename": FILENAME3,
+                    "stack_trace": STACKTRACE3,
+                    "bundle_name": None,
                 },
             ),
             (None, 404, {}),


### PR DESCRIPTION
In database, we have bundle_name as nullable and we would like the same to be applied to the API response model.

We did the same in https://github.com/apache/airflow/pull/48779 as well.



related: [48630](https://github.com/apache/airflow/issues/48630)

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
