### PR TITLE
Update task instance log and mark success url.

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1916,36 +1916,16 @@ class TaskInstance(Base, LoggingMixin):
         """Log URL for TaskInstance."""
         run_id = quote(self.run_id)
         base_url = conf.get_mandatory_value("webserver", "BASE_URL")
-        map_index = f"&map_index={self.map_index}" if self.map_index >= 0 else ""
-        _log_uri = (
-            f"{base_url}"
-            f"/dags"
-            f"/{self.dag_id}"
-            f"/grid"
-            f"?dag_run_id={run_id}"
-            f"&task_id={self.task_id}"
-            f"{map_index}"
-            "&tab=logs"
-        )
-        if self.logical_date:
-            base_date = quote(self.logical_date.strftime("%Y-%m-%dT%H:%M:%S%z"))
-            _log_uri = f"{_log_uri}&base_date={base_date}"
+        map_index = f"/mapped/{self.map_index}" if self.map_index >= 0 else ""
+        try_number = f"?try_number={self.try_number}" if self.try_number > 0 else ""
+        _log_uri = f"{base_url}/dags/{self.dag_id}/runs/{run_id}/tasks/{self.task_id}{map_index}{try_number}"
+
         return _log_uri
 
     @property
     def mark_success_url(self) -> str:
         """URL to mark TI success."""
-        base_url = conf.get_mandatory_value("webserver", "BASE_URL")
-        return (
-            f"{base_url}"
-            "/confirm"
-            f"?task_id={self.task_id}"
-            f"&dag_id={self.dag_id}"
-            f"&dag_run_id={quote(self.run_id)}"
-            "&upstream=false"
-            "&downstream=false"
-            "&state=success"
-        )
+        return self.log_url
 
     @provide_session
     def current_state(self, session: Session = NEW_SESSION) -> str:


### PR DESCRIPTION
Update task instance log and mark success url in Airflow 3. With Airflow 3 there is no dedicated mark success url. Users can go to task instance index page which is also the logs tab and mark the task instance as success.

closes #46902