### PR TITLE
Introduce separate channel for trigger workloads

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -172,8 +172,10 @@ def supervisor_builder(mocker, session):
             job=job,
             pid=process.pid,
             stdin=mocker.Mock(),
+            trigger_stdin=mocker.Mock(),
             process=process,
             requests_fd=-1,
+            trigger_requests_fd=-1,
             capacity=10,
         )
         # Mock the selector
@@ -447,7 +449,7 @@ def test_trigger_create_race_condition_18392(session, supervisor_builder, spy_ag
         return True
 
     supervisor.run()
-    assert supervisor.stdin.write.call_count == 1
+    assert supervisor.trigger_stdin.write.call_count == 1
 
 
 @pytest.mark.execution_timeout(5)

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -385,6 +385,13 @@ class WatchedSubprocess:
     _requests_fd: int
     """File descriptor for request handling."""
 
+    """"
+    It require special case to handle the workloads and api calls to api-server in Triggerer, due to mixing up messages
+    a separate channel is used to send the workloads from parent process to child process the child process.
+    connect_stdin will use this channel to read the workloads in read_workload method.
+    trigger_stdin: trigger parent process uses this to send the workloads to child process.
+    _trigger_requests_fd: trigger child process uses this to read the workloads.
+    """
     _trigger_requests_fd: int | None = None
     trigger_stdin: BinaryIO | None = None
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -540,6 +540,8 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
     input: TextIO
 
+    trigger_input: TextIO = attrs.field(init=False, default=None)
+
     request_socket: FileIO = attrs.field(init=False, default=None)
 
     # We could be "clever" here and set the default to this based type parameters and a custom

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -540,6 +540,11 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
     input: TextIO
 
+    """"
+    It require special case to handle the workloads and api calls to api-server, due to mixing up messages
+    a separate channel is used to send the workloads from parent process to child process the child process.
+    connect_stdin will use this channel to read the workloads in read_workload method.
+    """
     trigger_input: TextIO = attrs.field(init=False, default=None)
 
     request_socket: FileIO = attrs.field(init=False, default=None)


### PR DESCRIPTION
 closes: #48820

realted: #48819 #48747

### Why
Introducing a separate channel for trigger workloads.
Currently when multiple tasks are entering into trigger, the messages are mixing up with Trigger Workloads. this is due to the read side when we are trying to read same sys.stdin, causing this problem IMHO. When this mixing happens we are loosing the Trigger Workloads as its read in different place.

### What
Created two new sockets to handle Trigger Workloads, when main process writes with `trigger_stdin` and in child process this Workloads will be reading from the `trigger_requests_fd`

Have observed this behaviour while testing DagStateTrigger/WorkflowTrigger

![image](https://github.com/user-attachments/assets/dfb3945f-1c3a-49bc-9dcb-0f16cd2d7ec4)

Connections are failing to retrieve in Trigger, when multiple tasks running in tirgger.

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/5cb5c209-003f-4f9a-a6ad-d582d851eb70" />


### After 

Retrieved connections properly for all the task and their own connection id, have created a separate connection for each task to verify whether messages are mixing up or not.  Looking good.


<img width="1700" alt="image" src="https://github.com/user-attachments/assets/056ed197-c87b-402f-82cf-48cf8f46dc52" />

<img width="1719" alt="image" src="https://github.com/user-attachments/assets/57fad6f4-8cf9-4ab8-a413-3cfd7db88c80" />


<img width="1740" alt="image" src="https://github.com/user-attachments/assets/abb611c6-4c85-49fa-8a54-f18650fcc408" />



- [x] Add tests

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
