### PR TITLE
Fix import paths in release notes.

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -449,8 +449,8 @@ Refactored Internal Utilities
 
 Several core components have been moved to more intuitive or stable locations:
 
-- The ``SecretsMasker`` class has been relocated to ``airflow.utils.secrets_masker``.
-- The ``ObjectStoragePath`` utility previously located under ``airflow.io`` is now available via ``airflow.utils.object_storage_path``.
+- The ``SecretsMasker`` class has been relocated to ``airflow.sdk.execution_time.secrets_masker``.
+- The ``ObjectStoragePath`` utility previously located under ``airflow.io`` is now available via ``airflow.sdk``.
 
 These changes simplify imports and reflect broader efforts to stabilize utility interfaces across the Airflow codebase.
 

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 7509538c98611fdf412cefaf85506cc5
-source-date-epoch: 1745930526
+release-notes-hash: e3095649be58cb5c0bdf6e247825f798
+source-date-epoch: 1745734115

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: e3095649be58cb5c0bdf6e247825f798
-source-date-epoch: 1745734115
+release-notes-hash: 4a33893e65bbabc29d00816684bb9b78
+source-date-epoch: 1746029438


### PR DESCRIPTION
The import paths in release notes have to be updated due to move to `task.sdk` .

User report : https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1745614658605369