### PR TITLE
Remove `AbstractOperator` from `airflow/models`

### DIFF
--- a/airflow-core/src/airflow/models/abstractoperator.py
+++ b/airflow-core/src/airflow/models/abstractoperator.py
@@ -18,129 +18,17 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Callable
 
 from airflow.configuration import conf
 from airflow.sdk.definitions._internal.abstractoperator import (
-    AbstractOperator as TaskSDKAbstractOperator,
+    AbstractOperator as AbstractOperator,
     NotMapped as NotMapped,  # Re-export this for compat
+    TaskStateChangeCallback as TaskStateChangeCallback,
 )
-from airflow.sdk.definitions.context import Context
-from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.trigger_rule import TriggerRule
-from airflow.utils.weight_rule import db_safe_priority
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
-    from airflow.sdk.bases.operator import BaseOperator
-    from airflow.task.priority_strategy import PriorityWeightStrategy
-    from airflow.triggers.base import StartTriggerArgs
-
-TaskStateChangeCallback = Callable[[Context], None]
 
 DEFAULT_OWNER: str = conf.get_mandatory_value("operators", "default_owner")
-DEFAULT_POOL_SLOTS: int = 1
-DEFAULT_PRIORITY_WEIGHT: int = 1
-DEFAULT_EXECUTOR: str | None = None
 DEFAULT_QUEUE: str = conf.get_mandatory_value("operators", "default_queue")
-DEFAULT_IGNORE_FIRST_DEPENDS_ON_PAST: bool = conf.getboolean(
-    "scheduler", "ignore_first_depends_on_past_by_default"
-)
-DEFAULT_WAIT_FOR_PAST_DEPENDS_BEFORE_SKIPPING: bool = False
-DEFAULT_RETRIES: int = conf.getint("core", "default_task_retries", fallback=0)
-DEFAULT_RETRY_DELAY: datetime.timedelta = datetime.timedelta(
-    seconds=conf.getint("core", "default_task_retry_delay", fallback=300)
-)
-MAX_RETRY_DELAY: int = conf.getint("core", "max_task_retry_delay", fallback=24 * 60 * 60)
 
-DEFAULT_TRIGGER_RULE: TriggerRule = TriggerRule.ALL_SUCCESS
 DEFAULT_TASK_EXECUTION_TIMEOUT: datetime.timedelta | None = conf.gettimedelta(
     "core", "default_task_execution_timeout"
 )
-
-
-class AbstractOperator(LoggingMixin, TaskSDKAbstractOperator):
-    """
-    Common implementation for operators, including unmapped and mapped.
-
-    This base class is more about sharing implementations, not defining a common
-    interface. Unfortunately it's difficult to use this as the common base class
-    for typing due to BaseOperator carrying too much historical baggage.
-
-    The union type ``from airflow.models.operator import Operator`` is easier
-    to use for typing purposes.
-
-    :meta private:
-    """
-
-    weight_rule: PriorityWeightStrategy
-
-    def unmap(self, resolve: None | dict[str, Any] | tuple[Context, Session]) -> BaseOperator:
-        """
-        Get the "normal" operator from current abstract operator.
-
-        MappedOperator uses this to unmap itself based on the map index. A non-
-        mapped operator (i.e. BaseOperator subclass) simply returns itself.
-
-        :meta private:
-        """
-        raise NotImplementedError()
-
-    def expand_start_from_trigger(self, *, context: Context, session: Session) -> bool:
-        """
-        Get the start_from_trigger value of the current abstract operator.
-
-        MappedOperator uses this to unmap start_from_trigger to decide whether to start the task
-        execution directly from triggerer.
-
-        :meta private:
-        """
-        raise NotImplementedError()
-
-    def expand_start_trigger_args(self, *, context: Context, session: Session) -> StartTriggerArgs | None:
-        """
-        Get the start_trigger_args value of the current abstract operator.
-
-        MappedOperator uses this to unmap start_trigger_args to decide how to start a task from triggerer.
-
-        :meta private:
-        """
-        raise NotImplementedError()
-
-    @property
-    def priority_weight_total(self) -> int:
-        """
-        Total priority weight for the task. It might include all upstream or downstream tasks.
-
-        Depending on the weight rule:
-
-        - WeightRule.ABSOLUTE - only own weight
-        - WeightRule.DOWNSTREAM - adds priority weight of all downstream tasks
-        - WeightRule.UPSTREAM - adds priority weight of all upstream tasks
-        """
-        # TODO: This should live in the WeightStragies themselves, not in here
-        from airflow.task.priority_strategy import (
-            _AbsolutePriorityWeightStrategy,
-            _DownstreamPriorityWeightStrategy,
-            _UpstreamPriorityWeightStrategy,
-        )
-
-        if isinstance(self.weight_rule, _AbsolutePriorityWeightStrategy):
-            return db_safe_priority(self.priority_weight)
-        elif isinstance(self.weight_rule, _DownstreamPriorityWeightStrategy):
-            upstream = False
-        elif isinstance(self.weight_rule, _UpstreamPriorityWeightStrategy):
-            upstream = True
-        else:
-            upstream = False
-        dag = self.get_dag()
-        if dag is None:
-            return db_safe_priority(self.priority_weight)
-        return db_safe_priority(
-            self.priority_weight
-            + sum(
-                dag.task_dict[task_id].priority_weight
-                for task_id in self.get_flat_relative_ids(upstream=upstream)
-            )
-        )

