### PR TITLE
fix: correct invalid arg timeout

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/base.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/base.py
@@ -88,7 +88,7 @@ class KafkaBaseHook(BaseHook):
         """Test Connectivity from the UI."""
         try:
             config = self.get_connection(self.kafka_config_id).extra_dejson
-            t = AdminClient(config, timeout=10).list_topics()
+            t = AdminClient(config).list_topics(timeout=10)
             if t:
                 return True, "Connection successful."
         except Exception as e:

--- a/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_base.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_base.py
@@ -56,7 +56,9 @@ class TestKafkaBaseHook:
         config = {"bootstrap.servers": MagicMock()}
         mock_get_connection.return_value.extra_dejson = config
         connection = hook.test_connection()
-        admin_client.assert_called_once_with(config, timeout=10)
+        admin_client.assert_called_once_with(config)
+        mock_admin_instance = admin_client.return_value
+        mock_admin_instance.list_topics.assert_called_once_with(timeout=TIMEOUT)
         assert connection == (True, "Connection successful.")
 
     @mock.patch(
@@ -68,7 +70,9 @@ class TestKafkaBaseHook:
         config = {"bootstrap.servers": MagicMock()}
         mock_get_connection.return_value.extra_dejson = config
         connection = hook.test_connection()
-        admin_client.assert_called_once_with(config, timeout=TIMEOUT)
+        admin_client.assert_called_once_with(config)
+        mock_admin_instance = admin_client.return_value
+        mock_admin_instance.list_topics.assert_called_once_with(timeout=TIMEOUT)
         assert connection == (False, "Failed to establish connection.")
 
     @mock.patch("airflow.providers.apache.kafka.hooks.base.AdminClient")


### PR DESCRIPTION
closes: #49406

as per [docs](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.admin.AdminClient.list_topics) it's the list_topics has the timeout parameter


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
