### PR TITLE
Handle 'fail_fast' dags with task sdk and execution API server

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -27,12 +27,12 @@ from starlette.routing import Mount
 
 from airflow.api_fastapi.core_api.app import (
     init_config,
-    init_dag_bag,
     init_error_handlers,
     init_flask_plugins,
     init_middlewares,
     init_views,
 )
+from airflow.api_fastapi.core_api.init_dagbag import get_dag_bag
 from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
@@ -81,13 +81,16 @@ def create_app(apps: str = "all") -> FastAPI:
         root_path=API_ROOT_PATH.removesuffix("/"),
     )
 
+    dag_bag = get_dag_bag()
+
     if "execution" in apps_list or "all" in apps_list:
         task_exec_api_app = create_task_execution_api_app()
+        task_exec_api_app.state.dag_bag = dag_bag
         init_error_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 
     if "core" in apps_list or "all" in apps_list:
-        init_dag_bag(app)
+        app.state.dag_bag = dag_bag
         init_plugins(app)
         init_auth_manager(app)
         init_flask_plugins(app)

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -30,22 +30,12 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from airflow.api_fastapi.auth.tokens import get_signing_key
-from airflow.api_fastapi.core_api.init_dagbag import get_dag_bag
 from airflow.api_fastapi.core_api.middleware import FlaskExceptionsMiddleware
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.settings import AIRFLOW_PATH
 
 log = logging.getLogger(__name__)
