### PR TITLE
Force use of symetric JWT algorithm for internal logs server

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -110,6 +110,8 @@ def _fetch_logs_from_service(url, log_relative_path):
     timeout = conf.getint("webserver", "log_fetch_timeout_sec", fallback=None)
     generator = JWTGenerator(
         secret_key=get_signing_key("webserver", "secret_key"),
+        # Since we are using a secret key, we need to be explicit about the algorithm here too
+        algorithm="HS512",
         private_key=None,
         issuer=None,
         valid_for=conf.getint("webserver", "log_request_clock_grace", fallback=30),

--- a/providers/fab/src/airflow/providers/fab/www/serve_logs.py
+++ b/providers/fab/src/airflow/providers/fab/www/serve_logs.py
@@ -73,6 +73,7 @@ def create_app():
     signer = JWTValidator(
         issuer=None,
         secret_key=get_signing_key("webserver", "secret_key"),
+        algorithm="HS512",
         leeway=leeway,
         audience="task-instance-logs",
     )


### PR DESCRIPTION
Since the logs server was hard-coded to use a secret_key, if a user specified
the `api_auth`.`jwt_algorithm` config section it would have interferred and
caused this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/airflow/utils/log/file_task_handler.py", line 567, in _read_from_logs_server
    response = _fetch_logs_from_service(url, rel_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/airflow/utils/log/file_task_handler.py", line 112, in _fetch_logs_from_service
    headers={"Authorization": generator.generate({"filename": log_relative_path})},
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/airflow/api_fastapi/auth/tokens.py", line 458, in generate
    return jwt.encode(claims, self.signing_arg, algorithm=self.algorithm, headers=headers)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/jwt/api_jwt.py", line 78, in encode
    return api_jws.encode(
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/jwt/api_jws.py", line 170, in encode
    key = alg_obj.prepare_key(key)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/jwt/algorithms.py", line 738, in prepare_key
    raise InvalidKeyError(
jwt.exceptions.InvalidKeyError: Expecting a EllipticCurvePrivateKey/EllipticCurvePublicKey. Wrong key provided for EdDSA algorithms
```

The fix is to force a use of HS512 (the same one you would get if you didn't
specify an algorithm and did pass just a secret_key)

Fixes #48759

(See also https://github.com/apache/airflow/issues/49028 though)
