### PR TITLE
Always avoid modifying Readme and Changelog in pre-commit

### DIFF
--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -108,10 +108,6 @@ on:  # yamllint disable-line rule:truthy
         description: "Whether to use uv to build the image (true/false)"
         required: true
         type: string
-      only-pyproject-toml-files-changed:
-        description: "Whether only pyproject.toml files changed in the PR"
-        required: true
-        type: string
     secrets:
       DOCS_AWS_ACCESS_KEY_ID:
         required: true
@@ -205,7 +201,6 @@ jobs:
           SKIP_GROUP_OUTPUT: "true"
           DEFAULT_BRANCH: ${{ inputs.branch }}
           RUFF_FORMAT: "github"
-          ONLY_PYPROJECT_TOML_FILES_CHANGED: ${{ inputs.only-pyproject-toml-files-changed }}
 
   mypy:
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,6 @@ jobs:
       needs-helm-tests: ${{ steps.selective-checks.outputs.needs-helm-tests }}
       needs-mypy: ${{ steps.selective-checks.outputs.needs-mypy }}
       only-new-ui-files: ${{ steps.selective-checks.outputs.only-new-ui-files }}
-      only-pyproject-toml-files-changed: >-
-        ${{ steps.selective-checks.outputs.only-pyproject-toml-files-changed }}
       postgres-exclude: ${{ steps.selective-checks.outputs.postgres-exclude }}
       postgres-versions: ${{ steps.selective-checks.outputs.postgres-versions }}
       prod-image-build: ${{ steps.selective-checks.outputs.prod-image-build }}
@@ -290,7 +288,6 @@ jobs:
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
       docs-build: ${{ needs.build-info.outputs.docs-build }}
       needs-api-codegen: ${{ needs.build-info.outputs.needs-api-codegen }}
-      only-pyproject-toml-files-changed: $${ needs.build-info.outputs.only-pyproject-toml-files-changed }}
       default-postgres-version: ${{ needs.build-info.outputs.default-postgres-version }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}

--- a/scripts/ci/pre_commit/update_providers_build_files.py
+++ b/scripts/ci/pre_commit/update_providers_build_files.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -75,17 +74,9 @@ cmd = [
     "--reapply-templates-only",
     "--skip-git-fetch",
     "--only-min-version-update",
+    "--skip-changelog",
+    "--skip-readme",
 ]
-
-if os.environ.get("ONLY_PYPROJECT_TOML_CHANGED", "") == "true":
-    # in order to make dependabot happy we skip generating changelog/readme when only
-    # pyproject.toml files changed
-    cmd.extend(
-        [
-            "--skip-changelog",
-            "--skip-readme",
-        ]
-    )
 
 cmd.extend(providers)
 res = subprocess.run(


### PR DESCRIPTION
The idea of conditionally skipping modifying readme and changelog when only pyproject.toml changesd was a bad one - it would have hit us back in the next commit - after the dependabot one would be merged.

Better to leave it for release manager's documentation upgrade to actually generate those files.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
