### PR TITLE
Change default executor in pod template to support executor parameter in task

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -95,7 +95,7 @@ spec:
     - envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 6 }}
       env:
         - name: AIRFLOW__CORE__EXECUTOR
-          value: LocalExecutor
+          value: {{ .Values.executor | quote }}
         {{- if or .Values.workers.kerberosSidecar.enabled .Values.workers.kerberosInitContainer.enabled}}
         - name: KRB5_CONFIG
           value:  {{ .Values.kerberos.configPath | quote }}


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/48667
related: https://github.com/apache/airflow/issues/48667

### Changes

- The default pod_template's ```AIRFLOW__CORE__EXECUTOR``` value, previously hardcoded to LocalExecutor, now respects the setting from ```values.yaml```.

### Why we need?

There is an issue when using multiple executors: if a specific executor is explicitly defined in a task parameter, the pod created by the pod_template may fail to run properly. This happens because the default pod_template generated by the Helm chart hardcodes the executor to ```LocalExecutor``` via the ```AIRFLOW__CORE__EXECUTOR``` environment variable.

For example, in an environment where ```KubernetesExecutor``` is used, if a task is defined in the DAG with the ```executor="KubernetesExecutor"``` parameter, the pod will still have ```AIRFLOW__CORE__EXECUTOR=LocalExecutor``` in its environment variables. This leads to the following error:

```sh
airflow.exceptions.UnknownExecutorException: Unknown executor being loaded: KubernetesExecutor
```

To resolve this and improve the user experience for Helm chart users, I’ve updated the default pod_template so that the ```AIRFLOW__CORE__EXECUTOR``` value matches the executor defined in ```values.yaml```.

After this change, I confirmed that tasks using ```KubernetesExecutor``` run successfully with the following DAG:

```python
from airflow import DAG
from airflow.operators.bash import BashOperator
from datetime import datetime

default_args = {
    'start_date': datetime(2023, 1, 1),
}

with DAG(
    dag_id='kubernetes_hello_world',
    default_args=default_args,
    schedule_interval=None,
    catchup=False,
    tags=['test'],
) as dag:
    hello_task = BashOperator(
        task_id='print_hello',
        executor='KubernetesExecutor',  # Warning!
        bash_command='echo "Hello, World from KubernetesExecutor!"'
    )
```

<img width="384" alt="image" src="https://github.com/user-attachments/assets/3c073bb3-5f15-480b-bea0-2c2e13648083" />

Let me know if any additional clarification is needed!

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
