### PR TITLE
Improve dag error handling

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -175,10 +175,9 @@ def init_config(app: FastAPI) -> None:
 
 
 def init_error_handlers(app: FastAPI) -> None:
-    from airflow.api_fastapi.common.exceptions import DatabaseErrorHandlers
+    from airflow.api_fastapi.common.exceptions import ERROR_HANDLERS
 
-    # register database error handlers
-    for handler in DatabaseErrorHandlers:
+    for handler in ERROR_HANDLERS:
         app.add_exception_handler(handler.exception_cls, handler.exception_handler)
 
 

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -500,6 +500,23 @@ class UnknownExecutorException(ValueError):
     """Raised when an attempt is made to load an executor which is not configured."""
 
 
+class DeserializationError(Exception):
+    """
+    Raised when a Dag cannot be deserialized.
+
+    This exception should be raised using exception chaining:
+    `raise DeserializationError(dag_id) from original_exception`
+    """
+
+    def __init__(self, dag_id: str | None = None):
+        self.dag_id = dag_id
+        if dag_id is None:
+            message = "Missing Dag ID in serialized Dag"
+        else:
+            message = f"An unexpected error occurred while trying to deserialize Dag '{dag_id}'"
+        super().__init__(message)
+
+
 def __getattr__(name: str):
     """Provide backward compatibility for moved exceptions."""
     if name == "AirflowDagCycleException":

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2392,7 +2392,7 @@ class SerializedDAG(DAG, BaseSerialization):
             raise DeserializationError(dag_id) from err
 
         try:
-            return cls._deserialize_dag_internal(encoded_dag)
+            return cls._deserialize_dag_internal(encoded_dag, client_defaults)
         except _TimetableNotRegistered:
             raise
         except (ValueError, KeyError) as err:
@@ -2400,7 +2400,9 @@ class SerializedDAG(DAG, BaseSerialization):
             raise DeserializationError(dag_id) from err
 
     @classmethod
-    def _deserialize_dag_internal(cls, encoded_dag: dict[str, Any]) -> SerializedDAG:
+    def _deserialize_dag_internal(
+        cls, encoded_dag: dict[str, Any], client_defaults: dict[str, Any] | None = None
+    ) -> SerializedDAG:
         """Handle the main Dag deserialization logic."""
         dag = SerializedDAG(dag_id=encoded_dag["dag_id"], schedule=None)
 

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2401,7 +2401,7 @@ class SerializedDAG(DAG, BaseSerialization):
 
     @classmethod
     def _deserialize_dag_internal(cls, encoded_dag: dict[str, Any]) -> SerializedDAG:
-        """Handle the main DAG deserialization logic."""
+        """Handle the main Dag deserialization logic."""
         dag = SerializedDAG(dag_id=encoded_dag["dag_id"], schedule=None)
 
         # Note: Context is passed explicitly through method parameters, no class attributes needed

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2385,7 +2385,7 @@ class SerializedDAG(DAG, BaseSerialization):
         try:
             if "dag_id" not in encoded_dag:
                 raise RuntimeError(
-                    "Encoded dag object has no dag_id key.  You may need to run `airflow dags reserialize`."
+                    "Encoded dag object has no dag_id key. You may need to run `airflow dags reserialize`."
                 )
         except RuntimeError as err:
             dag_id = encoded_dag.get("dag_id", None)

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -47,7 +47,7 @@ from airflow import macros
 from airflow._shared.timezones.timezone import coerce_datetime, from_timestamp, parse_timezone, utcnow
 from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallbackRequest
 from airflow.configuration import conf as airflow_conf
-from airflow.exceptions import AirflowException, SerializationError, TaskDeferred
+from airflow.exceptions import AirflowException, DeserializationError, SerializationError, TaskDeferred
 from airflow.models.connection import Connection
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
@@ -2382,11 +2382,26 @@ class SerializedDAG(DAG, BaseSerialization):
         cls, encoded_dag: dict[str, Any], client_defaults: dict[str, Any] | None = None
     ) -> SerializedDAG:
         """Deserializes a DAG from a JSON object."""
-        if "dag_id" not in encoded_dag:
-            raise RuntimeError(
-                "Encoded dag object has no dag_id key.  You may need to run `airflow dags reserialize`."
-            )
+        try:
+            if "dag_id" not in encoded_dag:
+                raise RuntimeError(
+                    "Encoded dag object has no dag_id key.  You may need to run `airflow dags reserialize`."
+                )
+        except RuntimeError as err:
+            dag_id = encoded_dag.get("dag_id", None)
+            raise DeserializationError(dag_id) from err
 
+        try:
+            return cls._deserialize_dag_internal(encoded_dag)
+        except _TimetableNotRegistered:
+            raise
+        except (ValueError, KeyError) as err:
+            dag_id = encoded_dag.get("dag_id", None)
+            raise DeserializationError(dag_id) from err
+
+    @classmethod
+    def _deserialize_dag_internal(cls, encoded_dag: dict[str, Any]) -> SerializedDAG:
+        """Handle the main DAG deserialization logic."""
         dag = SerializedDAG(dag_id=encoded_dag["dag_id"], schedule=None)
 
         # Note: Context is passed explicitly through method parameters, no class attributes needed


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Improve error handling for DAG access in API endpoints

This PR improves error handling when accessing DAGs via API endpoints:

- Add consistent error handling for DAG access across API endpoints
- Handle ImportError and SyntaxError with 422 status code and clear error messages
- Handle generic exceptions with 500 status code
- Provide clear error messages for different failure scenarios
- Update API documentation to include new error response codes
- Add comprehensive tests for error handling scenarios

This change ensures users get clear feedback when DAGs fail to load
due to import errors, syntax errors, or other unexpected issues.

closes: #48960

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).