### PR TITLE
Handle when dag code record is missing

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
@@ -64,15 +64,16 @@ def get_dag_source(
             status.HTTP_404_NOT_FOUND,
             f"The source code of the DAG {dag_id}, version_number {version_number} was not found",
         )
-    if dag_code := dag_version.dag_code:
-        content = dag_code.source_code
-    else:
-        content = f"# Code not found for dag '{dag_id}'"
-        if version_number:
-            content += f" and version '{version_number}'"
-        content += "."
-    version_number = dag_version.version_number
-    dag_source_model = DAGSourceResponse(dag_id=dag_id, content=content, version_number=version_number)
+    if not dag_version.dag_code:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail=f"Code not found. dag_id='{dag_id}' version_number='{version_number}'",
+        )
+    dag_source_model = DAGSourceResponse(
+        dag_id=dag_id,
+        content=dag_version.dag_code.source_code,
+        version_number=dag_version.version_number,
+    )
 
     if accept == Mimetype.TEXT:
         return Response(dag_source_model.content, media_type=Mimetype.TEXT)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
@@ -64,8 +64,10 @@ def get_dag_source(
             status.HTTP_404_NOT_FOUND,
             f"The source code of the DAG {dag_id}, version_number {version_number} was not found",
         )
-
-    dag_source = dag_version.dag_code.source_code
+    if dag_code := dag_version.dag_code:
+        dag_source = dag_code.source_code
+    else:
+        dag_source = None
     version_number = dag_version.version_number
     dag_source_model = DAGSourceResponse(dag_id=dag_id, content=dag_source, version_number=version_number)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
@@ -65,11 +65,14 @@ def get_dag_source(
             f"The source code of the DAG {dag_id}, version_number {version_number} was not found",
         )
     if dag_code := dag_version.dag_code:
-        dag_source = dag_code.source_code
+        content = dag_code.source_code
     else:
-        dag_source = None
+        content = f"# Code not found for dag '{dag_id}'"
+        if version_number:
+            content += f" and version '{version_number}'"
+        content += "."
     version_number = dag_version.version_number
-    dag_source_model = DAGSourceResponse(dag_id=dag_id, content=dag_source, version_number=version_number)
+    dag_source_model = DAGSourceResponse(dag_id=dag_id, content=content, version_number=version_number)
 
     if accept == Mimetype.TEXT:
         return Response(dag_source_model.content, media_type=Mimetype.TEXT)

--- a/airflow-core/src/airflow/models/dagcode.py
+++ b/airflow-core/src/airflow/models/dagcode.py
@@ -120,7 +120,7 @@ class DagCode(Base):
                 code = f.read()
             return code
         except FileNotFoundError:
-            test_mode = conf.get("core", "unit_test_mode")
+            test_mode = conf.getboolean("core", "unit_test_mode")
             if test_mode:
                 return "source_code"
             raise

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -28,6 +28,8 @@ import {
   useDagSourceServiceGetDagSource,
   useDagVersionServiceGetDagVersion,
 } from "openapi/queries";
+import type { ApiError } from "openapi/requests/core/ApiError";
+import type { DAGSourceResponse } from "openapi/requests/types.gen";
 import DagVersionSelect from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
@@ -65,7 +67,7 @@ export const Code = () => {
     data: code,
     error: codeError,
     isLoading: isCodeLoading,
-  } = useDagSourceServiceGetDagSource({
+  } = useDagSourceServiceGetDagSource<DAGSourceResponse, ApiError | null>({
     dagId: dagId ?? "",
     versionNumber: selectedVersion,
   });
@@ -126,7 +128,8 @@ export const Code = () => {
           </Button>
         </HStack>
       </HStack>
-      <ErrorAlert error={error ?? codeError} />
+      {/* We want to show an empty state on 404 instead of an error */}
+      <ErrorAlert error={error ?? (codeError?.status === 404 ? undefined : codeError)} />
       <ProgressBar size="xs" visibility={isLoading || isCodeLoading ? "visible" : "hidden"} />
       <div
         style={{
@@ -174,6 +177,7 @@ export const Code = () => {
           style={style}
           wrapLongLines={wrap}
         >
+          {codeError?.status === 404 && !Boolean(code?.content) ? "No Code Found" : ""}
           {code?.content ?? ""}
         </SyntaxHighlighter>
       </div>

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -740,7 +740,7 @@ key3 = value3
             run_command('bash -c "exit 1"')
 
     def test_confirm_unittest_mod(self):
-        assert conf.get("core", "unit_test_mode")
+        assert conf.getboolean("core", "unit_test_mode")
 
     def test_enum_default_task_weight_rule_from_conf(self):
         test_conf = AirflowConfigParser(default_config="")


### PR DESCRIPTION
Currently if DagCode record is missing, api server throws 500 error.

We need to tolerate missing dag code record.
