### PR TITLE
Add Listener notification in patch_task_instance api endpoint

### DIFF
--- a/airflow-core/docs/administration-and-deployment/listeners.rst
+++ b/airflow-core/docs/administration-and-deployment/listeners.rst
@@ -40,6 +40,8 @@ DagRun State Change Events
 --------------------------
 
 DagRun state change events occur when a :class:`~airflow.models.dagrun.DagRun` changes state.
+Beginning with Airflow 3, listeners are also notified whenever a state change is triggered through the API
+(for ``on_dag_run_success`` and ``on_dag_run_failed``) e.g., when a DagRun is marked as success from the Airflow UI.
 
 - ``on_dag_run_running``
 
@@ -66,8 +68,12 @@ DagRun state change events occur when a :class:`~airflow.models.dagrun.DagRun` c
 TaskInstance State Change Events
 --------------------------------
 
-TaskInstance state change events occur when a :class:`~airflow.models.taskinstance.TaskInstance` changes state.
+TaskInstance state change events occur when a :class:`~airflow.sdk.execution_time.task_runner.RuntimeTaskInstance` changes state.
 You can use these events to react to ``LocalTaskJob`` state changes.
+Starting with Airflow 3, listeners are also notified when a state change is triggered through the API
+(for ``on_task_instance_success`` and ``on_task_instance_failed``) e.g., when marking a task instance as success from the Airflow UI.
+In such cases, the listener will receive a :class:`~airflow.models.taskinstance.TaskInstance` instance instead
+of a :class:`~airflow.sdk.execution_time.task_runner.RuntimeTaskInstance` instance.
 
 - ``on_task_instance_running``
 
@@ -182,12 +188,14 @@ For example if you want to implement a listener that uses the ``error`` field in
 List of changes in the listener interfaces since 2.8.0 when they were introduced:
 
 
-+-----------------+--------------------------------------------+-------------------------------------------------------------------------+
-| Airflow Version | Affected method                            | Change                                                                  |
-+=================+============================================+=========================================================================+
-| 2.10.0          | ``on_task_instance_failed``                | An error field added to the interface                                   |
-+-----------------+--------------------------------------------+-------------------------------------------------------------------------+
-| 3.0.0           | ``on_task_instance_running``,              | ``session`` argument removed from task instance listeners,              |
-|                 | ``on_task_instance_success``,              | ``task_instance`` object is now an instance of ``RuntimeTaskInstance``  |
-|                 | ``on_task_instance_failed``                |                                                                         |
-+-----------------+--------------------------------------------+-------------------------------------------------------------------------+
++-----------------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Airflow Version | Affected method                            | Change                                                                                                                        |
++=================+============================================+===============================================================================================================================+
+| 2.10.0          | ``on_task_instance_failed``                | An error field added to the interface                                                                                         |
++-----------------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| 3.0.0           | ``on_task_instance_running``               | ``session`` argument removed from task instance listeners,                                                                    |
+|                 |                                            | ``task_instance`` object is now an instance of ``RuntimeTaskInstance``                                                        |
++-----------------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| 3.0.0           | ``on_task_instance_failed``,               | ``session`` argument removed from task instance listeners,                                                                    |
+|                 | ``on_task_instance_success``               | ``task_instance`` object is now an instance of ``RuntimeTaskInstance`` when on worker and ``TaskInstance`` when on API server |
++-----------------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, cast
 
+import structlog
 from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
@@ -64,6 +65,7 @@ from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_
 from airflow.api_fastapi.core_api.security import GetUserDep, ReadableTIFilterDep, requires_access_dag
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import TaskNotFound
+from airflow.listeners.listener import get_listener_manager
 from airflow.models import Base, DagRun
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance as TI, clear_task_instances
@@ -72,6 +74,8 @@ from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
 from airflow.utils.db import get_query_count
 from airflow.utils.state import DagRunState, TaskInstanceState
+
+log = structlog.get_logger(__name__)
 
 task_instances_router = AirflowRouter(tags=["Task Instance"], prefix="/dags/{dag_id}")
 task_instances_prefix = "/dagRuns/{dag_run_id}/taskInstances"
@@ -882,6 +886,20 @@ def patch_task_instance(
                     status.HTTP_409_CONFLICT, f"Task id {task_id} is already in {data['new_state']} state"
                 )
             ti = tis[0] if isinstance(tis, list) else tis
