### PR TITLE
Extend Edge Worker CLI commands operate on remote edge workers

### DIFF
--- a/providers/edge3/pyproject.toml
+++ b/providers/edge3/pyproject.toml
@@ -61,8 +61,6 @@ dependencies = [
     "apache-airflow-providers-fab>=1.5.3",
     "pydantic>=2.11.0",
     "retryhttp>=1.2.0,!=1.3.0",
-    "psycopg2-binary>=2.9.10",
-    "asyncpg>=0.30.0"
 ]
 
 [dependency-groups]

--- a/providers/edge3/pyproject.toml
+++ b/providers/edge3/pyproject.toml
@@ -61,6 +61,8 @@ dependencies = [
     "apache-airflow-providers-fab>=1.5.3",
     "pydantic>=2.11.0",
     "retryhttp>=1.2.0,!=1.3.0",
+    "psycopg2-binary>=2.9.10",
+    "asyncpg>=0.30.0"
 ]
 
 [dependency-groups]

--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -654,7 +654,7 @@ def list_edge_workers(args, session: Session = NEW_SESSION) -> None:
         "queues",
         "maintenance_comment",
     ]
-    all_hosts = [{f: str(host.__getattribute__(f)) for f in fields} for host in all_hosts_iter]
+    all_hosts = [{f: host.__getattribute__(f) for f in fields} for host in all_hosts_iter]
     AirflowConsole().print_as(data=all_hosts, output=args.output)
 
 
@@ -690,8 +690,11 @@ def remote_worker_update_maintenance_comment(args) -> None:
         raise SystemExit(f"Error: Edge Worker {args.edge_hostname} is unknown!")
     from airflow.providers.edge3.models.edge_worker import change_maintenance_comment
 
-    change_maintenance_comment(args.edge_hostname, args.comments)
-    logger.info("Maintenance comments updated for %s by %s.", args.edge_hostname, getuser())
+    try:
+        change_maintenance_comment(args.edge_hostname, args.comments)
+        logger.info("Maintenance comments updated for %s by %s.", args.edge_hostname, getuser())
+    except TypeError:
+        raise SystemExit
 
 
 @cli_utils.action_cli
@@ -702,8 +705,11 @@ def remove_remote_worker(args) -> None:
         raise SystemExit(f"Error: Edge Worker {args.edge_hostname} is unknown!")
     from airflow.providers.edge3.models.edge_worker import remove_worker
 
