### PR TITLE
Improve `docs-build` selective checks to include RELEASE_NOTES.rst

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -207,6 +207,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^chart/RELEASE_NOTES\.txt",
             r"^chart/values\.schema\.json",
             r"^chart/values\.json",
+            r"^RELEASE_NOTES\.rst",
         ],
         FileGroupForCi.UI_FILES: [
             r"^airflow-core/src/airflow/ui/",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1157,6 +1157,29 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 id="Run only ui tests for PR with new UI only changes.",
             )
         ),
+        pytest.param(
+            ("RELEASE_NOTES.rst",),
+            {
+                "selected-providers-list-as-string": None,
+                "all-python-versions": "['3.9']",
+                "all-python-versions-list-as-string": "3.9",
+                "python-versions": "['3.9']",
+                "python-versions-list-as-string": "3.9",
+                "ci-image-build": "true",
+                "needs-helm-tests": "false",
+                "run-tests": "false",
+                "run-amazon-tests": "false",
+                "docs-build": "true",
+                "skip-pre-commits": ALL_SKIPPED_COMMITS_ON_NO_CI_IMAGE,
+                "upgrade-to-newer-dependencies": "false",
+                "core-test-types-list-as-strings-in-json": None,
+                "providers-test-types-list-as-strings-in-json": None,
+                "individual-providers-test-types-list-as-strings-in-json": None,
+                "needs-mypy": "false",
+                "mypy-checks": "[]",
+            },
+            id="Run docs-build for RELEASE_NOTES.rst",
+        ),
     ],
 )
 def test_expected_output_pull_request_main(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Saw two occurrences when the selective checks didnt run docs build on two PRs in just two days:

1. https://github.com/apache/airflow/actions/runs/14568615451/job/40861758301 (fixed later by: https://github.com/apache/airflow/pull/49493/files)
2. https://github.com/apache/airflow/pull/49455 (fixed later by https://github.com/apache/airflow/pull/49493/files)


So it is better to catch this sort of thing by running docs-build on RELEASE_NOTES.rst to avoid any such CI failures.




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
