### PR TITLE
Rename directory for dag processor child process logs

### DIFF
--- a/airflow-core/newsfragments/aip-66.significant.rst
+++ b/airflow-core/newsfragments/aip-66.significant.rst
@@ -10,6 +10,14 @@ The following DAG parsing configuration options were moved into the ``dag_proces
 * ``[scheduler] stale_dag_threshold`` → ``[dag_processor] stale_dag_threshold``
 * ``[scheduler] print_stats_interval`` → ``[dag_processor] print_stats_interval``
 
+The following DAG parsing configuration options were moved into the ``logging`` section:
+
+* ``[scheduler] child_process_log_directory`` → ``[logging] dag_processor_child_process_log_directory``
+
+The default value of ``[logging] dag_processor_child_process_log_directory`` was changed from
+``AIRFLOW_HOME/logs/scheduler`` to ``AIRFLOW_HOME/logs/dag-processor``, which moves the parsing logs for dag files into
+that new location.
+
 The "subdir" concept has been superseded by the "bundle" concept. Users are able to
 define separate bundles for different DAG folders, and can refer to them by the bundle name
 instead of their location on disk.
@@ -64,3 +72,4 @@ Triggers can come from anywhere else on ``sys.path`` instead.
     * [x] ``[scheduler] stale_dag_threshold`` → ``[dag_processor] stale_dag_threshold``
     * [x] ``[scheduler] print_stats_interval`` → ``[dag_processor] print_stats_interval``
     * [x] ``[scheduler] dag_dir_list_interval`` → ``[dag_processor] refresh_interval``
+    * [x] ``[scheduler] dag_dir_list_interval`` → ``[logging] dag_processor_child_process_log_directory``

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -622,6 +622,10 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("scheduler", "zombie_detection_interval"),
         renamed_to=ConfigParameter("scheduler", "task_instance_heartbeat_timeout_detection_interval"),
     ),
+    ConfigChange(
+        config=ConfigParameter("scheduler", "child_process_log_directory"),
+        renamed_to=ConfigParameter("logging", "dag_processor_child_process_log_directory"),
+    ),
     # celery
     ConfigChange(
         config=ConfigParameter("celery", "stalled_task_timeout"),

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -53,8 +53,6 @@ DAG_PROCESSOR_LOG_TARGET: str = conf.get_mandatory_value("logging", "DAG_PROCESS
 
 BASE_LOG_FOLDER: str = os.path.expanduser(conf.get_mandatory_value("logging", "BASE_LOG_FOLDER"))
 
-PROCESSOR_LOG_FOLDER: str = conf.get_mandatory_value("scheduler", "CHILD_PROCESS_LOG_DIRECTORY")
-
 DEFAULT_LOGGING_CONFIG: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -713,7 +713,7 @@ logging:
         There are a few existing configurations that assume this is set to the default.
         If you choose to override this you may need to update the
         ``[logging] dag_processor_manager_log_location`` and
-        ``[logging] child_process_log_directory settings`` as well.
+        ``[logging] dag_processor_child_process_log_directory settings`` as well.
       version_added: 2.0.0
       type: string
       example: ~
@@ -872,6 +872,13 @@ logging:
       example: ~
       default: "[%%(asctime)s] [SOURCE:DAG_PROCESSOR]
         {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s"
+    dag_processor_child_process_log_directory:
+      description: |
+        Determines the directory where logs for the child processes of the dag processor will be stored
+      version_added: ~
+      type: string
+      example: ~
+      default: "{AIRFLOW_HOME}/logs/dag_processor"
     log_formatter_class:
       description: |
         Determines the formatter class used by Airflow for structuring its log messages
@@ -2159,13 +2166,6 @@ scheduler:
       type: float
       example: ~
       default: "300.0"
-    child_process_log_directory:
-      description: |
-        Determines the directory where logs for the child processes of the scheduler will be stored
-      version_added: ~
-      type: string
-      example: ~
-      default: "{AIRFLOW_HOME}/logs/scheduler"
     task_instance_heartbeat_timeout:
       description: |
         Local task jobs periodically heartbeat to the DB. If the job has

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -199,7 +199,9 @@ class DagFileProcessorManager(LoggingMixin):
         factory=_config_int_factory("dag_processor", "max_callbacks_per_loop")
     )
 
-    base_log_dir: str = attrs.field(factory=_config_get_factory("scheduler", "CHILD_PROCESS_LOG_DIRECTORY"))
+    base_log_dir: str = attrs.field(
+        factory=_config_get_factory("logging", "dag_processor_child_process_log_directory")
+    )
     _latest_log_symlink_date: datetime = attrs.field(factory=datetime.today, init=False)
 
     bundle_refresh_check_interval: int = attrs.field(


### PR DESCRIPTION
Since we don't parse dags in the scheduler any longer, we should rename the directory that we log in for dag file parsing.