### PR TITLE
fix(serialized_dag): skip asset dag dep when the asset ref cannot be resolved into a valid asset

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -23,7 +23,7 @@ import logging
 import zlib
 from collections.abc import Iterable, Iterator, Sequence
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import sqlalchemy_jsonfield
 import uuid6
@@ -174,27 +174,40 @@ class _DagDependenciesResolver:
         dep_data["dependency_id"] = str(self.asset_key_to_id[unique_key])
         return DagDependency(**dep_data)
 
-    def resolve_asset_name_ref_dag_dep(self, dep_data) -> Sequence[DagDependency]:
+    def resolve_asset_ref_dag_dep(
+        self, dep_data: dict, ref_type: Literal["asset-name-ref", "asset-uri-ref"]
+    ) -> Sequence[DagDependency]:
+        if ref_type == "asset-name-ref":
+            ref_to_asset_id_name = self.asset_ref_name_to_asset_id_name
+        elif ref_type == "asset-uri-ref":
+            ref_to_asset_id_name = self.asset_ref_uri_to_asset_id_name
+        else:
+            raise ValueError(
+                f"ref_type {ref_type} is invalid. It should be either asset-name-ref or asset-uri-ref"
+            )
+
         dep_id = dep_data["dependency_id"]
-        is_source_ref = dep_data["source"] == "asest-name-ref"
+        is_source_ref = dep_data["source"] == ref_type
         dag_deps = []
-        if dep_id in self.asset_ref_name_to_asset_id_name:
-            asset_id, asset_name = self.asset_ref_name_to_asset_id_name[dep_id]
+        if dep_id in ref_to_asset_id_name:
+            # The asset ref can be resolved into a valid asset
+            asset_id, asset_name = ref_to_asset_id_name[dep_id]
             dag_deps.append(
                 # asset
                 DagDependency(
-                    source="asset" if is_source_ref else f"asset-name-ref:{dep_id}",
-                    target=f"asset-name-ref:{dep_id}" if is_source_ref else "asset",
+                    source="asset" if is_source_ref else f"{ref_type}:{dep_id}",
+                    target=f"{ref_type}:{dep_id}" if is_source_ref else "asset",
                     label=asset_name,
                     dependency_type="asset",
                     dependency_id=str(asset_id),
                 )
             )
+
             asset_ref_source = f"asset:{asset_id}" if is_source_ref else dep_data["source"]
             asset_ref_target = dep_data["target"] if is_source_ref else f"asset:{asset_id}"
         else:
-            asset_ref_source = "asset-name-ref" if is_source_ref else dep_data["source"]
-            asset_ref_target = dep_data["target"] if is_source_ref else "asset-name-ref"
+            asset_ref_source = ref_type if is_source_ref else dep_data["source"]
+            asset_ref_target = dep_data["target"] if is_source_ref else ref_type
 
         dag_deps.append(
             # asset ref
@@ -202,46 +215,17 @@ class _DagDependenciesResolver:
                 source=asset_ref_source,
                 target=asset_ref_target,
                 label=dep_id,
-                dependency_type="asset-name-ref",
+                dependency_type=ref_type,
                 dependency_id=dep_id,
             )
         )
         return dag_deps
+
+    def resolve_asset_name_ref_dag_dep(self, dep_data) -> Sequence[DagDependency]:
+        return self.resolve_asset_ref_dag_dep(dep_data=dep_data, ref_type="asset-name-ref")
 
     def resolve_asset_uri_ref_dag_dep(self, dep_data: dict) -> Sequence[DagDependency]:
-        dep_id = dep_data["dependency_id"]
-        is_source_ref = dep_data["source"] == "asest-uri-ref"
-        dag_deps = []
-        if dep_id in self.asset_ref_uri_to_asset_id_name:
-            asset_id, asset_name = self.asset_ref_uri_to_asset_id_name[dep_id]
-            dag_deps.append(
-                # asset
-                DagDependency(
-                    source="asset" if is_source_ref else f"asset-uri-ref:{dep_id}",
-                    target=f"asset-uri-ref:{dep_id}" if is_source_ref else "asset",
-                    label=asset_name,
-                    dependency_type="asset",
-                    dependency_id=str(asset_id),
-                )
-            )
-
-            asset_ref_source = f"asset:{asset_id}" if is_source_ref else dep_data["source"]
-            asset_ref_target = dep_data["target"] if is_source_ref else f"asset:{asset_id}"
-        else:
-            asset_ref_source = "asset-name-ref" if is_source_ref else dep_data["source"]
-            asset_ref_target = dep_data["target"] if is_source_ref else "asset-name-ref"
-
-        dag_deps.append(
-            # asset ref
-            DagDependency(
-                source=asset_ref_source,
-                target=asset_ref_target,
-                label=dep_id,
-                dependency_type="asset-uri-ref",
-                dependency_id=dep_id,
-            )
-        )
-        return dag_deps
+        return self.resolve_asset_ref_dag_dep(dep_data=dep_data, ref_type="asset-uri-ref")
 
     def resolve_asset_alias_dag_dep(self, dep_data: dict) -> Iterator[DagDependency]:
         dep_id = dep_data["dependency_id"]


### PR DESCRIPTION
## Why
When resolving dag dependencies, I originally assumed all asset refs would be valid. However, users might pass an invalid one, which breaks the UI

## What
Check whether there's an asset resolved before generating dag deps for asset refs. If not, we'll use that asset ref as root/node node with no asset

close: #48789

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
