### PR TITLE
Fix `region` parameter in EKS operators/sensors

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -217,7 +217,6 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         "fargate_selectors",
         "create_fargate_profile_kwargs",
         "wait_for_completion",
-        "region",
     )
 
     def __init__(
@@ -259,18 +258,16 @@ class EksCreateClusterOperator(AwsBaseOperator[EksHook]):
         self.fargate_selectors = fargate_selectors or [{"namespace": DEFAULT_NAMESPACE_NAME}]
         self.fargate_profile_name = fargate_profile_name
         self.deferrable = deferrable
-        self.region = region
-        super().__init__(
-            **kwargs,
-        )
 
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+
+        super().__init__(**kwargs)
 
     def execute(self, context: Context):
         if self.compute:
@@ -468,7 +465,6 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         "nodegroup_name",
         "create_nodegroup_kwargs",
         "wait_for_completion",
-        "region",
     )
 
     def __init__(
@@ -497,16 +493,16 @@ class EksCreateNodegroupOperator(AwsBaseOperator[EksHook]):
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
-        self.region = region
-        super().__init__(**kwargs)
 
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+
+        super().__init__(**kwargs)
 
     def execute(self, context: Context):
         self.log.info(self.task_id)
@@ -599,7 +595,6 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
         "fargate_profile_name",
         "create_fargate_profile_kwargs",
         "wait_for_completion",
-        "region",
     )
 
     def __init__(
@@ -628,17 +623,15 @@ class EksCreateFargateProfileOperator(AwsBaseOperator[EksHook]):
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
         self.compute = "fargate"
-        self.region = region
-        super().__init__(
-            **kwargs,
-        )
+
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+        super().__init__(**kwargs)
 
     def execute(self, context: Context):
         _create_compute(
@@ -710,7 +703,7 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "force_delete_compute", "wait_for_completion", "region"
+        "cluster_name", "force_delete_compute", "wait_for_completion"
     )
 
     def __init__(
@@ -732,16 +725,16 @@ class EksDeleteClusterOperator(AwsBaseOperator[EksHook]):
         self.deferrable = deferrable
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
-        self.region = region
-        super().__init__(**kwargs)
 
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+
+        super().__init__(**kwargs)
 
     def execute(self, context: Context):
         if self.deferrable:
@@ -842,7 +835,7 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "nodegroup_name", "wait_for_completion", "region"
+        "cluster_name", "nodegroup_name", "wait_for_completion"
     )
 
     def __init__(
@@ -862,16 +855,15 @@ class EksDeleteNodegroupOperator(AwsBaseOperator[EksHook]):
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
-        self.region = region
-        super().__init__(**kwargs)
 
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+        super().__init__(**kwargs)
 
     def execute(self, context: Context):
         self.hook.delete_nodegroup(clusterName=self.cluster_name, nodegroupName=self.nodegroup_name)
@@ -932,7 +924,7 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
 
     aws_hook_class = EksHook
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "fargate_profile_name", "wait_for_completion", "region"
+        "cluster_name", "fargate_profile_name", "wait_for_completion"
     )
 
     def __init__(
@@ -946,21 +938,20 @@ class EksDeleteFargateProfileOperator(AwsBaseOperator[EksHook]):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
         self.cluster_name = cluster_name
         self.fargate_profile_name = fargate_profile_name
         self.wait_for_completion = wait_for_completion
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
-        self.region = region
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+        super().__init__(**kwargs)
 
     def execute(self, context: Context):
         self.hook.delete_fargate_profile(

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
@@ -133,7 +133,7 @@ class EksClusterStateSensor(EksBaseSensor):
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
 
-    template_fields: Sequence[str] = aws_template_fields("cluster_name", "target_state", "region")
+    template_fields: Sequence[str] = aws_template_fields("cluster_name", "target_state")
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
 
@@ -144,14 +144,14 @@ class EksClusterStateSensor(EksBaseSensor):
         region: str | None = None,
         **kwargs,
     ):
-        super().__init__(target_state=target_state, target_state_type=ClusterStates, **kwargs)
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+        super().__init__(target_state=target_state, target_state_type=ClusterStates, **kwargs)
 
     def get_state(self) -> ClusterStates:
         return self.hook.get_cluster_state(clusterName=self.cluster_name)
@@ -182,7 +182,7 @@ class EksFargateProfileStateSensor(EksBaseSensor):
     """
 
     template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "fargate_profile_name", "target_state", "region"
+        "cluster_name", "fargate_profile_name", "target_state"
     )
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
@@ -195,16 +195,15 @@ class EksFargateProfileStateSensor(EksBaseSensor):
         target_state: FargateProfileStates = FargateProfileStates.ACTIVE,
         **kwargs,
     ):
-        super().__init__(target_state=target_state, target_state_type=FargateProfileStates, **kwargs)
-        self.fargate_profile_name = fargate_profile_name
-        self.region = region
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+        super().__init__(target_state=target_state, target_state_type=FargateProfileStates, **kwargs)
+        self.fargate_profile_name = fargate_profile_name
 
     def get_state(self) -> FargateProfileStates:
         return self.hook.get_fargate_profile_state(
@@ -236,9 +235,7 @@ class EksNodegroupStateSensor(EksBaseSensor):
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     """
 
-    template_fields: Sequence[str] = aws_template_fields(
-        "cluster_name", "nodegroup_name", "target_state", "region"
-    )
+    template_fields: Sequence[str] = aws_template_fields("cluster_name", "nodegroup_name", "target_state")
     ui_color = "#ff9900"
     ui_fgcolor = "#232F3E"
 
@@ -250,16 +247,15 @@ class EksNodegroupStateSensor(EksBaseSensor):
         region: str | None = None,
         **kwargs,
     ):
-        super().__init__(target_state=target_state, target_state_type=NodegroupStates, **kwargs)
-        self.region = region
-        self.nodegroup_name = nodegroup_name
         if region is not None:
-            self.region_name = region
             warnings.warn(
-                message="Parameter `region` will be deprecated. Use the parameter `region_name` instead",
+                message="Parameter `region` is deprecated. Use the parameter `region_name` instead",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
+            kwargs["region_name"] = region
+        super().__init__(target_state=target_state, target_state_type=NodegroupStates, **kwargs)
+        self.nodegroup_name = nodegroup_name
 
     def get_state(self) -> NodegroupStates:
         return self.hook.get_nodegroup_state(clusterName=self.cluster_name, nodegroupName=self.nodegroup_name)


### PR DESCRIPTION
#48192 introduced a bug in `EksClusterStateSensor`. `region` is specified in the list of templated fields but not saved as attribute which causes:

```
[2025-04-11 17:18:06,028] {taskinstance.py:2948} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py", line 353, in _do_render_template_fields
    value = getattr(parent, attr_name)
AttributeError: 'EksClusterStateSensor' object has no attribute 'region'
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
