### PR TITLE
Handle scenario where api.base_url is unset for FabAuthManager login

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -68,13 +68,13 @@ class FabIndexView(IndexView):
     def index(self):
         if g.user is not None and g.user.is_authenticated:
             token = get_auth_manager().generate_jwt(g.user)
-            response = make_response(redirect(f"{conf.get('api', 'base_url')}", code=302))
+            response = make_response(redirect(str(request.base_url), code=302))
 
             secure = conf.has_option("api", "ssl_cert")
             response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
 
             return response
-        return redirect(conf.get("api", "base_url", fallback="/"), code=302)
+        return redirect(str(request.base_url), code=302)
 
 
 def show_traceback(error):


### PR DESCRIPTION
Resolves #49229

Login with FabAuthManager fails when api.base_url is unset. This should fix it

Aligning implementation with #49118 which should resolve the infinite redirect
