### PR TITLE
Handle null when there is no error from API response

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
@@ -39,7 +39,7 @@ export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: b
     return <Skeleton height="9" width="225px" />;
   }
 
-  if ((error as ExpandedApiError).status === 403) {
+  if (Boolean(error) && (error as ExpandedApiError).status === 403) {
     return undefined;
   }
 


### PR DESCRIPTION
Related #49643 . Error could be null when API gives successful response and error seems to be casted as always not null resulting in below stack trace.

```
Uncaught TypeError: error is null
    PluginImportErrors PluginImportErrors.tsx:42
    React 14
    performReactRefresh @react-refresh:160
    performReactRefresh @react-refresh:150
    enqueueUpdate @react-refresh:392
PluginImportErrors.tsx:42:7
```

cc: @pierrejeambrun 