### PR TITLE
Convert 'sslmode' in conn uri to 'ssl' for asyncpg

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -230,6 +230,7 @@ def _convert_asyncpg_connect_args(args: Iterable[tuple[str, str]]) -> Iterator[t
             yield "ssl", v
         else:
             yield k, v
+    yield "statement_cache_size", "0"
 
 
 def _get_async_conn_uri_from_sync(sync_uri: str) -> str:


### PR DESCRIPTION
We currently only do very trivial handling. This can be improved incrementally when requested.

See docstring in implementation for more context. There's more explaination than the actual fix.

Also rewrote async conn uri logic so we can parse different parts out in a more structured way.