### PR TITLE
Fix Edge3 provider history retrieval when generating documentation

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -325,9 +325,7 @@ def _get_all_changes_for_package(
     )
     providers_folder_paths_for_git_commit_retrieval = [
         provider_details.root_provider_path,
-        provider_details.previous_source_provider_distribution_path,
-        provider_details.previous_documentation_provider_distribution_path,
-        provider_details.original_source_provider_distribution_path,
+        *provider_details.possible_old_provider_paths,
     ]
     if not reapply_templates_only and result.returncode == 0:
         if get_verbose():

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -36,8 +36,6 @@ from airflow_breeze.utils.packages import (
     get_long_package_name,
     get_min_airflow_version,
     get_pip_package_name,
-    get_previous_documentation_distribution_path,
-    get_previous_source_providers_distribution_path,
     get_provider_details,
     get_provider_info_dict,
     get_provider_requirements,
@@ -47,25 +45,12 @@ from airflow_breeze.utils.packages import (
     get_suspended_provider_ids,
     validate_provider_info_with_runtime_schema,
 )
-from airflow_breeze.utils.path_utils import AIRFLOW_ROOT_PATH, DOCS_ROOT
+from airflow_breeze.utils.path_utils import AIRFLOW_ROOT_PATH
 
 
 def test_get_available_packages():
     assert len(get_available_distributions()) > 70
     assert all(package not in REGULAR_DOC_PACKAGES for package in get_available_distributions())
-
-
-def test_get_source_package_path():
-    assert get_previous_source_providers_distribution_path("apache.hdfs") == AIRFLOW_ROOT_PATH.joinpath(
-        "providers", "src", "airflow", "providers", "apache", "hdfs"
-    )
-
-
-def test_get_old_documentation_package_path():
-    assert (
-        get_previous_documentation_distribution_path("apache.hdfs")
-        == DOCS_ROOT / "apache-airflow-providers-apache-hdfs"
-    )
 
 
 def test_expand_all_provider_distributions():


### PR DESCRIPTION
The documentation generated during edge provider docs generation was wrong because it did not include rename of the provider. This change should bring all the history back, it also simplifies and makes more obvious how retrieval of the historical commits work.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
