### PR TITLE
Rework socket setup for supervisor and subprocess to handle large messages

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -269,7 +269,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
     def _handle_request(self, msg: ToManager, log: FilteringBoundLogger) -> None:  # type: ignore[override]
         from airflow.sdk.api.datamodels._generated import ConnectionResponse, VariableResponse
 
-        resp: Any = None
+        resp: BaseModel | None = None
         dump_opts = {}
         if isinstance(msg, DagFileParsingResult):
             self.parsing_result = msg

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -21,7 +21,7 @@ import os
 import sys
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, BinaryIO, Callable, ClassVar, Literal, Union
+from typing import TYPE_CHECKING, Annotated, Any, BinaryIO, Callable, ClassVar, Literal, Union
 
 import attrs
 from pydantic import BaseModel, Field, TypeAdapter
@@ -255,7 +255,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
             requests_fd=self._requests_fd,
             callback_requests=callbacks,
         )
-        self.stdin.write(msg.model_dump_json().encode() + b"\n")
+        self.send_msg(msg)
 
     @functools.cached_property
     def client(self) -> Client:
@@ -269,7 +269,8 @@ class DagFileProcessorProcess(WatchedSubprocess):
     def _handle_request(self, msg: ToManager, log: FilteringBoundLogger) -> None:  # type: ignore[override]
         from airflow.sdk.api.datamodels._generated import ConnectionResponse, VariableResponse
 
-        resp = None
+        resp: Any = None
+        dump_opts = {}
         if isinstance(msg, DagFileParsingResult):
             self.parsing_result = msg
             return
@@ -277,22 +278,24 @@ class DagFileProcessorProcess(WatchedSubprocess):
             conn = self.client.connections.get(msg.conn_id)
             if isinstance(conn, ConnectionResponse):
                 conn_result = ConnectionResult.from_conn_response(conn)
-                resp = conn_result.model_dump_json(exclude_unset=True, by_alias=True).encode()
+                resp = conn_result
+                dump_opts = {"exclude_unset": True, "by_alias": True}
             else:
-                resp = conn.model_dump_json().encode()
+                resp = conn
         elif isinstance(msg, GetVariable):
             var = self.client.variables.get(msg.key)
             if isinstance(var, VariableResponse):
                 var_result = VariableResult.from_variable_response(var)
-                resp = var_result.model_dump_json(exclude_unset=True).encode()
+                resp = var_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = var.model_dump_json().encode()
+                resp = var
         else:
             log.error("Unhandled request", msg=msg)
             return
 
         if resp:
-            self.stdin.write(resp + b"\n")
+            self.send_msg(resp, **dump_opts)
 
     @property
     def is_ready(self) -> bool:

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -21,7 +21,7 @@ import os
 import sys
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, BinaryIO, Callable, ClassVar, Literal, Union
+from typing import TYPE_CHECKING, Annotated, BinaryIO, Callable, ClassVar, Literal, Union
 
 import attrs
 from pydantic import BaseModel, Field, TypeAdapter

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -336,7 +336,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         proc = super().start(id=job.id, job=job, target=cls.run_in_process, logger=logger, **kwargs)
 
         msg = messages.StartTriggerer(requests_fd=proc._requests_fd)
-        proc.stdin.write(msg.model_dump_json().encode() + b"\n")
+        proc.stdin.sendall(msg.model_dump_json().encode() + b"\n")
         return proc
 
     @functools.cached_property
@@ -351,7 +351,8 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
     def _handle_request(self, msg: ToTriggerSupervisor, log: FilteringBoundLogger) -> None:  # type: ignore[override]
         from airflow.sdk.api.datamodels._generated import ConnectionResponse, VariableResponse, XComResponse
 
-        resp = None
+        resp: BaseModel | None = None
+        dump_opts = {}
 
         if isinstance(msg, messages.TriggerStateChanges):
             if msg.events:
