### PR TITLE
Introduce a separate config for async db flags

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -629,9 +629,22 @@ database:
         <https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#setting-up-a-postgresql-database>`__
         e.g ``connect_args={"timeout":30}`` can be defined in ``airflow_local_settings.py`` and
         can be imported as shown below
+
+        *Changed in 3.0.0*: This configuration is only applied to synchronous engines, such as psycopg2.
+        See ``sql_alchemy_connect_args_async``.
       version_added: 2.3.0
       type: string
       example: 'airflow_local_settings.connect_args'
+      default: ~
+    sql_alchemy_connect_args_async:
+      description: |
+        Import path for connect args in SQLAlchemy. Defaults to an empty dict.
+        This is similar to ``sql_alchemy_connect_args``, but only for async connections.
+
+        This configuration is only applied to async engines, such as asyncpg.
+      version_added: 3.0.0
+      type: string
+      example: 'airflow_local_settings.connect_args_async'
       default: ~
     sql_alchemy_session_maker:
       description: |

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -532,6 +532,18 @@ database:
       sensitive: true
       example: ~
       default: "sqlite:///{AIRFLOW_HOME}/airflow.db"
+    sql_alchemy_conn_async:
+      description: |
+        The SQLAlchemy connection string to the metadata database used for async connections.
+        If this is not set, Airflow automatically derives a string by converting ``sql_alchemy_conn``.
+        Unfortunately, this conversion logic does not always work due to various incompatibilities
+        between sync and async db driver implementations. This sets the connection string directly
+        without any conversion instead.
+      version_added: 3.0.0
+      type: string
+      sensitive: true
+      example: "postgresql+asyncpg://postgres:airflow@postgres/airflow"
+      default: ~
     sql_alchemy_engine_args:
       description: |
         Extra engine specific keyword args passed to SQLAlchemy's create_engine, as a JSON-encoded value

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -539,7 +539,7 @@ database:
         Unfortunately, this conversion logic does not always work due to various incompatibilities
         between sync and async db driver implementations. This sets the connection string directly
         without any conversion instead.
-      version_added: 3.0.0
+      version_added: 3.1.0
       type: string
       sensitive: true
       example: "postgresql+asyncpg://postgres:airflow@postgres/airflow"
@@ -642,7 +642,7 @@ database:
         e.g ``connect_args={"timeout":30}`` can be defined in ``airflow_local_settings.py`` and
         can be imported as shown below
 
-        *Changed in 3.0.0*: This configuration is only applied to synchronous engines, such as psycopg2.
+        *Changed in 3.1.0*: This configuration is only applied to synchronous engines, such as psycopg2.
         See ``sql_alchemy_connect_args_async``.
       version_added: 2.3.0
       type: string
@@ -654,7 +654,7 @@ database:
         This is similar to ``sql_alchemy_connect_args``, but only for async connections.
 
         This configuration is only applied to async engines, such as asyncpg.
-      version_added: 3.0.0
+      version_added: 3.1.0
       type: string
       example: 'airflow_local_settings.connect_args_async'
       default: ~

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -225,8 +225,12 @@ def configure_vars():
     global DAGS_FOLDER
     global PLUGINS_FOLDER
     global DONOT_MODIFY_HANDLERS
-    SQL_ALCHEMY_CONN = conf.get("database", "SQL_ALCHEMY_CONN")
-    SQL_ALCHEMY_CONN_ASYNC = _get_async_conn_uri_from_sync(sync_uri=SQL_ALCHEMY_CONN)
+
+    SQL_ALCHEMY_CONN = conf.get("database", "sql_alchemy_conn")
+    if conf.has_option("database", "sql_alchemy_conn_async"):
+        SQL_ALCHEMY_CONN_ASYNC = conf.get("database", "sql_alchemy_conn_async")
+    else:
+        SQL_ALCHEMY_CONN_ASYNC = _get_async_conn_uri_from_sync(sync_uri=SQL_ALCHEMY_CONN)
 
     DAGS_FOLDER = os.path.expanduser(conf.get("core", "DAGS_FOLDER"))
 

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -26,7 +26,7 @@ import sys
 import warnings
 from collections.abc import Callable
 from importlib import metadata
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import pluggy
 from packaging.version import Version
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
     from airflow.api_fastapi.common.types import UIAlert
-    from airflow.typing_compat import Literal
 
 log = logging.getLogger(__name__)
 

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -1715,6 +1715,7 @@ def test_sensitive_values():
     # items not matching this pattern must be added here manually
     sensitive_values = {
         ("database", "sql_alchemy_conn"),
+        ("database", "sql_alchemy_conn_async"),
         ("core", "fernet_key"),
         ("api_auth", "jwt_secret"),
         ("api", "secret_key"),
@@ -1730,7 +1731,7 @@ def test_sensitive_values():
         ("opensearch", "password"),
         ("webserver", "secret_key"),
     }
-    all_keys = {(s, k) for s, v in conf.configuration_description.items() for k in v.get("options")}
+    all_keys = {(s, k) for s, v in conf.configuration_description.items() for k in v["options"]}
     suspected_sensitive = {(s, k) for (s, k) in all_keys if k.endswith(("password", "kwargs"))}
     exclude_list = {
         ("aws_batch_executor", "submit_job_kwargs"),


### PR DESCRIPTION
Even if we're using the same database (say Postgres), their sync and async clients (say psycopg2 and asyncpg) are not entirely compatible. Sometimes you just need a way to set things differently.

An alternative to #49383...