### PR TITLE
Change Trigger<->Supervisor communication to avoid stalls

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -330,7 +330,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         proc = super().start(id=job.id, job=job, target=cls.run_in_process, logger=logger, **kwargs)
 
         msg = messages.StartTriggerer(requests_fd=proc._requests_fd)
-        proc.stdin.write(msg.model_dump_json().encode("utf-8") + b"\n")
+        proc.stdin.write(msg.model_dump_json().encode() + b"\n")
         return proc
 
     @functools.cached_property
@@ -909,8 +909,6 @@ class TriggerRunner:
         async with SUPERVISOR_COMMS.lock:
             # Tell the monitor that we've finished triggers so it can update things
             self.requests_sock.write(msg.model_dump_json(exclude_none=True).encode() + b"\n")
-            # async for line in stdin:
-            #     msg = self.decoder.validate_json(line)
             line = await self.response_sock.readline()
 
         if line == b"":  # EoF received!

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -184,14 +184,12 @@ class messages:
         requests_fd: int
         type: Literal["StartTriggerer"] = "StartTriggerer"
 
-    class CancelTriggers(BaseModel):
-        """Request to cancel running triggers."""
-
-        ids: Iterable[int]
-        type: Literal["CancelTriggersMessage"] = "CancelTriggersMessage"
-
     class TriggerStateChanges(BaseModel):
