### PR TITLE
Fix finding assets in serialized mapped operator

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1976,6 +1976,14 @@ class LazyDeserializedDAG(pydantic.BaseModel):
             set(filter(None, (task[Encoding.VAR].get("owner") for task in self.data["dag"]["tasks"])))
         )
 
+    @staticmethod
+    def _get_mapped_operator_ports(task: dict, direction: str):
+        return task["partial_kwargs"][direction]
+
+    @staticmethod
+    def _get_base_operator_ports(task: dict, direction: str):
+        return task[direction]
+
     def get_task_assets(
         self,
         inlets: bool = True,
@@ -1984,13 +1992,18 @@ class LazyDeserializedDAG(pydantic.BaseModel):
     ) -> Generator[tuple[str, AssetT], None, None]:
         for task in self.data["dag"]["tasks"]:
             task = task[Encoding.VAR]
+            if task.get("_is_mapped"):
+                ports_getter = self._get_mapped_operator_ports
+            else:
+                ports_getter = self._get_base_operator_ports
             directions = ("inlets",) if inlets else ()
             if outlets:
                 directions += ("outlets",)
             for direction in directions:
-                if not (ports := task.get(direction)):
+                try:
+                    ports = ports_getter(task, direction)
+                except KeyError:
                     continue
-
                 for port in ports:
                     obj = BaseSerialization.deserialize(port)
                     if isinstance(obj, of_type):

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -218,6 +218,7 @@ _PARTIAL_DEFAULTS: dict[str, Any] = {
     "inlets": [],
     "outlets": [],
     "allow_nested_operators": True,
+    "executor_config": {},
 }
 
 
@@ -334,8 +335,7 @@ else:
         )
 
         # Fill fields not provided by the user with default values.
-        for k, v in _PARTIAL_DEFAULTS.items():
-            partial_kwargs.setdefault(k, v)
+        partial_kwargs.update((k, v) for k, v in _PARTIAL_DEFAULTS.items() if k not in partial_kwargs)
 
         # Post-process arguments. Should be kept in sync with _TaskDecorator.expand().
         if "task_concurrency" in kwargs:  # Reject deprecated option.
@@ -355,7 +355,6 @@ else:
         partial_kwargs["max_retry_delay"] = BaseOperator._convert_max_retry_delay(
             partial_kwargs.get("max_retry_delay", None)
         )
-        partial_kwargs.setdefault("executor_config", {})
 
         for k in ("execute", "failure", "success", "retry", "skipped"):
             partial_kwargs[attr] = _collect_callbacks(partial_kwargs.get(attr := f"on_{k}_callback"))


### PR DESCRIPTION
Previously, the get_task_assets function did not correctly account for mapped operators, causing outlets and inlets defined in such operators being lost when parsing DAGs. This fixes the issue by looking at values under the correct keys.