### PR TITLE
Ensure fab provider is installed when running EdgeExecutor

### DIFF
--- a/providers/edge3/pyproject.toml
+++ b/providers/edge3/pyproject.toml
@@ -58,15 +58,9 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-fab>=1.5.3",
     "pydantic>=2.11.0",
     "retryhttp>=1.2.0,!=1.3.0",
-]
-
-# The optional dependencies should be modified in place in the generated file
-# Any change in the dependencies is preserved when the file is regenerated
-[project.optional-dependencies]
-"fab" = [
-    "apache-airflow-providers-fab"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
I noticed that FAB dependency is missing in edge3 package. The FastAPI/Connexion API needs FAB to be working (authentication of API requests from remote). This might be un-tangled in future as cleanup and FAB does not need to be used... so as a fix until cleaned this adds the missing install dependency.

Exception seen in the logs when starting w/o FAB installed:
```
[2025-04-20T09:56:50.115+0000] {plugins_manager.py:262} ERROR - Failed to import plugin edge_executor
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/airflow/plugins_manager.py", line 254, in load_entrypoint_plugins
    plugin_class = entry_point.load()
                   ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/usr/local/lib/python3.12/site-packages/airflow/providers/edge3/plugins/edge_executor_plugin.py", line 39, in <module>
    from airflow.providers.fab.www.auth import has_access_view
ModuleNotFoundError: No module named 'airflow.providers.fab'
```