### PR TITLE
Force query cache to always refetch on opening mark/clear modals

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -56,6 +56,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagRunId,
     options: {
       enabled: open,
+      refetchOnMount: "always",
     },
     requestBody: {
       only_failed: onlyFailed,

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -68,6 +68,7 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
     dagId,
     options: {
       enabled: open,
+      refetchOnMount: "always",
     },
     requestBody: {
       dag_run_id: dagRunId,

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -63,6 +63,7 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
     mapIndex,
     options: {
       enabled: open,
+      refetchOnMount: "always",
     },
     requestBody: {
       include_downstream: downstream,


### PR DESCRIPTION
UI fix for https://github.com/apache/airflow/issues/48933#issuecomment-2800914568

We should assume that the dry run data is always out of date when the mark as or clear modal opens.

closes https://github.com/apache/airflow/issues/48933

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
