### PR TITLE
Fix Execution API incompatibilty with addition of `consumed_asset_events`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_04_10.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_04_10.py
@@ -17,17 +17,14 @@
 
 from __future__ import annotations
 
-from cadwyn import HeadVersion, Version, VersionBundle
+from cadwyn import VersionChange, schema
 
-from airflow.api_fastapi.execution_api.versions.v2025_03_26 import (
-    AddIncludePriorDatesParam,
-    RemoveTIRuntimeChecksEndpoint,
-)
-from airflow.api_fastapi.execution_api.versions.v2025_04_10 import AddConsumedAssetEventsField
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun
 
-bundle = VersionBundle(
-    HeadVersion(),
-    Version("2025-04-10", AddConsumedAssetEventsField),
-    Version("2025-03-26", RemoveTIRuntimeChecksEndpoint, AddIncludePriorDatesParam),
-    Version("2025-03-19"),
-)
+
+class AddConsumedAssetEventsField(VersionChange):
+    """Add the `consumed_asset_events` to DagRun model."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (schema(DagRun).field("consumed_asset_events").didnt_exist,)

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -27,7 +27,7 @@ from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue
 
-API_VERSION: Final[str] = "2025-03-26"
+API_VERSION: Final[str] = "2025-04-10"
 
 
 class AssetAliasReferenceAssetEventDagRun(BaseModel):


### PR DESCRIPTION
Unfortunately since we have forbid extra in the generated client this resulted
in old clients failing to work with new servers, one of the things we are
deliberately using Cadwyn to avoid.

And it does help, when we remember/know to use it.

This fixes this specific case, and I've created #48887 to catch it in CI
long-term.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
