### PR TITLE
Return explicit 404 errors for `/health` and `/api/v1/*`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, JSONResponse
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
@@ -63,6 +63,32 @@ def init_views(app: FastAPI) -> None:
         ),
         name="webapp_static_folder",
     )
+
+    @app.get("/health", include_in_schema=False)
+    def old_health():
+        # If someone has the `/health` endpoint from Airflow 2 set up, we want this to be a 404, not serve the
+        # default index.html for the SPA.
+        #
+        # This is a 404, not a redirect, as setups need correcting to account for this, and a redirect might
+        # hide the issue
+        return JSONResponse(
+            status_code=404,
+            content={"error": "Moved in Airflow 3. Please change config to check `/api/v2/monitor/health`"},
+        )
+
+    @app.get("/api/v1/{_:path}", include_in_schema=False)
+    def old_api(_):
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": "/api/v1 has been removed in Airflow 3, please use its upgraded version /api/v2 instead."
+            },
+        )
+
+    @app.get("/api/{_:path}", include_in_schema=False)
+    def api_not_found(_):
+        """Catch all route to handle invalid API endpoints."""
+        return JSONResponse(status_code=404, content={"error": "API route not found"})
 
     @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def webapp(request: Request, rest_of_path: str):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -7312,30 +7312,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v2/{rest_of_path}:
-    get:
-      summary: Not Found Handler
-      description: Catch all route to handle invalid endpoints.
-      operationId: not_found_handler
-      parameters:
-      - name: rest_of_path
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Rest Of Path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     AppBuilderMenuItemResponse:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/__init__.py
@@ -17,8 +17,7 @@
 
 from __future__ import annotations
 
-from fastapi import Request, status
-from starlette.responses import JSONResponse
+from fastapi import status
 
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
@@ -93,9 +92,3 @@ public_router.include_router(authenticated_router)
 public_router.include_router(monitor_router)
 public_router.include_router(version_router)
 public_router.include_router(auth_router)
-
-
-@public_router.get("/{rest_of_path:path}", include_in_schema=False)
-def not_found_handler(request: Request, rest_of_path: str):
-    """Catch all route to handle invalid endpoints."""
-    return JSONResponse(status_code=404, content={"error": "invalid route"})

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -17,7 +17,6 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
-  DefaultService,
   DependenciesService,
   EventLogService,
   ExtraLinksService,
@@ -1798,22 +1797,6 @@ export const UseLoginServiceLogoutKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [useLoginServiceLogoutKey, ...(queryKey ?? [{ next }])];
-export type DefaultServiceNotFoundHandlerDefaultResponse = Awaited<
-  ReturnType<typeof DefaultService.notFoundHandler>
->;
-export type DefaultServiceNotFoundHandlerQueryResult<
-  TData = DefaultServiceNotFoundHandlerDefaultResponse,
-  TError = unknown,
-> = UseQueryResult<TData, TError>;
-export const useDefaultServiceNotFoundHandlerKey = "DefaultServiceNotFoundHandler";
-export const UseDefaultServiceNotFoundHandlerKeyFn = (
-  {
-    restOfPath,
-  }: {
-    restOfPath: string;
-  },
-  queryKey?: Array<unknown>,
-) => [useDefaultServiceNotFoundHandlerKey, ...(queryKey ?? [{ restOfPath }])];
 export type AssetServiceCreateAssetEventMutationResult = Awaited<
   ReturnType<typeof AssetService.createAssetEvent>
 >;

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -16,7 +16,6 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
-  DefaultService,
   DependenciesService,
   EventLogService,
   ExtraLinksService,