-        """Report state change about triggers back to the TriggerRunnerSupervisor."""
+        """
+        Report state change about triggers back to the TriggerRunnerSupervisor.
+
+        The supervisor will respond with a TriggerStateSync message.
+        """
 
         type: Literal["TriggerStateChanges"] = "TriggerStateChanges"
         events: Annotated[
@@ -204,12 +202,17 @@ class messages:
         failures: list[tuple[int, list[str] | None]] | None = None
         finished: list[int] | None = None
 
+    class TriggerStateSync(BaseModel):
+        type: Literal["TriggerStateSync"] = "TriggerStateSync"
+
+        to_create: list[workloads.RunTrigger]
+        to_cancel: set[int]
+
 
 ToTriggerRunner = Annotated[
     Union[
-        workloads.RunTrigger,
-        messages.CancelTriggers,
         messages.StartTriggerer,
+        messages.TriggerStateSync,
         ConnectionResult,
         VariableResult,
         XComResult,
@@ -236,9 +239,9 @@ The types of messages that the async Trigger Runner can send back up to the supe
 class TriggerLoggingFactory:
     log_path: str
 
-    ti: RuntimeTI
+    ti: RuntimeTI = attrs.field(repr=False)
 
-    bound_logger: WrappedLogger = attrs.field(init=False)
+    bound_logger: WrappedLogger = attrs.field(init=False, repr=False)
 
     def __call__(self, processors: Iterable[structlog.typing.Processor]) -> WrappedLogger:
         if hasattr(self, "bound_logger"):
@@ -302,6 +305,10 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
     # FinishedTriggers message
     cancelling_triggers: set[int] = attrs.field(factory=set, init=False)
 
+    # A list of RunTrigger workloads to send to the async process when it next checks in. We can't send it
+    # directly as all comms has to be initiated by the subprocess
+    creating_triggers: deque[workloads.RunTrigger] = attrs.field(factory=deque, init=False)
+
     # Outbound queue of events
     events: deque[tuple[int, events.TriggerEvent]] = attrs.field(factory=deque, init=False)
 
@@ -323,7 +330,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         proc = super().start(id=job.id, job=job, target=cls.run_in_process, logger=logger, **kwargs)
 
         msg = messages.StartTriggerer(requests_fd=proc._requests_fd)
-        proc._send(msg)
+        proc.stdin.write(msg.model_dump_json().encode("utf-8") + b"\n")
         return proc
 
     @functools.cached_property
@@ -341,7 +348,6 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         resp = None
 
         if isinstance(msg, messages.TriggerStateChanges):
-            log.debug("State change from async process", state=msg)
             if msg.events:
                 self.events.extend(msg.events)
             if msg.failures:
@@ -353,6 +359,19 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 # only need to remove the last reference to it to close the open FH
                 if factory := self.logger_cache.pop(id, None):
                     factory.upload_to_remote()
+
+            response = messages.TriggerStateSync(
+                to_create=[],
+                to_cancel=self.cancelling_triggers,
+            )
+
+            # Pull out of these deques in a thread-safe manner
+            while self.creating_triggers:
+                workload = self.creating_triggers.popleft()
+                response.to_create.append(workload)
+            self.running_triggers.update(m.id for m in response.to_create)
+            resp = response.model_dump_json().encode()
+
         elif isinstance(msg, GetConnection):
             conn = self.client.connections.get(msg.conn_id)
             if isinstance(conn, ConnectionResponse):
@@ -391,10 +410,11 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 log.error("Trigger runner process has died! Exiting.")
                 break
             with Trace.start_span(span_name="triggerer_job_loop", component="TriggererJobRunner"):
+                self.load_triggers()
+
                 # Wait for up to 1 second for activity
                 self._service_subprocess(1)
 
-                self.load_triggers()
                 self.handle_events()
                 self.handle_failed_triggers()
                 self.clean_unused()
@@ -461,9 +481,6 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 "capacity left": capacity_left,
             }
         )
-
-    def _send(self, msg: BaseModel):
-        self.stdin.write(msg.model_dump_json().encode("utf-8") + b"\n")
 
     def update_triggers(self, requested_trigger_ids: set[int]):
         """
@@ -533,14 +550,11 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
             to_create.append(workload)
 
-        for workload in to_create:
-            self._send(workload)
-        self.running_triggers.update(m.id for m in to_create)
+        self.creating_triggers.extend(to_create)
 
         if cancel_trigger_ids:
             # Enqueue orphaned triggers for cancellation
             self.cancelling_triggers.update(cancel_trigger_ids)
-            self._send(messages.CancelTriggers(ids=cancel_trigger_ids))
 
     def _register_pipe_readers(self, stdout: socket, stderr: socket, requests: socket, logs: socket):
         super()._register_pipe_readers(stdout, stderr, requests, logs)
@@ -655,6 +669,9 @@ class TriggerRunner:
     log: FilteringBoundLogger = structlog.get_logger()
 
     requests_sock: asyncio.StreamWriter
+    response_sock: asyncio.StreamReader
+
+    decoder: TypeAdapter[ToTriggerRunner]
 
     def __init__(self):
         super().__init__()
@@ -665,28 +682,10 @@ class TriggerRunner:
         self.events = deque()
         self.failed_triggers = deque()
         self.job_id = None
-
-    def init_comms(self):
-        """Init supervisor comms."""
-        from airflow.sdk.execution_time import task_runner
-
-        comms_decoder = task_runner.CommsDecoder[ToTriggerRunner, ToTriggerSupervisor](
-            input=sys.stdin,
-            decoder=TypeAdapter[ToTriggerRunner](ToTriggerRunner),
-        )
-
-        msg = comms_decoder.get_message()
-        if not isinstance(msg, messages.StartTriggerer):
-            raise RuntimeError(f"Required first message to be a messages.StartTriggerer, it was {msg}")
-        comms_decoder.request_socket = os.fdopen(msg.requests_fd, "wb", buffering=0)
-
-        task_runner.SUPERVISOR_COMMS = comms_decoder
+        self.decoder = TypeAdapter(ToTriggerRunner)
 
     def run(self):
         """Sync entrypoint - just run a run in an async loop."""
-        # Make sure comms are initialized before allowing any Triggers to run
-        self.init_comms()
-
         asyncio.run(self.arun())
 
     async def arun(self):
@@ -695,25 +694,25 @@ class TriggerRunner:
 
         Actual triggers run in their own separate coroutines.
         """
-        watchdog = asyncio.create_task(self.block_watchdog())
-        ready_event = asyncio.Event()
-        read_workloads = asyncio.create_task(self.read_workloads(ready_event))
+        # Make sure comms are initialized before allowing any Triggers to run
+        await self.init_comms()
 
-        await ready_event.wait()
+        watchdog = asyncio.create_task(self.block_watchdog())
+
         last_status = time.monotonic()
         try:
             while not self.stop:
                 # Raise exceptions from the tasks
-                if read_workloads.done():
-                    read_workloads.result()
                 if watchdog.done():
                     watchdog.result()
 
                 # Run core logic
+
+                finished_ids = await self.cleanup_finished_triggers()
+                # This also loads the triggers we need to create or cancel
+                await self.sync_state_to_supervisor(finished_ids)
                 await self.create_triggers()
                 await self.cancel_triggers()
-                finished_ids = await self.cleanup_finished_triggers()
-                await self.sync_state_to_supervisor(finished_ids)
                 # Sleep for a bit
                 await asyncio.sleep(1)
                 # Every minute, log status
@@ -723,29 +722,32 @@ class TriggerRunner:
                     last_status = now
 
         except Exception:
-            log.exception("Trigger runner failed")
+            try:
+                await log.aexception("Trigger runner failed")
+            except BrokenPipeError:
+                pass
             self.stop = True
             raise
-        read_workloads.cancel()
         # Wait for supporting tasks to complete
         await watchdog
-        await read_workloads
 
-    async def read_workloads(self, ready_event: asyncio.Event):
+    async def init_comms(self):
         """
-        Read the triggers to run on stdin.
+        Set up the communications pipe between this process and the supervisor.
 
-        This reads-and-decodes the JSON lines send by the TriggerRunnerSupervisor to us on our stdint
+        This also sets up the SUPERVISOR_COMMS so that TaskSDK code can work as expected too (but that will
+        need to be wrapped in an ``sync_to_async()`` call)
         """
         from airflow.sdk.execution_time import task_runner
 
         loop = asyncio.get_event_loop()
 
-        task = asyncio.current_task(loop=loop)
-        if TYPE_CHECKING:
-            assert task
-        # Set the event on done callback so that this FN fails the arun wakes up and we catch the exception
-        task.add_done_callback(lambda _: ready_event.set())
+        comms_decoder = task_runner.CommsDecoder[ToTriggerRunner, ToTriggerSupervisor](
+            input=sys.stdin,
+            decoder=self.decoder,
+        )
+
+        task_runner.SUPERVISOR_COMMS = comms_decoder
 
         async def connect_stdin() -> asyncio.StreamReader:
             reader = asyncio.StreamReader()
@@ -753,26 +755,20 @@ class TriggerRunner:
             await loop.connect_read_pipe(lambda: protocol, sys.stdin)
             return reader
 
-        stdin = await connect_stdin()
+        self.response_sock = await connect_stdin()
 
-        decoder = TypeAdapter[ToTriggerRunner](ToTriggerRunner)
+        line = await self.response_sock.readline()
 
+        msg = self.decoder.validate_json(line)
+        if not isinstance(msg, messages.StartTriggerer):
+            raise RuntimeError(f"Required first message to be a messages.StartTriggerer, it was {msg}")
+
+        comms_decoder.request_socket = os.fdopen(msg.requests_fd, "wb", buffering=0)
         writer_transport, writer_protocol = await loop.connect_write_pipe(
             lambda: asyncio.streams.FlowControlMixin(loop=loop),
-            task_runner.SUPERVISOR_COMMS.request_socket,
+            comms_decoder.request_socket,
         )
         self.requests_sock = asyncio.streams.StreamWriter(writer_transport, writer_protocol, None, loop)
-
-        # Tell `arun` it can start the main loop now
-        ready_event.set()
-
-        async for line in stdin:
-            msg = decoder.validate_json(line)
-
-            if isinstance(msg, workloads.RunTrigger):
-                self.to_create.append(msg)
-            elif isinstance(msg, messages.CancelTriggers):
-                self.to_cancel.extend(msg.ids)
 
     async def create_triggers(self):
         """Drain the to_create queue and create all new triggers that have been requested in the DB."""
@@ -882,6 +878,8 @@ class TriggerRunner:
         return finished_ids
 
     async def sync_state_to_supervisor(self, finished_ids: list[int]):
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
         # Copy out of our deques in threadsafe manner to sync state with parent
         events_to_send = []
         while self.events:
@@ -898,7 +896,6 @@ class TriggerRunner:
             events=events_to_send, finished=finished_ids, failures=failures_to_send
         )
 
