### PR TITLE
Improvements to rendered API docs

### DIFF
--- a/airflow-core/docs/conf.py
+++ b/airflow-core/docs/conf.py
@@ -345,7 +345,7 @@ graphviz_output_format = "svg"
 
 main_openapi_path = Path(main_openapi_file).parent.joinpath("v1-generated.yaml")
 sam_openapi_path = Path(sam_openapi_file).parent.joinpath("v1-generated.yaml")
-redocs = [
+redoc = [
     {
         "name": "Simple auth manager token API",
         "page": "core-concepts/auth-manager/simple/sam-token-api-ref",

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -77,6 +77,7 @@ def create_app(apps: str = "all") -> FastAPI:
         "depending on the need of the frontend. Users should not rely on those but use the public ones instead.",
         lifespan=lifespan,
         root_path=API_ROOT_PATH.removesuffix("/"),
+        version="2",
     )
 
     dag_bag = get_dag_bag()

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -5,7 +5,7 @@ info:
     are stable and backward compatible. Endpoints located under ``/ui`` are dedicated
     to the UI and are subject to breaking change depending on the need of the frontend.
     Users should not rely on those but use the public ones instead.
-  version: 0.1.0
+  version: '2'
 paths:
   /ui/auth/menus:
     get:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/core/OpenAPI.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/core/OpenAPI.ts
@@ -49,7 +49,7 @@ export const OpenAPI: OpenAPIConfig = {
   PASSWORD: undefined,
   TOKEN: undefined,
   USERNAME: undefined,
-  VERSION: "0.1.0",
+  VERSION: "2",
   WITH_CREDENTIALS: false,
   interceptors: {
     request: new Interceptors(),


### PR DESCRIPTION
Somehow in #48760 we mistakenly changed `redoc` to `redocs` variable, which
doesn't do anything :) This makes the redoc docs render and build again

It was saying "Airflow API (0.1.0)" which isn't right, so that is fixed too

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
