### PR TITLE
Help pip to find appropriate boto for aiobotocore

### DIFF
--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -95,7 +95,10 @@ dependencies = [
 # TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
 # boto3 have native async support and we move away from aio aiobotocore
 "aiobotocore" = [
-    "aiobotocore[boto3]>=2.20.0",
+    "aiobotocore[boto3]>=2.21.1",
+    # boto3 here should be synchronized with latest aiobotocore version otherwise pip might get
+    # into a backtracking loop and fail to install the package
+    "boto3<1.37.2,>=1.37.0"
 ]
 "cncf.kubernetes" = [
     "apache-airflow-providers-cncf-kubernetes>=7.2.0",
@@ -163,7 +166,7 @@ dev = [
     "apache-airflow-providers-salesforce",
     "apache-airflow-providers-ssh",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    "aiobotocore>=2.13.0",
+    "aiobotocore[boto3]>=2.21.1",
     "apache-airflow-providers-postgres",
     "aws_xray_sdk>=2.12.0",
     "moto[cloudformation,glue]>=5.1.2",


### PR DESCRIPTION
Seems that `pip` has troubles with finding the right boto3 for aiobotocore which results in resolution too deep when trying higher versions of boto3 than aiobotocore supports.

This limit should come from the aibotocore[boto3] extra, but apparently `pip` does not use it straight away to limit boto3, instaead it attempts to find resolution for higher versions of boto3 and discard it later with aiobotocore.

We pin the latest aiobotocore - this way in the future when we enable dependabot, we will be able to upgrade aiobotocore together with updating the limits for botocore.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
