### PR TITLE
Update airflow config update to show breaking config changes by default

### DIFF
--- a/airflow-core/newsfragments/47070.significant.rst
+++ b/airflow-core/newsfragments/47070.significant.rst
@@ -19,7 +19,7 @@ See :ref:`Differences between "trigger" and "data interval" timetables` for more
 
 * Migration rules needed
 
-  * ``airflow config lint``
+  * ``airflow config update``
 
-    * [ ] ``scheduler.create_cron_data_intervals``
-    * [ ] ``scheduler.create_delta_data_intervals``
+    * [x] ``scheduler.create_cron_data_intervals``
+    * [x] ``scheduler.create_delta_data_intervals``

--- a/airflow-core/newsfragments/47761.significant.rst
+++ b/airflow-core/newsfragments/47761.significant.rst
@@ -26,9 +26,9 @@ If you have these configuration options in your ``airflow.cfg`` file, you need t
 
 * Migration rules needed
 
-  * ``airflow config lint``
+  * ``airflow config update``
 
-    * [ ] Remove ``[core] hostname`` configuration option from config if value is ``:``
-    * [ ] Remove ``[email] email_backend`` configuration option from config if value is ``airflow.contrib.utils.sendgrid.send_email``
-    * [ ] Remove ``[logging] log_filename_template`` configuration option from config if value is ``{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log``
-    * [ ] Remove ``[elasticsearch] log_id_template`` configuration option from config if value is ``{dag_id}-{task_id}-{logical_date}-{try_number}``
+    * [x] Remove ``[core] hostname`` configuration option from config if value is ``:``
+    * [x] Remove ``[email] email_backend`` configuration option from config if value is ``airflow.contrib.utils.sendgrid.send_email``
+    * [x] Remove ``[logging] log_filename_template`` configuration option from config if value is ``{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log``
+    * [x] Remove ``[elasticsearch] log_id_template`` configuration option from config if value is ``{dag_id}-{task_id}-{logical_date}-{try_number}``

--- a/airflow-core/newsfragments/48579.significant.rst
+++ b/airflow-core/newsfragments/48579.significant.rst
@@ -17,6 +17,6 @@ Users should switch to ``LocalExecutor`` or ``CeleryExecutor`` as alternatives.
 
 * Migration rules needed
 
-  * ``airflow config lint``
+  * ``airflow config update``
 
-    * [ ] Convert all ``DebugExecutor`` to ``LocalExecutor`` when present in ``[core] executor``
+    * [x] Convert all ``DebugExecutor`` to ``LocalExecutor`` when present in ``[core] executor``

--- a/airflow-core/newsfragments/49223.significant.rst
+++ b/airflow-core/newsfragments/49223.significant.rst
@@ -7,9 +7,9 @@ Update in ``airflow config update`` command to show breaking config changes by d
 * Types of change
 
   * [ ] Dag changes
-  * [x] Config changes
+  * [ ] Config changes
   * [ ] API changes
-  * [x] CLI changes
+  * [ ] CLI changes
   * [ ] Behaviour changes
   * [ ] Plugin changes
   * [ ] Dependency changes

--- a/airflow-core/newsfragments/49223.significant.rst
+++ b/airflow-core/newsfragments/49223.significant.rst
@@ -4,6 +4,26 @@ Update in ``airflow config update`` command to show breaking config changes by d
   * ``airflow config update --fix`` to applies only the breaking changes and updates airflow.cfg accordingly.
   * ``airflow config update --fix --all-recommendations`` updates both breaking and non-breaking recommended changes in your configuration.
 
+* Breaking Migration rules created
+
+  * ``airflow config update``
+
+    * ``core.executor``: default value change from ``SequentialExecutor`` to ``LocalExecutor``
+    * ``logging.log_filename_template``: remove configuration if value equals either
+          ``{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log`` or
+          ``dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{% if ti.map_index >= 0 %}map_index={{ ti.map_index }}/{% endif %}attempt={{ try_number }}.log``
+    * ``webserver.web_server_host`` → ``api.host``
+    * ``webserver.web_server_port`` → ``api.port``
+    * ``webserver.workers`` → ``api.workers``
+    * ``webserver.web_server_ssl_cert`` → ``api.ssl_cert``
+    * ``webserver.web_server_ssl_key`` → ``api.ssl_key``
+    * ``webserver.access_logfile`` → ``api.access_logfile``
+    * ``scheduler.catchup_by_default``: default value change from ``True`` to ``False``
+    * ``scheduler.dag_dir_list_interval`` → ``dag_processor.refresh_interval``
+    * ``triggerer.default_capacity`` → ``triggerer.capacity``
+    * ``elasticsearch.log_id_template``: remove configuration if value equals ``{dag_id}-{task_id}-{logical_date}-{try_number}``
+
+
 * Types of change
 
   * [ ] Dag changes
@@ -14,22 +34,3 @@ Update in ``airflow config update`` command to show breaking config changes by d
   * [ ] Plugin changes
   * [ ] Dependency changes
   * [ ] Code interface changes
-
-* Breaking Migration rules needed
-
-  * ``airflow config update``
-
-    * [x] ``core.executor``: default value change from ``SequentialExecutor`` to ``LocalExecutor``
-    * [x] ``logging.log_filename_template``: remove configuration if value equals either
-          ``{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log`` or
-          ``dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{% if ti.map_index >= 0 %}map_index={{ ti.map_index }}/{% endif %}attempt={{ try_number }}.log``
-    * [x] ``webserver.web_server_host`` → ``api.host``
-    * [x] ``webserver.web_server_port`` → ``api.port``
-    * [x] ``webserver.workers`` → ``api.workers``
-    * [x] ``webserver.web_server_ssl_cert`` → ``api.ssl_cert``
-    * [x] ``webserver.web_server_ssl_key`` → ``api.ssl_key``
-    * [x] ``webserver.access_logfile`` → ``api.access_logfile``
-    * [x] ``scheduler.catchup_by_default``: default value change from ``True`` to ``False``
-    * [x] ``scheduler.dag_dir_list_interval`` → ``dag_processor.refresh_interval``
-    * [x] ``triggerer.default_capacity`` → ``triggerer.capacity``
-    * [x] ``elasticsearch.log_id_template``: remove configuration if value equals ``{dag_id}-{task_id}-{logical_date}-{try_number}``

--- a/airflow-core/newsfragments/49223.significant.rst
+++ b/airflow-core/newsfragments/49223.significant.rst
@@ -1,0 +1,35 @@
+Update in ``airflow config update`` command to show breaking config changes by default.
+
+  * By default, the ``airflow config update`` shows a dry run (i.e. it does not modify your ``airflow.cfg``) and displays only the breaking configuration changes. This helps users avoid being overwhelmed by non-critical recommendations.
+  * ``airflow config update --fix`` to applies only the breaking changes and updates airflow.cfg accordingly.
+  * ``airflow config update --fix --all-recommendations`` updates both breaking and non-breaking recommended changes in your configuration.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [x] Config changes
+  * [ ] API changes
+  * [x] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes
+
+* Breaking Migration rules needed
+
+  * ``airflow config update``
+
+    * [x] ``core.executor``: default value change from ``SequentialExecutor`` to ``LocalExecutor``
+    * [x] ``logging.log_filename_template``: remove configuration if value equals either
+          ``{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log`` or
+          ``dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{% if ti.map_index >= 0 %}map_index={{ ti.map_index }}/{% endif %}attempt={{ try_number }}.log``
+    * [x] ``webserver.web_server_host`` → ``api.host``
+    * [x] ``webserver.web_server_port`` → ``api.port``
+    * [x] ``webserver.workers`` → ``api.workers``
+    * [x] ``webserver.web_server_ssl_cert`` → ``api.ssl_cert``
+    * [x] ``webserver.web_server_ssl_key`` → ``api.ssl_key``
+    * [x] ``webserver.access_logfile`` → ``api.access_logfile``
+    * [x] ``scheduler.catchup_by_default``: default value change from ``True`` to ``False``
+    * [x] ``scheduler.dag_dir_list_interval`` → ``dag_processor.refresh_interval``
+    * [x] ``triggerer.default_capacity`` → ``triggerer.capacity``
+    * [x] ``elasticsearch.log_id_template``: remove configuration if value equals ``{dag_id}-{task_id}-{logical_date}-{try_number}``

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -820,7 +820,7 @@ ARG_UPDATE_CONFIG_FIX = Arg(
 
 ARG_UPDATE_ALL_RECOMMENDATIONS = Arg(
     ("--all-recommendations",),
-    help="Include non-breaking (recommended) changes along with breaking ones. (Use with --fix or --dry-run)",
+    help="Include non-breaking (recommended) changes along with breaking ones. (Also use with --fix)",
     action="store_true",
 )
 

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -812,6 +812,18 @@ ARG_UPDATE_CONFIG_IGNORE_OPTION = Arg(
     help="The option name(s) to ignore to update in the airflow config.",
     type=string_list_type,
 )
+ARG_UPDATE_CONFIG_FIX = Arg(
+    ("--fix",),
+    help="Automatically apply the configuration changes instead of performing a dry run. (Default: dry-run mode)",
+    action="store_true",
+)
+
+ARG_UPDATE_ALL_RECOMMENDATIONS = Arg(
+    ("--all-recommendations",),
+    help="Include non-breaking (recommended) changes along with breaking ones. (Use with --fix or --dry-run)",
+    action="store_true",
+)
+
 
 # jobs check
 ARG_JOB_TYPE_FILTER = Arg(
@@ -1657,8 +1669,9 @@ CONFIG_COMMANDS = (
             ARG_UPDATE_CONFIG_OPTION,
             ARG_UPDATE_CONFIG_IGNORE_SECTION,
             ARG_UPDATE_CONFIG_IGNORE_OPTION,
-            ARG_DRY_RUN,
             ARG_VERBOSE,
+            ARG_UPDATE_CONFIG_FIX,
+            ARG_UPDATE_ALL_RECOMMENDATIONS,
         ),
     ),
 )

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -820,7 +820,7 @@ def update_config(args) -> None:
     By default, this command will perform a dry-run (showing the changes only) and list only
     the breaking configuration changes by scanning the current configuration file for parameters that have
     been renamed, removed, or had their default values changed in Airflow 3.0. To see or fix all recommended
-    changes, use the --all-recommendation argument. To automatically update your airflow.cfg file, use
+    changes, use the --all-recommendations argument. To automatically update your airflow.cfg file, use
     the --fix argument. This command cleans up the existing comments in airflow.cfg but creates a backup of
     the old airflow.cfg file.
 
@@ -830,14 +830,14 @@ def update_config(args) -> None:
             Example: --dry-run
 
         --fix: flag (optional)
-            Automatically fix/apply the breaking changes (or all changes if --all-recommendation is also
+            Automatically fix/apply the breaking changes (or all changes if --all-recommendations is also
             specified)
             Example: --fix
 
-        --all-recommendation: flag (optional)
+        --all-recommendations: flag (optional)
             Include non-breaking (recommended) changes as well as breaking ones.
             Can be used with --dry-run or --fix.
-            Example: --all-recommendation
+            Example: --all-recommendations
 
         --section: str (optional)
             Comma-separated list of configuration sections to update.
@@ -860,21 +860,21 @@ def update_config(args) -> None:
             airflow config update
 
         2. Dry-run mode showing all recommendations:
-            airflow config update --all-recommendation
+            airflow config update --all-recommendations
 
         3. Apply (fix) only breaking changes:
             airflow config update --fix
 
         4. Apply (fix) all recommended changes:
-            airflow config update --fix --all-recommendation
+            airflow config update --fix --all-recommendations
 
-        3. Show changes only the specific sections:
+        5. Show changes only the specific sections:
             airflow config update --section core,database
 
-        4.Show changes only the specific options:
+        6.Show changes only the specific options:
             airflow config update --option sql_alchemy_conn,dag_concurrency
 
-        5. Ignores the specific section:
+        7. Ignores the specific section:
             airflow config update --ignore-section webserver
 
     :param args: The CLI arguments for updating configuration.

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -164,6 +164,11 @@ CONFIGS_CHANGES = [
         breaking=True,
     ),
     ConfigChange(
+        config=ConfigParameter("core", "hostname"),
+        was_removed=True,
+        remove_if_equals=":",
+    ),
+    ConfigChange(
         config=ConfigParameter("core", "check_slas"),
         suggestion="The SLA feature is removed in Airflow 3.0, to be replaced with Airflow Alerts in future",
     ),

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -84,22 +84,28 @@ class ConfigChange:
 
     :param config: The configuration parameter being changed.
     :param default_change: If the change is a default value change.
+    :param old_default: The old default value (valid only if default_change is True).
     :param new_default: The new default value for the configuration parameter.
     :param suggestion: A suggestion for replacing or handling the removed configuration.
     :param renamed_to: The new section and option if the configuration is renamed.
     :param was_deprecated: If the config is removed, whether the old config was deprecated.
     :param was_removed: If the config is removed.
     :param is_invalid_if: If the current config value is invalid in the future.
+    :param breaking: Mark if this change is known to be breaking and causing errors/ warnings / deprecations.
+    :param remove_if_equals: For removal rules, remove the option only if its current value equals this value.
     """
 
     config: ConfigParameter
     default_change: bool = False
+    old_default: str | bool | int | float | None = None
     new_default: str | bool | int | float | None = None
     suggestion: str = ""
     renamed_to: ConfigParameter | None = None
     was_deprecated: bool = True
     was_removed: bool = True
     is_invalid_if: Any = None
+    breaking: bool = False
+    remove_if_equals: str | bool | int | float | None = None
 
     @property
     def message(self) -> str | None:
@@ -108,10 +114,9 @@ class ConfigChange:
             value = conf.get(self.config.section, self.config.option)
             if value != self.new_default:
                 return (
-                    f"Changed default value of `{self.config.option}` "
-                    f"configuration parameter in `{self.config.section}` to `{self.new_default}`. "
-                    f"You currently have `{value}` set. "
-                    f"{self.suggestion} "
+                    f"Changed default value of `{self.config.option}` in `{self.config.section}` "
+                    f"from `{self.old_default}` to `{self.new_default}`. "
+                    f"You currently have `{value}` set. {self.suggestion}"
                 )
         if self.renamed_to:
             if self.config.section != self.renamed_to.section:
@@ -153,8 +158,10 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("core", "executor"),
         default_change=True,
+        old_default="SequentialExecutor",
         new_default="LocalExecutor",
         was_removed=False,
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("core", "check_slas"),
@@ -290,6 +297,18 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("logging", "log_processor_filename_template"),
         was_deprecated=False,
     ),
+    ConfigChange(
+        config=ConfigParameter("logging", "log_filename_template"),
+        was_removed=True,
+        remove_if_equals="{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log",
+        breaking=True,
+    ),
+    ConfigChange(
+        config=ConfigParameter("logging", "log_filename_template"),
+        was_removed=True,
+        remove_if_equals="dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{% if ti.map_index >= 0 %}map_index={{ ti.map_index }}/{% endif %}attempt={{ try_number }}.log",
+        breaking=True,
+    ),
     # metrics
     ConfigChange(
         config=ConfigParameter("metrics", "metrics_use_pattern_match"),
@@ -362,14 +381,17 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_host"),
         renamed_to=ConfigParameter("api", "host"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_port"),
         renamed_to=ConfigParameter("api", "port"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "workers"),
         renamed_to=ConfigParameter("api", "workers"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_worker_timeout"),
@@ -378,14 +400,17 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_ssl_cert"),
         renamed_to=ConfigParameter("api", "ssl_cert"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_ssl_key"),
         renamed_to=ConfigParameter("api", "ssl_key"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "access_logfile"),
         renamed_to=ConfigParameter("api", "access_logfile"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "error_logfile"),
@@ -522,6 +547,7 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("scheduler", "catchup_by_default"),
         default_change=True,
+        old_default="True",
         was_removed=False,
         new_default="False",
         suggestion="In Airflow 3.0 the default value for `catchup_by_default` is set to `False`. "
@@ -530,6 +556,21 @@ CONFIGS_CHANGES = [
         "If your DAGs rely on catchup behavior, not explicitly defined in the DAG definition, "
         "set this configuration parameter to `True` in the `scheduler` section of your `airflow.cfg` "
         "to enable the behavior from Airflow 2.x.",
+        breaking=True,
+    ),
+    ConfigChange(
+        config=ConfigParameter("scheduler", "create_cron_data_intervals"),
+        default_change=True,
+        old_default="True",
+        new_default="False",
+        was_removed=False,
+    ),
+    ConfigChange(
+        config=ConfigParameter("scheduler", "create_delta_data_intervals"),
+        default_change=True,
+        old_default=True,
+        new_default=False,
+        was_removed=False,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "processor_poll_interval"),
@@ -609,6 +650,7 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("scheduler", "dag_dir_list_interval"),
         renamed_to=ConfigParameter("dag_processor", "refresh_interval"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "local_task_job_heartbeat_sec"),
@@ -665,6 +707,20 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("triggerer", "default_capacity"),
         renamed_to=ConfigParameter("triggerer", "capacity"),
+        breaking=True,
+    ),
+    # email
+    ConfigChange(
+        config=ConfigParameter("email", "email_backend"),
+        was_removed=True,
+        remove_if_equals="airflow.contrib.utils.sendgrid.send_email",
+    ),
+    # elasticsearch
+    ConfigChange(
+        config=ConfigParameter("elasticsearch", "log_id_template"),
+        was_removed=True,
+        remove_if_equals="{dag_id}-{task_id}-{logical_date}-{try_number}",
+        breaking=True,
     ),
 ]
 
@@ -761,14 +817,27 @@ def update_config(args) -> None:
     """
     Update the airflow.cfg file to migrate configuration changes from Airflow 2.x to Airflow 3.
 
-    This command scans the current configuration file for parameters that have been renamed,
-    removed, or had their default values changed in Airflow 3.0, and automatically updates
-    the configuration file. This command cleans up the existing comments in airflow.cfg
+    By default, this command will perform a dry-run (showing the changes only) and list only
+    the breaking configuration changes by scanning the current configuration file for parameters that have
+    been renamed, removed, or had their default values changed in Airflow 3.0. To see or fix all recommended
+    changes, use the --all-recommendation argument. To automatically update your airflow.cfg file, use
+    the --fix argument. This command cleans up the existing comments in airflow.cfg but creates a backup of
+    the old airflow.cfg file.
 
     CLI Arguments:
         --dry-run: flag (optional)
             Dry-run mode (print the changes without modifying airflow.cfg)
             Example: --dry-run
+
+        --fix: flag (optional)
+            Automatically fix/apply the breaking changes (or all changes if --all-recommendation is also
+            specified)
+            Example: --fix
+
+        --all-recommendation: flag (optional)
+            Include non-breaking (recommended) changes as well as breaking ones.
+            Can be used with --dry-run or --fix.
+            Example: --all-recommendation
 
         --section: str (optional)
             Comma-separated list of configuration sections to update.
@@ -787,19 +856,25 @@ def update_config(args) -> None:
             Example: --ignore-option check_slas
 
     Examples:
-        1. Dry-run mode (print the changes in modified airflow.cfg):
-            airflow config update --dry-run
-
-        2. Update the entire configuration file:
+        1. Dry-run mode (print the changes in modified airflow.cfg) showing only breaking changes:
             airflow config update
 
-        3. Update only the 'core' and 'database' sections:
+        2. Dry-run mode showing all recommendations:
+            airflow config update --all-recommendation
+
+        3. Apply (fix) only breaking changes:
+            airflow config update --fix
+
+        4. Apply (fix) all recommended changes:
+            airflow config update --fix --all-recommendation
+
+        3. Show changes only the specific sections:
             airflow config update --section core,database
 
-        4. Update only specific options:
+        4.Show changes only the specific options:
             airflow config update --option sql_alchemy_conn,dag_concurrency
 
-        5. Ignore updates for a specific section:
+        5. Ignores the specific section:
             airflow config update --ignore-section webserver
 
     :param args: The CLI arguments for updating configuration.
@@ -808,6 +883,9 @@ def update_config(args) -> None:
     changes_applied: list[str] = []
     modifications = ConfigModifications()
 
+    include_all = args.all_recommendations if args.all_recommendations else False
+    apply_fix = args.fix if args.fix else False
+    dry_run = not apply_fix
     update_sections = args.section if args.section else None
     update_options = args.option if args.option else None
     ignore_sections = args.ignore_section if args.ignore_section else []
@@ -821,6 +899,8 @@ def update_config(args) -> None:
         display_sensitive=True,
     )
     for change in CONFIGS_CHANGES:
+        if not include_all and not change.breaking:
+            continue
         conf_section = change.config.section.lower()
         conf_option = change.config.option.lower()
         full_key = f"{conf_section}.{conf_option}"
@@ -841,11 +921,12 @@ def update_config(args) -> None:
             continue
 
         current_value = value_data[0]
+        prefix = "[[red]BREAKING[/red]]" if change.breaking else "[[yellow]Recommended[/yellow]]"
         if change.default_change:
             if str(current_value) != str(change.new_default):
                 modifications.add_default_update(conf_section, conf_option, str(change.new_default))
                 changes_applied.append(
-                    f"Updated default value of '{conf_section}/{conf_option}' from "
+                    f"{prefix} Updated default value of '{conf_section}/{conf_option}' from "
                     f"'{current_value}' to '{change.new_default}'."
                 )
         if change.renamed_to:
@@ -853,12 +934,19 @@ def update_config(args) -> None:
                 conf_section, conf_option, change.renamed_to.section, change.renamed_to.option
             )
             changes_applied.append(
-                f"Renamed '{conf_section}/{conf_option}' to "
+                f"{prefix} Renamed '{conf_section}/{conf_option}' to "
                 f"'{change.renamed_to.section.lower()}/{change.renamed_to.option.lower()}'."
             )
         elif change.was_removed:
-            modifications.add_remove(conf_section, conf_option)
-            changes_applied.append(f"Removed '{conf_section}/{conf_option}' from configuration.")
+            if change.remove_if_equals is not None:
+                if str(current_value) == str(change.remove_if_equals):
+                    modifications.add_remove(conf_section, conf_option)
+                    changes_applied.append(
+                        f"{prefix} Removed '{conf_section}/{conf_option}' from configuration."
+                    )
+            else:
+                modifications.add_remove(conf_section, conf_option)
+                changes_applied.append(f"{prefix} Removed '{conf_section}/{conf_option}' from configuration.")
 
     backup_path = f"{AIRFLOW_CONFIG}.bak"
     try:
@@ -868,7 +956,7 @@ def update_config(args) -> None:
         console.print(f"Failed to create backup: {e}")
         raise AirflowConfigException("Backup creation failed. Aborting update_config operation.")
 
-    if args.dry_run:
+    if dry_run:
         console.print("[blue]Dry-run mode enabled. No changes will be written to airflow.cfg.[/blue]")
         with StringIO() as config_output:
             conf.write_custom_config(
@@ -889,9 +977,14 @@ def update_config(args) -> None:
             )
 
     if changes_applied:
-        console.print("[green]The following updates were applied:[/green]")
+        console.print("[green]The following are the changes in airflow config:[/green]")
         for change_msg in changes_applied:
             console.print(f"  - {change_msg}")
+        if dry_run:
+            console.print(
+                "[blue]Dry-run is mode enabled. To apply above airflow.cfg run the command "
+                "with `--fix`.[/blue]"
+            )
     else:
         console.print("[green]No updates needed. Your configuration is already up-to-date.[/green]")
 

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -128,7 +128,7 @@ class ConfigChange:
                 f"`{self.config.option}` configuration parameter renamed to `{self.renamed_to.option}` "
                 f"in the `{self.config.section}` section."
             )
-        if self.was_removed:
+        if self.was_removed and not self.remove_if_equals:
             return (
                 f"Removed{' deprecated' if self.was_deprecated else ''} `{self.config.option}` configuration parameter "
                 f"from `{self.config.section}` section. "
@@ -564,13 +564,15 @@ CONFIGS_CHANGES = [
         old_default="True",
         new_default="False",
         was_removed=False,
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "create_delta_data_intervals"),
         default_change=True,
-        old_default=True,
-        new_default=False,
+        old_default="True",
+        new_default="False",
         was_removed=False,
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "processor_poll_interval"),
@@ -825,10 +827,6 @@ def update_config(args) -> None:
     the old airflow.cfg file.
 
     CLI Arguments:
-        --dry-run: flag (optional)
-            Dry-run mode (print the changes without modifying airflow.cfg)
-            Example: --dry-run
-
         --fix: flag (optional)
             Automatically fix/apply the breaking changes (or all changes if --all-recommendations is also
             specified)
@@ -836,7 +834,7 @@ def update_config(args) -> None:
 
         --all-recommendations: flag (optional)
             Include non-breaking (recommended) changes as well as breaking ones.
-            Can be used with --dry-run or --fix.
+            Can be used with --fix.
             Example: --all-recommendations
 
         --section: str (optional)

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -256,7 +256,7 @@ class TestConfigLint:
         normalized_output = re.sub(r"\s+", " ", output.strip())
         normalized_message = re.sub(r"\s+", " ", removed_config.message.strip())
 
-        assert normalized_message in normalized_output
+        assert normalized_message.lower() in normalized_output.lower()
 
     @pytest.mark.parametrize(
         "default_changed_config",

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -253,8 +253,10 @@ class TestConfigLint:
 
             output = temp_stdout.getvalue()
 
-        normalized_output = re.sub(r"\s+", " ", output.strip())
-        normalized_message = re.sub(r"\s+", " ", removed_config.message.strip())
+        normalized_output = re.sub(r"\s+", " ", output.strip()) if output else ""
+        normalized_message = (
+            re.sub(r"\s+", " ", removed_config.message.strip()) if removed_config.message else ""
+        )
 
         assert normalized_message.lower() in normalized_output.lower()
 

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -496,74 +496,77 @@ class TestConfigLint:
 
 
 class TestCliConfigUpdate:
-    @classmethod
-    def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+    @conf_vars({("core", "executor"): "SequentialExecutor"})
+    def test_update_config_all_options_dry_run(self, tmp_path, monkeypatch, capsys):
+        cfg_file = tmp_path / "airflow.cfg"
+        initial_config = "[core]\nexecutor = SequentialExecutor\n"
+        cfg_file.write_text(initial_config)
 
-    @pytest.fixture(autouse=True)
-    def setup_fake_airflow_cfg(self, tmp_path, monkeypatch):
-        fake_config = tmp_path / "airflow.cfg"
-        fake_config.write_text(
-            """
-            [test_admin]
-            rename_key = legacy_value
-            remove_key = to_be_removed
-            [test_core]
-            dags_folder = /some/path/to/dags
-            default_key = OldDefault"""
+        monkeypatch.setattr(config_command, "AIRFLOW_CONFIG", str(cfg_file))
+
+        def fake_write_custom_config(file, **kwargs):
+            file.write("updated_config_dry_run")
+
+        monkeypatch.setattr(conf, "write_custom_config", fake_write_custom_config)
+
+        parser = cli_parser.get_parser()
+        args = parser.parse_args(
+            [
+                "config",
+                "update",
+                "--all-recommendations",
+            ]
         )
-        monkeypatch.setenv("AIRFLOW_CONFIG", str(fake_config))
-        monkeypatch.setattr(config_command, "AIRFLOW_CONFIG", str(fake_config))
-        conf.read(str(fake_config))
-        return fake_config
 
-    def test_update_renamed_option(self, monkeypatch, setup_fake_airflow_cfg):
-        fake_config = setup_fake_airflow_cfg
-        renamed_change = ConfigChange(
-            config=ConfigParameter("test_admin", "rename_key"),
-            renamed_to=ConfigParameter("test_core", "renamed_key"),
+        config_command.update_config(args)
+
+        output = capsys.readouterr().out
+
+        assert "Dry-run mode enabled" in output
+        assert "The following are the changes in airflow config:" in output
+
+        current_cfg = cfg_file.read_text()
+        assert initial_config in current_cfg, "Dry-run should not modify the config file."
+
+    @conf_vars({("core", "executor"): "SequentialExecutor"})
+    def test_update_config_all_options_fix(self, tmp_path, monkeypatch, capsys):
+        cfg_file = tmp_path / "airflow.cfg"
+        initial_config = "[core]\nexecutor = SequentialExecutor\n"
+        cfg_file.write_text(initial_config)
+
+        monkeypatch.setattr(config_command, "AIRFLOW_CONFIG", str(cfg_file))
+
+        def fake_write_custom_config(file, **kwargs):
+            file.write("updated_config")
+
+        monkeypatch.setattr(conf, "write_custom_config", fake_write_custom_config)
+
+        def fake_copy2(src, dst):
+            with open(dst, "w") as f:
+                f.write("backup_config")
+
+        monkeypatch.setattr(shutil, "copy2", fake_copy2)
+
+        parser = cli_parser.get_parser()
+        args = parser.parse_args(
+            [
+                "config",
+                "update",
+                "--fix",
+                "--all-recommendations",
+            ]
         )
-        monkeypatch.setattr(config_command, "CONFIGS_CHANGES", [renamed_change])
-        assert conf.has_option("test_admin", "rename_key")
-        args = self.parser.parse_args(["config", "update"])
-        config_command.update_config(args)
-        content = fake_config.read_text()
-        admin_section = content.split("[test_admin]")[-1]
-        assert "rename_key" not in admin_section
-        core_section = content.split("[test_core]")[-1]
-        assert "renamed_key" in core_section
-        assert "# Renamed from test_admin.rename_key" in content
 
-    def test_update_removed_option(self, monkeypatch, setup_fake_airflow_cfg):
-        fake_config = setup_fake_airflow_cfg
-        removed_change = ConfigChange(
-            config=ConfigParameter("test_admin", "remove_key"),
-            suggestion="Option removed in Airflow 3.0.",
-        )
-        monkeypatch.setattr(config_command, "CONFIGS_CHANGES", [removed_change])
-        assert conf.has_option("test_admin", "remove_key")
-        args = self.parser.parse_args(["config", "update"])
         config_command.update_config(args)
-        content = fake_config.read_text()
-        assert "remove_key" not in content
 
-    def test_update_no_changes(self, monkeypatch, capsys):
-        monkeypatch.setattr(config_command, "CONFIGS_CHANGES", [])
-        args = self.parser.parse_args(["config", "update"])
-        config_command.update_config(args)
-        captured = capsys.readouterr().out
-        assert "No updates needed" in captured
+        output = capsys.readouterr().out
+        assert "Backup saved as" in output
+        assert "The following are the changes in airflow config:" in output
 
-    def test_update_backup_creation(self, monkeypatch):
-        removed_change = ConfigChange(
-            config=ConfigParameter("test_admin", "remove_key"),
-            suggestion="Option removed.",
-        )
-        monkeypatch.setattr(config_command, "CONFIGS_CHANGES", [removed_change])
-        assert conf.has_option("test_admin", "remove_key")
-        args = self.parser.parse_args(["config", "update"])
-        mock_copy = mock.MagicMock()
-        monkeypatch.setattr(shutil, "copy2", mock_copy)
-        config_command.update_config(args)
-        backup_path = os.environ.get("AIRFLOW_CONFIG") + ".bak"
-        mock_copy.assert_called_once_with(os.environ.get("AIRFLOW_CONFIG"), backup_path)
+        updated_cfg = cfg_file.read_text()
+        assert "updated_config" in updated_cfg, "Fix mode should update the configuration file."
+
+        backup_path = str(cfg_file) + ".bak"
+        assert os.path.exists(backup_path), "Backup file should be created."
+        backup_content = open(backup_path).read()
+        assert "backup_config" in backup_content, "Backup file should contain the original content."


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
`airflow.cfg` in Airflow 2. x usually has 2000+ lines of configs. Users typically want to change only the configurations causing issues in airflow migrations rather than dealing with a long list of config changes they may not fully understand.

This PR refines the `airflow config update` to better serve users upgrading to Airflow 3.0. Key changes include:
- **Dry-Run by default (Breaking Changes Only):**  
  The `airflow config update` command now defaults to a dry run (same as `--dry-run`) and displays only the breaking configuration changes. This avoids overwhelming users with recommended but non-critical changes. The breaking changes here are the configs causing errors/ warnings / deprecations.

- **New CLI Arguments:**  
  - **`--fix`**: Applies the breaking changes instead of a dry run.  
  - **`--all-recommendations`**: When used with either `--dry-run` or `--fix`, it includes all recommended changes (i.e., non-breaking ones) in addition to breaking ones.

**CLI Command Argument:**

- **Dry-run mode (showing only breaking changes):**  
  ```
  airflow config update
  ```
I tested it default airflow.cfg from Airflow 2.10.5:
<img width="886" alt="Screenshot 2025-04-14 at 8 42 12 PM" src="https://github.com/user-attachments/assets/421fd2db-32f0-4ad3-b4eb-fc795a6245d1" />


- **Dry-run mode including all recommendations (breaking + non-breaking):**  
  ```
  airflow config update --all-recommendations
  ```
I tested it default airflow.cfg from Airflow 2.10.5:
<img width="1067" alt="Screenshot 2025-04-14 at 8 42 41 PM" src="https://github.com/user-attachments/assets/4ee46eb0-dad4-48da-822f-fc520003c675" />


- **Apply only the breaking changes:**  
  ```
  airflow config update --fix
  ```
I tested it default airflow.cfg from Airflow 2.10.5:
<img width="995" alt="Screenshot 2025-04-14 at 8 42 54 PM" src="https://github.com/user-attachments/assets/12b0fd5f-ab0c-49d9-a965-188f0e454af6" />


- **Apply all recommended changes (both breaking and non-breaking):**  
  ```
  airflow config update --fix --all-recommendations
  ```

- **Update only specific sections (e.g. `core` and `database`):**  
  ```
  airflow config update --section core,database
  ```

- **Update only specific options (e.g. `sql_alchemy_conn` and `dag_concurrency`):**  
  ```
  airflow config update --option sql_alchemy_conn,dag_concurrency
  ```

- **Ignore a specific section (e.g. `webserver`):**  
  ```
  airflow config update --ignore-section webserver
  ```

- **Ignore specific options (e.g. `smtp_user` and `session_lifetime_days`):**  
  ```
  airflow config update --ignore-option smtp_user,session_lifetime_days
  ```


**Breaking config changes**  
<hr>

Section | Option | Change Type | Old Value / Condition | New Value / New Config Name
-- | -- | -- | -- | --
core | executor | Default Value Change | SequentialExecutor | LocalExecutor
logging | log_filename_template | Removal | {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log | The actual replacement value will be updated after defaults are loaded from config.yml
logging | log_filename_template | Removal | dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{% if ti.map_index >= 0 %}map_index={{ ti.map_index }}/{% endif %}attempt={{ try_number }}.log | The actual replacement value will be updated after defaults are loaded from config.yml
webserver | web_server_host | Rename | web_server_host | host (in [api])
webserver | web_server_port | Rename | web_server_port | port (in [api])
webserver | workers | Rename | workers | workers (in [api])
webserver | web_server_ssl_cert | Rename | web_server_ssl_cert | ssl_cert (in [api])
webserver | web_server_ssl_key | Rename | web_server_ssl_key | ssl_key (in [api])
webserver | access_logfile | Rename | access_logfile | access_logfile (in [api])
scheduler | catchup_by_default | Default Value Change | True | False
scheduler | dag_dir_list_interval | Rename | dag_dir_list_interval | refresh_interval (in [dag_processor])
triggerer | default_capacity | Rename | default_capacity | capacity (in [triggerer])
elasticsearch | log_id_template | Removal | {dag_id}-{task_id}-{logical_date}-{try_number} | Removed



closes: [#49202](https://github.com/apache/airflow/issues/49202)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
