### PR TITLE
Display bundle version in details tab

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -132,6 +132,12 @@ export const Details = () => {
               <Table.Cell>Trigger Source</Table.Cell>
               <Table.Cell>{dagRun.triggered_by}</Table.Cell>
             </Table.Row>
+            {dagRun.bundle_version !== null && (
+              <Table.Row>
+                <Table.Cell>Bundle Version</Table.Cell>
+                <Table.Cell>{dagRun.bundle_version}</Table.Cell>
+              </Table.Row>
+            )}
             <Table.Row>
               <Table.Cell>Dag Version(s)</Table.Cell>
               <Table.Cell>


### PR DESCRIPTION
Frontend of https://github.com/apache/airflow/pull/49726, display the bundle version of a dag run in the details tab for versioned bundles. The row will be missing for unversionned bundles.

<img width="1506" alt="Screenshot 2025-04-25 at 11 23 17" src="https://github.com/user-attachments/assets/4678cbf5-3e42-4037-bd55-c86d854e5447" />
<img width="1498" alt="Screenshot 2025-04-25 at 11 24 39" src="https://github.com/user-attachments/assets/0de25edd-83fb-42e0-af23-6cdc10fe68cc" />
