### PR TITLE
Use asset name in schedule instead of uri

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -20,7 +20,7 @@ import dayjs from "dayjs";
 import { FiDatabase } from "react-icons/fi";
 
 import { useAssetServiceNextRunAssets } from "openapi/queries";
-import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import type { AssetResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { AssetExpression, type ExpressionType } from "src/components/AssetExpression";
 import type { NextRunEvent } from "src/components/AssetExpression/types";
 import { Button, Popover } from "src/components/ui";
@@ -53,7 +53,8 @@ export const AssetSchedule = ({ dag }: Props) => {
         <Button loading={isLoading} paddingInline={0} size="sm" variant="ghost">
           <FiDatabase style={{ display: "inline" }} />
           {nextRunEvents.length === 1 ? (
-            nextRunEvents[0]?.uri
+            ((nextRun?.asset_expression as { all: Array<AssetResponse> }).all[0]?.name ??
+            nextRunEvents[0]?.uri)
           ) : (
             <>
               {pendingEvents.length}


### PR DESCRIPTION
We should try to use asset.name when possible


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
