### PR TITLE
Mark DagRun as success when no teardown tasks are running

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -215,17 +215,35 @@ def set_dag_run_state_to_success(
     if not run_id:
         raise ValueError(f"Invalid dag_run_id: {run_id}")
 
-    # Mark all task instances of the dag run to success - except for teardown as they need to complete work.
+    # Mark all task instances of the dag run to success - except for running teardown as they need to complete work.
     normal_tasks = [task for task in dag.tasks if not task.is_teardown]
+    teardown_tasks = [task for task in dag.tasks if task.is_teardown]
+    running_states = (
+        TaskInstanceState.RUNNING,
+        TaskInstanceState.DEFERRED,
+        TaskInstanceState.UP_FOR_RESCHEDULE,
+    )
+    running_teardown_tis: list[TaskInstance] = session.scalars(
+        select(TaskInstance).where(
+            TaskInstance.dag_id == dag.dag_id,
+            TaskInstance.run_id == run_id,
+            TaskInstance.task_id.in_([task.task_id for task in teardown_tasks]),
+            TaskInstance.state.in_(running_states),
+        )
+    ).all()
 
-    # Mark the dag run to success.
-    if commit and len(normal_tasks) == len(dag.tasks):
+    # Mark the dag run to success if there are no running teardown tasks.
+    if commit and len(running_teardown_tis) == 0:
         _set_dag_run_state(dag.dag_id, run_id, DagRunState.SUCCESS, session)
 
-    for task in normal_tasks:
+    task_ids_of_running_teardown_tis = [ti.task_id for ti in running_teardown_tis]
+    tasks_to_mark_success = normal_tasks + [
+        task for task in teardown_tasks if task.task_id not in task_ids_of_running_teardown_tis
+    ]
+    for task in tasks_to_mark_success:
         task.dag = dag
     return set_state(
-        tasks=normal_tasks,
+        tasks=tasks_to_mark_success,
         run_id=run_id,
         state=TaskInstanceState.SUCCESS,
         commit=commit,

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -56,7 +56,9 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker):
     assert "teardown" not in task_dict
 
 
-@pytest.mark.parametrize("unfinished_state", list(State.unfinished))
+@pytest.mark.parametrize(
+    "unfinished_state", sorted([state for state in State.unfinished if state is not None])
+)
 def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, unfinished_state):
     with dag_maker("TEST_DAG_1"):
         with EmptyOperator(task_id="teardown").as_teardown():
@@ -86,7 +88,7 @@ def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, u
 
 
 @pytest.mark.parametrize(
-    "finished_state", [state for state in State.finished if state != TaskInstanceState.SUCCESS]
+    "finished_state", sorted([state for state in State.finished if state != TaskInstanceState.SUCCESS])
 )
 def test_set_dag_run_state_to_success_finished_teardown(dag_maker: DagMaker, finished_state):
     with dag_maker("TEST_DAG_1"):

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from sqlalchemy import select
 
 from airflow.api.common.mark_tasks import set_dag_run_state_to_failed, set_dag_run_state_to_success
+from airflow.models.dagrun import DagRun
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.utils.state import TaskInstanceState
+from airflow.utils.state import DagRunState, TaskInstanceState
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
@@ -54,23 +56,67 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker):
     assert "teardown" not in task_dict
 
 
-def test_set_dag_run_state_to_success(dag_maker: DagMaker):
+def test_set_dag_run_state_to_success_running_teardown(dag_maker: DagMaker):
     with dag_maker("TEST_DAG_1"):
-        with EmptyOperator(task_id="teardown").as_teardown():
-            EmptyOperator(task_id="running")
-            EmptyOperator(task_id="pending")
+        (
+            [EmptyOperator(task_id="running"), EmptyOperator(task_id="pending")]
+            >> EmptyOperator(task_id="teardown_running").as_teardown()
+            >> EmptyOperator(task_id="teardown_deferred").as_teardown()
+            >> EmptyOperator(task_id="teardown_reschedule").as_teardown()
+        )
+
     dr = dag_maker.create_dagrun()
     for ti in dr.get_task_instances():
-        if ti.task_id == "running":
+        if ti.task_id == "running" or ti.task_id == "teardown_running":
             ti.set_state(TaskInstanceState.RUNNING)
