### PR TITLE
AIP-84: alias `dag_display_name` for `TI`, `TIH`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -55,6 +55,7 @@ class TaskInstanceResponse(BaseModel):
     try_number: int
     max_tries: int
     task_display_name: str
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_run", "dag_model", "dag_display_name"))
     hostname: str | None
     unixname: str | None
     pool: str
@@ -140,6 +141,7 @@ class TaskInstanceHistoryResponse(BaseModel):
     try_number: int
     max_tries: int
     task_display_name: str
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_run", "dag_model", "dag_display_name"))
     hostname: str | None
     unixname: str | None
     pool: str

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -9623,6 +9623,9 @@ components:
         task_display_name:
           type: string
           title: Task Display Name
+        dag_display_name:
+          type: string
+          title: Dag Display Name
         hostname:
           anyOf:
           - type: string
@@ -9696,6 +9699,7 @@ components:
       - try_number
       - max_tries
       - task_display_name
+      - dag_display_name
       - hostname
       - unixname
       - pool
@@ -9768,6 +9772,9 @@ components:
         task_display_name:
           type: string
           title: Task Display Name
+        dag_display_name:
+          type: string
+          title: Dag Display Name
         hostname:
           anyOf:
           - type: string
@@ -9866,6 +9873,7 @@ components:
       - try_number
       - max_tries
       - task_display_name
+      - dag_display_name
       - hostname
       - unixname
       - pool

--- a/airflow-core/src/airflow/models/taskinstancehistory.py
+++ b/airflow-core/src/airflow/models/taskinstancehistory.py
@@ -113,6 +113,13 @@ class TaskInstanceHistory(Base):
         foreign_keys=[dag_version_id],
     )
 
