### PR TITLE
Fix `Stats` and `PluginImportErrors` layout

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
@@ -38,7 +38,7 @@ export const DAGImportErrors = ({ iconOnly = false }: { readonly iconOnly?: bool
     return <Skeleton height="9" width="225px" />;
   }
 
-  if (importErrorsCount === 0) {
+  if (importErrorsCount <= 0) {
     return undefined;
   }
 

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
@@ -38,7 +38,7 @@ export const DAGImportErrors = ({ iconOnly = false }: { readonly iconOnly?: bool
     return <Skeleton height="9" width="225px" />;
   }
 
-  if (importErrorsCount <= 0) {
+  if (importErrorsCount === 0) {
     return undefined;
   }
 

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
@@ -43,7 +43,7 @@ export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: b
     return undefined;
   }
 
-  if (importErrorsCount <= 0) {
+  if (importErrorsCount === 0) {
     return undefined;
   }
 

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrors.tsx
@@ -43,44 +43,44 @@ export const PluginImportErrors = ({ iconOnly = false }: { readonly iconOnly?: b
     return undefined;
   }
 
+  if (importErrorsCount <= 0) {
+    return undefined;
+  }
+
   return (
     <Box alignItems="center" display="flex" maxH="10px">
       <ErrorAlert error={error} />
-      {importErrorsCount > 0 && (
-        <>
-          {iconOnly ? (
-            <StateBadge
-              as={Button}
-              colorPalette="failed"
-              height={7}
-              onClick={onOpen}
-              title={pluralize("Plugin Import Error", importErrorsCount)}
-            >
-              <LuPlug size="0.5rem" />
-              {importErrorsCount}
-            </StateBadge>
-          ) : (
-            <Button
-              alignItems="center"
-              borderRadius="md"
-              display="flex"
-              gap={2}
-              onClick={onOpen}
-              variant="outline"
-            >
-              <StateBadge colorPalette="failed">
-                <LuPlug />
-                {importErrorsCount}
-              </StateBadge>
-              <Box alignItems="center" display="flex" gap={1}>
-                <Text fontWeight="bold">Plugin Import Errors</Text>
-                <FiChevronRight />
-              </Box>
-            </Button>
-          )}
-          <PluginImportErrorsModal importErrors={importErrors} onClose={onClose} open={open} />
-        </>
+      {iconOnly ? (
+        <StateBadge
+          as={Button}
+          colorPalette="failed"
+          height={7}
+          onClick={onOpen}
+          title={pluralize("Plugin Import Error", importErrorsCount)}
+        >
+          <LuPlug size="0.5rem" />
+          {importErrorsCount}
+        </StateBadge>
+      ) : (
+        <Button
+          alignItems="center"
+          borderRadius="md"
+          display="flex"
+          gap={2}
+          onClick={onOpen}
+          variant="outline"
+        >
+          <StateBadge colorPalette="failed">
+            <LuPlug />
+            {importErrorsCount}
+          </StateBadge>
+          <Box alignItems="center" display="flex" gap={1}>
+            <Text fontWeight="bold">Plugin Import Errors</Text>
+            <FiChevronRight />
+          </Box>
+        </Button>
       )}
+      <PluginImportErrorsModal importErrors={importErrors} onClose={onClose} open={open} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
@@ -56,7 +56,7 @@ export const Stats = () => {
         </Heading>
       </Flex>
 
-      <HStack columns={{ base: 1, lg: 5, md: 3 }} gap={4}>
+      <HStack columns={{ base: 1, lg: 6, md: 3 }} gap={4}>
         <StatsCard
           colorScheme="failed"
           count={failedDagsCount}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why

- currently the PluginImportErrors would render when the count == 0 which would cause the visually incorrect gap in the `Stats`

## How 

- return undefined if count <= 0, the "<" is to not show strange negative int to user
- make the column 6 synced with current StatsCard num

cc: @bbovenzi @pierrejeambrun 

before
![image](https://github.com/user-attachments/assets/014ced0f-ed4c-4bd1-88b2-e8f26e9b68f7)

after
![image](https://github.com/user-attachments/assets/79b12b7d-8bf4-4cb4-a1a2-c0e2ba29b391)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