-        # Only send a message if there is anything to say
         if not events_to_send:
             msg.events = None
 
@@ -908,9 +905,23 @@ class TriggerRunner:
         if not finished_ids:
             msg.finished = None
 
-        if msg.events or msg.finished or msg.failures:
+        # Block triggers from making any requests for the duration of this
+        async with SUPERVISOR_COMMS.lock:
             # Tell the monitor that we've finished triggers so it can update things
             self.requests_sock.write(msg.model_dump_json(exclude_none=True).encode() + b"\n")
+            # async for line in stdin:
+            #     msg = self.decoder.validate_json(line)
+            line = await self.response_sock.readline()
+
+        if line == b"":  # EoF received!
+            if task := asyncio.current_task():
+                task.cancel("EOF - shutting down")
+
+        resp = self.decoder.validate_json(line)
+        if not isinstance(resp, messages.TriggerStateSync):
+            raise RuntimeError(f"Expected to get a TriggerStateSync message, instead we got f{type(msg)}")
+        self.to_create.extend(resp.to_create)
+        self.to_cancel.extend(resp.to_cancel)
 
     async def block_watchdog(self):
         """

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -622,6 +622,10 @@ class DummyTriggerRunnerSupervisor(TriggerRunnerSupervisor):
         super().handle_events()
 
 
+@pytest.mark.xfail(
+    reason="We know that test is flaky and have no time to fix it before 3.0. "
+    "We should fix it later. TODO: AIP-72"
+)
 @pytest.mark.asyncio
 @pytest.mark.execution_timeout(20)
 async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -24,7 +24,7 @@ import selectors
 import time
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pendulum
 import pytest
@@ -200,22 +200,30 @@ def test_trigger_lifecycle(spy_agency: SpyAgency, session):
 
     try:
         # Spy on it so we can see what gets send, but also call the original.
-        send_spy = spy_agency.spy_on(TriggerRunnerSupervisor._send, owner=TriggerRunnerSupervisor)
+        message = None
 
-        trigger_runner_supervisor._service_subprocess(0.1)
+        @spy_agency.spy_for(trigger_runner_supervisor.stdin.write)
+        def write_spy(self, line, *args, **kwargs):
+            nonlocal message
+            message = messages.TriggerStateSync.model_validate_json(line)
+            trigger_runner_supervisor.stdin.write.call_original(line, *args, **kwargs)
+
         trigger_runner_supervisor.load_triggers()
+        trigger_runner_supervisor._service_subprocess(0.1)
+
         # Make sure it turned up in TriggerRunner's queue
         assert trigger_runner_supervisor.running_triggers == {trigger_orm.id}
 
-        spy_agency.assert_spy_called_with(
-            send_spy,
+        assert message is not None, "spy was not called"
+        assert len(message.to_create) == 1
+        assert message.to_create[0] == (
             workloads.RunTrigger.model_construct(
                 id=trigger_orm.id,
                 ti=ANY,
                 classpath=trigger.serialize()[0],
                 encrypted_kwargs=trigger_orm.encrypted_kwargs,
                 kind="RunTrigger",
-            ),
+            )
         )
         # OK, now remove it from the DB
         session.delete(trigger_orm)
@@ -287,13 +295,18 @@ class TestTriggerRunner:
         assert "got an unexpected keyword argument 'not_exists_arg'" in str(err)
 
     @pytest.mark.asyncio
-    async def test_invalid_trigger(self):
+    @patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True)
+    async def test_invalid_trigger(self, supervisor_builder):
         """Test the behaviour when we try to run an invalid Trigger"""
         workload = workloads.RunTrigger.model_construct(
             id=1, ti=None, classpath="fake.classpath", encrypted_kwargs={}
         )
         trigger_runner = TriggerRunner()
         trigger_runner.requests_sock = MagicMock()
+        trigger_runner.response_sock = AsyncMock()
+        trigger_runner.response_sock.readline.return_value = (
+            b'{"type": "TriggerStateSync", "to_create": [], "to_cancel": []}\n'
+        )
 
         trigger_runner.to_create.append(workload)
 
@@ -367,7 +380,7 @@ async def test_trigger_create_race_condition_38599(session, supervisor_builder):
     # Instead of running job_runner1._execute, we will run the individual methods
     # to control the timing of the execution.
     supervisor1.load_triggers()
-    assert supervisor1.running_triggers == {trigger_orm.id}
+    assert {t.id for t in supervisor1.creating_triggers} == {trigger_orm.id}
     trigger_orm = session.get(Trigger, trigger_orm.id)
     assert trigger_orm.task_instance is not None, "Pre-condition"
 
@@ -394,59 +407,6 @@ async def test_trigger_create_race_condition_38599(session, supervisor_builder):
     assert supervisor2.running_triggers == set()
     # We should have not sent anything to the async runner process
     supervisor2.stdin.write.assert_not_called()
-
-
-def test_trigger_create_race_condition_18392(session, supervisor_builder, spy_agency: SpyAgency):
-    """
-    This verifies the resolution of race condition documented in github issue #18392.
-    Triggers are queued for creation by TriggerJob.load_triggers.
-    There was a race condition where multiple triggers would be created unnecessarily.
-    What happens is the runner completes the trigger and purges from the "running" list.
-    Then job.load_triggers is called and it looks like the trigger is not running but should,
-    so it queues it again.
-
-    The scenario is as follows:
-        1. job.load_triggers (trigger now queued and sent to subprocess)
-        2. runner.create_triggers (trigger now running)
-        3. job.handle_events (trigger still appears running so state not updated in DB)
-        4. runner.cleanup_finished_triggers (trigger completed at this point; trigger from "running" set)
-        5. job.load_triggers (trigger not running, but also not purged from DB, so it is queued again)
-        6. runner.create_triggers (trigger created again)
-
-    This test verifies that under this scenario only one trigger is created.
-    """
-    trigger = TimeDeltaTrigger(delta=datetime.timedelta(microseconds=1))
-    trigger_orm = Trigger.from_object(trigger)
-    session.add(trigger_orm)
-    session.flush()
-
-    dag = DagModel(dag_id="test-dag")
-    dag_run = DagRun(dag.dag_id, run_id="abc", run_type="none")
-    ti = TaskInstance(PythonOperator(task_id="dummy-task", python_callable=print), run_id=dag_run.run_id)
-    ti.dag_id = dag.dag_id
-    ti.trigger_id = trigger_orm.id
-    session.add(dag)
-    session.add(dag_run)
-    session.add(ti)
-
-    session.commit()
-
-    supervisor = supervisor_builder()
-
-    iteration = 0
-
-    # Hook into something in each iteration of the loop
-    @spy_agency.spy_for(TriggerRunnerSupervisor.is_alive)
-    def is_alive(self):
-        nonlocal iteration
-        iteration += 1
-        if iteration >= 2:
-            self.stop = True
-
-        return True
-
-    supervisor.run()
-    assert supervisor.stdin.write.call_count == 1
 
 
 @pytest.mark.execution_timeout(5)
@@ -574,7 +534,7 @@ def test_failed_trigger(session, dag_maker, supervisor_builder):
     supervisor.load_triggers()
 
     # Make sure it got picked up
-    assert supervisor.running_triggers == {trigger_orm.id}, "Pre-condition"
+    assert {t.id for t in supervisor.creating_triggers} == {trigger_orm.id}, "Pre-condition"
     # Simulate receiving the state update message
 
     supervisor._handle_request(
@@ -662,12 +622,7 @@ class DummyTriggerRunnerSupervisor(TriggerRunnerSupervisor):
         super().handle_events()
 
 
-@pytest.mark.xfail(
-    reason="We know that test is flaky and have no time to fix it before 3.0. "
-    "We should fix it later. TODO: AIP-72"
-)
 @pytest.mark.asyncio
-@pytest.mark.flaky(reruns=2, reruns_delay=10)
 @pytest.mark.execution_timeout(20)
 async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_maker):
     """Checks that the trigger will successfully access Variables, Connections and XComs."""

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -22,6 +22,7 @@ description = "Python Task SDK for Apache Airflow DAG Authors"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9, <3.13"
 dependencies = [
+    "aiologic>=0.14.0",
     "attrs>=24.2.0, !=25.2.0",
     "httpx>=0.27.0",
     "jinja2>=3.1.5",

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -382,16 +382,16 @@ class WatchedSubprocess:
     decoder: ClassVar[TypeAdapter]
     """The decoder to use for incoming messages from the child process."""
 
-    _process: psutil.Process
+    _process: psutil.Process = attrs.field(repr=False)
     _requests_fd: int
     """File descriptor for request handling."""
 
     _num_open_sockets: int = 4
     _exit_code: int | None = attrs.field(default=None, init=False)
 
-    selector: selectors.BaseSelector = attrs.field(factory=selectors.DefaultSelector)
+    selector: selectors.BaseSelector = attrs.field(factory=selectors.DefaultSelector, repr=False)
 
-    process_log: FilteringBoundLogger
+    process_log: FilteringBoundLogger = attrs.field(repr=False)
 
     subprocess_logs_to_stdout: bool = False
     """Duplicate log messages to stdout, or only send them to ``self.process_log``."""

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -23,7 +23,6 @@ import contextvars
 import functools
 import os
 import sys
-import threading
 import time
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from datetime import datetime, timezone
@@ -32,6 +31,7 @@ from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, TextIO, TypeVar
 
+import aiologic
 import attrs
 import lazy_object_proxy
 import structlog
@@ -547,7 +547,7 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
     # "sort of wrong default"
     decoder: TypeAdapter[ReceiveMsgType] = attrs.field(factory=lambda: TypeAdapter(ToTask), repr=False)
 
-    lock: threading.Lock = attrs.field(factory=threading.Lock, repr=False)
+    lock: aiologic.Lock = attrs.field(factory=aiologic.Lock, repr=False)
 
     def get_message(self) -> ReceiveMsgType:
         """


