### PR TITLE
Mock out span generation for dag.test

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -1681,6 +1681,10 @@ class DAG(TaskSDKDag, LoggingMixin):
                 conf=run_conf,
                 triggered_by=DagRunTriggeredByType.TEST,
             )
+            # Start a mock span so that one is present and not started downstream. We
+            # don't care about otel in dag.test and starting the span during dagrun update
+            # is not functioning properly in this context anyway.
+            dr.start_dr_spans_if_needed(tis=[])
 
             tasks = self.task_dict
             self.log.debug("starting dagrun")


### PR DESCRIPTION
Create an active span for the dag run before we call `update_state` on it for the first time. This way the span generation code does not run (which fails to work in the context see traceback below), we don't care about spans in the context of dag.test anyway.

Here is the exception that was thrown before this PR as a result of #43941:

```
devel-common/src/tests_common/test_utils/system_tests.py:68: in test_run
    dag_run = dag.test(
airflow-core/src/airflow/utils/session.py:102: in wrapper
    return func(*args, session=session, **kwargs)
airflow-core/src/airflow/models/dag.py:1705: in test
    schedulable_tis, _ = dr.update_state(session=session)
airflow-core/src/airflow/utils/session.py:99: in wrapper
    return func(*args, **kwargs)
airflow-core/src/airflow/models/dagrun.py:1197: in update_state
    self.start_dr_spans_if_needed(tis=tis)
airflow-core/src/airflow/utils/session.py:102: in wrapper
    return func(*args, session=session, **kwargs)
airflow-core/src/airflow/models/dagrun.py:968: in start_dr_spans_if_needed
    if self.span_status == SpanStatus.NOT_STARTED or self.span_status == SpanStatus.NEEDS_CONTINUANCE:
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/attributes.py:487: in __get__
    return self.impl.get(state, dict_)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/attributes.py:959: in get
    value = self._fire_loader_callables(state, key, passive)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/attributes.py:990: in _fire_loader_callables
    return state._load_expired(state, passive)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/state.py:712: in _load_expired
    self.manager.expired_attribute_loader(self, toload, passive)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/loading.py:1369: in load_scalar_attributes
    raise orm_exc.DetachedInstanceError(
E   sqlalchemy.orm.exc.DetachedInstanceError: Instance <DagRun at 0x75a69394bbe0> is not bound to a Session; attribute refresh operation cannot proceed (Background on this error at: https://sqlalche.me/e/14/bhk3)
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
