### PR TITLE
Add missing `airflow config lint` rules and update/fix newsfragments

### DIFF
--- a/airflow-core/newsfragments/47070.significant.rst
+++ b/airflow-core/newsfragments/47070.significant.rst
@@ -21,5 +21,5 @@ See :ref:`Differences between "trigger" and "data interval" timetables` for more
 
   * ``airflow config lint``
 
-    * [x] ``scheduler.create_cron_data_intervals`` (default changed to ``False``)
-    * [x] ``scheduler.create_delta_data_intervals`` (default changed to ``False``)
+    * [ ] ``scheduler.create_cron_data_intervals``
+    * [ ] ``scheduler.create_delta_data_intervals``

--- a/airflow-core/newsfragments/47070.significant.rst
+++ b/airflow-core/newsfragments/47070.significant.rst
@@ -21,5 +21,5 @@ See :ref:`Differences between "trigger" and "data interval" timetables` for more
 
   * ``airflow config lint``
 
-    * [ ] ``scheduler.create_cron_data_intervals``
-    * [ ] ``scheduler.create_delta_data_intervals``
+    * [x] ``scheduler.create_cron_data_intervals`` (default changed to ``False``)
+    * [x] ``scheduler.create_delta_data_intervals`` (default changed to ``False``)

--- a/airflow-core/newsfragments/48066.significant.rst
+++ b/airflow-core/newsfragments/48066.significant.rst
@@ -48,31 +48,31 @@ The following configuration options are now unused and have been removed:
 
   * ``airflow config lint``
 
-    * [ ] Remove configuration option ``[webserver] web_server_master_timeout``
-    * [ ] Remove configuration option ``[webserver] worker_refresh_batch_size``
-    * [ ] Remove configuration option ``[webserver] worker_refresh_interval``
-    * [ ] Remove configuration option ``[webserver] reload_on_plugin_change``
-    * [ ] Remove configuration option ``[webserver] worker_class``
-    * [ ] Remove configuration option ``[webserver] expose_stacktrace``
-    * [ ] Remove configuration option ``[webserver] log_fetch_delay_sec``
-    * [ ] Remove configuration option ``[webserver] log_auto_tailing_offset``
-    * [ ] Remove configuration option ``[webserver] log_animation_speed``
-    * [ ] Remove configuration option ``[webserver] default_dag_run_display_number``
-    * [ ] Remove configuration option ``[webserver] enable_proxy_fix``
-    * [ ] Remove configuration option ``[webserver] proxy_fix_x_for``
-    * [ ] Remove configuration option ``[webserver] proxy_fix_x_proto``
-    * [ ] Remove configuration option ``[webserver] proxy_fix_x_host``
-    * [ ] Remove configuration option ``[webserver] proxy_fix_x_port``
-    * [ ] Remove configuration option ``[webserver] proxy_fix_x_prefix``
-    * [ ] Remove configuration option ``[webserver] cookie_secure``
-    * [ ] Remove configuration option ``[webserver] analytics_tool``
-    * [ ] Remove configuration option ``[webserver] analytics_id``
-    * [ ] Remove configuration option ``[webserver] analytics_url``
-    * [ ] Remove configuration option ``[webserver] show_recent_stats_for_completed_runs``
-    * [ ] Remove configuration option ``[webserver] run_internal_api``
-    * [ ] Remove configuration option ``[webserver] caching_hash_method``
-    * [ ] Remove configuration option ``[webserver] show_trigger_form_if_no_params``
-    * [ ] Remove configuration option ``[webserver] num_recent_configurations_for_trigger``
-    * [ ] Remove configuration option ``[webserver] allowed_payload_size``
-    * [ ] Remove configuration option ``[webserver] max_form_memory_size``
-    * [ ] Remove configuration option ``[webserver] max_form_parts``
+    * [x] Remove configuration option ``[webserver] web_server_master_timeout``
+    * [x] Remove configuration option ``[webserver] worker_refresh_batch_size``
+    * [x] Remove configuration option ``[webserver] worker_refresh_interval``
+    * [x] Remove configuration option ``[webserver] reload_on_plugin_change``
+    * [x] Remove configuration option ``[webserver] worker_class``
+    * [x] Remove configuration option ``[webserver] expose_stacktrace``
+    * [x] Remove configuration option ``[webserver] log_fetch_delay_sec``
+    * [x] Remove configuration option ``[webserver] log_auto_tailing_offset``
+    * [x] Remove configuration option ``[webserver] log_animation_speed``
+    * [x] Remove configuration option ``[webserver] default_dag_run_display_number``
+    * [x] Remove configuration option ``[webserver] enable_proxy_fix``
+    * [x] Remove configuration option ``[webserver] proxy_fix_x_for``
+    * [x] Remove configuration option ``[webserver] proxy_fix_x_proto``
+    * [x] Remove configuration option ``[webserver] proxy_fix_x_host``
+    * [x] Remove configuration option ``[webserver] proxy_fix_x_port``
+    * [x] Remove configuration option ``[webserver] proxy_fix_x_prefix``
+    * [x] Remove configuration option ``[webserver] cookie_secure``
+    * [x] Remove configuration option ``[webserver] analytics_tool``
+    * [x] Remove configuration option ``[webserver] analytics_id``
+    * [x] Remove configuration option ``[webserver] analytics_url``
+    * [x] Remove configuration option ``[webserver] show_recent_stats_for_completed_runs``
+    * [x] Remove configuration option ``[webserver] run_internal_api``
+    * [x] Remove configuration option ``[webserver] caching_hash_method``
+    * [x] Remove configuration option ``[webserver] show_trigger_form_if_no_params``
+    * [x] Remove configuration option ``[webserver] num_recent_configurations_for_trigger``
+    * [x] Remove configuration option ``[webserver] allowed_payload_size``
+    * [x] Remove configuration option ``[webserver] max_form_memory_size``
+    * [x] Remove configuration option ``[webserver] max_form_parts``

