### PR TITLE
Introduce lower bind to lxml as 5.4.0

### DIFF
--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
     # python3-saml is dependent on xmlsec and seems they do not pin it, pinning here would be needed
     # We can remove it after https://github.com/xmlsec/python-xmlsec/issues/344 is fixed
     "xmlsec!=1.3.15,>=1.3.14",
+    "lxml<5.4.0,>=5.3.2",
     "sagemaker-studio>=1.0.9",
     "marshmallow>=3",
 ]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Recent failure in CI: https://github.com/apache/airflow/actions/runs/14613850677/job/40997825403 is due to:

```
334c334
< google-cloud-aiplatform==1.89.0
---
> google-cloud-aiplatform==1.90.0
356c356
< google-cloud-logging==3.12.0
---
> google-cloud-logging==3.12.1
462c462
< lxml==5.3.2
---
> lxml==5.4.0
490,493c490,493
< mypy-boto3-appflow==1.37.0
< mypy-boto3-rds==1.37.21
< mypy-boto3-redshift-data==1.37.8
< mypy-boto3-s3==1.37.24
---
> mypy-boto3-appflow==1.38.0
> mypy-boto3-rds==1.38.0
> mypy-boto3-redshift-data==1.38.0
> mypy-boto3-s3==1.38.0
```

lxml released a 5.4.0 which doesnt seem to work with 1.3.14 xmlsec. And this is not resolved: https://github.com/xmlsec/python-xmlsec/issues/344 so we cannot even remove the !=1.3.15 on xmlsec.

Hence, trying to fix by adding bounds to `lxml` instead

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
