### PR TITLE
Set rc0 as suffix used for chicken-egg-providers

### DIFF
--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -27,11 +27,6 @@ on:  # yamllint disable-line rule:truthy
         description: 'Skip Latest: Set to true if not latest.'
         default: ''
         required: false
-      includePreRelease:
-        description: 'Include pre-release: Set to true to include pre-releases.'
-        default: ''
-        type: boolean
-        required: false
 permissions:
   contents: read
   packages: read
@@ -52,7 +47,6 @@ jobs:
       defaultPythonVersion: ${{ steps.selective-checks.outputs.default-python-version }}
       chicken-egg-providers: ${{ steps.selective-checks.outputs.chicken-egg-providers }}
       skipLatest: ${{ github.event.inputs.skipLatest == '' && ' ' || '--skip-latest' }}
-      includePreRelease: ${{ github.event.inputs.includePreRelease == '' && ' ' || '--include-pre-release' }}
       limitPlatform: ${{ github.repository == 'apache/airflow' && ' ' || '--limit-platform linux/amd64' }}
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -151,16 +145,16 @@ jobs:
       - name: "Create airflow_cache builder"
         run: docker buildx create --name airflow_cache
       - name: "Prepare chicken-eggs provider distributions"
-        # In case of provider distributions which use latest dev0 version of providers, we should prepare them
+        # In case of provider distributions which use latest r00 version of providers, we should prepare them
         # from the source code, not from the PyPI because they have apache-airflow>=X.Y.Z dependency
-        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.dev0
+        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.rc0
         shell: bash
         env:
           CHICKEN_EGG_PROVIDERS: ${{ needs.build-info.outputs.chicken-egg-providers }}
         run: >
           breeze release-management prepare-provider-distributions
           --distribution-format wheel
-          --version-suffix-for-pypi dev0 ${CHICKEN_EGG_PROVIDERS}
+          --version-suffix-for-pypi rc0 ${CHICKEN_EGG_PROVIDERS}
         if: needs.build-info.outputs.chicken-egg-providers != ''
       - name: "Copy dist packages to docker-context files"
         shell: bash


### PR DESCRIPTION
Learning from yesterday frantic attempts to relase Airflow 3.0.0rc3 with some providers that were changed mid-flight, this is the last step to make both regular release in main (with dev0) and the dockerhub release (with rc0) works.

The way how it works:

* after #49373 we are flooring >= dependencies for all airflow distributions to >= XX0 (where XX might be dev or rc)

* we are building all chicken-egg-providers with rc0 suffix now. for example fab 2.0.1 will be locally built as 2.0.1rc0, git 0.0.2 will be built as 0.0.2rc0. Both will have apache-airflow >= 3.0.0rc0 as dependency. Similarly common.messaging that is already released as 1.0.0 will be locally build as 1.0.0rc0 as it is still chicken-egg-provider until we release Airflow 3.0.0. if it is already released as 1.0.0rc0, we will skip building it locally and use PyPI version.

This should work in all cases:

* when we already released final version (common.messaging), we are going to have locally built common.messaging 1.0.0rc0 which will have apache-airflow>=3.0.0rc0. The 1.0.0 of common.messaging from PyPI cannot be used because it has apache-airflow>=3.0.0. Airlfow 3.0.0rc0 wil be built with common.messaging >= 1.0.0rc0 so all requirements will be satisfied.

* when we have not yet released chicken-egg-provider such as git 0.0.2) we will locally build 0.0.2rc0 (unless it is already released) and use this one locally. Airflow will use git >= 0.0.2rc0 if min version is set to 0.0.2.

* In case such provider (git 0.0.2) has been released already as rc0, it will be skipped automatically when building it and we will use `PyPI` version instead

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
