### PR TITLE
feat: add expire_time configuration to OracleHook connection

### DIFF
--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -226,6 +226,10 @@ class OracleHook(DbApiHook):
         elif purity == "default":
             conn_config["purity"] = oracledb.PURITY_DEFAULT
 
+        expire_time = conn.extra_dejson.get("expire_time")
+        if expire_time:
+            conn_config["expire_time"] = expire_time
+
         conn = oracledb.connect(**conn_config)  # type: ignore[assignment]
         if mod is not None:
             conn.module = mod

--- a/providers/oracle/tests/unit/oracle/hooks/test_oracle.py
+++ b/providers/oracle/tests/unit/oracle/hooks/test_oracle.py
@@ -131,6 +131,15 @@ class TestOracleHookConn:
             assert kwargs["purity"] == purity.get(pur)
 
     @mock.patch("airflow.providers.oracle.hooks.oracle.oracledb.connect")
+    def test_get_conn_expire_time(self, mock_connect):
+        self.connection.extra = json.dumps({"expire_time": 10})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
+        assert args == ()
+        assert kwargs["expire_time"] == 10
+
+    @mock.patch("airflow.providers.oracle.hooks.oracle.oracledb.connect")
     def test_set_current_schema(self, mock_connect):
         self.connection.schema = "schema_name"
         self.connection.extra = json.dumps({"service_name": "service_name"})


### PR DESCRIPTION
This pull request introduces a new expire_time parameter to the connection_extras in the OracleHook. This enhancement allows users to define an expiration time for connections, improving connection lifecycle management and addressing scenarios where idle connections are terminated by firewalls.

closes: #32844


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
