### PR TITLE
Simplify logic flow of initialize_airflow_tests fixture

### DIFF
--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -368,7 +368,7 @@ def _initialize_airflow_db(force_db_init: bool, airflow_home: str | Path):
     from tests_common.test_utils.db import initial_db_init
 
     if force_db_init:
-        print("Initializing the DB - forced with --with-db-init switch.")
+        print("Initializing the DB - forced with --with-db-init flag.")
     else:
         print(
             "Initializing the DB - first time after entering the container.\n"

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -340,9 +340,8 @@ def pytest_addoption(parser: pytest.Parser):
 @pytest.fixture(autouse=True, scope="session")
 def initialize_airflow_tests(request):
     """Set up Airflow testing environment."""
-    print(" AIRFLOW ".center(60, "="))
-
-    from tests_common.test_utils.db import initial_db_init
+    # To separate this line from test name in case of verbosity runs
+    print("\n" + " AIRFLOW ".center(60, "="))
 
     # Setup test environment for breeze
     home = os.path.expanduser("~")
@@ -350,37 +349,43 @@ def initialize_airflow_tests(request):
 
     print(f"Home of the user: {home}\nAirflow home {airflow_home}")
 
-    # Initialize Airflow db if required
-    lock_file = os.path.join(airflow_home, ".airflow_db_initialised")
     if not skip_db_tests and not request.config.option.no_db_init:
-        if request.config.option.db_init:
-            from tests_common.test_utils.db import initial_db_init
+        _initialize_airflow_db(request.config.option.db_init, airflow_home)
 
-            print("Initializing the DB - forced with --with-db-init switch.")
-            initial_db_init()
-        elif not os.path.exists(lock_file):
-            print(
-                "Initializing the DB - first time after entering the container.\n"
-                "You can force re-initialization the database by adding --with-db-init switch to run-tests."
-            )
-            initial_db_init()
-            # Create pid file
-            with open(lock_file, "w+"):
-                pass
-        else:
-            print(
-                "Skipping initializing of the DB as it was initialized already.\n"
-                "You can re-initialize the database by adding --with-db-init flag when running tests."
-            )
-    integration_kerberos = os.environ.get("INTEGRATION_KERBEROS")
-    if integration_kerberos == "true":
-        # Initialize kerberos
-        kerberos = os.environ.get("KRB5_KTNAME")
-        if kerberos:
-            subprocess.check_call(["kinit", "-kt", kerberos, "bob@EXAMPLE.COM"])
-        else:
-            print("Kerberos enabled! Please setup KRB5_KTNAME environment variable")
-            sys.exit(1)
+    if os.environ.get("INTEGRATION_KERBEROS") == "true":
+        _initialize_kerberos()
+
+
+def _initialize_airflow_db(force_db_init: bool, airflow_home: str | Path):
+    db_init_lock_file = Path(airflow_home).joinpath(".airflow_db_initialised")
+    if not force_db_init and db_init_lock_file.exists():
+        print(
+            "Skipping initializing of the DB as it was initialized already.\n"
+            "You can re-initialize the database by adding --with-db-init flag when running tests."
+        )
+        return
+
+    from tests_common.test_utils.db import initial_db_init
+
+    if force_db_init:
+        print("Initializing the DB - forced with --with-db-init switch.")
+    else:
+        print(
+            "Initializing the DB - first time after entering the container.\n"
+            "Initialization can be also forced by adding --with-db-init flag when running tests."
+        )
+
+    initial_db_init()
+    db_init_lock_file.touch(exist_ok=True)
+
+
+def _initialize_kerberos():
+    kerberos = os.environ.get("KRB5_KTNAME")
+    if not kerberos:
+        print("Kerberos enabled! Please setup KRB5_KTNAME environment variable")
+        sys.exit(1)
+
+    subprocess.check_call(["kinit", "-kt", kerberos, "bob@EXAMPLE.COM"])
 
 
 def _find_all_deprecation_ignore_files() -> list[str]:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While checking other tests, I found that `initial_db_init` is imported twice inside this fixture.
Also, following the function logic at a glance was a bit hard. 

This PR removes redundant import and streamlines the logic inside `initialize_airflow_tests`:

- separate db and kerberos initialization to functions
- remove double import of `initial_db_init` and import only if it is needed
- use pathlib.Path in lock file operations
- unify message wording


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
