### PR TITLE
Another attempt to avoid limits for compatibility tests

### DIFF
--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -175,7 +175,7 @@ jobs:
       GITHUB_USERNAME: ${{ github.actor }}
       INCLUDE_NOT_READY_PROVIDERS: "true"
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.compat.python-version }}"
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
+      VERSION_SUFFIX_FOR_PYPI: "post0"
       VERBOSE: "true"
       CLEAN_AIRFLOW_INSTALLATION: "true"
     if: inputs.skip-providers-tests != 'true'

--- a/providers/common/compat/provider.yaml
+++ b/providers/common/compat/provider.yaml
@@ -25,8 +25,6 @@ state: ready
 source-date-epoch: 1743477800
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  # TODO : update it to the right version when we release next wave
-  - 1.7.0
   - 1.6.0
   - 1.5.1
   - 1.5.0

--- a/providers/common/compat/pyproject.toml
+++ b/providers/common/compat/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-common-compat"
-version = "1.7.0"
+version = "1.6.0"
 description = "Provider package apache-airflow-providers-common-compat for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -106,8 +106,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.7.0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.7.0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.6.0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.6.0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/common/compat/src/airflow/providers/common/compat/__init__.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "1.7.0"
+__version__ = "1.6.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.9.0"


### PR DESCRIPTION
The #49562 added a change for common.compat to be usable for compatibility tests. This is another attempt of avoiding to bump the version artifficially

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
