### PR TITLE
Remove extra slash so that the runs tab is selected.

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -96,7 +96,7 @@ export const DagBreadcrumb = () => {
   }
 
   if (runId === undefined && taskId !== undefined) {
-    links.push({ label: "All Runs", title: "Dag Run", value: `/dags/${dagId}/runs/` });
+    links.push({ label: "All Runs", title: "Dag Run", value: `/dags/${dagId}/runs` });
     links.push({ label: task?.task_display_name ?? taskId, title: "Task" });
   }
 


### PR DESCRIPTION
On selecting a task and then selecting "all runs" an extra slash is present due to which the runs tab is not selected in the tab panel in UI though it goes to the runs page.

On main : 

http://localhost:8000/dags/test_asset_and/runs/

After PR 

http://localhost:8000/dags/test_asset_and/runs