### PR TITLE
Add ability to filter dag runs table by run_type

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -2561,6 +2561,14 @@ paths:
             format: date-time
           - type: 'null'
           title: Updated At Lte
+      - name: run_type
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Run Type
       - name: state
         in: query
         required: false

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -37,6 +37,7 @@ from airflow.api_fastapi.common.parameters import (
     FilterParam,
     LimitFilter,
     OffsetFilter,
+    QueryDagRunRunTypesFilter,
     QueryDagRunStateFilter,
     QueryLimit,
     QueryOffset,
@@ -300,6 +301,7 @@ def get_dag_runs(
     start_date_range: Annotated[RangeFilter, Depends(datetime_range_filter_factory("start_date", DagRun))],
     end_date_range: Annotated[RangeFilter, Depends(datetime_range_filter_factory("end_date", DagRun))],
     update_at_range: Annotated[RangeFilter, Depends(datetime_range_filter_factory("updated_at", DagRun))],
+    run_type: QueryDagRunRunTypesFilter,
     state: QueryDagRunStateFilter,
     order_by: Annotated[
         SortParam,
@@ -349,6 +351,7 @@ def get_dag_runs(
             end_date_range,
             update_at_range,
             state,
+            run_type,
             readable_dag_runs_filter,
         ],
         order_by=order_by,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -636,6 +636,7 @@ export const UseDagRunServiceGetDagRunsKeyFn = (
     orderBy,
     runAfterGte,
     runAfterLte,
+    runType,
     startDateGte,
     startDateLte,
     state,
@@ -652,6 +653,7 @@ export const UseDagRunServiceGetDagRunsKeyFn = (
     orderBy?: string;
     runAfterGte?: string;
     runAfterLte?: string;
+    runType?: string[];
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -673,6 +675,7 @@ export const UseDagRunServiceGetDagRunsKeyFn = (
       orderBy,
       runAfterGte,
       runAfterLte,
+      runType,
       startDateGte,
       startDateLte,
       state,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -843,6 +843,7 @@ export const ensureUseDagRunServiceGetUpstreamAssetEventsData = (
  * @param data.endDateLte
  * @param data.updatedAtGte
  * @param data.updatedAtLte
+ * @param data.runType
  * @param data.state
  * @param data.orderBy
  * @returns DAGRunCollectionResponse Successful Response
@@ -861,6 +862,7 @@ export const ensureUseDagRunServiceGetDagRunsData = (
     orderBy,
     runAfterGte,
     runAfterLte,
+    runType,
     startDateGte,
     startDateLte,
     state,
@@ -877,6 +879,7 @@ export const ensureUseDagRunServiceGetDagRunsData = (
     orderBy?: string;
     runAfterGte?: string;
     runAfterLte?: string;
+    runType?: string[];
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -896,6 +899,7 @@ export const ensureUseDagRunServiceGetDagRunsData = (
       orderBy,
       runAfterGte,
       runAfterLte,
+      runType,
       startDateGte,
       startDateLte,
       state,
@@ -914,6 +918,7 @@ export const ensureUseDagRunServiceGetDagRunsData = (
         orderBy,
         runAfterGte,
         runAfterLte,
+        runType,
         startDateGte,
         startDateLte,
         state,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -843,6 +843,7 @@ export const prefetchUseDagRunServiceGetUpstreamAssetEvents = (
  * @param data.endDateLte
  * @param data.updatedAtGte
  * @param data.updatedAtLte
+ * @param data.runType
  * @param data.state
  * @param data.orderBy
  * @returns DAGRunCollectionResponse Successful Response
@@ -861,6 +862,7 @@ export const prefetchUseDagRunServiceGetDagRuns = (
     orderBy,
     runAfterGte,
     runAfterLte,
+    runType,
     startDateGte,
     startDateLte,
     state,
@@ -877,6 +879,7 @@ export const prefetchUseDagRunServiceGetDagRuns = (
     orderBy?: string;
     runAfterGte?: string;
     runAfterLte?: string;
+    runType?: string[];
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -896,6 +899,7 @@ export const prefetchUseDagRunServiceGetDagRuns = (
       orderBy,
       runAfterGte,
       runAfterLte,
+      runType,
       startDateGte,
       startDateLte,
       state,
@@ -914,6 +918,7 @@ export const prefetchUseDagRunServiceGetDagRuns = (
         orderBy,
         runAfterGte,
         runAfterLte,
+        runType,
         startDateGte,
         startDateLte,
         state,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -1042,6 +1042,7 @@ export const useDagRunServiceGetUpstreamAssetEvents = <
  * @param data.endDateLte
  * @param data.updatedAtGte
  * @param data.updatedAtLte
+ * @param data.runType
  * @param data.state
  * @param data.orderBy
  * @returns DAGRunCollectionResponse Successful Response
@@ -1063,6 +1064,7 @@ export const useDagRunServiceGetDagRuns = <
     orderBy,
     runAfterGte,
     runAfterLte,
+    runType,
     startDateGte,
     startDateLte,
     state,
@@ -1079,6 +1081,7 @@ export const useDagRunServiceGetDagRuns = <
     orderBy?: string;
     runAfterGte?: string;
     runAfterLte?: string;
+    runType?: string[];
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1101,6 +1104,7 @@ export const useDagRunServiceGetDagRuns = <
         orderBy,
         runAfterGte,
         runAfterLte,
+        runType,
         startDateGte,
         startDateLte,
         state,
@@ -1121,6 +1125,7 @@ export const useDagRunServiceGetDagRuns = <
         orderBy,
         runAfterGte,
         runAfterLte,
+        runType,
         startDateGte,
         startDateLte,
         state,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1019,6 +1019,7 @@ export const useDagRunServiceGetUpstreamAssetEventsSuspense = <
  * @param data.endDateLte
  * @param data.updatedAtGte
  * @param data.updatedAtLte
+ * @param data.runType
  * @param data.state
  * @param data.orderBy
  * @returns DAGRunCollectionResponse Successful Response
@@ -1040,6 +1041,7 @@ export const useDagRunServiceGetDagRunsSuspense = <
     orderBy,
     runAfterGte,
     runAfterLte,
+    runType,
     startDateGte,
     startDateLte,
     state,
@@ -1056,6 +1058,7 @@ export const useDagRunServiceGetDagRunsSuspense = <
     orderBy?: string;
     runAfterGte?: string;
     runAfterLte?: string;
+    runType?: string[];
     startDateGte?: string;
     startDateLte?: string;
     state?: string[];
@@ -1078,6 +1081,7 @@ export const useDagRunServiceGetDagRunsSuspense = <
         orderBy,
         runAfterGte,
         runAfterLte,
+        runType,
         startDateGte,
         startDateLte,
         state,
@@ -1098,6 +1102,7 @@ export const useDagRunServiceGetDagRunsSuspense = <
         orderBy,
         runAfterGte,
         runAfterLte,
+        runType,
         startDateGte,
         startDateLte,
         state,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1477,6 +1477,7 @@ export class DagRunService {
    * @param data.endDateLte
    * @param data.updatedAtGte
    * @param data.updatedAtLte
+   * @param data.runType
    * @param data.state
    * @param data.orderBy
    * @returns DAGRunCollectionResponse Successful Response
@@ -1502,6 +1503,7 @@ export class DagRunService {
         end_date_lte: data.endDateLte,
         updated_at_gte: data.updatedAtGte,
         updated_at_lte: data.updatedAtLte,
+        run_type: data.runType,
         state: data.state,
         order_by: data.orderBy,
       },

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2038,6 +2038,7 @@ export type GetDagRunsData = {
   orderBy?: string;
   runAfterGte?: string | null;
   runAfterLte?: string | null;
+  runType?: Array<string>;
   startDateGte?: string | null;
   startDateLte?: string | null;
   state?: Array<string>;

--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -25,6 +25,7 @@ export enum SearchParamsKeys {
   NAME_PATTERN = "name_pattern",
   OFFSET = "offset",
   PAUSED = "paused",
+  RUN_TYPE = "run_type",
   SORT = "sort",
   SOURCE = "log_source",
   START_DATE = "start_date",

--- a/airflow-core/src/airflow/ui/src/constants/stateOptions.ts
+++ b/airflow-core/src/airflow/ui/src/constants/stateOptions.ts
@@ -51,3 +51,13 @@ export const dagRunStateOptions = createListCollection({
     { label: "Success", value: "success" },
   ],
 });
+
+export const dagRunTypeOptions = createListCollection({
+  items: [
+    { label: "All Run Types", value: "all" },
+    { label: "Backfill", value: "backfill" },
+    { label: "Manual", value: "manual" },
+    { label: "Scheduled", value: "scheduled" },
+    { label: "Asset Triggered", value: "asset_triggered" },
+  ],
+});


### PR DESCRIPTION
Use `QueryDagRunRunTypesFilter` in the list dag runs endpoint to allow the UI to show a dropdown to filter the dag runs list by run type.


<img width="877" alt="Screenshot 2025-04-07 at 11 34 12 AM" src="https://github.com/user-attachments/assets/c24183ab-3278-4715-9758-0da4cb11dd81" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
