### PR TITLE
Make Xcom compatible with AF2 in system tests in google provider

### DIFF
--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_queries.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_queries.py
@@ -176,7 +176,7 @@ with DAG(
 
     get_data_result = BashOperator(
         task_id="get_data_result",
-        bash_command=f"echo {get_data.output}",
+        bash_command=f'echo "{get_data.output}"',
     )
 
     # [START howto_operator_bigquery_check]

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gcs.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.providers.google.cloud.operators.gcs import (
     GCSCreateBucketOperator,
     GCSDeleteBucketOperator,
@@ -57,8 +58,14 @@ HOME = "/home/airflow/gcs"
 PREFIX = f"{HOME}/data/{DAG_ID}_{ENV_ID}/"
 
 
+def _unwrap_xcom(result):
+    if AIRFLOW_V_3_0_PLUS:
+        return result
+    return result[0]
+
+
 def _assert_copied_files_exist(ti):
-    objects = ti.xcom_pull(task_ids=["list_objects"], key="return_value")
+    objects = _unwrap_xcom(ti.xcom_pull(task_ids=["list_objects"], key="return_value"))
 
     assert PREFIX + OBJECT_1 in objects
     assert f"{PREFIX}subdir/{OBJECT_1}" in objects

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine.py
@@ -25,6 +25,7 @@ import os
 from datetime import datetime
 
 from airflow.models.dag import DAG
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKECreateClusterOperator,
     GKEDeleteClusterOperator,
@@ -95,8 +96,15 @@ with DAG(
 
     # [START howto_operator_gke_xcom_result]
     pod_task_xcom_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('pod_task_xcom') }}\"",
         task_id="pod_task_xcom_result",
+        bash_command="""
+        {% if params.airflow_v3 %}
+        echo "{{ task_instance.xcom_pull('pod_task_xcom') }}"
+        {% else %}
+        echo "{{ task_instance.xcom_pull('pod_task_xcom')[0] }}"
+        {% endif %}
+        """,
+        params={"airflow_v3": AIRFLOW_V_3_0_PLUS},
     )
     # [END howto_operator_gke_xcom_result]
 

--- a/providers/google/tests/system/google/cloud/translate/example_translate.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from airflow.models.dag import DAG
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.providers.google.cloud.operators.translate import CloudTranslateTextOperator
 from airflow.providers.standard.operators.bash import BashOperator
 
@@ -49,7 +50,15 @@ with DAG(
     # [END howto_operator_translate_text]
     # [START howto_operator_translate_access]
     translation_access = BashOperator(
-        task_id="access", bash_command="echo '{{ task_instance.xcom_pull(\"translate\") }}'"
+        task_id="access",
+        bash_command="""
+        {% if params.airflow_v3 %}
+        echo '{{ task_instance.xcom_pull("translate") }}'
+        {% else %}
+        echo '{{ task_instance.xcom_pull("translate")[0] }}'
+        {% endif %}
+        """,
+        params={"airflow_v3": AIRFLOW_V_3_0_PLUS},
     )
     # [END howto_operator_translate_access]
     product_set_create >> translation_access


### PR DESCRIPTION
This PR adds compatibility for system tests in Google provider to read values form Xcom for both AF2 and AF3. 
Since in AF3 we changed the way of storing values, there is no need to read from list anymore. 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
