### PR TITLE
Make git connection optional for git dag bundle

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -84,10 +84,11 @@ class GitDagBundle(BaseDagBundle):
         if self.git_conn_id:
             try:
                 self.hook = GitHook(git_conn_id=self.git_conn_id, repo_url=self.repo_url)
-                self.repo_url = self.repo_url or self.hook.repo_url
-                self._log.debug("repo_url updated from hook", repo_url=self.repo_url)
             except AirflowException as e:
                 self._log.warning("Could not create GitHook", conn_id=self.git_conn_id, exc=e)
+            else:
+                self.repo_url = self.hook.repo_url
+                self._log.debug("repo_url updated from hook", repo_url=self.repo_url)
 
     def _initialize(self):
         with self.lock():

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+from contextlib import nullcontext
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -53,7 +54,7 @@ class GitDagBundle(BaseDagBundle):
         *,
         tracking_ref: str,
         subdir: str | None = None,
-        git_conn_id: str = "git_default",
+        git_conn_id: str | None = None,
         repo_url: str | None = None,
         **kwargs,
     ) -> None:
@@ -79,16 +80,19 @@ class GitDagBundle(BaseDagBundle):
         )
 
         self._log.debug("bundle configured")
-        try:
-            self.hook = GitHook(git_conn_id=self.git_conn_id, repo_url=self.repo_url)
-            self.repo_url = self.hook.repo_url
-            self._log.debug("repo_url updated from hook", repo_url=self.repo_url)
-        except AirflowException as e:
-            self._log.warning("Could not create GitHook", conn_id=self.git_conn_id, exc=e)
+        self.hook: GitHook | None = None
+        if self.git_conn_id:
+            try:
+                self.hook = GitHook(git_conn_id=self.git_conn_id, repo_url=self.repo_url)
+                self.repo_url = self.repo_url or self.hook.repo_url
+                self._log.debug("repo_url updated from hook", repo_url=self.repo_url)
+            except AirflowException as e:
+                self._log.warning("Could not create GitHook", conn_id=self.git_conn_id, exc=e)
 
     def _initialize(self):
         with self.lock():
-            with self.hook.configure_hook_env():
+            cm = self.hook.configure_hook_env() if self.hook else nullcontext()
+            with cm:
                 self._clone_bare_repo_if_required()
                 self._ensure_version_in_bare_repo()
 
@@ -134,7 +138,7 @@ class GitDagBundle(BaseDagBundle):
                     url=self.repo_url,
                     to_path=self.bare_repo_path,
                     bare=True,
-                    env=self.hook.env,
+                    env=self.hook.env if self.hook else None,
                 )
             except GitCommandError as e:
                 raise AirflowException("Error cloning repository") from e
@@ -177,10 +181,10 @@ class GitDagBundle(BaseDagBundle):
 
     def _fetch_bare_repo(self):
         refspecs = ["+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"]
-        if self.hook.env:
-            with self.bare_repo.git.custom_environment(GIT_SSH_COMMAND=self.hook.env.get("GIT_SSH_COMMAND")):
-                self.bare_repo.remotes.origin.fetch(refspecs)
-        else:
+        cm = nullcontext()
+        if self.hook and (cmd := self.hook.env.get("GIT_SSH_COMMAND")):
+            cm = self.bare_repo.git.custom_environment(GIT_SSH_COMMAND=cmd)
+        with cm:
             self.bare_repo.remotes.origin.fetch(refspecs)
 
     def refresh(self) -> None:
@@ -188,7 +192,8 @@ class GitDagBundle(BaseDagBundle):
             raise AirflowException("Refreshing a specific version is not supported")
 
         with self.lock():
-            with self.hook.configure_hook_env():
+            cm = self.hook.configure_hook_env() if self.hook else nullcontext()
+            with cm:
                 self._fetch_bare_repo()
                 self.repo.remotes.origin.fetch(
                     ["+refs/heads/*:refs/remotes/origin/*", "+refs/tags/*:refs/tags/*"]

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -511,6 +511,7 @@ class TestGitDagBundle:
             name="test",
             tracking_ref="main",
             subdir="subdir",
+            git_conn_id="git_default",
         )
         bundle.initialize = mock.MagicMock()
         view_url = bundle.view_url("0f0f0f")


### PR DESCRIPTION
Make it so we don't need to define a git connection for a git dag bundle.