### PR TITLE
Don't update start_date when resuming a TI from deferral

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -130,8 +130,11 @@ def ti_run(
 
     # We exclude_unset to avoid updating fields that are not set in the payload
     data = ti_run_payload.model_dump(exclude_unset=True)
+
+    # don't update start date when resuming from deferral
     if ti.next_kwargs:
         data.pop("start_date")
+
     query = update(TI).where(TI.id == ti_id_str).values(data)
 
     previous_state = ti.state

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -130,7 +130,8 @@ def ti_run(
 
     # We exclude_unset to avoid updating fields that are not set in the payload
     data = ti_run_payload.model_dump(exclude_unset=True)
-
+    if ti.next_kwargs:
+        data.pop("start_date")
     query = update(TI).where(TI.id == ti_id_str).values(data)
 
     previous_state = ti.state

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -223,8 +223,7 @@ class TriggerDagRunOperator(BaseOperator):
             if dag_model.is_paused:
                 if AIRFLOW_V_3_0_PLUS:
                     raise DagIsPaused(dag_id=self.trigger_dag_id)
-                else:
-                    raise AirflowException(f"Dag {self.trigger_dag_id} is paused")
+                raise AirflowException(f"Dag {self.trigger_dag_id} is paused")
 
         if AIRFLOW_V_3_0_PLUS:
             self._trigger_dag_af_3(context=context, run_id=run_id, parsed_logical_date=parsed_logical_date)


### PR DESCRIPTION
This allows duration to reflect the overall time from task start to task completion, which is how the metric was calculated in 2.x.