@@ -2516,24 +2515,4 @@ export const ensureUseLoginServiceLogoutData = (
   queryClient.ensureQueryData({
     queryKey: Common.UseLoginServiceLogoutKeyFn({ next }),
     queryFn: () => LoginService.logout({ next }),
-  });
-/**
- * Not Found Handler
- * Catch all route to handle invalid endpoints.
- * @param data The data for the request.
- * @param data.restOfPath
- * @returns unknown Successful Response
- * @throws ApiError
- */
-export const ensureUseDefaultServiceNotFoundHandlerData = (
-  queryClient: QueryClient,
-  {
-    restOfPath,
-  }: {
-    restOfPath: string;
-  },
-) =>
-  queryClient.ensureQueryData({
-    queryKey: Common.UseDefaultServiceNotFoundHandlerKeyFn({ restOfPath }),
-    queryFn: () => DefaultService.notFoundHandler({ restOfPath }),
   });

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -16,7 +16,6 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
-  DefaultService,
   DependenciesService,
   EventLogService,
   ExtraLinksService,
@@ -2516,24 +2515,4 @@ export const prefetchUseLoginServiceLogout = (
   queryClient.prefetchQuery({
     queryKey: Common.UseLoginServiceLogoutKeyFn({ next }),
     queryFn: () => LoginService.logout({ next }),
-  });
-/**
- * Not Found Handler
- * Catch all route to handle invalid endpoints.
- * @param data The data for the request.
- * @param data.restOfPath
- * @returns unknown Successful Response
- * @throws ApiError
- */
-export const prefetchUseDefaultServiceNotFoundHandler = (
-  queryClient: QueryClient,
-  {
-    restOfPath,
-  }: {
-    restOfPath: string;
-  },
-) =>
-  queryClient.prefetchQuery({
-    queryKey: Common.UseDefaultServiceNotFoundHandlerKeyFn({ restOfPath }),
-    queryFn: () => DefaultService.notFoundHandler({ restOfPath }),
   });

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -17,7 +17,6 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
-  DefaultService,
   DependenciesService,
   EventLogService,
   ExtraLinksService,
@@ -2994,32 +2993,6 @@ export const useLoginServiceLogout = <
   useQuery<TData, TError>({
     queryKey: Common.UseLoginServiceLogoutKeyFn({ next }, queryKey),
     queryFn: () => LoginService.logout({ next }) as TData,
-    ...options,
-  });
-/**
- * Not Found Handler
- * Catch all route to handle invalid endpoints.
- * @param data The data for the request.
- * @param data.restOfPath
- * @returns unknown Successful Response
- * @throws ApiError
- */
-export const useDefaultServiceNotFoundHandler = <
-  TData = Common.DefaultServiceNotFoundHandlerDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  {
-    restOfPath,
-  }: {
-    restOfPath: string;
-  },
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useQuery<TData, TError>({
-    queryKey: Common.UseDefaultServiceNotFoundHandlerKeyFn({ restOfPath }, queryKey),
-    queryFn: () => DefaultService.notFoundHandler({ restOfPath }) as TData,
     ...options,
   });
 /**

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -16,7 +16,6 @@ import {
   DagWarningService,
   DagsService,
   DashboardService,
-  DefaultService,
   DependenciesService,
   EventLogService,
   ExtraLinksService,
@@ -2971,31 +2970,5 @@ export const useLoginServiceLogoutSuspense = <
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseLoginServiceLogoutKeyFn({ next }, queryKey),
     queryFn: () => LoginService.logout({ next }) as TData,
-    ...options,
-  });
-/**
- * Not Found Handler
- * Catch all route to handle invalid endpoints.
- * @param data The data for the request.
- * @param data.restOfPath
- * @returns unknown Successful Response
- * @throws ApiError
- */
-export const useDefaultServiceNotFoundHandlerSuspense = <
-  TData = Common.DefaultServiceNotFoundHandlerDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  {
-    restOfPath,
-  }: {
-    restOfPath: string;
-  },
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDefaultServiceNotFoundHandlerKeyFn({ restOfPath }, queryKey),
-    queryFn: () => DefaultService.notFoundHandler({ restOfPath }) as TData,
     ...options,
   });

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -215,8 +215,6 @@ import type {
   LoginResponse,
   LogoutData,
   LogoutResponse,
-  NotFoundHandlerData,
-  NotFoundHandlerResponse,
 } from "./types.gen";
 
 export class AuthLinksService {
@@ -3582,29 +3580,6 @@ export class LoginService {
       },
       errors: {
         307: "Temporary Redirect",
-        422: "Validation Error",
-      },
-    });
-  }
-}
-
-export class DefaultService {
-  /**
-   * Not Found Handler
-   * Catch all route to handle invalid endpoints.
-   * @param data The data for the request.
-   * @param data.restOfPath
-   * @returns unknown Successful Response
-   * @throws ApiError
-   */
-  public static notFoundHandler(data: NotFoundHandlerData): CancelablePromise<NotFoundHandlerResponse> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/api/v2/{rest_of_path}",
-      path: {
-        rest_of_path: data.restOfPath,
-      },
-      errors: {
         422: "Validation Error",
       },
     });

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2656,12 +2656,6 @@ export type LogoutData = {
 
 export type LogoutResponse = unknown;
 
-export type NotFoundHandlerData = {
-  restOfPath: string;
-};
-
-export type NotFoundHandlerResponse = unknown;
-
 export type $OpenApiTs = {
   "/ui/auth/menus": {
     get: {
@@ -5481,21 +5475,6 @@ export type $OpenApiTs = {
          * Temporary Redirect
          */
         307: HTTPExceptionResponse;
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError;
-      };
-    };
-  };
-  "/api/v2/{rest_of_path}": {
-    get: {
-      req: NotFoundHandlerData;
-      res: {
-        /**
-         * Successful Response
-         */
-        200: unknown;
         /**
          * Validation Error
          */

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/test_routes.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/test_routes.py
@@ -24,7 +24,6 @@ NO_AUTH_PATHS = {
     "/api/v2/auth/logout",
     "/api/v2/version",
     "/api/v2/monitor/health",
-    "/api/v2/{rest_of_path:path}",
 }
 
 
@@ -57,4 +56,8 @@ def test_invalid_routes_return_404(test_client):
     """Invalid routes should return a 404."""
     response = test_client.get("/api/v2/nonexistent")
     assert response.status_code == 404
-    assert response.json() == {"error": "invalid route"}
+    assert response.json() == {"error": "API route not found"}
+
+    response = test_client.get("/api/nonexistent")
+    assert response.status_code == 404
+    assert response.json() == {"error": "API route not found"}

--- a/scripts/in_container/run_update_fastapi_api_spec.py
+++ b/scripts/in_container/run_update_fastapi_api_spec.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 from fastapi.openapi.utils import get_openapi
+from fastapi.routing import APIRoute
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX, create_app
 from airflow.api_fastapi.auth.managers.simple import __file__ as SIMPLE_AUTH_MANAGER_PATH
@@ -46,9 +47,8 @@ def generate_file(app: FastAPI, file_path: Path, prefix: str = ""):
     # The persisted openapi spec will list all endpoints (public and ui), this
     # is used for code generation.
     for route in app.routes:
-        if getattr(route, "name") == "webapp":
-            continue
-        route.__setattr__("include_in_schema", True)
+        if isinstance(route, APIRoute) and route.path.startswith("/ui/"):
+            route.include_in_schema = True
 
     with file_path.open("w+") as f:
         openapi_schema = get_openapi(


### PR DESCRIPTION
THe current behaviour would be for this to hit the catchall route and serve up
the index.html for the SPA, but for these routes explicitly we don't want
that.

- `/health` was in Airflow 2 and was commonly used for Kube healthchecks --
  we want this to fail as it should be hitting the new URL instead
- `/api/v1` similarly, we want an explicit 404 for anything still hitting the
  old API rather than the confusion of getting HTML back when the client
  likely expects JSON.

I have also moved the catchall route from `/api/v2/` to `/api/`, as anything
under `/api/` is, well, an API and returning a 404 there is better.

This also corrects a small mistake in the API doc generation where we were
setting _all_ endpoints to include_in_schema=True, including the /api/v2/
catch all. Hence the change in the generated code

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
