### PR TITLE
Fall back when a task cannot be expanded

### DIFF
--- a/airflow-core/src/airflow/models/baseoperator.py
+++ b/airflow-core/src/airflow/models/baseoperator.py
@@ -621,7 +621,7 @@ class BaseOperator(TaskSDKBaseOperator):
             raise NotImplementedError(f"Not implemented for {type(task)}")
 
         # https://github.com/python/cpython/issues/86153
-        # WHile we support Python 3.9 we can't rely on the type hint, we need to pass the type explicitly to
+        # While we support Python 3.9 we can't rely on the type hint, we need to pass the type explicitly to
         # register.
         @get_mapped_ti_count.register(TaskSDKAbstractOperator)
         @classmethod


### PR DESCRIPTION
When rendering a dag in the API, we must take account for cases when a mapped task cannot be expanded, either due to the upstream has not been resolved, or cannot provide a value due to failure.

When this happens, we simply count 1 ti for the unexpanded task. This is how the scheduler represent the task internally, and should be a good enough value for UI representation.

Close #48786.