### PR TITLE
Adding change in `xcom_pull` behaviour to release notes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -335,11 +335,11 @@ aligning with the broader asset-aware execution model introduced in Airflow 3.0.
 Predictable Behaviour of ``xcom_pull``
 """"""""""""""""""""""""""""""""""""""
 
-In Airflow 2, the xcom_pull() method allowed pulling XComs by key without specifying task_ids, despite the fact that the underlying
+In Airflow 2, the ``xcom_pull()`` method allowed pulling XComs by key without specifying task_ids, despite the fact that the underlying
 DB model defines task_id as part of the XCom primary key. This created ambiguity: if two tasks pushed XComs with the same key,
-xcom_pull() would pull whichever one happened to be first, leading to unpredictable behavior.
+``xcom_pull()`` would pull whichever one happened to be first, leading to unpredictable behavior.
 
-Airflow 3 resolves im inconsistency by requiring task_ids when pulling by key. This change aligns with the task-scoped nature of
+Airflow 3 resolves im inconsistency by requiring ``task_ids`` when pulling by key. This change aligns with the task-scoped nature of
 XComs as defined by the schema, ensuring predictable and consistent behavior.
 
 DAG Authors should update their dags to use ``task_ids`` if their dags used ``xcom_pull`` without ``task_ids`` such as::

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -331,6 +331,26 @@ The internal representation of asset event triggers now also includes an explici
 aligning with the broader asset-aware execution model introduced in Airflow 3.0. DAG authors interacting directly with
 ``inlet_events`` may need to update logic that assumes the previous structure.
 
+
+Predictable Behaviour of ``xcom_pull``
+""""""""""""""""""""""""""""""""""""""
+
+In Airflow 2, the xcom_pull() method allowed pulling XComs by key without specifying task_ids, despite the fact that the underlying
+DB model defines task_id as part of the XCom primary key. This created ambiguity: if two tasks pushed XComs with the same key,
+xcom_pull() would pull whichever one happened to be first, leading to unpredictable behavior.
+
+Airflow 3 resolves im inconsistency by requiring task_ids when pulling by key. This change aligns with the task-scoped nature of
+XComs as defined by the schema, ensuring predictable and consistent behavior.
+
+DAG Authors should update their dags to use ``task_ids`` if their dags used ``xcom_pull`` without ``task_ids`` such as::
+
+  kwargs["ti"].xcom_pull(key="key")
+
+Should be updated to::
+
+  kwargs["ti"].xcom_pull(task_ids="task1", key="key")
+
+
 Removed Configuration Keys
 """""""""""""""""""""""""""
 

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: d6622a46946d657cc24c720819fd1c20
-source-date-epoch: 1745313640
+release-notes-hash: 4d3a20b56440122fcbd72bf1b8c9020e
+source-date-epoch: 1745314549

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 00a97e0a1a68a6eebd9803edbc7a8b84
-source-date-epoch: 1745220190
+release-notes-hash: d6622a46946d657cc24c720819fd1c20
+source-date-epoch: 1745313640


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Theres a change in behaviour in xcom_pull, for the better and to make it less ambiguous. 

Adding to migration docs so folks dont miss it and dont rely on old behaviour.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
