### PR TITLE
Use scheme-relative URLs for the UI so https works out of the box more often

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -306,9 +306,10 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
 
         @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
         def webapp(request: Request, rest_of_path: str):
+            schema_relative_base = str(request.base_url).removeprefix(request.base_url.scheme + ":")
             return templates.TemplateResponse(
                 "/index.html",
-                {"request": request, "backend_server_base_url": str(request.base_url)},
+                {"request": request, "backend_server_base_url": schema_relative_base},
                 media_type="text/html",
             )
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/router.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/router.tsx
@@ -32,12 +32,10 @@ export const routerConfig = [
   },
 ];
 
-const baseHref = document.querySelector("head>base")?.getAttribute("href");
-const baseUrl =
-  baseHref !== null && baseHref !== undefined && baseHref !== ""
-    ? baseHref
-    : `${globalThis.location.origin}/`;
+const baseHref = document.querySelector("head>base")?.getAttribute("href") ?? "";
 
-const basename = new URL(`${baseUrl}auth`).pathname;
+// Resolve the scheme-relative URL from the base relative to the current URL
+const baseUrl = new URL(baseHref, globalThis.location.origin);
+const basename = new URL("auth", baseUrl).pathname;
 
 export const router = createBrowserRouter(routerConfig, { basename });

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -66,9 +66,10 @@ def init_views(app: FastAPI) -> None:
 
     @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def webapp(request: Request, rest_of_path: str):
+        schema_relative_base = str(request.base_url).removeprefix(request.base_url.scheme + ":")
         return templates.TemplateResponse(
             "/index.html",
-            {"request": request, "backend_server_base_url": str(request.base_url)},
+            {"request": request, "backend_server_base_url": schema_relative_base},
             media_type="text/html",
         )
 

--- a/airflow-core/src/airflow/ui/src/main.tsx
+++ b/airflow-core/src/airflow/ui/src/main.tsx
@@ -45,11 +45,10 @@ axios.interceptors.response.use(
 
       params.set("next", globalThis.location.href);
 
-      const baseHref = document.querySelector("head>base")?.getAttribute("href");
-      const baseUrl =
-        baseHref !== null && baseHref !== undefined && baseHref !== ""
-          ? baseHref
-          : `${globalThis.location.origin}/`;
+      const baseHref = document.querySelector("head>base")?.getAttribute("href") ?? "";
+
+      // Resolve the scheme-relative URL from the base relative to the current URL
+      const baseUrl = new URL(baseHref, globalThis.location.origin);
 
       const loginPath = new URL("api/v2/auth/login", baseUrl).pathname;
 


### PR DESCRIPTION
If you don't carefully read all the docs, you might not notice that you have
to specify `--proxy-headers` _and_ make sure your Reverse Proxy sets these
headers correctly.

We can work around this quite easily and make it Just Work, so lets do that.

(This PR driven by the fact that, for some reason in 2025, Istio, a common
Ingress ROuter and Service Mesh in larger Kube deploys seems hard to configure
to send the X-Forwarded-* headers correctly without low level envoy filters.
Ick.)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
