### PR TITLE
Unify chart k8s label & add some missing k8s labels

### DIFF
--- a/chart/templates/api-server/api-server-poddisruptionbudget.yaml
+++ b/chart/templates/api-server/api-server-poddisruptionbudget.yaml
@@ -30,7 +30,7 @@ metadata:
     tier: airflow
     component: api-server
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- if or (.Values.labels) (.Values.apiServer.labels) }}
       {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 4 }}

--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -34,8 +34,8 @@ metadata:
   labels:
     tier: airflow
     component: airflow-cleanup-pods
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -28,6 +28,7 @@ metadata:
   name: {{ include "cleanup.serviceAccountName" . }}
   labels:
     tier: airflow
+    component: airflow-cleanup-pods
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -28,6 +28,7 @@ kind: ConfigMap
 metadata:
   name: {{ tpl $configMapName $Global | quote }}
   labels:
+    tier: airflow
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}

--- a/chart/templates/priorityclasses/priority-classes.yaml
+++ b/chart/templates/priorityclasses/priority-classes.yaml
@@ -28,6 +28,7 @@ kind: PriorityClass
 metadata:
   name: {{ $Global.Release.Name }}-{{ $e.name }}
   labels:
+    tier: airflow
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}

--- a/chart/templates/priorityclasses/priority-classes.yaml
+++ b/chart/templates/priorityclasses/priority-classes.yaml
@@ -29,6 +29,7 @@ metadata:
   name: {{ $Global.Release.Name }}-{{ $e.name }}
   labels:
     release: {{ $Global.Release.Name }}
+    chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
 preemptionPolicy: {{ default "PreemptLowerPriority" $e.preemptionPolicy }}
 value: {{ $e.value | required "value is required for priority classes" }}
 description: "This priority class will not cause other pods to be preempted."

--- a/chart/templates/priorityclasses/priority-classes.yaml
+++ b/chart/templates/priorityclasses/priority-classes.yaml
@@ -30,6 +30,7 @@ metadata:
   labels:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
+    heritage: {{ $Global.Release.Service }}
 preemptionPolicy: {{ default "PreemptLowerPriority" $e.preemptionPolicy }}
 value: {{ $e.value | required "value is required for priority classes" }}
 description: "This priority class will not cause other pods to be preempted."

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -30,7 +30,7 @@ metadata:
     tier: airflow
     component: scheduler
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- if or (.Values.labels) (.Values.scheduler.labels) }}
       {{- mustMerge .Values.scheduler.labels .Values.labels | toYaml | nindent 4 }}

--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-elasticsearch
   labels:
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ include "airflow.fullname" . }}-elasticsearch
   labels:
+    tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -28,6 +28,7 @@ kind: Secret
 metadata:
   name: {{ tpl $secretName $Global | quote }}
   labels:
+    tier: airflow
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -29,7 +29,7 @@ metadata:
   labels:
     tier: airflow
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -28,6 +28,7 @@ metadata:
   name: {{ .Release.Name }}-fernet-key
   labels:
     tier: airflow
+    component: webserver
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -28,7 +28,6 @@ metadata:
   name: {{ .Release.Name }}-fernet-key
   labels:
     tier: airflow
-    component: webserver
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/flower-secret.yaml
+++ b/chart/templates/secrets/flower-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ include "airflow.fullname" . }}-flower
   labels:
+    tier: airflow
     component: flower
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/chart/templates/secrets/flower-secret.yaml
+++ b/chart/templates/secrets/flower-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ include "airflow.fullname" . }}-flower
   labels:
+    component: flower
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/flower-secret.yaml
+++ b/chart/templates/secrets/flower-secret.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-flower
   labels:
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/git-ssh-key-secret.yaml
+++ b/chart/templates/secrets/git-ssh-key-secret.yaml
@@ -22,6 +22,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
+    tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/git-ssh-key-secret.yaml
+++ b/chart/templates/secrets/git-ssh-key-secret.yaml
@@ -23,7 +23,7 @@ kind: Secret
 metadata:
   labels:
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/kerberos-keytab-secret.yaml
+++ b/chart/templates/secrets/kerberos-keytab-secret.yaml
@@ -29,7 +29,7 @@ metadata:
     tier: airflow
     component: webserver
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -37,7 +37,7 @@ metadata:
   labels:
     tier: airflow
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/opensearch-secret.yaml
+++ b/chart/templates/secrets/opensearch-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ include "airflow.fullname" . }}-opensearch
   labels:
+    tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/opensearch-secret.yaml
+++ b/chart/templates/secrets/opensearch-secret.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-opensearch
   labels:
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/pgbouncer-certificates-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-certificates-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ template "pgbouncer_certificates_secret" . }}
   labels:
+    component: pgbouncer
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/pgbouncer-certificates-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-certificates-secret.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ template "pgbouncer_certificates_secret" . }}
   labels:
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/pgbouncer-certificates-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-certificates-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ template "pgbouncer_certificates_secret" . }}
   labels:
+    tier: airflow
     component: pgbouncer
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/chart/templates/secrets/pgbouncer-config-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-config-secret.yaml
@@ -29,7 +29,7 @@ metadata:
     tier: airflow
     component: pgbouncer
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/pgbouncer-stats-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-stats-secret.yaml
@@ -29,7 +29,7 @@ metadata:
     tier: airflow
     component: pgbouncer
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -38,7 +38,7 @@ metadata:
     tier: airflow
     component: redis
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/registry-secret.yaml
+++ b/chart/templates/secrets/registry-secret.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-registry
   labels:
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/registry-secret.yaml
+++ b/chart/templates/secrets/registry-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 metadata:
   name: {{ include "airflow.fullname" . }}-registry
   labels:
+    tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}

--- a/chart/templates/secrets/result-backend-connection-secret.yaml
+++ b/chart/templates/secrets/result-backend-connection-secret.yaml
@@ -37,7 +37,7 @@ metadata:
   labels:
     tier: airflow
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/secrets/webserver-secret-key-secret.yaml
+++ b/chart/templates/secrets/webserver-secret-key-secret.yaml
@@ -30,7 +30,7 @@ metadata:
     tier: airflow
     component: webserver
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}

--- a/chart/templates/webserver/webserver-poddisruptionbudget.yaml
+++ b/chart/templates/webserver/webserver-poddisruptionbudget.yaml
@@ -30,7 +30,7 @@ metadata:
     tier: airflow
     component: webserver
     release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- if or (.Values.labels) (.Values.webserver.labels) }}
       {{- mustMerge .Values.webserver.labels .Values.labels | toYaml | nindent 4 }}

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -401,7 +401,7 @@ class TestBaseChartTest:
         }
 
         kind_names_tuples = [
-            (f"{release_name}-airflow-cleanup", "ServiceAccount", None),
+            (f"{release_name}-airflow-cleanup", "ServiceAccount", "airflow-cleanup-pods"),
             (f"{release_name}-config", "ConfigMap", "config"),
             (f"{release_name}-airflow-create-user-job", "ServiceAccount", "create-user-job"),
             (f"{release_name}-airflow-flower", "ServiceAccount", "flower"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -420,7 +420,7 @@ class TestBaseChartTest:
             (f"{release_name}-cleanup-role", "Role", None),
             (f"{release_name}-cleanup-rolebinding", "RoleBinding", None),
             (f"{release_name}-create-user", "Job", "create-user-job"),
-            (f"{release_name}-fernet-key", "Secret", None),
+            (f"{release_name}-fernet-key", "Secret", "webserver"),
             (f"{release_name}-flower", "Deployment", "flower"),
             (f"{release_name}-flower", "Service", "flower"),
             (f"{release_name}-flower-policy", "NetworkPolicy", "airflow-flower-policy"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -420,7 +420,7 @@ class TestBaseChartTest:
             (f"{release_name}-cleanup-role", "Role", None),
             (f"{release_name}-cleanup-rolebinding", "RoleBinding", None),
             (f"{release_name}-create-user", "Job", "create-user-job"),
-            (f"{release_name}-fernet-key", "Secret", "webserver"),
+            (f"{release_name}-fernet-key", "Secret", None),
             (f"{release_name}-flower", "Deployment", "flower"),
             (f"{release_name}-flower", "Service", "flower"),
             (f"{release_name}-flower-policy", "NetworkPolicy", "airflow-flower-policy"),

--- a/helm-tests/tests/helm_tests/security/test_extra_configmaps_secrets.py
+++ b/helm-tests/tests/helm_tests/security/test_extra_configmaps_secrets.py
@@ -147,6 +147,7 @@ class TestExtraConfigMapsSecrets:
             "release": RELEASE_NAME,
             "heritage": "Helm",
             "chart": mock.ANY,
+            "tier": "airflow",
         }
         for k8s_object in k8s_objects:
             assert k8s_object["metadata"]["labels"] == expected_labels
@@ -183,6 +184,7 @@ class TestExtraConfigMapsSecrets:
             "release": RELEASE_NAME,
             "heritage": "Helm",
             "chart": mock.ANY,
+            "tier": "airflow",
         }
         for k8s_object in k8s_objects:
             assert k8s_object["metadata"]["labels"] == {**common_labels, **chart_labels, **local_labels}


### PR DESCRIPTION
I noticed that the k8s `chart` label differs across the current `1.16.0` helm chart version. This PR proposes the unification of it with some additions of `tier` and `component` labels in the missing places.