### PR TITLE
Fix Dag Code text selection bg

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -131,10 +131,13 @@ export const Code = () => {
       {/* We want to show an empty state on 404 instead of an error */}
       <ErrorAlert error={error ?? (codeError?.status === 404 ? undefined : codeError)} />
       <ProgressBar size="xs" visibility={isLoading || isCodeLoading ? "visible" : "hidden"} />
-      <div
-        style={{
-          fontSize: "14px",
+      <Box
+        css={{
+          "& *::selection": {
+            bg: "gray.emphasized",
+          },
         }}
+        fontSize="14px"
       >
         <SyntaxHighlighter
           language="python"
@@ -179,7 +182,7 @@ export const Code = () => {
         >
           {codeError?.status === 404 && !Boolean(code?.content) ? "No Code Found" : (code?.content ?? "")}
         </SyntaxHighlighter>
-      </div>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/49582

Dark:
<img width="674" alt="Screenshot 2025-04-23 at 2 55 13 PM" src="https://github.com/user-attachments/assets/223e4434-e175-4b34-acb2-919d3cd51286" />

Light:
<img width="755" alt="Screenshot 2025-04-23 at 2 55 17 PM" src="https://github.com/user-attachments/assets/b330431c-9624-4a38-b355-bc624608d618" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
