### PR TITLE
Mark mssql and samba tests as db-tests

### DIFF
--- a/providers/microsoft/mssql/tests/unit/microsoft/mssql/hooks/test_mssql.py
+++ b/providers/microsoft/mssql/tests/unit/microsoft/mssql/hooks/test_mssql.py
@@ -29,35 +29,12 @@ from airflow.providers.microsoft.mssql.dialects.mssql import MsSqlDialect
 
 from tests_common.test_utils.file_loading import load_file_from_resources
 
+pytestmark = pytest.mark.db_test
+
 try:
     from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
 except ImportError:
     pytest.skip("MSSQL not available", allow_module_level=True)
-
-PYMSSQL_CONN = Connection(
-    conn_type="mssql", host="ip", schema="share", login="username", password="password", port=8081
-)
-PYMSSQL_CONN_ALT = Connection(
-    conn_type="mssql", host="ip", schema="", login="username", password="password", port=8081
-)
-PYMSSQL_CONN_ALT_1 = Connection(
-    conn_type="mssql",
-    host="ip",
-    schema="",
-    login="username",
-    password="password",
-    port=8081,
-    extra={"SQlalchemy_Scheme": "mssql+testdriver"},
-)
-PYMSSQL_CONN_ALT_2 = Connection(
-    conn_type="mssql",
-    host="ip",
-    schema="",
-    login="username",
-    password="password",
-    port=8081,
-    extra={"SQlalchemy_Scheme": "mssql+testdriver", "myparam": "5@-//*"},
-)
 
 
 def get_target_fields(self, table: str) -> list[str] | None:
@@ -214,7 +191,6 @@ class TestMsSqlHook:
         hook = MsSqlHook()
         assert hook.sqlalchemy_scheme == hook.DEFAULT_SQLALCHEMY_SCHEME
 
-    @pytest.mark.db_test
     def test_sqlalchemy_scheme_is_from_hook(self):
         hook = MsSqlHook(sqlalchemy_scheme="mssql+mytestdriver")
         assert hook.sqlalchemy_scheme == "mssql+mytestdriver"
@@ -245,6 +221,9 @@ class TestMsSqlHook:
         get_primary_keys,
     )
     def test_generate_insert_sql(self, get_connection):
+        PYMSSQL_CONN = Connection(
+            conn_type="mssql", host="ip", schema="share", login="username", password="password", port=8081
+        )
         get_connection.return_value = PYMSSQL_CONN
 
         hook = MsSqlHook(escape_word_format="[{}]")

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -28,12 +28,7 @@ from airflow.providers.samba.hooks.samba import SambaHook
 
 PATH_PARAMETER_NAMES = {"path", "src", "dst"}
 
-CONNECTION = Connection(
-    host="ip",
-    schema="share",
-    login="username",
-    password="password",
-)
+pytestmark = pytest.mark.db_test
 
 
 class TestSambaHook:
@@ -45,6 +40,12 @@ class TestSambaHook:
     @mock.patch("smbclient.register_session")
     @mock.patch("airflow.hooks.base.BaseHook.get_connection")
     def test_context_manager(self, get_conn_mock, register_session):
+        CONNECTION = Connection(
+            host="ip",
+            schema="share",
+            login="username",
+            password="password",
+        )
         get_conn_mock.return_value = CONNECTION
         register_session.return_value = None
         with SambaHook("samba_default"):
@@ -95,6 +96,13 @@ class TestSambaHook:
     )
     @mock.patch("airflow.hooks.base.BaseHook.get_connection")
     def test_method(self, get_conn_mock, name):
+        CONNECTION = Connection(
+            host="ip",
+            schema="share",
+            login="username",
+            password="password",
+        )
+
         get_conn_mock.return_value = CONNECTION
         hook = SambaHook("samba_default")
         connection_settings = {
@@ -141,6 +149,13 @@ class TestSambaHook:
     )
     @mock.patch("airflow.hooks.base.BaseHook.get_connection")
     def test__join_path(self, get_conn_mock, path, full_path):
+        CONNECTION = Connection(
+            host="ip",
+            schema="share",
+            login="username",
+            password="password",
+        )
+
         get_conn_mock.return_value = CONNECTION
         hook = SambaHook("samba_default")
         assert hook._join_path(path) == full_path


### PR DESCRIPTION
In some circumstances - when run together with a subset of DB tests mssql and samba tests that were not marked as db_tests created a connection and caused non-db tests to fail.

Marking them as db tests and moving connections to test methods solves the problem.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
