### PR TITLE
Change default page_size from 100 to 50

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -94,7 +94,7 @@ class LimitFilter(BaseParam[NonNegativeInt]):
         return select.limit(self.value)
 
     @classmethod
-    def depends(cls, limit: NonNegativeInt = 100) -> LimitFilter:
+    def depends(cls, limit: NonNegativeInt = 50) -> LimitFilter:
         return cls().set_value(limit)
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -117,7 +117,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -383,7 +383,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -503,7 +503,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: order_by
         in: query
@@ -589,7 +589,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -684,7 +684,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -802,7 +802,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -1412,7 +1412,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -1927,7 +1927,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -2461,7 +2461,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -3108,7 +3108,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -3166,7 +3166,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -3343,7 +3343,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -3741,7 +3741,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -4007,7 +4007,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -4109,7 +4109,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -4204,7 +4204,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -4418,7 +4418,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -4574,7 +4574,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -4836,7 +4836,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -5285,7 +5285,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -5947,7 +5947,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -6717,7 +6717,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -7020,7 +7020,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query
@@ -7149,7 +7149,7 @@ paths:
         schema:
           type: integer
           minimum: 0
-          default: 100
+          default: 50
           title: Limit
       - name: offset
         in: query

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1393,7 +1393,7 @@ api:
       type: integer
       example: ~
       version_added: 2.0.0
-      default: "100"
+      default: "50"
     access_control_allow_headers:
       description: |
         Used in response to a preflight request to indicate which HTTP
@@ -1782,7 +1782,7 @@ webserver:
       version_added: ~
       type: string
       example: ~
-      default: "100"
+      default: "50"
     navbar_color:
       description: |
         Define the color of navigation bar

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -504,9 +504,10 @@ class TestGetAssetsEndpointPagination(TestAssets):
             ("/assets?limit=1", ["s3://bucket/key/1"]),
             ("/assets?limit=100", [f"s3://bucket/key/{i}" for i in range(1, 101)]),
             # Offset test data
-            ("/assets?offset=1", [f"s3://bucket/key/{i}" for i in range(2, 102)]),
-            ("/assets?offset=3", [f"s3://bucket/key/{i}" for i in range(4, 104)]),
+            ("/assets?offset=1", [f"s3://bucket/key/{i}" for i in range(2, 52)]),
+            ("/assets?offset=3", [f"s3://bucket/key/{i}" for i in range(4, 54)]),
             # Limit and offset test data
+            ("/assets?offset=50&limit=50", [f"s3://bucket/key/{i}" for i in range(51, 101)]),
             ("/assets?offset=3&limit=3", [f"s3://bucket/key/{i}" for i in [4, 5, 6]]),
         ],
     )
@@ -525,7 +526,7 @@ class TestGetAssetsEndpointPagination(TestAssets):
         response = test_client.get("/assets")
 
         assert response.status_code == 200
-        assert len(response.json()["assets"]) == 100
+        assert len(response.json()["assets"]) == 50
 
 
 class TestAssetAliases:
@@ -605,8 +606,8 @@ class TestGetAssetAliasesEndpointPagination(TestAssetAliases):
             ("/assets/aliases?limit=1", ["simple1"]),
             ("/assets/aliases?limit=100", [f"simple{i}" for i in range(1, 101)]),
             # Offset test data
-            ("/assets/aliases?offset=1", [f"simple{i}" for i in range(2, 102)]),
-            ("/assets/aliases?offset=3", [f"simple{i}" for i in range(4, 104)]),
+            ("/assets/aliases?offset=1", [f"simple{i}" for i in range(2, 52)]),
+            ("/assets/aliases?offset=3", [f"simple{i}" for i in range(4, 54)]),
             # Limit and offset test data
             ("/assets/aliases?offset=3&limit=3", ["simple4", "simple5", "simple6"]),
         ],
@@ -624,7 +625,7 @@ class TestGetAssetAliasesEndpointPagination(TestAssetAliases):
         self.create_asset_aliases(num=110)
         response = test_client.get("/assets/aliases")
         assert response.status_code == 200
-        assert len(response.json()["asset_aliases"]) == 100
+        assert len(response.json()["asset_aliases"]) == 50
 
 
 class TestGetAssetEvents(TestAssets):
@@ -791,8 +792,8 @@ class TestGetAssetEvents(TestAssets):
             ({"limit": "1"}, [1]),
             ({"limit": "100"}, list(range(1, 101))),
             # Offset test data
-            ({"offset": "1"}, list(range(2, 102))),
-            ({"offset": "3"}, list(range(4, 104))),
+            ({"offset": "1"}, list(range(2, 52))),
+            ({"offset": "3"}, list(range(4, 54))),
         ],
     )
     def test_limit_and_offset(self, test_client, params, expected_asset_ids):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -716,7 +716,7 @@ class TestGetMappedTaskInstances:
 
         assert response.status_code == 200
         assert response.json()["total_entries"] == 110
-        assert len(response.json()["task_instances"]) == 100
+        assert len(response.json()["task_instances"]) == 50
 
     def test_offset_limit(self, test_client, one_task_with_many_mapped_tis):
         response = test_client.get(

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -334,7 +334,7 @@ class TestGetUsersPagination(TestUserEndpoint):
         assert response.status_code == 200
         # Explicit add the 2 users on setUp
         assert response.json["total_entries"] == 200 + len(["test", "test_no_permissions"])
-        assert len(response.json["users"]) == 100
+        assert len(response.json["users"]) == 50
 
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self):


### PR DESCRIPTION
There is nowhere in the UI where 100 items ever fit into a page without a ton of scrolling. This leads to a lot of excessive page rendering. Let's change the page_size default


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
