### PR TITLE
Fix task removal when there's serdag change in versioned bundle

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -63,8 +63,8 @@ def _trigger_dag(
     :return: list of triggered dags
     """
     dag = dag_bag.get_dag(dag_id, session=session)  # prefetch dag if it is stored serialized
-
-    if dag is None or dag_id not in dag_bag.dags:
+    dag_info = dag_id, None  # Using None since we don't have bundle_version information
+    if dag is None or dag_info not in dag_bag.dags:
         raise DagNotFound(f"Dag id {dag_id} not found")
 
     run_after = run_after or timezone.coerce_datetime(timezone.utcnow())

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -523,7 +523,7 @@ def dag_report(args) -> None:
         if bundle.name not in bundles_to_reserialize:
             continue
         bundle.initialize()
-        dagbag = DagBag(bundle.path, include_examples=False)
+        dagbag = DagBag(bundle.path, include_examples=False, bundle_version=bundle.version)
         all_dagbag_stats.extend(dagbag.dagbag_stats)
 
     AirflowConsole().print_as(
@@ -629,7 +629,7 @@ def _parse_and_get_dag(dag_id: str) -> DAG | None:
         bag = DagBag(
             dag_folder=dag_absolute_path, include_examples=False, safe_mode=False, load_op_links=False
         )
-        return bag.dags.get(dag_id)
+        return bag.dags.get((dag_id, bundle.version))
 
 
 @cli_utils.action_cli

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -871,6 +871,7 @@ class DagFileProcessorManager(LoggingMixin):
             id=id,
             path=dag_file.absolute_path,
             bundle_path=cast("Path", dag_file.bundle_path),
+            bundle_version=dag_file.bundle_version,
             callbacks=callback_to_execute_for_file,
             selector=self.selector,
             logger=logger,

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -251,7 +251,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
         callbacks: list[CallbackRequest],
         path: str | os.PathLike[str],
         bundle_path: Path,
-        bundle_version: str | None,
+        bundle_version: str | None = None,
     ) -> None:
         msg = DagFileParseRequest(
             file=os.fspath(path),

--- a/airflow-core/src/airflow/models/dag_version.py
+++ b/airflow-core/src/airflow/models/dag_version.py
@@ -140,6 +140,7 @@ class DagVersion(Base):
         dag_id: str,
         version_number: int | None = None,
         *,
+        bundle_version: str | None = None,
         session: Session = NEW_SESSION,
     ) -> DagVersion | None:
         """
@@ -147,12 +148,15 @@ class DagVersion(Base):
 
         :param dag_id: The DAG ID.
         :param version_number: The version number.
+        :param bundle_version: The bundle version.
         :param session: The database session.
         :return: The version of the DAG or None if not found.
         """
         version_select_obj = select(cls).where(cls.dag_id == dag_id)
         if version_number:
             version_select_obj = version_select_obj.where(cls.version_number == version_number)
+        if bundle_version:
+            version_select_obj = version_select_obj.where(cls.bundle_version == bundle_version)
 
         return session.scalar(version_select_obj.order_by(cls.id.desc()).limit(1))
 

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -234,7 +234,7 @@ def get_dag_by_file_location(dag_id: str):
             f"Dag {dag_id!r} could not be found; either it does not exist or it failed to parse."
         )
     dagbag = DagBag(dag_folder=dag_model.fileloc)
-    return dagbag.dags[dag_id]
+    return dagbag.dags[(dag_id, None)]
 
 
 def _search_for_dag_file(val: str | None) -> str | None:
@@ -275,7 +275,7 @@ def get_dag(subdir: str | None, dag_id: str, from_db: bool = False) -> DAG:
     else:
         first_path = process_subdir(subdir)
         dagbag = DagBag(first_path)
-        dag = dagbag.dags.get(dag_id)  # avoids db calls made in get_dag
+        dag = dagbag.dags.get((dag_id, None))  # avoids db calls made in get_dag
         # Create a SchedulerDAG since some of the CLI commands rely on DB access
         dag = DAG.from_sdk_dag(dag)
     if not dag:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -92,7 +92,7 @@ class TestGetExtraLinks:
 
         DagBundlesManager().sync_bundles_to_db()
         dag_bag = DagBag(os.devnull, include_examples=False)
-        dag_bag.dags = {self.dag.dag_id: self.dag}
+        dag_bag.dags = {(self.dag.dag_id, None): self.dag}
         test_client.app.state.dag_bag = dag_bag
         dag_bag.sync_to_db("dags-folder", None)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -259,7 +259,7 @@ class TestTaskInstancesLog:
         # Recreate DAG without tasks
         dagbag = self.app.state.dag_bag
         dag = DAG(self.DAG_ID, schedule=None, start_date=timezone.parse(self.default_time))
-        del dagbag.dags[self.DAG_ID]
+        del dagbag.dags[(self.DAG_ID, None)]
         dagbag.bag_dag(dag=dag)
 
         key = self.app.state.secret_key

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -66,9 +66,9 @@ class TestTaskEndpoint:
         task4 >> task5
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {
-            dag.dag_id: dag,
-            mapped_dag.dag_id: mapped_dag,
-            unscheduled_dag.dag_id: unscheduled_dag,
+            (dag.dag_id, None): dag,
+            (mapped_dag.dag_id, None): mapped_dag,
+            (unscheduled_dag.dag_id, None): unscheduled_dag,
         }
         test_client.app.state.dag_bag = dag_bag
 

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -111,8 +111,8 @@ class TestCliTasks:
 
     @pytest.mark.execution_timeout(120)
     def test_cli_list_tasks(self):
-        for dag_id in self.dagbag.dags:
-            args = self.parser.parse_args(["tasks", "list", dag_id])
+        for dag_info in self.dagbag.dags:
+            args = self.parser.parse_args(["tasks", "list", dag_info[0]])
             task_command.task_list(args)
 
     def test_test(self):
@@ -338,7 +338,7 @@ class TestCliTasks:
         )
 
     def test_task_states_for_dag_run(self):
-        dag2 = DagBag().dags["example_python_operator"]
+        dag2 = DagBag().dags[("example_python_operator", None)]
         task2 = dag2.get_task(task_id="print_the_context")
 
         dag2 = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag2))

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -559,7 +559,8 @@ class TestDagFileProcessorManager:
                 b'"bundle_path":"/opt/airflow/dags",'
                 b'"requests_fd":123,'
                 b'"callback_requests":[],'
-                b'"type":"DagFileParseRequest"'
+                b'"type":"DagFileParseRequest",'
+                b'"bundle_version":null'
                 b"}\n",
             ),
             pytest.param(
@@ -590,7 +591,8 @@ class TestDagFileProcessorManager:
                 b'"type":"DagCallbackRequest"'
                 b"}"
                 b"],"
-                b'"type":"DagFileParseRequest"'
+                b'"type":"DagFileParseRequest",'
+                b'"bundle_version":null'
                 b"}\n",
             ),
         ],
@@ -883,6 +885,7 @@ class TestDagFileProcessorManager:
                     id=mock.ANY,
                     path=Path(dag2_path.bundle_path, dag2_path.rel_path),
                     bundle_path=dag2_path.bundle_path,
+                    bundle_version=None,
                     callbacks=[dag2_req1],
                     selector=mock.ANY,
                     logger=mock_logger,
@@ -892,6 +895,7 @@ class TestDagFileProcessorManager:
                     id=mock.ANY,
                     path=Path(dag1_path.bundle_path, dag1_path.rel_path),
                     bundle_path=dag1_path.bundle_path,
+                    bundle_version=None,
                     callbacks=[dag1_req1, dag1_req2],
                     selector=mock.ANY,
                     logger=mock_logger,

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -305,7 +305,7 @@ def test_parse_file_with_dag_callbacks(spy_agency):
     dag = DAG(dag_id="a", on_failure_callback=on_failure)
 
     def fake_collect_dags(self, *args, **kwargs):
-        self.dags[dag.dag_id] = dag
+        self.dags[(dag.dag_id, None)] = dag
 
     spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
 
@@ -341,7 +341,7 @@ def test_parse_file_with_task_callbacks(spy_agency):
         BaseOperator(task_id="b", on_failure_callback=on_failure)
 
     def fake_collect_dags(self, *args, **kwargs):
-        self.dags[dag.dag_id] = dag
+        self.dags[(dag.dag_id, None)] = dag
 
     spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3342,8 +3342,8 @@ class TestSchedulerJob:
 
         dag_version_1 = DagVersion.get_latest_version(dr.dag_id, session=session)
         assert dr.dag_versions[-1].id == dag_version_1.id
-        assert self.job_runner.dagbag.dags == {"test_verify_integrity_if_dag_changed": dag}
-        assert len(self.job_runner.dagbag.dags.get("test_verify_integrity_if_dag_changed").tasks) == 1
+        assert self.job_runner.dagbag.dags == {("test_verify_integrity_if_dag_changed", None): dag}
+        assert len(self.job_runner.dagbag.dags.get(("test_verify_integrity_if_dag_changed", None)).tasks) == 1
 
         # Now let's say the DAG got updated (new task got added)
         BashOperator(task_id="bash_task_1", dag=dag, bash_command="echo hi")
@@ -3359,8 +3359,8 @@ class TestSchedulerJob:
         assert len(drs) == 1
         dr = drs[0]
         assert dr.dag_versions[-1].id == dag_version_2.id
-        assert self.job_runner.dagbag.dags == {"test_verify_integrity_if_dag_changed": dag}
-        assert len(self.job_runner.dagbag.dags.get("test_verify_integrity_if_dag_changed").tasks) == 2
+        assert self.job_runner.dagbag.dags == {("test_verify_integrity_if_dag_changed", None): dag}
+        assert len(self.job_runner.dagbag.dags.get(("test_verify_integrity_if_dag_changed", None)).tasks) == 2
 
         tis_count = (
             session.query(func.count(TaskInstance.task_id))

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -73,13 +73,13 @@ class TestDagCode:
 
     def _write_two_example_dags(self, session):
         example_dags = make_example_dags(example_dags_module)
-        bash_dag = example_dags["example_bash_operator"]
+        bash_dag = example_dags[("example_bash_operator", None)]
         SDM.write_dag(bash_dag, bundle_name="testing")
         dag_version = DagVersion.get_latest_version("example_bash_operator")
         x = DagCode(dag_version, bash_dag.fileloc)
         session.add(x)
         session.commit()
-        xcom_dag = example_dags["example_xcom"]
+        xcom_dag = example_dags[("example_xcom", None)]
         SDM.write_dag(xcom_dag, bundle_name="testing")
         dag_version = DagVersion.get_latest_version("example_xcom")
         x = DagCode(dag_version, xcom_dag.fileloc)
@@ -129,7 +129,7 @@ class TestDagCode:
         Test that code can be retrieved from DB when you do not have access to Code file.
         Source Code should at least exist in one of DB or File.
         """
-        example_dag = make_example_dags(example_dags_module).get("example_bash_operator")
+        example_dag = make_example_dags(example_dags_module).get(("example_bash_operator", None))
         SDM.write_dag(example_dag, bundle_name="testing")
 
         # Mock that there is no access to the Dag File
@@ -142,7 +142,7 @@ class TestDagCode:
 
     def test_db_code_created_on_serdag_change(self, session, testing_dag_bundle):
         """Test new DagCode is created in DB when ser dag is changed"""
-        example_dag = make_example_dags(example_dags_module).get("example_bash_operator")
+        example_dag = make_example_dags(example_dags_module).get(("example_bash_operator", None))
         SDM.write_dag(example_dag, bundle_name="testing")
 
         dag = DAG.from_sdk_dag(example_dag)

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -141,7 +141,7 @@ class TestSerializedDagModel:
     def test_serialized_dag_is_updated_if_dag_is_changed(self, testing_dag_bundle):
         """Test Serialized DAG is updated if DAG is changed"""
         example_dags = make_example_dags(example_dags_module)
-        example_bash_op_dag = example_dags.get("example_bash_operator")
+        example_bash_op_dag = example_dags.get(("example_bash_operator", None))
         dag_updated = SDM.write_dag(dag=example_bash_op_dag, bundle_name="testing")
         assert dag_updated is True
 
@@ -194,7 +194,7 @@ class TestSerializedDagModel:
         serialized_dags = SDM.read_all_dags()
         assert len(example_dags) == len(serialized_dags)
 
-        dag = example_dags.get("example_bash_operator")
+        dag = example_dags.get(("example_bash_operator", None))
 
         # DAGs are serialized and deserialized to access create_dagrun object
         sdag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag=dag))
