### PR TITLE
Add aarch64 -> arm64 platform normalization in breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -343,7 +343,7 @@ ALL_HISTORICAL_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3
 def get_default_platform_machine() -> str:
     machine = platform.uname().machine.lower()
     # Some additional conversion for various platforms...
-    machine = {"x86_64": "amd64"}.get(machine, machine)
+    machine = {"x86_64": "amd64", "aarch64": "arm64"}.get(machine, machine)
     return machine
 
 


### PR DESCRIPTION
`get_default_platfrom_machine` is missing conversion of `aarch64` to `arm64`. This causes commands such as `breeze shell` fail with the following error. 

![image](https://github.com/user-attachments/assets/77b5689e-3931-4a1a-90bd-df227adda9db)