--- a/airflow-core/newsfragments/48528.significant.rst
+++ b/airflow-core/newsfragments/48528.significant.rst
@@ -19,4 +19,4 @@ Users should switch to ``LocalExecutor`` or ``CeleryExecutor`` as alternatives.
 
   * ``airflow config lint``
 
-    * [ ] Convert all ``SequentialExecutor`` to ``LocalExecutor`` in ``[core] executor``
+    * [x] Convert all ``SequentialExecutor`` to ``LocalExecutor`` in ``[core] executor``

--- a/airflow-core/newsfragments/48579.significant.rst
+++ b/airflow-core/newsfragments/48579.significant.rst
@@ -19,4 +19,4 @@ Users should switch to ``LocalExecutor`` or ``CeleryExecutor`` as alternatives.
 
   * ``airflow config lint``
 
-    * [ ] Convert all ``DebugExecutor`` to ``dag.test()`` when present in ``[core] executor``
+    * [ ] Convert all ``DebugExecutor`` to ``LocalExecutor`` when present in ``[core] executor``

--- a/airflow-core/newsfragments/api-38.significant.rst
+++ b/airflow-core/newsfragments/api-38.significant.rst
@@ -20,8 +20,8 @@
 
   * ``airflow config lint``
 
-    * [ ] ``core.dag_default_view``
-    * [ ] ``core.dag_orientation``
+    * [x] ``core.dag_default_view``
+    * [x] ``core.dag_orientation``
 
   * ruff
 

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -166,6 +166,14 @@ CONFIGS_CHANGES = [
         "raising a hard error on validation failure.",
     ),
     ConfigChange(
+        config=ConfigParameter("core", "dag_default_view"),
+        was_deprecated=False,
+    ),
+    ConfigChange(
+        config=ConfigParameter("core", "dag_orientation"),
+        was_deprecated=False,
+    ),
+    ConfigChange(
         config=ConfigParameter("core", "dataset_manager_class"),
         renamed_to=ConfigParameter("core", "asset_manager_class"),
     ),

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -517,9 +517,6 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("scheduler", "dependency_detector"),
     ),
     ConfigChange(
-        config=ConfigParameter("scheduler", "dependency_detector"),
-    ),
-    ConfigChange(
         config=ConfigParameter("scheduler", "allow_trigger_in_future"),
     ),
     ConfigChange(
@@ -533,18 +530,6 @@ CONFIGS_CHANGES = [
         "If your DAGs rely on catchup behavior, not explicitly defined in the DAG definition, "
         "set this configuration parameter to `True` in the `scheduler` section of your `airflow.cfg` "
         "to enable the behavior from Airflow 2.x.",
-    ),
-    ConfigChange(
-        config=ConfigParameter("scheduler", "create_cron_data_intervals"),
-        default_change=True,
-        new_default=False,
-        was_removed=False,
-    ),
-    ConfigChange(
-        config=ConfigParameter("scheduler", "create_delta_data_intervals"),
-        default_change=True,
-        new_default=False,
-        was_removed=False,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "processor_poll_interval"),

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -517,6 +517,9 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("scheduler", "dependency_detector"),
     ),
     ConfigChange(
+        config=ConfigParameter("scheduler", "dependency_detector"),
+    ),
+    ConfigChange(
         config=ConfigParameter("scheduler", "allow_trigger_in_future"),
     ),
     ConfigChange(
@@ -530,6 +533,18 @@ CONFIGS_CHANGES = [
         "If your DAGs rely on catchup behavior, not explicitly defined in the DAG definition, "
         "set this configuration parameter to `True` in the `scheduler` section of your `airflow.cfg` "
         "to enable the behavior from Airflow 2.x.",
+    ),
+    ConfigChange(
+        config=ConfigParameter("scheduler", "create_cron_data_intervals"),
+        default_change=True,
+        new_default=False,
+        was_removed=False,
+    ),
+    ConfigChange(
+        config=ConfigParameter("scheduler", "create_delta_data_intervals"),
+        default_change=True,
+        new_default=False,
+        was_removed=False,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "processor_poll_interval"),


### PR DESCRIPTION
## Why
Some of the `airflow config lint` rules was not implemented back to the time changes were made. Also found some outdated newsfragments

## What
* Add the following `airflow config lint` rules
    * core.dag_default_view
    * core.dag_orientation
* update outdated newsframgments 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
