### PR TITLE
Fix timezone setting for logical date input on Trigger Run form

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -18,10 +18,13 @@
  */
 import { Input, Button, Box, Spacer, HStack, Field, Stack } from "@chakra-ui/react";
 import dayjs from "dayjs";
+import tz from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { useEffect, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { FiPlay } from "react-icons/fi";
 
+import { useTimezone } from "src/context/timezone";
 import { useDagParams } from "src/queries/useDagParams";
 import { useParamStore } from "src/queries/useParamStore";
 import { useTogglePause } from "src/queries/useTogglePause";
@@ -33,6 +36,9 @@ import { JsonEditor } from "../JsonEditor";
 import { Accordion } from "../ui";
 import { Checkbox } from "../ui/Checkbox";
 import EditableMarkdown from "./EditableMarkdown";
+
+dayjs.extend(utc);
+dayjs.extend(tz);
 
 type TriggerDAGFormProps = {
   readonly dagId: string;
@@ -51,6 +57,7 @@ export type DagRunTriggerParams = {
 const TriggerDAGForm = ({ dagId, isPaused, onClose, open }: TriggerDAGFormProps) => {
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const initialParamsDict = useDagParams(dagId, open);
+  const { selectedTimezone } = useTimezone();
   const { error: errorTrigger, isPending, triggerDagRun } = useTrigger({ dagId, onSuccessConfirm: onClose });
   const { conf, setConf } = useParamStore();
   const [unpause, setUnpause] = useState(true);
@@ -61,8 +68,8 @@ const TriggerDAGForm = ({ dagId, isPaused, onClose, open }: TriggerDAGFormProps)
     defaultValues: {
       conf,
       dagRunId: "",
-      // Default logical date to now
-      logicalDate: dayjs().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+      // Default logical date to now, show it in the selected timezone
+      logicalDate: dayjs().tz(selectedTimezone).format("YYYY-MM-DDTHH:mm:ss.SSS"),
       note: "",
     },
   });
@@ -83,7 +90,10 @@ const TriggerDAGForm = ({ dagId, isPaused, onClose, open }: TriggerDAGFormProps)
         },
       });
     }
-    triggerDagRun(data);
+    triggerDagRun({
+      ...data,
+      logicalDate: dayjs(data.logicalDate).tz(selectedTimezone, true).toISOString(),
+    });
   };
 
   const validateAndPrettifyJson = (value: string) => {

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -20,6 +20,7 @@ import { useDisclosure } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
+import { useState } from "react";
 import { FiClock, FiGrid, FiLogOut, FiMoon, FiSun, FiUser } from "react-icons/fi";
 import { MdOutlineAccountTree } from "react-icons/md";
 import { useLocalStorage } from "usehooks-ts";
@@ -42,8 +43,10 @@ export const UserSettingsButton = () => {
   const { selectedTimezone } = useTimezone();
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">("default_dag_view", "grid");
 
+  const [time, setTime] = useState(dayjs());
+
   return (
-    <Menu.Root positioning={{ placement: "right" }}>
+    <Menu.Root onOpenChange={() => setTime(dayjs())} positioning={{ placement: "right" }}>
       <Menu.Trigger asChild>
         <NavButton icon={<FiUser size="1.75rem" />} title="User" />
       </Menu.Trigger>
@@ -79,7 +82,7 @@ export const UserSettingsButton = () => {
         </Menu.Item>
         <Menu.Item onClick={onOpenTimezone} value="timezone">
           <FiClock size="1.25rem" style={{ marginRight: "8px" }} />
-          {dayjs().tz(selectedTimezone).format("HH:mm z (Z)")}
+          {dayjs(time).tz(selectedTimezone).format("HH:mm z (Z)")}
         </Menu.Item>
         <Menu.Item onClick={onOpenLogout} value="logout">
           <FiLogOut size="1.25rem" style={{ marginRight: "8px" }} />


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/49542

Make sure to show the logical date input in the user-selected timezone and then that time be properly sent to the API.

How to test:
- Set your timezone to something other than your default region
- Open the trigger dag run modal
- See the default logical date time match your selected timezone
- Submit
- See the dag run start immediately



Also, made sure the time we show in the User Settings is always up-to-date

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
