### PR TITLE
Run all tests when git provider changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -102,6 +102,7 @@ class FileGroupForCi(Enum):
     JAVASCRIPT_PRODUCTION_FILES = "javascript_scans"
     ALWAYS_TESTS_FILES = "always_test_files"
     API_FILES = "api_files"
+    GIT_PROVIDER_FILES = "git_provider_files"
     API_CODEGEN_FILES = "api_codegen_files"
     HELM_FILES = "helm_files"
     DEPENDENCY_FILES = "dependency_files"
@@ -168,6 +169,9 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^airflow-core/src/airflow/api_fastapi/",
             r"^airflow-core/tests/unit/api/",
             r"^airflow-core/tests/unit/api_fastapi/",
+        ],
+        FileGroupForCi.GIT_PROVIDER_FILES: [
+            r"^providers/git/src/",
         ],
         FileGroupForCi.API_CODEGEN_FILES: [
             r"^airflow-core/src/airflow/api_fastapi/core_api/openapi/.*generated\.yaml",
@@ -530,6 +534,16 @@ class SelectiveChecks:
             CI_FILE_GROUP_MATCHES,
         ):
             get_console().print("[warning]Running full set of tests because api files changed[/]")
+            return True
+        if self._matching_files(
+            FileGroupForCi.GIT_PROVIDER_FILES,
+            CI_FILE_GROUP_MATCHES,
+        ):
+            # TODO(potiuk): remove me when we get rid of the dependency
+            get_console().print(
+                "[warning]Running full set of tests because git provider files changed "
+                "and for now we have core tests depending on them.[/]"
+            )
             return True
         if self._matching_files(
             FileGroupForCi.TESTS_UTILS_FILES,

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1301,6 +1301,41 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
     [
         (
             pytest.param(
+                ("providers/git/src/airflow/providers/git/test_file.py",),
+                (),
+                "main",
+                {
+                    "selected-providers-list-as-string": ALL_PROVIDERS_AFFECTED,
+                    "all-python-versions": "['3.9']",
+                    "all-python-versions-list-as-string": "3.9",
+                    "all-versions": "false",
+                    "mysql-versions": "['8.0']",
+                    "postgres-versions": "['13']",
+                    "python-versions": "['3.9']",
+                    "python-versions-list-as-string": "3.9",
+                    "kubernetes-versions": "['v1.29.12']",
+                    "kubernetes-versions-list-as-string": "v1.29.12",
+                    "kubernetes-combos-list-as-string": "3.9-v1.29.12",
+                    "ci-image-build": "true",
+                    "prod-image-build": "true",
+                    "run-tests": "true",
+                    "skip-providers-tests": "false",
+                    "docs-build": "true",
+                    "docs-list-as-string": ALL_DOCS_SELECTED_FOR_BUILD,
+                    "full-tests-needed": "true",
+                    "skip-pre-commits": ALL_SKIPPED_COMMITS_BY_DEFAULT_ON_ALL_TESTS_NEEDED,
+                    "upgrade-to-newer-dependencies": "false",
+                    "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
+                    "needs-mypy": "true",
+                    "mypy-checks": ALL_MYPY_CHECKS,
+                },
+                id="Everything should run including all providers when git provider is changed"
+                "(special case for now)",
+            )
+        ),
+        (
+            pytest.param(
                 ("INTHEWILD.md",),
                 ("full tests needed", "all versions"),
                 "main",


### PR DESCRIPTION
Git provider is now used in serialization and versioning tests in core - so until we separate them, we should trigger all tests when the git provider changes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
