### PR TITLE
[1/4] Transition of `get` config command

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -204,7 +204,7 @@ class ConfigOperations(BaseOperations):
     def get(self, section: str, option: str) -> Config | ServerResponseError:
         """Get a config from the API server."""
         try:
-            self.response = self.client.get(f"/section/{section}/option/{option}")
+            self.response = self.client.get(f"/config/section/{section}/option/{option}")
             return Config.model_validate_json(self.response.content)
         except ServerResponseError as e:
             raise e

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -554,11 +554,14 @@ AUTH_COMMANDS = (
     ),
 )
 
-CONFIG_COMMANDS = ActionCommand(
-    name="get-value",
-    help="Get a configuration value",
-    func=lazy_load_command("airflowctl.ctl.commands.config_command.get_value"),
-    args=(ARG_CONFIG_SECTION, ARG_CONFIG_OPTION),
+CONFIG_COMMANDS = (
+    ActionCommand(
+        name="get-value",
+        help="Print the value of the configuration",
+        description="Print the value of the configuration",
+        func=lazy_load_command("airflowctl.ctl.commands.config_command.get_value"),
+        args=(ARG_CONFIG_SECTION, ARG_CONFIG_OPTION),
+    ),
 )
 
 

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -192,6 +192,20 @@ ARG_AUTH_PASSWORD = Arg(
     nargs="?",
 )
 
+# Config arguments
+ARG_CONFIG_SECTION = Arg(
+    flags=("--section",),
+    type=str,
+    dest="section",
+    help="The section of the configuration",
+)
+ARG_CONFIG_OPTION = Arg(
+    flags=("--option",),
+    type=str,
+    dest="option",
+    help="The option of the configuration",
+)
+
 
 class ActionCommand(NamedTuple):
     """Single CLI command."""
@@ -540,6 +554,13 @@ AUTH_COMMANDS = (
     ),
 )
 
+CONFIG_COMMANDS = ActionCommand(
+    name="get-value",
+    help="Get a configuration value",
+    func=lazy_load_command("airflowctl.ctl.commands.config_command.get_value"),
+    args=(ARG_CONFIG_SECTION, ARG_CONFIG_OPTION),
+)
+
 
 core_commands: list[CLICommand] = [
     GroupCommand(
@@ -547,6 +568,11 @@ core_commands: list[CLICommand] = [
         help="Manage authentication for CLI. "
         "Either pass token from environment variable/parameter or pass username and password.",
         subcommands=AUTH_COMMANDS,
+    ),
+    GroupCommand(
+        name="config",
+        help="Perform Config operations",
+        subcommands=CONFIG_COMMANDS,
     ),
 ]
 # Add generated group commands

--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Config sub-commands using API client instead of direct database access."""
+
+from __future__ import annotations
+
+from airflow.exceptions import AirflowConfigException
+from airflowctl.api.client import Client, provide_api_client
+
+
+@provide_api_client
+def show_config(args):
+    """Show current application configuration."""
+    pass
+
+
+@provide_api_client
+def get_value(args, cli_api_client: Client):
+    """Get one value from configuration."""
+    try:
+        response = cli_api_client.configs.get_value(section=args.section, option=args.option)
+        if response and "value" in response:
+            print(response["value"])
+    except AirflowConfigException:
+        pass
+
+
+@provide_api_client
+def lint_config(args) -> None:
+    """Lint the airflow.cfg file for removed, or renamed configurations."""
+    pass
+
+
+@provide_api_client
+def update_config(args) -> None:
+    """Update the airflow.cfg file to migrate configuration changes from Airflow 2.x to Airflow 3."""
+    pass

--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -18,34 +18,34 @@
 
 from __future__ import annotations
 
-from airflow.exceptions import AirflowConfigException
-from airflowctl.api.client import Client, provide_api_client
+from httpx import HTTPStatusError
+
+from airflowctl.api.client import Client, ClientKind, provide_api_client
 
 
-@provide_api_client
+@provide_api_client(kind=ClientKind.CLI)
 def show_config(args):
     """Show current application configuration."""
     pass
 
 
-@provide_api_client
-def get_value(args, cli_api_client: Client):
+@provide_api_client(kind=ClientKind.CLI)
+def get_value(args, api_client: Client):
     """Get one value from configuration."""
     try:
-        response = cli_api_client.configs.get(section=args.section, option=args.option)
-        if response and "value" in response:
-            print(response["value"])
-    except AirflowConfigException:
+        response = api_client.configs.get(section=args.section, option=args.option)
+        print(response.sections[0].options[0].value)
+    except HTTPStatusError:
         pass
 
 
-@provide_api_client
+@provide_api_client(kind=ClientKind.CLI)
 def lint_config(args) -> None:
     """Lint the airflow.cfg file for removed, or renamed configurations."""
     pass
 
 
-@provide_api_client
+@provide_api_client(kind=ClientKind.CLI)
 def update_config(args) -> None:
     """Update the airflow.cfg file to migrate configuration changes from Airflow 2.x to Airflow 3."""
     pass

--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -32,7 +32,7 @@ def show_config(args):
 def get_value(args, cli_api_client: Client):
     """Get one value from configuration."""
     try:
-        response = cli_api_client.configs.get_value(section=args.section, option=args.option)
+        response = cli_api_client.configs.get(section=args.section, option=args.option)
         if response and "value" in response:
             print(response["value"])
     except AirflowConfigException:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -224,7 +224,7 @@ class TestConfigOperations:
         )
 
         def handle_request(request: httpx.Request) -> httpx.Response:
-            assert request.url.path == f"/api/v2/section/{self.section}/option/{self.option}"
+            assert request.url.path == f"/api/v2/config/section/{self.section}/option/{self.option}"
             return httpx.Response(200, json=response_config.model_dump())
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import contextlib
+from io import StringIO
+from unittest import mock
+
+from airflowctl.api.client import Client
+from airflowctl.ctl import cli_config, cli_parser
+
+
+class TestCliConfigGetValue:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = cli_parser.get_parser()
+
+    def test_should_display_value(self):
+        mock_client = mock.MagicMock(spec=Client)
+        mock_client.configs.get_value.return_value = {"value": "test_value"}
+
+        args = self.parser.parse_args(["config", "get-value", "--section", "core", "--option", "test_key"])
+
+        with contextlib.redirect_stdout(StringIO()) as temp_stdout:
+            cli_config.get_value(args, cli_api_client=mock_client)
+
+        assert temp_stdout.getvalue().strip() == "test_value"
+        mock_client.configs.get_value.assert_called_once_with(section="core", option="test_key")
+
+    # def test_should_not_raise_exception_when_section_for_config_with_value_defined_elsewhere_is_missing(self):
+    #     pass
+
+    # def test_should_raise_exception_when_option_is_missing(self):
+    #     pass


### PR DESCRIPTION
partially closes: #45664 
parent issue: #45661 

implements `get-value` config command. unit tests are added.