### PR TITLE
Add 3.X/2.X clarification for celerykubernetesexecutor in Helm Chart docs

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -36,7 +36,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Features
 
-* Supported executors: ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``, ``LocalKubernetesExecutor``, ``CeleryKubernetesExecutor``
+* Supported executors: ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``
 * Supported AWS executors with AWS provider version ``8.21.0+``:
    * ``airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor``
    * ``airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor``

--- a/chart/README.md
+++ b/chart/README.md
@@ -37,7 +37,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 ## Features
 
 * Supported executors (all Airflow versions): ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``
-* Supported executors (Airflow version ``2.0+``): ``LocalKubernetesExecutor``, ``CeleryKubernetesExecutor``
+* Supported executors (Airflow version ``2.X.X``): ``LocalKubernetesExecutor``, ``CeleryKubernetesExecutor``
 * Supported AWS executors with AWS provider version ``8.21.0+``:
    * ``airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor``
    * ``airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor``

--- a/chart/README.md
+++ b/chart/README.md
@@ -36,7 +36,8 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Features
 
-* Supported executors: ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``
+* Supported executors (all Airflow versions): ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``
+* Supported executors (Airflow version ``2.0+``): ``LocalKubernetesExecutor``, ``CeleryKubernetesExecutor``
 * Supported AWS executors with AWS provider version ``8.21.0+``:
    * ``airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor``
    * ``airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor``

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -323,8 +323,10 @@ rbac:
   createSCCRoleBinding: false
 
 # Airflow executor
-# One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
-# Specify executors in a prioritized list to leverage multiple execution environments as needed.
+# One of: LocalExecutor, CeleryExecutor, KubernetesExecutor
+# For Airflow <3.0, LocalKubernetesExecutor and CeleryKubernetesExecutor are also supported
+# Specify executors in a prioritized list to leverage multiple execution environments as needed 
+# https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently
 executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -323,9 +323,9 @@ rbac:
   createSCCRoleBinding: false
 
 # Airflow executor
-# One of: LocalExecutor, CeleryExecutor, KubernetesExecutor
-# For Airflow <3.0, LocalKubernetesExecutor and CeleryKubernetesExecutor are also supported
-# Specify executors in a prioritized list to leverage multiple execution environments as needed 
+# One or multiple of: LocalExecutor, CeleryExecutor, KubernetesExecutor
+# For Airflow <3.0, LocalKubernetesExecutor and CeleryKubernetesExecutor are also supported.
+# Specify executors in a prioritized list to leverage multiple execution environments as needed:
 # https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently
 executor: "CeleryExecutor"
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The helm chart still references the hybrid operators as valid options. As I didn't really notice this change when going through the release notes, this hopefully helps other people from trying to select the `CeleryKubernetesOperator` and debug the resulting errors.

closes: #49897
related: #47322

<!-- Please keep an empty line above the dashes. -->
---
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
