### PR TITLE
Display plugin import errors in the UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ErrorAlert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ErrorAlert.tsx
@@ -22,7 +22,7 @@ import type { HTTPExceptionResponse, HTTPValidationError } from "openapi-gen/req
 
 import { Alert } from "./ui";
 
-type ExpandedApiError = {
+export type ExpandedApiError = {
   body: HTTPExceptionResponse | HTTPValidationError | undefined;
 } & ApiError;
 

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 import { Box, Text, Button, useDisclosure, Skeleton } from "@chakra-ui/react";
-import { AiOutlineApi } from "react-icons/ai";
 import { FiChevronRight } from "react-icons/fi";
+import { LuPlug } from "react-icons/lu";
 
 import { usePluginServiceImportErrors } from "openapi/queries";
 import { ErrorAlert } from "src/components/ErrorAlert";
@@ -52,7 +52,7 @@ export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: b
               onClick={onOpen}
               title={pluralize("Plugin Import Error", importErrorsCount)}
             >
-              <AiOutlineApi size="0.5rem" />
+              <LuPlug size="0.5rem" />
               {importErrorsCount}
             </StateBadge>
           ) : (
@@ -65,7 +65,7 @@ export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: b
               variant="outline"
             >
               <StateBadge colorPalette="failed">
-                <AiOutlineApi />
+                <LuPlug />
                 {importErrorsCount}
               </StateBadge>
               <Box alignItems="center" display="flex" gap={1}>

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
@@ -21,7 +21,7 @@ import { FiChevronRight } from "react-icons/fi";
 import { LuPlug } from "react-icons/lu";
 
 import { usePluginServiceImportErrors } from "openapi/queries";
-import { ErrorAlert } from "src/components/ErrorAlert";
+import { ErrorAlert, type ExpandedApiError } from "src/components/ErrorAlert";
 import { StateBadge } from "src/components/StateBadge";
 import { pluralize } from "src/utils";
 
@@ -37,6 +37,10 @@ export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: b
 
   if (isLoading) {
     return <Skeleton height="9" width="225px" />;
+  }
+
+  if ((error as ExpandedApiError).status === 403) {
+    return undefined;
   }
 
   return (

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
@@ -1,0 +1,82 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Text, Button, useDisclosure, Skeleton } from "@chakra-ui/react";
+import { AiOutlineApi } from "react-icons/ai";
+import { FiChevronRight } from "react-icons/fi";
+
+import { usePluginServiceImportErrors } from "openapi/queries";
+import { ErrorAlert } from "src/components/ErrorAlert";
+import { StateBadge } from "src/components/StateBadge";
+import { pluralize } from "src/utils";
+
+import { PluginImportErrorsModal } from "./PluginImportErrorsModal";
+
+export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: boolean }) => {
+  const { onClose, onOpen, open } = useDisclosure();
+
+  const { data, error, isLoading } = usePluginServiceImportErrors();
+
+  const importErrorsCount = data?.total_entries ?? 0;
+  const importErrors = data?.import_errors ?? [];
+
+  if (isLoading) {
+    return <Skeleton height="9" width="225px" />;
+  }
+
+  return (
+    <Box alignItems="center" display="flex" maxH="10px">
+      <ErrorAlert error={error} />
+      {importErrorsCount > 0 && (
+        <>
+          {iconOnly ? (
+            <StateBadge
+              as={Button}
+              colorPalette="failed"
+              height={7}
+              onClick={onOpen}
+              title={pluralize("Plugin Import Error", importErrorsCount)}
+            >
+              <AiOutlineApi size="0.5rem" />
+              {importErrorsCount}
+            </StateBadge>
+          ) : (
+            <Button
+              alignItems="center"
+              borderRadius="md"
+              display="flex"
+              gap={2}
+              onClick={onOpen}
+              variant="outline"
+            >
+              <StateBadge colorPalette="failed">
+                <AiOutlineApi />
+                {importErrorsCount}
+              </StateBadge>
+              <Box alignItems="center" display="flex" gap={1}>
+                <Text fontWeight="bold">Plugin Import Errors</Text>
+                <FiChevronRight />
+              </Box>
+            </Button>
+          )}
+          <PluginImportErrorsModal importErrors={importErrors} onClose={onClose} open={open} />
+        </>
+      )}
+    </Box>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrorsModal.tsx
@@ -1,0 +1,115 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Heading, Text, HStack, Input } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { LuFileWarning } from "react-icons/lu";
+import { PiFilePy } from "react-icons/pi";
+
+import type { PluginImportErrorResponse } from "openapi/requests/types.gen";
+import { Accordion, Dialog } from "src/components/ui";
+import { Pagination } from "src/components/ui/Pagination";
+
+type PluginImportErrorsModalProps = {
+  importErrors: Array<PluginImportErrorResponse>;
+  onClose: () => void;
+  open: boolean;
+};
+
+const PAGE_LIMIT = 15;
+
+export const PluginImportErrorsModal: React.FC<PluginImportErrorsModalProps> = ({
+  importErrors,
+  onClose,
+  open,
+}) => {
+  const [page, setPage] = useState(1);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [filteredErrors, setFilteredErrors] = useState(importErrors);
+
+  const startRange = (page - 1) * PAGE_LIMIT;
+  const endRange = startRange + PAGE_LIMIT;
+  const visibleItems = filteredErrors.slice(startRange, endRange);
+
+  const onOpenChange = () => {
+    setSearchQuery("");
+    setPage(1);
+    onClose();
+  };
+
+  useEffect(() => {
+    const query = searchQuery.toLowerCase();
+    const filtered = importErrors.filter((error) => error.source.toLowerCase().includes(query));
+
+    setFilteredErrors(filtered);
+    setPage(1);
+  }, [searchQuery, importErrors]);
+
+  return (
+    <Dialog.Root onOpenChange={onOpenChange} open={open} scrollBehavior="inside" size="xl">
+      <Dialog.Content backdrop>
+        <Dialog.Header>
+          <HStack fontSize="xl">
+            <LuFileWarning />
+            <Heading>Plugin Import Errors</Heading>
+          </HStack>
+          <Input
+            mt={4}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search by file"
+            value={searchQuery}
+          />
+        </Dialog.Header>
+
+        <Dialog.CloseTrigger />
+
+        <Dialog.Body>
+          <Accordion.Root collapsible multiple size="md" variant="enclosed">
+            {visibleItems.map((importError) => (
+              <Accordion.Item key={importError.error} value={importError.source}>
+                <Accordion.ItemTrigger cursor="pointer">
+                  <PiFilePy />
+                  {importError.source}
+                </Accordion.ItemTrigger>
+                <Accordion.ItemContent>
+                  <Text color="fg.error" fontSize="sm" whiteSpace="pre-wrap">
+                    <code>{importError.error}</code>
+                  </Text>
+                </Accordion.ItemContent>
+              </Accordion.Item>
+            ))}
+          </Accordion.Root>
+        </Dialog.Body>
+
+        <Pagination.Root
+          count={filteredErrors.length}
+          onPageChange={(event) => setPage(event.page)}
+          p={4}
+          page={page}
+          pageSize={PAGE_LIMIT}
+        >
+          <HStack>
+            <Pagination.PrevTrigger />
+            <Pagination.Items />
+            <Pagination.NextTrigger />
+          </HStack>
+        </Pagination.Root>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
@@ -22,6 +22,7 @@ import { FiClipboard, FiZap } from "react-icons/fi";
 import { useDagServiceGetDags } from "openapi/queries";
 
 import { DAGImportErrors } from "./DAGImportErrors";
+import { PluginImportErrors } from "./PluginImportErrors";
 import { StatsCard } from "./StatsCard";
 
 export const Stats = () => {
@@ -66,6 +67,8 @@ export const Stats = () => {
         />
 
         <DAGImportErrors />
+
+        <PluginImportErrors />
 
         {queuedDagsCount > 0 ? (
           <StatsCard

--- a/airflow-core/src/airflow/ui/src/pages/Plugins.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Plugins.tsx
@@ -16,13 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Heading } from "@chakra-ui/react";
+import { Box, Heading, HStack } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { usePluginServiceGetPlugins } from "openapi/queries";
 import type { PluginResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { ErrorAlert } from "src/components/ErrorAlert";
+
+import { PluginImportErrors } from "./Dashboard/Stats/PluginImportErrors";
 
 const columns: Array<ColumnDef<PluginResponse>> = [
   {
@@ -42,7 +44,10 @@ export const Plugins = () => {
 
   return (
     <Box p={2}>
-      <Heading>Plugins</Heading>
+      <HStack>
+        <Heading>Plugins</Heading>
+        <PluginImportErrors iconOnly />
+      </HStack>
       <DataTable
         columns={columns}
         data={data?.plugins ?? []}


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/48994

Depends on https://github.com/apache/airflow/pull/49436

I plan a follow up PR to re-organize files and factorize code between the DagImportErrors and PluginImportErrors.

![Screenshot 2025-04-23 at 19 58 10](https://github.com/user-attachments/assets/dc8809d4-99b4-4e89-882f-812207848831)
![Screenshot 2025-04-23 at 19 58 18](https://github.com/user-attachments/assets/e20d0080-40e1-49f8-b9e9-b9a88c41aeb4)
![Screenshot 2025-04-23 at 20 04 42](https://github.com/user-attachments/assets/cbc5d881-9cae-4b87-9453-0789668eeb10)

