### PR TITLE
Add mapping for deprecated default value for executor in core section

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -151,6 +151,12 @@ CONFIGS_CHANGES = [
     ),
     # core
     ConfigChange(
+        config=ConfigParameter("core", "executor"),
+        default_change=True,
+        new_default="LocalExecutor",
+        was_removed=False,
+    ),
+    ConfigChange(
         config=ConfigParameter("core", "check_slas"),
         suggestion="The SLA feature is removed in Airflow 3.0, to be replaced with Airflow Alerts in future",
     ),
@@ -781,9 +787,10 @@ def update_config(args) -> None:
 
     config_dict = conf.as_dict(
         display_source=True,
-        include_env=True,
-        include_cmds=True,
+        include_env=False,
+        include_cmds=False,
         include_secret=True,
+        display_sensitive=True,
     )
     for change in CONFIGS_CHANGES:
         conf_section = change.config.section.lower()
@@ -806,7 +813,6 @@ def update_config(args) -> None:
             continue
 
         current_value = value_data[0]
-
         if change.default_change:
             if str(current_value) != str(change.new_default):
                 modifications.add_default_update(conf_section, conf_option, str(change.new_default))

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -388,6 +388,9 @@ class AirflowConfigParser(ConfigParser):
                 "XX-set-after-default-config-loaded-XX",
             ),
         },
+        "core": {
+            "executor": (re.compile(re.escape("SequentialExecutor")), "LocalExecutor"),
+        },
     }
 
     _available_logging_levels = ["CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Currently, config setting `AIRFLOW__CORE__EXECUTOR=SequentialExecutor` in Airflow 3.0 causes issues without providing a proper error message. This PR does two changes:

1. When `AIRFLOW__CORE__EXECUTOR=SequentialExecutor` is set, it now throws an appropriate error and updates the default executor to `LocalExecutor` within the `validate()` method of `configuration.py`.
2. It also adds a mapping for the default value change for `AIRFLOW__CORE__EXECUTOR` in the `airflow config update` command. `airflow config upgrade` upgrades `executor=SequentialExecutor` to `executor=LocalExecutor`.

I tested it, and you can see that the yellow warning is now from configuration validation, while the rest of it is from the `airflow config update` as in the following screenshot:
<img width="1653" alt="Screenshot 2025-04-04 at 9 00 16 PM" src="https://github.com/user-attachments/assets/eb98ec18-4e32-4009-8c6b-129e1bee81b6" />

`airflow.cfg` before:
<img width="436" alt="Screenshot 2025-04-04 at 9 00 00 PM" src="https://github.com/user-attachments/assets/96371541-aa3b-4d5e-909a-34a43d04bc33" />


After running `airflow config update`, airflow.cfg is change to:
<img width="548" alt="Screenshot 2025-04-04 at 9 00 28 PM" src="https://github.com/user-attachments/assets/0dc6f277-6bf1-4649-ba17-d30e4496d297" />

closes: [#48765](https://github.com/apache/airflow/issues/48765)
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
