### PR TITLE
Floor version suffix when referring to other airflow pre-releases

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -127,6 +127,7 @@ from airflow_breeze.utils.packages import (
     PackageSuspendedException,
     expand_all_provider_distributions,
     find_matching_long_package_names,
+    floor_version_suffix,
     get_available_distributions,
     get_provider_details,
     get_provider_distributions_metadata,
@@ -421,8 +422,9 @@ def update_version_suffix_in_pyproject_toml(version_suffix: str, pyproject_toml_
             if not line.endswith(
                 f'.{version_suffix}"',
             ):
-                get_console().print(f"[info]Updating version suffix to {version_suffix} for {line}.")
-                line = line.rstrip('",') + f'.{version_suffix}",'
+                floored_version_suffix = floor_version_suffix(version_suffix)
+                get_console().print(f"[info]Updating version suffix to {floored_version_suffix} for {line}.")
+                line = line.rstrip('",') + f'.{floored_version_suffix}",'
             else:
                 get_console().print(
                     f"[info]Not updating version suffix to {version_suffix} for {line} as it already has the "

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -635,7 +635,7 @@ DEFAULT_EXTRAS = [
     # END OF EXTRAS LIST UPDATED BY PRE COMMIT
 ]
 
-CHICKEN_EGG_PROVIDERS = " ".join(["git", "fab", "standard", "openlineage"])
+CHICKEN_EGG_PROVIDERS = " ".join(["git", "common.messaging", "fab", "standard", "openlineage"])
 
 
 PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -471,6 +471,11 @@ def get_dist_package_name_prefix(provider_id: str) -> str:
     return "apache_airflow_providers_" + provider_id.replace(".", "_")
 
 
+def floor_version_suffix(version_suffix: str) -> str:
+    # always use `pre-release`+ `0` as the version suffix
+    return version_suffix.rstrip("0123456789") + "0"
+
+
 def apply_version_suffix(install_clause: str, version_suffix: str) -> str:
     # Need to resolve a version suffix based on PyPi versions, but can ignore local version suffix.
     pypi_version_suffix = remove_local_version_suffix(version_suffix)
@@ -492,10 +497,7 @@ def apply_version_suffix(install_clause: str, version_suffix: str) -> str:
         from packaging.version import Version
 
         base_version = Version(version).base_version
-        # always use `pre-release`+ `0` as the version suffix
-        pypi_version_suffix = pypi_version_suffix.rstrip("0123456789") + "0"
-
-        target_version = Version(str(base_version) + "." + pypi_version_suffix)
+        target_version = Version(str(base_version) + "." + floor_version_suffix(pypi_version_suffix))
         return prefix + ">=" + str(target_version)
     return install_clause
 


### PR DESCRIPTION
When we are referring to other airflow distribution packages with pre-release suffix, when we have >= comparision we should always floor the suffix version (i.e. if we are preparing rc3, we should have >= ...rc0 ) - this should cover the edge case (like in case of common.messaging) where we have already released final version, and we are not releasing a new RC. This allows to install the latest RC candidate of such already released provider.

We were already doing it when preparing providers, in order to allow providers to depend on each other when released together, but we also add the rc suffix also in airflow packages and there we did not floor the pre-release version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
