### PR TITLE
bump min version of pre-installed providers to latest

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -138,10 +138,10 @@ dependencies = [
     "uuid6>=2024.7.10",
     # pre-installed providers
     "apache-airflow-providers-common-compat>=1.6.0",
-    "apache-airflow-providers-common-io>=1.5.2",
-    "apache-airflow-providers-common-sql>=1.24.1",
-    "apache-airflow-providers-smtp>=2.0.1",
-    "apache-airflow-providers-standard>=0.2.0",
+    "apache-airflow-providers-common-io>=1.5.3",
+    "apache-airflow-providers-common-sql>=1.25.0",
+    "apache-airflow-providers-smtp>=2.0.2",
+    "apache-airflow-providers-standard>=0.4.0",
 ]
 
 


### PR DESCRIPTION
latest versions contains needed bug fixes and missing features (for example moving base notifier) thus we need to make sure Airflow 3 runs on latest version of providers to work smoothly