### PR TITLE
Make default execution server URL be relative to API Base URL

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -536,11 +536,12 @@ core:
       default: "4096"
     execution_api_server_url:
       description: |
-        The url of the execution api server.
+        The url of the execution api server. Default is ``{BASE_URL}/execution/``
+        where ``{BASE_URL}`` is the base url of the API Server.
       version_added: 3.0.0
       type: string
       example: ~
-      default: "http://localhost:8080/execution/"
+      default: ~
 database:
   description: ~
   options:

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -108,6 +108,10 @@ def _execute_work(log: logging.Logger, workload: workloads.ExecuteTask) -> None:
     from airflow.sdk.execution_time.supervisor import supervise
 
     setproctitle(f"airflow worker -- LocalExecutor: {workload.ti.id}")
+
+    base_url = conf.get("api", "base_url", fallback="/")
+    default_execution_api_server = f"{base_url.rstrip('/')}/execution/"
+
     # This will return the exit code of the task process, but we don't care about that, just if the
     # _supervisor_ had an error reporting the state back (which will result in an exception.)
     supervise(
@@ -116,7 +120,7 @@ def _execute_work(log: logging.Logger, workload: workloads.ExecuteTask) -> None:
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
         token=workload.token,
-        server=conf.get("core", "execution_api_server_url"),
+        server=conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
         log_path=workload.log_path,
     )
 

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -26,10 +26,11 @@ from kgb import spy_on
 from uuid6 import uuid7
 
 from airflow.executors import workloads
-from airflow.executors.local_executor import LocalExecutor
+from airflow.executors.local_executor import LocalExecutor, _execute_work
 from airflow.utils import timezone
 from airflow.utils.state import State
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
 pytestmark = pytest.mark.db_test
@@ -166,3 +167,38 @@ class TestLocalExecutor:
             pass
         finally:
             executor.end()
+
+    @pytest.mark.parametrize(
+        ["conf_values", "expected_server"],
+        [
+            (
+                {
+                    ("api", "base_url"): "http://test-server",
+                    ("core", "execution_api_server_url"): None,
+                },
+                "http://test-server/execution/",
+            ),
+            (
+                {
+                    ("api", "base_url"): "http://test-server",
+                    ("core", "execution_api_server_url"): "http://custom-server/execution/",
+                },
+                "http://custom-server/execution/",
+            ),
+        ],
+        ids=["base_url_fallback", "custom_server"],
+    )
+    @mock.patch("airflow.sdk.execution_time.supervisor.supervise")
+    def test_execution_api_server_url_config(self, mock_supervise, conf_values, expected_server):
+        """Test that execution_api_server_url is correctly configured with fallback"""
+        with conf_vars(conf_values):
+            _execute_work(log=mock.ANY, workload=mock.MagicMock())
+
+            mock_supervise.assert_called_with(
+                ti=mock.ANY,
+                dag_rel_path=mock.ANY,
+                bundle_info=mock.ANY,
+                token=mock.ANY,
+                server=expected_server,
+                log_path=mock.ANY,
+            )

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -158,13 +158,16 @@ def execute_workload(input: str) -> None:
 
     log.info("[%s] Executing workload in Celery: %s", celery_task_id, workload)
 
+    base_url = conf.get("api", "base_url", fallback="/")
+    default_execution_api_server = f"{base_url.rstrip('/')}/execution/"
+
     supervise(
         # This is the "wrong" ti type, but it duck types the same. TODO: Create a protocol for this.
         ti=workload.ti,  # type: ignore[arg-type]
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
         token=workload.token,
-        server=conf.get("core", "execution_api_server_url"),
+        server=conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
         log_path=workload.log_path,
     )
 

--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -271,6 +271,9 @@ class _EdgeWorkerCli:
             setproctitle(f"airflow edge worker: {workload.ti.key}")
 
             try:
+                base_url = conf.get("api", "base_url", fallback="/")
+                default_execution_api_server = f"{base_url.rstrip('/')}/execution/"
+
                 supervise(
                     # This is the "wrong" ti type, but it duck types the same. TODO: Create a protocol for this.
                     # Same like in airflow/executors/local_executor.py:_execute_work()
@@ -278,7 +281,9 @@ class _EdgeWorkerCli:
                     dag_rel_path=workload.dag_rel_path,
                     bundle_info=workload.bundle_info,
                     token=workload.token,
-                    server=conf.get("core", "execution_api_server_url"),
+                    server=conf.get(
+                        "core", "execution_api_server_url", fallback=default_execution_api_server
+                    ),
                     log_path=workload.log_path,
                 )
                 return 0

--- a/task-sdk/src/airflow/sdk/execution_time/execute_workload.py
+++ b/task-sdk/src/airflow/sdk/execution_time/execute_workload.py
@@ -54,7 +54,10 @@ def execute_workload(workload: ExecuteTask) -> None:
         raise ValueError(f"Executor does not know how to handle {type(workload)}")
 
     log.info("Executing workload", workload=workload)
-    server = conf.get("core", "execution_api_server_url")
+
+    base_url = conf.get("api", "base_url", fallback="/")
+    default_execution_api_server = f"{base_url.rstrip('/')}/execution/"
+    server = conf.get("core", "execution_api_server_url", fallback=default_execution_api_server)
     log.info("Connecting to server:", server=server)
 
     supervise(


### PR DESCRIPTION
The execution API server URL is now more flexible and configurable:

- Remove hardcoded default URL "http://localhost:8080/execution/"
- Add fallback mechanism to construct URL from base_url config
- Default is now `"{BASE_URL}/execution/"` where BASE_URL comes from `api.base_url` config


Note: The code duplication here is intentional since I am touching different providers: Celery, Edge. So, keeping the logic in a central location has a big disadvantage, as that provider won't work until that Airflow version is released!

related: https://github.com/apache/airflow/issues/49725

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
