### PR TITLE
Add bundle_version to DagRun response

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -76,6 +76,7 @@ class DAGRunResponse(BaseModel):
     conf: dict
     note: str | None
     dag_versions: list[DagVersionResponse]
+    bundle_version: str | None
 
 
 class DAGRunCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -940,6 +940,11 @@ components:
             $ref: '#/components/schemas/DagVersionResponse'
           type: array
           title: Dag Versions
+        bundle_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bundle Version
       type: object
       required:
       - dag_run_id
@@ -958,6 +963,7 @@ components:
       - conf
       - note
       - dag_versions
+      - bundle_version
       title: DAGRunResponse
       description: DAG Run serializer for responses.
     DAGRunStates:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -8337,6 +8337,11 @@ components:
             $ref: '#/components/schemas/DagVersionResponse'
           type: array
           title: Dag Versions
+        bundle_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bundle Version
       type: object
       required:
       - dag_run_id
@@ -8355,6 +8360,7 @@ components:
       - conf
       - note
       - dag_versions
+      - bundle_version
       title: DAGRunResponse
       description: DAG Run serializer for responses.
     DAGRunsBatchBody:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2255,6 +2255,17 @@ export const $DAGRunResponse = {
       type: "array",
       title: "Dag Versions",
     },
+    bundle_version: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Bundle Version",
+    },
   },
   type: "object",
   required: [
@@ -2274,6 +2285,7 @@ export const $DAGRunResponse = {
     "conf",
     "note",
     "dag_versions",
+    "bundle_version",
   ],
   title: "DAGRunResponse",
   description: "DAG Run serializer for responses.",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -577,6 +577,7 @@ export type DAGRunResponse = {
   };
   note: string | null;
   dag_versions: Array<DagVersionResponse>;
+  bundle_version: string | null;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1144,6 +1144,7 @@ class TestPostAssetMaterialize(TestAssets):
         response = test_client.post("/assets/1/materialize")
         assert response.status_code == 200
         assert response.json() == {
+            "bundle_version": None,
             "dag_run_id": mock.ANY,
             "dag_id": self.DAG_ASSET1_ID,
             "dag_versions": mock.ANY,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -167,6 +167,7 @@ def get_dag_versions_dict(dag_versions: list[DagVersion]) -> list[dict]:
 
 def get_dag_run_dict(run: DagRun):
     return {
+        "bundle_version": None,
         "dag_run_id": run.run_id,
         "dag_id": run.dag_id,
         "logical_date": from_datetime_to_zulu_without_ms(run.logical_date),
@@ -1303,6 +1304,7 @@ class TestTriggerDagRun:
             session.query(DagRun).where(DagRun.dag_id == DAG1_ID, DagRun.run_id == expected_dag_run_id).one()
         )
         expected_response_json = {
+            "bundle_version": None,
             "conf": {},
             "dag_id": DAG1_ID,
             "dag_run_id": expected_dag_run_id,
@@ -1492,6 +1494,7 @@ class TestTriggerDagRun:
 
         assert response_1.status_code == 200
         assert response_1.json() == {
+            "bundle_version": None,
             "dag_run_id": RUN_ID_1,
             "dag_id": DAG1_ID,
             "dag_versions": mock.ANY,
@@ -1576,6 +1579,7 @@ class TestTriggerDagRun:
         )
         assert response.status_code == 200
         assert response.json() == {
+            "bundle_version": None,
             "dag_run_id": mock.ANY,
             "dag_id": DAG1_ID,
             "dag_versions": mock.ANY,

--- a/airflow-core/tests/unit/cli/commands/test_asset_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_asset_command.py
@@ -141,6 +141,7 @@ def test_cli_assets_materialize(parser: ArgumentParser) -> None:
 
     assert run_list[0] | undeterministic == undeterministic | {
         "conf": {},
+        "bundle_version": None,
         "dag_id": "asset1_producer",
         "end_date": None,
         "last_scheduling_decision": None,

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1219,6 +1219,7 @@ class DAGRunResponse(BaseModel):
     conf: Annotated[dict[str, Any], Field(title="Conf")]
     note: Annotated[str | None, Field(title="Note")] = None
     dag_versions: Annotated[list[DagVersionResponse], Field(title="Dag Versions")]
+    bundle_version: Annotated[str | None, Field(title="Bundle Version")] = None
 
 
 class DAGRunsBatchBody(BaseModel):


### PR DESCRIPTION
The field was missing.

Note on relationship to #49007...

In #49007 the concern was raised about the DagVersion record not pointing to the current bundle version when the bundle version changed but dag structure did not.

The user assumed that this meant the dag run was associated with the wrong bundle version. Adding the dag run bundle version will let the user see that that the associaton is correct.

Users may now see two "bundle versions" in the dag run response.  But the reason for this can be understood.  If the DagVersion record points to an older bundle version, it is because the dag structure did not change when the code changed.  But since the scheduler just cares about dag structure, it doesn't matter, and it still tells the truth -- the version of the dag version is the bundle version which caused that revision.

closes https://github.com/apache/airflow/issues/49007
