### PR TITLE
Mark DAGModel stale and associate bundle on import errors

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -296,9 +296,14 @@ def _update_import_errors(
                 get_listener_manager().hook.on_new_dag_import_error(filename=filename, stacktrace=stacktrace)
             except Exception:
                 log.exception("error calling listener")
-        session.query(DagModel).filter(
-            DagModel.fileloc == filename, DagModel.bundle_name == bundle_name
-        ).update({"has_import_errors": True})
+        session.query(DagModel).filter(DagModel.fileloc == filename).update(
+            {
+                "has_import_errors": True,
+                "bundle_name": bundle_name,
+                "is_stale": True,
+            },
+            synchronize_session="fetch",
+        )
 
 
 def update_dag_parsing_results_in_db(

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -31,7 +31,7 @@ import logging
 import traceback
 from typing import TYPE_CHECKING, NamedTuple
 
-from sqlalchemy import delete, func, insert, select, tuple_
+from sqlalchemy import delete, func, insert, select, tuple_, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, load_only
 
@@ -296,13 +296,15 @@ def _update_import_errors(
                 get_listener_manager().hook.on_new_dag_import_error(filename=filename, stacktrace=stacktrace)
             except Exception:
                 log.exception("error calling listener")
-        session.query(DagModel).filter(DagModel.fileloc == filename).update(
-            {
-                "has_import_errors": True,
-                "bundle_name": bundle_name,
-                "is_stale": True,
-            },
-            synchronize_session="fetch",
+        session.execute(
+            update(DagModel)
+            .where(DagModel.fileloc == filename)
+            .values(
+                has_import_errors=True,
+                bundle_name=bundle_name,
+                is_stale=True,
+            )
+            .execution_options(synchronize_session="fetch")
         )
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
When a file parse encounters an import error, update the corresponding DagModel (filtered by file loc) to set has_import_errors, bundle_name, and is_stale in one go. This restores the intended behaviour, where DAGs with import errors are deactivated and flagged immediately. 

I have tested this locally by adding import errors to DAG file. It marked it as stale and DAG was not shown in the list. Once import errors were resolved DAG was visible again.

Closes [#49618](https://github.com/apache/airflow/issues/49618)
Closes: [#49617](https://github.com/apache/airflow/issues/49617)
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
