### PR TITLE
Fix bug in retrieving Connections from DB

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -35,7 +35,6 @@ from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
 from airflow.sdk.execution_time.secrets_masker import mask_secret
 from airflow.secrets.cache import SecretCache
-from airflow.secrets.metastore import MetastoreBackend
 from airflow.utils.helpers import prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.module_loading import import_string
@@ -459,6 +458,26 @@ class Connection(Base, LoggingMixin):
         :param conn_id: connection id
         :return: connection
         """
+        # TODO: This is not the best way of having compat, but it's "better than erroring" for now. This still
+        # means SQLA etc is loaded, but we can't avoid that unless/until we add import shims as a big
+        # back-compat layer
+
+        # If this is set it means are in some kind of execution context (Task, Dag Parse or Triggerer perhaps)
+        # and should use the Task SDK API server path
+        if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
+            # TODO: AIP 72: Add deprecation here once we move this module to task sdk.
+            from airflow.sdk import Connection as TaskSDKConnection
+            from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+
+            try:
+                return TaskSDKConnection.get(conn_id=conn_id)
+            except AirflowRuntimeError as e:
+                if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
+                    log.debug("Unable to retrieve connection from MetastoreBackend using Task SDK")
+                    raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+                else:
+                    raise
+
         # check cache first
         # enabled only if SecretCache.init() has been called first
         try:
@@ -469,26 +488,6 @@ class Connection(Base, LoggingMixin):
 
         # iterate over backends if not in cache (or expired)
         for secrets_backend in ensure_secrets_loaded():
-            if isinstance(secrets_backend, MetastoreBackend):
-                # TODO: This is not the best way of having compat, but it's "better than erroring" for now. This still
-                # means SQLA etc is loaded, but we can't avoid that unless/until we add import shims as a big
-                # back-compat layer
-
-                # If this is set it means are in some kind of execution context (Task, Dag Parse or Triggerer perhaps)
-                # and should use the Task SDK API server path
-                if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
-                    # TODO: AIP 72: Add deprecation here once we move this module to task sdk.
-                    from airflow.sdk import Connection as TaskSDKConnection
-                    from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
-
-                    try:
-                        return TaskSDKConnection.get(conn_id=conn_id)
-                    except AirflowRuntimeError as e:
-                        if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
-                            log.debug("Unable to retrieve connection from MetastoreBackend using Task SDK")
-                            raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
-                        else:
-                            raise
             try:
                 conn = secrets_backend.get_connection(conn_id=conn_id)
                 if conn:

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -18,11 +18,15 @@
 from __future__ import annotations
 
 import re
+import sys
+from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models import Connection
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.execution_time.comms import ErrorResponse
 
 
 class TestConnection:
@@ -273,3 +277,62 @@ class TestConnection:
             "stream": True,
             "headers": {"Content-Type": "application/json", "X-Requested-By": "Airflow"},
         }
+
+    @mock.patch("airflow.sdk.Connection")
+    def test_get_connection_from_secrets_task_sdk_success(self, mock_task_sdk_connection):
+        """Test the get_connection_from_secrets method with Task SDK success path."""
+        # Mock sys.modules for task_runner
+        mock_task_runner = mock.MagicMock()
+        mock_task_runner.SUPERVISOR_COMMS = True
+
+        expected_connection = Connection(conn_id="test_conn", conn_type="test_type")
+        mock_task_sdk_connection.get.return_value = expected_connection
+
+        with mock.patch.dict(sys.modules, {"airflow.sdk.execution_time.task_runner": mock_task_runner}):
+            result = Connection.get_connection_from_secrets("test_conn")
+            assert result.conn_id == expected_connection.conn_id
+            assert result.conn_type == expected_connection.conn_type
+
+    @mock.patch("airflow.sdk.Connection")
+    def test_get_connection_from_secrets_task_sdk_not_found(self, mock_task_sdk_connection):
+        """Test the get_connection_from_secrets method with Task SDK not found path."""
+        mock_task_runner = mock.MagicMock()
+        mock_task_runner.SUPERVISOR_COMMS = True
+
+        mock_task_sdk_connection.get.side_effect = AirflowRuntimeError(
+            error=ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND)
+        )
+
+        with mock.patch.dict(sys.modules, {"airflow.sdk.execution_time.task_runner": mock_task_runner}):
+            with pytest.raises(AirflowNotFoundException):
+                Connection.get_connection_from_secrets("test_conn")
+
+    @mock.patch.dict(sys.modules, {"airflow.sdk.execution_time.task_runner": None})
+    @mock.patch("airflow.sdk.Connection")
+    @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_connection")
+    @mock.patch("airflow.secrets.metastore.MetastoreBackend.get_connection")
+    def test_get_connection_from_secrets_metastore_backend(
+        self, mock_db_backend, mock_env_backend, mock_task_sdk_connection
+    ):
+        """Test the get_connection_from_secrets should call all the backends."""
+
+        mock_env_backend.return_value = None
+        mock_db_backend.return_value = Connection(conn_id="test_conn", conn_type="test", password="pass")
+
+        # Mock TaskSDK Connection to verify it is never imported
+        mock_task_sdk_connection.get.side_effect = Exception("TaskSDKConnection should not be used")
+
+        result = Connection.get_connection_from_secrets("test_conn")
+
+        expected_connection = Connection(conn_id="test_conn", conn_type="test", password="pass")
+
+        # Verify the result is from MetastoreBackend
+        assert result.conn_id == expected_connection.conn_id
+        assert result.conn_type == expected_connection.conn_type
+
+        # Verify TaskSDKConnection was never used
+        mock_task_sdk_connection.get.assert_not_called()
+
+        # Verify the backends were called
+        mock_env_backend.assert_called_once_with(conn_id="test_conn")
+        mock_db_backend.assert_called_once_with(conn_id="test_conn")


### PR DESCRIPTION
Because of the bug we never got connections from DB. This is because we had a condition that if connection from DB was requested, get connection from Task SDK.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