@@ -219,7 +219,7 @@ class TestSerializedDagModel:
         the serialized DAG JSON.
         """
         example_dags = make_example_dags(example_dags_module)
-        example_params_trigger_ui = example_dags.get("example_params_trigger_ui")
+        example_params_trigger_ui = example_dags.get(("example_params_trigger_ui", None))
         before = list(example_params_trigger_ui.params.keys())
 
         SDM.write_dag(example_params_trigger_ui, bundle_name="testing")
@@ -285,7 +285,7 @@ class TestSerializedDagModel:
             example_dags = self._write_example_dags()
             ordered_example_dags = dict(sorted(example_dags.items()))
             hashes = set()
-            for dag_id in ordered_example_dags.keys():
+            for dag_id, _ in ordered_example_dags.keys():
                 smd = session.execute(select(SDM.dag_hash).where(SDM.dag_id == dag_id)).one()
                 hashes.add(smd.dag_hash)
             return hashes

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -339,7 +339,7 @@ def make_user_defined_macro_filter_dag():
         bash_command='echo "{{ last_dagrun(dag) }}"',
         dag=dag,
     )
-    return {dag.dag_id: dag}
+    return {(dag.dag_id, None): dag}
 
 
 def get_excluded_patterns() -> Generator[str, None, None]:
@@ -357,7 +357,7 @@ def collect_dags(dag_folder=None):
     """Collects DAGs to test."""
     dags = {}
     import_errors = {}
-    dags.update({"simple_dag": make_simple_dag()})
+    dags.update({("simple_dag", None): make_simple_dag()})
     dags.update(make_user_defined_macro_filter_dag())
 
     if dag_folder is None:
@@ -1613,7 +1613,7 @@ class TestStringifiedDAGs:
             "airflow-core/src/airflow/example_dags/example_dynamic_task_mapping.py", include_examples=False
         )
         assert not dagbag.import_errors
-        dag = dagbag.dags["example_dynamic_task_mapping"]
+        dag = dagbag.dags[("example_dynamic_task_mapping", None)]
         ser_dag = SerializedDAG.to_dict(dag)
         # We should not include `_is_sensor` most of the time (as it would be wasteful). Check we don't
         assert "_is_sensor" not in ser_dag["dag"]["tasks"][0]["__var"]

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -593,7 +593,7 @@ class TestStringifiedDAGs:
                 break
             dag = SerializedDAG.from_json(v)
             assert isinstance(dag, DAG)
-            stringified_dags[dag.dag_id] = dag
+            stringified_dags[(dag.dag_id, None)] = dag
 
         dags, _ = collect_dags("airflow/example_dags")
         assert set(stringified_dags.keys()) == set(dags.keys())

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -82,7 +82,8 @@ def _bootstrap_dagbag():
             dagbag.sync_to_db(session=session)
 
         # Deactivate the unknown ones
-        DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
+        dag_ids = [key[0] for key in dagbag.dags.keys()]
+        DAG.deactivate_unknown_dags(dag_ids, session=session)
 
 
 def initial_db_init():

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler_system.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler_system.py
@@ -79,7 +79,7 @@ class TestGCSTaskHandlerSystem(GoogleSystemTest):
             assert subprocess.Popen(["airflow", "scheduler", "--num-runs", "1"]).wait() == 0
 
         ti = session.query(TaskInstance).filter(TaskInstance.task_id == "create_entry_group").first()
-        dag = DagBag(dag_folder=example_complex.__file__).dags["example_complex"]
+        dag = DagBag(dag_folder=example_complex.__file__).dags[("example_complex", None)]
         task = dag.task_dict["create_entry_group"]
         ti.task = task
         self.assert_remote_logs("INFO - Task exited with return code 0", ti)

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_execution.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_execution.py
@@ -96,7 +96,10 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 dag_folder=TEST_DAG_FOLDER,
                 include_examples=False,
             )
-            dag = dagbag.dags.get(("test_openlineage_execution", None))
+            key = "test_openlineage_execution"
+            if AIRFLOW_V_3_0_PLUS:
+                key = "test_openlineage_execution", None
+            dag = dagbag.dags.get(key)
             task = dag.get_task(task_name)
 
             if AIRFLOW_V_3_0_PLUS:
@@ -206,7 +209,10 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 dag_folder=TEST_DAG_FOLDER,
                 include_examples=False,
             )
-            dag = dagbag.dags.get(("test_openlineage_execution", None))
+            key = "test_openlineage_execution"
+            if AIRFLOW_V_3_0_PLUS:
+                key = "test_openlineage_execution", None
+            dag = dagbag.dags.get(key)
             task = dag.get_task("execute_long_stall")
 
             if AIRFLOW_V_3_0_PLUS:

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_execution.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_execution.py
@@ -96,7 +96,7 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 dag_folder=TEST_DAG_FOLDER,
                 include_examples=False,
             )
-            dag = dagbag.dags.get("test_openlineage_execution")
+            dag = dagbag.dags.get(("test_openlineage_execution", None))
             task = dag.get_task(task_name)
 
             if AIRFLOW_V_3_0_PLUS:
@@ -206,7 +206,7 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 dag_folder=TEST_DAG_FOLDER,
                 include_examples=False,
             )
-            dag = dagbag.dags.get("test_openlineage_execution")
+            dag = dagbag.dags.get(("test_openlineage_execution", None))
             task = dag.get_task("execute_long_stall")
 
             if AIRFLOW_V_3_0_PLUS:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -518,11 +518,12 @@ def parse(what: StartupDetails) -> RuntimeTaskInstance:
         include_examples=False,
         safe_mode=False,
         load_op_links=False,
+        bundle_version=bundle_info.version,
     )
     if TYPE_CHECKING:
         assert what.ti.dag_id
 
-    dag = bag.dags[what.ti.dag_id]
+    dag = bag.dags[(what.ti.dag_id, bundle_info.version)]
 
     # install_loader()
 


### PR DESCRIPTION
Ensure DAG runs in a versioned bundle use the correct serialized DAG (serdag) version.

Previously, when a DAG had multiple versions due to changes (e.g., a task removed), running DAG runs would sometimes incorrectly use the latest serialized DAG, even if they were started with an older version. This caused tasks that should still run to be incorrectly marked as removed.

The issue was caused by the scheduler not considering `bundle_version` when retrieving the DAG from the `dagbag`, defaulting to the latest available version.

This fix updates `dagbag.dags` to store DAGs keyed by both `dag_id` and `bundle_version`. All DAG retrievals in scheduling are now made with the correct version context, ensuring task consistency for running DAG runs.

Also introduces a `GetDag` Protocol for precise typing of the cached DAG getter, now supporting both `dag_id` and `bundle_version` parameters.


How to reproduce:
Using the dag below in a git bundle, create a run, then comment out the first section, uncomment the second quickly while the first is still in the sleep task. Run the task and you will see the astronomer task marked removed.

```python
from airflow import DAG
from airflow.providers.standard.operators.bash import BashOperator

with DAG(dag_id="demo"):
    # First run
    sleep = BashOperator(task_id="sleep", bash_command="sleep 300")
    hello = BashOperator(task_id="hello", bash_command="echo 'Hello'")
    astronomer = BashOperator(task_id="astronomer", bash_command="echo 'Astonomer'")

    sleep >> hello >> astronomer

    # Second run
    #sleep = BashOperator(task_id="sleep", bash_command="sleep 45")
    #hello = BashOperator(task_id="hello", bash_command="echo 'Hello Astronomer!!'")

    #sleep >> hello
```

Closes: https://github.com/apache/airflow/issues/49007
