### PR TITLE
Remove the "dev0" usage from the CI

### DIFF
--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -116,7 +116,6 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       DEFAULT_BRANCH: ${{ inputs.branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ inputs.constraints-branch }}
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
       GITHUB_REPOSITORY: ${{ github.repository }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -429,7 +429,7 @@ jobs:
       - name: "Generate airflow python client"
         run: >
           breeze release-management prepare-python-client --distribution-format both
-          --version-suffix-for-pypi dev0 --python-client-repo ./airflow-client-python
+          --python-client-repo ./airflow-client-python
       - name: "Show diff"
         run: git diff --color HEAD
         working-directory: ./airflow-client-python

--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -59,7 +59,6 @@ jobs:
       INCLUDE_SUCCESS_OUTPUTS: "true"
       PYTHON_VERSIONS: ${{ inputs.python-versions-list-as-string }}
       VERBOSE: "true"
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
     steps:
       - name: "Cleanup repo"
         shell: bash
@@ -107,19 +106,16 @@ jobs:
           CHICKEN_EGG_PROVIDERS: ${{ inputs.chicken-egg-providers }}
         run: >
           breeze release-management prepare-provider-distributions --include-not-ready-providers
-          --distribution-format wheel --version-suffix-for-pypi dev0
-          ${CHICKEN_EGG_PROVIDERS}
+          --distribution-format wheel ${CHICKEN_EGG_PROVIDERS}
         if: inputs.chicken-egg-providers != ''
       - name: "Prepare airflow distributions"
         shell: bash
         run: >
-          breeze release-management prepare-airflow-distributions
-          --distribution-format wheel --version-suffix-for-pypi dev0
+          breeze release-management prepare-airflow-distributions --distribution-format wheel
       - name: "Prepare task-sdk distribution"
         shell: bash
         run: >
-          breeze release-management prepare-task-sdk-distributions
-          --distribution-format wheel --version-suffix-for-pypi dev0
+          breeze release-management prepare-task-sdk-distributions --distribution-format wheel
       - name: "PyPI constraints"
         shell: bash
         timeout-minutes: 25

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -126,7 +126,6 @@ jobs:
     if: inputs.prod-image-build == 'true'
     env:
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
-      VERSION_SUFFIX_FOR_PYPI: ${{ inputs.branch == 'main' && 'dev0' || '' }}
     steps:
       - name: "Cleanup repo"
         shell: bash
@@ -153,7 +152,7 @@ jobs:
         run: >
           breeze release-management prepare-provider-distributions
           --distributions-list-file ./prod_image_installed_providers.txt
-          --distribution-format wheel --include-not-ready-providers
+          --distribution-format wheel --include-not-ready-providers --skip-tag-check
         if: >
           inputs.upload-package-artifact == 'true' &&
           inputs.build-provider-distributions == 'true'
@@ -206,7 +205,6 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
       DEFAULT_BRANCH: ${{ inputs.branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ inputs.constraints-branch }}
-      VERSION_SUFFIX_FOR_PYPI: ${{ inputs.branch == 'main' && 'dev0' || '' }}
       INCLUDE_NOT_READY_PROVIDERS: "true"
       # You can override CONSTRAINTS_GITHUB_REPOSITORY by setting secret in your repo but by default the
       # Airflow one is going to be used

--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -116,7 +116,6 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python }}"
       UPGRADE_TO_NEWER_DEPENDENCIES: "false"
       VERBOSE: "true"
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
     steps:
       - name: "Cleanup repo"
         shell: bash
@@ -191,7 +190,6 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python }}"
       UPGRADE_TO_NEWER_DEPENDENCIES: "false"
       VERBOSE: "true"
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
     if: inputs.include-prod-images == 'true'
     steps:
       - name: "Cleanup repo"

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -153,8 +153,7 @@ jobs:
           CHICKEN_EGG_PROVIDERS: ${{ needs.build-info.outputs.chicken-egg-providers }}
         run: >
           breeze release-management prepare-provider-distributions
-          --distribution-format wheel
-          --version-suffix-for-pypi rc1 ${CHICKEN_EGG_PROVIDERS}
+          --distribution-format wheel ${CHICKEN_EGG_PROVIDERS}
         if: needs.build-info.outputs.chicken-egg-providers != ''
       - name: "Copy dist packages to docker-context files"
         shell: bash

