### PR TITLE
Fix failing tests after subdir path bundle URL merged

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -56,7 +56,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "another_bundle_name",
                     "bundle_version": "some_commit_hash",
-                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash/dags",
                     "created_at": mock.ANY,
                     "dag_id": "ANOTHER_DAG_ID",
                     "id": mock.ANY,
@@ -69,7 +69,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "dag_maker",
                     "bundle_version": "some_commit_hash1",
-                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1/dags",
                     "created_at": mock.ANY,
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
@@ -82,7 +82,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "dag_maker",
                     "bundle_version": "some_commit_hash2",
-                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2/dags",
                     "created_at": mock.ANY,
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
@@ -95,7 +95,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "dag_maker",
                     "bundle_version": "some_commit_hash3",
-                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3",
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3/dags",
                     "created_at": mock.ANY,
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
@@ -139,7 +139,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "another_bundle_name",
                             "bundle_version": "some_commit_hash",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash/dags",
                             "created_at": mock.ANY,
                             "dag_id": "ANOTHER_DAG_ID",
                             "id": mock.ANY,
@@ -148,7 +148,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash1",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -157,7 +157,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash2",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -166,7 +166,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash3",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -183,7 +183,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash1",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -192,7 +192,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash2",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -201,7 +201,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash3",
-                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3",
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -274,7 +274,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "dag_id": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}",
+                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
             },
         }
@@ -1961,7 +1961,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
                 "dag_id": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}",
+                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
             },
         }
@@ -3023,7 +3023,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 "dag_id": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}",
+                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
             },
         }


### PR DESCRIPTION
The #49239 broke main with tests not updated after changing subpath

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
