### PR TITLE
Use 'git_default' if the user defines nothing

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -56,7 +56,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "another_bundle_name",
                     "bundle_version": "some_commit_hash",
-                    "bundle_url": None,
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash/dags",
                     "created_at": mock.ANY,
                     "dag_id": "ANOTHER_DAG_ID",
                     "id": mock.ANY,
@@ -69,7 +69,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "dag_maker",
                     "bundle_version": "some_commit_hash1",
-                    "bundle_url": None,
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1/dags",
                     "created_at": mock.ANY,
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
@@ -82,7 +82,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "dag_maker",
                     "bundle_version": "some_commit_hash2",
-                    "bundle_url": None,
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2/dags",
                     "created_at": mock.ANY,
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
@@ -95,7 +95,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                 {
                     "bundle_name": "dag_maker",
                     "bundle_version": "some_commit_hash3",
-                    "bundle_url": None,
+                    "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3/dags",
                     "created_at": mock.ANY,
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
@@ -139,7 +139,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "another_bundle_name",
                             "bundle_version": "some_commit_hash",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash/dags",
                             "created_at": mock.ANY,
                             "dag_id": "ANOTHER_DAG_ID",
                             "id": mock.ANY,
@@ -148,7 +148,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash1",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -157,7 +157,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash2",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -166,7 +166,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash3",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -183,7 +183,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash1",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash1/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -192,7 +192,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash2",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash2/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
@@ -201,7 +201,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                         {
                             "bundle_name": "dag_maker",
                             "bundle_version": "some_commit_hash3",
-                            "bundle_url": None,
+                            "bundle_url": "fakeprotocol://test_host.github.com/tree/some_commit_hash3/dags",
                             "created_at": mock.ANY,
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -274,7 +274,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "dag_id": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": None,
+                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
             },
         }
@@ -1961,7 +1961,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
                 "dag_id": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": None,
+                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
             },
         }
@@ -3023,7 +3023,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 "dag_id": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": None,
+                "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
             },
         }

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -80,11 +80,14 @@ class GitDagBundle(BaseDagBundle):
 
         self._log.debug("bundle configured")
         self.hook: GitHook | None = None
-        if self.git_conn_id:
+        if not repo_url:
+            if not git_conn_id:
+                self._log.debug("Neither git_conn_id nor repo_url provided; loading 'git_default'")
+                git_conn_id = "git_default"
             try:
-                self.hook = GitHook(git_conn_id=self.git_conn_id, repo_url=self.repo_url)
+                self.hook = GitHook(git_conn_id=git_conn_id)
             except AirflowException as e:
-                self._log.warning("Could not create GitHook", conn_id=self.git_conn_id, exc=e)
+                self._log.warning("Could not create GitHook", conn_id=git_conn_id, exc=e)
             else:
                 self.repo_url = self.hook.repo_url
                 self._log.debug("repo_url updated from hook")

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -116,7 +116,7 @@ class TestGitDagBundle:
             tracking_ref=GIT_DEFAULT_BRANCH,
             repo_url="https://github.com/apache/zzzairflow",
         )
-        assert bundle.repo_url == f"https://{ACCESS_TOKEN}@github.com/apache/zzzairflow"
+        assert bundle.repo_url == "https://github.com/apache/zzzairflow"
 
     def test_falls_back_to_connection_host_when_no_repo_url_provided(self):
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=GIT_DEFAULT_BRANCH)
@@ -564,9 +564,7 @@ class TestGitDagBundle:
             name="testa",
             tracking_ref="main",
             git_conn_id=conn_id,
-            repo_url="some_repo_url",
         )
-        assert bundle.repo_url == "some_repo_url"
         assert isinstance(bundle.hook, expected_hook_type)
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")


### PR DESCRIPTION
When using a GitDagBundle, the user should tell us where the git repo is by either repo_url or git_conn_id. If the user provides neither, try to find a Connection named 'git_default' instead of failing directly.

If repo_url is provided, we won't try to find any Connection.