### PR TITLE
Fix get_confluent_token callback for Managed Kafka service

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/managed_kafka.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/managed_kafka.py
@@ -120,7 +120,7 @@ class ManagedKafkaHook(GoogleBaseHook):
             error = operation.exception(timeout=timeout)
             raise AirflowException(error)
 
-    def get_confluent_token(self):
+    def get_confluent_token(self, config_str: str):
         """Get the authentication token for confluent client."""
         token_provider = ManagedKafkaTokenProvider(credentials=self.get_credentials())
         token = token_provider.confluent_token()

--- a/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_consumer_group.py
+++ b/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_consumer_group.py
@@ -181,8 +181,10 @@ with DAG(
         location=LOCATION,
         cluster_id=CLUSTER_ID,
         consumer_group_id=CONSUMER_GROUP_ID,
-        consumer_group={},
-        update_mask={},
+        consumer_group={
+            "topics": {},
+        },
+        update_mask={"paths": ["topics"]},
     )
     # [END how_to_cloud_managed_kafka_update_consumer_group_operator]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have fixed the `get_confluent_token`  callback function. 
As mentioned in the [documentation](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration) each callback function should have `config_str` parameter as default. Without this parameter this callback function doesn't work correctly and doesn't generate a token.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
