### PR TITLE
Bump Serialized DAG to v2 and handle conversion from v1

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
@@ -41,8 +41,7 @@ class DagVersionResponse(BaseModel):
     def bundle_url(self) -> str | None:
         if self.bundle_name:
             return DagBundlesManager().view_url(self.bundle_name, self.bundle_version)
-        else:
-            return None
+        return None
 
 
 class DAGVersionCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
@@ -31,7 +31,7 @@ class DagVersionResponse(BaseModel):
     id: UUID
     version_number: int
     dag_id: str
-    bundle_name: str
+    bundle_name: str | None
     bundle_version: str | None
     created_at: datetime
 
@@ -39,7 +39,10 @@ class DagVersionResponse(BaseModel):
     @computed_field  # type: ignore[misc]
     @property
     def bundle_url(self) -> str | None:
-        return DagBundlesManager().view_url(self.bundle_name, self.bundle_version)
+        if self.bundle_name:
+            return DagBundlesManager().view_url(self.bundle_name, self.bundle_version)
+        else:
+            return None
 
 
 class DAGVersionCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -9629,7 +9629,9 @@ components:
           type: string
           title: Dag Id
         bundle_name:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Bundle Name
         bundle_version:
           anyOf:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -21,6 +21,7 @@ import collections
 import itertools
 from typing import Annotated
 
+import structlog
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
@@ -58,6 +59,7 @@ from airflow.models.dag_version import DagVersion
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.utils.state import TaskInstanceState
 
+log = structlog.get_logger(logger_name=__name__)
 grid_router = AirflowRouter(prefix="/grid", tags=["Grid"])
 
 
@@ -171,6 +173,14 @@ def grid_data(
                 .order_by(DagVersion.id)  # ascending cus this is mostly for pre-3.0 upgrade
                 .limit(1)
             )
+        if not version.serialized_dag:
+            log.error(
+                "No serialized dag found",
+                dag_id=tis[0].dag_id,
+                version_id=version.id,
+                version_number=version.version_number,
+            )
+            continue
         run_dag = version.serialized_dag.dag
         task_node_map = get_task_group_map(dag=run_dag)
         for ti in tis:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
@@ -22,6 +22,7 @@ from operator import methodcaller
 from typing import Callable
 from uuid import UUID
 
+import structlog
 from sqlalchemy import select
 from typing_extensions import Any
 
@@ -46,6 +47,8 @@ from airflow.sdk.definitions.taskgroup import MappedTaskGroup, TaskGroup
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.task_group import task_group_to_dict
+
+log = structlog.get_logger(logger_name=__name__)
 
 
 @cache
@@ -275,6 +278,13 @@ def _get_serdag(ti, session):
         )
     if not dag_version:
         raise RuntimeError("No dag_version object could be found.")
+    if not dag_version.serialized_dag:
+        log.error(
+            "No serialized dag found",
+            dag_id=dag_version.dag_id,
+            version_id=dag_version.id,
+            version_number=dag_version.version_number,
+        )
     return dag_version.serialized_dag
 
 
@@ -283,7 +293,10 @@ def get_combined_structure(task_instances, session):
     merged_nodes = []
     # we dedup with serdag, as serdag.dag varies somehow?
     serdags = {_get_serdag(ti, session) for ti in task_instances}
-    dags = [serdag.dag for serdag in serdags]
+    dags = []
+    for serdag in serdags:
+        if serdag:
+            dags.append(serdag.dag)
     for dag in dags:
         nodes = [task_group_to_dict(child) for child in dag.task_group.topological_sort()]
         _merge_node_dicts(merged_nodes, nodes)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -356,7 +356,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .join(TI.dag_model)
                 .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
-                .where(DagModel.bundle_name.is_not(None))
+                .where(DM.bundle_name.is_not(None))
                 .options(selectinload(TI.dag_model))
                 .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
             )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -356,6 +356,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .join(TI.dag_model)
                 .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
+                .where(DagModel.bundle_name.is_not(None))
                 .options(selectinload(TI.dag_model))
                 .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
             )

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1691,7 +1691,7 @@ class SerializedDAG(DAG, BaseSerialization):
         except SerializationError:
             raise
         except Exception as e:
