### PR TITLE
Fix broken link in development index

### DIFF
--- a/devel-common/src/sphinx_exts/docs_build/dev_index_template.html.jinja2
+++ b/devel-common/src/sphinx_exts/docs_build/dev_index_template.html.jinja2
@@ -45,7 +45,7 @@
   <h1 class="page-title">Apache Airflow Documentation</h1>
   <div class="row">
     <div class="col-md order-md-1">
-      <img src="https://github.com/apache/airflow/raw/main/airflow/www/static/pin_100.png" alt="Apache Airflow - logo" width="100" height="100">
+      <img src="https://github.com/apache/airflow/raw/main/airflow-core/src/airflow/ui/public/pin_100.png" alt="Apache Airflow - logo" width="100" height="100">
     </div>
 
     <div class="col-md">


### PR DESCRIPTION
Fixes: #49191

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
