### PR TITLE
Add section in event-driven scheduling doc to mention infinite scheduling

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/event-scheduling.rst
+++ b/airflow-core/docs/authoring-and-scheduling/event-scheduling.rst
@@ -100,7 +100,7 @@ It might inherit from the existing trigger as well if both triggers share some c
 Avoid infinite scheduling
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The reason why some triggers are not compatible with event-driven scheduling is, some triggers are waiting
+The reason why some triggers are not compatible with event-driven scheduling is that they are waiting
 for an external resource to reach a given state. Examples:
 
 * Wait for a file to exist in a storage service

--- a/airflow-core/docs/authoring-and-scheduling/event-scheduling.rst
+++ b/airflow-core/docs/authoring-and-scheduling/event-scheduling.rst
@@ -97,6 +97,31 @@ event-driven scheduling, then a new trigger must be created.
 This new trigger must inherit ``BaseEventTrigger`` and ensure it properly works with event-driven scheduling.
 It might inherit from the existing trigger as well if both triggers share some common code.
 
+Avoid infinite scheduling
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The reason why some triggers are not compatible with event-driven scheduling is, some triggers are waiting
+for an external resource to reach a given state. Examples:
+
+* Wait for a file to exist in a storage service
+* Wait for a job to be in a success state
+* Wait for a row to be present in a database
+
+Scheduling under such conditions can lead to infinite rescheduling. This is because once the condition becomes true,
+it is likely to remain true for an extended period.
+
+For example, consider a DAG scheduled to run when a specific job reaches a "success" state.
+Once the job succeeds, it will typically remain in that state. As a result, the DAG will be triggered repeatedly every
+time the triggerer checks the condition.
+
+Another example is the ``S3KeyTrigger``, which checks for the presence of a specific file in an S3 bucket.
+Once the file is created, the trigger will continue to succeed on every check, since the condition
+"is file X present in bucket Y" remains true.
+This leads to the DAG being triggered indefinitely every time the trigger mechanism runs.
+
+When creating custom triggers, be cautious about using conditions that remain permanently true once met.
+This can unintentionally result in infinite DAG executions and overwhelm your system.
+
 Use cases for event-driven dags
 -------------------------------
 


### PR DESCRIPTION
Relates to #48885.

As called out in this [comment](https://github.com/apache/airflow/issues/48885#issuecomment-2784046753), adding a section in the documentation about the "infinite scheduling" issue we have when creating a trigger. Users creating custom triggers should be aware of that issue and take it into consideration in their implementation.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
