### PR TITLE
Move secrets_masker patch to conftest and use as fixture

### DIFF
--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -20,6 +20,7 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
+from unittest.mock import patch
 
 import pytest
 
@@ -266,3 +267,13 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
         return context.model_dump(exclude_unset=True, mode="json")
 
     return _make_context_dict
+
+
+@pytest.fixture
+def set_secrets_masker():
+    from airflow.sdk.execution_time.secrets_masker import SecretsMasker
+
+    secrets_masker = SecretsMasker()
+    with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+        with patch("airflow.sdk.execution_time.secrets_masker.re.escape", lambda x: x):
+            yield secrets_masker

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -269,11 +269,10 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
     return _make_context_dict
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def set_secrets_masker():
     from airflow.sdk.execution_time.secrets_masker import SecretsMasker
 
     secrets_masker = SecretsMasker()
     with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
-        with patch("airflow.sdk.execution_time.secrets_masker.re.escape", lambda x: x):
-            yield secrets_masker
+        yield secrets_masker

--- a/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
+++ b/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
@@ -435,7 +435,7 @@ class TestRedactedIO:
     @pytest.fixture(autouse=True)
     def reset_secrets_masker(self, set_secrets_masker):
         mask_secret(p)
-        yield
+        return
 
     def test_redacts_from_print(self, capsys):
         # Without redacting, password is printed.

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -119,7 +119,6 @@ def local_dag_bundle_cfg(path, name="my-bundle"):
 
 
 @pytest.mark.usefixtures("disable_capturing")
-@pytest.mark.usefixtures("set_secrets_masker")
 class TestWatchedSubprocess:
     def test_reading_from_pipes(self, captured_logs, time_machine):
         def subprocess_main():

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -119,6 +119,7 @@ def local_dag_bundle_cfg(path, name="my-bundle"):
 
 
 @pytest.mark.usefixtures("disable_capturing")
+@pytest.mark.usefixtures("set_secrets_masker")
 class TestWatchedSubprocess:
     def test_reading_from_pipes(self, captured_logs, time_machine):
         def subprocess_main():


### PR DESCRIPTION
As mentioned @kaxil in slack its causing issue when we run. failing to load secrets_masker.

`pytest task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestWatchedSubprocess::test_reading_from_pipes`

```
___________________________________________________________________________________ TestWatchedSubprocess.test_reading_from_pipes ____________________________________________________________________________________
task-sdk/tests/task_sdk/execution_time/test_supervisor.py:165: in test_reading_from_pipes
    rc = proc.wait()
task-sdk/src/airflow/sdk/execution_time/supervisor.py:761: in wait
    self._monitor_subprocess()
task-sdk/src/airflow/sdk/execution_time/supervisor.py:819: in _monitor_subprocess
    alive = self._service_subprocess(max_wait_time=max_wait_time) is None
task-sdk/src/airflow/sdk/execution_time/supervisor.py:653: in _service_subprocess
    need_more = socket_handler(key.fileobj)
task-sdk/src/airflow/sdk/execution_time/supervisor.py:1066: in cb
    gen.send(line)
task-sdk/src/airflow/sdk/execution_time/supervisor.py:1126: in forward_to_log
    log.log(level, msg, chan=chan)
/usr/local/lib/python3.10/site-packages/structlog/_native.py:179: in log
    return self._proxy_to_logger(name, event, **kw)
/usr/local/lib/python3.10/site-packages/structlog/_base.py:222: in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
/usr/local/lib/python3.10/site-packages/structlog/_base.py:173: in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
task-sdk/src/airflow/sdk/log.py:109: in mask_logs
    event_dict = redact(event_dict)  # type: ignore[assignment]
task-sdk/src/airflow/sdk/execution_time/secrets_masker.py:117: in redact
    return _secrets_masker().redact(value, name, max_depth)
task-sdk/src/airflow/sdk/execution_time/secrets_masker.py:125: in _secrets_masker
    raise RuntimeError(
E   RuntimeError: Logging Configuration Error! No SecretsMasker found! If you have custom logging, please make sure you configure it taking airflow configuration as a base as explained at https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/logging-tasks.html#advanced-configuration
```
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
