### PR TITLE
[Internal API][only 2.10] Fixed setting rendered_map_index via internal api

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -828,8 +828,11 @@ def _set_ti_attrs(target, source, include_dag_run=False):
     target.trigger_id = source.trigger_id
     target.next_method = source.next_method
     target.next_kwargs = source.next_kwargs
+    # These checks are required to make sure that note and rendered_map_index are not
+    # reset during refresh_from_db as DB still contains None values and would reset the fields
     if source.note and isinstance(source, TaskInstancePydantic):
         target.note = source.note
+    if source.rendered_map_index and isinstance(source, TaskInstancePydantic):
         target.rendered_map_index = source.rendered_map_index
 
     if include_dag_run:


### PR DESCRIPTION
# Overview

This PR fixes an issue with the current rendered_map_index implementation. If map index is rendered during task execution and the rendered_map_index  of the TI in DB is empty the refresh_from_db will reset the rendered_map_index to None. It is required  before using the source to check that it is not none. Still checking only for Phydantic calss to affect only the internal api logic and not access old implementation. 

# Details of change:
* Check if  refresh_from_db  is set before using the source to set the value.