### PR TITLE
update `_run_inline_trigger` to make its logic clearer

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -2542,8 +2542,12 @@ if STATICA_HACK:  # pragma: no cover
 
 def _run_inline_trigger(trigger):
     async def _run_inline_trigger_main():
-        async for event in trigger.run():
-            return event
+        # We can replace it with `return await anext(trigger.run(), default=None)`
+        # when we drop support for Python 3.9
+        try:
+            return await trigger.run().__anext__()
+        except StopAsyncIteration:
+            return None
 
     return asyncio.run(_run_inline_trigger_main())
 


### PR DESCRIPTION
The way `_run_inline_trigger` works has always been confusing, and it wasn't clear that it only returned the first `TriggerEvent`. Using `__anext__` instead of looping over its result (async iterator) and returning the first element makes things clearer for developers.