### PR TITLE
Fix generation of local provider documentation index

### DIFF
--- a/devel-common/src/sphinx_exts/docs_build/dev_index_generator.py
+++ b/devel-common/src/sphinx_exts/docs_build/dev_index_generator.py
@@ -24,13 +24,13 @@ from pathlib import Path
 import jinja2
 
 # isort:off (needed to workaround isort bug)
+from sphinx_exts.docs_build.code_utils import AIRFLOW_CONTENT_ROOT_PATH
 from sphinx_exts.provider_yaml_utils import load_package_data
 
 # isort:on (needed to workaround isort bug)
 
-CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
-DOCS_DIR = os.path.abspath(os.path.join(CURRENT_DIR, os.pardir, os.pardir))
-BUILD_DIR = os.path.abspath(os.path.join(DOCS_DIR, "_build"))
+CURRENT_DIR = Path(os.path.dirname(__file__)).resolve()
+GENERATED_BUILD_DOCS_PATH = AIRFLOW_CONTENT_ROOT_PATH / "generated" / "_build" / "docs"
 ALL_PROVIDER_YAMLS_WITH_SUSPENDED = load_package_data(include_suspended=True)
 
 
@@ -47,7 +47,7 @@ def _render_template(template_name, **kwargs):
 def _render_content():
     providers = []
     provider_yamls = {p["package-name"]: p for p in ALL_PROVIDER_YAMLS_WITH_SUSPENDED}
-    for path in sorted(Path(BUILD_DIR).glob("docs/apache-airflow-providers-*/")):
+    for path in sorted(GENERATED_BUILD_DOCS_PATH.glob("apache-airflow-providers-*/")):
         package_name = path.name
         try:
             providers.append(provider_yamls[package_name])


### PR DESCRIPTION
When building providers locally we have a special template to generate local index of built providers. This index stopped being generated after #48760. This PR fixes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
