### PR TITLE
Fix GetDagRunState and GetTICount response conversion

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -424,7 +424,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             resp = dr_count
         elif isinstance(msg, GetDagRunState):
             dr_resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)
-            resp = dr_resp
+            resp = DagRunStateResult.from_api_response(dr_resp)
 
         elif isinstance(msg, GetTICount):
             ti_count = self.client.task_instances.get_count(

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -427,7 +427,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             resp = DagRunStateResult.from_api_response(dr_resp)
 
         elif isinstance(msg, GetTICount):
-            ti_count = self.client.task_instances.get_count(
+            resp = self.client.task_instances.get_count(
                 dag_id=msg.dag_id,
                 task_ids=msg.task_ids,
                 task_group_id=msg.task_group_id,
@@ -435,7 +435,6 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 run_ids=msg.run_ids,
                 states=msg.states,
             )
-            resp = ti_count.model_dump_json().encode()
         else:
             raise ValueError(f"Unknown message type {type(msg)}")
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -719,7 +719,11 @@ class CustomTriggerDagRun(BaseTrigger):
             states=self.states,
             logical_dates=self.logical_dates,
         )
-        yield TriggerEvent({"count": dag_run_states_count})
+        dag_run_state = await sync_to_async(RuntimeTaskInstance.get_dagrun_state)(
+            dag_id=self.trigger_dag_id,
+            run_id=self.run_ids[0],
+        )
+        yield TriggerEvent({"count": dag_run_states_count, "dag_run_state": dag_run_state})
 
 
 @pytest.mark.xfail(
@@ -729,10 +733,10 @@ class CustomTriggerDagRun(BaseTrigger):
 @pytest.mark.asyncio
 @pytest.mark.flaky(reruns=2, reruns_delay=10)
 @pytest.mark.execution_timeout(30)
-async def test_trigger_can_fetch_trigger_dag_run_count_in_deferrable(session, dag_maker):
+async def test_trigger_can_fetch_trigger_dag_run_count_and_state_in_deferrable(session, dag_maker):
     """Checks that the trigger will successfully fetch the count of trigger DAG runs."""
     # Create the test DAG and task
-    with dag_maker(dag_id="trigger_can_fetch_trigger_dag_run_count_in_deferrable", session=session):
+    with dag_maker(dag_id="trigger_can_fetch_trigger_dag_run_count_and_state_in_deferrable", session=session):
         EmptyOperator(task_id="dummy1")
     dr = dag_maker.create_dagrun()
     task_instance = dr.task_instances[0]
@@ -766,7 +770,7 @@ async def test_trigger_can_fetch_trigger_dag_run_count_in_deferrable(session, da
     task_instance.refresh_from_db()
     assert task_instance.state == TaskInstanceState.SCHEDULED
     assert task_instance.next_method != "__fail__"
-    assert task_instance.next_kwargs == {"event": {"count": 1}}
+    assert task_instance.next_kwargs == {"event": {"count": 1, "dag_run_state": "running"}}
 
 
 class CustomTriggerWorkflowStateTrigger(BaseTrigger):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -64,6 +64,7 @@ from airflow.sdk.execution_time.comms import (
     AssetEventsResult,
     AssetResult,
     ConnectionResult,
+    DagRunStateResult,
     DeferTask,
     DeleteXCom,
     ErrorResponse,
@@ -1021,7 +1022,8 @@ class ActivitySubprocess(WatchedSubprocess):
                 msg.reset_dag_run,
             )
         elif isinstance(msg, GetDagRunState):
-            resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)
+            dr_resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)
+            resp = DagRunStateResult.from_api_response(dr_resp)
         elif isinstance(msg, GetTaskRescheduleStartDate):
             resp = self.client.task_instances.get_reschedule_start_date(msg.ti_id, msg.try_number)
         elif isinstance(msg, GetTICount):


### PR DESCRIPTION
This is likely broken part of this change https://github.com/apache/airflow/pull/48949
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
