### PR TITLE
Fix missing last DAG run caused by incorrect parameters and join logic

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -203,6 +203,13 @@ paths:
           - $ref: '#/components/schemas/DagRunState'
           - type: 'null'
           title: Last Dag Run State
+      - name: order_by
+        in: query
+        required: false
+        schema:
+          type: string
+          default: dag_id
+          title: Order By
       responses:
         '200':
           description: Successful Response

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -1639,6 +1639,7 @@ export const UseDagsServiceRecentDagRunsKeyFn = (
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -1652,6 +1653,7 @@ export const UseDagsServiceRecentDagRunsKeyFn = (
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -1670,6 +1672,7 @@ export const UseDagsServiceRecentDagRunsKeyFn = (
       lastDagRunState,
       limit,
       offset,
+      orderBy,
       owners,
       paused,
       tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -2274,6 +2274,7 @@ export const ensureUseAuthLinksServiceGetAuthMenusData = (queryClient: QueryClie
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -2288,6 +2289,7 @@ export const ensureUseDagsServiceRecentDagRunsData = (
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -2301,6 +2303,7 @@ export const ensureUseDagsServiceRecentDagRunsData = (
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -2317,6 +2320,7 @@ export const ensureUseDagsServiceRecentDagRunsData = (
       lastDagRunState,
       limit,
       offset,
+      orderBy,
       owners,
       paused,
       tags,
@@ -2332,6 +2336,7 @@ export const ensureUseDagsServiceRecentDagRunsData = (
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -2274,6 +2274,7 @@ export const prefetchUseAuthLinksServiceGetAuthMenus = (queryClient: QueryClient
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -2288,6 +2289,7 @@ export const prefetchUseDagsServiceRecentDagRuns = (
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -2301,6 +2303,7 @@ export const prefetchUseDagsServiceRecentDagRuns = (
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -2317,6 +2320,7 @@ export const prefetchUseDagsServiceRecentDagRuns = (
       lastDagRunState,
       limit,
       offset,
+      orderBy,
       owners,
       paused,
       tags,
@@ -2332,6 +2336,7 @@ export const prefetchUseDagsServiceRecentDagRuns = (
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -2721,6 +2721,7 @@ export const useAuthLinksServiceGetAuthMenus = <
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -2738,6 +2739,7 @@ export const useDagsServiceRecentDagRuns = <
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -2751,6 +2753,7 @@ export const useDagsServiceRecentDagRuns = <
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -2770,6 +2773,7 @@ export const useDagsServiceRecentDagRuns = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,
@@ -2787,6 +2791,7 @@ export const useDagsServiceRecentDagRuns = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -2698,6 +2698,7 @@ export const useAuthLinksServiceGetAuthMenusSuspense = <
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -2715,6 +2716,7 @@ export const useDagsServiceRecentDagRunsSuspense = <
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -2728,6 +2730,7 @@ export const useDagsServiceRecentDagRunsSuspense = <
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -2747,6 +2750,7 @@ export const useDagsServiceRecentDagRunsSuspense = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,
@@ -2764,6 +2768,7 @@ export const useDagsServiceRecentDagRunsSuspense = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -3423,6 +3423,7 @@ export class DagsService {
    * @param data.excludeStale
    * @param data.paused
    * @param data.lastDagRunState
+   * @param data.orderBy
    * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
    * @throws ApiError
    */
@@ -3443,6 +3444,7 @@ export class DagsService {
         exclude_stale: data.excludeStale,
         paused: data.paused,
         last_dag_run_state: data.lastDagRunState,
+        order_by: data.orderBy,
       },
       errors: {
         422: "Validation Error",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2608,6 +2608,7 @@ export type RecentDagRunsData = {
   lastDagRunState?: DagRunState | null;
   limit?: number;
   offset?: number;
+  orderBy?: string;
   owners?: Array<string>;
   paused?: boolean | null;
   tags?: Array<string>;

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -42,7 +42,6 @@ export const useDags = (
 
   const refetchInterval = useAutoRefresh({});
 
-  const { orderBy, ...runsParams } = searchParams;
   const {
     data: runsData,
     error: runsError,
@@ -50,8 +49,8 @@ export const useDags = (
     isLoading: isRunsLoading,
   } = useDagsServiceRecentDagRuns(
     {
-      ...runsParams,
-      dagRunsLimit: 14,
+      ...searchParams,
+      dagRunsLimit: 1,
     },
     undefined,
     {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/49135
### Issue Summary
Dag List page have missing last DAG runs on some DAGs. 
Currently, the frontend logic calls `dags` from public API to fetch list of DAGs. However, the public API does not include last DAG run, so an additional API call to `recent_dag_runs` from UI API is necessary. 

The issue stems from unmatched search params from both calls causing different set of DAGs returned causing missing last run.

### Solution
1. Include order_by param to `recent_dag_runs` call which previously is not included
2. Set dag_runs_limit to 1 (was 14) - as proposed in https://github.com/apache/airflow/issues/49135#issuecomment-2809566654. This ensures we only fetch one DagRun per DAG instead of applying the final `limit` across multiple runs.
3. During further testing, I found that step 2 alone isn’t enough. If some DAGs don’t have any runs, the limits and offsets won’t align properly. To fix this, this PR changed the join logic so the query now starts from DAGModel and does a LEFT JOIN to recent runs. This ensures pagination works at the DAG level and includes DAGs with no runs. After pagination is done the DAGs with no runs is excluded from final response.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
