### PR TITLE
Fix backfill padding bottom

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -116,7 +116,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
 
   return (
     <>
-      <VStack alignItems="stretch" gap={2} pt={4}>
+      <VStack alignItems="stretch" gap={2} mb={4} pt={4}>
         <Box>
           <Text fontSize="md" fontWeight="medium" mb={1}>
             Date Range


### PR DESCRIPTION
At the bottom of the form, the "unpause checkbox" and the `info component` have no space in between. This adds the same margin bottom as the one in the `Trigger Dag Form`.

### Before 
![Screenshot 2025-04-23 at 16 27 48](https://github.com/user-attachments/assets/d733d99c-352b-42ef-9061-9fb622c6b18a)


### After 
![Screenshot 2025-04-23 at 16 27 34](https://github.com/user-attachments/assets/b478b21c-64c7-40c2-a357-ad8d80ec4dcf)
