### PR TITLE
Properly allow variable delete from models

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -302,7 +302,7 @@ class Variable(Base, LoggingMixin):
             )
 
     @staticmethod
-    def delete(key: str, session: Session | None = None) -> None | int:
+    def delete(key: str, session: Session | None = None) -> int:
         """
         Delete an Airflow Variable for a given key.
 
@@ -327,7 +327,7 @@ class Variable(Base, LoggingMixin):
             TaskSDKVariable.delete(
                 key=key,
             )
-            return None
+            return 1
 
         ctx: contextlib.AbstractContextManager
         if session is not None:

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -302,7 +302,7 @@ class Variable(Base, LoggingMixin):
             )
 
     @staticmethod
-    def delete(key: str, session: Session | None = None) -> int:
+    def delete(key: str, session: Session | None = None) -> None | int:
         """
         Delete an Airflow Variable for a given key.
 
@@ -327,6 +327,7 @@ class Variable(Base, LoggingMixin):
             TaskSDKVariable.delete(
                 key=key,
             )
+            return None
 
         ctx: contextlib.AbstractContextManager
         if session is not None:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Using variable.delete from models was failing (maybe due to refactor before merging https://github.com/apache/airflow/pull/49141).

Thanks Jens for noticing. Turns out it was a missing return statement!!!

Tested with Jens dag again and it works fine now.

![image](https://github.com/user-attachments/assets/f20aeba4-f935-4e4a-a0ac-24e60d4cc2cf)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
