### PR TITLE
Remove dev0 suffix from Airflow version

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -59,7 +59,7 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by pre-commit
-version = "3.0.0.dev0"
+version = "3.0.0"
 
 dependencies = [
     "a2wsgi>=1.10.8",

--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -25,7 +25,7 @@
 # lib.)  This is required by some IDEs to resolve the import paths.
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
-__version__ = "3.0.0.dev0"
+__version__ = "3.0.0"
 
 import os
 import sys

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -261,7 +261,7 @@ def test_validate_provider_info_with_schema():
     "provider_id, min_version",
     [
         ("amazon", "2.9.0"),
-        ("fab", "3.0.0.dev0"),
+        ("fab", "3.0.0"),
     ],
 )
 def test_get_min_airflow_version(provider_id: str, min_version: str):

--- a/docker-stack-docs/README.md
+++ b/docker-stack-docs/README.md
@@ -31,12 +31,12 @@ Every time a new version of Airflow is released, the images are prepared in the
 [apache/airflow DockerHub](https://hub.docker.com/r/apache/airflow)
 for all the supported Python versions.
 
-You can find the following images there (Assuming Airflow version `3.0.0.dev0`):
+You can find the following images there (Assuming Airflow version `3.0.0`):
 
 * `apache/airflow:latest` - the latest released Airflow image with default Python version (3.12 currently)
 * `apache/airflow:latest-pythonX.Y` - the latest released Airflow image with specific Python version
-* `apache/airflow:3.0.0.dev0` - the versioned Airflow image with default Python version (3.12 currently)
-* `apache/airflow:3.0.0.dev0-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:3.0.0` - the versioned Airflow image with default Python version (3.12 currently)
+* `apache/airflow:3.0.0-pythonX.Y` - the versioned Airflow image with specific Python version
 
 Those are "reference" regular images. They contain the most common set of extras, dependencies and providers that are
 often used by the users and they are good to "try-things-out" when you want to just take Airflow for a spin,
@@ -47,8 +47,8 @@ via [Building the image](https://airflow.apache.org/docs/docker-stack/build.html
 
 * `apache/airflow:slim-latest`              - the latest released Airflow image with default Python version (3.12 currently)
 * `apache/airflow:slim-latest-pythonX.Y`    - the latest released Airflow image with specific Python version
-* `apache/airflow:slim-3.0.0.dev0`           - the versioned Airflow image with default Python version (3.12 currently)
-* `apache/airflow:slim-3.0.0.dev0-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:slim-3.0.0`           - the versioned Airflow image with default Python version (3.12 currently)
+* `apache/airflow:slim-3.0.0-pythonX.Y` - the versioned Airflow image with specific Python version
 
 The Apache Airflow image provided as convenience package is optimized for size, and
 it provides just a bare minimal set of the extras and dependencies installed and in most cases

--- a/docker-stack-docs/docker-examples/extending/add-airflow-configuration/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-airflow-configuration/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 ENV AIRFLOW__CORE__LOAD_EXAMPLES=True
 ENV AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=my_conn_string
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-apt-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-apt-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-build-essential-extend/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-build-essential-extend/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages-constraints/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages-constraints/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml --constraint "${HOME}/constraints.txt"
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages-uv/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages-uv/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 
 # The `uv` tools is Rust packaging tool that is much faster than `pip` and other installer
 # Support for uv as installation tool is experimental

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-requirement-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-requirement-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 COPY requirements.txt /
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" -r /requirements.txt
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/custom-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/custom-providers/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 RUN pip install "apache-airflow==${AIRFLOW_VERSION}" --no-cache-dir apache-airflow-providers-docker==2.5.1
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/embedding-dags/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/embedding-dags/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 
 COPY --chown=airflow:root test_dag.py /opt/airflow/dags
 

--- a/docker-stack-docs/docker-examples/extending/writable-directory/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/writable-directory/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.0.0.dev0
+FROM apache/airflow:3.0.0
 RUN umask 0002; \
     mkdir -p ~/writeable-directory
 # [END Dockerfile]

--- a/docker-stack-docs/entrypoint.rst
+++ b/docker-stack-docs/entrypoint.rst
@@ -132,7 +132,7 @@ if you specify extra arguments. For example:
 
 .. code-block:: bash
 
-  docker run -it apache/airflow:3.0.0.dev0-python3.9 bash -c "ls -la"
+  docker run -it apache/airflow:3.0.0-python3.9 bash -c "ls -la"
   total 16
   drwxr-xr-x 4 airflow root 4096 Jun  5 18:12 .
   drwxr-xr-x 1 root    root 4096 Jun  5 18:12 ..
@@ -144,7 +144,7 @@ you pass extra parameters. For example:
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:3.0.0.dev0-python3.9 python -c "print('test')"
+  > docker run -it apache/airflow:3.0.0-python3.9 python -c "print('test')"
   test
 
 If first argument equals to "airflow" - the rest of the arguments is treated as an airflow command
@@ -152,13 +152,13 @@ to execute. Example:
 
 .. code-block:: bash
 
-   docker run -it apache/airflow:3.0.0.dev0-python3.9 airflow webserver
+   docker run -it apache/airflow:3.0.0-python3.9 airflow webserver
 
 If there are any other arguments - they are simply passed to the "airflow" command
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:3.0.0.dev0-python3.9 help
+  > docker run -it apache/airflow:3.0.0-python3.9 help
     usage: airflow [-h] GROUP_OR_COMMAND ...
 
     positional arguments:
@@ -363,7 +363,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD=admin" \
-      apache/airflow:3.0.0.dev0-python3.9 webserver
+      apache/airflow:3.0.0-python3.9 webserver
 
 
 .. code-block:: bash
@@ -372,7 +372,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:3.0.0.dev0-python3.9 webserver
+      apache/airflow:3.0.0-python3.9 webserver
 
 The commands above perform initialization of the SQLite database, create admin user with admin password
 and Admin role. They also forward local port ``8080`` to the webserver port and finally start the webserver.
@@ -412,6 +412,6 @@ Example:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:3.0.0.dev0-python3.9 webserver
+      apache/airflow:3.0.0-python3.9 webserver
 
 This method is only available starting from Docker image of Airflow 2.1.1 and above.

--- a/providers/common/messaging/README.rst
+++ b/providers/common/messaging/README.rst
@@ -53,7 +53,7 @@ Requirements
 ==================  ==================
 PIP package         Version required
 ==================  ==================
-``apache-airflow``  ``>=3.0.0.dev0``
+``apache-airflow``  ``>=3.0.0``
 ==================  ==================
 
 Cross provider package dependencies

--- a/providers/common/messaging/docs/index.rst
+++ b/providers/common/messaging/docs/index.rst
@@ -94,12 +94,12 @@ For the minimum Airflow version supported, see ``Requirements`` below.
 Requirements
 ------------
 
-The minimum Apache Airflow version supported by this provider distribution is ``3.0.0.dev0``.
+The minimum Apache Airflow version supported by this provider distribution is ``3.0.0``.
 
 ==================  ==================
 PIP package         Version required
 ==================  ==================
-``apache-airflow``  ``>=3.0.0.dev0``
+``apache-airflow``  ``>=3.0.0``
 ==================  ==================
 
 Cross provider package dependencies

--- a/providers/common/messaging/pyproject.toml
+++ b/providers/common/messaging/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = "~=3.9"
 # Make sure to run ``breeze static-checks --type update-providers-dependencies --all-files``
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
-    "apache-airflow>=3.0.0.dev0",
+    "apache-airflow>=3.0.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/common/messaging/src/airflow/providers/common/messaging/__init__.py
+++ b/providers/common/messaging/src/airflow/providers/common/messaging/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.0.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "3.0.0.dev0"
+    "3.0.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-common-messaging:{__version__}` needs Apache Airflow 3.0.0.dev0+"
+        f"The package `apache-airflow-providers-common-messaging:{__version__}` needs Apache Airflow 3.0.0+"
     )

--- a/providers/fab/README.rst
+++ b/providers/fab/README.rst
@@ -53,7 +53,7 @@ Requirements
 ==========================================  ==================
 PIP package                                 Version required
 ==========================================  ==================
-``apache-airflow``                          ``>=3.0.0.dev0``
+``apache-airflow``                          ``>=3.0.0``
 ``apache-airflow-providers-common-compat``  ``>=1.2.1``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1,<2.3``

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -102,12 +102,12 @@ For the minimum Airflow version supported, see ``Requirements`` below.
 Requirements
 ------------
 
-The minimum Apache Airflow version supported by this provider distribution is ``3.0.0.dev0``.
+The minimum Apache Airflow version supported by this provider distribution is ``3.0.0``.
 
 ==========================================  ==================
 PIP package                                 Version required
 ==========================================  ==================
-``apache-airflow``                          ``>=3.0.0.dev0``
+``apache-airflow``                          ``>=3.0.0``
 ``apache-airflow-providers-common-compat``  ``>=1.2.1``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1,<2.3``

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = "~=3.9"
 # Make sure to run ``breeze static-checks --type update-providers-dependencies --all-files``
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
-    "apache-airflow>=3.0.0.dev0",
+    "apache-airflow>=3.0.0",
     "apache-airflow-providers-common-compat>=1.2.1",
     # Blinker use for signals in Flask, this is an optional dependency in Flask 2.2 and lower.
     # In Flask 2.3 it becomes a mandatory dependency, and flask signals are always available.

--- a/providers/fab/src/airflow/providers/fab/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.0.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "3.0.0.dev0"
+    "3.0.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-fab:{__version__}` needs Apache Airflow 3.0.0.dev0+"
+        f"The package `apache-airflow-providers-fab:{__version__}` needs Apache Airflow 3.0.0+"
     )

