### PR TITLE
Instantiate logger while logging loaded secrets backend

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1238,6 +1238,8 @@ def ensure_secrets_backend_loaded() -> list[BaseSecretsBackend]:
 
     backends = ensure_secrets_loaded(default_backends=DEFAULT_SECRETS_SEARCH_PATH_WORKERS)
 
+    log = structlog.get_logger(logger_name="supervisor")
+
     log.info(
         "Secrets backends loaded for worker",
         count=len(backends),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When we use things like Variable.get etc, it passed through the ensure_secrets_backend call: https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/execution_time/context.py#L229

In such cases there's no logger initiated in this function scope and it complains:
```
[2025-04-14, 16:10:39] ERROR - Task failed with exception: source="task"
ValueError: I/O operation on closed file.
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 809 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1072 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 408 in wrapper

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/decorator.py", line 251 in execute

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 408 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 212 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 235 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 81 in run

File "/files/dags/dags/integration_test.py", line 101 in variable

File "/opt/airflow/airflow-core/src/airflow/models/variable.py", line 212 in set

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/variable.py", line 65 in set

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 229 in _set_variable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 1241 in ensure_secrets_backend_loaded

File "/usr/local/lib/python3.9/site-packages/structlog/_native.py", line 144 in meth

File "/usr/local/lib/python3.9/site-packages/structlog/_base.py", line 223 in _proxy_to_logger

File "/usr/local/lib/python3.9/site-packages/structlog/_output.py", line 217 in msg
```

This shouldnt be the case so initiating the logger locally too.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