--- a/airflow-core/src/airflow/models/baseoperator.py
+++ b/airflow-core/src/airflow/models/baseoperator.py
@@ -39,10 +39,6 @@ from airflow.exceptions import AirflowException
 
 # Keeping this file at all is a temp thing as we migrate the repo to the task sdk as the base, but to keep
 # main working and useful for others to develop against we use the TaskSDK here but keep this file around
-from airflow.models.abstractoperator import (
-    AbstractOperator,
-    NotMapped,
-)
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.sdk.bases.operator import (
     BaseOperator as TaskSDKBaseOperator,
@@ -52,7 +48,10 @@ from airflow.sdk.bases.operator import (
     cross_downstream as cross_downstream,
     get_merged_defaults as get_merged_defaults,
 )
-from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator as TaskSDKAbstractOperator
+from airflow.sdk.definitions._internal.abstractoperator import (
+    AbstractOperator as TaskSDKAbstractOperator,
+    NotMapped,
+)
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.taskgroup import MappedTaskGroup, TaskGroup
 from airflow.serialization.enums import DagAttributeTypes
@@ -109,7 +108,7 @@ def coerce_resources(resources: dict[str, Any] | None) -> Resources | None:
     return Resources(**resources)
 
 
-class BaseOperator(TaskSDKBaseOperator, AbstractOperator):
+class BaseOperator(TaskSDKBaseOperator):
     r"""
     Abstract base class for all operators.
 

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -117,9 +117,9 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
 
-    from airflow.models.abstractoperator import TaskStateChangeCallback
     from airflow.models.dagbag import DagBag
     from airflow.models.operator import Operator
+    from airflow.sdk.definitions._internal.abstractoperator import TaskStateChangeCallback
     from airflow.serialization.serialized_objects import MaybeSerializedDAG
     from airflow.typing_compat import Literal
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -65,13 +65,13 @@ from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import Log
-from airflow.models.abstractoperator import NotMapped
 from airflow.models.backfill import Backfill
 from airflow.models.base import Base, StringID
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.models.taskinstancehistory import TaskInstanceHistory as TIH
 from airflow.models.tasklog import LogTemplate
 from airflow.models.taskmap import TaskMap
+from airflow.sdk.definitions._internal.abstractoperator import NotMapped
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING
 import attrs
 import structlog
 
-from airflow.models.abstractoperator import AbstractOperator
 from airflow.sdk.definitions.mappedoperator import MappedOperator as TaskSDKMappedOperator
 from airflow.triggers.base import StartTriggerArgs
 from airflow.utils.helpers import prevent_duplicates
@@ -47,8 +46,7 @@ log = structlog.get_logger(__name__)
     getstate_setstate=False,
     repr=False,
 )
-# TODO: Task-SDK: Multiple inheritance is a crime. There must be a better way
-class MappedOperator(TaskSDKMappedOperator, AbstractOperator):  # type: ignore[misc] # It complains about weight_rule being different
+class MappedOperator(TaskSDKMappedOperator):  # type: ignore[misc] # It complains about weight_rule being different
     """Object representing a mapped operator in a DAG."""
 
     def expand_start_from_trigger(self, *, context: Context, session: Session) -> bool:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -2294,7 +2294,7 @@ class TaskInstance(Base, LoggingMixin):
 
         For exponential backoff, retry_delay is used as base and will be converted to seconds.
         """
-        from airflow.models.abstractoperator import MAX_RETRY_DELAY
+        from airflow.sdk.definitions._internal.abstractoperator import MAX_RETRY_DELAY
 
         delay = self.task.retry_delay
         if self.task.retry_exponential_backoff:

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -127,9 +127,9 @@ class TriggerRuleDep(BaseTIDep):
         :param dep_context: The current dependency context.
         :param session: Database session.
         """
-        from airflow.models.abstractoperator import NotMapped
         from airflow.models.expandinput import NotFullyPopulated
         from airflow.models.taskinstance import TaskInstance
+        from airflow.sdk.definitions._internal.abstractoperator import NotMapped
 
         @functools.lru_cache
         def _get_expanded_ti_count() -> int:

--- a/airflow-core/tests/unit/models/test_baseoperator.py
+++ b/airflow-core/tests/unit/models/test_baseoperator.py
@@ -64,7 +64,7 @@ class ClassWithCustomAttributes:
 
 class TestBaseOperator:
     def test_trigger_rule_validation(self):
-        from airflow.models.abstractoperator import DEFAULT_TRIGGER_RULE
+        from airflow.sdk.definitions._internal.abstractoperator import DEFAULT_TRIGGER_RULE
 
         fail_fast_dag = DAG(
             dag_id="test_dag_trigger_rule_validation",

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -18,11 +18,9 @@
 from __future__ import annotations
 
 import datetime
-import itertools
 import logging
 import os
 import pickle
-import re
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -87,7 +85,6 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.timezone import datetime as datetime_tz
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
-from airflow.utils.weight_rule import WeightRule
 
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import (
@@ -219,90 +216,6 @@ class TestDag:
         """
         dag = DAG("DAG", schedule=None, default_args={"start_date": None})
         assert dag.timezone == settings.TIMEZONE
-
-    def test_dag_task_priority_weight_total(self):
-        width = 5
-        depth = 5
-        weight = 5
-        pattern = re.compile("stage(\\d*).(\\d*)")
-        # Fully connected parallel tasks. i.e. every task at each parallel
-        # stage is dependent on every task in the previous stage.
-        # Default weight should be calculated using downstream descendants
-        with DAG("dag", schedule=None, start_date=DEFAULT_DATE, default_args={"owner": "owner1"}) as dag:
-            pipeline = [
-                [EmptyOperator(task_id=f"stage{i}.{j}", priority_weight=weight) for j in range(width)]
-                for i in range(depth)
-            ]
-            for upstream, downstream in zip(pipeline, pipeline[1:]):
-                for up_task, down_task in itertools.product(upstream, downstream):
-                    down_task.set_upstream(up_task)
-
-            for task in dag.task_dict.values():
-                match = pattern.match(task.task_id)
-                task_depth = int(match.group(1))
-                # the sum of each stages after this task + itself
-                correct_weight = ((depth - (task_depth + 1)) * width + 1) * weight
-
-                calculated_weight = task.priority_weight_total
-                assert calculated_weight == correct_weight
-
-    def test_dag_task_priority_weight_total_using_upstream(self):
-        # Same test as above except use 'upstream' for weight calculation
-        weight = 3
-        width = 5
-        depth = 5
-        pattern = re.compile("stage(\\d*).(\\d*)")
-        with DAG("dag", schedule=None, start_date=DEFAULT_DATE, default_args={"owner": "owner1"}) as dag:
-            pipeline = [
-                [
-                    EmptyOperator(
-                        task_id=f"stage{i}.{j}",
-                        priority_weight=weight,
-                        weight_rule=WeightRule.UPSTREAM,
-                    )
-                    for j in range(width)
-                ]
-                for i in range(depth)
-            ]
-            for upstream, downstream in zip(pipeline, pipeline[1:]):
-                for up_task, down_task in itertools.product(upstream, downstream):
-                    down_task.set_upstream(up_task)
-
-            for task in dag.task_dict.values():
-                match = pattern.match(task.task_id)
-                task_depth = int(match.group(1))
-                # the sum of each stages after this task + itself
-                correct_weight = (task_depth * width + 1) * weight
-
-                calculated_weight = task.priority_weight_total
-                assert calculated_weight == correct_weight
-
-    def test_dag_task_priority_weight_total_using_absolute(self):
-        # Same test as above except use 'absolute' for weight calculation
-        weight = 10
-        width = 5
-        depth = 5
-        with DAG("dag", schedule=None, start_date=DEFAULT_DATE, default_args={"owner": "owner1"}) as dag:
-            pipeline = [
-                [
-                    EmptyOperator(
-                        task_id=f"stage{i}.{j}",
-                        priority_weight=weight,
-                        weight_rule=WeightRule.ABSOLUTE,
-                    )
-                    for j in range(width)
-                ]
-                for i in range(depth)
-            ]
-            for upstream, downstream in zip(pipeline, pipeline[1:]):
-                for up_task, down_task in itertools.product(upstream, downstream):
-                    down_task.set_upstream(up_task)
-
-            for task in dag.task_dict.values():
-                # the sum of each stages after this task + itself
-                correct_weight = weight
-                calculated_weight = task.priority_weight_total
-                assert calculated_weight == correct_weight
 
     @pytest.mark.parametrize(
         "cls, expected",
@@ -1497,7 +1410,7 @@ class TestDag:
         non_fail_fast_dag.add_task(task_with_non_default_trigger_rule)
 
         # a fail stop dag should allow default trigger rule
-        from airflow.models.abstractoperator import DEFAULT_TRIGGER_RULE
+        from airflow.sdk.definitions._internal.abstractoperator import DEFAULT_TRIGGER_RULE
 
         fail_fast_dag = DAG(
             dag_id="test_dag_add_task_checks_trigger_rule",

--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
 
 
-@patch("airflow.models.abstractoperator.AbstractOperator.render_template")
+@patch("airflow.sdk.definitions._internal.abstractoperator.AbstractOperator.render_template")
 def test_task_mapping_with_dag_and_list_of_pandas_dataframe(mock_render_template, caplog):
     class UnrenderableClass:
         def __bool__(self):

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -4311,7 +4311,7 @@ def test_refresh_from_task(pool_override, queue_by_policy, monkeypatch):
         assert ti.pool == task.pool
 
     assert ti.pool_slots == task.pool_slots
-    assert ti.priority_weight == task.priority_weight_total
+    assert ti.priority_weight == task.weight_rule.get_weight(ti)
     assert ti.run_as_user == task.run_as_user
     assert ti.max_tries == task.retries
     assert ti.executor_config == task.executor_config

--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -25,7 +25,6 @@ from collections.abc import (
     Collection,
     Iterable,
     Iterator,
-    Mapping,
 )
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -34,6 +33,7 @@ import methodtools
 from airflow.sdk.definitions._internal.mixins import DependencyMixin
 from airflow.sdk.definitions._internal.node import DAGNode
 from airflow.sdk.definitions._internal.templater import Templater
+from airflow.sdk.definitions.context import Context
 from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
@@ -43,13 +43,12 @@ if TYPE_CHECKING:
 
     from airflow.sdk.bases.operator import BaseOperator
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
-    from airflow.sdk.definitions.context import Context
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.mappedoperator import MappedOperator
     from airflow.sdk.definitions.taskgroup import MappedTaskGroup
     from airflow.sdk.types import Operator
 
-TaskStateChangeCallback = Callable[[Mapping[str, Any]], None]
+TaskStateChangeCallback = Callable[[Context], None]
 
 DEFAULT_OWNER: str = "airflow"
 DEFAULT_POOL_SLOTS: int = 1

--- a/task-sdk/src/airflow/sdk/definitions/_internal/node.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/node.py
@@ -24,12 +24,9 @@ from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-import methodtools
-
 from airflow.sdk.definitions._internal.mixins import DependencyMixin
 
 if TYPE_CHECKING:
-    from airflow.sdk.definitions._internal.types import Logger
     from airflow.sdk.definitions.abstractoperator import Operator
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.edges import EdgeModifier
@@ -82,6 +79,10 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
     upstream_task_ids: set[str]
     downstream_task_ids: set[str]
 
+    _log_config_logger_name: str | None = None
+    _logger_name: str | None = None
+    _cached_logger: logging.Logger | None = None
+
     def __init__(self):
         self.upstream_task_ids = set()
         self.downstream_task_ids = set()
@@ -110,12 +111,34 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
             return self.dag.dag_id
         return "_in_memory_dag_"
 
-    @methodtools.lru_cache()  # type: ignore[misc]
     @property
-    def log(self) -> Logger:
+    def log(self) -> logging.Logger:
+        """
+        Get a logger for this node.
+
+        The logger name is determined by:
+        1. Using _logger_name if provided
+        2. Otherwise, using the class's module and qualified name
+        3. Prefixing with _log_config_logger_name if set
+        """
+        if self._cached_logger is not None:
+            return self._cached_logger
+
         typ = type(self)
-        name = f"{typ.__module__}.{typ.__qualname__}"
-        return logging.getLogger(name)
+
+        logger_name: str = (
+            self._logger_name if self._logger_name is not None else f"{typ.__module__}.{typ.__qualname__}"
+        )
+
+        if self._log_config_logger_name:
+            logger_name = (
+                f"{self._log_config_logger_name}.{logger_name}"
+                if logger_name
+                else self._log_config_logger_name
+            )
+
+        self._cached_logger = logging.getLogger(logger_name)
+        return self._cached_logger
 
     @property
     @abstractmethod

--- a/task-sdk/src/airflow/sdk/definitions/_internal/types.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/types.py
@@ -62,14 +62,7 @@ SET_DURING_EXECUTION = SetDuringExecution()
 
 
 if TYPE_CHECKING:
-    import logging
-
     from airflow.sdk.definitions._internal.node import DAGNode
-
-    Logger = logging.Logger
-else:
-
-    class Logger: ...
 
 
 def validate_instance_args(instance: DAGNode, expected_arg_types: dict[str, Any]) -> None:

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Union
 import attrs
 import methodtools
 
-from airflow.models.abstractoperator import NotMapped
 from airflow.sdk.definitions._internal.abstractoperator import (
     DEFAULT_EXECUTOR,
     DEFAULT_IGNORE_FIRST_DEPENDS_ON_PAST,
@@ -41,6 +40,7 @@ from airflow.sdk.definitions._internal.abstractoperator import (
     DEFAULT_WAIT_FOR_PAST_DEPENDS_BEFORE_SKIPPING,
     DEFAULT_WEIGHT_RULE,
     AbstractOperator,
+    NotMapped,
 )
 from airflow.sdk.definitions._internal.expandinput import (
     DictOfListsExpandInput,

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -603,7 +603,7 @@ class MappedTaskGroup(TaskGroup):
         self._expand_input = expand_input
 
     def __iter__(self):
-        from airflow.models.abstractoperator import AbstractOperator
+        from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
 
         for child in self.children.values():
             if isinstance(child, AbstractOperator) and child.trigger_rule == TriggerRule.ALWAYS:


### PR DESCRIPTION
This is not needed now that Task SDK's `AbstractOperator` is used everywhere

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
