### PR TITLE
Fix Typo caused by #49721 in auth manager index

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -148,7 +148,7 @@ delete the cookie.
 
     response = RedirectResponse(url="/")
 
-    secure = bool(conf.get("api", "ssl_cert", fallack=""))
+    secure = bool(conf.get("api", "ssl_cert", fallback=""))
     response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
     return response
 


### PR DESCRIPTION
Fixing typo in auth manager doc caused by #49721
