### PR TITLE
Fix UI to use UI/backfill endpoint again

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -22,8 +22,8 @@ import { RiArrowGoBackFill } from "react-icons/ri";
 
 import {
   useBackfillServiceCancelBackfill,
-  useBackfillServiceListBackfills,
-  useBackfillServiceListBackfillsKey,
+  useBackfillServiceListBackfills1,
+  useBackfillServiceListBackfills1Key,
   useBackfillServicePauseBackfill,
   useBackfillServiceUnpauseBackfill,
 } from "openapi/queries";
@@ -47,12 +47,12 @@ const buttonProps = {
 
 const onSuccess = async () => {
   await queryClient.invalidateQueries({
-    queryKey: [useBackfillServiceListBackfillsKey],
+    queryKey: [useBackfillServiceListBackfills1Key],
   });
 };
 
 const BackfillBanner = ({ dagId }: Props) => {
-  const { data, isLoading } = useBackfillServiceListBackfills({
+  const { data, isLoading } = useBackfillServiceListBackfills1({
     dagId,
   });
   const [backfill] = data?.backfills.filter((bf) => bf.completed_at === null) ?? [];

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -20,7 +20,7 @@ import { Box, Heading, Text } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useParams } from "react-router-dom";
 
-import { useBackfillServiceListBackfills } from "openapi/queries";
+import { useBackfillServiceListBackfills1 } from "openapi/queries";
 import type { BackfillResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
@@ -109,7 +109,7 @@ export const Backfills = () => {
 
   const { dagId = "" } = useParams();
 
-  const { data, error, isFetching, isLoading } = useBackfillServiceListBackfills({
+  const { data, error, isFetching, isLoading } = useBackfillServiceListBackfills1({
     dagId,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,


### PR DESCRIPTION
We noticed that after [PR #49311](https://github.com/apache/airflow/pull/49311), we started using api/v2 instead of backfill/ui. This PR addresses that change.
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
