### PR TITLE
Load TI related objects when purging TIs without heartbeat

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2188,6 +2188,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         limit_dttm = timezone.utcnow() - timedelta(seconds=self._task_instance_heartbeat_timeout_secs)
         task_instances_without_heartbeats = session.scalars(
             select(TI)
+            .options(selectinload(TI.dag_model))
+            .options(selectinload(TI.dag_run))
+            .options(selectinload(TI.dag_version))
             .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
             .join(DM, TI.dag_id == DM.dag_id)
             .where(


### PR DESCRIPTION
This query joins to DagModel but doesn't load the TI related dag_model or any other
related objects used in the following TaskCallbackRequest Arguments, resulting in
detached instance error when requesting callback.

This PR fixes it by using selectinload for fast loading of the related
objects used in the TaskCallbackRequest

