### PR TITLE
Remove cgroups extra since the dep has been removed

### DIFF
--- a/airflow-core/LICENSE
+++ b/airflow-core/LICENSE
@@ -246,7 +246,6 @@ The text of each license is also included at 3rd-party-licenses/LICENSE-[project
 
     (BSD 3 License) d3 v5.16.0 (https://d3js.org)
     (BSD 3 License) d3-shape v2.1.0 (https://github.com/d3/d3-shape)
-    (BSD 3 License) cgroupspy 0.2.1 (https://github.com/cloudsigma/cgroupspy)
 
 ========================================================================
 See 3rd-party-licenses/LICENSES-ui.txt for packages used in `/airflow/www`

--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -164,9 +164,6 @@ dependencies = [
 "apache-webhdfs" = [
     "apache-airflow-providers-apache-hdfs",
 ]
-"cgroups" = [
-    "cgroupspy>=0.2.2",
-]
 "cloudpickle" = [
     "cloudpickle>=2.2.1",
 ]
@@ -223,7 +220,7 @@ dependencies = [
     "uv>=0.6.13",
 ]
 "all" = [
-    "apache-airflow-core[aiobotocore,async,apache-atlas,apache-webhdfs,cgroups,cloudpickle,github-enterprise,google-auth,graphviz,kerberos,ldap,otel,pandas,rabbitmq,s3fs,sentry,statsd,uv]"
+    "apache-airflow-core[aiobotocore,async,apache-atlas,apache-webhdfs,cloudpickle,github-enterprise,google-auth,graphviz,kerberos,ldap,otel,pandas,rabbitmq,s3fs,sentry,statsd,uv]"
 ]
 
 [project.scripts]

--- a/clients/python/LICENSE
+++ b/clients/python/LICENSE
@@ -247,7 +247,6 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
 
     (BSD 3 License) d3 v5.16.0 (https://d3js.org)
     (BSD 3 License) d3-shape v2.1.0 (https://github.com/d3/d3-shape)
-    (BSD 3 License) cgroupspy 0.2.1 (https://github.com/cloudsigma/cgroupspy)
 
 ========================================================================
 See licenses/LICENSES-ui.txt for packages used in `/airflow/www`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,6 @@ packages = []
 "async" = [
     "apache-airflow-core[async]"
 ]
-"cgroups" = [
-    "apache-airflow-core[cgroups]"
-]
 "cloudpickle" = [
     "apache-airflow-core[cloudpickle]"
 ]


### PR DESCRIPTION
The cgroups extra was in place for the CgroupTaskRunner, but that was removed
in #43551 -- so this extra is for installing something that Airflow doesn't
use anymore. Bye bye!

@potiuk's latest email on dev list made me realised that this one isn't needed anymore

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
