### PR TITLE
Add map_index filter option to GetTICount and GetTaskStates

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -677,13 +677,12 @@ def get_task_instance_states(
         group_tasks = _get_group_tasks(dag_id, task_group_id, session, logical_dates, run_ids)
 
         if task_ids:
-            results = results | group_tasks
+            results = results + group_tasks
         else:
             results = group_tasks
 
     if map_index is not None:
         results = [task for task in results if task.map_index == map_index]
-
     [
         run_id_task_state_map[task.run_id].update(
             {task.task_id: task.state}

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -619,9 +619,10 @@ def get_task_instance_count(
         group_tasks = _get_group_tasks(dag_id, task_group_id, session, logical_dates, run_ids)
 
         # Get unique (task_id, map_index) pairs
-        if map_index is None:
-            task_map_pairs = [(ti.task_id, ti.map_index) for ti in group_tasks]
-        else:
+
+        task_map_pairs = [(ti.task_id, ti.map_index) for ti in group_tasks]
+
+        if map_index is not None:
             task_map_pairs = [(ti.task_id, ti.map_index) for ti in group_tasks if ti.map_index == map_index]
 
         if not task_map_pairs:
@@ -676,10 +677,7 @@ def get_task_instance_states(
     if task_group_id:
         group_tasks = _get_group_tasks(dag_id, task_group_id, session, logical_dates, run_ids)
 
-        if task_ids:
-            results = results + group_tasks
-        else:
-            results = group_tasks
+        results = results + group_tasks if task_ids else group_tasks
 
     if map_index is not None:
         results = [task for task in results if task.map_index == map_index]

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -430,6 +430,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         elif isinstance(msg, GetTICount):
             resp = self.client.task_instances.get_count(
                 dag_id=msg.dag_id,
+                map_index=msg.map_index,
                 task_ids=msg.task_ids,
                 task_group_id=msg.task_group_id,
                 logical_dates=msg.logical_dates,
@@ -440,6 +441,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         elif isinstance(msg, GetTaskStates):
             run_id_task_state_map = self.client.task_instances.get_task_states(
                 dag_id=msg.dag_id,
+                map_index=msg.map_index,
                 task_ids=msg.task_ids,
                 task_group_id=msg.task_group_id,
                 logical_dates=msg.logical_dates,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1662,7 +1662,6 @@ class TestGetTaskStates:
             "task_states": {
                 "test": {
                     "group1.task1": "success",
-                    "task2": "failed",
                 },
             },
         }
@@ -1802,21 +1801,21 @@ class TestGetTaskStates:
                 None,
                 [1, 2, 3],
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
-                {"task1": "success", "add_one": "success"},
+                {"task1": "success", "add_one_0": "success", "add_one_1": "success", "add_one_2": "success"},
                 id="with-default-map-index-None",
             ),
             pytest.param(
                 0,
                 [1, 2, 3],
                 {"-1": State.SUCCESS, "0": State.FAILED, "1": State.SUCCESS, "2": State.SUCCESS},
-                {"add_one": "failed"},
+                {"add_one_0": "failed"},
                 id="with-map-index-0",
             ),
             pytest.param(
                 1,
                 [1, 2, 3],
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.FAILED, "2": State.SUCCESS},
-                {"add_one": "failed"},
+                {"add_one_1": "failed"},
                 id="with-map-index-1",
             ),
         ),
@@ -1867,7 +1866,13 @@ class TestGetTaskStates:
                 None,
                 None,
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
-                {"group1.add_one": "success", "group1.task2": "success", "task1": "success"},
+                {
+                    "group1.add_one_0": "success",
+                    "group1.add_one_1": "success",
+                    "group1.add_one_2": "success",
+                    "group1.task2": "success",
+                    "task1": "success",
+                },
                 id="with-default-map-index-None",
             ),
             pytest.param(
@@ -1885,7 +1890,12 @@ class TestGetTaskStates:
                 None,
                 "group1",
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
-                {"task1": "success", "group1.task2": "success", "group1.add_one": "success"},
+                {
+                    "group1.task2": "success",
+                    "group1.add_one_0": "success",
+                    "group1.add_one_1": "success",
+                    "group1.add_one_2": "success",
+                },
                 id="with-task-group-id-and-map-index-None",
             ),
             pytest.param(
@@ -1894,7 +1904,7 @@ class TestGetTaskStates:
                 None,
                 "group1",
                 {"-1": State.SUCCESS, "0": State.FAILED, "1": State.SUCCESS, "2": State.SUCCESS},
-                {"group1.add_one": "failed"},
+                {"group1.add_one_0": "failed"},
                 id="with-task-group-id-and-map-index-0",
             ),
         ),
@@ -1914,7 +1924,7 @@ class TestGetTaskStates:
         """
         case1: map_index is None, task_ids is None, task_group_name is None, it should fetch all the task states
         case2: when map index -1 and provided task_ids, it should return the task states of task_ids
-        case3: when map index is None and provided task_group_id, it should return the task states of tasks under the task group and normal task states (because the task_ids filter is None)
+        case3: when map index is None and provided task_group_id, it should return the task states of tasks under the task group and normal task states under task group
         case4: when map index is 0 and provided task_group_id, it should return the task states of tasks under the task group that falls under map index = 0
         """
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1907,6 +1907,15 @@ class TestGetTaskStates:
                 {"group1.add_one_0": "failed"},
                 id="with-task-group-id-and-map-index-0",
             ),
