### PR TITLE
Pass mapIndex to filter the relevant task instance while clearing mapped tasks.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -77,7 +77,7 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
       include_past: past,
       include_upstream: upstream,
       only_failed: onlyFailed,
-      task_ids: [taskId],
+      task_ids: [[taskId, mapIndex]],
     },
   });
 


### PR DESCRIPTION
`task_ids` can be a list of `task_id` or list of tuples of `[task_id, map_index]` . Passing `mapIndex` value helps in filtering the correct task instance for the map_index value instead of filtering all the mapped instances for a task. For a non-mapped task also passing `mapIndex` as -1 works so this can be always passed. This is already done for marking the task instance state.

Closes #49291 