### PR TITLE
tests: Fix OpenLineage VariableTransport's initialization

### DIFF
--- a/providers/openlineage/tests/system/openlineage/conftest.py
+++ b/providers/openlineage/tests/system/openlineage/conftest.py
@@ -30,7 +30,7 @@ def set_transport_variable():
     lm.clear()
     listener = OpenLineageListener()
     listener.adapter._client = listener.adapter.get_or_create_openlineage_client()
-    listener.adapter._client.transport = VariableTransport()
+    listener.adapter._client.transport = VariableTransport({})
     lm.add_listener(listener)
     yield
     lm.clear()

--- a/providers/openlineage/tests/system/openlineage/example_openlineage.json
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage.json
@@ -54,7 +54,6 @@
                         "operator_class_path": "{{ result.endswith('.PythonOperator') }}",
                         "wait_for_downstream": false,
                         "retry_exponential_backoff": false,
-                        "ignore_first_depends_on_past": false,
                         "wait_for_past_depends_before_skipping": false
                     },
                     "taskUuid": "{{ is_uuid(result) }}"
@@ -144,7 +143,6 @@
                         "operator_class_path": "{{ result.endswith('.PythonOperator') }}",
                         "wait_for_downstream": false,
                         "retry_exponential_backoff": false,
-                        "ignore_first_depends_on_past": false,
                         "wait_for_past_depends_before_skipping": false
                     },
                     "taskUuid": "{{ is_uuid(result) }}"

--- a/providers/openlineage/tests/system/openlineage/example_openlineage.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage.py
@@ -29,12 +29,9 @@ def do_nothing():
     pass
 
 
-default_args = {"start_date": datetime(2021, 1, 1), "retries": 1}
-
 # Instantiate the DAG
 with DAG(
     "openlineage_basic_dag",
-    default_args=default_args,
     start_date=datetime(2021, 1, 1),
     schedule=None,
     catchup=False,

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_mapped_sensor.json
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_mapped_sensor.json
@@ -6,7 +6,7 @@
             "runId": "{{ is_uuid(result) }}"
         },
         "job": {
-            "namespace": "default",
+            "namespace": "{{ result is string }}",
             "name": "openlineage_sensor_mapped_tasks_dag.wait_for_10_seconds",
             "facets": {
                 "jobType": {
@@ -24,7 +24,7 @@
             "runId": "{{ is_uuid(result) }}"
         },
         "job": {
-            "namespace": "default",
+            "namespace": "{{ result is string }}",
             "name": "openlineage_sensor_mapped_tasks_dag.wait_for_10_seconds",
             "facets": {
                 "jobType": {
@@ -42,7 +42,7 @@
             "runId": "{{ is_uuid(result) }}"
         },
         "job": {
-            "namespace": "default",
+            "namespace": "{{ result is string }}",
             "name": "openlineage_sensor_mapped_tasks_dag.wait_for_10_seconds",
             "facets": {
                 "jobType": {
@@ -61,7 +61,7 @@
             "runId": "{{ is_uuid(result) }}"
         },
         "job": {
-            "namespace": "default",
+            "namespace": "{{ result is string }}",
             "name": "openlineage_sensor_mapped_tasks_dag.wait_for_10_seconds",
             "facets": {
                 "jobType": {

--- a/providers/openlineage/tests/system/openlineage/operator.py
+++ b/providers/openlineage/tests/system/openlineage/operator.py
@@ -217,11 +217,11 @@ class OpenLineageTestOperator(BaseOperator):
                 self.event_templates[key] = event
         for key, template in self.event_templates.items():  # type: ignore[union-attr]
             send_event = Variable.get(key=key, deserialize_json=True)
+            self.log.info("Events: %s, %s, %s", send_event, len(send_event), type(send_event))
             if len(send_event) == 0:
                 raise ValueError(f"No event for key {key}")
             if len(send_event) != 1 and not self.multiple_events:
                 raise ValueError(f"Expected one event for key {key}, got {len(send_event)}")
-            self.log.info("Events: %s, %s, %s", send_event, len(send_event), type(send_event))
             if not match(template, json.loads(send_event[0]), self.env):
                 raise ValueError("Event received does not match one specified in test")
         if self.delete:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When running OL system tests not with breeze or not within Airflow repo environment, the VariableTransport can be initialized with OpenLineage's Default Transport Factory, that always passes config, so the VariableTransport needs to be adjusted. 

Also added small logging changes, for easier debugging.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
