### PR TITLE
fix(serialized_objects): handle both inlet and outlet in v1 to v2 convert

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1840,7 +1840,8 @@ class SerializedDAG(DAG, BaseSerialization):
             return obj
 
         for old, new in dag_renames:
-            dag_dict[new] = dag_dict.pop(old)
+            if old in dag_dict:
+                dag_dict[new] = dag_dict.pop(old)
 
         if default_args := dag_dict.get("default_args"):
             for k in tasks_remove:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1903,15 +1903,15 @@ class SerializedDAG(DAG, BaseSerialization):
                 task_var.pop(k, None)
             for old, new in task_renames:
                 task_var[new] = task_var.pop(old)
-            for item in task_var.get("outlets", []):
+            for item in itertools.chain(*(task_var.get(key, []) for key in ("inlets", "outlets"))):
+                original_item_type = item["__type"]
                 if isinstance(item, dict) and "__type" in item:
-                    item["__type"] = replace_dataset_in_str(item["__type"])
-            for item in task_var.get("inlets", []):
-                if isinstance(item, dict) and "__type" in item:
-                    item["__type"] = replace_dataset_in_str(item["__type"])
+                    item["__type"] = replace_dataset_in_str(original_item_type)
+
                 var_ = item["__var"]
-                var_["name"] = None
-                var_["group"] = None
+                if original_item_type == "dataset":
+                    var_["name"] = var_["uri"]
+                var_["group"] = "asset"
 
         # Set on the root TG
         dag_dict["task_group"]["group_display_name"] = ""


### PR DESCRIPTION
## Why
serialized outlets was not converted.

## What
convert outlet from v1 (dataset) to v2 (asset) version


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
