### PR TITLE
feat: Explicitly propagate airflow logging level to OL client

### DIFF
--- a/providers/openlineage/docs/guides/developer.rst
+++ b/providers/openlineage/docs/guides/developer.rst
@@ -504,15 +504,23 @@ Marquez can help you pinpoint which facets are not being formed properly so you 
 
 Debug settings
 ^^^^^^^^^^^^^^
-For debugging purposes, ensure that the `Airflow logging level <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level>`_
-is set to ``DEBUG`` and that the :ref:`debug_mode <options:debug_mode>` is enabled for OpenLineage integration.
-This will increase the detail in Airflow logs and include additional environmental information in OpenLineage events.
+For debugging purposes, ensure that both `Airflow logging level <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level>`_
+and `OpenLineage client logging level <https://openlineage.io/docs/client/python#environment-variables>`_ is set to ``DEBUG``.
+The latest provider auto-syncs Airflow's logging level with the OpenLineage client, removing the need for manual configuration.
+
+For DebugFacet, containing additional information (e.g., list of all packages installed), to be appended to all OL events
+enable :ref:`debug_mode <options:debug_mode>` for OpenLineage integration.
+
+Keep in mind that enabling these settings will increase the detail in Airflow logs (which will increase their size) and
+add extra information to OpenLineage events. It's recommended to use them temporarily, primarily for debugging purposes.
 
 When seeking help with debugging, always try to provide the following:
 
 -    Airflow scheduler logs with the logging level set to DEBUG
 -    Airflow worker logs (task logs) with the logging level set to DEBUG
 -    OpenLineage events with debug_mode enabled
+-    Information about Airflow version and OpenLineage provider version
+-    Information about any custom modifications made to the deployment environment where the Airflow is running
 
 
 Where can I learn more?

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -61,6 +61,21 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 pytestmark = pytest.mark.db_test
 
 
+@pytest.mark.parametrize(
+    "env_vars, expected_logging",
+    [
+        ({"AIRFLOW__LOGGING__LOGGING_LEVEL": "DEBUG"}, "DEBUG"),
+        ({"AIRFLOW__LOGGING__LOGGING_LEVEL": "INFO"}, None),
+        ({}, None),  # When no value is provided, default should be INFO and propagation is skipped.
+    ],
+)
+def test_create_client_logging_propagation(env_vars, expected_logging):
+    with patch.dict(os.environ, env_vars, clear=True):
+        assert os.getenv("OPENLINEAGE_CLIENT_LOGGING") is None
+        OpenLineageAdapter().get_or_create_openlineage_client()
+        assert os.getenv("OPENLINEAGE_CLIENT_LOGGING") == expected_logging
+
+
 @patch.dict(
     os.environ,
     {"OPENLINEAGE_URL": "http://ol-api:5000", "OPENLINEAGE_API_KEY": "api-key"},


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Due to changes in Airflow logging settings in Airflow 3, setting `AIRFLOW__LOGGING__LOGGING_LEVEL=DEBUG` is not enough for OpenLineage client to log on DEBUG level. I'm assuming it's because in OL client we use `logging.getLogger(__name__)` that then fallbacks to root logger, and not `airflow` logger or its descendants used and configured in AF3? As we can't tie the OL client directly with Airflow logging in the OL client's code -  we explicitly propagate Airflow logging level from the OL provider to OL client, if OL client's logging level is not already set explicitly by the user. This looks like easy and foolproof solution so that the users debugging OpenLineage can still do so with use of single variable: `AIRFLOW__LOGGING__LOGGING_LEVEL` without the need to manually specify `OPENLINEAGE_CLIENT_LOGGING`.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
