### PR TITLE
Include trigger event payload in asset event

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -252,7 +252,9 @@ class Trigger(Base):
             return
         for asset in trigger.assets:
             AssetManager.register_asset_change(
-                asset=asset.to_public(), session=session, extra={"from_trigger": True}
+                asset=asset.to_public(),
+                extra={"from_trigger": True, "payload": event.payload},
+                session=session,
             )
 
     @classmethod

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -176,7 +176,7 @@ def test_submit_event(session, create_task_instance):
     assert session.query(AssetEvent).filter_by(asset_id=asset.id).count() == 1
 
     event = session.query(AssetEvent).filter_by(asset_id=asset.id).first()
-    assert event.extra == {"from_trigger": True}
+    assert event.extra == {"from_trigger": True, "payload": 42}
 
 
 def test_submit_failure(session, create_task_instance):


### PR DESCRIPTION
[AIP-82] allows triggering an asset from the triggerer with a trigger event. A trigger event can contain extra information, but we did not forward it to the asset event; the trigger event is simply lost.

This adds a field 'payload' on the triggered asset event's extra that holds the source trigger event's content. Example to retrieve the trigger event:

    a = Asset(name="a", watchers=[AssetWatcher(...)])

    @task
    def process_message(triggering_asset_events):
        for event in triggering_asset_events[a]:
            print(event.extra["payload"])  # TriggerEvent payload.

[AIP-82]: https://cwiki.apache.org/confluence/x/egzOEg