### PR TITLE
[Docs] Correct asset event listener typo

### DIFF
--- a/airflow-core/docs/administration-and-deployment/listeners.rst
+++ b/airflow-core/docs/administration-and-deployment/listeners.rst
@@ -101,7 +101,7 @@ Asset Events
 --------------
 
 - ``on_asset_created``
-- ``on_dataset_alias_created``
+- ``on_asset_alias_created``
 - ``on_asset_changed``
 
 Asset events occur when Asset management operations are run.


### PR DESCRIPTION
Based on this: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/listeners/spec/asset.py

The listener is now called `on_asset_alias_created` :) 