### PR TITLE
Remove FAB entry from `NOTICE`

### DIFF
--- a/airflow-core/NOTICE
+++ b/airflow-core/NOTICE
@@ -14,13 +14,6 @@ This product contains a modified portion of 'Hue' developed by Cloudera, Inc.
 * Copyright 2009-2017 Cloudera Inc.
 
 
-Flask App Builder:
------
-This product contains a modified portion of 'Flask App Builder' developed by Daniel Vaz Gaspar.
-(https://github.com/dpgaspar/Flask-AppBuilder).
-
-* Copyright 2013, Daniel Vaz Gaspar
-
 Chakra UI:
 -----
 This product contains a modified portion of 'Chakra UI' developed by Segun Adebayo.

--- a/providers/fab/NOTICE
+++ b/providers/fab/NOTICE
@@ -1,0 +1,14 @@
+Apache Airflow
+Copyright 2016-2025 The Apache Software Foundation
+
+This product includes software developed at The Apache Software
+Foundation (http://www.apache.org/).
+
+=======================================================================
+
+Flask App Builder:
+-----
+This product contains a modified portion of 'Flask App Builder' developed by Daniel Vaz Gaspar.
+(https://github.com/dpgaspar/Flask-AppBuilder).
+
+* Copyright 2013, Daniel Vaz Gaspar


### PR DESCRIPTION
This isn't true anymore

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