+    dag_run = relationship(
+        "DagRun",
+        primaryjoin="TaskInstanceHistory.run_id == DagRun.run_id",
+        viewonly=True,
+        foreign_keys=[run_id],
+    )
+
     def __init__(
         self,
         ti: TaskInstance,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4098,6 +4098,10 @@ export const $TaskInstanceHistoryResponse = {
       type: "string",
       title: "Task Display Name",
     },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
+    },
     hostname: {
       anyOf: [
         {
@@ -4235,6 +4239,7 @@ export const $TaskInstanceHistoryResponse = {
     "try_number",
     "max_tries",
     "task_display_name",
+    "dag_display_name",
     "hostname",
     "unixname",
     "pool",
@@ -4348,6 +4353,10 @@ export const $TaskInstanceResponse = {
     task_display_name: {
       type: "string",
       title: "Task Display Name",
+    },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
     },
     hostname: {
       anyOf: [
@@ -4536,6 +4545,7 @@ export const $TaskInstanceResponse = {
     "try_number",
     "max_tries",
     "task_display_name",
+    "dag_display_name",
     "hostname",
     "unixname",
     "pool",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1107,6 +1107,7 @@ export type TaskInstanceHistoryResponse = {
   try_number: number;
   max_tries: number;
   task_display_name: string;
+  dag_display_name: string;
   hostname: string | null;
   unixname: string | null;
   pool: string;
@@ -1140,6 +1141,7 @@ export type TaskInstanceResponse = {
   try_number: number;
   max_tries: number;
   task_display_name: string;
+  dag_display_name: string;
   hostname: string | null;
   unixname: string | null;
   pool: string;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -179,6 +179,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         assert response.json() == {
             "dag_id": "example_python_operator",
             "dag_version": None,
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -241,6 +242,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
             "dag_run_id": run_id,
+            "dag_display_name": "dag_with_multiple_versions",
             "map_index": -1,
             "logical_date": mock.ANY,
             "start_date": None,
@@ -308,6 +310,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         assert data == {
             "dag_id": "example_python_operator",
             "dag_version": None,
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -358,6 +361,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         assert response.json() == {
             "dag_id": "example_python_operator",
             "dag_version": None,
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -404,6 +408,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         assert response.json() == {
             "dag_id": "example_python_operator",
             "dag_version": None,
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -507,6 +512,7 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
             assert response.json() == {
                 "dag_id": "example_python_operator",
                 "dag_version": None,
+                "dag_display_name": "example_python_operator",
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
                 "logical_date": "2020-01-01T00:00:00Z",
@@ -1672,6 +1678,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response.status_code == 200
         assert response.json() == {
             "dag_id": "example_python_operator",
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -1707,6 +1714,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response.status_code == 200
         assert response.json() == {
             "dag_id": "example_python_operator",
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -1771,6 +1779,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
 
             assert response.json() == {
                 "dag_id": "example_python_operator",
+                "dag_display_name": "example_python_operator",
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
                 "executor": None,
@@ -1833,6 +1842,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
 
         assert data == {
             "dag_id": "example_python_operator",
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -1869,6 +1879,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
 
         assert response.json() == {
             "dag_id": "example_python_operator",
+            "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -1934,6 +1945,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response.json() == {
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
+            "dag_display_name": "dag_with_multiple_versions",
             "dag_run_id": run_id,
             "map_index": -1,
             "start_date": None,
@@ -2413,6 +2425,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         expected_response = [
             {
                 "dag_id": "example_python_operator",
+                "dag_display_name": "example_python_operator",
                 "dag_version": None,
                 "dag_run_id": "TEST_DAG_RUN_ID_0",
                 "task_id": "print_the_context",
@@ -2760,6 +2773,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "task_instances": [
                 {
                     "dag_id": "example_python_operator",
+                    "dag_display_name": "example_python_operator",
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
                     "executor": None,
@@ -2786,6 +2800,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 },
                 {
                     "dag_id": "example_python_operator",
+                    "dag_display_name": "example_python_operator",
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
                     "executor": None,
@@ -2845,6 +2860,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "task_instances": [
                 {
                     "dag_id": "example_python_operator",
+                    "dag_display_name": "example_python_operator",
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
                     "executor": None,
@@ -2913,6 +2929,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 "task_instances": [
                     {
                         "dag_id": "example_python_operator",
+                        "dag_display_name": "example_python_operator",
                         "duration": 10000.0,
                         "end_date": "2020-01-03T00:00:00Z",
                         "executor": None,
@@ -2939,6 +2956,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     },
                     {
                         "dag_id": "example_python_operator",
+                        "dag_display_name": "example_python_operator",
                         "duration": 10000.0,
                         "end_date": "2020-01-03T00:00:00Z",
                         "executor": None,
@@ -2996,6 +3014,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
         assert response.json()["task_instances"][0] == {
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
+            "dag_display_name": "dag_with_multiple_versions",
             "dag_run_id": run_id,
             "map_index": -1,
             "start_date": None,
@@ -3033,6 +3052,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
     ENDPOINT_URL = "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
     NEW_STATE = "failed"
     DAG_ID = "example_python_operator"
+    DAG_DISPLAY_NAME = "example_python_operator"
     TASK_ID = "print_the_context"
     RUN_ID = "TEST_DAG_RUN_ID"
 
@@ -3091,6 +3111,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == 200
         assert response.json() == {
             "dag_id": self.DAG_ID,
+            "dag_display_name": self.DAG_DISPLAY_NAME,
             "dag_version": None,
             "dag_run_id": self.RUN_ID,
             "logical_date": "2020-01-01T00:00:00Z",
@@ -3307,6 +3328,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 200,
                 {
                     "dag_id": "example_python_operator",
+                    "dag_display_name": "example_python_operator",
                     "dag_version": None,
                     "dag_run_id": "TEST_DAG_RUN_ID",
                     "logical_date": "2020-01-01T00:00:00Z",
@@ -3418,6 +3440,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         response_data = response.json()
         assert response_data == {
             "dag_id": self.DAG_ID,
+            "dag_display_name": self.DAG_DISPLAY_NAME,
             "dag_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
@@ -3463,6 +3486,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         response_data = response.json()
         assert response_data == {
             "dag_id": self.DAG_ID,
+            "dag_display_name": self.DAG_DISPLAY_NAME,
             "dag_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
@@ -3525,6 +3549,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
 
             assert response_data == {
                 "dag_id": self.DAG_ID,
+                "dag_display_name": self.DAG_DISPLAY_NAME,
                 "dag_version": None,
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
@@ -3604,6 +3629,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
     DAG_ID = "example_python_operator"
     TASK_ID = "print_the_context"
     RUN_ID = "TEST_DAG_RUN_ID"
+    DAG_DISPLAY_NAME = "example_python_operator"
 
     @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
     def test_should_call_mocked_api(self, mock_set_ti_state, test_client, session):
@@ -3631,6 +3657,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             "task_instances": [
                 {
                     "dag_id": self.DAG_ID,
+                    "dag_display_name": self.DAG_DISPLAY_NAME,
                     "dag_version": None,
                     "dag_run_id": self.RUN_ID,
                     "logical_date": "2020-01-01T00:00:00Z",
@@ -3872,6 +3899,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                     "task_instances": [
                         {
                             "dag_id": "example_python_operator",
+                            "dag_display_name": "example_python_operator",
                             "dag_version": None,
                             "dag_run_id": "TEST_DAG_RUN_ID",
                             "logical_date": "2020-01-01T00:00:00Z",

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1410,6 +1410,7 @@ class TaskInstanceHistoryResponse(BaseModel):
     try_number: Annotated[int, Field(title="Try Number")]
     max_tries: Annotated[int, Field(title="Max Tries")]
     task_display_name: Annotated[str, Field(title="Task Display Name")]
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
     hostname: Annotated[str | None, Field(title="Hostname")] = None
     unixname: Annotated[str | None, Field(title="Unixname")] = None
     pool: Annotated[str, Field(title="Pool")]
@@ -1444,6 +1445,7 @@ class TaskInstanceResponse(BaseModel):
     try_number: Annotated[int, Field(title="Try Number")]
     max_tries: Annotated[int, Field(title="Max Tries")]
     task_display_name: Annotated[str, Field(title="Task Display Name")]
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
     hostname: Annotated[str | None, Field(title="Hostname")] = None
     unixname: Annotated[str | None, Field(title="Unixname")] = None
     pool: Annotated[str, Field(title="Pool")]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `dag_display_name` in datamodels

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
