### PR TITLE
Allow pulling XCom from inlet events

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -17,13 +17,20 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 
 import structlog
 
 from airflow.sdk.execution_time.comms import DeleteXCom, GetXCom, SetXCom, XComResult
 
 log = structlog.get_logger(logger_name="task")
+
+
+class TIKeyProtocol(Protocol):
+    dag_id: str
+    task_id: str
+    run_id: str
+    map_index: int
 
 
 class BaseXCom:
@@ -116,7 +123,7 @@ class BaseXCom:
     def get_value(
         cls,
         *,
-        ti_key: Any,
+        ti_key: TIKeyProtocol,
         key: str,
     ) -> Any:
         """

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -113,7 +113,7 @@ class AssetResult(AssetResponse):
         return cls(**asset_response.model_dump(exclude_defaults=True), type="AssetResult")
 
 
-@attrs.define
+@attrs.define(kw_only=True)
 class AssetEventSourceTaskInstance:
     """Used in AssetEventResult."""
 

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -44,11 +44,12 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from airflow.sdk import Variable
-    from airflow.sdk.api.datamodels._generated import AssetEventDagRunReference, AssetEventResponse
+    from airflow.sdk.api.datamodels._generated import AssetEventDagRunReference
     from airflow.sdk.bases.operator import BaseOperator
     from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.execution_time.comms import (
+        AssetEventResult,
         AssetEventsResult,
         AssetResult,
         ConnectionResult,
@@ -485,7 +486,7 @@ class InletEventsAccessors(Mapping[Union[int, Asset, AssetAlias, AssetRef], Any]
     def __len__(self) -> int:
         return len(self._inlets)
 
-    def __getitem__(self, key: int | Asset | AssetAlias | AssetRef) -> list[AssetEventResponse]:
+    def __getitem__(self, key: int | Asset | AssetAlias | AssetRef) -> list[AssetEventResult]:
         from airflow.sdk.definitions.asset import Asset
         from airflow.sdk.execution_time.comms import (
             ErrorResponse,
@@ -527,7 +528,7 @@ class InletEventsAccessors(Mapping[Union[int, Asset, AssetAlias, AssetRef], Any]
         if TYPE_CHECKING:
             assert isinstance(msg, AssetEventsResult)
 
-        return msg.asset_events
+        return list(msg.iter_asset_event_results())
 
 
 @cache  # Prevent multiple API access.

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -44,11 +44,11 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from airflow.sdk import Variable
-    from airflow.sdk.api.datamodels._generated import AssetEventDagRunReference
     from airflow.sdk.bases.operator import BaseOperator
     from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.execution_time.comms import (
+        AssetEventDagRunReferenceResult,
         AssetEventResult,
         AssetEventsResult,
         AssetResult,
@@ -332,20 +332,20 @@ class _AssetRefResolutionMixin:
 @attrs.define
 class TriggeringAssetEventsAccessor(
     _AssetRefResolutionMixin,
-    Mapping[Union[Asset, AssetAlias, AssetRef], Sequence["AssetEventDagRunReference"]],
+    Mapping[Union[Asset, AssetAlias, AssetRef], Sequence["AssetEventDagRunReferenceResult"]],
 ):
     """Lazy mapping of triggering asset events."""
 
-    _events: Mapping[BaseAssetUniqueKey, Sequence[AssetEventDagRunReference]]
+    _events: Mapping[BaseAssetUniqueKey, Sequence[AssetEventDagRunReferenceResult]]
 
     @classmethod
-    def build(cls, events: Iterable[AssetEventDagRunReference]) -> TriggeringAssetEventsAccessor:
-        collected: dict[BaseAssetUniqueKey, list[AssetEventDagRunReference]] = collections.defaultdict(list)
+    def build(cls, events: Iterable[AssetEventDagRunReferenceResult]) -> TriggeringAssetEventsAccessor:
+        coll: dict[BaseAssetUniqueKey, list[AssetEventDagRunReferenceResult]] = collections.defaultdict(list)
         for event in events:
-            collected[AssetUniqueKey(name=event.asset.name, uri=event.asset.uri)].append(event)
+            coll[AssetUniqueKey(name=event.asset.name, uri=event.asset.uri)].append(event)
             for alias in event.source_aliases:
-                collected[AssetAliasUniqueKey(name=alias.name)].append(event)
-        return cls(collected)
+                coll[AssetAliasUniqueKey(name=alias.name)].append(event)
+        return cls(coll)
 
     def __str__(self) -> str:
         return f"TriggeringAssetEventAccessor(_events={self._events})"
@@ -359,7 +359,7 @@ class TriggeringAssetEventsAccessor(
     def __len__(self) -> int:
         return len(self._events)
 
-    def __getitem__(self, key: Asset | AssetAlias | AssetRef) -> Sequence[AssetEventDagRunReference]:
+    def __getitem__(self, key: Asset | AssetAlias | AssetRef) -> Sequence[AssetEventDagRunReferenceResult]:
         hashable_key: BaseAssetUniqueKey
         if isinstance(key, Asset):
             hashable_key = AssetUniqueKey.from_asset(key)

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.sdk import get_current_context
-from airflow.sdk.api.datamodels._generated import AssetEventDagRunReference, AssetResponse
+from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
 from airflow.sdk.definitions.asset import (
     Asset,
     AssetAlias,
@@ -36,14 +36,19 @@ from airflow.sdk.definitions.connection import Connection
 from airflow.sdk.definitions.variable import Variable
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
+    AssetEventDagRunReferenceResult,
     AssetEventResult,
+    AssetEventSourceTaskInstance,
     AssetEventsResult,
     AssetResult,
     ConnectionResult,
     ErrorResponse,
     GetAssetByName,
     GetAssetByUri,
+    GetAssetEventByAsset,
+    GetXCom,
     VariableResult,
+    XComResult,
 )
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor,
@@ -471,7 +476,7 @@ class TestTriggeringAssetEventsAccessor:
     @pytest.fixture
     def accessor(self, event_data):
         return TriggeringAssetEventsAccessor.build(
-            [AssetEventDagRunReference.model_validate(d) for d in event_data],
+            AssetEventDagRunReferenceResult.model_validate(d) for d in event_data
         )
 
     @pytest.mark.parametrize(
@@ -484,7 +489,7 @@ class TestTriggeringAssetEventsAccessor:
         ],
     )
     def test_getitem(self, event_data, accessor, key, result_indexes):
-        expected = [AssetEventDagRunReference.model_validate(event_data[index]) for index in result_indexes]
+        expected = [AssetEventDagRunReferenceResult.model_validate(event_data[i]) for i in result_indexes]
         assert accessor[key] == expected
 
     @pytest.mark.parametrize(
@@ -504,7 +509,7 @@ class TestTriggeringAssetEventsAccessor:
         result_indexes,
     ):
         mock_supervisor_comms.get_message.return_value = resolved_asset
-        expected = [AssetEventDagRunReference.model_validate(event_data[index]) for index in result_indexes]
+        expected = [AssetEventDagRunReferenceResult.model_validate(event_data[i]) for i in result_indexes]
         assert accessor[Asset.ref(name=name)] == expected
         assert len(mock_supervisor_comms.send_request.mock_calls) == 1
         assert mock_supervisor_comms.send_request.mock_calls[0].kwargs["msg"] == GetAssetByName(name=name)
@@ -527,11 +532,35 @@ class TestTriggeringAssetEventsAccessor:
         result_indexes,
     ):
         mock_supervisor_comms.get_message.return_value = resolved_asset
-        expected = [AssetEventDagRunReference.model_validate(event_data[index]) for index in result_indexes]
+        expected = [AssetEventDagRunReferenceResult.model_validate(event_data[i]) for i in result_indexes]
         assert accessor[Asset.ref(uri=uri)] == expected
         assert len(mock_supervisor_comms.send_request.mock_calls) == 1
         assert mock_supervisor_comms.send_request.mock_calls[0].kwargs["msg"] == GetAssetByUri(uri=uri)
         assert _AssetRefResolutionMixin._asset_ref_cache
+
+    def test_source_task_instance_xcom_pull(self, mock_supervisor_comms, accessor):
+        events = accessor[Asset("2")]
+        assert len(events) == 1
+        source = events[0].source_task_instance
+        assert source == AssetEventSourceTaskInstance(dag_id="d1", task_id="t2", run_id="r1", map_index=-1)
+
+        mock_supervisor_comms.reset_mock()
+        mock_supervisor_comms.get_message.side_effect = [
+            XComResult(key="return_value", value="__example_xcom_value__"),
+        ]
+        assert source.xcom_pull() == "__example_xcom_value__"
+        assert mock_supervisor_comms.send_request.mock_calls == [
+            mock.call(
+                log=mock.ANY,
+                msg=GetXCom(
+                    key="return_value",
+                    dag_id="d1",
+                    run_id="r1",
+                    task_id="t2",
+                    map_index=-1,
+                ),
+            ),
+        ]
 
 
 TEST_ASSET = Asset(name="test_uri", uri="test://test")
@@ -614,7 +643,9 @@ class TestInletEventAccessor:
             AssetResult(name="test_uri", uri="test://test", group="asset"),
             AssetResult(name="test_uri", uri="test://test", group="asset"),
         ]
-        return InletEventsAccessors(inlets=TEST_INLETS)
+        obj = InletEventsAccessors(inlets=TEST_INLETS)
+        mock_supervisor_comms.reset_mock()
+        return obj
 
     @pytest.mark.usefixtures("mock_supervisor_comms")
     def test__iter__(self, sample_inlet_evnets_accessor):
@@ -662,3 +693,60 @@ class TestInletEventAccessor:
     def test_for_asset_alias(self, mocked__getitem__, sample_inlet_evnets_accessor):
         sample_inlet_evnets_accessor.for_asset_alias(name="name")
         assert mocked__getitem__.call_args[0][0] == TEST_ASSET_ALIAS
+
+    def test_source_task_instance_xcom_pull(self, sample_inlet_evnets_accessor, mock_supervisor_comms):
+        mock_supervisor_comms.get_message.side_effect = [
+            AssetEventsResult(
+                asset_events=[
+                    AssetEventResponse(
+                        id=1,
+                        timestamp=timezone.utcnow(),
+                        asset=AssetResponse(name="test_uri", uri="test://test", group="asset"),
+                        created_dagruns=[],
+                        source_dag_id="__dag__",
+                        source_run_id="__run__",
+                        source_task_id="__task__",
+                        source_map_index=0,
+                    ),
+                    AssetEventResponse(
+                        id=1,
+                        timestamp=timezone.utcnow(),
+                        asset=AssetResponse(name="test_uri", uri="test://test", group="asset"),
+                        created_dagruns=[],
+                    ),
+                ],
+            )
+        ]
+        events = sample_inlet_evnets_accessor[Asset.ref(name="test_uri")]
+        assert mock_supervisor_comms.send_request.mock_calls == [
+            mock.call(log=mock.ANY, msg=GetAssetEventByAsset(name="test_uri", uri=None)),
+        ]
+
+        assert len(events) == 2
+        assert events[1].source_task_instance is None
+
+        source = events[0].source_task_instance
+        assert source == AssetEventSourceTaskInstance(
+            dag_id="__dag__",
+            run_id="__run__",
+            task_id="__task__",
+            map_index=0,
+        )
+
+        mock_supervisor_comms.reset_mock()
+        mock_supervisor_comms.get_message.side_effect = [
+            XComResult(key="return_value", value="__example_xcom_value__"),
+        ]
+        assert source.xcom_pull() == "__example_xcom_value__"
+        assert mock_supervisor_comms.send_request.mock_calls == [
+            mock.call(
+                log=mock.ANY,
+                msg=GetXCom(
+                    key="return_value",
+                    dag_id="__dag__",
+                    run_id="__run__",
+                    task_id="__task__",
+                    map_index=0,
+                ),
+            ),
+        ]

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -24,11 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.sdk import get_current_context
-from airflow.sdk.api.datamodels._generated import (
-    AssetEventDagRunReference,
-    AssetEventResponse,
-    AssetResponse,
-)
+from airflow.sdk.api.datamodels._generated import AssetEventDagRunReference, AssetResponse
 from airflow.sdk.definitions.asset import (
     Asset,
     AssetAlias,
@@ -40,6 +36,7 @@ from airflow.sdk.definitions.connection import Connection
 from airflow.sdk.definitions.variable import Variable
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
+    AssetEventResult,
     AssetEventsResult,
     AssetResult,
     ConnectionResult,
@@ -632,7 +629,7 @@ class TestInletEventAccessor:
     def test__get_item__(self, key, sample_inlet_evnets_accessor, mock_supervisor_comms):
         # This test only verifies a valid key can be used to access inlet events,
         # but not access asset events are fetched. That is verified in test_asset_events in execution_api
-        asset_event_resp = AssetEventResponse(
+        asset_event_resp = AssetEventResult(
             id=1,
             created_dagruns=[],
             timestamp=timezone.utcnow(),

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -49,7 +49,6 @@ from airflow.listeners.listener import get_listener_manager
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import DAG, BaseOperator, Connection, dag as dag_decorator, get_current_context
 from airflow.sdk.api.datamodels._generated import (
-    AssetEventResponse,
     AssetProfile,
     AssetResponse,
     DagRunState,
@@ -62,6 +61,7 @@ from airflow.sdk.definitions.asset import Asset, AssetAlias, Dataset, Model
 from airflow.sdk.definitions.param import DagParam
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
+    AssetEventResult,
     AssetEventsResult,
     BundleInfo,
     ConnectionResult,
@@ -821,7 +821,7 @@ def test_run_with_asset_outlets(
 
 def test_run_with_asset_inlets(create_runtime_ti, mock_supervisor_comms):
     """Test running a basic task that contains asset inlets."""
-    asset_event_resp = AssetEventResponse(
+    asset_event_resp = AssetEventResult(
         id=1,
         created_dagruns=[],
         timestamp=timezone.utcnow(),


### PR DESCRIPTION
This essentially adds a shorthand for doing XCom with ti information in an asset event. Instead of doing

    event = context["inlet_events"][asset][-1]
    XCom.get_one(
        dag_id=event.source_dag_id,
        task_id=event.source_task_id,
        run_id=event.source_run_id,
        map_index=event.source_map_index,
    )

You can simply do

    context["inlet_events"][asset][-1].source_task_instance.xcom_pull()

This was already possible in 2.x since the event is an SQLAlchemy model object, and can access the source_task_instance relationship. A simple wrapper has been added so we can do the same inside the task runner.

See #48951.

~~todo: also implement this for AssetEventDagRunReference~~ Done