### PR TITLE
Kill the Supervisor when heartbeat fails with state conflict

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -120,6 +120,9 @@ HEARTBEAT_TIMEOUT: int = conf.getint("scheduler", "task_instance_heartbeat_timeo
 MIN_HEARTBEAT_INTERVAL: int = conf.getint("workers", "min_heartbeat_interval")
 MAX_FAILED_HEARTBEATS: int = conf.getint("workers", "max_failed_heartbeats")
 
+
+SERVER_TERMINATED = "SERVER_TERMINATED"
+
 # These are the task instance states that require some additional information to transition into.
 # "Directly" here means that the PATCH API calls to transition into these states are
 # made from _handle_request() itself and don't have to come all the way to wait().
@@ -128,6 +131,7 @@ STATES_SENT_DIRECTLY = [
     IntermediateTIState.UP_FOR_RESCHEDULE,
     IntermediateTIState.UP_FOR_RETRY,
     TerminalTIState.SUCCESS,
+    SERVER_TERMINATED,
 ]
 
 
@@ -867,7 +871,13 @@ class ActivitySubprocess(WatchedSubprocess):
                     status_code=e.response.status_code,
                     ti_id=self.id,
                 )
+                self.process_log.error(
+                    "Server indicated the task shouldn't be running anymore. Terminating process",
+                    detail=e.detail,
+                )
                 self.kill(signal.SIGTERM, force=True)
+                self.process_log.error("Task killed!")
+                self._terminal_state = SERVER_TERMINATED
             else:
                 # If we get any other error, we'll just log it and try again next time
                 self._handle_heartbeat_failures()
@@ -904,6 +914,8 @@ class ActivitySubprocess(WatchedSubprocess):
         """
         if self._exit_code == 0:
             return self._terminal_state or TerminalTIState.SUCCESS
+        elif self._exit_code != 0 and self._terminal_state == "SERVER_TERMINATED":
+            return "SERVER_TERMINATED"
         return TerminalTIState.FAILED
 
     def _handle_request(self, msg: ToSupervisor, log: FilteringBoundLogger):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -914,8 +914,8 @@ class ActivitySubprocess(WatchedSubprocess):
         """
         if self._exit_code == 0:
             return self._terminal_state or TerminalTIState.SUCCESS
-        elif self._exit_code != 0 and self._terminal_state == "SERVER_TERMINATED":
-            return "SERVER_TERMINATED"
+        elif self._exit_code != 0 and self._terminal_state == SERVER_TERMINATED:
+            return SERVER_TERMINATED
         return TerminalTIState.FAILED
 
     def _handle_request(self, msg: ToSupervisor, log: FilteringBoundLogger):

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -472,6 +472,8 @@ class TestWatchedSubprocess:
         Test that ensures that the Supervisor does not cause the task to fail if the Task Instance is no longer
         in the running state. Instead, it logs the error and terminates the task process if it
         might be running in a different state or has already completed -- or running on a different worker.
+
+        Also verifies that the supervisor does not try to send the finish request (update_state) to the API server.
         """
         import airflow.sdk.execution_time.supervisor
 
@@ -501,12 +503,14 @@ class TestWatchedSubprocess:
                         409,
                         json={
                             "reason": "not_running",
-                            "message": "TI is no longer in the running state and task should terminate",
+                            "message": "TI is no longer in the 'running' state. Task state might be externally set and task should terminate",
                             "current_state": "success",
                         },
                     )
             elif request.url.path == f"/task-instances/{ti_id}/run":
                 return httpx.Response(200, json=make_ti_context_dict())
+            elif request.url.path == f"/task-instances/{ti_id}/state":
+                pytest.fail("Should not have sent a state update request")
             # Return a 204 for all other requests
             return httpx.Response(status_code=204)
 
@@ -518,16 +522,18 @@ class TestWatchedSubprocess:
             bundle_info=FAKE_BUNDLE,
         )
 
-        # Wait for the subprocess to finish -- it should have been terminated
+        # Wait for the subprocess to finish -- it should have been terminated with SIGTERM
         assert proc.wait() == -signal.SIGTERM
+        assert proc._exit_code == -signal.SIGTERM
+        assert proc.final_state == "SERVER_TERMINATED"
 
         assert request_count["count"] == 2
-        # Verify the number of requests made
+        # Verify the error was logged
         assert captured_logs == [
             {
                 "detail": {
                     "reason": "not_running",
-                    "message": "TI is no longer in the running state and task should terminate",
+                    "message": "TI is no longer in the 'running' state. Task state might be externally set and task should terminate",
                     "current_state": "success",
                 },
                 "event": "Server indicated the task shouldn't be running anymore",
@@ -536,7 +542,24 @@ class TestWatchedSubprocess:
                 "logger": "supervisor",
                 "timestamp": mocker.ANY,
                 "ti_id": ti_id,
-            }
+            },
+            {
+                "detail": {
+                    "current_state": "success",
+                    "message": "TI is no longer in the 'running' state. Task state might be externally set and task should terminate",
+                    "reason": "not_running",
+                },
+                "event": "Server indicated the task shouldn't be running anymore. Terminating process",
+                "level": "error",
+                "logger": "task",
+                "timestamp": mocker.ANY,
+            },
+            {
+                "event": "Task killed!",
+                "level": "error",
+                "logger": "task",
+                "timestamp": mocker.ANY,
+            },
         ]
 
     @pytest.mark.parametrize("captured_logs", [logging.WARNING], indirect=True)


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/48928

This PR has 3 changes:

1. Supervisor now does not try to send the final state to the  `update_state` when there is a state conflict. It also shows the log in the Task logs about it.
2. ~Adds a validation on the API server on `update_state` (`/execution/task-instances/{ti.id}/state`) endpoint to fail when a TI is not in a Running state. This can happen when a state is changed using UI for example (using Mark as Success)~
3. ~Fixed signal handling. The DB error that was highlighted in https://github.com/apache/airflow/issues/48928 is because somehow while running as `LocalExecutor`, the `SIGINT -> SIGTERM -> SIGKILL` sent to task process via the `self.kill` is caught by `scheduler_job_runner.py` by the following code block. This is now fixed!~

**UPDATE**: I separated (2) and (3) into separate PRs: https://github.com/apache/airflow/pull/49025 & https://github.com/apache/airflow/pull/49026


**Before**:

<img width="1539" alt="image" src="https://github.com/user-attachments/assets/1f78abf6-3d3c-4af7-bdde-abcbe0966bb8" />



**After**:

<img width="1719" alt="image" src="https://github.com/user-attachments/assets/07bbf1e2-0819-42e2-9bc2-9b832c475363" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
