### PR TITLE
Add note in FAB migration doc

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -697,7 +697,8 @@ database:
     external_db_managers:
       description: |
         List of DB managers to use to migrate external tables in airflow database. The managers must inherit
-        from BaseDBManager
+        from BaseDBManager. If ``FabAuthManager`` is configured in the environment,
+        ``airflow.providers.fab.auth_manager.models.db.FABDBManager`` is automatically added.
       version_added: 3.0.0
       type: string
       example: "airflow.providers.fab.auth_manager.models.db.FABDBManager"

--- a/providers/fab/docs/upgrading.rst
+++ b/providers/fab/docs/upgrading.rst
@@ -28,6 +28,10 @@ must run ``airflow fab-db migrate`` to migrate your database with the schema cha
 upgrading to. If ``FABDBManager`` is included in the ``[core] external_db_managers`` configuration, the migrations will
 be run automatically as part of the ``airflow db migrate`` command.
 
+.. note::
+    If FAB auth manager is configured as auth manager in your environment, ``FABDBManager`` is automatically added in the
+    ``[core] external_db_managers`` configuration.
+
 How to upgrade
 ==============
 To upgrade the FAB provider, you need to install the new version of the package. You can do this using ``pip``.


### PR DESCRIPTION
FAB auth manager adds automatically `FABDBManager` as part of `[core] external_db_managers`. We should mention that in docs.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
