### PR TITLE
Fix gcp remote log module import in airflow local settings

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -147,7 +147,6 @@ if REMOTE_LOGGING:
             f"{type(remote_task_handler_kwargs)}"
         )
     delete_local_copy = conf.getboolean("logging", "delete_local_logs")
-    print(delete_local_copy)
 
     if remote_base_log_folder.startswith("s3://"):
         from airflow.providers.amazon.aws.log.s3_task_handler import S3RemoteLogIO

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -190,6 +190,7 @@ if REMOTE_LOGGING:
                     "base_log_folder": BASE_LOG_FOLDER,
                     "remote_base": remote_base_log_folder,
                     "delete_local_copy": delete_local_copy,
+
                     "gcp_key_path": key_path,
                 }
                 | remote_task_handler_kwargs

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -147,6 +147,7 @@ if REMOTE_LOGGING:
             f"{type(remote_task_handler_kwargs)}"
         )
     delete_local_copy = conf.getboolean("logging", "delete_local_logs")
+    print(delete_local_copy)
 
     if remote_base_log_folder.startswith("s3://"):
         from airflow.providers.amazon.aws.log.s3_task_handler import S3RemoteLogIO
@@ -180,7 +181,7 @@ if REMOTE_LOGGING:
         )
         remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("gs://"):
-        from airflow.providers.google.cloud.logs.gcs_task_handler import GCSRemoteLogIO
+        from airflow.providers.google.cloud.log.gcs_task_handler import GCSRemoteLogIO
 
         key_path = conf.get_mandatory_value("logging", "google_key_path", fallback=None)
 
@@ -194,7 +195,7 @@ if REMOTE_LOGGING:
                 }
                 | remote_task_handler_kwargs
             )
-        )
+        )  # type: ignore[assignment]
         remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("wasb"):
         from airflow.providers.microsoft.azure.log.wasb_task_handler import WasbRemoteLogIO

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -194,7 +194,7 @@ if REMOTE_LOGGING:
                 }
                 | remote_task_handler_kwargs
             )
-        )  # type: ignore[assignment]
+        )
         remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("wasb"):
         from airflow.providers.microsoft.azure.log.wasb_task_handler import WasbRemoteLogIO

--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -190,7 +190,6 @@ if REMOTE_LOGGING:
                     "base_log_folder": BASE_LOG_FOLDER,
                     "remote_base": remote_base_log_folder,
                     "delete_local_copy": delete_local_copy,
-
                     "gcp_key_path": key_path,
                 }
                 | remote_task_handler_kwargs

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -61,11 +61,13 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
     remote_base: str
     base_log_folder: Path = attrs.field(converter=Path)
     delete_local_copy: bool
+    project_id: str
 
     gcp_key_path: str | None
     gcp_keyfile_dict: dict | None
     scopes: Collection[str] | None
-    project_id: str
+
+    processors = ()
 
     def upload(self, path: os.PathLike, ti: RuntimeTI):
         """Upload the given log path to the remote storage."""

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -56,7 +56,7 @@ _DEFAULT_SCOPESS = frozenset(
 logger = logging.getLogger(__name__)
 
 
-@attrs.define
+@attrs.define(kw_only=True)
 class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
     remote_base: str
     base_log_folder: Path = attrs.field(converter=Path)

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -56,7 +56,7 @@ _DEFAULT_SCOPESS = frozenset(
 logger = logging.getLogger(__name__)
 
 
-@attrs.define(kw_only=True)
+@attrs.define
 class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
     remote_base: str
     base_log_folder: Path = attrs.field(converter=Path)
@@ -69,7 +69,7 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
 
     processors = ()
 
-    def upload(self, path: os.PathLike, ti: RuntimeTI):
+    def upload(self, path: os.PathLike | str, ti: RuntimeTI):
         """Upload the given log path to the remote storage."""
         path = Path(path)
         if path.is_absolute():


### PR DESCRIPTION
Gcp log module path pointed to logs. causing ModuleNotFoundError.

User reported in slack. https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1745522030825469

```
│ Traceback (most recent call last):                                                                                                                                                                                                                
│   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/logging_config.py", line 57, in load_logging_config                                                                                                                             
│     logging_config = import_string(logging_class_path)                                                                                                                                                                                            
│   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/module_loading.py", line 39, in import_string                                                                                                                             
│     module = import_module(module_path)                                                                                                                                                                                                           
│   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module                                                                                                                                                              
│     return _bootstrap._gcd_import(name[level:], package, level)                                                                                                                                                                                   
│   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import                                                                                                                                                                                 
│   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load                                                                                                                                                                              
│   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked                                                                                                                                                                     
│   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked                                                                                                                                                                               
│   File "<frozen importlib._bootstrap_external>", line 883, in exec_module                                                                                                                                                                         
│   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed                                                                                                                                                                    
│   File "/log_config/k8_log_config.py", line 8, in <module>                                                                                                                                                                                        
│     from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG                                                                                                                                                            
│   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/config_templates/airflow_local_settings.py", line 183, in <module>                                                                                                              
│     from airflow.providers.google.cloud.logs.gcs_task_handler import GCSRemoteLogIO                                                                                                                                                               
│ ModuleNotFoundError: No module named 'airflow.providers.google.cloud.logs'      
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
