### PR TITLE
AIP-38: sort by key as default and borden checkbox borderWidth in `Variables`

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -52,6 +52,7 @@ const getColumns = ({
     accessorKey: "select",
     cell: ({ row }) => (
       <Checkbox
+        borderWidth={1}
         checked={selectedRows.get(row.original.key)}
         colorPalette="blue"
         onCheckedChange={(event) => onRowSelect(row.original.key, Boolean(event.checked))}
@@ -60,6 +61,7 @@ const getColumns = ({
     enableSorting: false,
     header: () => (
       <Checkbox
+        borderWidth={1}
         checked={allRowsSelected}
         colorPalette="blue"
         onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
@@ -107,6 +109,7 @@ const getColumns = ({
 export const Variables = () => {
   const { setTableURLState, tableURLState } = useTableURLState({
     pagination: { pageIndex: 0, pageSize: 30 },
+    sorting: [{ desc: false, id: "key" }],
   }); // To make multiselection smooth
   const [searchParams, setSearchParams] = useSearchParams();
   const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType = SearchParamsKeys;
@@ -211,7 +214,6 @@ export const Variables = () => {
         <ActionBar.Content>
           <ActionBar.SelectionTrigger>{selectedRows.size} selected</ActionBar.SelectionTrigger>
           <ActionBar.Separator />
-          {/* TODO: Implement the export selected */}
           <Tooltip content="Delete selected variables">
             <DeleteVariablesButton clearSelections={clearSelections} deleteKeys={[...selectedRows.keys()]} />
           </Tooltip>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#48104

## Why 

- do have sort function but do not have default sort
- checkbox is hardly to be seen

## How 

- add default sorting into default table state
- borden the width of the checkbox
- minor change: remove `TODO: Implement the export selected` since it seems like it's already been done.

**before**

![image](https://github.com/user-attachments/assets/17970c57-0f65-462c-be8a-1d7ecb0d3b2c)
![image](https://github.com/user-attachments/assets/558c0ef0-dc14-4744-b8aa-b7627429d66b)


**after**

![image](https://github.com/user-attachments/assets/57f8e25b-d4dc-437e-b67f-81b752a5fdb9)
![image](https://github.com/user-attachments/assets/9b26aff8-0670-48ab-afa5-014ff976b87c)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
