### PR TITLE
Remove sort indicators on XCom table

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
@@ -43,6 +43,7 @@ const columns: Array<ColumnDef<XComResponse>> = [
         <RouterLink to={`/dags/${original.dag_id}`}>{original.dag_id}</RouterLink>
       </Link>
     ),
+    enableSorting: false,
     header: "Dag",
   },
   {
@@ -54,6 +55,7 @@ const columns: Array<ColumnDef<XComResponse>> = [
         </RouterLink>
       </Link>
     ),
+    enableSorting: false,
     header: "Run Id",
   },
   {
@@ -77,6 +79,7 @@ const columns: Array<ColumnDef<XComResponse>> = [
   },
   {
     accessorKey: "map_index",
+    enableSorting: false,
     header: "Map Index",
   },
   {


### PR DESCRIPTION
related to: https://github.com/apache/airflow/pull/44869#issuecomment-2821024080

XCom endpoint is not yet sortable. Remove the sortable columns in the Xcom table to avoid confusion.


![Screenshot 2025-04-22 at 14 17 07](https://github.com/user-attachments/assets/c3d9df09-5444-4acc-b71e-b0b8d269e508)
