### PR TITLE
Show pending states in historic metrics

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -19,6 +19,7 @@
 import { Box, Heading, HStack } from "@chakra-ui/react";
 import type { DAGRunStates } from "openapi-gen/requests/types.gen";
 import { FiBarChart } from "react-icons/fi";
+import { Link as RouterLink } from "react-router-dom";
 
 import { StateBadge } from "src/components/StateBadge";
 
@@ -26,7 +27,7 @@ import { MetricSection } from "./MetricSection";
 
 type DagRunMetricsProps = {
   readonly dagRunStates: DAGRunStates;
-  readonly endDate: string;
+  readonly endDate?: string;
   readonly startDate: string;
   readonly total: number;
 };
@@ -36,10 +37,14 @@ const DAGRUN_STATES: Array<keyof DAGRunStates> = ["queued", "running", "success"
 export const DagRunMetrics = ({ dagRunStates, endDate, startDate, total }: DagRunMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} p={2}>
     <HStack mb={4}>
-      <StateBadge colorPalette="blue" fontSize="md" variant="solid">
-        <FiBarChart />
-        {total}
-      </StateBadge>
+      <RouterLink
+        to={`/dag_runs?start_date=${startDate}${endDate === undefined ? "" : `&end_date=${endDate}`}`}
+      >
+        <StateBadge colorPalette="blue" fontSize="md" variant="solid">
+          <FiBarChart />
+          {total}
+        </StateBadge>
+      </RouterLink>
       <Heading size="md">Dag Runs</Heading>
     </HStack>
     {DAGRUN_STATES.map((state) => (

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -39,7 +39,6 @@ export const HistoricalMetrics = () => {
   const [assetSortBy, setAssetSortBy] = useState("-timestamp");
 
   const { data, error, isLoading } = useDashboardServiceHistoricalMetrics({
-    endDate,
     startDate,
   });
 
@@ -80,14 +79,8 @@ export const HistoricalMetrics = () => {
             {isLoading ? <MetricSectionSkeleton /> : undefined}
             {!isLoading && data !== undefined && (
               <Box>
-                <DagRunMetrics
-                  dagRunStates={data.dag_run_states}
-                  endDate={endDate}
-                  startDate={startDate}
-                  total={dagRunTotal}
-                />
+                <DagRunMetrics dagRunStates={data.dag_run_states} startDate={startDate} total={dagRunTotal} />
                 <TaskInstanceMetrics
-                  endDate={endDate}
                   startDate={startDate}
                   taskInstanceStates={data.task_instance_states}
                   total={taskRunTotal}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -27,7 +27,7 @@ const BAR_WIDTH = 100;
 const BAR_HEIGHT = 5;
 
 type MetricSectionProps = {
-  readonly endDate: string;
+  readonly endDate?: string;
   readonly kind: string;
   readonly runs: number;
   readonly startDate: string;
@@ -42,11 +42,17 @@ export const MetricSection = ({ endDate, kind, runs, startDate, state, total }: 
   const stateWidth = total === 0 ? 0 : (runs / total) * BAR_WIDTH;
   const remainingWidth = BAR_WIDTH - stateWidth;
 
+  const searchParams = new URLSearchParams(`?state=${state}&start_date=${startDate}`);
+
+  if (endDate !== undefined) {
+    searchParams.append("end_date", endDate);
+  }
+
   return (
     <VStack align="left" gap={1} mb={4} ml={0} pl={0}>
       <Flex justify="space-between">
         <HStack>
-          <RouterLink to={`/${kind}?state=${state}&start_date=${startDate}&end_date=${endDate}`}>
+          <RouterLink to={`/${kind}?${searchParams.toString()}`}>
             <StateBadge fontSize="md" state={state}>
               {runs}
             </StateBadge>

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -19,13 +19,14 @@
 import { Box, Heading, HStack } from "@chakra-ui/react";
 import type { TaskInstanceState, TaskInstanceStateCount } from "openapi-gen/requests/types.gen";
 import { MdOutlineTask } from "react-icons/md";
+import { Link as RouterLink } from "react-router-dom";
 
 import { StateBadge } from "src/components/StateBadge";
 
 import { MetricSection } from "./MetricSection";
 
 type TaskInstanceMetricsProps = {
-  readonly endDate: string;
+  readonly endDate?: string;
   readonly startDate: string;
   readonly taskInstanceStates: TaskInstanceStateCount;
   readonly total: number;
@@ -54,10 +55,14 @@ export const TaskInstanceMetrics = ({
 }: TaskInstanceMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} mt={2} p={2}>
     <HStack mb={4}>
-      <StateBadge colorPalette="blue" fontSize="md" variant="solid">
-        <MdOutlineTask />
-        {total}
-      </StateBadge>
+      <RouterLink
+        to={`/task_instances?start_date=${startDate}${endDate === undefined ? "" : `&end_date=${endDate}`}`}
+      >
+        <StateBadge colorPalette="blue" fontSize="md" variant="solid">
+          <MdOutlineTask />
+          {total}
+        </StateBadge>
+      </RouterLink>
       <Heading size="md">Task Instances</Heading>
     </HStack>
     {TASK_STATES.sort((stateA, stateB) =>


### PR DESCRIPTION
Redoing after the previous PR got mixed up with breeze changes.

We were setting the end_date on the metrics for task instances and dag runs. Therefore any "pending" state was never shown.

Also, added a link to the overall "X Task Instances" and "Y Dag Runs" badges

<img width="834" alt="Screenshot 2025-04-14 at 5 37 58 PM" src="https://github.com/user-attachments/assets/82a78f07-3b00-4b6b-a894-882eb36b81cd" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
