### PR TITLE
Add possibility to have extra project metadata in providers

### DIFF
--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -475,6 +475,10 @@
             "examples": [
                 1609459200
             ]
+        },
+        "extra-project-metadata": {
+            "type": "string",
+            "description": "Extra project metadata. Added to pyproject.toml."
         }
     },
     "additionalProperties": false,

--- a/dev/breeze/src/airflow_breeze/templates/pyproject_TEMPLATE.toml.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/pyproject_TEMPLATE.toml.jinja2
@@ -69,6 +69,9 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 requires-python = "{{ REQUIRES_PYTHON }}"
+{% if EXTRA_PROJECT_METADATA -%}
+{{ EXTRA_PROJECT_METADATA }}
+{%- endif %}
 
 # The dependencies should be modified in place in the generated file.
 # Any change in the dependencies is preserved when the file is regenerated

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -94,6 +94,7 @@ class ProviderPackageDetails(NamedTuple):
     excluded_python_versions: list[str]
     plugins: list[PluginInfo]
     removed: bool
+    extra_project_metadata: str | None = None
 
 
 class PackageSuspendedException(Exception):
@@ -565,6 +566,7 @@ def get_provider_details(provider_id: str) -> ProviderPackageDetails:
         excluded_python_versions=provider_info.get("excluded-python-versions", []),
         plugins=plugins,
         removed=provider_info["state"] == "removed",
+        extra_project_metadata=provider_info.get("extra-project-metadata", ""),
     )
 
 
@@ -690,6 +692,7 @@ def get_provider_jinja_context(
             get_provider_requirements(provider_id), markdown=False
         ),
         "REQUIRES_PYTHON": requires_python_version,
+        "EXTRA_PROJECT_METADATA": provider_details.extra_project_metadata,
     }
     return context
 

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -121,3 +121,5 @@ config:
 
 auth-managers:
   - airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager
+
+extra-project-metadata: license-files = ["NOTICE", "*/LICENSE*"]

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 requires-python = "~=3.9"
-
+license-files = ["NOTICE", "*/LICENSE*"]
 # The dependencies should be modified in place in the generated file.
 # Any change in the dependencies is preserved when the file is regenerated
 # Make sure to run ``breeze static-checks --type update-providers-dependencies --all-files``


### PR DESCRIPTION
All our providers have pyproject.toml generated from template, in order to not drift apart. This PR adds a possibilty of getting extra project metadata configured in provider.yaml so that slight variations in pyproject.toml are allowed (for example adding 3rd-party licence files.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