--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -104,14 +104,14 @@ jobs:
       - name: "Prepare provider distributions: ${{ matrix.package-format }}"
         run: >
           breeze release-management prepare-provider-distributions --include-not-ready-providers
-          --version-suffix-for-pypi dev0 --distribution-format ${{ matrix.package-format }}
+          --skip-tag-check --distribution-format ${{ matrix.package-format }}
       - name: "Prepare airflow package: ${{ matrix.package-format }}"
         run: >
-          breeze release-management prepare-airflow-distributions --version-suffix-for-pypi dev0
+          breeze release-management prepare-airflow-distributions
           --distribution-format ${{ matrix.package-format }}
       - name: "Prepare task-sdk package: ${{ matrix.package-format }}"
         run: >
-          breeze release-management prepare-task-sdk-distributions --version-suffix-for-pypi dev0
+          breeze release-management prepare-task-sdk-distributions
           --distribution-format ${{ matrix.package-format }}
       - name: "Verify ${{ matrix.package-format }} packages with twine"
         run: |
@@ -175,7 +175,6 @@ jobs:
       GITHUB_USERNAME: ${{ github.actor }}
       INCLUDE_NOT_READY_PROVIDERS: "true"
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.compat.python-version }}"
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
       VERBOSE: "true"
       CLEAN_AIRFLOW_INSTALLATION: "true"
     if: inputs.skip-providers-tests != 'true'
@@ -198,7 +197,7 @@ jobs:
       - name: "Prepare provider distributions: wheel"
         run: >
           breeze release-management prepare-provider-distributions --include-not-ready-providers
-          --distribution-format wheel
+          --distribution-format wheel --skip-tag-check
       # yamllint disable rule:line-length
       - name: Remove incompatible Airflow ${{ matrix.compat.airflow-version }}:Python ${{ matrix.compat.python-version }} provider distributions
         env:

--- a/contributing-docs/testing/python_client_tests.rst
+++ b/contributing-docs/testing/python_client_tests.rst
@@ -44,4 +44,4 @@ To build the package, you can run the following command:
 .. code-block:: bash
 
     breeze release-management prepare-python-client --distribution-format both
-          --version-suffix-for-pypi dev0 --python-client-repo ./airflow-client-python
+          --python-client-repo ./airflow-client-python

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1175,7 +1175,7 @@ Herr id how to reproduce it.
 
    rm dist/*
    breeze release-management prepare-provider-distributions --include-not-ready-providers \
-      --version-suffix-for-pypi dev0 --distribution-format wheel
+      --skip-tag-check --distribution-format wheel
 
 3. Prepare provider constraints
 
@@ -1225,7 +1225,7 @@ Rebuilding single provider package can be done using this command:
 .. code-block:: bash
 
   breeze release-management prepare-provider-distributions \
-    --version-suffix-for-pypi dev0 --distribution-format wheel <provider>
+    --skip-tag-check --distribution-format wheel <provider>
 
 Lowest direct dependency resolution tests
 -----------------------------------------

--- a/dev/breeze/doc/05_test_commands.rst
+++ b/dev/breeze/doc/05_test_commands.rst
@@ -247,7 +247,7 @@ To package the client, clone the airflow-python-client repository and run the fo
 .. code-block:: bash
 
    breeze release-management prepare-python-client --distribution-format both
-          --version-suffix-for-pypi dev0 --python-client-repo ./airflow-client-python
+          --python-client-repo ./airflow-client-python
 
 .. code-block:: bash
 

--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -41,9 +41,9 @@ done
 #breeze release-management prepare-provider-distributions \
 #    --distributions-list-file ./prod_image_installed_providers.txt \
 #    --distribution-format wheel \
-#    --version-suffix-for-pypi dev0
+#    --skip-tag-check
 #
-##breeze release-management prepare-airflow-distributions --distribution-format wheel --version-suffix-for-pypi dev0
+##breeze release-management prepare-airflow-distributions --distribution-format wheel --skip-tag-check
 #
 #mv -v ./dist/*.whl ./docker-context-files && chmod a+r ./docker-context-files/*
 #


### PR DESCRIPTION
When we are building providers and airflow-core/task-sdk in our CI, we stop using `.dev0` suffix - instead, when needed we use the `--skip-tag-check` when building the providers - which should eventually automatically handle building chicken-egg providers without having to spcify and configuring them.

We want to first to make it work now without removing the "chicken-egg" provider configuration. But the next step will be using the feature where the chicken-egg providers configuration will be removed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
