### PR TITLE
Improve detection and handling of timed out DAG processor processes

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -992,7 +992,7 @@ class DagFileProcessorManager(LoggingMixin):
 
     def _kill_timed_out_processors(self):
         """Kill any file processors that timeout to defend against process hangs."""
-        now = time.time()
+        now = time.monotonic()
         processors_to_remove = []
         for file, processor in self._processors.items():
             duration = now - processor.start_time

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -312,9 +312,5 @@ class DagFileProcessorProcess(WatchedSubprocess):
 
         return self._num_open_sockets == 0
 
-    @property
-    def start_time(self) -> float:
-        return self._process.create_time()
-
     def wait(self) -> int:
         raise NotImplementedError(f"Don't call wait on {type(self).__name__} objects")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -147,6 +147,7 @@ class TestDagFileProcessorManager:
             stdin=write_end,
             requests_fd=123,
             logger_filehandle=logger_filehandle,
+            start_time=160000,
         )
         ret._num_open_sockets = 0
         return ret, read_end
@@ -518,9 +519,7 @@ class TestDagFileProcessorManager:
 
     def test_kill_timed_out_processors_kill(self):
         manager = DagFileProcessorManager(max_runs=1, processor_timeout=5)
-
         processor, _ = self.mock_processor()
-        processor._process.create_time.return_value = timezone.make_aware(datetime.min).timestamp()
         manager._processors = {
             DagFileInfo(
                 bundle_name="testing", rel_path=Path("abc.txt"), bundle_path=TEST_DAGS_FOLDER

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -133,7 +133,7 @@ class TestDagFileProcessorManager:
         clear_db_import_errors()
         clear_db_dag_bundles()
 
-    def mock_processor(self) -> tuple[DagFileProcessorProcess, socket]:
+    def mock_processor(self, start_time: float | None = None) -> tuple[DagFileProcessorProcess, socket]:
         proc = MagicMock()
         logger_filehandle = MagicMock()
         proc.create_time.return_value = time.time()
@@ -147,8 +147,9 @@ class TestDagFileProcessorManager:
             stdin=write_end,
             requests_fd=123,
             logger_filehandle=logger_filehandle,
-            start_time=160000,
         )
+        if start_time:
+            ret.start_time = start_time
         ret._num_open_sockets = 0
         return ret, read_end
 
@@ -519,7 +520,7 @@ class TestDagFileProcessorManager:
 
     def test_kill_timed_out_processors_kill(self):
         manager = DagFileProcessorManager(max_runs=1, processor_timeout=5)
-        processor, _ = self.mock_processor()
+        processor, _ = self.mock_processor(start_time=16000)
         manager._processors = {
             DagFileInfo(
                 bundle_name="testing", rel_path=Path("abc.txt"), bundle_path=TEST_DAGS_FOLDER

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -428,7 +428,7 @@ class WatchedSubprocess:
     subprocess_logs_to_stdout: bool = False
     """Duplicate log messages to stdout, or only send them to ``self.process_log``."""
 
-    start_time: float | None = None
+    start_time: float = attrs.field(factory=time.monotonic)
     """The start time of the child process."""
 
     @classmethod

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -428,6 +428,9 @@ class WatchedSubprocess:
     subprocess_logs_to_stdout: bool = False
     """Duplicate log messages to stdout, or only send them to ``self.process_log``."""
 
+    start_time: float
+    """The start time of the child process."""
+
     @classmethod
     def start(
         cls,
@@ -481,6 +484,7 @@ class WatchedSubprocess:
             process=psutil.Process(pid),
             requests_fd=requests_fd,
             process_log=logger,
+            start_time=time.monotonic(),
             **constructor_kwargs,
         )
 

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -428,7 +428,7 @@ class WatchedSubprocess:
     subprocess_logs_to_stdout: bool = False
     """Duplicate log messages to stdout, or only send them to ``self.process_log``."""
 
-    start_time: float
+    start_time: float | None
     """The start time of the child process."""
 
     @classmethod

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -428,7 +428,7 @@ class WatchedSubprocess:
     subprocess_logs_to_stdout: bool = False
     """Duplicate log messages to stdout, or only send them to ``self.process_log``."""
 
-    start_time: float | None
+    start_time: float | None = None
     """The start time of the child process."""
 
     @classmethod


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/49689

## Problem

start_time property on a dag file processor subprocess https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/dag_processing/processor.py#L315-L317 is calculated using boot_time in psutil: https://github.com/giampaolo/psutil/blob/d461f4c0f0aad1a039c7d8bb724a4c7288ef2f39/psutil/_pslinux.py#L1557


The problem here seems in our usage of it, when we use it as a property, looks like due to caching, in https://github.com/giampaolo/psutil/blob/d461f4c0f0aad1a039c7d8bb724a4c7288ef2f39/psutil/__init__.py#L774-L784 that the start_time of a subprocess is not updating when the system sleeps, leading to a earlier start_time. And while calculating duration we do a `time.time()` comparison, which obviously shifts leading to subprocess getting killed.

Shifting to use of time.monotonic gives a more accurate uptime calculation by not letting restarts or system clock dependency.

The fix seems to fix it.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
