### PR TITLE
Do not run runtime field filtering while generating metadata for prov…

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py
+++ b/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py
@@ -21,7 +21,7 @@ import json
 
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.github import get_tag_date
-from airflow_breeze.utils.packages import get_provider_info_dict
+from airflow_breeze.utils.packages import get_provider_distributions_metadata
 from airflow_breeze.utils.path_utils import PROVIDER_DEPENDENCIES_JSON_PATH
 
 DEPENDENCIES = json.loads(PROVIDER_DEPENDENCIES_JSON_PATH.read_text())
@@ -65,7 +65,7 @@ def generate_providers_metadata_for_package(
     airflow_release_dates: dict[str, str],
 ) -> dict[str, dict[str, str]]:
     get_console().print(f"[info]Generating metadata for {provider_id}")
-    provider_yaml_dict = get_provider_info_dict(provider_id)
+    provider_yaml_dict = get_provider_distributions_metadata().get(provider_id)
     provider_metadata: dict[str, dict[str, str]] = {}
     last_airflow_version = START_AIRFLOW_VERSION_FROM
     package_name = "apache-airflow-providers-" + provider_id.replace(".", "-")


### PR DESCRIPTION
…iders

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When running: `breeze release-management generate-providers-metadata --refresh-constraints`, it was using `get_provider_info_dict(provider_id)` due to which runtime filtering was being applied and the "versions" was getting nuked.

Error:
```
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ~~~~^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py", line 74, in generate_providers_metadata_for_package
    for provider_version in reversed(provider_yaml_dict["versions"]):
                                     ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'versions'
"""
```

Going back to getting provider_yaml using `get_provider_info_dict(provider_id)`.

Works fine now:
```
Generating metadata for airbyte
Generating metadata for amazon
Generating metadata for apache.cassandra
Generating metadata for apache.druid
Generating metadata for apache.hdfs
Generating metadata for apache.iceberg
Generating metadata for apache.kafka
Generating metadata for apache.livy
Generating metadata for apache.pinot
Generating metadata for apprise
Generating metadata for asana
Generating metadata for celery
Generating metadata for apache.impala
Generating metadata for apache.kylin
Generating metadata for arangodb
Generating metadata for atlassian.jira
Generating metadata for cncf.kubernetes
Generating metadata for apache.drill
Generating metadata for alibaba
Generating metadata for apache.spark
Generating metadata for apache.hive
Generating metadata for common.compat
Tag providers-apache-livy/4.3.0 not found in the repository
Generating metadata for apache.pig
Generating metadata for apache.flink
Generating metadata for common.messaging
Tag providers-common-messaging/1.0.0 not found in the repository
No constraints mention common.messaging in any Airflow version. Skipping it altogether.
Generating metadata for common.sql
Generating metadata for databricks
Tag providers-celery/3.10.5 not found in the repository
Generating metadata for cloudant
Generating metadata for common.io
Generating metadata for dbt.cloud
Generating metadata for discord
Tag providers-alibaba/3.0.2 not found in the repository
Generating metadata for edge
Generating metadata for exasol
Tag providers-edge/1.0.0 not found in the repository
No constraints mention edge in any Airflow version. Skipping it altogether.
Generating metadata for elasticsearch
Generating metadata for facebook
Generating metadata for git
Tag providers-git/0.0.1 not found in the repository
No constraints mention git in any Airflow version. Skipping it altogether.
Generating metadata for github
Tag providers-amazon/9.5.0 not found in the repository
Generating metadata for apache.beam
Generating metadata for google
Generating metadata for docker
Tag providers-common-sql/1.25.0 not found in the repository
Generating metadata for hashicorp
Generating metadata for ftp
Tag providers-apache-hive/9.0.5 not found in the repository
Generating metadata for imap
Tag providers-dbt-cloud/4.3.2 not found in the repository
Generating metadata for dingding
Generating metadata for jdbc
Tag providers-exasol/4.7.4 not found in the repository
Generating metadata for fab
Tag providers-databricks/7.3.0 not found in the repository
Generating metadata for datadog
Tag providers-cncf-kubernetes/10.4.1 not found in the repository
Generating metadata for cohere
Generating metadata for microsoft.azure
Tag providers-fab/2.0.0 not found in the repository
Generating metadata for microsoft.psrp
Generating metadata for mongo
Generating metadata for neo4j
Generating metadata for openai
Generating metadata for influxdb
Generating metadata for http
Generating metadata for openlineage
Generating metadata for opsgenie
Generating metadata for jenkins
Generating metadata for openfaas
Generating metadata for pagerduty
Generating metadata for microsoft.winrm
Generating metadata for pgvector
Generating metadata for odbc
Generating metadata for mysql
Generating metadata for pinecone
Generating metadata for postgres
Tag providers-google/15.0.0 not found in the repository
Generating metadata for grpc
Generating metadata for oracle
Tag providers-openlineage/2.1.2 not found in the repository
Generating metadata for opensearch
Generating metadata for qdrant
Generating metadata for salesforce
Generating metadata for segment
Generating metadata for sftp
Generating metadata for slack
Generating metadata for papermill
Generating metadata for redis
Generating metadata for snowflake
Generating metadata for ssh
Tag providers-microsoft-azure/12.3.0 not found in the repository
Generating metadata for microsoft.mssql
Generating metadata for sendgrid
Generating metadata for tableau
Generating metadata for teradata
Generating metadata for vertica
Tag providers-postgres/6.1.2 not found in the repository
Generating metadata for presto
Tag providers-papermill/3.10.0 not found in the repository
Generating metadata for samba
Generating metadata for yandex
Generating metadata for zendesk
Generating metadata for trino
Generating metadata for smtp
Tag providers-microsoft-mssql/4.2.2 not found in the repository
Tag providers-sftp/5.1.2 not found in the repository
Generating metadata for singularity
Generating metadata for standard
Generating metadata for telegram
Tag providers-standard/0.3.0 not found in the repository
No constraints mention standard in any Airflow version. Skipping it altogether.
Generating metadata for weaviate
Generating metadata for ydb
Tag providers-snowflake/6.2.0 not found in the repository
Generating metadata for sqlite
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
