### PR TITLE
Remove note about endpoint migration

### DIFF
--- a/contributing-docs/16_adding_api_endpoints.rst
+++ b/contributing-docs/16_adding_api_endpoints.rst
@@ -101,14 +101,6 @@ These models are defined to structure and validate the data handled by the API. 
 
 After adding or modifying Pydantic models, make sure to run the pre-commit hooks again to update any generated files.
 
-Situational: Legacy Endpoint Migration
---------------------------------------
-When migrating legacy endpoint to the new FastAPI API:
-
-1. Implement a feature complete endpoint in comparison to the legacy one or explain why this is not possible in your context.
-2. Make sure to have a good test coverage by copying over the legacy test cases to the new endpoint. This will guarantee an isofunctional new endpoint.
-3. Mark the legacy endpoint with the ``@mark_fastapi_migration_done`` decorator. This will help maintainers keep track of the endpoints remaining for the migration and those already migrated.
-
 ------
 
 If you happen to change architecture of Airflow, you can learn how we create our `Architecture diagrams <17_architecture_diagrams.rst>`__.


### PR DESCRIPTION
I don't think there is anything left to salvage from AF2 endpoints. Migration has been completed and the helper decorator has been removed.

This updates the doc accordingly.