### PR TITLE
Add base_url fallback for aws auth_manager

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/router/login.py
@@ -91,7 +91,7 @@ def login_callback(request: Request):
 
 def _init_saml_auth(request: Request) -> OneLogin_Saml2_Auth:
     request_data = _prepare_request(request)
-    base_url = conf.get(section="api", key="base_url")
+    base_url = conf.get(section="api", key="base_url", fallback="/")
     settings = {
         # We want to keep this flag on in case of errors.
         # It provides an error reasons, if turned off, it does not


### PR DESCRIPTION
Default value for api.base_url is empty and conf.get needs a fallback if api.base_url is unset

Aligning with #49292
Similar to #49229