### PR TITLE
Support cert and proxies in Vault client session setup

### DIFF
--- a/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -215,8 +215,10 @@ class _VaultClient(LoggingMixin):
             session = Session()
             session.mount("http://", adapter)
             session.mount("https://", adapter)
-            if self.kwargs and "verify" in self.kwargs:
-                session.verify = self.kwargs["verify"]
+
+            session.verify = self.kwargs.get("verify", session.verify)
+            session.cert = self.kwargs.get("cert", session.cert)
+            session.proxies = self.kwargs.get("proxies", session.proxies)
             self.kwargs["session"] = session
 
         _client = hvac.Client(url=self.url, **self.kwargs)

--- a/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
@@ -924,6 +924,76 @@ class TestVaultClient:
         mock_client.secrets.kv.v1.read_secret.assert_called_once_with(
             mount_point="secret", path="/path/to/secret"
         )
+    
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_existing_key_v1_with_proxies_applied(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        mock_client.secrets.kv.v1.read_secret.return_value = {
+            "request_id": "182d0673-618c-9889-4cba-4e1f4cfe4b4b",
+            "lease_id": "",
+            "renewable": False,
+            "lease_duration": 2764800,
+            "data": {"value": "world"},
+            "wrap_info": None,
+            "warnings": None,
+            "auth": None,
+        }
+
+        vault_client = _VaultClient(
+            auth_type="radius",
+            radius_host="radhost",
+            radius_port=8110,
+            radius_secret="pass",
+            kv_engine_version=1,
+            url="http://localhost:8180",
+            verify=False,
+            proxies={
+                'http': 'http://10.10.1.10:3128',
+                'https': 'http://10.10.1.10:1080',
+            }
+        )
+        secret = vault_client.get_secret(secret_path="/path/to/secret")
+        assert secret == {"value": "world"}
+        assert vault_client.kwargs["session"].proxies["http"] == "http://10.10.1.10:3128"
+        assert vault_client.kwargs["session"].proxies["https"] == "http://10.10.1.10:1080"
+        mock_client.secrets.kv.v1.read_secret.assert_called_once_with(
+            mount_point="secret", path="/path/to/secret"
+        )
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_existing_key_v1_with_client_cert_applied(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        mock_client.secrets.kv.v1.read_secret.return_value = {
+            "request_id": "182d0673-618c-9889-4cba-4e1f4cfe4b4b",
+            "lease_id": "",
+            "renewable": False,
+            "lease_duration": 2764800,
+            "data": {"value": "world"},
+            "wrap_info": None,
+            "warnings": None,
+            "auth": None,
+        }
+
+        vault_client = _VaultClient(
+            auth_type="radius",
+            radius_host="radhost",
+            radius_port=8110,
+            radius_secret="pass",
+            kv_engine_version=1,
+            url="http://localhost:8180",
+            verify=False,
+            cert=('/path/client.cert', '/path/client.key')
+        )
+        secret = vault_client.get_secret(secret_path="/path/to/secret")
+        assert secret == {"value": "world"}
+        assert vault_client.kwargs["session"].cert == ('/path/client.cert', '/path/client.key')
+        mock_client.secrets.kv.v1.read_secret.assert_called_once_with(
+            mount_point="secret", path="/path/to/secret"
+        )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_existing_key_v1_without_preconfigured_mount_point(self, mock_hvac):

--- a/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
@@ -924,7 +924,7 @@ class TestVaultClient:
         mock_client.secrets.kv.v1.read_secret.assert_called_once_with(
             mount_point="secret", path="/path/to/secret"
         )
-    
+
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_existing_key_v1_with_proxies_applied(self, mock_hvac):
         mock_client = mock.MagicMock()
@@ -950,9 +950,9 @@ class TestVaultClient:
             url="http://localhost:8180",
             verify=False,
             proxies={
-                'http': 'http://10.10.1.10:3128',
-                'https': 'http://10.10.1.10:1080',
-            }
+                "http": "http://10.10.1.10:3128",
+                "https": "http://10.10.1.10:1080",
+            },
         )
         secret = vault_client.get_secret(secret_path="/path/to/secret")
         assert secret == {"value": "world"}
@@ -986,11 +986,11 @@ class TestVaultClient:
             kv_engine_version=1,
             url="http://localhost:8180",
             verify=False,
-            cert=('/path/client.cert', '/path/client.key')
+            cert=("/path/client.cert", "/path/client.key"),
         )
         secret = vault_client.get_secret(secret_path="/path/to/secret")
         assert secret == {"value": "world"}
-        assert vault_client.kwargs["session"].cert == ('/path/client.cert', '/path/client.key')
+        assert vault_client.kwargs["session"].cert == ("/path/client.cert", "/path/client.key")
         mock_client.secrets.kv.v1.read_secret.assert_called_once_with(
             mount_point="secret", path="/path/to/secret"
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
### Description
Previously, only the 'verify' option was handled when creating the session for the Vault client. 
This change extends it to also support 'cert' (client certificates) and 'proxies' passed via kwargs ensuring compatibility with the hvac client, which reads these values from the session. ([HVAC Adapter](https://github.com/hvac/hvac/blob/main/hvac/adapters.py))
![image](https://github.com/user-attachments/assets/880a856a-4683-4049-89f9-ae9fad1cbef5)
This allows advanced connection configurations like mutual TLS authentication and proxy routing 
while preserving retry logic.

Updated tests to cover proxies and client cert cases.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
