### PR TITLE
Remove old dynamic attr accessing re dag resource in FAB provider

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -921,15 +921,14 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         dags = dagbag.dags.values()
 
         for dag in dags:
-            root_dag_id = dag.dag_id
             for resource_name, resource_values in self.RESOURCE_DETAILS_MAP.items():
-                dag_resource_name = self._resource_name(root_dag_id, resource_name)
+                dag_resource_name = permissions.resource_name(dag.dag_id, resource_name)
                 for action_name in resource_values["actions"]:
                     if (action_name, dag_resource_name) not in perms:
                         self._merge_perm(action_name, dag_resource_name)
 
             if dag.access_control is not None:
-                self.sync_perm_for_dag(root_dag_id, dag.access_control)
+                self.sync_perm_for_dag(dag.dag_id, dag.access_control)
 
     def sync_perm_for_dag(
         self,
@@ -949,7 +948,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         :return:
         """
         for resource_name, resource_values in self.RESOURCE_DETAILS_MAP.items():
-            dag_resource_name = self._resource_name(dag_id, resource_name)
+            dag_resource_name = permissions.resource_name(dag_id, resource_name)
             for dag_action_name in resource_values["actions"]:
                 self.create_permission(dag_action_name, dag_resource_name)
 
@@ -961,17 +960,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 "Not syncing DAG-level permissions for DAG '%s' as access control is unset.",
                 dag_id,
             )
-
-    def _resource_name(self, dag_id: str, resource_name: str) -> str:
-        """
-        Get the resource name from permissions.
-
-        This method is to keep compatibility with new FAB versions
-        running with old airflow versions.
-        """
-        if hasattr(permissions, "resource_name"):
-            return getattr(permissions, "resource_name")(dag_id, resource_name)
-        return getattr(permissions, "resource_name_for_dag")(dag_id)
 
     def _sync_dag_view_permissions(
         self,
@@ -1000,7 +988,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         # Revoking stale permissions for all possible DAG level resources
         for resource_name in self.RESOURCE_DETAILS_MAP.keys():
-            dag_resource_name = self._resource_name(dag_id, resource_name)
+            dag_resource_name = permissions.resource_name(dag_id, resource_name)
             if resource := self.get_resource(dag_resource_name):
                 existing_dag_perms = self.get_resource_permissions(resource)
                 for perm in existing_dag_perms:
@@ -1043,7 +1031,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                         f"The set of valid resource names is: {self.RESOURCE_DETAILS_MAP.keys()}"
                     )
 
-                dag_resource_name = self._resource_name(dag_id, resource_name)
+                dag_resource_name = permissions.resource_name(dag_id, resource_name)
                 self.log.debug("Syncing DAG-level permissions for DAG '%s'", dag_resource_name)
 
                 invalid_actions = set(actions) - self.RESOURCE_DETAILS_MAP[resource_name]["actions"]

--- a/providers/fab/src/airflow/providers/fab/www/security/permissions.py
+++ b/providers/fab/src/airflow/providers/fab/www/security/permissions.py
@@ -101,16 +101,3 @@ def resource_name(root_dag_id: str, resource: str) -> str:
     if root_dag_id.startswith(tuple(PREFIX_RESOURCES_MAP.keys())):
         return root_dag_id
     return f"{RESOURCE_DETAILS_MAP[resource]['prefix']}{root_dag_id}"
-
-
-def resource_name_for_dag(root_dag_id: str) -> str:
-    """
-    Return the resource name for a DAG id.
-
-    Note: This function is kept for backwards compatibility.
-    """
-    if root_dag_id == RESOURCE_DAG:
-        return root_dag_id
-    if root_dag_id.startswith(RESOURCE_DAG_PREFIX):
-        return root_dag_id
-    return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"


### PR DESCRIPTION
This looks like it used to be a backcompat thing.  But now the permissons module is included in fab provider, so the `if getattr` logic always evaluates true.  So the else block does nothing.  So we can remove it and remove this `_resource_name` helper.  Additionally, I remove some `root_dag_id` logic that is also obsolete, since min provider version for fab is 3.0.0.
