### PR TITLE
Remove @provide_session from Variable.set/update in models

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import sys
@@ -34,7 +35,7 @@ from airflow.sdk.execution_time.secrets_masker import mask_secret
 from airflow.secrets.cache import SecretCache
 from airflow.secrets.metastore import MetastoreBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import provide_session
+from airflow.utils.session import create_session, provide_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -180,13 +181,12 @@ class Variable(Base, LoggingMixin):
                 return var_val
 
     @staticmethod
-    @provide_session
     def set(
         key: str,
         value: Any,
         description: str | None = None,
         serialize_json: bool = False,
-        session: Session = None,
+        session: Session | None = None,
     ) -> None:
         """
         Set a value for an Airflow Variable with a given Key.
@@ -197,11 +197,8 @@ class Variable(Base, LoggingMixin):
         :param value: Value to set for the Variable
         :param description: Description of the Variable
         :param serialize_json: Serialize the value to a JSON string
-        :param session: Session
+        :param session: optional session, use if provided or create a new one
         """
-        # check if the secret exists in the custom secrets' backend.
-        Variable.check_for_write_conflict(key=key)
-
         # TODO: This is not the best way of having compat, but it's "better than erroring" for now. This still
         # means SQLA etc is loaded, but we can't avoid that unless/until we add import shims as a big
         # back-compat layer
@@ -225,18 +222,27 @@ class Variable(Base, LoggingMixin):
             )
             return
 
+        # check if the secret exists in the custom secrets' backend.
+        Variable.check_for_write_conflict(key=key)
         if serialize_json:
             stored_value = json.dumps(value, indent=2)
         else:
             stored_value = str(value)
 
-        Variable.delete(key, session=session)
-        session.add(Variable(key=key, val=stored_value, description=description))
-        session.flush()
-        # invalidate key in cache for faster propagation
-        # we cannot save the value set because it's possible that it's shadowed by a custom backend
-        # (see call to check_for_write_conflict above)
-        SecretCache.invalidate_variable(key)
+        ctx: contextlib.AbstractContextManager
+        if session is not None:
+            ctx = contextlib.nullcontext(session)
+        else:
+            ctx = create_session()
+
+        with ctx as session:
+            Variable.delete(key, session=session)
+            session.add(Variable(key=key, val=stored_value, description=description))
+            session.flush()
+            # invalidate key in cache for faster propagation
+            # we cannot save the value set because it's possible that it's shadowed by a custom backend
+            # (see call to check_for_write_conflict above)
+            SecretCache.invalidate_variable(key)
 
     @staticmethod
     @provide_session
@@ -244,7 +250,7 @@ class Variable(Base, LoggingMixin):
         key: str,
         value: Any,
         serialize_json: bool = False,
-        session: Session = None,
+        session: Session | None = None,
     ) -> None:
         """
         Update a given Airflow Variable with the Provided value.
@@ -252,19 +258,31 @@ class Variable(Base, LoggingMixin):
         :param key: Variable Key
         :param value: Value to set for the Variable
         :param serialize_json: Serialize the value to a JSON string
-        :param session: Session
+        :param session: optional session, use if provided or create a new one
         """
         Variable.check_for_write_conflict(key=key)
 
         if Variable.get_variable_from_secrets(key=key) is None:
             raise KeyError(f"Variable {key} does not exist")
-        obj = session.scalar(select(Variable).where(Variable.key == key))
-        if obj is None:
-            raise AttributeError(f"Variable {key} does not exist in the Database and cannot be updated.")
 
-        Variable.set(
-            key=key, value=value, description=obj.description, serialize_json=serialize_json, session=session
-        )
+        ctx: contextlib.AbstractContextManager
+        if session is not None:
+            ctx = contextlib.nullcontext(session)
+        else:
+            ctx = create_session()
+
+        with ctx as session:
+            obj = session.scalar(select(Variable).where(Variable.key == key))
+            if obj is None:
+                raise AttributeError(f"Variable {key} does not exist in the Database and cannot be updated.")
+
+            Variable.set(
+                key=key,
+                value=value,
+                description=obj.description,
+                serialize_json=serialize_json,
+                session=session,
+            )
 
     @staticmethod
     @provide_session

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -245,7 +245,6 @@ class Variable(Base, LoggingMixin):
             SecretCache.invalidate_variable(key)
 
     @staticmethod
-    @provide_session
     def update(
         key: str,
         value: Any,
@@ -260,6 +259,29 @@ class Variable(Base, LoggingMixin):
         :param serialize_json: Serialize the value to a JSON string
         :param session: optional session, use if provided or create a new one
         """
+        # TODO: This is not the best way of having compat, but it's "better than erroring" for now. This still
+        # means SQLA etc is loaded, but we can't avoid that unless/until we add import shims as a big
+        # back-compat layer
+
+        # If this is set it means are in some kind of execution context (Task, Dag Parse or Triggerer perhaps)
+        # and should use the Task SDK API server path
+        if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
+            warnings.warn(
+                "Using Variable.update from `airflow.models` is deprecated. Please use `from airflow.sdk import"
+                "Variable` instead and use `Variable.set` as it is an upsert.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            from airflow.sdk import Variable as TaskSDKVariable
+
+            # set is an upsert command, it can handle updates too
+            TaskSDKVariable.set(
+                key=key,
+                value=value,
+                serialize_json=serialize_json,
+            )
+            return
+
         Variable.check_for_write_conflict(key=key)
 
         if Variable.get_variable_from_secrets(key=key) is None:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/47920

In https://github.com/apache/airflow/issues/47920, if you try to use the Variable.set from airflow.models, it would complain of:
```
RuntimeError: Direct database access via the ORM is not allowed in Airflow 3.0
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 775 in run
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1038 in _execute_task
File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 409 in wrapper
File "/opt/airflow/task-sdk/src/airflow/sdk/bases/decorator.py", line 251 in execute
File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 409 in wrapper
File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 212 in execute
File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 235 in execute_callable
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 81 in run
File "/files/dags/integration_test.py", line 101 in variable
File "/opt/airflow/airflow-core/src/airflow/utils/session.py", line 101 in wrapper
File "/usr/local/lib/python3.12/contextlib.py", line 137 in __enter__
File "/opt/airflow/airflow-core/src/airflow/utils/session.py", line 41 in create_session
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 215 in __init__
[2025-04-10, 22:46:22] INFO - Task instance is in running state: chan="stdout": source="task"
[2025-04-10, 22:46:22] INFO -  Previous state of the Task instance: queued: chan="stdout": source="task"
[2025-04-10, 22:46:22] INFO - Current task name:variable: chan="stdout": source="task"
[2025-04-10, 22:46:22] INFO - Dag name:integration_test: chan="stdout": source="task"
```

And the reason this was occurring is because of the @provide_session present in set and update.
This lead to the task runner recognising it to use DB and failing.

Instead of doing that, i extended the utilities to not use @provide_session while also allowing possibility to pass in a session.

## Testing

DAG:
```
from __future__ import annotations

from airflow.models.baseoperator import BaseOperator
from airflow import DAG
from airflow.models import Variable


class CustomOperator(BaseOperator):
    def execute(self, context):
        Variable.set(key="set_key", value="set_value", description="This is being set from task sdk")


with DAG("example_variable_set_sdk_models", schedule=None, catchup=False) as dag:
    CustomOperator(task_id="set_var")

```

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/177bd2da-797b-4e9d-8408-d0e8e1bc4038" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b5cd36fe-3093-4b52-8240-841b3479d870" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
