### PR TITLE
Fix: SQLExecuteQueryOperator does not pass extra_dejson values to hook_params

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
@@ -161,9 +161,9 @@ class BaseSQLOperator(BaseOperator):
         :param hook_params: hook parameters
         :return: default hook for this connection
         """
-        hook_params = hook_params = hook_params or {}
+        hook_params = hook_params or {}
         connection = BaseHook.get_connection(conn_id)
-        conn_params = connection.get_extra_dejson()
+        conn_params = connection.extra_dejson
         for conn_param in conn_params:
             if conn_param not in hook_params:
                 hook_params[conn_param] = conn_params[conn_param]

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
@@ -161,7 +161,12 @@ class BaseSQLOperator(BaseOperator):
         :param hook_params: hook parameters
         :return: default hook for this connection
         """
+        hook_params = hook_params = hook_params or {}
         connection = BaseHook.get_connection(conn_id)
+        conn_params = connection.get_extra_dejson()
+        for conn_param in conn_params:
+            if conn_param not in hook_params:
+                hook_params[conn_param] = conn_params[conn_param]
         return connection.get_hook(hook_params=hook_params)
 
     @cached_property

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
@@ -113,6 +113,11 @@ class TestBaseSQLOperator:
 
 
 class TestSQLExecuteQueryOperator:
+    def setup_method(self):
+        self.task_id = "test_task"
+        self.conn_id = "sql_default"
+        self._operator = SQLExecuteQueryOperator(task_id=self.task_id, conn_id=self.conn_id, sql="sql")
+
     def _construct_operator(self, sql, **kwargs):
         dag = DAG("test_dag", schedule=None, start_date=datetime.datetime(2017, 1, 1))
         return SQLExecuteQueryOperator(
@@ -189,6 +194,23 @@ class TestSQLExecuteQueryOperator:
 
         assert descriptions == ("id", "name")
         assert result == [(1, "Alice"), (2, "Bob")]
+
+    @skip_if_force_lowest_dependencies_marker
+    def test_sql_operator_extra_dejson_fields_to_hook_params(self):
+        with mock.patch(
+            "airflow.providers.common.sql.operators.sql.BaseHook.get_connection",
+            return_value=Connection(conn_id="sql_default", conn_type="postgres"),
+        ) as mock_get_conn:
+            mock_get_conn.return_value = Connection(
+                conn_id="google_cloud_bigquery_default",
+                conn_type="gcpbigquery",
+                extra={"use_legacy_sql": False, "priority": "INTERACTIVE"},
+            )
+            self._operator.hook_params = {"use_legacy_sql": True, "location": "us-east1"}
+            assert self._operator._hook.conn_type == "gcpbigquery"
+            assert self._operator._hook.use_legacy_sql
+            assert self._operator._hook.location == "us-east1"
+            assert self._operator._hook.priority == "INTERACTIVE"
 
 
 class TestColumnCheckOperator:

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
@@ -208,7 +208,7 @@ class TestSQLExecuteQueryOperator:
             )
             self._operator.hook_params = {"use_legacy_sql": True, "location": "us-east1"}
             assert self._operator._hook.conn_type == "gcpbigquery"
-            assert self._operator._hook.use_legacy_sql
+            assert self._operator._hook.use_legacy_sql is True
             assert self._operator._hook.location == "us-east1"
             assert self._operator._hook.priority == "INTERACTIVE"
 

--- a/providers/redis/src/airflow/providers/redis/hooks/redis.py
+++ b/providers/redis/src/airflow/providers/redis/hooks/redis.py
@@ -43,7 +43,7 @@ class RedisHook(BaseHook):
     conn_type = "redis"
     hook_name = "Redis"
 
-    def __init__(self, redis_conn_id: str = default_conn_name) -> None:
+    def __init__(self, redis_conn_id: str = default_conn_name, **kwargs) -> None:
         """
         Prepare hook to connect to a Redis database.
 
@@ -53,11 +53,11 @@ class RedisHook(BaseHook):
         super().__init__()
         self.redis_conn_id = redis_conn_id
         self.redis = None
-        self.host = None
-        self.port = None
-        self.username = None
-        self.password = None
-        self.db = None
+        self.host = kwargs.get("host", None)
+        self.port = kwargs.get("port", None)
+        self.username = kwargs.get("username", None)
+        self.password = kwargs.get("password", None)
+        self.db = kwargs.get("db", None)
 
     def get_conn(self):
         """Return a Redis connection."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:




How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/49273

This PR fixes an issue in `SQLExecuteQueryOperator` where values from the connection’s extra_dejson are not passed to hook_params, even though the operator extends BaseSQLOperator, which supports them.

Currently, users have to manually duplicate values from the connection’s extras in the **hook_params** of the operator. This PR ensures that values in **extra_dejson** are automatically passed to hook_params, unless they are explicitly overridden.



<!-- Please keep an empty line above the dashes. -->

---
