### PR TITLE
Remove unnecessary `ti.current_state` function.

### DIFF
--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -258,7 +258,7 @@ def task_state(args) -> None:
     dag = get_dag(args.subdir, args.dag_id, from_db=True)
     task = dag.get_task(task_id=args.task_id)
     ti, _ = _get_ti(task, args.map_index, logical_date_or_run_id=args.logical_date_or_run_id)
-    print(ti.current_state())
+    print(ti.state)
 
 
 @cli_utils.action_cli(check_db=False)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1948,22 +1948,6 @@ class TaskInstance(Base, LoggingMixin):
         )
 
     @provide_session
-    def current_state(self, session: Session = NEW_SESSION) -> str:
-        """
-        Get the very latest state from the database.
-
-        If a session is passed, we use and looking up the state becomes part of the session,
-        otherwise a new session is used.
-
-        sqlalchemy.inspect is used here to get the primary keys ensuring that if they change
-        it will not regress
-
-        :param session: SQLAlchemy ORM Session
-        """
-        filters = (col == getattr(self, col.name) for col in inspect(TaskInstance).primary_key)
-        return session.query(TaskInstance.state).filter(*filters).scalar()
-
-    @provide_session
     def error(self, session: Session = NEW_SESSION) -> None:
         """
         Force the task instance's state to FAILED in the database.


### PR DESCRIPTION
This function has exactly one use outside of tests, in a cli command, where
the TI is fetched from the session directly before being passed to this
function, so we can simply access the `state` attribute and (modulo a tiny
window, which `current_state()` would still suffer from, albeit smaller) it
will give the same result

This is a small drive by tidy up.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
