### PR TITLE
Remove sqlite provider from preinstalled and use aiosqlite as core dep

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -63,6 +63,7 @@ version = "3.0.0"
 
 dependencies = [
     "a2wsgi>=1.10.8",
+    "aiosqlite>=0.20.0",
     # Alembic is important to handle our migrations in predictable and performant way. It is developed
     # together with SQLAlchemy. Our experience with Alembic is that it very stable in minor version
     # The 1.13.0 of alembic marked some migration code as SQLAlchemy 2+ only so we limit it to 1.13.1
@@ -139,7 +140,6 @@ dependencies = [
     "apache-airflow-providers-common-sql>=1.24.1",
     "apache-airflow-providers-smtp>=2.0.1",
     "apache-airflow-providers-standard>=0.2.0",
-    "apache-airflow-providers-sqlite>=4.0.1",
 ]
 
 

--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -31,7 +31,8 @@ from cryptography.fernet import Fernet
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection, crypto
-from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+
+sqlite = pytest.importorskip("airflow.providers.sqlite.hooks.sqlite")
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
@@ -594,6 +595,8 @@ class TestConnection:
         },
     )
     def test_using_env_var(self):
+        from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+
         conn = SqliteHook.get_connection(conn_id="test_uri")
         assert conn.host == "ec2.compute.com"
         assert conn.schema == "the_database"
@@ -610,6 +613,8 @@ class TestConnection:
         },
     )
     def test_using_unix_socket_env_var(self):
+        from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+
         conn = SqliteHook.get_connection(conn_id="test_uri_no_creds")
         assert conn.host == "ec2.compute.com"
         assert conn.schema == "the_database"
@@ -634,6 +639,8 @@ class TestConnection:
 
     @pytest.mark.db_test
     def test_env_var_priority(self):
+        from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+
         conn = SqliteHook.get_connection(conn_id="airflow_db")
         assert conn.host != "ec2.compute.com"
 
@@ -687,6 +694,8 @@ class TestConnection:
         },
     )
     def test_get_connections_env_var(self):
+        from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+
         conns = SqliteHook.get_connection(conn_id="test_uri")
         assert conns.host == "ec2.compute.com"
         assert conns.schema == "the_database"

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -17,7 +17,8 @@
 from __future__ import annotations
 
 import os
-from unittest import mock
+from importlib.metadata import PackageNotFoundError, metadata
+from unittest import SkipTest, mock
 
 import pytest
 
@@ -828,6 +829,12 @@ class TestPatchConnection(TestConnectionEndpoint):
 
 
 class TestConnection(TestConnectionEndpoint):
+    def setup_method(self):
+        try:
+            metadata("apache-airflow-providers-sqlite")
+        except PackageNotFoundError:
+            raise SkipTest("The SQlite distribution package is not installed.")
+
     @mock.patch.dict(os.environ, {"AIRFLOW__CORE__TEST_CONNECTION": "Enabled"})
     @pytest.mark.parametrize(
         "body, message",

--- a/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
@@ -25,5 +25,5 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 USER airflow
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" apache-airflow-providers-apache-spark==2.1.3
+RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" apache-airflow-providers-apache-spark==5.1.1
 # [END Dockerfile]

--- a/providers/apache/livy/pyproject.toml
+++ b/providers/apache/livy/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "apache-airflow-providers-common-compat",
     "apache-airflow-providers-http",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
+    "apache-airflow-providers-openlineage",
 ]
 
 # To build docs:

--- a/providers/sqlite/README.rst
+++ b/providers/sqlite/README.rst
@@ -54,7 +54,6 @@ Requirements
 PIP package                              Version required
 =======================================  ==================
 ``apache-airflow``                       ``>=2.9.0``
-``aiosqlite``                            ``>=0.20.0``
 ``apache-airflow-providers-common-sql``  ``>=1.20.0``
 =======================================  ==================
 

--- a/providers/sqlite/pyproject.toml
+++ b/providers/sqlite/pyproject.toml
@@ -58,7 +58,6 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.9.0",
-    "aiosqlite>=0.20.0",
     "apache-airflow-providers-common-sql>=1.20.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -725,10 +725,11 @@ testing = ["dev", "providers.tests", "tests_common", "tests", "system", "unit", 
 
 # All of the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level
-"scripts/ci/pre_commit/*.py" = ["E402"]
-"airflow-core/src/airflow/api/auth/backend/kerberos_auth.py" = ["E402"]
-"airflow-core/src/airflow/security/kerberos.py" = ["E402"]
-"airflow-core/src/airflow/security/utils.py" = ["E402"]
+"scripts/ci/pre_commit/*.py" = [ "E402" ]
+"airflow-core/src/airflow/api/auth/backend/kerberos_auth.py" = [ "E402" ]
+"airflow-core/src/airflow/security/kerberos.py" = [ "E402" ]
+"airflow-core/src/airflow/security/utils.py" = [ "E402" ]
+"airflow-core/tests/unit/always/test_connection.py" = [ "E402" ]
 "providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_auto_ml.py" = [ "E402"]
 "providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_batch_prediction_job.py" = [ "E402"]
 "providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_custom_job.py" = [ "E402"]


### PR DESCRIPTION
Aiosqlite has never been used by the sqlite provider it is really needed as async extension in case Airflow would be configured with async engine. So if we are removing sqlite provider as preinstalled, we should move aiosqlite as required depdendency of core as otherwise creating async sqlite engine will fail.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
