### PR TITLE
Removing init_dagbag from fastapi app

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/init_dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/init_dagbag.py
@@ -27,12 +27,3 @@ def get_dag_bag() -> DagBag:
     if os.environ.get("SKIP_DAGS_PARSING") == "True":
         return DagBag(os.devnull, include_examples=False)
     return DagBag(DAGS_FOLDER, read_dags_from_db=True)
-
-
-def init_dagbag(app):
-    """
-    Create global DagBag for webserver and API.
-
-    To access it use ``flask.current_app.dag_bag``.
-    """
-    app.dag_bag = get_dag_bag()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Idle function with no usages. Removing it to clean things up

Directly initialised inside `create_app` now.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
