### PR TITLE
Vertically align task log header components in fullscreen mode.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Heading } from "@chakra-ui/react";
+import { Box, Heading, VStack } from "@chakra-ui/react";
 import { useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 
@@ -104,16 +104,18 @@ export const Logs = () => {
       <Dialog.Root onOpenChange={onOpenChange} open={fullscreen} scrollBehavior="inside" size="full">
         <Dialog.Content backdrop>
           <Dialog.Header>
-            <Heading size="xl">{taskId}</Heading>
-            <TaskLogHeader
-              isFullscreen
-              onSelectTryNumber={onSelectTryNumber}
-              taskInstance={taskInstance}
-              toggleFullscreen={toggleFullscreen}
-              toggleWrap={toggleWrap}
-              tryNumber={tryNumber}
-              wrap={wrap}
-            />
+            <VStack gap={2}>
+              <Heading size="xl">{taskId}</Heading>
+              <TaskLogHeader
+                isFullscreen
+                onSelectTryNumber={onSelectTryNumber}
+                taskInstance={taskInstance}
+                toggleFullscreen={toggleFullscreen}
+                toggleWrap={toggleWrap}
+                tryNumber={tryNumber}
+                wrap={wrap}
+              />
+            </VStack>
           </Dialog.Header>
 
           <Dialog.CloseTrigger />


### PR DESCRIPTION
Closes #49416 . Using Box is another way but VStack felt explicit.

Before : 

![image](https://github.com/user-attachments/assets/15d3d416-f426-4d57-a9f0-dd9f043eb44e)

With PR :

![image](https://github.com/user-attachments/assets/7b8364a6-f021-4876-83b1-c48d8e9ab765)