-    remove_worker(args.edge_hostname)
-    logger.info("Edge Worker host %s removed by %s.", args.edge_hostname, getuser())
+    try:
+        remove_worker(args.edge_hostname)
+        logger.info("Edge Worker host %s removed by %s.", args.edge_hostname, getuser())
+    except TypeError:
+        raise SystemExit
 
 
 ARG_CONCURRENCY = Arg(

--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -61,6 +61,7 @@ from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     from airflow.providers.edge3.worker_api.datamodels import EdgeJobFetched
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 EDGE_WORKER_PROCESS_NAME = "edge-worker"
@@ -635,9 +636,7 @@ def _fetch_edge_hosts_from_db(session: Session = NEW_SESSION) -> list:
 @providers_configuration_loaded
 @provide_session
 def list_edge_workers(args, session: Session = NEW_SESSION) -> None:
-    """
-    Query the db to list all registered edge workers
-    """
+    """Query the db to list all registered edge workers."""
     all_hosts_iter = _fetch_edge_hosts_from_db(session)
     # Format and print worker info on the screen
     fields = [
@@ -660,9 +659,7 @@ def list_edge_workers(args, session: Session = NEW_SESSION) -> None:
 @providers_configuration_loaded
 @provide_session
 def _valid_host(hostname, session: Session = NEW_SESSION) -> bool:
-    """
-    Query the database to check if provided hostname exists
-    """
+    """Query the database to check if provided hostname exists."""
     all_hosts_iter = _fetch_edge_hosts_from_db(session)
     for host in all_hosts_iter:
         if hostname == host.worker_name:
@@ -673,58 +670,50 @@ def _valid_host(hostname, session: Session = NEW_SESSION) -> bool:
 @cli_utils.action_cli
 @providers_configuration_loaded
 def put_remote_worker_on_maintainance(args) -> None:
-    """
-    Put remote edge worker on maintenance
-    """
+    """Put remote edge worker on maintenance."""
     if not _valid_host(args.edge_hostname):
         raise SystemExit(f"Error: Edge Worker {args.edge_hostname} is unknown!")
     from airflow.providers.edge3.models.edge_worker import request_maintenance
 
     maintenance_comment = f"[{datetime.now().strftime('%Y-%m-%d %H:%M')}] - {getuser()} put node into maintenance mode\nComment: {args.comments}"
     request_maintenance(args.edge_hostname, args.comments)
-    logging.info(f"{args.edge_hostname} has been put on maintenance by {getuser()}!")
+    logger.info(f"{args.edge_hostname} has been put on maintenance by {getuser()}!")
 
 
 @cli_utils.action_cli
 @providers_configuration_loaded
 def remove_remote_worker_from_maintainance(args) -> None:
-    """
-    Remove remote edge worker from maintenance
-    """
+    """Remove remote edge worker from maintenance."""
     if not _valid_host(args.edge_hostname):
         raise SystemExit(f"Error: Edge Worker {args.edge_hostname} is unknown!")
     from airflow.providers.edge3.models.edge_worker import exit_maintenance
 
     exit_maintenance(args.edge_hostname)
-    logging.info(f"{args.edge_hostname} has removed maintenance by {getuser()}!")
+    logger.info(f"{args.edge_hostname} has removed maintenance by {getuser()}!")
 
 
 @cli_utils.action_cli
 @providers_configuration_loaded
 def remote_worker_update_maintenance_comment(args) -> None:
-    """
-    Update maintainence comments of the remote edge worker
-    """
+    """Update maintainence comments of the remote edge worker."""
     if not _valid_host(args.edge_hostname):
         raise SystemExit(f"Error: Edge Worker {args.edge_hostname} is unknown!")
     from airflow.providers.edge3.models.edge_worker import change_maintenance_comment
 
     change_maintenance_comment(args.edge_hostname, args.comments)
-    logging.info(f"Maintenance comments updated for {args.edge_hostname} by {getuser()}!")
+    logger.info(f"Maintenance comments updated for {args.edge_hostname} by {getuser()}!")
 
 
 @cli_utils.action_cli
 @providers_configuration_loaded
 def remove_remote_worker(args) -> None:
-    """
-    Remove remote edge worker entry from db
-    """
+    """Remove remote edge worker entry from db."""
     if not _valid_host(args.edge_hostname):
         raise SystemExit(f"Error: Edge Worker {args.edge_hostname} is unknown!")
     from airflow.providers.edge3.models.edge_worker import remove_worker
 
     remove_worker(args.edge_hostname)
-    logging.info(f"Edge Worker host {args.edge_hostname} removed by {getuser()}!")
+    logger.info(f"Edge Worker host {args.edge_hostname} removed by {getuser()}!")
 
 
 ARG_CONCURRENCY = Arg(

--- a/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
@@ -16,6 +16,11 @@
 # under the License.
 from __future__ import annotations
 
+import json
+import argparse
+import contextlib
+import importlib
+from io import StringIO
 import logging
 import os
 from datetime import datetime
@@ -27,9 +32,12 @@ import pytest
 import time_machine
 from requests import HTTPError, Response
 
+from airflow.cli import cli_parser
+from airflow.executors import executor_loader
 from airflow.providers.edge3.cli.dataclasses import Job
-from airflow.providers.edge3.cli.edge_command import _EdgeWorkerCli, _write_pid_to_pidfile
-from airflow.providers.edge3.models.edge_worker import EdgeWorkerState, EdgeWorkerVersionException
+from airflow.providers.edge3.cli import edge_command
+from airflow.providers.edge3.cli.edge_command import _EdgeWorkerCli, _write_pid_to_pidfile, _fetch_edge_hosts_from_db
+from airflow.providers.edge3.models.edge_worker import EdgeWorkerState, EdgeWorkerModel, EdgeWorkerVersionException
 from airflow.providers.edge3.worker_api.datamodels import (
     EdgeJobFetched,
     WorkerRegistrationReturn,
@@ -118,6 +126,13 @@ class _MockPopen(Popen):
 
 
 class TestEdgeWorkerCli:
+    @classmethod
+    def setup_class(cls):
+        with conf_vars({("core", "executor"): "airflow.providers.edge3.executors.edge_executor.EdgeExecutor"}):
+            importlib.reload(executor_loader)
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
+
     @pytest.fixture
     def mock_joblist(self, tmp_path: Path) -> list[Job]:
         logfile = tmp_path / "file.log"
@@ -145,6 +160,15 @@ class TestEdgeWorkerCli:
         test_worker = _EdgeWorkerCli(str(tmp_path / "mock.pid"), "mock", None, 8, 5, 5)
         _EdgeWorkerCli.jobs = mock_joblist
         return test_worker
+
+    @pytest.fixture
+    def mock_edgeworker(self) -> EdgeWorkerModel:
+        test_edgeworker = EdgeWorkerModel(
+            worker_name = "test_edge_worker",
+            state = "idle",
+            queues = ["default"],
+        )
+        return test_edgeworker
 
     @patch("airflow.providers.edge3.cli.edge_command.Process")
     @patch("airflow.providers.edge3.cli.edge_command.logs_logfile_path")
@@ -395,3 +419,16 @@ class TestEdgeWorkerCli:
         assert "edge_provider_version" in sysinfo
         assert "concurrency" in sysinfo
         assert sysinfo["concurrency"] == concurrency
+
+
+    def test_list_edge_workers(self, mock_edgeworker: EdgeWorkerModel):
+        mock_session = MagicMock()
+        args = self.parser.parse_args(["edge", "list-workers", "--output", "json"])
+        with contextlib.redirect_stdout(StringIO()) as temp_stdout:
+            with patch('airflow.providers.edge3.cli.edge_command._fetch_edge_hosts_from_db', return_value=[mock_edgeworker]):
+                edge_command.list_edge_workers(args, session=mock_session)
+                out = temp_stdout.getvalue()
+                edge_workers = json.loads(out)
+        for key in ["worker_name", "state", "queues", "jobs_active", "jobs_success", "jobs_failed", "jobs_taken", "maintenance_comment"]:
+            assert key in edge_workers[0]
+        assert any("test_edge_worker" in h["worker_name"] for h in edge_workers)

--- a/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import argparse
 import contextlib
 import importlib
 import json
@@ -132,6 +133,8 @@ class _MockPopen(Popen):
 
 
 class TestEdgeWorkerCli:
+    parser: argparse.ArgumentParser
+
     @classmethod
     def setup_class(cls):
         with conf_vars(
@@ -443,10 +446,6 @@ class TestEdgeWorkerCli:
             "worker_name",
             "state",
             "queues",
-            "jobs_active",
-            "jobs_success",
-            "jobs_failed",
-            "jobs_taken",
             "maintenance_comment",
         ]:
             assert key in edge_workers[0]

--- a/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
@@ -431,6 +431,7 @@ class TestEdgeWorkerCli:
         assert "concurrency" in sysinfo
         assert sysinfo["concurrency"] == concurrency
 
+    @pytest.mark.db_test
     def test_list_edge_workers(self, mock_edgeworker: EdgeWorkerModel):
         mock_session = MagicMock()
         args = self.parser.parse_args(["edge", "list-workers", "--output", "json"])

--- a/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
@@ -433,14 +433,13 @@ class TestEdgeWorkerCli:
 
     @pytest.mark.db_test
     def test_list_edge_workers(self, mock_edgeworker: EdgeWorkerModel):
-        mock_session = MagicMock()
         args = self.parser.parse_args(["edge", "list-workers", "--output", "json"])
         with contextlib.redirect_stdout(StringIO()) as temp_stdout:
             with patch(
-                "airflow.providers.edge3.cli.edge_command._fetch_edge_hosts_from_db",
+                "airflow.providers.edge3.models.edge_worker.get_registered_edge_hosts",
                 return_value=[mock_edgeworker],
             ):
-                edge_command.list_edge_workers(args, session=mock_session)
+                edge_command.list_edge_workers(args)
                 out = temp_stdout.getvalue()
                 edge_workers = json.loads(out)
         for key in [


### PR DESCRIPTION
EdgeExecutor is missing EdgeWorkerHosts html pages in Airflow 3. This PR attempts to bridge the gap by providing those utilities via CLI options. These options are intended to run on the server side ( or have access to the server and db). They aim to control the remote edge workers.

This PR enables the following functionality:
1. List all registered edge workers
2. Put an edge worker on maintenance mode
3. Update maintenance mode comments for a worker who is in maintenance mode
4. Remove edge worker from maintenance mode
5. Remove edge worker from the pool
