### PR TITLE
Treat single task_ids in xcom_pull the same as multiple

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -336,8 +336,6 @@ aligning with the broader asset-aware execution model introduced in Airflow 3.0.
 Behaviour change in ``xcom_pull``
 """""""""""""""""""""""""""""""""
 
-**Pulling without setting ``task_ids``**:
-
 In Airflow 2, the ``xcom_pull()`` method allowed pulling XComs by key without specifying task_ids, despite the fact that the underlying
 DB model defines task_id as part of the XCom primary key. This created ambiguity: if two tasks pushed XComs with the same key,
 ``xcom_pull()`` would pull whichever one happened to be first, leading to unpredictable behavior.
@@ -352,34 +350,6 @@ DAG Authors should update their dags to use ``task_ids`` if their dags used ``xc
 Should be updated to::
 
   kwargs["ti"].xcom_pull(task_ids="task1", key="key")
-
-
-**Return Type Change for Single Task ID**:
-
-In Airflow 2, when using ``xcom_pull()`` with a single task ID in a list (e.g., ``task_ids=["task1"]``), it would return a ``LazyXComSelectSequence``
-object containing one value. In Airflow 3.0.0, this behavior was changed to return the value directly.
-
-So, if you previously used:
-
-.. code-block:: python
-
-    xcom_values = kwargs["ti"].xcom_pull(task_ids=["task1"], key="key")
-    xcom_value = xcom_values[0]  # Access the first value
-
-You would now get the value directly, rather than a sequence containing one value.
-
-.. code-block:: python
-
-    xcom_value = kwargs["ti"].xcom_pull(task_ids=["task1"], key="key")
-
-The previous behaviour (returning list when passed a list) will be restored in Airflow 3.0.1 to maintain backward compatibility.
-
-However, it is recommended to be explicit about your intentions when using ``task_ids`` (after the fix in 3.0.1):
-
-- If you want a single value, use ``task_ids="task1"``
-- If you want a sequence, use ``task_ids=["task1"]``
-
-This makes the code more explicit and easier to understand.
 
 
 Removed Configuration Keys

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 77a6fba681cf21973ca9712136d1b51a
-source-date-epoch: 1745327923
+release-notes-hash: df3b67b987fd909d16f6158df78b3813
+source-date-epoch: 1745660315

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -325,6 +325,9 @@ class RuntimeTaskInstance(TaskInstance):
         if run_id is None:
             run_id = self.run_id
 
+        single_task_requested = isinstance(task_ids, (str, type(None)))
+        single_map_index_requested = isinstance(map_indexes, (int, type(None), ArgNotSet))
+
         if task_ids is None:
             # default to the current task if not provided
             task_ids = [self.task_id]
@@ -363,8 +366,9 @@ class RuntimeTaskInstance(TaskInstance):
             else:
                 xcoms.append(value)
 
-        if len(xcoms) == 1:
+        if single_task_requested and single_map_index_requested:
             return xcoms[0]
+
         return xcoms
 
     def xcom_push(self, key: str, value: Any):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/49540

## Problem

There is no need to handle some cases of xcom retrieval seperately.

Expected behaviour in airflow 2:
1. xcom_pull(task_ids=["task1"]) should not return a value but return  a `LazyXComSelectSequence` object which was to avoid pulling everything into memory at once (unlike session.execute(...).fetchall()). But this is no longer relevant as we get the xcoms we need to from the api server (using `get_one` from BaseXcom class).

So we need to have a similar abstraction so that the user code doesn't have to change when they called xcom_pull using single task_id in a list, like `ti.xcom_pull(task_ids=["task1"])`.


2. xcom_pull(task_ids="task1") should return a value and not a list of values

3. xcom_pull with one task_id and one map_indexes should return a value again and not an iterable

## Testing

### Testing with various combinations of task_ids

DAG used for testing:
```
from __future__ import annotations

import logging
from datetime import datetime

from airflow.decorators import task

from airflow.models.dag import DAG


log = logging.getLogger(__name__)


with DAG(
    "xcom_test",
    schedule=None,
    start_date=datetime(2021, 1, 1),
    catchup=False,
    tags=["example", "sheets"],
) as dag:
    @task
    def xcom_dict():
        return {"a": "b"}

    @task
    def read_xcom(**kwargs):
        xcom_dict_task_value_ids = kwargs["task_instance"].xcom_pull(task_ids=["xcom_dict"], key="return_value")
        print("With task ids in a list", type(xcom_dict_task_value_ids), xcom_dict_task_value_ids)
        print(xcom_dict_task_value_ids[0])

        xcom_dict_task_value_ids1 = kwargs["task_instance"].xcom_pull(task_ids="xcom_dict", key="return_value")
        print("Without a list", type(xcom_dict_task_value_ids1), xcom_dict_task_value_ids1)

        xcom_dict_task_value_ids_2 = kwargs["task_instance"].xcom_pull(task_ids=None, key="return_value")

        print("With None task_ids", type(xcom_dict_task_value_ids_2), xcom_dict_task_value_ids_2)

    xcom_dict = xcom_dict()

    read_xcom_task = read_xcom()

    xcom_dict >> read_xcom_task


```

This DAG tests three things:

1. xcom_pull with task_ids as list of one task_id, it should return an Iterable and not value. Verified by accessing using element access
2. xcom_pull with a single task_id without a list, it should return a value
3. xcom_pull with NONE task_id, it will return a value again but for the current task instance task_id, which is None.

![image](https://github.com/user-attachments/assets/a4d81727-1795-4f47-bd4a-7c103986f126)



### Testing with map_indexes

DAG:
```
from airflow.decorators import dag, task
from airflow.utils.timezone import datetime


@dag(schedule=None, start_date=datetime(2021, 1, 1), catchup=False)
def mapped_xcom_pull_example():
    @task
    def push_value(value):
        return value

    @task
    def collect_values(**context):
        ti = context["ti"]
        r = ti.xcom_pull(task_ids="push_value", map_indexes=[0, 1, 2])
        print("Collected values from mapped task:", r)

        print("Values in results are", r[0], r[1], r[2])

        return r

    push_value.expand(value=["apple", "banana", "cherry"]) >> collect_values()

mapped_xcom_pull_example()

```

![image](https://github.com/user-attachments/assets/075a73c9-b7a7-41e6-9a92-e01e371a5866)

![image](https://github.com/user-attachments/assets/abaea2bd-c5e4-4c77-9022-d1fc188989cd)


Observe that each value is pushed as a single value and we get it normally now.

Similar behaviour to AF2:
```
13167e4798c6
 ▶ Log message source details
[2025-04-25, 15:42:22 IST] {local_task_job_runner.py:123} ▶ Pre task execution logs
[2025-04-25, 15:42:22 IST] {logging_mixin.py:190} INFO - Collected values from mapped task: LazySelectSequence([3 items])
[2025-04-25, 15:42:22 IST] {logging_mixin.py:190} INFO - Values in results are apple banana cherry
[2025-04-25, 15:42:22 IST] {python.py:240} INFO - Done. Returned value was: LazySelectSequence([3 items])
[2025-04-25, 15:42:22 IST] {xcom.py:241} WARNING - Coercing mapped lazy proxy return value from task collect_values (DAG mapped_xcom_pull_example, run manual__2025-04-25T10:12:16.005448+00:00) to list, which may degrade performance. Review resource requirements for this operation, and call list() to suppress this message. See Dynamic Task Mapping documentation for more information about lazy proxy objects.
[2025-04-25, 15:42:22 IST] {taskinstance.py:341} ▶ Post task execution logs
```

We return a list instead of a `LazySelectSequence` though







<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
