### PR TITLE
Unpause DAG before triggering in AWS MWAA system test

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_mwaa.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa.py
@@ -56,6 +56,39 @@ sys_test_context_task = (
     .build()
 )
 
+
+@task
+def unpause_dag(env_name: str, dag_id: str):
+    mwaa_hook = MwaaHook()
+    response = mwaa_hook.invoke_rest_api(
+        env_name=env_name, path=f"/dags/{dag_id}", method="PATCH", body={"is_paused": False}
+    )
+    return not response["RestApiResponse"]["is_paused"]
+
+
+# This task in the system test verifies that the MwaaHook's IAM fallback mechanism continues to work with
+# the live MWAA API. This fallback depends on parsing a specific error message from the MWAA API, so we
+# want to ensure we find out if the API response format ever changes. Unit tests cover this with mocked
+# responses, but this system test validates against the real API.
+@task
+def test_iam_fallback(role_to_assume_arn, mwaa_env_name):
+    assumed_role = StsHook().conn.assume_role(
+        RoleArn=role_to_assume_arn, RoleSessionName="MwaaSysTestIamFallback"
+    )
+
+    credentials = assumed_role["Credentials"]
+    session = boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+    mwaa_hook = MwaaHook()
+    mwaa_hook.conn = session.client("mwaa")
+    response = mwaa_hook.invoke_rest_api(env_name=mwaa_env_name, path="/dags", method="GET")
+    return "dags" in response["RestApiResponse"]
+
+
 with DAG(
     dag_id=DAG_ID,
     schedule="@once",
@@ -87,33 +120,11 @@ with DAG(
     )
     # [END howto_sensor_mwaa_dag_run]
 
-    # This task in the system test verifies that the MwaaHook's IAM fallback mechanism continues to work with
-    # the live MWAA API. This fallback depends on parsing a specific error message from the MWAA API, so we
-    # want to ensure we find out if the API response format ever changes. Unit tests cover this with mocked
-    # responses, but this system test validates against the real API.
-    @task
-    def test_iam_fallback(role_to_assume_arn, mwaa_env_name):
-        sts_client = StsHook().conn
-        assumed_role = sts_client.assume_role(
-            RoleArn=role_to_assume_arn, RoleSessionName="MwaaSysTestIamFallback"
-        )
-
-        credentials = assumed_role["Credentials"]
-        session = boto3.Session(
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
-        )
-
-        mwaa_hook = MwaaHook()
-        mwaa_hook.conn = session.client("mwaa")
-        response = mwaa_hook.invoke_rest_api(env_name=mwaa_env_name, path="/dags", method="GET")
-        return "dags" in response["RestApiResponse"]
-
     chain(
         # TEST SETUP
         test_context,
         # TEST BODY
+        unpause_dag(env_name, trigger_dag_id),
         trigger_dag_run,
         wait_for_dag_run,
         test_iam_fallback(restricted_role_arn, env_name),


### PR DESCRIPTION
If the DAG on the external MWAA environment was paused, this test would fail because the triggered DAG run would never complete. Now, it will unpause the DAG in the beginning of the test.

I also moved another task definition to be defined outside of the DAG like the other system tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
