### PR TITLE
fix: add default args to dag details

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -154,6 +154,7 @@ class DAGDetailsResponse(DAGResponse):
     template_search_path: Iterable[str] | None
     timezone: str | None
     last_parsed: datetime | None
+    default_args: abc.MutableMapping | None
 
     @field_validator("timezone", mode="before")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -154,7 +154,7 @@ class DAGDetailsResponse(DAGResponse):
     template_search_path: Iterable[str] | None
     timezone: str | None
     last_parsed: datetime | None
-    default_args: abc.MutableMapping | None
+    default_args: abc.Mapping | None
 
     @field_validator("timezone", mode="before")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -7997,6 +7997,12 @@ components:
             format: date-time
           - type: 'null'
           title: Last Parsed
+        default_args:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Default Args
         file_token:
           type: string
           title: File Token
@@ -8051,6 +8057,7 @@ components:
       - template_search_path
       - timezone
       - last_parsed
+      - default_args
       - file_token
       - concurrency
       - latest_dag_version

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1720,6 +1720,18 @@ export const $DAGDetailsResponse = {
       ],
       title: "Last Parsed",
     },
+    default_args: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Default Args",
+    },
     file_token: {
       type: "string",
       title: "File Token",
@@ -1783,6 +1795,7 @@ export const $DAGDetailsResponse = {
     "template_search_path",
     "timezone",
     "last_parsed",
+    "default_args",
     "file_token",
     "concurrency",
     "latest_dag_version",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -472,6 +472,9 @@ export type DAGDetailsResponse = {
   template_search_path: Array<string> | null;
   timezone: string | null;
   last_parsed: string | null;
+  default_args: {
+    [key: string]: unknown;
+  } | null;
   /**
    * Return file token.
    */

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -128,6 +128,14 @@ export const Details = () => {
               <Table.Cell>Catchup</Table.Cell>
               <Table.Cell>{dag.catchup.toString()}</Table.Cell>
             </Table.Row>
+            {dag.default_args === null ? undefined : (
+              <Table.Row>
+                <Table.Cell>Default Args</Table.Cell>
+                <Table.Cell>
+                  <RenderedJsonField content={dag.default_args} />
+                </Table.Cell>
+              </Table.Row>
+            )}
             {dag.params === null ? undefined : (
               <Table.Row>
                 <Table.Cell>Params</Table.Cell>

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -113,6 +113,11 @@ class TestDagEndpoint:
             schedule=None,
             start_date=DAG1_START_DATE,
             doc_md="details",
+            default_args={
+                "depends_on_past": False,
+                "retries": 1,
+                "retry_delay": timedelta(minutes=5),
+            },
             params={"foo": 1},
             tags=["example"],
         ):
@@ -125,6 +130,11 @@ class TestDagEndpoint:
             schedule=None,
             start_date=DAG2_START_DATE,
             doc_md="details",
+            default_args={
+                "depends_on_past": False,
+                "retries": 1,
+                "retry_delay": timedelta(minutes=5),
+            },
             params={"foo": 1},
             max_active_tasks=16,
             max_active_runs=16,
@@ -415,6 +425,11 @@ class TestDagDetails(TestDagEndpoint):
             "dag_id": dag_id,
             "dag_display_name": dag_display_name,
             "dag_run_timeout": None,
+            "default_args": {
+                "depends_on_past": False,
+                "retries": 1,
+                "retry_delay": "PT5M",
+            },
             "description": None,
             "doc_md": "details",
             "end_date": None,

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1146,6 +1146,7 @@ class DAGDetailsResponse(BaseModel):
     template_search_path: Annotated[list[str] | None, Field(title="Template Search Path")] = None
     timezone: Annotated[str | None, Field(title="Timezone")] = None
     last_parsed: Annotated[datetime | None, Field(title="Last Parsed")] = None
+    default_args: Annotated[dict[str, Any] | None, Field(title="Default Args")] = None
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
     concurrency: Annotated[
         int, Field(description="Return max_active_tasks as concurrency.", title="Concurrency")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #43525 

## Why 
In the former Airflow (2.5.3), the UI could obtain the default args of DAGs through its API, while the REST API's `/dags/{dag_id}/details` endpoint did not expose this information. Due to API changes, the UI of Airflow 3 can no longer access default args.

## What 
* Make default args available in the dag details endpoint
* Add a row displaying default args on the `Details` page
<img width="960" alt="default_args" src="https://github.com/user-attachments/assets/479d5afb-26ca-4bd8-aab7-5f1493ffed83" />

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
