### PR TITLE
Autorefresh dagrun breadcrumb state when dagrun is in pending state.

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -28,9 +28,11 @@ import { BreadcrumbStats } from "src/components/BreadcrumbStats";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 export const DagBreadcrumb = () => {
   const { dagId = "", mapIndex = "-1", runId, taskId } = useParams();
+  const refetchInterval = useAutoRefresh({ dagId });
 
   const { data: dag } = useDagServiceGetDagDetails({
     dagId,
@@ -44,6 +46,7 @@ export const DagBreadcrumb = () => {
     undefined,
     {
       enabled: Boolean(runId),
+      refetchInterval: (query) => (isStatePending(query.state.data?.state) ? refetchInterval : false),
     },
   );
 


### PR DESCRIPTION
The breadcrumb is not auto refreshed after clearing a task instance and is left in queued state even after the task completes and grid is updated for the run. This is already done in other pages like dag run page and applies the auto refresh to breadcrumb too.