+        if ti.task_id == "teardown_deferred":
+            ti.set_state(TaskInstanceState.DEFERRED)
+        if ti.task_id == "teardown_reschedule":
+            ti.set_state(TaskInstanceState.UP_FOR_RESCHEDULE)
     dag_maker.session.flush()
     assert dr.dag
 
     updated_tis: list[TaskInstance] = set_dag_run_state_to_success(
         dag=dr.dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
+    run = dag_maker.session.scalar(select(DagRun).filter_by(dag_id=dr.dag_id, run_id=dr.run_id))
+    assert run.state != DagRunState.SUCCESS
     assert len(updated_tis) == 2
     task_dict = {ti.task_id: ti for ti in updated_tis}
     assert task_dict["running"].state == TaskInstanceState.SUCCESS
     assert task_dict["pending"].state == TaskInstanceState.SUCCESS
-    assert "teardown" not in task_dict
+    assert "teardown_running" not in task_dict
+    assert "teardown_deferred" not in task_dict
+    assert "teardown_reschedule" not in task_dict
+
+
+def test_set_dag_run_state_to_success_failed_teardown(dag_maker: DagMaker):
+    with dag_maker("TEST_DAG_1"):
+        (
+            [EmptyOperator(task_id="running"), EmptyOperator(task_id="pending")]
+            >> EmptyOperator(task_id="teardown_failed").as_teardown()
+            >> EmptyOperator(task_id="teardown_upstream_failed").as_teardown()
+        )
+
+    dr = dag_maker.create_dagrun()
+    for ti in dr.get_task_instances():
+        if ti.task_id == "running":
+            ti.set_state(TaskInstanceState.RUNNING)
+        if ti.task_id == "teardown_failed":
+            ti.set_state(TaskInstanceState.FAILED)
+        if ti.task_id == "teardown_upstream_failed":
+            ti.set_state(TaskInstanceState.UPSTREAM_FAILED)
+    dag_maker.session.flush()
+    assert dr.dag
+
+    updated_tis: list[TaskInstance] = set_dag_run_state_to_success(
+        dag=dr.dag, run_id=dr.run_id, commit=True, session=dag_maker.session
+    )
+    run = dag_maker.session.scalar(select(DagRun).filter_by(dag_id=dr.dag_id, run_id=dr.run_id))
+    assert run.state == DagRunState.SUCCESS
+    assert len(updated_tis) == 4
+    task_dict = {ti.task_id: ti for ti in updated_tis}
+    assert task_dict["running"].state == TaskInstanceState.SUCCESS
+    assert task_dict["pending"].state == TaskInstanceState.SUCCESS
+    assert task_dict["teardown_failed"].state == TaskInstanceState.SUCCESS
+    assert task_dict["teardown_upstream_failed"].state == TaskInstanceState.SUCCESS

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -59,9 +59,9 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker):
 @pytest.mark.parametrize("unfinished_state", list(State.unfinished))
 def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, unfinished_state):
     with dag_maker("TEST_DAG_1"):
-        running = EmptyOperator(task_id="running")
-        pending = EmptyOperator(task_id="pending")
-        [running, pending] >> EmptyOperator(task_id="teardown").as_teardown()
+        with EmptyOperator(task_id="teardown").as_teardown():
+            EmptyOperator(task_id="running")
+            EmptyOperator(task_id="pending")
 
     dr = dag_maker.create_dagrun()
     for ti in dr.get_task_instances():
@@ -90,9 +90,9 @@ def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, u
 )
 def test_set_dag_run_state_to_success_finished_teardown(dag_maker: DagMaker, finished_state):
     with dag_maker("TEST_DAG_1"):
-        running = EmptyOperator(task_id="running")
-        pending = EmptyOperator(task_id="pending")
-        [running, pending] >> EmptyOperator(task_id="teardown").as_teardown()
+        with EmptyOperator(task_id="teardown").as_teardown():
+            EmptyOperator(task_id="running")
+            EmptyOperator(task_id="pending")
     dr = dag_maker.create_dagrun()
     for ti in dr.get_task_instances():
         if ti.task_id == "running":


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #46937 


<!-- Please keep an empty line above the dashes. -->
---
When marking a dag run as success, first check if any teardown tasks are in state `running`, `deferred` or `up_for_reschedule` and if so, don't mark the dag run as success (because the teardowns need to complete). If all teardown tasks are in any other state, a dag run should be marked as success.
 
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
