### PR TITLE
Cleanup redundant hostname lookup and migrate to core hostname function.

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -23,7 +23,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.20.2b1``
+Release: ``0.20.3b1``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -36,7 +36,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.3b1/>`_.
 
 Installation
 ------------
@@ -78,4 +78,4 @@ Dependent package                                                               
 ==============================================================================================  =======
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.3b1/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.20.3b1
+..........
+
+Fix
+~~~
+
+* ``Cleanup redundant hostname lookup and migrate to core hostname function.``
+
+
 0.20.2b1
 ..........
 

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1741121867
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.20.2b1
+  - 0.20.3b1
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.20.2b1"
+version = "0.20.3b1"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -89,8 +89,8 @@ apache-airflow-providers-fab = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.2b1/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.3b1"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.20.3b1/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.20.2b1"
+__version__ = "0.20.3b1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/edge/src/airflow/providers/edge/cli/edge_command.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import platform
 import signal
 import sys
 from dataclasses import asdict
@@ -51,6 +50,7 @@ from airflow.providers.edge.cli.dataclasses import Job, MaintenanceMarker, Worke
 from airflow.providers.edge.models.edge_worker import EdgeWorkerState, EdgeWorkerVersionException
 from airflow.providers.edge.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils import cli as cli_utils, timezone
+from airflow.utils.net import getfqdn
 from airflow.utils.platform import IS_WINDOWS
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.state import TaskInstanceState
@@ -93,13 +93,6 @@ def force_use_internal_api_on_edge_worker():
 
 
 force_use_internal_api_on_edge_worker()
-
-
-def _hostname() -> str:
-    if IS_WINDOWS:
-        return platform.uname().node
-    else:
-        return os.uname()[1]
 
 
 def _status_signal() -> signal.Signals:
@@ -158,7 +151,7 @@ def _write_pid_to_pidfile(pid_file_path: str):
 
 def _edge_hostname() -> str:
     """Get the hostname of the edge worker that should be reported by tasks."""
-    return os.environ.get("HOSTNAME", _hostname())
+    return os.environ.get("HOSTNAME", getfqdn())
 
 
 class _EdgeWorkerCli:
@@ -498,7 +491,7 @@ def worker(args):
 
     edge_worker = _EdgeWorkerCli(
         pid_file_path=_pid_file_path(args.pid),
-        hostname=args.edge_hostname or _hostname(),
+        hostname=args.edge_hostname or getfqdn(),
         queues=args.queues.split(",") if args.queues else None,
         concurrency=args.concurrency,
         job_poll_interval=conf.getint("edge", "job_poll_interval"),

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1741121867,
-        "versions": ["0.20.2b1"],
+        "versions": ["0.20.3b1"],
         "plugins": [
             {
                 "name": "edge_executor",


### PR DESCRIPTION
While and after @AutomationDev85 today fixed the hostname consistency between task reporting and edge worker I scratched my head and... realized that the hostname handling is redundant to the general utility in airflow core.

This PR removed the redundant utility and uses the utility from core-utils.