### PR TITLE
Remove unused `_OPERATOR_EXTRA_LINKS` in serialized_objects

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -51,7 +51,6 @@ from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.xcom import XComModel
 from airflow.models.xcom_arg import SchedulerXComArg, deserialize_xcom_arg
-from airflow.providers_manager import ProvidersManager
 from airflow.sdk.bases.operator import BaseOperator as TaskSDKBaseOperator
 from airflow.sdk.definitions._internal.expandinput import EXPAND_INPUT_EMPTY
 from airflow.sdk.definitions.asset import (
@@ -117,26 +116,6 @@ if TYPE_CHECKING:
         pass
 
 log = logging.getLogger(__name__)
-
-_OPERATOR_EXTRA_LINKS: set[str] = {
-    "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink",
-    "airflow.providers.standard.sensors.external_task.ExternalDagLink",
-    # Deprecated names, so that existing serialized dags load straight away.
-    "airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink",
-    "airflow.operators.dagrun_operator.TriggerDagRunLink",
-    "airflow.providers.standard.sensors.external_task_sensor.ExternalTaskSensorLink",
-}
-
-
-@cache
-def get_operator_extra_links() -> set[str]:
-    """
-    Get the operator extra links.
-
-    This includes both the built-in ones, and those come from the providers.
-    """
-    _OPERATOR_EXTRA_LINKS.update(ProvidersManager().extra_links_class_names)
-    return _OPERATOR_EXTRA_LINKS
 
 
 @cache


### PR DESCRIPTION
In AF2 , `get_operator_extra_links` was used to get the extra links, and they were handled in webserver. In AF3 a new `XComOperatorLink` class added and  extra links are no longer processed in the webserver. Instead when a taks runs, the  get_link result is pushed to XCom . The webserver then reads it from the XCom.

For plugins defined links, They are converted to XComOperatorLink during deserialization so the webserver can read them too. https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/serialization/serialized_objects.py#L1607



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
