### PR TITLE
Replace break function in `pod-launcher-rolebinding.yaml`

### DIFF
--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -58,20 +58,22 @@ roleRef:
   name: {{ include "airflow.fullname" . }}-pod-launcher-role
   {{- end }}
 subjects:
+  {{- $schedulerAdded := false }}
   {{- range $executor := $executors }}
-  {{- if has $executor $schedulerLaunchExecutors }}
+  {{- if and (has $executor $schedulerLaunchExecutors) (not $schedulerAdded) }}
+  {{- $schedulerAdded = true }}
   - kind: ServiceAccount
     name: {{ include "scheduler.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"
-    {{- break -}}
   {{- end }}
   {{- end }}
+  {{- $workerAdded := false }}
   {{- range $executor := $executors }}
-  {{- if has $executor $workerLaunchExecutors }}
+  {{- if and (has $executor $workerLaunchExecutors) (not $workerAdded) }}
+  {{- $workerAdded = true }}
   - kind: ServiceAccount
     name: {{ include "worker.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"
-    {{- break -}}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- closes #49206 

## Why

The Airflow Helm chart currently uses the `break` function in `chart/templates/rbac/pod-launcher-rolebinding.yaml` which lead to error since `break` is not defined

## How

The PR replaces the `break` function usage with alternative control flow mechanisms in `pod-launcher-rolebinding.yaml`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
