### PR TITLE
Fix AWS auth manager system test

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/tests/test_aws_auth_manager.py
+++ b/providers/amazon/tests/system/amazon/aws/tests/test_aws_auth_manager.py
@@ -136,7 +136,7 @@ def base_app(region_name, avp_policy_store_id):
         with (
             patch.object(OneLogin_Saml2_IdPMetadataParser, "parse_remote") as mock_parse_remote,
             patch(
-                "airflow.providers.amazon.aws.auth_manager.router.login._init_saml_auth"
+                "airflow.providers.amazon.aws.auth_manager.routes.login._init_saml_auth"
             ) as mock_init_saml_auth,
         ):
             mock_parse_remote.return_value = SAML_METADATA_PARSED
@@ -197,12 +197,23 @@ class TestAwsAuthManager:
         for policy_store_id in policy_store_ids:
             client.delete_policy_store(policyStoreId=policy_store_id)
 
-    def test_login_admin(self, client_admin_permissions):
+    def test_login_admin_redirect(self, client_admin_permissions):
         response = client_admin_permissions.post(
-            AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login_callback", follow_redirects=False
+            AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login_callback",
+            follow_redirects=False,
+            data={"RelayState": "login-redirect"},
         )
         token = response.cookies.get(COOKIE_NAME_JWT_TOKEN)
         assert response.status_code == 303
         assert "location" in response.headers
-        assert response.headers["location"] == "/"
+        assert response.headers["location"] == "http://localhost:28080"
         assert token is not None
+
+    def test_login_admin_token(self, client_admin_permissions):
+        response = client_admin_permissions.post(
+            AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login_callback",
+            follow_redirects=False,
+            data={"RelayState": "login-token"},
+        )
+        assert response.status_code == 200
+        assert response.json()["access_token"]


### PR DESCRIPTION
#49419 broke the system test (which I shamefully did not run when working on #49419). This PR fixes the system test.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
