### PR TITLE
Revert "use key in dict instead of key in dict.keys in Airflow core (#49255)"

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -123,7 +123,7 @@ class DagBundlesManager(LoggingMixin):
     def sync_bundles_to_db(self, *, session: Session = NEW_SESSION) -> None:
         self.log.debug("Syncing DAG bundles to the database")
         stored = {b.name: b for b in session.query(DagBundleModel).all()}
-        for name in self._bundle_config:
+        for name in self._bundle_config.keys():
             if bundle := stored.pop(name, None):
                 bundle.active = True
             else:

--- a/airflow-core/src/airflow/metrics/otel_logger.py
+++ b/airflow-core/src/airflow/metrics/otel_logger.py
@@ -348,7 +348,7 @@ class MetricsMap:
         :param attributes: Counter attributes which were used to generate a unique key to store the counter.
         """
         key = _generate_key_name(name, attributes)
-        if key in self.map:
+        if key in self.map.keys():
             del self.map[key]
 
     def set_gauge_value(self, name: str, value: int | float, delta: bool, tags: Attributes):

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -2206,7 +2206,7 @@ class TaskInstance(Base, LoggingMixin):
                             f"Returned output was type {type(xcom_value)} "
                             "expected dictionary for multiple_outputs"
                         )
-                    for key in xcom_value:
+                    for key in xcom_value.keys():
                         if not isinstance(key, str):
                             raise AirflowException(
                                 "Returned dictionary keys must be strings when using "

--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -48,7 +48,7 @@ def get_connection_parameter_names() -> set[str]:
     """Return :class:`airflow.models.connection.Connection` constructor parameters."""
     from airflow.models.connection import Connection
 
-    return {k for k in signature(Connection.__init__).parameters if k != "self"}
+    return {k for k in signature(Connection.__init__).parameters.keys() if k != "self"}
 
 
 def _parse_env_file(file_path: str) -> tuple[dict[str, list[str]], list[FileSyntaxError]]:

--- a/airflow-core/src/airflow/security/permissions.py
+++ b/airflow-core/src/airflow/security/permissions.py
@@ -102,7 +102,7 @@ def resource_name(root_dag_id: str, resource: str) -> str:
     parent DAG, you should pass ``DagModel.root_dag_id`` to this function,
     for a subdag. A normal dag should pass the ``DagModel.dag_id``.
     """
-    if root_dag_id in RESOURCE_DETAILS_MAP:
+    if root_dag_id in RESOURCE_DETAILS_MAP.keys():
         return root_dag_id
     if root_dag_id.startswith(tuple(PREFIX_RESOURCES_MAP.keys())):
         return root_dag_id

--- a/airflow-core/src/airflow/utils/dag_cycle_tester.py
+++ b/airflow-core/src/airflow/utils/dag_cycle_tester.py
@@ -52,7 +52,7 @@ def check_cycle(dag: DAG) -> None:
                 return adjacent_task
         return None
 
-    for dag_task_id in dag.task_dict:
+    for dag_task_id in dag.task_dict.keys():
         if visited[dag_task_id] == CYCLE_DONE:
             continue
         path_stack.append(dag_task_id)

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -284,7 +284,7 @@ class TestLoadConnection:
             connections_by_conn_id = local_filesystem.load_connections_dict("a.yaml")
             for conn_id, connection in connections_by_conn_id.items():
                 expected_attrs = expected_attrs_dict[conn_id]
-                actual_attrs = {k: getattr(connection, k) for k in expected_attrs}
+                actual_attrs = {k: getattr(connection, k) for k in expected_attrs.keys()}
                 assert actual_attrs == expected_attrs
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -877,7 +877,7 @@ class TestConnection(TestConnectionEndpoint):
     )
     def test_connection_env_is_cleaned_after_run(self, test_client, body):
         test_client.post("/connections/test", json=body)