--- a/providers/git/README.rst
+++ b/providers/git/README.rst
@@ -53,7 +53,7 @@ Requirements
 ==================  ==================
 PIP package         Version required
 ==================  ==================
-``apache-airflow``  ``>=3.0.0.dev0``
+``apache-airflow``  ``>=3.0.0.dev``
 ``GitPython``       ``>=3.1.44``
 ==================  ==================
 

--- a/providers/git/docs/index.rst
+++ b/providers/git/docs/index.rst
@@ -90,11 +90,11 @@ For the minimum Airflow version supported, see ``Requirements`` below.
 Requirements
 ------------
 
-The minimum Apache Airflow version supported by this provider distribution is ``3.0.0.dev0``.
+The minimum Apache Airflow version supported by this provider distribution is ``3.0.0``.
 
 ==================  ==================
 PIP package         Version required
 ==================  ==================
-``apache-airflow``  ``>=3.0.0.dev0``
+``apache-airflow``  ``>=3.0.0``
 ``GitPython``       ``>=3.1.44``
 ==================  ==================

--- a/providers/git/pyproject.toml
+++ b/providers/git/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = "~=3.9"
 # Make sure to run ``breeze static-checks --type update-providers-dependencies --all-files``
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
-    "apache-airflow>=3.0.0.dev0",
+    "apache-airflow>=3.0.0.dev",
     "GitPython>=3.1.44",
 ]
 

--- a/providers/git/src/airflow/providers/git/__init__.py
+++ b/providers/git/src/airflow/providers/git/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "0.0.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "3.0.0.dev0"
+    "3.0.0.dev"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-git:{__version__}` needs Apache Airflow 3.0.0.dev0+"
+        f"The package `apache-airflow-providers-git:{__version__}` needs Apache Airflow 3.0.0.dev+"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,11 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by pre-commit
-version = "3.0.0.dev0"
+version = "3.0.0"
 
 dependencies = [
     "apache-airflow-task-sdk",
-    "apache-airflow-core==3.0.0.dev0",
+    "apache-airflow-core==3.0.0",
 ]
 
 packages = []

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -99,7 +99,7 @@ exclude_also = [
 
 [dependency-groups]
 codegen = [
-    "apache-airflow>=3.0.0.dev0",
+    "apache-airflow>=3.0.0",
     "datamodel-code-generator[http]==0.28.2",
     "svcs>=25.1.0",
     "ruff==0.11.2",


### PR DESCRIPTION
As we are preparing to the final release and plan to release providers like git or fab that have Airflow 3 as minimum version we should remove the dev0 suffix from Airflow

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
