### PR TITLE
update md5 type hints to respect PEP570

### DIFF
--- a/airflow-core/src/airflow/utils/hashlib_wrapper.py
+++ b/airflow-core/src/airflow/utils/hashlib_wrapper.py
@@ -24,11 +24,11 @@ if TYPE_CHECKING:
     from _typeshed import ReadableBuffer
 
 
-def md5(__string: ReadableBuffer = b"") -> hashlib._Hash:
+def md5(string: ReadableBuffer = b"", /) -> hashlib._Hash:
     """
     Safely allows calling the ``hashlib.md5`` function when ``usedforsecurity`` is disabled in configuration.
 
-    :param __string: The data to hash. Default to empty str byte.
+    :param string: The data to hash. Default to empty str byte.
     :return: The hashed value.
     """
-    return hashlib.md5(__string, usedforsecurity=False)  # type: ignore
+    return hashlib.md5(string, usedforsecurity=False)  # type: ignore


### PR DESCRIPTION
According to [PEP484](https://peps.python.org/pep-0484/#positional-only-arguments) (introduced in 2014 for Python 3.5):
```
All arguments with names beginning with __ are assumed to be positional-only, except if their names also end with __
```
Later, Python 3.8 introduced [PEP570](https://peps.python.org/pep-0570/) for Positional-Only Parameters:
```
This PEP proposes to introduce a new syntax, /, for specifying positional-only parameters in Python function definitions.
```