### PR TITLE
use NonNegativeInt for backfill_id

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
+from pydantic import NonNegativeInt
+
 
 @dataclass
 class ConfigurationDetails:
@@ -46,7 +48,7 @@ class DagDetails:
 class BackfillDetails:
     """Represents the details of a backfill."""
 
-    id: str | None = None
+    id: NonNegativeInt | None = None
 
 
 @dataclass

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from pydantic import NonNegativeInt
+
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.models.backfill import ReprocessBehavior
 
@@ -38,7 +40,7 @@ class BackfillPostBody(StrictBaseModel):
 class BackfillResponse(BaseModel):
     """Base serializer for Backfill."""
 
-    id: int
+    id: NonNegativeInt
     dag_id: str
     from_date: datetime
     to_date: datetime

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -595,6 +595,7 @@ components:
       properties:
         id:
           type: integer
+          minimum: 0.0
           title: Id
         dag_id:
           type: string

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -951,7 +951,8 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          type: integer
+          minimum: 0
           title: Backfill Id
       responses:
         '200':
@@ -997,6 +998,8 @@ paths:
         in: path
         required: true
         schema:
+          type: integer
+          minimum: 0
           title: Backfill Id
       responses:
         '200':
@@ -1048,6 +1051,8 @@ paths:
         in: path
         required: true
         schema:
+          type: integer
+          minimum: 0
           title: Backfill Id
       responses:
         '200':
@@ -1099,6 +1104,8 @@ paths:
         in: path
         required: true
         schema:
+          type: integer
+          minimum: 0
           title: Backfill Id
       responses:
         '200':

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -7152,6 +7152,7 @@ components:
       properties:
         id:
           type: integer
+          minimum: 0.0
           title: Id
         dag_id:
           type: string

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -20,6 +20,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from fastapi.exceptions import RequestValidationError
+from pydantic import NonNegativeInt
 from sqlalchemy import select, update
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
@@ -98,7 +99,7 @@ def list_backfills(
     ],
 )
 def get_backfill(
-    backfill_id: str,
+    backfill_id: NonNegativeInt,
     session: SessionDep,
 ) -> BackfillResponse:
     backfill = session.get(Backfill, backfill_id)
@@ -121,7 +122,7 @@ def get_backfill(
         Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)),
     ],
 )
-def pause_backfill(backfill_id, session: SessionDep) -> BackfillResponse:
+def pause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> BackfillResponse:
     b = session.get(Backfill, backfill_id)
     if not b:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Could not find backfill with id {backfill_id}")
@@ -147,7 +148,7 @@ def pause_backfill(backfill_id, session: SessionDep) -> BackfillResponse:
         Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)),
     ],
 )
-def unpause_backfill(backfill_id, session: SessionDep) -> BackfillResponse:
+def unpause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> BackfillResponse:
     b = session.get(Backfill, backfill_id)
     if not b:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Could not find backfill with id {backfill_id}")
@@ -172,7 +173,7 @@ def unpause_backfill(backfill_id, session: SessionDep) -> BackfillResponse:
         Depends(requires_access_backfill(method="PUT")),
     ],
 )
-def cancel_backfill(backfill_id, session: SessionDep) -> BackfillResponse:
+def cancel_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> BackfillResponse:
     b: Backfill = session.get(Backfill, backfill_id)
     if not b:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Could not find backfill with id {backfill_id}")

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -23,6 +23,7 @@ from urllib.parse import ParseResult, urljoin, urlparse
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt import ExpiredSignatureError, InvalidTokenError
+from pydantic import NonNegativeInt
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
@@ -198,7 +199,7 @@ def requires_access_backfill(method: ResourceMethod) -> Callable:
         request: Request,
         user: Annotated[BaseUser | None, Depends(get_user)] = None,
     ) -> None:
