### PR TITLE
Add ability to configure PERMANENT_SESSION_LIFETIME in fab for session logout.

### DIFF
--- a/airflow-core/newsfragments/41550.significant.rst
+++ b/airflow-core/newsfragments/41550.significant.rst
@@ -1,4 +1,4 @@
-Removed deprecated ``session_lifetime_days`` and ``force_log_out_after`` configuration parameters from ``webserver`` section. Please use ``session_lifetime_minutes``.
+Removed deprecated ``session_lifetime_days`` and ``force_log_out_after`` configuration parameters from ``webserver`` section. Please use ``session_lifetime_minutes`` from ``fab`` section.
 
 Removed deprecated ``policy`` parameter from ``airflow_local_settings``. Please use ``task_policy``.
 
@@ -17,6 +17,6 @@ Removed deprecated ``policy`` parameter from ``airflow_local_settings``. Please 
 
   * ``airflow config lint``
 
-    * [x] ``webserver.session_lifetime_days`` → ``webserver.session_lifetime_minutes``
-    * [x] ``webserver.force_log_out_after`` → ``webserver.session_lifetime_minutes``
+    * [x] ``webserver.session_lifetime_days`` → ``fab.session_lifetime_minutes``
+    * [x] ``webserver.force_log_out_after`` → ``fab.session_lifetime_minutes``
     * [x] ``policy`` → ``task_policy``

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -329,11 +329,11 @@ CONFIGS_CHANGES = [
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "session_lifetime_days"),
-        renamed_to=ConfigParameter("webserver", "session_lifetime_minutes"),
+        renamed_to=ConfigParameter("fab", "session_lifetime_minutes"),
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "force_log_out_after"),
-        renamed_to=ConfigParameter("webserver", "session_lifetime_minutes"),
+        renamed_to=ConfigParameter("fab", "session_lifetime_minutes"),
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_host"),

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -336,6 +336,10 @@ CONFIGS_CHANGES = [
         renamed_to=ConfigParameter("fab", "session_lifetime_minutes"),
     ),
     ConfigChange(
+        config=ConfigParameter("webserver", "session_lifetime_minutes"),
+        renamed_to=ConfigParameter("fab", "session_lifetime_minutes"),
+    ),
+    ConfigChange(
         config=ConfigParameter("webserver", "web_server_host"),
         renamed_to=ConfigParameter("api", "host"),
     ),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1862,14 +1862,6 @@ webserver:
       type: boolean
       example: ~
       default: "True"
-    session_lifetime_minutes:
-      description: |
-        The UI cookie lifetime in minutes. User will be logged out from UI after
-        ``[webserver] session_lifetime_minutes`` of non-activity
-      version_added: 1.10.13
-      type: integer
-      example: ~
-      default: "43200"
     instance_name:
       description: |
         Sets a custom page title for the DAGs overview page and site title for all pages

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -585,19 +585,6 @@ def prepare_syspath_for_dags_folder():
         sys.path.append(DAGS_FOLDER)
 
 
-def get_session_lifetime_config():
-    """Get session timeout configs and handle outdated configs gracefully."""
-    session_lifetime_minutes = conf.get("webserver", "session_lifetime_minutes", fallback=None)
-    minutes_per_day = 24 * 60
-    if not session_lifetime_minutes:
-        session_lifetime_days = 30
-        session_lifetime_minutes = minutes_per_day * session_lifetime_days
-
-    log.debug("User session lifetime is set to %s minutes.", session_lifetime_minutes)
-
-    return int(session_lifetime_minutes)
-
-
 def import_local_settings():
     """Import airflow_local_settings.py files to allow overriding any configs in settings.py file."""
     try:

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -28,8 +28,6 @@ import pytest
 
 from airflow.exceptions import AirflowClusterPolicyViolation, AirflowConfigException
 
