### PR TITLE
Have `KubernetesPodOperator` call `on_pod_cleanup` callbacks for failed tasks

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -688,15 +688,8 @@ class KubernetesPodOperator(BaseOperator):
             self.cleanup(
                 pod=pod_to_clean,
                 remote_pod=self.remote_pod,
+                context=context,
             )
-            for callback in self.callbacks:
-                callback.on_pod_cleanup(
-                    pod=pod_to_clean,
-                    client=self.client,
-                    mode=ExecutionMode.SYNC,
-                    context=context,
-                    operator=self,
-                )
 
         if self.do_xcom_push:
             return result
@@ -952,13 +945,10 @@ class KubernetesPodOperator(BaseOperator):
         self.cleanup(
             pod=pod,
             remote_pod=remote_pod,
+            context=context,
         )
-        for callback in self.callbacks:
-            callback.on_pod_cleanup(
-                pod=pod, client=self.client, mode=ExecutionMode.SYNC, operator=self, context=context
-            )
 
-    def cleanup(self, pod: k8s.V1Pod, remote_pod: k8s.V1Pod):
+    def cleanup(self, pod: k8s.V1Pod, remote_pod: k8s.V1Pod, context: Context):
         # Skip cleaning the pod in the following scenarios.
         # 1. If a task got marked as failed, "on_kill" method would be called and the pod will be cleaned up
         # there. Cleaning it up again will raise an exception (which might cause retry).
@@ -982,6 +972,15 @@ class KubernetesPodOperator(BaseOperator):
                 self._read_pod_events(pod, reraise=False)
 
         self.process_pod_deletion(remote_pod, reraise=False)
+
+        for callback in self.callbacks:
+            callback.on_pod_cleanup(
+                pod=remote_pod,
+                client=self.client,
+                mode=ExecutionMode.SYNC,
+                operator=self,
+                context=context,
+            )
 
         if self.skip_on_exit_code:
             container_statuses = (

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2396,10 +2396,11 @@ class TestKubernetesPodOperatorAsync:
     )
     def test_cleanup_log_pod_spec_on_failure(self, log_pod_spec_on_failure, expect_match):
         k = KubernetesPodOperator(task_id="task", log_pod_spec_on_failure=log_pod_spec_on_failure)
-        pod = k.build_pod_request_obj(create_context(k))
+        context = create_context(k)
+        pod = k.build_pod_request_obj(context)
         pod.status = V1PodStatus(phase=PodPhase.FAILED)
         with pytest.raises(AirflowException, match=expect_match):
-            k.cleanup(pod, pod)
+            k.cleanup(pod, pod, context)
 
     @patch(f"{HOOK_CLASS}.get_pod")
     @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1657,7 +1657,7 @@ class TestKubernetesPodOperator:
         assert mock_callbacks.on_pod_cleanup.call_args.kwargs == {
             "client": k.client,
             "mode": ExecutionMode.SYNC,
-            "pod": k.pod,
+            "pod": self.await_pod_mock.return_value,
             "operator": k,
             "context": context,
         }
@@ -1744,7 +1744,7 @@ class TestKubernetesPodOperator:
         assert mock_callbacks.on_pod_cleanup.call_args.kwargs == {
             "client": k.client,
             "mode": ExecutionMode.SYNC,
-            "pod": k.pod,
+            "pod": self.await_pod_mock.return_value,
             "operator": k,
             "context": context,
         }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #49441
Currently the `on_pod_cleanup` callbacks are only called if the `cleanup` method completes successfully, but the `cleanup` method raises exceptions if the task failed.  This changes `KubernetesPodOperator` to call the `on_pod_cleanup` callbacks from within the `cleanup` method before it raises such exceptions.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