### PR DESCRIPTION
The TriggerRunnerSupervisor previoulsy sent messges to the Triggerer directly
when a trigger needed to be created or cancelled, and this initially worked
fine, but when we later added the ability for Triggers to access Connections
and Variables this ended up causing problems.

The issue was that we broke one of the "rules" of comms, which is even
documented as such in `airflow/sdk/exeuction_time/comms.py`:

> * No messages are sent to task process except in response to a request.
>   (This is because the task process will be running user's code, so we can't
>   read from stdin until we enter our code, such as when requesting an XCom
)   value etc.)

The net result of this was that since the supervisor sent messages
un-solicited, if things were timed badly, then the trigger would send a
request for a Conn, and the supervisor would reply with a trigger to create
etc.

This sort of instability was very likely the cause of our flakeyness in the
`test_trigger_can_access_variables_connections_and_xcoms` test.

This fixes things by making the TriggerRunnerSupervisor collect the triggers
to create/cancel in a deqeue in memory, and respond to the TriggerStateChanges
messages with TriggerStateSync with the info it would have sent on an
as-needed basis.

In order to make sure that we only send+receive one message at a time I have
swapped from the `threading.lock` to `aiologic.Lock` which allows for better
locking/waiting behaviour between threads (which is what Triggers will use via
the `sync_to_async`) and the main TriggerRunner.

Fixes #48820 in a different manner.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
