### PR TITLE
Stabilize min provider version update

### DIFF
--- a/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
+++ b/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
@@ -84,12 +84,12 @@ console.print("[bright_blue]Updating min-provider versions in apache-airflow\n")
 all_providers_metadata = json.loads(PROVIDER_METADATA_FILE_PATH.read_text())
 
 
-def find_min_provider_version(provider_id: str, how_old: timedelta) -> Version | None:
+def find_min_provider_version(provider_id: str) -> Version | None:
     metadata = all_providers_metadata.get(provider_id)
     if not metadata:
         return None
-    current_date = datetime.now(tz=timezone.utc)
-    cut_off_date = current_date - how_old
+    # We should periodically update the starting date to avoid pip install resolution issues
+    cut_off_date = datetime.fromisoformat("2024-10-12T00:00:00Z")
     last_version_newer_than_cutoff: Version | None = None
     date_released: datetime | None = None
     versions: list[Version] = sorted([parse_version(version) for version in metadata])
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     all_provider_lines = []
     for provider_id in all_providers:
         distribution_name = provider_distribution_name(provider_id)
-        min_provider_version = find_min_provider_version(provider_id, CUT_OFF_TIMEDELTA)
+        min_provider_version = find_min_provider_version(provider_id)
         if min_provider_version:
             all_provider_lines.append(f'    "{distribution_name}>={min_provider_version}",\n')
             all_optional_dependencies.append(


### PR DESCRIPTION
The check was based on current time and that would include a bit of a random static failures in main, rather than that, we should opt for manually upgrading the cut-off time periodically.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