-
-
-def init_dag_bag(app: FastAPI) -> None:
-    """
-    Create global DagBag for the FastAPI application.
-
-    To access it use ``request.app.state.dag_bag``.
-    """
-    app.state.dag_bag = get_dag_bag()
 
 
 def init_views(app: FastAPI) -> None:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -314,7 +314,7 @@ def ti_update_state(
         if updated_state == TerminalTIState.FAILED:
             ti = session.get(TI, ti_id_str)
             ser_dag = request.app.state.dag_bag.get_dag(dag_id)
-            if ser_dag.__dict__.get("fail_fast", False):
+            if ser_dag and ser_dag.__dict__.get("fail_fast", False):
                 task_dict = ser_dag.__dict__.get("task_dict", {})
                 task_teardown_map = {k: v.is_teardown for k, v in task_dict.items()}
                 _stop_remaining_tasks(task_instance=ti, task_teardown_map=task_teardown_map, session=session)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -314,8 +314,8 @@ def ti_update_state(
         if updated_state == TerminalTIState.FAILED:
             ti = session.get(TI, ti_id_str)
             ser_dag = request.app.state.dag_bag.get_dag(dag_id)
-            if ser_dag and ser_dag.__dict__.get("fail_fast", False):
-                task_dict = ser_dag.__dict__.get("task_dict", {})
+            if ser_dag and getattr(ser_dag, "fail_fast", False):
+                task_dict = getattr(ser_dag, "task_dict")
                 task_teardown_map = {k: v.is_teardown for k, v in task_dict.items()}
                 _stop_remaining_tasks(task_instance=ti, task_teardown_map=task_teardown_map, session=session)
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -419,9 +419,13 @@ def _stop_remaining_tasks(*, task_instance: TaskInstance, task_teardown_map=None
         if not teardown:
             if ti.state == TaskInstanceState.RUNNING:
                 log.info("Forcing task %s to fail due to dag's `fail_fast` setting", ti.task_id)
+                msg = f"Forcing task {ti.task_id} to fail due to `fail_fast` property set in the dag"
+                session.add(Log(event="fail task", extra=msg, task_instance=ti.key))
                 ti.error(session)
             else:
                 log.info("Setting task %s to SKIPPED due to dag's `fail_fast` setting.", ti.task_id)
+                msg = f"Skipping task {ti.task_id} due to dag's `fail_fast` setting."
+                session.add(Log(event="skip task", extra=msg, task_instance=ti.key))
                 ti.set_state(state=TaskInstanceState.SKIPPED, session=session)
         else:
             log.info("Not skipping teardown task '%s'", ti.task_id)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -419,12 +419,12 @@ def _stop_remaining_tasks(*, task_instance: TaskInstance, task_teardown_map=None
         if not teardown:
             if ti.state == TaskInstanceState.RUNNING:
                 log.info("Forcing task %s to fail due to dag's `fail_fast` setting", ti.task_id)
-                msg = f"Forcing task {ti.task_id} to fail due to `fail_fast` property set in the dag"
+                msg = "Forcing task to fail due to dag's `fail_fast` setting."
                 session.add(Log(event="fail task", extra=msg, task_instance=ti.key))
                 ti.error(session)
             else:
                 log.info("Setting task %s to SKIPPED due to dag's `fail_fast` setting.", ti.task_id)
-                msg = f"Skipping task {ti.task_id} due to dag's `fail_fast` setting."
+                msg = "Skipping task due to dag's `fail_fast` setting."
                 session.add(Log(event="skip task", extra=msg, task_instance=ti.key))
                 ti.set_state(state=TaskInstanceState.SKIPPED, session=session)
         else:

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -176,6 +176,7 @@
           }
         },
         "catchup": { "type": "boolean" },
+        "fail_fast": { "type": "boolean" },
         "fileloc": { "type" : "string"},
         "relative_fileloc": { "type" : "string"},
         "_processor_dags_folder": {

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -372,9 +372,9 @@ class TestTIUpdateState:
     @pytest.mark.parametrize(
         ("state", "end_date", "expected_state"),
         [
-            # (State.SUCCESS, DEFAULT_END_DATE, State.SUCCESS),
+            (State.SUCCESS, DEFAULT_END_DATE, State.SUCCESS),
             (State.FAILED, DEFAULT_END_DATE, State.FAILED),
-            # (State.SKIPPED, DEFAULT_END_DATE, State.SKIPPED),
+            (State.SKIPPED, DEFAULT_END_DATE, State.SKIPPED),
         ],
     )
     def test_ti_update_state_to_terminal(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -372,9 +372,9 @@ class TestTIUpdateState:
     @pytest.mark.parametrize(
         ("state", "end_date", "expected_state"),
         [
-            (State.SUCCESS, DEFAULT_END_DATE, State.SUCCESS),
+            # (State.SUCCESS, DEFAULT_END_DATE, State.SUCCESS),
             (State.FAILED, DEFAULT_END_DATE, State.FAILED),
-            (State.SKIPPED, DEFAULT_END_DATE, State.SKIPPED),
+            # (State.SKIPPED, DEFAULT_END_DATE, State.SKIPPED),
         ],
     )
     def test_ti_update_state_to_terminal(
@@ -596,8 +596,8 @@ class TestTIUpdateState:
             mock.patch(
                 "airflow.api_fastapi.common.db.common.Session.execute",
                 side_effect=[
-                    mock.Mock(one=lambda: ("running", 1, 0)),  # First call returns "queued"
-                    mock.Mock(one=lambda: ("running", 1, 0)),  # Second call returns "queued"
+                    mock.Mock(one=lambda: ("running", 1, 0, "dag")),  # First call returns "queued"
+                    mock.Mock(one=lambda: ("running", 1, 0, "dag")),  # Second call returns "queued"
                     SQLAlchemyError("Database error"),  # Last call raises an error
                 ],
             ),

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -32,17 +32,13 @@ def test_main_app_lifespan(client):
         assert test_app.state.lifespan_called, "Lifespan not called on Execution API app."
 
 
-@mock.patch("airflow.api_fastapi.app.init_dag_bag")
 @mock.patch("airflow.api_fastapi.app.init_views")
 @mock.patch("airflow.api_fastapi.app.init_plugins")
 @mock.patch("airflow.api_fastapi.app.create_task_execution_api_app")
-def test_core_api_app(
-    mock_create_task_exec_api, mock_init_plugins, mock_init_views, mock_init_dag_bag, client
-):
+def test_core_api_app(mock_create_task_exec_api, mock_init_plugins, mock_init_views, client):
     test_app = client(apps="core").app
 
     # Assert that core-related functions were called
-    mock_init_dag_bag.assert_called_once_with(test_app)
     mock_init_views.assert_called_once_with(test_app)
     mock_init_plugins.assert_called_once_with(test_app)
 
@@ -50,20 +46,16 @@ def test_core_api_app(
     mock_create_task_exec_api.assert_not_called()
 
 
-@mock.patch("airflow.api_fastapi.app.init_dag_bag")
 @mock.patch("airflow.api_fastapi.app.init_views")
 @mock.patch("airflow.api_fastapi.app.init_plugins")
 @mock.patch("airflow.api_fastapi.app.create_task_execution_api_app")
-def test_execution_api_app(
-    mock_create_task_exec_api, mock_init_plugins, mock_init_views, mock_init_dag_bag, client
-):
+def test_execution_api_app(mock_create_task_exec_api, mock_init_plugins, mock_init_views, client):
     client(apps="execution")
 
     # Assert that execution-related functions were called
     mock_create_task_exec_api.assert_called_once()
 
     # Assert that core-related functions were NOT called
-    mock_init_dag_bag.assert_not_called()
     mock_init_views.assert_not_called()
     mock_init_plugins.assert_not_called()
 
@@ -78,15 +70,13 @@ def test_execution_api_app_lifespan(client):
         assert execution_app[0].state.lifespan_called, "Lifespan not called on Execution API app."
 
 
-@mock.patch("airflow.api_fastapi.app.init_dag_bag")
 @mock.patch("airflow.api_fastapi.app.init_views")
 @mock.patch("airflow.api_fastapi.app.init_plugins")
 @mock.patch("airflow.api_fastapi.app.create_task_execution_api_app")
-def test_all_apps(mock_create_task_exec_api, mock_init_plugins, mock_init_views, mock_init_dag_bag, client):
+def test_all_apps(mock_create_task_exec_api, mock_init_plugins, mock_init_views, client):
     test_app = client(apps="all").app
 
     # Assert that core-related functions were called
-    mock_init_dag_bag.assert_called_once_with(test_app)
     mock_init_views.assert_called_once_with(test_app)
     mock_init_plugins.assert_called_once_with(test_app)
 

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1045,7 +1045,6 @@ DAG._DAG__serialized_fields = frozenset(a.name for a in attrs.fields(DAG)) - {  
     "has_on_success_callback",
     "has_on_failure_callback",
     "auto_register",
-    "fail_fast",
     "schedule",
 }
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


closes: https://github.com/apache/airflow/issues/44951

## What?

Dags have a property `fail_fast`: Fails currently running tasks when task in DAG fails. Warning: A fail stop dag can only have tasks with the default trigger rule (“all_success”). An exception will be thrown if any task in a fail stop dag has a non default trigger rule.

This is a property which is kinda used in a way that is a task fails, all its upstream "running" TIs should fail if they are non teardown.

## Approach

- Since it is a dag level property, i figured thta instead of sending values like: `fail_stop` / `fast_fail` is set from the execution side, we can know it earlier itself during parse time.
- So it makes sense to store it in the serdag but not as a new column as it may affect versioning but insterad we will store it in the "data" part which is the serialised dag in dict form
- Now when a task is running and IT fails, during the `update_state` call in the api server, we will check if it is from a fail stop dag, if yes, we construct the information needed for the exisiting logic: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/taskinstance.py#L395-L423 to mark all the downstream TIs as failed.

This information involves:
- Getting the serdag during the api endpoint flow
- Getting the fail_fast property from the serdag that we stored earlier
- Adding a new parameter `task_teardown_map` to the earlier logic: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/taskinstance.py#L395-L423
- This property will be having value like:
{task-id: if the task is a teardown one}
- This value will be sent across to the utility to handle the way it has been doing.

## Testing

DAG:
```
from airflow import DAG

from datetime import datetime
import time

from airflow.providers.standard.operators.python import PythonOperator


def start_fn():
    import time
    time.sleep(5)
    assert 1 == 0

with DAG(
    dag_id="fail_fast_dag",
    schedule=None,
    tags=["fail_fast"],
    start_date=datetime(2024, 1, 1),
    catchup=False,
    fail_fast=True
) as dag:

    start = PythonOperator(
        task_id="start",
        python_callable=start_fn,
    )

    end = PythonOperator(
        task_id="end",
        python_callable=lambda: time.sleep(10),
    )

    end1 = PythonOperator(
        task_id="end1",
        python_callable=lambda: time.sleep(10),
    )

    end2 = PythonOperator(
        task_id="end2",
        python_callable=lambda: time.sleep(10),
    )

    [start, end, end1, end2]

```


- Added the "fail_fast" property to serialised dags.

Before:

```

{"__version": 1, "dag": {"edge_info": {}, "disable_bundle_versioning": false, "start_date": 1704067200.0, "tags": ["fail_fast"], "dag_id": "fail_fast_dag", "timetable": {"__type": "airflow.timetables.simple.NullTimetable", "__var": {}}, "relative_fileloc": "dags/fail_fast.py", "timezone": "UTC", "fileloc": "/files/dags/dags/fail_fast.py", "catchup": false, "task_group": {"_group_id": null, "group_display_name": "", "prefix_group_id": true, "tooltip": "", "ui_color": "CornflowerBlue", "ui_fgcolor": "#000", "children": {"start": ["operator", "start"], "end": ["operator", "end"], "end1": ["operator", "end1"], "end2": ["operator", "end2"]}, "upstream_group_ids": [], "downstream_group_ids": [], "upstream_task_ids": [], "downstream_task_ids": []}, "_processor_dags_folder": "/files/dags", "tasks": [{"__var": {"pool": "default_pool", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "ui_fgcolor": "#000", "is_setup": false, "weight_rule": "downstream", "ui_color": "#ffefeb", "template_ext": [], "_needs_expansion": false, "task_id": "start", "is_teardown": false, "start_from_trigger": false, "task_type": "PythonOperator", "downstream_task_ids": [], "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.start_fn", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"pool": "default_pool", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "ui_fgcolor": "#000", "is_setup": false, "weight_rule": "downstream", "ui_color": "#ffefeb", "template_ext": [], "_needs_expansion": false, "task_id": "end", "is_teardown": false, "start_from_trigger": false, "task_type": "PythonOperator", "downstream_task_ids": [], "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.<lambda>", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"pool": "default_pool", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "ui_fgcolor": "#000", "is_setup": false, "weight_rule": "downstream", "ui_color": "#ffefeb", "template_ext": [], "_needs_expansion": false, "task_id": "end1", "is_teardown": false, "start_from_trigger": false, "task_type": "PythonOperator", "downstream_task_ids": [], "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.<lambda>", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"pool": "default_pool", "template_fields": ["templates_dict", "op_args", "op_kwargs"], "ui_fgcolor": "#000", "is_setup": false, "weight_rule": "downstream", "ui_color": "#ffefeb", "template_ext": [], "_needs_expansion": false, "task_id": "end2", "is_teardown": false, "start_from_trigger": false, "task_type": "PythonOperator", "downstream_task_ids": [], "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.<lambda>", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}], "dag_dependencies": [], "params": []}}

```


After:
```
{"__version": 1, "dag": {"relative_fileloc": "dags/fail_fast.py", "disable_bundle_versioning": false, "edge_info": {}, "timetable": {"__type": "airflow.timetables.simple.NullTimetable", "__var": {}}, "tags": ["fail_fast"], "fail_fast": true, "task_group": {"_group_id": null, "group_display_name": "", "prefix_group_id": true, "tooltip": "", "ui_color": "CornflowerBlue", "ui_fgcolor": "#000", "children": {"start": ["operator", "start"], "end": ["operator", "end"], "end1": ["operator", "end1"], "end2": ["operator", "end2"]}, "upstream_group_ids": [], "downstream_group_ids": [], "upstream_task_ids": [], "downstream_task_ids": []}, "timezone": "UTC", "dag_id": "fail_fast_dag", "catchup": false, "fileloc": "/files/dags/dags/fail_fast.py", "start_date": 1704067200.0, "_processor_dags_folder": "/files/dags", "tasks": [{"__var": {"is_setup": false, "ui_fgcolor": "#000", "_needs_expansion": false, "downstream_task_ids": [], "weight_rule": "downstream", "task_type": "PythonOperator", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "pool": "default_pool", "template_ext": [], "template_fields": ["templates_dict", "op_args", "op_kwargs"], "is_teardown": false, "task_id": "start", "start_from_trigger": false, "ui_color": "#ffefeb", "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.start_fn", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"is_setup": false, "ui_fgcolor": "#000", "_needs_expansion": false, "downstream_task_ids": [], "weight_rule": "downstream", "task_type": "PythonOperator", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "pool": "default_pool", "template_ext": [], "template_fields": ["templates_dict", "op_args", "op_kwargs"], "is_teardown": false, "task_id": "end", "start_from_trigger": false, "ui_color": "#ffefeb", "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.<lambda>", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"is_setup": false, "ui_fgcolor": "#000", "_needs_expansion": false, "downstream_task_ids": [], "weight_rule": "downstream", "task_type": "PythonOperator", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "pool": "default_pool", "template_ext": [], "template_fields": ["templates_dict", "op_args", "op_kwargs"], "is_teardown": false, "task_id": "end1", "start_from_trigger": false, "ui_color": "#ffefeb", "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.<lambda>", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}, {"__var": {"is_setup": false, "ui_fgcolor": "#000", "_needs_expansion": false, "downstream_task_ids": [], "weight_rule": "downstream", "task_type": "PythonOperator", "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}, "on_failure_fail_dagrun": false, "pool": "default_pool", "template_ext": [], "template_fields": ["templates_dict", "op_args", "op_kwargs"], "is_teardown": false, "task_id": "end2", "start_from_trigger": false, "ui_color": "#ffefeb", "python_callable_name": "unusual_prefix_da9c2c228bc9403a99c6a97b86b9947d9ec0ca62_fail_fast.<lambda>", "_task_module": "airflow.providers.standard.operators.python", "_is_empty": false, "_can_skip_downstream": false, "start_trigger_args": null, "op_args": [], "op_kwargs": {}}, "__type": "operator"}], "dag_dependencies": [], "params": []}}

```

Task 1 fails cos of wrong assert
![image](https://github.com/user-attachments/assets/e9f0bd31-0e0a-4212-aa37-c3002d4fceee)


All other running tasks, end, end1 and end2 fail:
![image](https://github.com/user-attachments/assets/854531a4-0511-4b96-b0e6-748e2213084b)

![image](https://github.com/user-attachments/assets/5c5d7c6d-9df8-4495-b513-249a82357524)

![image](https://github.com/user-attachments/assets/04221ef0-10b0-4c80-8445-84c40efff6e1)



Audit log entries:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0a524bd8-e536-4307-9664-a5546b7e23a3" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
