### PR TITLE
Display bundle version in Dag details tab

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -70,6 +70,12 @@ export const Details = () => {
                 <Time datetime={dag.last_parsed} />
               </Table.Cell>
             </Table.Row>
+            {dag.bundle_version !== null && (
+              <Table.Row>
+                <Table.Cell>Bundle Version</Table.Cell>
+                <Table.Cell>{dag.bundle_version}</Table.Cell>
+              </Table.Row>
+            )}
             <Table.Row>
               <Table.Cell>Latest Dag Version</Table.Cell>
               <Table.Cell>


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/49771

Display the bundle version of a Dag in the details tab.

### When the bundle version is not null
<img width="1512" alt="Screenshot 2025-04-25 at 15 47 54" src="https://github.com/user-attachments/assets/67233423-575b-4205-a599-d02d746182d0" />

### When the bundle version is null
<img width="1511" alt="Screenshot 2025-04-25 at 15 47 36" src="https://github.com/user-attachments/assets/a2d33939-244f-4cb7-b892-ae39c6d70422" />