-            raise SerializationError(f"Failed to serialize DAG {dag.dag_id!r}") from e
+            raise SerializationError(f"Failed to serialize DAG {dag.dag_id!r}: {e}")
 
     @classmethod
     def deserialize_dag(cls, encoded_dag: dict[str, Any]) -> SerializedDAG:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1135,8 +1135,6 @@ class DependencyDetector:
         """Detect dependencies set directly on the DAG object."""
         if not dag:
             return
-        if not dag.timetable:
-            return
         yield from dag.timetable.asset_condition.iter_dag_dependencies(source="", target=dag.dag_id)
 
 

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1843,7 +1843,12 @@ class SerializedDAG(DAG, BaseSerialization):
                         "__var": {},
                         "__type": "airflow.timetables.simple.OnceTimetable",
                     }
-                if sched == "@daily":
+                elif sched == "@continuous":
+                    dag_dict["timetable"] = {
+                        "__var": {},
+                        "__type": "airflow.timetables.simple.ContinuousTimetable",
+                    }
+                elif sched == "@daily":
                     dag_dict["timetable"] = {
                         "__var": {
                             "interval": 0.0,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3413,7 +3413,14 @@ export const $DagVersionResponse = {
       title: "Dag Id",
     },
     bundle_name: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Bundle Name",
     },
     bundle_version: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -911,7 +911,7 @@ export type DagVersionResponse = {
   id: string;
   version_number: number;
   dag_id: string;
-  bundle_name: string;
+  bundle_name: string | null;
   bundle_version: string | null;
   created_at: string;
   readonly bundle_url: string | null;

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -122,7 +122,7 @@ executor_config_pod = k8s.V1Pod(
 TYPE = Encoding.TYPE
 VAR = Encoding.VAR
 serialized_simple_dag_ground_truth = {
-    "__version": 1,
+    "__version": 2,
     "dag": {
         "default_args": {
             "__type": "dict",
@@ -917,7 +917,7 @@ class TestStringifiedDAGs:
         expected_timetable,
     ):
         serialized = {
-            "__version": 1,
+            "__version": 2,
             "dag": {
                 "default_args": {"__type": "dict", "__var": {}},
                 "dag_id": "simple_dag",
@@ -933,7 +933,7 @@ class TestStringifiedDAGs:
 
     def test_deserialization_timetable_unregistered(self):
         serialized = {
-            "__version": 1,
+            "__version": 2,
             "dag": {
                 "default_args": {"__type": "dict", "__var": {}},
                 "dag_id": "simple_dag",
@@ -2201,7 +2201,7 @@ class TestStringifiedDAGs:
     def test_params_upgrade(self):
         """When pre-2.2.0 param (i.e. primitive) is deserialized we convert to Param"""
         serialized = {
-            "__version": 1,
+            "__version": 2,
             "dag": {
                 "dag_id": "simple_dag",
                 "fileloc": "/path/to/file.py",
@@ -2222,7 +2222,7 @@ class TestStringifiedDAGs:
         This test asserts that the params are still deserialized properly.
         """
         serialized = {
-            "__version": 1,
+            "__version": 2,
             "dag": {
                 "dag_id": "simple_dag",
                 "fileloc": "/path/to/file.py",
@@ -2249,7 +2249,7 @@ class TestStringifiedDAGs:
         test only to ensure that params stored in 2.2.0 can still be parsed correctly.
         """
         serialized = {
-            "__version": 1,
+            "__version": 2,
             "dag": {
                 "dag_id": "simple_dag",
                 "fileloc": "/path/to/file.py",
@@ -2266,7 +2266,7 @@ class TestStringifiedDAGs:
 
     def test_params_serialize_default(self):
         serialized = {
-            "__version": 1,
+            "__version": 2,
             "dag": {
                 "dag_id": "simple_dag",
                 "fileloc": "/path/to/file.py",

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -459,7 +459,6 @@ def test_serialized_dag_has_task_concurrency_limits(dag_maker):
     assert lazy_serialized_dag.has_task_concurrency_limits
 
 
-<<<<<<< HEAD
 def test_get_task_assets():
     asset1 = Asset("1")
     with DAG("testdag") as source_dag:
@@ -477,17 +476,32 @@ def test_get_task_assets():
         ("d", asset1),
     ]
 
-V1_SERDAG = '{"__version": 1, "dag": {"fileloc": "/Users/dstandish/code/try_2_10_5/dags/some_test.py", "tags": ["example"], "edge_info": {}, "catchup": false, "_task_group": {"_group_id": null, "prefix_group_id": true, "tooltip": "", "ui_color": "CornflowerBlue", "ui_fgcolor": "#000", "children": {"generate_value": ["operator", "generate_value"], "print_value": ["operator", "print_value"], "print_value__1": ["operator", "print_value__1"]}, "upstream_group_ids": [], "downstream_group_ids": [], "upstream_task_ids": [], "downstream_task_ids": []}, "timezone": "UTC", "_dag_id": "xcom", "start_date": 1609459200.0, "schedule_interval": null, "_processor_dags_folder": "/Users/dstandish/code/try_2_10_5/dags", "tasks": [{"__var": {"doc_md": "Empty function.", "is_setup": false, "_log_config_logger_name": "airflow.task.operators", "pool": "default_pool", "task_id": "generate_value", "weight_rule": "downstream", "is_teardown": false, "ui_color": "#ffefeb", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "start_from_trigger": false, "template_ext": [], "downstream_task_ids": ["print_value"], "_needs_expansion": false, "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"doc_md": "Empty function.", "is_setup": false, "_log_config_logger_name": "airflow.task.operators", "pool": "default_pool", "task_id": "print_value", "weight_rule": "downstream", "is_teardown": false, "ui_color": "#ffefeb", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "start_from_trigger": false, "template_ext": [], "downstream_task_ids": ["print_value__1"], "_needs_expansion": false, "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): generate_value>),)", "op_kwargs": {}}, "__type": "operator"}, {"__var": {"doc_md": "Empty function.", "is_setup": false, "_log_config_logger_name": "airflow.task.operators", "pool": "default_pool", "task_id": "print_value__1", "weight_rule": "downstream", "is_teardown": false, "ui_color": "#ffefeb", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "start_from_trigger": false, "template_ext": [], "downstream_task_ids": [], "_needs_expansion": false, "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): print_value>),)", "op_kwargs": {}}, "__type": "operator"}], "dag_dependencies": [], "params": []}}'
+
+V1_SERDAG = '{"__version": 1, "dag": {"fileloc": "/Users/dstandish/code/try_2_10_5/dags/some_test.py", "_task_group": {"_group_id": null, "prefix_group_id": true, "tooltip": "", "ui_color": "CornflowerBlue", "ui_fgcolor": "#000", "children": {"generate_value": ["operator", "generate_value"], "print_value": ["operator", "print_value"], "print_value__1": ["operator", "print_value__1"]}, "upstream_group_ids": [], "downstream_group_ids": [], "upstream_task_ids": [], "downstream_task_ids": []}, "catchup": false, "timezone": "UTC", "edge_info": {}, "timetable": {"__type": "airflow.timetables.interval.CronDataIntervalTimetable", "__var": {"expression": "0 0 * * *", "timezone": "UTC"}}, "start_date": 1609459200.0, "tags": ["example"], "_dag_id": "my_dag", "_processor_dags_folder": "/Users/dstandish/code/try_2_10_5/dags", "tasks": [{"__var": {"template_fields": ["templates_dict", "op_args", "op_kwargs"], "doc_md": "Empty function.", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "downstream_task_ids": ["print_value"], "ui_color": "#ffefeb", "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "_log_config_logger_name": "airflow.task.operators", "task_id": "generate_value", "weight_rule": "downstream", "start_from_trigger": false, "_needs_expansion": false, "is_teardown": false, "pool": "default_pool", "is_setup": false, "template_ext": [], "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"template_fields": ["templates_dict", "op_args", "op_kwargs"], "doc_md": "Empty function.", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "downstream_task_ids": ["print_value__1"], "ui_color": "#ffefeb", "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "_log_config_logger_name": "airflow.task.operators", "task_id": "print_value", "weight_rule": "downstream", "start_from_trigger": false, "_needs_expansion": false, "is_teardown": false, "pool": "default_pool", "is_setup": false, "template_ext": [], "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): generate_value>),)", "op_kwargs": {}}, "__type": "operator"}, {"__var": {"template_fields": ["templates_dict", "op_args", "op_kwargs"], "doc_md": "Empty function.", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "downstream_task_ids": [], "ui_color": "#ffefeb", "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "_log_config_logger_name": "airflow.task.operators", "task_id": "print_value__1", "weight_rule": "downstream", "start_from_trigger": false, "_needs_expansion": false, "is_teardown": false, "pool": "default_pool", "is_setup": false, "template_ext": [], "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): print_value>),)", "op_kwargs": {}}, "__type": "operator"}], "dag_dependencies": [], "params": []}}'
 
 
-def test_deser_v1_serdag():
-    V1_SERDAG_DICT = json.loads(V1_SERDAG)
+@pytest.mark.parametrize("serdag_json", [V1_SERDAG])
+def test_deser_v1_serdag(serdag_json):
+    V1_SERDAG_DICT = json.loads(serdag_json)
+    v1_dag_json = json.dumps(V1_SERDAG_DICT, sort_keys=True, indent=2)
     # print(json.dumps(V1_SERDAG_DICT, indent=2))
     dag = SerializedDAG.from_dict(V1_SERDAG_DICT)
-    v2_dag_dict = SerializedDAG.to_dict(dag)
-    v2_json = json.dumps(v2_dag_dict)
-    v1_dag_dict = json.loads(v2_json)
-    SerializedDAG.conversion_v1(v1_dag_dict, to_version=1)
-    v1_dag_dict = json.loads(json.dumps(v1_dag_dict,sort_keys=True))
-    v2_dag_dict = json.loads(json.dumps(v2_dag_dict,sort_keys=True))
-    assert v1_dag_dict == v2_dag_dict
+    new_dag_dict = SerializedDAG.to_dict(dag)
+    assert new_dag_dict["__version"] == 2
+    SerializedDAG.conversion_v1(new_dag_dict, to_version=1)
+    # now, the things we won't try to convert back
+    # this is inadvertently updated
+    v1_serdag_dict = json.loads(v1_dag_json)
+    del new_dag_dict["dag"]["_processor_dags_folder"]
+    del v1_serdag_dict["dag"]["_processor_dags_folder"]
+    # group_display_name does not exist in v1 schema
+    tg = new_dag_dict["dag"]["_task_group"]
+    del tg["group_display_name"]
+    # # v2 has no top level `schedule_interval`
+    # del v1_serdag_dict["dag"]["schedule_interval"]
+    for task_raw in v1_serdag_dict["dag"]["tasks"]:
+        task = task_raw["__var"]
+        del task["_log_config_logger_name"]
+    v1_dag_json = json.dumps(v1_serdag_dict, sort_keys=True, indent=2)
+    converted_back = json.dumps(new_dag_dict, sort_keys=True, indent=2)
+    assert converted_back == v1_dag_json

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -459,6 +459,7 @@ def test_serialized_dag_has_task_concurrency_limits(dag_maker):
     assert lazy_serialized_dag.has_task_concurrency_limits
 
 
+<<<<<<< HEAD
 def test_get_task_assets():
     asset1 = Asset("1")
     with DAG("testdag") as source_dag:
@@ -475,3 +476,18 @@ def test_get_task_assets():
         ("c", asset1),
         ("d", asset1),
     ]
+
+V1_SERDAG = '{"__version": 1, "dag": {"fileloc": "/Users/dstandish/code/try_2_10_5/dags/some_test.py", "tags": ["example"], "edge_info": {}, "catchup": false, "_task_group": {"_group_id": null, "prefix_group_id": true, "tooltip": "", "ui_color": "CornflowerBlue", "ui_fgcolor": "#000", "children": {"generate_value": ["operator", "generate_value"], "print_value": ["operator", "print_value"], "print_value__1": ["operator", "print_value__1"]}, "upstream_group_ids": [], "downstream_group_ids": [], "upstream_task_ids": [], "downstream_task_ids": []}, "timezone": "UTC", "_dag_id": "xcom", "start_date": 1609459200.0, "schedule_interval": null, "_processor_dags_folder": "/Users/dstandish/code/try_2_10_5/dags", "tasks": [{"__var": {"doc_md": "Empty function.", "is_setup": false, "_log_config_logger_name": "airflow.task.operators", "pool": "default_pool", "task_id": "generate_value", "weight_rule": "downstream", "is_teardown": false, "ui_color": "#ffefeb", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "start_from_trigger": false, "template_ext": [], "downstream_task_ids": ["print_value"], "_needs_expansion": false, "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"doc_md": "Empty function.", "is_setup": false, "_log_config_logger_name": "airflow.task.operators", "pool": "default_pool", "task_id": "print_value", "weight_rule": "downstream", "is_teardown": false, "ui_color": "#ffefeb", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "start_from_trigger": false, "template_ext": [], "downstream_task_ids": ["print_value__1"], "_needs_expansion": false, "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): generate_value>),)", "op_kwargs": {}}, "__type": "operator"}, {"__var": {"doc_md": "Empty function.", "is_setup": false, "_log_config_logger_name": "airflow.task.operators", "pool": "default_pool", "task_id": "print_value__1", "weight_rule": "downstream", "is_teardown": false, "ui_color": "#ffefeb", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "start_from_trigger": false, "template_ext": [], "downstream_task_ids": [], "_needs_expansion": false, "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): print_value>),)", "op_kwargs": {}}, "__type": "operator"}], "dag_dependencies": [], "params": []}}'
+
+
+def test_deser_v1_serdag():
+    V1_SERDAG_DICT = json.loads(V1_SERDAG)
+    # print(json.dumps(V1_SERDAG_DICT, indent=2))
+    dag = SerializedDAG.from_dict(V1_SERDAG_DICT)
+    v2_dag_dict = SerializedDAG.to_dict(dag)
+    v2_json = json.dumps(v2_dag_dict)
+    v1_dag_dict = json.loads(v2_json)
+    SerializedDAG.conversion_v1(v1_dag_dict, to_version=1)
+    v1_dag_dict = json.loads(json.dumps(v1_dag_dict,sort_keys=True))
+    v2_dag_dict = json.loads(json.dumps(v2_dag_dict,sort_keys=True))
+    assert v1_dag_dict == v2_dag_dict

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -475,33 +475,3 @@ def test_get_task_assets():
         ("c", asset1),
         ("d", asset1),
     ]
-
-
-V1_SERDAG = '{"__version": 1, "dag": {"fileloc": "/Users/dstandish/code/try_2_10_5/dags/some_test.py", "_task_group": {"_group_id": null, "prefix_group_id": true, "tooltip": "", "ui_color": "CornflowerBlue", "ui_fgcolor": "#000", "children": {"generate_value": ["operator", "generate_value"], "print_value": ["operator", "print_value"], "print_value__1": ["operator", "print_value__1"]}, "upstream_group_ids": [], "downstream_group_ids": [], "upstream_task_ids": [], "downstream_task_ids": []}, "catchup": false, "timezone": "UTC", "edge_info": {}, "timetable": {"__type": "airflow.timetables.interval.CronDataIntervalTimetable", "__var": {"expression": "0 0 * * *", "timezone": "UTC"}}, "start_date": 1609459200.0, "tags": ["example"], "_dag_id": "my_dag", "_processor_dags_folder": "/Users/dstandish/code/try_2_10_5/dags", "tasks": [{"__var": {"template_fields": ["templates_dict", "op_args", "op_kwargs"], "doc_md": "Empty function.", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "downstream_task_ids": ["print_value"], "ui_color": "#ffefeb", "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "_log_config_logger_name": "airflow.task.operators", "task_id": "generate_value", "weight_rule": "downstream", "start_from_trigger": false, "_needs_expansion": false, "is_teardown": false, "pool": "default_pool", "is_setup": false, "template_ext": [], "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"template_fields": ["templates_dict", "op_args", "op_kwargs"], "doc_md": "Empty function.", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "downstream_task_ids": ["print_value__1"], "ui_color": "#ffefeb", "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "_log_config_logger_name": "airflow.task.operators", "task_id": "print_value", "weight_rule": "downstream", "start_from_trigger": false, "_needs_expansion": false, "is_teardown": false, "pool": "default_pool", "is_setup": false, "template_ext": [], "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): generate_value>),)", "op_kwargs": {}}, "__type": "operator"}, {"__var": {"template_fields": ["templates_dict", "op_args", "op_kwargs"], "doc_md": "Empty function.", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "downstream_task_ids": [], "ui_color": "#ffefeb", "on_failure_fail_dagrun": false, "ui_fgcolor": "#000", "_log_config_logger_name": "airflow.task.operators", "task_id": "print_value__1", "weight_rule": "downstream", "start_from_trigger": false, "_needs_expansion": false, "is_teardown": false, "pool": "default_pool", "is_setup": false, "template_ext": [], "_task_type": "_PythonDecoratedOperator", "_task_module": "airflow.decorators.python", "_operator_name": "@task", "_is_empty": false, "start_trigger_args": null, "op_args": "(XComArg(<Task(_PythonDecoratedOperator): print_value>),)", "op_kwargs": {}}, "__type": "operator"}], "dag_dependencies": [], "params": []}}'
-
-
-@pytest.mark.parametrize("serdag_json", [V1_SERDAG])
-def test_deser_v1_serdag(serdag_json):
-    V1_SERDAG_DICT = json.loads(serdag_json)
-    v1_dag_json = json.dumps(V1_SERDAG_DICT, sort_keys=True, indent=2)
-    # print(json.dumps(V1_SERDAG_DICT, indent=2))
-    dag = SerializedDAG.from_dict(V1_SERDAG_DICT)
-    new_dag_dict = SerializedDAG.to_dict(dag)
-    assert new_dag_dict["__version"] == 2
-    SerializedDAG.conversion_v1(new_dag_dict, to_version=1)
-    # now, the things we won't try to convert back
-    # this is inadvertently updated
-    v1_serdag_dict = json.loads(v1_dag_json)
-    del new_dag_dict["dag"]["_processor_dags_folder"]
-    del v1_serdag_dict["dag"]["_processor_dags_folder"]
-    # group_display_name does not exist in v1 schema
-    tg = new_dag_dict["dag"]["_task_group"]
-    del tg["group_display_name"]
-    # # v2 has no top level `schedule_interval`
-    # del v1_serdag_dict["dag"]["schedule_interval"]
-    for task_raw in v1_serdag_dict["dag"]["tasks"]:
-        task = task_raw["__var"]
-        del task["_log_config_logger_name"]
-    v1_dag_json = json.dumps(v1_serdag_dict, sort_keys=True, indent=2)
-    converted_back = json.dumps(new_dag_dict, sort_keys=True, indent=2)
-    assert converted_back == v1_dag_json

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -357,6 +357,8 @@ class MappedOperator(AbstractOperator):
     def get_serialized_fields(cls):
         # Not using 'cls' here since we only want to serialize base fields.
         return (frozenset(attrs.fields_dict(MappedOperator)) | {"task_type"}) - {
+            "_is_empty",
+            "_can_skip_downstream",
             "_task_type",
             "dag",
             "deps",


### PR DESCRIPTION
A number of changes have been made to the serialized DAG structure between 2.x and 3.0, and with the addition of DAG versioning in 3.0 we can't use our old approach of simply force-reserializing all DAGs anymore.

So instead we bump the version record (that has been `1` since it was first introduced in 1.10.7, even though there were changes) and upgrade from the latest format in Airflow 2.x such that the Webserver will be able to display things for it.

The scheduler is not so easy to fix, so we use a proxy of "skip things that haven't been re-processed" yet by making the scheduler ignore DAGs that don't a bundle name set (as all dags processed in 3.0 have this set, even if it is for a local file bundle)