### PR TITLE
Pre validate presence of precommit cache tarball instead of hard failing

### DIFF
--- a/.github/actions/install-pre-commit/action.yml
+++ b/.github/actions/install-pre-commit/action.yml
@@ -61,6 +61,16 @@ runs:
         key: cache-pre-commit-v4-${{ inputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
         path: /tmp/
       id: restore-pre-commit-cache
+    - name: "Check if pre-commit cache tarball exists"
+      shell: bash
+      run: |
+        if [ -f /tmp/cache-pre-commit.tar.gz ]; then
+          echo "✅ Cache tarball found: /tmp/cache-pre-commit.tar.gz"
+        else
+          echo "❌ Cache tarball missing. Expected /tmp/cache-pre-commit.tar.gz"
+          exit 1
+        fi
+      if: steps.restore-pre-commit-cache.outputs.stash-hit == 'true'
     - name: "Restore .cache from the tar file"
       run: tar -C ~ -xzf /tmp/cache-pre-commit.tar.gz
       shell: bash


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

If the cache for precommit doesn't exist for whatever reason, we hard fail:
```
Restoring cache-pre-commit-v4-3.9.22-276776138b8a4070079290945ec242b6ec55d95697ef02cd88e69ca3c1b45704-main from branch main.
Run # Catch errors in the download with || to avoid the whole workflow failing
error fetching artifacts: HTTP 500 (https://api.github.com/repos/apache/airflow/actions/runs/14672061[252](https://github.com/apache/airflow/actions/runs/14676573280/job/41193677372#step:6:260)/artifacts?per_page=100)
Run if [ "success" == "success" ]; then
Run tar -C ~ -xzf /tmp/cache-pre-commit.tar.gz
tar (child): /tmp/cache-pre-commit.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

It would be useful to not do that and have a stage that checks for presence before proceeding.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
