### PR TITLE
Adding dependency on `google-cloud-bigquery-storage` temporarily for google

### DIFF
--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -77,9 +77,11 @@ dependencies = [
     "google-auth-httplib2>=0.0.1",
     # google-cloud-aiplatform doesn't install ray for python 3.12 (issue: https://github.com/googleapis/python-aiplatform/issues/5252).
     # Temporarily lock in ray 2.42.0 which is compatible with python 3.12 until linked issue is solved.
+    # Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed
     "google-cloud-aiplatform[evaluation,ray]>=1.73.0;python_version < '3.12'",
     "google-cloud-aiplatform[evaluation]>=1.73.0;python_version >= '3.12'",
     "ray[default]==2.42.0 ; python_version >= '3.12'",
+    "google-cloud-bigquery-storage==2.31.0; python_version >= '3.12'",
     "google-cloud-alloydb>=0.4.0",
     "google-cloud-automl>=2.12.0",
     # Excluded versions contain bug https://github.com/apache/airflow/issues/39541 which is resolved in 3.24.0


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Due to: #49797, we conditionally add dependency on ray and this now introduces an issue where `google-cloud-bigquery-storage` doesnt install for python 3.12


Python 3.12:
```
31c31
< PyAthena==3.12.2
---
> PyAthena==3.13.0
49c49
< aenum==3.1.15
---
> aenum==3.1.16
52a53
> aiohttp-cors==0.8.1
138c139
< celery==5.5.1
---
> celery==5.5.2
142c143
< cfn-lint==1.34.1
---
> cfn-lint==1.34.2
154a156
> colorful==0.5.6
212c214
< google-api-python-client==2.167.0
---
> google-api-python-client==2.168.0
275c277
< h11==0.14.0
---
> h11==0.16.0
280c282
< httpcore==1.0.8
---
> httpcore==1.0.9
306c308
< ipython==9.1.0
---
> ipython==9.2.0
367c369,370
< msal==1.32.0
---
> msal==1.32.3
> msgpack==1.1.0
375c378
< mypy-boto3-rds==1.38.0
---
> mypy-boto3-rds==1.38.2
396,398c399,403
< openlineage-integration-common==1.31.0
< openlineage-python==1.31.0
< openlineage_sql==1.31.0
---
> opencensus-context==0.1.3
> opencensus==0.11.4
> openlineage-integration-common==1.32.0
> openlineage-python==1.32.0
> openlineage_sql==1.32.0
455a461
> py-spy==0.4.0
458c464
< pyarrow-hotfix==0.6
---
> pyarrow-hotfix==0.7
508c514,515
< qdrant-client==1.14.1
---
> qdrant-client==1.14.2
> ray==2.42.0
554a562
> smart-open==7.1.0
593c601
< structlog==25.2.0
---
> structlog==25.3.0
599c607
< teradatasql==20.0.0.29
---
> teradatasql==20.0.0.30
671c679
< ydb==3.21.0
---
> ydb==3.21.1
```


Python 3.11:
```
53c53
< PyAthena==3.12.2
---
> PyAthena==3.13.0
71c71
< aenum==3.1.15
---
> aenum==3.1.16
74a75
> aiohttp-cors==0.8.1
255,256c256,257
< celery==5.5.1
< certifi==2025.1.31
---
> celery==5.5.2
> certifi==2025.4.26
259c260
< cfn-lint==1.34.1
---
> cfn-lint==1.34.2
271a273
> colorful==0.5.6
331c333
< google-api-python-client==2.167.0
---
> google-api-python-client==2.168.0
341a344
> google-cloud-bigquery-storage==2.31.0
394c397
< h11==0.14.0
---
> h11==0.16.0
399c402
< httpcore==1.0.8
---
> httpcore==1.0.9
484c487,488
< msal==1.32.0
---
> msal==1.32.3
> msgpack==1.1.0
492c496
< mypy-boto3-rds==1.38.0
---
> mypy-boto3-rds==1.38.2
512a517,518
> opencensus-context==0.1.3
> opencensus==0.11.4
573a580
> py-spy==0.4.0
576c583
< pyarrow-hotfix==0.6
---
> pyarrow-hotfix==0.7
627c634,635
< qdrant-client==1.14.1
---
> qdrant-client==1.14.2
> ray==2.42.0
671a680
> smart-open==7.1.0
677c686
< snowflake-snowpark-python==1.30.0
---
> snowflake-snowpark-python==1.31.0
712c721
< structlog==25.2.0
---
> structlog==25.3.0
718c727
< teradatasql==20.0.0.29
---
> teradatasql==20.0.0.30
768c777
< uv==0.6.16
---
> uv==0.6.17
791c800
< ydb==3.21.0
---
> ydb==3.21.1
```


Leading to CI failures like: https://github.com/apache/airflow/actions/runs/14676573280

Temp attaching a new dependency to fix ci


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
