### PR TITLE
Mask sensitive values from conn & variables in task runner & DAG parsing

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -476,7 +476,7 @@ class Connection(Base, LoggingMixin):
                         mask_secret(conn.password)
                     if conn.extra:
                         mask_secret(conn.extra)
-                return TaskSDKConnection.get(conn_id=conn_id)
+                return conn
             except AirflowRuntimeError as e:
                 if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
                     log.debug("Unable to retrieve connection from MetastoreBackend using Task SDK")

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -470,6 +470,12 @@ class Connection(Base, LoggingMixin):
             from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 
             try:
+                conn = TaskSDKConnection.get(conn_id=conn_id)
+                if isinstance(conn, TaskSDKConnection):
+                    if conn.password:
+                        mask_secret(conn.password)
+                    if conn.extra:
+                        mask_secret(conn.extra)
                 return TaskSDKConnection.get(conn_id=conn_id)
             except AirflowRuntimeError as e:
                 if e.error.error == ErrorType.CONNECTION_NOT_FOUND:

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -154,11 +154,15 @@ class Variable(Base, LoggingMixin):
             from airflow.sdk import Variable as TaskSDKVariable
             from airflow.sdk.definitions._internal.types import NOTSET
 
-            return TaskSDKVariable.get(
+            var_val = TaskSDKVariable.get(
                 key,
                 default=NOTSET if default_var is cls.__NO_DEFAULT_SENTINEL else default_var,
                 deserialize_json=deserialize_json,
             )
+            if isinstance(var_val, str):
+                mask_secret(var_val, key)
+
+            return var_val
 
         var_val = Variable.get_variable_from_secrets(key=key)
         if var_val is None:

--- a/airflow-core/tests/unit/hooks/test_base.py
+++ b/airflow-core/tests/unit/hooks/test_base.py
@@ -67,6 +67,8 @@ class TestBaseHook:
         hook = BaseHook(logger_name="")
         hook.get_connection(conn_id="test_conn")
 
+        print(mock_supervisor_comms.send_request.call_args_list)
+
         mock_supervisor_comms.send_request.assert_called_once_with(
             msg=GetConnection(conn_id="test_conn"), log=mock.ANY
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


## Problem
When we retrieve connection / variables in the task runner or execution context (dag parsing too), we arent masking the details that need to be masked. This is leading to an issue where if we print the sensitive details in stdout, not using logger, it doesnt mask the values in logs.


## Visual of the issue

Define a connection using:
```
airflow connections add 'example-conn' \
    --conn-type 'postgres' \
    --conn-login 'airflow_user' \
    --conn-password 'random-password' \
    --conn-host 'localhost' \
    --conn-port '5432' \
    --conn-schema 'mydb' \
    --conn-extra '{"api_key": "this-is-an-api-key"}'

```
![image (30)](https://github.com/user-attachments/assets/58d046f0-72cf-417e-a07c-14745af58e94)





DAG:
```

from airflow import DAG

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Connection


def print_sensitive():
    c = Connection.get("example-conn")
    print("Retrieved connection. Its password is:", c.password)
    print("Retrieved connection. Its extra is:", c.extra)


with DAG(
    dag_id="print_sensitive_data",
    schedule=None,
) as dag:

    print_sensitive_task = PythonOperator(
        task_id="print_sensitive_task",
        python_callable=print_sensitive,
    )
```
![image (31)](https://github.com/user-attachments/assets/9ff8780b-608e-4081-b584-902aa4b49b01)


Or even use a dag that does the same at top level of the dag (not within task):

```
from airflow import DAG

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Connection

c = Connection.get("example-conn")

def print_sensitive():
    print("Retrieved connection from toplevel. Its password is:", c.password)
    print("Retrieved connection from toplevel. Its extra is:", c.extra)


with DAG(
    dag_id="print_sensitive_data",
    schedule=None,
) as dag:

    print_sensitive_task = PythonOperator(
        task_id="print_sensitive_task",
        python_callable=print_sensitive,
    )
```
![image (32)](https://github.com/user-attachments/assets/f935b749-7796-448a-8e76-ce611e8c7c81)


**The fix is to mask those details as and when we retrieve them too so that they are masked.** 


After fix, same DAG code:
![image (33)](https://github.com/user-attachments/assets/7cbb69cc-842e-443c-8367-918637e3aac3)
![image (34)](https://github.com/user-attachments/assets/b4f8d0c9-da4f-45ec-bc36-1a244ec7c411)





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
