### PR TITLE
Cleanup AUTH_TYPE import comments in default_webserver_config.py

### DIFF
--- a/airflow-core/src/airflow/config_templates/default_webserver_config.py
+++ b/airflow-core/src/airflow/config_templates/default_webserver_config.py
@@ -23,10 +23,10 @@ import os
 
 from flask_appbuilder.const import AUTH_DB
 
-# from airflow.www.fab_security.manager import AUTH_LDAP
-# from airflow.www.fab_security.manager import AUTH_OAUTH
-# from airflow.www.fab_security.manager import AUTH_OID
-# from airflow.www.fab_security.manager import AUTH_REMOTE_USER
+# from flask_appbuilder.const import AUTH_LDAP
+# from flask_appbuilder.const import AUTH_OAUTH
+# from flask_appbuilder.const import AUTH_OID
+# from flask_appbuilder.const import AUTH_REMOTE_USER
 
 
 basedir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Cleaning up import AUTH_TYPE object to use flask_appbuilder. The use of airflow.www.fab_security.manager is deprecated. 
