### PR TITLE
Show backfill banner after creating a new backfill

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Box, HStack, Spacer, Text, type ButtonProps } from "@chakra-ui/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { MdPause, MdPlayArrow, MdStop } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 
@@ -27,7 +28,6 @@ import {
   useBackfillServicePauseBackfill,
   useBackfillServiceUnpauseBackfill,
 } from "openapi/queries";
-import { queryClient } from "src/queryClient";
 
 import Time from "../Time";
 import { Button, ProgressBar } from "../ui";
@@ -45,17 +45,18 @@ const buttonProps = {
   variant: "outline",
 } satisfies ButtonProps;
 
-const onSuccess = async () => {
-  await queryClient.invalidateQueries({
-    queryKey: [useBackfillServiceListBackfills1Key],
-  });
-};
-
 const BackfillBanner = ({ dagId }: Props) => {
   const { data, isLoading } = useBackfillServiceListBackfills1({
     dagId,
   });
   const [backfill] = data?.backfills.filter((bf) => bf.completed_at === null) ?? [];
+
+  const queryClient = useQueryClient();
+  const onSuccess = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: [useBackfillServiceListBackfills1Key],
+    });
+  };
 
   const { isPending: isPausePending, mutate: pauseMutate } = useBackfillServicePauseBackfill({ onSuccess });
   const { isPending: isUnPausePending, mutate: unpauseMutate } = useBackfillServiceUnpauseBackfill({

--- a/airflow-core/src/airflow/ui/src/main.tsx
+++ b/airflow-core/src/airflow/ui/src/main.tsx
@@ -28,7 +28,7 @@ import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
 
-import { queryClient } from "./queryClient";
+import { client } from "./queryClient";
 import { system } from "./theme";
 import { clearToken, tokenHandler } from "./utils/tokenHandler";
 
@@ -65,7 +65,7 @@ createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>
     <ChakraProvider value={system}>
       <ColorModeProvider>
-        <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={client}>
           <TimezoneProvider>
             <RouterProvider router={router} />
           </TimezoneProvider>

--- a/airflow-core/src/airflow/ui/src/queries/useCreateBackfill.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useCreateBackfill.ts
@@ -16,20 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { useBackfillServiceCreateBackfill, useBackfillServiceListBackfillsKey } from "openapi/queries";
+import { useBackfillServiceCreateBackfill, useBackfillServiceListBackfills1Key } from "openapi/queries";
 import type { CreateBackfillData } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
-import { queryClient } from "src/queryClient";
 
 export const useCreateBackfill = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
   const [dateValidationError, setDateValidationError] = useState<unknown>(undefined);
   const [error, setError] = useState<unknown>(undefined);
+  const queryClient = useQueryClient();
 
   const onSuccess = async () => {
     await queryClient.invalidateQueries({
-      queryKey: [useBackfillServiceListBackfillsKey],
+      queryKey: [useBackfillServiceListBackfills1Key],
     });
     toaster.create({
       description: "Backfill jobs have been successfully triggered.",

--- a/airflow-core/src/airflow/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.ts
@@ -26,7 +26,7 @@ if (OpenAPI.BASE.endsWith("/")) {
   OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
 }
 
-export const queryClient = new QueryClient({
+export const client = new QueryClient({
   defaultOptions: {
     mutations: {
       retry: 1,

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -54,7 +54,7 @@ import { XCom } from "src/pages/XCom";
 
 import { Configs } from "./pages/Configs";
 import { Security } from "./pages/Security";
-import { queryClient } from "./queryClient";
+import { client } from "./queryClient";
 
 const taskInstanceRoutes = [
   { element: <Logs />, index: true },
@@ -193,7 +193,7 @@ export const routerConfig = [
     ),
     // Use react router loader to ensure we have the config before any other requests are made
     loader: async () => {
-      const data = await queryClient.ensureQueryData(
+      const data = await client.ensureQueryData(
         queryOptions({
           queryFn: ConfigService.getConfigs,
           queryKey: UseConfigServiceGetConfigsKeyFn(),


### PR DESCRIPTION
We weren't invalidating the correct queries and therefore the backfill banner wasn't showing up when a user Ran a new Backfill.

We should also access queryClient through `useQueryClient()`. So we renamed our client default values variable too

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