@@ -376,29 +377,32 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 workload = self.creating_triggers.popleft()
                 response.to_create.append(workload)
             self.running_triggers.update(m.id for m in response.to_create)
-            resp = response.model_dump_json().encode()
+            resp = response
 
         elif isinstance(msg, GetConnection):
             conn = self.client.connections.get(msg.conn_id)
             if isinstance(conn, ConnectionResponse):
                 conn_result = ConnectionResult.from_conn_response(conn)
-                resp = conn_result.model_dump_json(exclude_unset=True, by_alias=True).encode()
+                resp = conn_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = conn.model_dump_json().encode()
+                resp = conn
         elif isinstance(msg, GetVariable):
             var = self.client.variables.get(msg.key)
             if isinstance(var, VariableResponse):
                 var_result = VariableResult.from_variable_response(var)
-                resp = var_result.model_dump_json(exclude_unset=True).encode()
+                resp = var_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = var.model_dump_json().encode()
+                resp = var
         elif isinstance(msg, GetXCom):
             xcom = self.client.xcoms.get(msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.map_index)
             if isinstance(xcom, XComResponse):
                 xcom_result = XComResult.from_xcom_response(xcom)
-                resp = xcom_result.model_dump_json(exclude_unset=True).encode()
+                resp = xcom_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = xcom.model_dump_json().encode()
+                resp = xcom
         elif isinstance(msg, GetDRCount):
             dr_count = self.client.dag_runs.get_count(
                 dag_id=msg.dag_id,
@@ -406,16 +410,16 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 run_ids=msg.run_ids,
                 states=msg.states,
             )
-            resp = dr_count.model_dump_json().encode()
+            resp = dr_count
         elif isinstance(msg, GetDagRunState):
             dr_resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)
-            resp = DagRunStateResult.from_api_response(dr_resp).model_dump_json().encode()
+            resp = dr_resp
 
         else:
             raise ValueError(f"Unknown message type {type(msg)}")
 
         if resp:
-            self.stdin.write(resp + b"\n")
+            self.send_msg(resp, **dump_opts)
 
     def run(self) -> None:
         """Run synchronously and handle all database reads/writes."""

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -336,7 +336,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         proc = super().start(id=job.id, job=job, target=cls.run_in_process, logger=logger, **kwargs)
 
         msg = messages.StartTriggerer(requests_fd=proc._requests_fd)
-        proc.stdin.sendall(msg.model_dump_json().encode() + b"\n")
+        proc.send_msg(msg)
         return proc
 
     @functools.cached_property

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -202,11 +202,11 @@ def test_trigger_lifecycle(spy_agency: SpyAgency, session):
         # Spy on it so we can see what gets send, but also call the original.
         message = None
 
-        @spy_agency.spy_for(trigger_runner_supervisor.stdin.write)
-        def write_spy(self, line, *args, **kwargs):
+        @spy_agency.spy_for(TriggerRunnerSupervisor.send_msg)
+        def send_msg_spy(self, msg, *args, **kwargs):
             nonlocal message
-            message = messages.TriggerStateSync.model_validate_json(line)
-            trigger_runner_supervisor.stdin.write.call_original(line, *args, **kwargs)
+            message = msg
+            TriggerRunnerSupervisor.send_msg.call_original(self, msg, *args, **kwargs)
 
         trigger_runner_supervisor.load_triggers()
         trigger_runner_supervisor._service_subprocess(0.1)

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -31,17 +31,14 @@ from collections.abc import Generator
 from contextlib import suppress
 from datetime import datetime, timezone
 from http import HTTPStatus
-from socket import SocketIO, socket, socketpair
+from socket import SO_SNDBUF, SOL_SOCKET, SocketIO, socket, socketpair
 from typing import (
     TYPE_CHECKING,
-    BinaryIO,
     Callable,
     ClassVar,
-    Literal,
     NoReturn,
     TextIO,
     cast,
-    overload,
 )
 from uuid import UUID
 
