### PR TITLE
Ensure sqlalchemy[asyncio] extra is in core deps

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -124,7 +124,7 @@ dependencies = [
     # See https://sqlalche.me/e/b8d9 for details of deprecated features
     # you can set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.
     # The issue tracking it is https://github.com/apache/airflow/issues/28723
-    "sqlalchemy>=1.4.49,<2.0",
+    "sqlalchemy[asyncio]>=1.4.49,<2.0",
     "sqlalchemy-jsonfield>=1.0",
     "sqlalchemy-utils>=0.41.2",
     "svcs>=25.1.0",


### PR DESCRIPTION
This is required for async sqlalchemy operations.  This surfaces e.g. when we install with `--no-dev` and run the api-server, we'll get missing module `greenlet` error in api-server logs.
