### PR TITLE
fix(ui): fix broken input field string

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
@@ -48,7 +48,7 @@ export const FieldString = ({ name }: FlexibleFormElementProps) => {
         }}
         placeholder={param.schema.examples ? "Start typing to see options." : undefined}
         size="sm"
-        value={JSON.stringify(param.value ?? "")}
+        value={(param.value ?? "") as string}
       />
       {param.schema.examples ? (
         <datalist id={`list_${name}`}>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: [#ISSUE](https://github.com/apache/airflow/issues/48850)
related: [#ISSUE](https://github.com/apache/airflow/issues/48863)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/48863 https://github.com/apache/airflow/issues/48850

The issue was introduced by commit https://github.com/apache/airflow/commit/d4ab484325504ec0ccd144c9a389a19500483475
CMIIW @bbovenzi,  from what I understand, your change was made to explicitly cast using JSON.stringify to address an ESLint warning. `eslint-disable-next-line @typescript-eslint/no-base-to-string`.

Stringifying  using JSON.stringify results in over-escaping. This PR proposes the usage of `as string` as a type assertion to resolve the warning. Please let me know if there's a specific context that I missed, happy to adjust if needed. Thanks!

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
