### PR TITLE
Integrate `alembic check` in ci

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -2193,6 +2193,7 @@ class DagModel(Base):
 
     has_task_concurrency_limits = Column(Boolean, nullable=False)
     has_import_errors = Column(Boolean(), default=False, server_default="0")
+    test_field = Column(String(2000), nullable=True)
 
     # The logical date of the next dag run.
     next_dagrun = Column(UtcDateTime)

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from alembic.autogenerate import compare_metadata
+from alembic.command import check
 from alembic.config import Config
 from alembic.migration import MigrationContext
 from alembic.runtime.environment import EnvironmentContext
@@ -305,3 +306,13 @@ class TestDb:
         )
         with pytest.raises(AirflowException, match=re.escape(msg)):
             downgrade(to_revision=_REVISION_HEADS_MAP["2.7.0"])
+
+    def test_has_pending_upgrade_ops(self):
+        with mock.patch.dict(
+            os.environ, {"AIRFLOW__DATABASE__ALEMBIC_INI_FILE_PATH": "/tmp/alembic.ini"}, clear=True
+        ):
+            config = _get_alembic_config()
+            assert config.config_file_name == "/tmp/alembic.ini"
+
+        config = _get_alembic_config()
+        check(config)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

## Related Issue

closes #48998
cc: @ashb 

## Why

Since Alembic 1.9, a built-in command `alembic check` is available to checks if there are pending upgrade operations in the migration file, to integrating this check into our CI ensures that no model changes go unnoticed, preventing potential issues that could arise when applying migrations in production.

## How

 - add a new step to the ci

---


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