@@ -50,7 +47,7 @@ import httpx
 import msgspec
 import psutil
 import structlog
-from pydantic import TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 
 from airflow.configuration import conf
 from airflow.sdk.api.client import Client, ServerResponseError
@@ -67,7 +64,6 @@ from airflow.sdk.execution_time.comms import (
     AssetEventsResult,
     AssetResult,
     ConnectionResult,
-    DagRunStateResult,
     DeferTask,
     DeleteXCom,
     ErrorResponse,
@@ -129,31 +125,24 @@ STATES_SENT_DIRECTLY = [
 ]
 
 
-@overload
-def mkpipe() -> tuple[socket, socket]: ...
-
-
-@overload
-def mkpipe(remote_read: Literal[True]) -> tuple[socket, BinaryIO]: ...
+BUFFER_SIZE = 4096
 
 
 def mkpipe(
     remote_read: bool = False,
-) -> tuple[socket, socket | BinaryIO]:
+) -> tuple[socket, socket]:
     """Create a pair of connected sockets."""
     rsock, wsock = socketpair()
     local, remote = (wsock, rsock) if remote_read else (rsock, wsock)
 
-    local.setblocking(False)
-
-    io: BinaryIO | socket
     if remote_read:
-        # If _we_ are writing, we don't want to buffer
-        io = cast("BinaryIO", local.makefile("wb", buffering=0))
-    else:
-        io = local
+        # Setting a 4KB buffer here if possible, if not, it still works, so we will suppress all exceptions
+        with suppress(Exception):
+            local.setsockopt(SO_SNDBUF, SOL_SOCKET, BUFFER_SIZE)
+        # set nonblocking to True so that send or sendall waits till all data is sent
+        local.setblocking(True)
 
-    return remote, io
+    return remote, local
 
 
 def _subprocess_main():
@@ -376,7 +365,7 @@ class WatchedSubprocess:
     pid: int
     """The process ID of the child process"""
 
-    stdin: BinaryIO
+    stdin: socket
     """The handle connected to stdin of the child process"""
 
     decoder: ClassVar[TypeAdapter]
@@ -504,6 +493,11 @@ class WatchedSubprocess:
         # We want to keep servicing this process until we've read up to EOF from all the sockets.
         self._num_open_sockets -= 1
 
+    def send_msg(self, msg: BaseModel, **dump_opts):
+        """Send the given pydantic message to the subprocess at once by encoding it and adding a line break."""
+        b = msg.model_dump_json(**dump_opts).encode() + b"\n"
+        self.stdin.sendall(b)
+
     def handle_requests(self, log: FilteringBoundLogger) -> Generator[None, bytes, None]:
         """Handle incoming requests from the task process, respond with the appropriate data."""
         while True:
@@ -527,7 +521,7 @@ class WatchedSubprocess:
                 )
 
                 # Send error response back to task so that the error appears in the task logs