+            try:
+                if data["new_state"] == TaskInstanceState.SUCCESS:
+                    get_listener_manager().hook.on_task_instance_success(
+                        previous_state=None, task_instance=ti
+                    )
+                elif data["new_state"] == TaskInstanceState.FAILED:
+                    get_listener_manager().hook.on_task_instance_failed(
+                        previous_state=None,
+                        task_instance=ti,
+                        error=f"TaskInstance's state was manually set to `{TaskInstanceState.FAILED}`.",
+                    )
+            except Exception:
+                log.exception("error calling listener")
+
         elif key == "note":
             if update_mask or body.note is not None:
                 if ti.task_instance_note is None:

--- a/airflow-core/src/airflow/listeners/spec/taskinstance.py
+++ b/airflow-core/src/airflow/listeners/spec/taskinstance.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from pluggy import HookspecMarker
 
 if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance
     from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
     from airflow.utils.state import TaskInstanceState
 
@@ -34,14 +35,16 @@ def on_task_instance_running(previous_state: TaskInstanceState | None, task_inst
 
 
 @hookspec
-def on_task_instance_success(previous_state: TaskInstanceState | None, task_instance: RuntimeTaskInstance):
+def on_task_instance_success(
+    previous_state: TaskInstanceState | None, task_instance: RuntimeTaskInstance | TaskInstance
+):
     """Execute when task state changes to SUCCESS. previous_state can be None."""
 
 
 @hookspec
 def on_task_instance_failed(
     previous_state: TaskInstanceState | None,
-    task_instance: RuntimeTaskInstance,
+    task_instance: RuntimeTaskInstance | TaskInstance,
     error: None | str | BaseException,
 ):
     """Execute when task state changes to FAIL. previous_state can be None."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -30,6 +30,7 @@ from sqlalchemy import select
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
+from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
@@ -3031,6 +3032,39 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
     DAG_ID = "example_python_operator"
     TASK_ID = "print_the_context"
     RUN_ID = "TEST_DAG_RUN_ID"
+
+    @pytest.fixture(autouse=True)
+    def clean_listener_manager(self):
+        get_listener_manager().clear()
+        yield
+        get_listener_manager().clear()
+
+    @pytest.mark.parametrize(
+        "state, listener_state",
+        [
+            ("success", [TaskInstanceState.SUCCESS]),
+            ("failed", [TaskInstanceState.FAILED]),
+            ("skipped", []),
+        ],
+    )
+    def test_patch_task_instance_notifies_listeners(self, test_client, session, state, listener_state):
+        from unit.listeners.class_listener import ClassBasedListener
+
+        self.create_task_instances(session)
+
+        listener = ClassBasedListener()
+        get_listener_manager().add_listener(listener)
+        test_client.patch(
+            self.ENDPOINT_URL,
+            json={
+                "new_state": state,
+            },
+        )
+
+        response2 = test_client.get(self.ENDPOINT_URL)
+        assert response2.status_code == 200
+        assert response2.json()["state"] == state
+        assert listener.state == listener_state
 
     @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
     def test_should_call_mocked_api(self, mock_set_ti_state, test_client, session):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Similar to what #45652 did for DagRun, I'm following up with task instance endpoint. In short: if task's state is changed manually we will still get listener's notification. This allows f.e. OpenLineage to emit its events and lineage backends to reflect the state change and keep in sync with Airflow.

This PR also modifies the listener's spec for listener's `on_task_instance_success` and `on_task_instance_failed` task methods, so that they accept not only RunTimeTaskInstance available on the worker, but also TaskInstance model when on API server.

I saw three possible ways to implement this:

1. Modify the current listener 's `on_success` and `on_failed` task methods to accept TaskInstance and adjust the logic within the listener accordingly.
2. Introduce a separate method to the listener specification, such as `on_task_instance_manual_state_change`.
3. To maintain consistency, add two new methods to the listener specification one for DAGRun and one for task manual state changes. This would allow the listener to treat manual state changes differently for both DagRun and Task, but I'm not sure if it's needed.

Option 2 could potentially lead to inconsistencies: currently we notify using the “old” listener methods for DagRun, since we’re dealing with the same DagRun model (there is no distinction between the model on the scheduler and the API server). While option 3 might offer a more consistent approach, it would also mean that the existing listeners wouldn’t support the "new" manual DagRun state notifications on day 0 of Airflow 3 as they'd have to implement new method for that, which seems unnecessary given that there is no technical reason for this limitation. Since the manual DagRun listener notifications are important from my point of view, it’s important to ensure they are functioning with the current listeners.

With that in mind, I opted for approach 1. Since listener's task methods already need updates to be compatible with Airflow 3 (due to the transition from TaskInstance to RunTimeTaskInstance in the specification), this approach seems the most sensible.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
