### PR TITLE
Adding flask app configuration docs to FAB provider

### DIFF
--- a/providers/fab/docs/auth-manager/configuring-flask-app.rst
+++ b/providers/fab/docs/auth-manager/configuring-flask-app.rst
@@ -30,9 +30,10 @@ You could also enhance / modify the underlying flask app directly,
 as the `app context <https://flask.palletsprojects.com/en/2.3.x/appcontext/>`_ is pushed to ``webserver_config.py``:
 
 .. code-block:: python
+
     from flask import current_app as app
 
 
-    @app.before_request
+    @app.before_requestq
     def print_custom_message() -> None:
         print("Executing before every request")

--- a/providers/fab/docs/auth-manager/configuring-flask-app.rst
+++ b/providers/fab/docs/auth-manager/configuring-flask-app.rst
@@ -18,10 +18,9 @@
 Configuring Flask Application for Airflow Webserver
 ===================================================
 
-Airflow uses Flask to render the web UI. When you initialize the Airflow webserver, predefined configuration
+``FabAuthManager`` and Airflow 2 plugins uses Flask to render the web UI.When initialized, predefined configuration
 is used, based on the ``webserver`` section of the ``airflow.cfg`` file. You can override these settings
-and add any extra settings however by adding flask configuration to ``webserver_config.py`` file in your
-``$AIRFLOW_HOME`` directory. This file is automatically loaded by the webserver.
+and add any extra settings by adding flask configuration to ``webserver_config.py`` file specified in ``[fab] config_file`` (by default it is ``$AIRFLOW_HOME/webserver_config.py``). This file is automatically loaded by the webserver.
 
 For example if you would like to change rate limit strategy to "moving window", you can set the
 ``RATELIMIT_STRATEGY`` to ``moving-window``.

--- a/providers/fab/docs/auth-manager/configuring-flask-app.rst
+++ b/providers/fab/docs/auth-manager/configuring-flask-app.rst
@@ -1,0 +1,38 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Configuring Flask Application for Airflow Webserver
+===================================================
+
+Airflow uses Flask to render the web UI. When you initialize the Airflow webserver, predefined configuration
+is used, based on the ``webserver`` section of the ``airflow.cfg`` file. You can override these settings
+and add any extra settings however by adding flask configuration to ``webserver_config.py`` file in your
+``$AIRFLOW_HOME`` directory. This file is automatically loaded by the webserver.
+
+For example if you would like to change rate limit strategy to "moving window", you can set the
+``RATELIMIT_STRATEGY`` to ``moving-window``.
+
+You could also enhance / modify the underlying flask app directly,
+as the `app context <https://flask.palletsprojects.com/en/2.3.x/appcontext/>`_ is pushed to ``webserver_config.py``:
+
+.. code-block:: python
+    from flask import current_app as app
+
+
+    @app.before_request
+    def print_custom_message() -> None:
+        print("Executing before every request")

--- a/providers/fab/docs/auth-manager/index.rst
+++ b/providers/fab/docs/auth-manager/index.rst
@@ -30,6 +30,7 @@ Follow the below topics as well to understand other aspects of FAB auth manager:
 * :doc:`access-control`. How FAB auth manager manage users and permissions
 * :doc:`webserver-authentication`. To learn the different options available in FAB auth manager to authenticate users
 * :doc:`security`. To learn the different options available in FAB auth manager to secure the UI provided by FAB auth manager
+* :doc:`configuring-flask-app`. To learn the configuration options available for the flask app for Airflow webserver.
 
 .. toctree::
     :hidden:

--- a/providers/fab/docs/auth-manager/index.rst
+++ b/providers/fab/docs/auth-manager/index.rst
@@ -30,7 +30,7 @@ Follow the below topics as well to understand other aspects of FAB auth manager:
 * :doc:`access-control`. How FAB auth manager manage users and permissions
 * :doc:`webserver-authentication`. To learn the different options available in FAB auth manager to authenticate users
 * :doc:`security`. To learn the different options available in FAB auth manager to secure the UI provided by FAB auth manager
-* :doc:`configuring-flask-app`. To learn the configuration options available for the flask app for Airflow webserver.
+* :doc:`configuring-flask-app`. To learn the configuration options available for the flask app used by ``FabAuthManager``.
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Follow up of https://github.com/apache/airflow/pull/49393/


Moving these docs to fab provider

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
