### PR TITLE
Add counts to pool bar

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolBar.tsx
@@ -87,11 +87,13 @@ const PoolBar = ({ pool }: PoolBarProps) => (
                 alignItems="center"
                 bg={`${color}.solid`}
                 flex={flexValue}
+                gap={0.5}
                 h="100%"
                 justifyContent="center"
                 position="relative"
               >
                 {icon}
+                {slotValue}
               </Flex>
             </Tooltip>
           );


### PR DESCRIPTION
Add the pool count number next to the icon in the PoolBar component


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
