### PR TITLE
Adding type checking assert to cron.get_next

### DIFF
--- a/airflow-core/src/airflow/timetables/_cron.py
+++ b/airflow-core/src/airflow/timetables/_cron.py
@@ -108,6 +108,8 @@ class CronMixin:
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_next(datetime.datetime)
+        if TYPE_CHECKING:
+            assert isinstance(scheduled, datetime.datetime)
         if not _covers_every_hour(cron):
             return convert_to_utc(make_aware(scheduled, self._timezone))
         delta = scheduled - naive
@@ -118,6 +120,8 @@ class CronMixin:
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_prev(datetime.datetime)
+        if TYPE_CHECKING:
+            assert isinstance(scheduled, datetime.datetime)
         if not _covers_every_hour(cron):
             return convert_to_utc(make_aware(scheduled, self._timezone))
         delta = naive - scheduled


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Croniter released new version:
```
564c564
< types-croniter==5.0.1.20250322
---
> types-croniter==6.0.0.20250411
```

Due to this the cron.get_prev can return float as well causing mypy to complain:
```
airflow-core/src/airflow/timetables/_cron.py:112: error: Incompatible return
value type (got "None", expected "DateTime")  [return-value]
                return convert_to_utc(make_aware(scheduled, self._timezone...
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/timetables/_cron.py:112: error: No overload variant of
"make_aware" matches argument types "float", "Union[Timezone, FixedTimezone]" 
[call-overload]
                return convert_to_utc(make_aware(scheduled, self._timezone...
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/timetables/_cron.py:112: note: Possible overload variants:
airflow-core/src/airflow/timetables/_cron.py:112: note:     def make_aware(value: None, timezone: Optional[tzinfo] = ...) -> None
airflow-core/src/airflow/timetables/_cron.py:112: note:     def make_aware(value: DateTime, timezone: Optional[tzinfo] = ...) -> DateTime
airflow-core/src/airflow/timetables/_cron.py:112: note:     def make_aware(value: datetime, timezone: Optional[tzinfo] = ...) -> datetime
Found 2 errors in 1 file (checked 971 source files)
Error 1 returned
You are running mypy with the folders selected. If you want to reproduce it locally, you need to run the following command:

pre-commit run --hook-stage manual mypy-<folder> --all-files
```

Added a type checking for it so that its happy 🗡️ 

Example: https://github.com/apache/airflow/actions/runs/14404400215/job/40397831030

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