-from tests_common.test_utils.config import conf_vars
-
 SETTINGS_FILE_POLICY = """
 def test_policy(task_instance):
     task_instance.run_as_user = "myself"
@@ -207,30 +205,6 @@ class TestLocalSettings:
             task_instance.owner = "airflow"
             with pytest.raises(AirflowClusterPolicyViolation):
                 settings.task_must_have_owners(task_instance)
-
-
-class TestUpdatedConfigNames:
-    @conf_vars({("webserver", "session_lifetime_minutes"): "43200"})
-    def test_config_val_is_default(self):
-        from airflow import settings
-
-        session_lifetime_config = settings.get_session_lifetime_config()
-        assert session_lifetime_config == 43200
-
-    @conf_vars({("webserver", "session_lifetime_minutes"): "43201"})
-    def test_config_val_is_not_default(self):
-        from airflow import settings
-
-        session_lifetime_config = settings.get_session_lifetime_config()
-        assert session_lifetime_config == 43201
-
-    @conf_vars({("webserver", "session_lifetime_days"): ""})
-    def test_uses_updated_session_timeout_config_by_default(self):
-        from airflow import settings
-
-        session_lifetime_config = settings.get_session_lifetime_config()
-        default_timeout_minutes = 30 * 24 * 60
-        assert session_lifetime_config == default_timeout_minutes
 
 
 _local_db_path_error = pytest.raises(AirflowConfigException, match=r"Cannot use relative path:")

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -83,6 +83,14 @@ config:
         type: string
         example: ~
         default: "airflow.providers.fab.auth_manager.api.auth.backend.session"
+      session_lifetime_minutes:
+        description: |
+          The UI cookie lifetime in minutes. User will be logged out from UI after
+          ``[fab] session_lifetime_minutes`` of non-activity
+        version_added: 2.0.0
+        type: integer
+        example: ~
+        default: "43200"
 
 auth-managers:
   - airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -58,6 +58,13 @@ def get_provider_info():
                         "example": None,
                         "default": "airflow.providers.fab.auth_manager.api.auth.backend.session",
                     },
+                    "session_lifetime_minutes": {
+                        "description": "The UI cookie lifetime in minutes. User will be logged out from UI after\n``[fab] session_lifetime_minutes`` of non-activity\n",
+                        "version_added": "2.0.0",
+                        "type": "integer",
+                        "example": None,
+                        "default": "43200",
+                    },
                 },
             }
         },

--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import timedelta
 from os.path import isabs
 
 from flask import Flask
@@ -56,6 +57,8 @@ def create_app(enable_plugins: bool):
     flask_app.secret_key = conf.get("webserver", "SECRET_KEY")
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
+
     webserver_config = conf.get_mandatory_value("webserver", "config_file")
     # Enable customizations in webserver_config.py to be applied via Flask.current_app.
     with flask_app.app_context():

--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -41,6 +41,7 @@ from airflow.providers.fab.www.extensions.init_views import (
     init_error_handlers,
     init_plugins,
 )
+from airflow.providers.fab.www.utils import get_session_lifetime_config
 
 app: Flask | None = None
 
@@ -57,7 +58,7 @@ def create_app(enable_plugins: bool):
     flask_app.secret_key = conf.get("webserver", "SECRET_KEY")
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
+    flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=get_session_lifetime_config())
 
     webserver_config = conf.get_mandatory_value("webserver", "config_file")
     # Enable customizations in webserver_config.py to be applied via Flask.current_app.

--- a/providers/fab/tests/unit/fab/www/test_auth.py
+++ b/providers/fab/tests/unit/fab/www/test_auth.py
@@ -246,27 +246,3 @@ class TestHasAccessDagEntities:
 
         mock_call.assert_not_called()
         assert result.headers["Location"] == "login_url"
-
-
-class TestUpdatedConfigNames:
-    @conf_vars({("fab", "session_lifetime_minutes"): "43200"})
-    def test_config_val_is_default(self):
-        from airflow.providers.fab.www.utils import get_session_lifetime_config
-
-        session_lifetime_config = get_session_lifetime_config()
-        assert session_lifetime_config == 43200
-
-    @conf_vars({("fab", "session_lifetime_minutes"): "43201"})
-    def test_config_val_is_not_default(self):
-        from airflow.providers.fab.www.utils import get_session_lifetime_config
-
-        session_lifetime_config = get_session_lifetime_config()
-        assert session_lifetime_config == 43201
-
-    @conf_vars({("fab", "session_lifetime_days"): ""})
-    def test_uses_updated_session_timeout_config_by_default(self):
-        from airflow.providers.fab.www.utils import get_session_lifetime_config
-
-        session_lifetime_config = get_session_lifetime_config()
-        default_timeout_minutes = 30 * 24 * 60
-        assert session_lifetime_config == default_timeout_minutes

--- a/providers/fab/tests/unit/fab/www/test_auth.py
+++ b/providers/fab/tests/unit/fab/www/test_auth.py
@@ -246,3 +246,27 @@ class TestHasAccessDagEntities:
 
         mock_call.assert_not_called()
         assert result.headers["Location"] == "login_url"
+
+
+class TestUpdatedConfigNames:
+    @conf_vars({("fab", "session_lifetime_minutes"): "43200"})
+    def test_config_val_is_default(self):
+        from airflow.providers.fab.www.utils import get_session_lifetime_config
+
+        session_lifetime_config = get_session_lifetime_config()
+        assert session_lifetime_config == 43200
+
+    @conf_vars({("fab", "session_lifetime_minutes"): "43201"})
+    def test_config_val_is_not_default(self):
+        from airflow.providers.fab.www.utils import get_session_lifetime_config
+
+        session_lifetime_config = get_session_lifetime_config()
+        assert session_lifetime_config == 43201
+
+    @conf_vars({("fab", "session_lifetime_days"): ""})
+    def test_uses_updated_session_timeout_config_by_default(self):
+        from airflow.providers.fab.www.utils import get_session_lifetime_config
+
+        session_lifetime_config = get_session_lifetime_config()
+        default_timeout_minutes = 30 * 24 * 60
+        assert session_lifetime_config == default_timeout_minutes

--- a/providers/fab/tests/unit/fab/www/test_utils.py
+++ b/providers/fab/tests/unit/fab/www/test_utils.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow.providers.fab.www.utils import get_session_lifetime_config
+
+from tests_common.test_utils.config import conf_vars
+
+
+class TestUpdatedConfigNames:
+    @conf_vars({("fab", "session_lifetime_minutes"): "43200"})
+    def test_config_val_is_default(self):
+        session_lifetime_config = get_session_lifetime_config()
+        assert session_lifetime_config == 43200
+
+    @conf_vars({("fab", "session_lifetime_minutes"): "43201"})
+    def test_config_val_is_not_default(self):
+        session_lifetime_config = get_session_lifetime_config()
+        assert session_lifetime_config == 43201
+
+    @conf_vars({("fab", "session_lifetime_days"): ""})
+    def test_uses_updated_session_timeout_config_by_default(self):
+        session_lifetime_config = get_session_lifetime_config()
+        default_timeout_minutes = 30 * 24 * 60
+        assert session_lifetime_config == default_timeout_minutes


### PR DESCRIPTION
When a user logs in through FAB the session cookie is set and once the jwt token for the UI expires the UI redirects to the login page. The login page picks up the session cookie to login back the user and redirect them to home page. The value for `PERMANENT_SESSION_LIFETIME` in flask is 31 days by default. This causes a logged in user to be active for 31 days despite the jwt token expiration time. This used to be configurable in Airflow 2 in old webserver code using Flask and this PR adds back the option to configure it through webserver.session_lifetime_minutes in airflow configuration with default value of 43200 minutes ( 30 days).

Another consideration is do we need this setting at all since Airflow 2 used FAB and session but Airflow 3 uses JWT token so JWT token expiry should effectively logout the user and user should not be auto logged in which means this should be set to zero.

https://flask.palletsprojects.com/en/stable/config/#PERMANENT_SESSION_LIFETIME

Related #48787