### PR TITLE
fix path of `Building documentation`

### DIFF
--- a/contributing-docs/README.rst
+++ b/contributing-docs/README.rst
@@ -81,7 +81,7 @@ To learn how to setup your environment for development and how to develop and te
 
 * `Testing <09_testing.rst>`__ describes what kind of tests we have and how to run them.
 
-* `Building documentation <../docs/README.rst>`__ describes how to build the documentation locally.
+* `Building documentation <../devel-common/src/docs/README.rst>`__ describes how to build the documentation locally.
 
 * `Working with Git <10_working_with_git.rst>`__ describes the Git branches used in Airflow,
   how to sync your fork and how to rebase your PR.


### PR DESCRIPTION
Hi, I found that there's an incorrect path in the **"Building documentation"** section of `contributing-docs/README.rst`. It redirects to a 404 page.

<img width="1729" alt="截圖 2025-04-04 下午3 18 18" src="https://github.com/user-attachments/assets/2ad8f0a9-6b45-4378-bf05-07d8caf2921b" />


This PR fixes it by updating to the correct path.