-        backfill_id: str | None = request.path_params.get("backfill_id")
+        backfill_id: NonNegativeInt | None = request.path_params.get("backfill_id")
 
         _requires_access(
             is_authorized_callback=lambda: get_auth_manager().is_authorized_backfill(

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -116,6 +116,7 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
+    from pydantic import NonNegativeInt
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
 
@@ -257,7 +258,7 @@ def _create_orm_dagrun(
     state: DagRunState | None,
     run_type: DagRunType,
     creating_job_id: int | None,
-    backfill_id: int | None,
+    backfill_id: NonNegativeInt | None,
     triggered_by: DagRunTriggeredByType,
     session: Session = NEW_SESSION,
 ) -> DagRun:
@@ -1795,7 +1796,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         state: DagRunState,
         start_date: datetime | None = None,
         creating_job_id: int | None = None,
-        backfill_id: int | None = None,
+        backfill_id: NonNegativeInt | None = None,
         session: Session = NEW_SESSION,
     ) -> DagRun:
         """

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from opentelemetry.sdk.trace import Span
+    from pydantic import NonNegativeInt
     from sqlalchemy.orm import Query, Session
 
     from airflow.models.baseoperator import BaseOperator
@@ -290,7 +291,7 @@ class DagRun(Base, LoggingMixin):
         creating_job_id: int | None = None,
         data_interval: tuple[datetime, datetime] | None = None,
         triggered_by: DagRunTriggeredByType | None = None,
-        backfill_id: int | None = None,
+        backfill_id: NonNegativeInt | None = None,
         bundle_version: str | None = None,
     ):
         # For manual runs where logical_date is None, ensure no data_interval is set.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -270,7 +270,7 @@ export const UseBackfillServiceGetBackfillKeyFn = (
   {
     backfillId,
   }: {
-    backfillId: string;
+    backfillId: number;
   },
   queryKey?: Array<unknown>,
 ) => [useBackfillServiceGetBackfillKey, ...(queryKey ?? [{ backfillId }])];

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -354,7 +354,7 @@ export const ensureUseBackfillServiceGetBackfillData = (
   {
     backfillId,
   }: {
-    backfillId: string;
+    backfillId: number;
   },
 ) =>
   queryClient.ensureQueryData({

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -354,7 +354,7 @@ export const prefetchUseBackfillServiceGetBackfill = (
   {
     backfillId,
   }: {
-    backfillId: string;
+    backfillId: number;
   },
 ) =>
   queryClient.prefetchQuery({

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -446,7 +446,7 @@ export const useBackfillServiceGetBackfill = <
   {
     backfillId,
   }: {
-    backfillId: string;
+    backfillId: number;
   },
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
@@ -3640,7 +3640,7 @@ export const useBackfillServicePauseBackfill = <
       TData,
       TError,
       {
-        backfillId: unknown;
+        backfillId: number;
       },
       TContext
     >,
@@ -3651,7 +3651,7 @@ export const useBackfillServicePauseBackfill = <
     TData,
     TError,
     {
-      backfillId: unknown;
+      backfillId: number;
     },
     TContext
   >({
@@ -3676,7 +3676,7 @@ export const useBackfillServiceUnpauseBackfill = <
       TData,
       TError,
       {
-        backfillId: unknown;
+        backfillId: number;
       },
       TContext
     >,
@@ -3687,7 +3687,7 @@ export const useBackfillServiceUnpauseBackfill = <
     TData,
     TError,
     {
-      backfillId: unknown;
+      backfillId: number;
     },
     TContext
   >({
@@ -3712,7 +3712,7 @@ export const useBackfillServiceCancelBackfill = <
       TData,
       TError,
       {
-        backfillId: unknown;
+        backfillId: number;
       },
       TContext
     >,
@@ -3723,7 +3723,7 @@ export const useBackfillServiceCancelBackfill = <
     TData,
     TError,
     {
-      backfillId: unknown;
+      backfillId: number;
     },
     TContext
   >({

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -423,7 +423,7 @@ export const useBackfillServiceGetBackfillSuspense = <
   {
     backfillId,
   }: {
-    backfillId: string;
+    backfillId: number;
   },
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -427,6 +427,7 @@ export const $BackfillResponse = {
   properties: {
     id: {
       type: "integer",
+      minimum: 0,
       title: "Id",
     },
     dag_id: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1882,25 +1882,25 @@ export type CreateBackfillData = {
 export type CreateBackfillResponse = BackfillResponse;
 
 export type GetBackfillData = {
-  backfillId: string;
+  backfillId: number;
 };
 
 export type GetBackfillResponse = BackfillResponse;
 
 export type PauseBackfillData = {
-  backfillId: unknown;
+  backfillId: number;
 };
 
 export type PauseBackfillResponse = BackfillResponse;
 
 export type UnpauseBackfillData = {
-  backfillId: unknown;
+  backfillId: number;
 };
 
 export type UnpauseBackfillResponse = BackfillResponse;
 
 export type CancelBackfillData = {
-  backfillId: unknown;
+  backfillId: number;
 };
 
 export type CancelBackfillResponse = BackfillResponse;

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -65,15 +65,21 @@ const BackfillBanner = ({ dagId }: Props) => {
   const { isPending: isStopPending, mutate: stopPending } = useBackfillServiceCancelBackfill({ onSuccess });
 
   const togglePause = () => {
-    if (backfill?.is_paused) {
+    if (backfill === undefined) {
+      return;
+    }
+    if (backfill.is_paused) {
       unpauseMutate({ backfillId: backfill.id });
     } else {
-      pauseMutate({ backfillId: backfill?.id });
+      pauseMutate({ backfillId: backfill.id });
     }
   };
 
   const cancel = () => {
-    stopPending({ backfillId: backfill?.id });
+    if (backfill === undefined) {
+      return;
+    }
+    stopPending({ backfillId: backfill.id });
   };
 
   if (isLoading || backfill === undefined) {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -165,6 +165,16 @@ class TestGetBackfill(TestBackfillEndpoint):
         assert response.status_code == 404
         assert response.json().get("detail") == "Backfill not found"
 
+    def test_invalid_id(self, test_client):
+        response = test_client.get("/backfills/invalid_id")
+        assert response.status_code == 422
+        response_detail = response.json()["detail"][0]
+        assert response_detail["input"] == "invalid_id"
+        assert response_detail["loc"] == ["path", "backfill_id"]
+        assert (
+            response_detail["msg"] == "Input should be a valid integer, unable to parse string as an integer"
+        )
+
 
 class TestCreateBackfill(TestBackfillEndpoint):
     @pytest.mark.parametrize(
@@ -759,6 +769,16 @@ class TestCancelBackfill(TestBackfillEndpoint):
         states = [x.state for x in dag_runs]
         assert states == ["running", "failed", "failed", "failed", "failed"]
 
+    def test_invalid_id(self, test_client):
+        response = test_client.put("/backfills/invalid_id/cancel")
+        assert response.status_code == 422
+        response_detail = response.json()["detail"][0]
+        assert response_detail["input"] == "invalid_id"
+        assert response_detail["loc"] == ["path", "backfill_id"]
+        assert (
+            response_detail["msg"] == "Input should be a valid integer, unable to parse string as an integer"
+        )
+
 
 class TestPauseBackfill(TestBackfillEndpoint):
     def test_pause_backfill(self, session, test_client):
@@ -805,6 +825,16 @@ class TestPauseBackfill(TestBackfillEndpoint):
         response = unauthorized_test_client.put(f"/backfills/{backfill.id}/pause")
         assert response.status_code == 403
 
+    def test_invalid_id(self, test_client):
+        response = test_client.put("/backfills/invalid_id/pause")
+        assert response.status_code == 422
+        response_detail = response.json()["detail"][0]
+        assert response_detail["input"] == "invalid_id"
+        assert response_detail["loc"] == ["path", "backfill_id"]
+        assert (
+            response_detail["msg"] == "Input should be a valid integer, unable to parse string as an integer"
+        )
+
 
 class TestUnpauseBackfill(TestBackfillEndpoint):
     def test_unpause_backfill(self, session, test_client):
@@ -832,3 +862,13 @@ class TestUnpauseBackfill(TestBackfillEndpoint):
             "updated_at": mock.ANY,
         }
         check_last_log(session, dag_id=None, event="unpause_backfill", logical_date=None)
+
+    def test_invalid_id(self, test_client):
+        response = test_client.put("/backfills/invalid_id/unpause")
+        assert response.status_code == 422
+        response_detail = response.json()["detail"][0]
+        assert response_detail["input"] == "invalid_id"
+        assert response_detail["loc"] == ["path", "backfill_id"]
+        assert (
+            response_detail["msg"] == "Input should be a valid integer, unable to parse string as an integer"
+        )

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, RootModel
 
 
 class AppBuilderMenuItemResponse(BaseModel):
@@ -997,7 +997,7 @@ class BackfillResponse(BaseModel):
     Base serializer for Backfill.
     """
 
-    id: Annotated[int, Field(title="Id")]
+    id: Annotated[NonNegativeInt, Field(title="Id")]
     dag_id: Annotated[str, Field(title="Dag Id")]
     from_date: Annotated[datetime, Field(title="From Date")]
     to_date: Annotated[datetime, Field(title="To Date")]

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class AppBuilderMenuItemResponse(BaseModel):
@@ -997,7 +997,7 @@ class BackfillResponse(BaseModel):
     Base serializer for Backfill.
     """
 
-    id: Annotated[NonNegativeInt, Field(title="Id")]
+    id: Annotated[int, Field(ge=0, title="Id")]
     dag_id: Annotated[str, Field(title="Dag Id")]
     from_date: Annotated[datetime, Field(title="From Date")]
     to_date: Annotated[datetime, Field(title="To Date")]

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -22,6 +22,7 @@ import json
 import uuid
 from contextlib import redirect_stdout
 from io import StringIO
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
@@ -73,6 +74,9 @@ from airflowctl.api.datamodels.generated import (
     VariableResponse,
     VersionInfo,
 )
+
+if TYPE_CHECKING:
+    from pydantic import NonNegativeInt
 
 
 def make_api_client(
@@ -165,7 +169,7 @@ class TestAssetsOperations:
 
 
 class TestBackfillOperations:
-    backfill_id: int = 1
+    backfill_id: NonNegativeInt = 1
 
     def test_create(self):
         backfill_body = BackfillPostBody(

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -210,7 +210,7 @@ class TestAwsAuthManager:
         "details, user, expected_user, expected_entity_id",
         [
             (None, mock, ANY, None),
-            (BackfillDetails(id="1"), mock, mock, "1"),
+            (BackfillDetails(id=1), mock, mock, 1),
         ],
     )
     @patch.object(AwsAuthManager, "avp_facade")


### PR DESCRIPTION
Noticed test failures in another PR - https://github.com/apache/airflow/actions/runs/14634141646/job/41061963159?pr=49599

backfill_id is defined as an integer in DB. So, making it NonNegativeInt

