### PR TITLE
Import XComArg from TaskSDK definitions

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -77,10 +77,10 @@ if TYPE_CHECKING:
 
     import jinja2
 
-    from airflow.models.xcom_arg import XComArg
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.taskgroup import TaskGroup
+    from airflow.sdk.definitions.xcom_arg import XComArg
     from airflow.serialization.enums import DagAttributeTypes
     from airflow.task.priority_strategy import PriorityWeightStrategy
     from airflow.triggers.base import BaseTrigger, StartTriggerArgs
@@ -1389,7 +1389,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         return self._dag is not None
 
     def _set_xcomargs_dependencies(self) -> None:
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         for f in self.template_fields:
             arg = getattr(self, f, NOTSET)
@@ -1418,7 +1418,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 generate_content >> send_email
 
         """
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         if field not in self.template_fields:
             return
@@ -1465,10 +1465,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     @property
     def output(self) -> XComArg:
         """Returns reference to XCom pushed by current operator."""
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
-        # TODO: Task-SDK: remove this type ignore once XComArg is ported over
-        return XComArg(operator=self)  # type: ignore[call-overload]
+        return XComArg(operator=self)
 
     @classmethod
     def get_serialized_fields(cls):

--- a/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
@@ -67,14 +67,14 @@ def is_mappable(v: Any) -> TypeGuard[OperatorExpandArgument]:
 
 # To replace tedious isinstance() checks.
 def _is_parse_time_mappable(v: OperatorExpandArgument) -> TypeGuard[Mapping | Sequence]:
-    from airflow.models.xcom_arg import XComArg
+    from airflow.sdk.definitions.xcom_arg import XComArg
 
     return not isinstance(v, (MappedArgument, XComArg))
 
 
 # To replace tedious isinstance() checks.
 def _needs_run_time_resolution(v: OperatorExpandArgument) -> TypeGuard[MappedArgument | XComArg]:
-    from airflow.models.xcom_arg import XComArg
+    from airflow.sdk.definitions.xcom_arg import XComArg
 
     return isinstance(v, (MappedArgument, XComArg))
 
@@ -187,7 +187,7 @@ class DictOfListsExpandInput(ResolveMixin):
         raise IndexError(f"index {map_index} is over mapped length")
 
     def iter_references(self) -> Iterable[tuple[Operator, str]]:
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         for x in self.value.values():
             if isinstance(x, XComArg):
@@ -238,7 +238,7 @@ class ListOfDictsExpandInput(ResolveMixin):
         raise NotFullyPopulated({"expand_kwargs() argument"})
 
     def iter_references(self) -> Iterable[tuple[Operator, str]]:
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         if isinstance(self.value, XComArg):
             yield from self.value.iter_references()

--- a/task-sdk/src/airflow/sdk/definitions/edges.py
+++ b/task-sdk/src/airflow/sdk/definitions/edges.py
@@ -70,9 +70,9 @@ class EdgeModifier(DependencyMixin):
         nodes: DependencyMixin | Sequence[DependencyMixin],
         stream: list[DependencyMixin],
     ):
-        from airflow.models.xcom_arg import XComArg
         from airflow.sdk.definitions._internal.node import DAGNode
         from airflow.sdk.definitions.taskgroup import TaskGroup
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         for node in self._make_list(nodes):
             if isinstance(node, (TaskGroup, XComArg, DAGNode)):
@@ -92,9 +92,9 @@ class EdgeModifier(DependencyMixin):
         the nodes are from the same TaskGroup, we will leave them as DAGNodes and not
         convert them to TaskGroups
         """
-        from airflow.models.xcom_arg import XComArg
         from airflow.sdk.definitions._internal.node import DAGNode
         from airflow.sdk.definitions.taskgroup import TaskGroup
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         group_ids = set()
         for node in [*self._upstream, *self._downstream]:

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -68,11 +68,11 @@ if TYPE_CHECKING:
         OperatorExpandArgument,
         OperatorExpandKwargsArgument,
     )
-    from airflow.models.xcom_arg import XComArg
     from airflow.sdk.bases.operator import BaseOperator
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.param import ParamsDict
+    from airflow.sdk.definitions.xcom_arg import XComArg
     from airflow.sdk.types import Operator
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
     from airflow.triggers.base import StartTriggerArgs
@@ -192,7 +192,7 @@ class OperatorPartial:
         return self._expand(DictOfListsExpandInput(mapped_kwargs), strict=False)
 
     def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> MappedOperator:
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         if isinstance(kwargs, Sequence):
             for item in kwargs:
@@ -338,7 +338,7 @@ class MappedOperator(AbstractOperator):
         return f"<Mapped({self._task_type}): {self.task_id}>"
 
     def __attrs_post_init__(self):
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         if self.get_closest_mapped_task_group() is not None:
             raise NotImplementedError("operator expansion in an expanded task group is not yet supported")
@@ -675,7 +675,7 @@ class MappedOperator(AbstractOperator):
     @property
     def output(self) -> XComArg:
         """Return reference to XCom pushed by current operator."""
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         return XComArg(operator=self)
 

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -655,7 +655,7 @@ class MappedTaskGroup(TaskGroup):
 
     def iter_mapped_dependencies(self) -> Iterator[Operator]:
         """Upstream dependencies that provide XComs used by this mapped task group."""
-        from airflow.models.xcom_arg import XComArg
+        from airflow.sdk.definitions.xcom_arg import XComArg
 
         for op, _ in XComArg.iter_xcom_references(self._expand_input):
             yield op


### PR DESCRIPTION
Now that we have XComArg ported TaskSDK, hope we can import it from the TaskSDK definitions.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