+            pytest.param(
+                -1,
+                [1, 2, 3],
+                ["task1"],
+                "group1",
+                {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"task1": "success", "group1.task2": "success"},
+                id="with-task-id-and-task-group-map-index-(-1)",
+            ),
         ),
     )
     def test_get_task_states_mix_of_task_and_task_group_dynamic_task_mapping(
@@ -1926,6 +1935,7 @@ class TestGetTaskStates:
         case2: when map index -1 and provided task_ids, it should return the task states of task_ids
         case3: when map index is None and provided task_group_id, it should return the task states of tasks under the task group and normal task states under task group
         case4: when map index is 0 and provided task_group_id, it should return the task states of tasks under the task group that falls under map index = 0
+        case5: when map index is -1 and provided both task_id and task_group_id, it should return the task states of tasks under the task group that falls under map index = -1 and normal task_ids states
         """
 
         with dag_maker(session=session, serialized=True) as dag:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1539,7 +1539,7 @@ class TestGetCount:
             "expected_count",
         ],
         (
-            pytest.param(None, [1, 2, 3], None, None, 5, id="use-default-map-index"),
+            pytest.param(None, [1, 2, 3], None, None, 5, id="use-default-map-index-None"),
             pytest.param(-1, [1, 2, 3], ["task1"], None, 1, id="with-task-ids-and-map-index-(-1)"),
             pytest.param(None, [1, 2, 3], None, "group1", 4, id="with-task-group-id-and-map-index-None"),
             pytest.param(0, [1, 2, 3], None, "group1", 1, id="with-task-group-id-and-map-index-0"),
@@ -1803,21 +1803,21 @@ class TestGetTaskStates:
                 [1, 2, 3],
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
                 {"task1": "success", "add_one": "success"},
-                id="use-default-map-index",
+                id="with-default-map-index-None",
             ),
             pytest.param(
                 0,
                 [1, 2, 3],
                 {"-1": State.SUCCESS, "0": State.FAILED, "1": State.SUCCESS, "2": State.SUCCESS},
                 {"add_one": "failed"},
-                id="use-default-map-index-0",
+                id="with-map-index-0",
             ),
             pytest.param(
                 1,
                 [1, 2, 3],
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.FAILED, "2": State.SUCCESS},
                 {"add_one": "failed"},
-                id="use-default-map-index-1",
+                id="with-map-index-1",
             ),
         ),
     )
@@ -1868,7 +1868,7 @@ class TestGetTaskStates:
                 None,
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
                 {"group1.add_one": "success", "group1.task2": "success", "task1": "success"},
-                id="use-default-map-index",
+                id="with-default-map-index-None",
             ),
             pytest.param(
                 -1,
@@ -1877,7 +1877,7 @@ class TestGetTaskStates:
                 None,
                 {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
                 {"task1": "success"},
-                id="use-map-index-(-1)",
+                id="with-task-ids-map-index-(-1)",
             ),
             pytest.param(
                 None,
@@ -1915,7 +1915,7 @@ class TestGetTaskStates:
         case1: map_index is None, task_ids is None, task_group_name is None, it should fetch all the task states
         case2: when map index -1 and provided task_ids, it should return the task states of task_ids
         case3: when map index is None and provided task_group_id, it should return the task states of tasks under the task group and normal task states (because the task_ids filter is None)
-        case4: when map index is 0 and provided task_group_id, it should return the task states of tasks under the task group that falls map index = 0
+        case4: when map index is 0 and provided task_group_id, it should return the task states of tasks under the task group that falls under map index = 0
         """
 
         with dag_maker(session=session, serialized=True) as dag:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1447,6 +1447,156 @@ class TestGetCount:
         assert response.status_code == 200
         assert response.json() == 2
 
+    def test_get_count_with_map_index_less_than_zero(self, client, session, create_task_instance):
+        create_task_instance(task_id="task1", state=State.SUCCESS, run_id="runid1", dag_id="map_index_test")
+        session.commit()
+
+        response = client.get(
+            "/execution/task-instances/count",
+            params={"dag_id": "map_index_test", "states": [State.SUCCESS], "map_index": -1},
+        )
+        assert response.status_code == 200
+        assert response.json() == 1
+
+    def test_get_count_with_multiple_tasks_and_map_index_less_than_zero(
+        self, dag_maker, client, session, create_task_instance
+    ):
+        with dag_maker("test_get_count_with_multiple_tasks_and_map_index_less_than_zero"):
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+            EmptyOperator(task_id="task3")
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances()
+
+        # Set different states for the task instances
+        for ti, state in zip(tis, [State.SUCCESS, State.FAILED, State.SKIPPED]):
+            ti.state = state
+            session.merge(ti)
+        session.commit()
+
+        response = client.get(
+            "/execution/task-instances/count",
+            params={
+                "dag_id": "test_get_count_with_multiple_tasks_and_map_index_less_than_zero",
+                "map_index": -1,
+            },
+        )
+        assert response.status_code == 200
+        assert response.json() == 3
+
+    @pytest.mark.parametrize(
+        ["map_index", "dynamic_task_args", "expected_count"],
+        (
+            pytest.param(None, [1, 2, 3], 4, id="use-default-map-index"),
+            pytest.param(-1, [1, 2, 3], 1, id="map-index-(-1)"),
+            pytest.param(0, [1, 2, 3], 1, id="map-index-0"),
+            pytest.param(1, [1, 2, 3], 1, id="map-index-1"),
+            pytest.param(2, [1, 2, 3], 1, id="map-index-2"),
+        ),
+    )
+    def test_get_count_for_dynamic_task_mapping(
+        self, dag_maker, client, session, map_index, dynamic_task_args, expected_count
+    ):
+        """
+        case 1: map_index is None, it should fetch all the tasks
+        other cases: when map index is provided, it should return the count of tasks that falls under the map index
+        """
+        with dag_maker(session=session) as dag:
+            EmptyOperator(task_id="op1")
+
+            @dag.task()
+            def add_one(x):
+                return [x + 1]
+
+            add_one.expand(x=dynamic_task_args)
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances()
+
+        for ti in tis:
+            ti.state = State.SUCCESS
+            session.merge(ti)
+        session.commit()
+
+        map_index = {} if map_index is None else {"map_index": map_index}
+
+        response = client.get(
+            "/execution/task-instances/count",
+            params={"dag_id": dr.dag_id, "run_ids": [dr.run_id], **map_index},
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_count
+
+    @pytest.mark.parametrize(
+        [
+            "map_index",
+            "dynamic_task_args",
+            "task_ids",
+            "task_group_name",
+            "expected_count",
+        ],
+        (
+            pytest.param(None, [1, 2, 3], None, None, 5, id="use-default-map-index"),
+            pytest.param(-1, [1, 2, 3], ["task1"], None, 1, id="with-task-ids-and-map-index-(-1)"),
+            pytest.param(None, [1, 2, 3], None, "group1", 4, id="with-task-group-id-and-map-index-None"),
+            pytest.param(0, [1, 2, 3], None, "group1", 1, id="with-task-group-id-and-map-index-0"),
+            pytest.param(-1, [1, 2, 3], None, "group1", 1, id="with-task-group-id-and-map-index-(-1)"),
+        ),
+    )
+    def test_get_count_mix_of_task_and_task_group_dynamic_task_mapping(
+        self,
+        dag_maker,
+        client,
+        session,
+        map_index,
+        dynamic_task_args,
+        task_ids,
+        task_group_name,
+        expected_count,
+    ):
+        """
+        case 1: map_index is None, task_ids is None, task_group_name is None, it should fetch all the tasks
+        case 2: when map index -1 and provided task_ids, it should return the count of task_ids
+        case 3: when map index is None and provided task_group_id, it should return the count of tasks under the task group
+        case 4: when map index is 0 and provided task_group_id, it should return the count of tasks under the task group that falls map index =0
+        case 5: when map index is -1 and provided task_group_id, it should return the count of tasks under the task group that falls map index =-1 i.e this task is not mapped
+        """
+
+        with dag_maker(session=session, serialized=True) as dag:
+            EmptyOperator(task_id="task1")
+
+            with TaskGroup("group1"):
+
+                @dag.task()
+                def add_one(x):
+                    return [x + 1]
+
+                add_one.expand(x=dynamic_task_args)
+
+                EmptyOperator(task_id="task2")
+
+        dr = dag_maker.create_dagrun(session=session)
+
+        session.commit()
+        params = {}
+
+        if task_ids:
+            params["task_ids"] = task_ids
+        if task_group_name:
+            params["task_group_id"] = task_group_name
+        if map_index is not None:
+            params["map_index"] = map_index
+
+        response = client.get(
+            "/execution/task-instances/count",
+            params={"dag_id": dr.dag_id, "run_ids": [dr.run_id], **params},
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_count
+
 
 class TestGetTaskStates:
     def setup_method(self):
@@ -1644,3 +1794,159 @@ class TestGetTaskStates:
             "reason": "not_found",
             "message": "DAG non_existent_dag not found",
         }
+
+    @pytest.mark.parametrize(
+        ["map_index", "dynamic_task_args", "states", "expected"],
+        (
+            pytest.param(
+                None,
+                [1, 2, 3],
+                {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"task1": "success", "add_one": "success"},
+                id="use-default-map-index",
+            ),
+            pytest.param(
+                0,
+                [1, 2, 3],
+                {"-1": State.SUCCESS, "0": State.FAILED, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"add_one": "failed"},
+                id="use-default-map-index-0",
+            ),
+            pytest.param(
+                1,
+                [1, 2, 3],
+                {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.FAILED, "2": State.SUCCESS},
+                {"add_one": "failed"},
+                id="use-default-map-index-1",
+            ),
+        ),
+    )
+    def test_get_task_states_for_dynamic_task_mapping(
+        self, dag_maker, client, session, map_index, dynamic_task_args, states, expected
+    ):
+        """
+        case 1: map_index is None, it should fetch all the tasks
+        other cases: when map index is provided, it should return the count of tasks that falls under the map index
+        """
+        with dag_maker(session=session, serialized=True) as dag:
+            EmptyOperator(task_id="task1")
+
+            @dag.task()
+            def add_one(x):
+                return [x + 1]
+
+            add_one.expand(x=dynamic_task_args)
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            ti.state = states.get(str(ti.map_index))
+            session.merge(ti)
+        session.commit()
+
+        map_index = {} if map_index is None else {"map_index": map_index}
+
+        response = client.get("/execution/task-instances/states", params={"dag_id": dr.dag_id, **map_index})
+        assert response.status_code == 200
+        assert response.json() == {"task_states": {dr.run_id: expected}}
+
+    @pytest.mark.parametrize(
+        [
+            "map_index",
+            "dynamic_task_args",
+            "task_ids",
+            "task_group_name",
+            "states",
+            "expected",
+        ],
+        (
+            pytest.param(
+                None,
+                [1, 2, 3],
+                None,
+                None,
+                {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"group1.add_one": "success", "group1.task2": "success", "task1": "success"},
+                id="use-default-map-index",
+            ),
+            pytest.param(
+                -1,
+                [1, 2, 3],
+                ["task1"],
+                None,
+                {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"task1": "success"},
+                id="use-map-index-(-1)",
+            ),
+            pytest.param(
+                None,
+                [1, 2, 3],
+                None,
+                "group1",
+                {"-1": State.SUCCESS, "0": State.SUCCESS, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"task1": "success", "group1.task2": "success", "group1.add_one": "success"},
+                id="with-task-group-id-and-map-index-None",
+            ),
+            pytest.param(
+                0,
+                [1, 2, 3],
+                None,
+                "group1",
+                {"-1": State.SUCCESS, "0": State.FAILED, "1": State.SUCCESS, "2": State.SUCCESS},
+                {"group1.add_one": "failed"},
+                id="with-task-group-id-and-map-index-0",
+            ),
+        ),
+    )
+    def test_get_task_states_mix_of_task_and_task_group_dynamic_task_mapping(
+        self,
+        dag_maker,
+        client,
+        session,
+        map_index,
+        dynamic_task_args,
+        task_ids,
+        task_group_name,
+        states,
+        expected,
+    ):
+        """
+        case1: map_index is None, task_ids is None, task_group_name is None, it should fetch all the task states
+        case2: when map index -1 and provided task_ids, it should return the task states of task_ids
+        case3: when map index is None and provided task_group_id, it should return the task states of tasks under the task group and normal task states (because the task_ids filter is None)
+        case4: when map index is 0 and provided task_group_id, it should return the task states of tasks under the task group that falls map index = 0
+        """
+
+        with dag_maker(session=session, serialized=True) as dag:
+            EmptyOperator(task_id="task1")
+
+            with TaskGroup("group1"):
+
+                @dag.task()
+                def add_one(x):
+                    return [x + 1]
+
+                add_one.expand(x=dynamic_task_args)
+
+                EmptyOperator(task_id="task2")
+
+        dr = dag_maker.create_dagrun(session=session)
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            ti.state = states.get(str(ti.map_index))
+            session.merge(ti)
+        session.commit()
+        params = {}
+
+        if task_ids:
+            params["task_ids"] = task_ids
+        if task_group_name:
+            params["task_group_id"] = task_group_name
+        if map_index is not None:
+            params["map_index"] = map_index
+
+        response = client.get("/execution/task-instances/states", params={"dag_id": dr.dag_id, **params})
+        assert response.status_code == 200
+        assert response.json() == {"task_states": {dr.run_id: expected}}

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -222,7 +222,6 @@ class TaskInstanceOperations:
         """Get count of task instances matching the given criteria."""
         params = {
             "dag_id": dag_id,
-            "map_index": map_index,
             "task_ids": task_ids,
             "task_group_id": task_group_id,
             "logical_dates": [d.isoformat() for d in logical_dates] if logical_dates is not None else None,
@@ -232,6 +231,9 @@ class TaskInstanceOperations:
 
         # Remove None values from params
         params = {k: v for k, v in params.items() if v is not None}
+
+        if map_index is not None and map_index >= 0:
+            params.update({"map_index": map_index})  # type: ignore[dict-item]
 
         resp = self.client.get("task-instances/count", params=params)
         return TICount(count=resp.json())
@@ -248,7 +250,6 @@ class TaskInstanceOperations:
         """Get task states given criteria."""
         params = {
             "dag_id": dag_id,
-            "map_index": map_index,
             "task_ids": task_ids,
             "task_group_id": task_group_id,
             "logical_dates": [d.isoformat() for d in logical_dates] if logical_dates is not None else None,
@@ -257,6 +258,9 @@ class TaskInstanceOperations:
 
         # Remove None values from params
         params = {k: v for k, v in params.items() if v is not None}
+
+        if map_index is not None and map_index >= 0:
+            params.update({"map_index": map_index})  # type: ignore[dict-item]
 
         resp = self.client.get("task-instances/states", params=params)
         return TaskStatesResponse.model_validate_json(resp.read())

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -212,6 +212,7 @@ class TaskInstanceOperations:
     def get_count(
         self,
         dag_id: str,
+        map_index: int | None = None,
         task_ids: list[str] | None = None,
         task_group_id: str | None = None,
         logical_dates: list[datetime] | None = None,
@@ -221,6 +222,7 @@ class TaskInstanceOperations:
         """Get count of task instances matching the given criteria."""
         params = {
             "dag_id": dag_id,
+            "map_index": map_index,
             "task_ids": task_ids,
             "task_group_id": task_group_id,
             "logical_dates": [d.isoformat() for d in logical_dates] if logical_dates is not None else None,
@@ -237,6 +239,7 @@ class TaskInstanceOperations:
     def get_task_states(
         self,
         dag_id: str,
+        map_index: int | None = None,
         task_ids: list[str] | None = None,
         task_group_id: str | None = None,
         logical_dates: list[datetime] | None = None,
@@ -245,6 +248,7 @@ class TaskInstanceOperations:
         """Get task states given criteria."""
         params = {
             "dag_id": dag_id,
+            "map_index": map_index,
             "task_ids": task_ids,
             "task_group_id": task_group_id,
             "logical_dates": [d.isoformat() for d in logical_dates] if logical_dates is not None else None,

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -560,6 +560,7 @@ class GetTaskRescheduleStartDate(BaseModel):
 
 class GetTICount(BaseModel):
     dag_id: str
+    map_index: int | None = None
     task_ids: list[str] | None = None
     task_group_id: str | None = None
     logical_dates: list[AwareDatetime] | None = None
@@ -570,6 +571,7 @@ class GetTICount(BaseModel):
 
 class GetTaskStates(BaseModel):
     dag_id: str
+    map_index: int | None = None
     task_ids: list[str] | None = None
     task_group_id: str | None = None
     logical_dates: list[AwareDatetime] | None = None

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1099,6 +1099,7 @@ class ActivitySubprocess(WatchedSubprocess):
         elif isinstance(msg, GetTICount):
             resp = self.client.task_instances.get_count(
                 dag_id=msg.dag_id,
+                map_index=msg.map_index,
                 task_ids=msg.task_ids,
                 task_group_id=msg.task_group_id,
                 logical_dates=msg.logical_dates,
@@ -1108,6 +1109,7 @@ class ActivitySubprocess(WatchedSubprocess):
         elif isinstance(msg, GetTaskStates):
             task_states_map = self.client.task_instances.get_task_states(
                 dag_id=msg.dag_id,
+                map_index=msg.map_index,
                 task_ids=msg.task_ids,
                 task_group_id=msg.task_group_id,
                 logical_dates=msg.logical_dates,

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -413,6 +413,7 @@ class RuntimeTaskInstance(TaskInstance):
     @staticmethod
     def get_ti_count(
         dag_id: str,
+        map_index: int | None = None,
         task_ids: list[str] | None = None,
         task_group_id: str | None = None,
         logical_dates: list[datetime] | None = None,
@@ -427,6 +428,7 @@ class RuntimeTaskInstance(TaskInstance):
                 log=log,
                 msg=GetTICount(
                     dag_id=dag_id,
+                    map_index=map_index,
                     task_ids=task_ids,
                     task_group_id=task_group_id,
                     logical_dates=logical_dates,
@@ -444,6 +446,7 @@ class RuntimeTaskInstance(TaskInstance):
     @staticmethod
     def get_task_states(
         dag_id: str,
+        map_index: int | None = None,
         task_ids: list[str] | None = None,
         task_group_id: str | None = None,
         logical_dates: list[datetime] | None = None,
@@ -457,6 +460,7 @@ class RuntimeTaskInstance(TaskInstance):
                 log=log,
                 msg=GetTaskStates(
                     dag_id=dag_id,
+                    map_index=map_index,
                     task_ids=task_ids,
                     task_group_id=task_group_id,
                     logical_dates=logical_dates,

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -88,6 +88,7 @@ class RuntimeTaskInstanceProtocol(Protocol):
     @staticmethod
     def get_ti_count(
         dag_id: str,
+        map_index: int | None = None,
         task_ids: list[str] | None = None,
         task_group_id: str | None = None,
         logical_dates: list[AwareDatetime] | None = None,
@@ -98,6 +99,7 @@ class RuntimeTaskInstanceProtocol(Protocol):
     @staticmethod
     def get_task_states(
         dag_id: str,
+        map_index: int | None = None,
         task_ids: list[str] | None = None,
         task_group_id: str | None = None,
         logical_dates: list[AwareDatetime] | None = None,

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -452,13 +452,13 @@ class TestTaskInstanceOperations:
             assert params.get_list("logical_dates") == logical_dates_str
             assert params.get_list("run_ids") == []
             assert params.get_list("states") == states
-            assert params["map_index"] == "-1"
+            assert params["map_index"] == "0"
             return httpx.Response(200, json=10)
 
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.task_instances.get_count(
             dag_id="test_dag",
-            map_index=-1,
+            map_index=0,
             task_ids=task_ids,
             task_group_id="group1",
             logical_dates=logical_dates,
@@ -496,7 +496,7 @@ class TestTaskInstanceOperations:
             assert params.get_list("logical_dates") == logical_dates_str
             assert params.get_list("task_ids") == []
             assert params.get_list("run_ids") == []
-            assert params.get("map_index") == "-1"
+            assert params.get("map_index") == "0"
             return httpx.Response(
                 200, json={"task_states": {"run_id": {"group1.task1": "success", "group1.task2": "failed"}}}
             )
@@ -504,7 +504,7 @@ class TestTaskInstanceOperations:
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.task_instances.get_task_states(
             dag_id="test_dag",
-            map_index=-1,
+            map_index=0,
             task_group_id="group1",
             logical_dates=logical_dates,
         )

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -452,11 +452,13 @@ class TestTaskInstanceOperations:
             assert params.get_list("logical_dates") == logical_dates_str
             assert params.get_list("run_ids") == []
             assert params.get_list("states") == states
+            assert params["map_index"] == "-1"
             return httpx.Response(200, json=10)
 
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.task_instances.get_count(
             dag_id="test_dag",
+            map_index=-1,
             task_ids=task_ids,
             task_group_id="group1",
             logical_dates=logical_dates,
@@ -494,6 +496,7 @@ class TestTaskInstanceOperations:
             assert params.get_list("logical_dates") == logical_dates_str
             assert params.get_list("task_ids") == []
             assert params.get_list("run_ids") == []
+            assert params.get("map_index") == "-1"
             return httpx.Response(
                 200, json={"task_states": {"run_id": {"group1.task1": "success", "group1.task2": "failed"}}}
             )
@@ -501,6 +504,7 @@ class TestTaskInstanceOperations:
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.task_instances.get_task_states(
             dag_id="test_dag",
+            map_index=-1,
             task_group_id="group1",
             logical_dates=logical_dates,
         )

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -1396,6 +1396,7 @@ class TestHandleRequest:
                 (),
                 {
                     "dag_id": "test_dag",
+                    "map_index": None,
                     "logical_dates": None,
                     "run_ids": None,
                     "states": None,
@@ -1426,6 +1427,7 @@ class TestHandleRequest:
                 (),
                 {
                     "dag_id": "test_dag",
+                    "map_index": None,
                     "task_ids": None,
                     "logical_dates": None,
                     "run_ids": None,


### PR DESCRIPTION
Adding mapping index option to GetTICount and GetTaskStates.

The default option is None, because if the user not input any task_ids/task_group_id, we would want to fetch all the tasks that satsfies other condition(dag_id, run_ids).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