-                error_resp = (
+                self.send_msg(
                     ErrorResponse(
                         error=ErrorType.API_SERVER_ERROR,
                         detail={
@@ -536,10 +530,7 @@ class WatchedSubprocess:
                             "detail": error_details,
                         },
                     )
-                    .model_dump_json()
-                    .encode()
                 )
-                self.stdin.write(error_resp + b"\n")
 
     def _handle_request(self, msg, log: FilteringBoundLogger) -> None:
         raise NotImplementedError()
@@ -747,8 +738,7 @@ class ActivitySubprocess(WatchedSubprocess):
         log.debug("Sending", msg=msg)
 
         try:
-            self.stdin.write(msg.model_dump_json().encode())
-            self.stdin.write(b"\n")
+            self.send_msg(msg)
         except BrokenPipeError:
             # Debug is fine, the process will have shown _something_ in it's last_chance exception handler
             log.debug("Couldn't send startup message to Subprocess - it died very early", pid=self.pid)
@@ -900,7 +890,8 @@ class ActivitySubprocess(WatchedSubprocess):
 
     def _handle_request(self, msg: ToSupervisor, log: FilteringBoundLogger):
         log.debug("Received message from task runner", msg=msg)
-        resp = None
+        resp: BaseModel | None = None
+        dump_opts = {}
         if isinstance(msg, TaskState):
             self._terminal_state = msg.state
             self._task_end_time_monotonic = time.monotonic()
@@ -921,27 +912,29 @@ class ActivitySubprocess(WatchedSubprocess):
                 if conn.extra:
                     mask_secret(conn.extra)
                 conn_result = ConnectionResult.from_conn_response(conn)
-                resp = conn_result.model_dump_json(exclude_unset=True, by_alias=True).encode()
+                resp = conn_result
+                dump_opts = {"exclude_unset": True, "by_alias": True}
             else:
-                resp = conn.model_dump_json().encode()
+                resp = conn
         elif isinstance(msg, GetVariable):
             var = self.client.variables.get(msg.key)
             if isinstance(var, VariableResponse):
                 if var.value:
                     mask_secret(var.value)
                 var_result = VariableResult.from_variable_response(var)
-                resp = var_result.model_dump_json(exclude_unset=True).encode()
+                resp = var_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = var.model_dump_json().encode()
+                resp = var
         elif isinstance(msg, GetXCom):
             xcom = self.client.xcoms.get(
                 msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.map_index, msg.include_prior_dates
             )
             xcom_result = XComResult.from_xcom_response(xcom)
-            resp = xcom_result.model_dump_json().encode()
+            resp = xcom_result
         elif isinstance(msg, GetXComCount):
             len = self.client.xcoms.head(msg.dag_id, msg.run_id, msg.task_id, msg.key)
-            resp = XComCountResponse(len=len).model_dump_json().encode()
+            resp = XComCountResponse(len=len)
         elif isinstance(msg, DeferTask):
             self._terminal_state = IntermediateTIState.DEFERRED
             self.client.task_instances.defer(self.id, msg)
@@ -964,45 +957,47 @@ class ActivitySubprocess(WatchedSubprocess):
             asset_resp = self.client.assets.get(name=msg.name)
             if isinstance(asset_resp, AssetResponse):
                 asset_result = AssetResult.from_asset_response(asset_resp)
-                resp = asset_result.model_dump_json(exclude_unset=True).encode()
+                resp = asset_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = asset_resp.model_dump_json().encode()
+                resp = asset_resp
         elif isinstance(msg, GetAssetByUri):
             asset_resp = self.client.assets.get(uri=msg.uri)
             if isinstance(asset_resp, AssetResponse):
                 asset_result = AssetResult.from_asset_response(asset_resp)
-                resp = asset_result.model_dump_json(exclude_unset=True).encode()
+                resp = asset_result
+                dump_opts = {"exclude_unset": True}
             else:
-                resp = asset_resp.model_dump_json().encode()
+                resp = asset_resp
         elif isinstance(msg, GetAssetEventByAsset):
             asset_event_resp = self.client.asset_events.get(uri=msg.uri, name=msg.name)
             asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)
-            resp = asset_event_result.model_dump_json(exclude_unset=True).encode()
+            resp = asset_event_result
+            dump_opts = {"exclude_unset": True}
         elif isinstance(msg, GetAssetEventByAssetAlias):
             asset_event_resp = self.client.asset_events.get(alias_name=msg.alias_name)
             asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)
-            resp = asset_event_result.model_dump_json(exclude_unset=True).encode()
+            resp = asset_event_result
+            dump_opts = {"exclude_unset": True}
         elif isinstance(msg, GetPrevSuccessfulDagRun):
             dagrun_resp = self.client.task_instances.get_previous_successful_dagrun(self.id)
             dagrun_result = PrevSuccessfulDagRunResult.from_dagrun_response(dagrun_resp)
