### PR TITLE
feat: direct configuration of running pod log lines number

### DIFF
--- a/airflow-core/src/airflow/config_templates/provider_config_fallback_defaults.cfg
+++ b/airflow-core/src/airflow/config_templates/provider_config_fallback_defaults.cfg
@@ -115,6 +115,7 @@ ca_certs =
 [kubernetes_executor]
 api_client_retry_configuration =
 logs_task_metadata = False
+running_pod_log_lines = 100
 pod_template_file =
 worker_container_repository =
 worker_container_tag =

--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -374,6 +374,14 @@ config:
         type: integer
         example: ~
         default: "0"
+      running_pod_log_lines:
+        description: |
+          The number of the log lines starting from the end to get from of the running pod.
+          -1 for unlimited lines.
+        version_added: ~
+        type: integer
+        example: ~
+        default: "100"
 
 executors:
   - airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -276,6 +276,13 @@ def get_provider_info():
                         "example": None,
                         "default": "0",
                     },
+                    "running_pod_log_lines": {
+                        "description": "The number of the log lines starting from the end to get from of the running pod.\n-1 for unlimited lines.\n",
+                        "version_added": None,
+                        "type": "integer",
+                        "example": None,
+                        "default": "100",
+                    },
                 },
             },
         },

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1334,6 +1334,12 @@ class TestKubernetesExecutor:
     def test_cli_commands_vended(self):
         assert KubernetesExecutor.get_cli_commands()
 
+
+class TestKubernetesExecutorTaskPodLogs:
+    """
+    Tests for KubernetesExecutor task pod logs related functionality.
+    """
+
     def test_annotations_for_logging_task_metadata(self):
         annotations_test = {
             "dag_id": "dag",
@@ -1370,12 +1376,6 @@ class TestKubernetesExecutor:
                 assert annotations_actual == expected_annotations
         finally:
             get_logs_task_metadata.cache_clear()
-
-
-class TestKubernetesExecutorTaskPodLogs:
-    """
-    Tests for KubernetesExecutor task pod logs related functionality.
-    """
 
     def attr_pytest_warns(self):
         return pytest.warns(


### PR DESCRIPTION
- `KubernetesExecutor.RUNNING_POD_LOG_LINES` deprecated warning
- new `running_pod_log_lines` option in `kubernetes_executor` section
- add ability to disable line limit with `-1` value
- expanded tests for logging behavior
- move other logging tests under single test class

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #48710 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
