### PR TITLE
Add backcompat shim for get_current_context

### DIFF
--- a/airflow-core/src/airflow/operators/__init__.py
+++ b/airflow-core/src/airflow/operators/__init__.py
@@ -35,6 +35,7 @@ __deprecated_classes = {
         "ExternalPythonOperator": "airflow.providers.standard.operators.python.ExternalPythonOperator",
         "BranchExternalPythonOperator": "airflow.providers.standard.operators.python.BranchExternalPythonOperator",
         "BranchPythonVirtualenvOperator": "airflow.providers.standard.operators.python.BranchPythonVirtualenvOperator",
+        "get_current_context": "airflow.providers.standard.operators.python.get_current_context",
     },
     "bash":{
         "BashOperator": "airflow.providers.standard.operators.bash.BashOperator",

--- a/airflow-core/src/airflow/operators/__init__.py
+++ b/airflow-core/src/airflow/operators/__init__.py
@@ -35,7 +35,7 @@ __deprecated_classes = {
         "ExternalPythonOperator": "airflow.providers.standard.operators.python.ExternalPythonOperator",
         "BranchExternalPythonOperator": "airflow.providers.standard.operators.python.BranchExternalPythonOperator",
         "BranchPythonVirtualenvOperator": "airflow.providers.standard.operators.python.BranchPythonVirtualenvOperator",
-        "get_current_context": "airflow.providers.standard.operators.python.get_current_context",
+        "get_current_context": "airflow.sdk.get_current_context",
     },
     "bash":{
         "BashOperator": "airflow.providers.standard.operators.bash.BashOperator",

--- a/airflow-core/src/airflow/utils/deprecation_tools.py
+++ b/airflow-core/src/airflow/utils/deprecation_tools.py
@@ -72,6 +72,8 @@ def add_deprecated_classes(
     """
     Add deprecated class PEP-563 imports and warnings modules to the package.
 
+    Side note: It also works for methods, not just classes.
+
     :param module_imports: imports to use
     :param package: package name
     :param override_deprecated_classes: override target classes with deprecated ones. If module +


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


`get_current_context` was historically used from `airflow.operators.python` and the backcompat shim for it didnt exist. Adding the shim so that old dags like that can work.

DAG:

```

def print_hello():
    from airflow.operators.python import get_current_context
    context = get_current_context()
    print(context)
```

Works fine now. 

![image](https://github.com/user-attachments/assets/72b9d413-c449-4ea8-a568-91298d73373f)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