-            resp = dagrun_result.model_dump_json(exclude_unset=True).encode()
+            resp = dagrun_result
+            dump_opts = {"exclude_unset": True}
         elif isinstance(msg, TriggerDagRun):
-            dr_resp = self.client.dag_runs.trigger(
+            resp = self.client.dag_runs.trigger(
                 msg.dag_id,
                 msg.run_id,
                 msg.conf,
                 msg.logical_date,
                 msg.reset_dag_run,
             )
-            resp = dr_resp.model_dump_json().encode()
         elif isinstance(msg, GetDagRunState):
-            dr_resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)
-            resp = DagRunStateResult.from_api_response(dr_resp).model_dump_json().encode()
+            resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)
         elif isinstance(msg, GetTaskRescheduleStartDate):
-            tr_resp = self.client.task_instances.get_reschedule_start_date(msg.ti_id, msg.try_number)
-            resp = tr_resp.model_dump_json().encode()
+            resp = self.client.task_instances.get_reschedule_start_date(msg.ti_id, msg.try_number)
         elif isinstance(msg, GetTICount):
-            ti_count = self.client.task_instances.get_count(
+            resp = self.client.task_instances.get_count(
                 dag_id=msg.dag_id,
                 task_ids=msg.task_ids,
                 task_group_id=msg.task_group_id,
@@ -1010,21 +1005,19 @@ class ActivitySubprocess(WatchedSubprocess):
                 run_ids=msg.run_ids,
                 states=msg.states,
             )
-            resp = ti_count.model_dump_json().encode()
         elif isinstance(msg, GetDRCount):
-            dr_count = self.client.dag_runs.get_count(
+            resp = self.client.dag_runs.get_count(
                 dag_id=msg.dag_id,
                 logical_dates=msg.logical_dates,
                 run_ids=msg.run_ids,
                 states=msg.states,
             )
-            resp = dr_count.model_dump_json().encode()
         else:
             log.error("Unhandled request", msg=msg)
             return
 
         if resp:
-            self.stdin.write(resp + b"\n")
+            self.send_msg(resp, **dump_opts)
 
 
 # Sockets, even the `.makefile()` function don't correctly do line buffering on reading. If a chunk is read

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -124,7 +124,8 @@ STATES_SENT_DIRECTLY = [
     TerminalTIState.SUCCESS,
 ]
 
-
+# Setting a fair buffer size here to handle most message sizes. Intention is to enforce a buffer size
+# that is big enough to handle small to medium messages while not enforcing hard latency issues
 BUFFER_SIZE = 4096
 
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -1430,8 +1430,6 @@ class TestHandleRequest:
         generator = watched_subprocess.handle_requests(log=mocker.Mock())
         # Initialize the generator
         next(generator)
-
-        # Send a message
         msg = message.model_dump_json().encode() + b"\n"
         generator.send(msg)
         time_machine.move_to(timezone.datetime(2024, 10, 31), tick=False)


### PR DESCRIPTION
…sages

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/48852

Our supervisor subprocess communication model is using socket pairs. One problem encountered recently was as linked in the issue when a very large xcom was used, the channel would send incomplete message leading to the subprocess waiting forever.

In this PR i am making some improvements that will benefit us in such cases. 

Key changes:
1. Switiching to a socket
2. Using sendall()
3. Setting `local.setblocking(True)` so that the entire message is sent across to subprocess.


Testing with dag in the issue:
```
from airflow.sdk import dag
from airflow.decorators import task


@dag()
def lazy_list_xcom():
    @task
    def create_long_list():
        big_list = [[i for i in range(100)] for _ in range(1000)]
        return big_list

    @task
    def print_list(x):
        print(x)

    print_list(create_long_list())


lazy_list_xcom()
```

<img width="1720" alt="image" src="https://github.com/user-attachments/assets/d872615d-a457-4b7d-bcf5-37abf36cf178" />


<img width="1720" alt="image" src="https://github.com/user-attachments/assets/1d4fea35-2840-436a-9211-646e7b45f215" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
