### PR TITLE
Add link to tag to filter dags associated with the tag.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -16,25 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text, HStack } from "@chakra-ui/react";
+import { Box, Text, HStack, StackSeparator } from "@chakra-ui/react";
 import React, { type ReactNode } from "react";
 
 import { Tooltip } from "./ui";
 
 type ListProps = {
   readonly icon?: ReactNode;
+  readonly interactive?: boolean;
   readonly items: Array<ReactNode | string>;
   readonly maxItems?: number;
   readonly separator?: string;
 };
 
-export const LimitedItemsList = ({ icon, items, maxItems, separator = ", " }: ListProps) => {
+export const LimitedItemsList = ({
+  icon,
+  interactive = false,
+  items,
+  maxItems,
+  separator = ", ",
+}: ListProps) => {
   const shouldTruncate = maxItems !== undefined && items.length > maxItems;
   const displayItems = shouldTruncate ? items.slice(0, maxItems) : items;
   const remainingItems = shouldTruncate ? items.slice(maxItems) : [];
-  const remainingItemsList = remainingItems
-    .map((item) => (typeof item === "string" ? item : "item"))
-    .join(", ");
+  const remainingItemsList = interactive ? (
+    <HStack separator={<StackSeparator />}>{remainingItems}</HStack>
+  ) : (
+    `More items: ${remainingItems.map((item) => (typeof item === "string" ? item : "item")).join(", ")}`
+  );
 
   if (!items.length) {
     return undefined;
@@ -57,9 +66,9 @@ export const LimitedItemsList = ({ icon, items, maxItems, separator = ", " }: Li
           remainingItems.length === 1 ? (
             <Text as="span">{remainingItems[0]}</Text>
           ) : (
-            <Tooltip content={`More items: ${remainingItemsList}`}>
+            <Tooltip content={remainingItemsList} interactive={interactive}>
               <Text as="span" cursor="help">
-                , +{remainingItems.length} more
+                +{remainingItems.length} more
               </Text>
             </Tooltip>
           )

--- a/airflow-core/src/airflow/ui/src/pages/Dag/DagHeader.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/DagHeader.test.tsx
@@ -24,7 +24,7 @@ import { afterEach, describe, it, expect, beforeAll, afterAll } from "vitest";
 import type { DAGDetailsResponse } from "openapi/requests/types.gen";
 import { handlers } from "src/mocks/handlers";
 import { MOCK_DAG } from "src/mocks/handlers/dag";
-import { BaseWrapper } from "src/utils/Wrapper";
+import { Wrapper } from "src/utils/Wrapper";
 
 import { Header } from "./Header";
 
@@ -41,9 +41,9 @@ afterAll(() => server.close());
 describe("Dag Documentation Modal", () => {
   it("Display documentation button when doc_md is present", async () => {
     render(
-      <BaseWrapper>
+      <Wrapper>
         <Header dag={MOCK_DAG as unknown as DAGDetailsResponse} />
-      </BaseWrapper>,
+      </Wrapper>,
     );
 
     await waitFor(() => expect(screen.getByTestId("markdown-button")).toBeInTheDocument());
@@ -55,10 +55,10 @@ describe("Dag Documentation Modal", () => {
 
   it("Do not display documentation button only doc_md is not present", () => {
     render(
-      <BaseWrapper>
+      <Wrapper>
         {/* eslint-disable-next-line unicorn/no-null */}
         <Header dag={{ ...MOCK_DAG, doc_md: null } as unknown as DAGDetailsResponse} />
-      </BaseWrapper>,
+      </Wrapper>,
     );
 
     expect(screen.queryByTestId("markdown-button")).toBeNull();

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -102,6 +102,6 @@ describe("DagCard", () => {
 
     render(<DagCard dag={expandedMockDag} />, { wrapper: Wrapper });
     expect(screen.getByTestId("dag-tag")).toBeInTheDocument();
-    expect(screen.getByText(", +2 more")).toBeInTheDocument();
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { FiTag } from "react-icons/fi";
+import { Link as RouterLink } from "react-router-dom";
 
 import type { DagTagResponse } from "openapi/requests/types.gen";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
@@ -31,7 +32,11 @@ type Props = {
 export const DagTags = ({ hideIcon = false, tags }: Props) => (
   <LimitedItemsList
     icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
-    items={tags.map(({ name }) => name)}
+    items={tags.map(({ name }) => (
+      <RouterLink key={name} to={`/dags?tags=${name}`}>
+        {name}
+      </RouterLink>
+    ))}
     maxItems={MAX_TAGS}
   />
 );

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -32,6 +32,7 @@ type Props = {
 export const DagTags = ({ hideIcon = false, tags }: Props) => (
   <LimitedItemsList
     icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
+    interactive
     items={tags.map(({ name }) => (
       <RouterLink key={name} to={`/dags?tags=${name}`}>
         {name}


### PR DESCRIPTION
In Airflow 2 the tag used to be a link on click filters the dags associated with the tag. This adds the same in Airflow 3.

Closes #49673 