### PR TITLE
fix bug with showing invalid creds on Login UI

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
@@ -79,7 +79,7 @@ export const Login = () => {
         </Heading>
       </Flex>
 
-      {error === null && <ErrorAlert error={error} />}
+      {Boolean(error) && <ErrorAlert error={error} />}
 
       <Text mb={4}>Enter your username and password below:</Text>
       <LoginForm isPending={isPending} onLogin={onLogin} />


### PR DESCRIPTION
Using Boolean(error) shows the error:
![image](https://github.com/user-attachments/assets/7da6d181-6c7b-48de-974b-b04c65c258d5)
