### PR TITLE
Support using asset ref to emit alias event

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -371,22 +371,27 @@ class TriggeringAssetEventsAccessor(
 
 
 @attrs.define
-class OutletEventAccessor:
+class OutletEventAccessor(_AssetRefResolutionMixin):
     """Wrapper to access an outlet asset event in template."""
 
     key: BaseAssetUniqueKey
     extra: dict[str, Any] = attrs.Factory(dict)
     asset_alias_events: list[AssetAliasEvent] = attrs.field(factory=list)
 
-    def add(self, asset: Asset, extra: dict[str, Any] | None = None) -> None:
+    def add(self, asset: Asset | AssetRef, extra: dict[str, Any] | None = None) -> None:
         """Add an AssetEvent to an existing Asset."""
         if not isinstance(self.key, AssetAliasUniqueKey):
             return
 
+        if isinstance(asset, AssetRef):
+            asset_key = self._resolve_asset_ref(asset)
+        else:
+            asset_key = AssetUniqueKey.from_asset(asset)
+
         asset_alias_name = self.key.name
         event = AssetAliasEvent(
             source_alias_name=asset_alias_name,
-            dest_asset_key=AssetUniqueKey.from_asset(asset),
+            dest_asset_key=asset_key,
             extra=extra or {},
         )
         self.asset_alias_events.append(event)

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -352,29 +352,13 @@ class TestCurrentContext:
 
 class TestOutletEventAccessor:
     @pytest.mark.parametrize(
-        "key, asset_alias_events",
-        (
-            (AssetUniqueKey.from_asset(Asset("test_uri")), []),
-            (
-                AssetAliasUniqueKey.from_asset_alias(AssetAlias("test_alias")),
-                [
-                    AssetAliasEvent(
-                        source_alias_name="test_alias",
-                        dest_asset_key=AssetUniqueKey(uri="test_uri", name="test_uri"),
-                        extra={},
-                    )
-                ],
-            ),
-        ),
+        "add_arg",
+        [
+            Asset("name", "uri"),
+            Asset.ref(name="name"),
+            Asset.ref(uri="uri"),
+        ],
     )
-    def test_add(self, key, asset_alias_events, mock_supervisor_comms):
-        asset = Asset("test_uri")
-        mock_supervisor_comms.get_message.return_value = asset
-
-        outlet_event_accessor = OutletEventAccessor(key=key, extra={})
-        outlet_event_accessor.add(asset)
-        assert outlet_event_accessor.asset_alias_events == asset_alias_events
-
     @pytest.mark.parametrize(
         "key, asset_alias_events",
         (
@@ -384,19 +368,49 @@ class TestOutletEventAccessor:
                 [
                     AssetAliasEvent(
                         source_alias_name="test_alias",
-                        dest_asset_key=AssetUniqueKey(name="test-asset", uri="test://asset-uri/"),
+                        dest_asset_key=AssetUniqueKey(name="name", uri="uri"),
                         extra={},
                     )
                 ],
             ),
         ),
     )
-    def test_add_with_db(self, key, asset_alias_events, mock_supervisor_comms):
-        asset = Asset(uri="test://asset-uri", name="test-asset")
-        mock_supervisor_comms.get_message.return_value = asset
+    def test_add(self, add_arg, key, asset_alias_events, mock_supervisor_comms):
+        mock_supervisor_comms.get_message.return_value = AssetResponse(name="name", uri="uri", group="")
+
+        outlet_event_accessor = OutletEventAccessor(key=key, extra={})
+        outlet_event_accessor.add(add_arg)
+        assert outlet_event_accessor.asset_alias_events == asset_alias_events
+
+    @pytest.mark.parametrize(
+        "add_arg",
+        [
+            Asset("name", "uri"),
+            Asset.ref(name="name"),
+            Asset.ref(uri="uri"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "key, asset_alias_events",
+        (
+            (AssetUniqueKey.from_asset(Asset("test_uri")), []),
+            (
+                AssetAliasUniqueKey.from_asset_alias(AssetAlias("test_alias")),
+                [
+                    AssetAliasEvent(
+                        source_alias_name="test_alias",
+                        dest_asset_key=AssetUniqueKey(name="name", uri="uri"),
+                        extra={},
+                    )
+                ],
+            ),
+        ),
+    )
+    def test_add_with_db(self, add_arg, key, asset_alias_events, mock_supervisor_comms):
+        mock_supervisor_comms.get_message.return_value = AssetResponse(name="name", uri="uri", group="")
 
         outlet_event_accessor = OutletEventAccessor(key=key, extra={"not": ""})
-        outlet_event_accessor.add(asset, extra={})
+        outlet_event_accessor.add(add_arg, extra={})
         assert outlet_event_accessor.asset_alias_events == asset_alias_events
 
 


### PR DESCRIPTION
This is not very efficient; we basically make an extra API call to resolve the reference.

[There's an existing issue to refactor all this to make everything more efficient.](https://github.com/apache/airflow/issues/47899)

Close #47718.