-        assert not any([key.startswith(CONN_ENV_PREFIX) for key in os.environ])
+        assert not any([key.startswith(CONN_ENV_PREFIX) for key in os.environ.keys()])
 
     @pytest.mark.parametrize(
         "body",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -2361,7 +2361,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         ]
         for task_instance in expected_response:
             assert task_instance in [
-                {key: ti[key] for key in task_instance} for ti in response.json()["task_instances"]
+                {key: ti[key] for key in task_instance.keys()} for ti in response.json()["task_instances"]
             ]
         assert response.json()["total_entries"] == 6
         assert failed_dag_runs == 0
@@ -2529,7 +2529,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         ]
         for task_instance in expected_response:
             assert task_instance in [
-                {key: ti[key] for key in task_instance} for ti in response.json()["task_instances"]
+                {key: ti[key] for key in task_instance.keys()} for ti in response.json()["task_instances"]
             ]
         assert response.json()["total_entries"] == 6
 
@@ -2614,7 +2614,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         ]
         for task_instance in expected_response:
             assert task_instance in [
-                {key: ti[key] for key in task_instance} for ti in response.json()["task_instances"]
+                {key: ti[key] for key in task_instance.keys()} for ti in response.json()["task_instances"]
             ]
         assert response.json()["total_entries"] == 6
 

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -220,8 +220,8 @@ class TestDagFileProcessorManager:
         # even though it is first in '_file_path_queue'
         # a new processor is created with 'file_2' and not 'file_1'.
 
-        assert file_1 in manager._processors
-        assert file_2 in manager._processors
+        assert file_1 in manager._processors.keys()
+        assert file_2 in manager._processors.keys()
         assert deque([file_3]) == manager._file_queue
 
     def test_handle_removed_files_when_processor_file_path_not_in_new_file_paths(self):

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -286,7 +286,7 @@ class TestSerializedDagModel:
             example_dags = self._write_example_dags()
             ordered_example_dags = dict(sorted(example_dags.items()))
             hashes = set()
-            for dag_id in ordered_example_dags:
+            for dag_id in ordered_example_dags.keys():
                 smd = session.execute(select(SDM.dag_hash).where(SDM.dag_id == dag_id)).one()
                 hashes.add(smd.dag_hash)
             return hashes

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -875,8 +875,8 @@ def test_fetch_logs_from_service_with_not_matched_no_proxy(mock_send, monkeypatc
     _, kwargs = mock_send.call_args
     assert "proxies" in kwargs
     proxies = kwargs["proxies"]
-    assert "http" in proxies
-    assert "no" in proxies
+    assert "http" in proxies.keys()
+    assert "no" in proxies.keys()
 
 
 @mock.patch("requests.adapters.HTTPAdapter.send")
@@ -894,5 +894,5 @@ def test_fetch_logs_from_service_with_cidr_no_proxy(mock_send, monkeypatch):
     _, kwargs = mock_send.call_args
     assert "proxies" in kwargs
     proxies = kwargs["proxies"]
-    assert "http" not in proxies
-    assert "no" not in proxies
+    assert "http" not in proxies.keys()
+    assert "no" not in proxies.keys()

--- a/airflow-core/tests/unit/utils/test_otel_utils.py
+++ b/airflow-core/tests/unit/utils/test_otel_utils.py
@@ -699,8 +699,8 @@ From task sub_span3.
         assert span_name_to_test == span_dict.get(span_id)["name"]
 
         # The span isn't a root span.
-        assert span_id not in root_span_dict
-        assert span_id in span_dict
+        assert span_id not in root_span_dict.keys()
+        assert span_id in span_dict.keys()
 
         expected_child_span_names = ["task_1_sub_span"]
         actual_child_span_names = []


### PR DESCRIPTION
This reverts commit ca3ea8eab7614038ffb37493871806d04071c4a8.

For more details: https://github.com/apache/airflow/pull/49255#issuecomment-2807510435