### PR TITLE
Fixed all /health instances in the docs with v3 endpoint of /api/v2/m…

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst
@@ -36,7 +36,7 @@ Webserver Health Check Endpoint
 -------------------------------
 
 To check the health status of your Airflow instance, you can simply access the endpoint
-``/health``. It will return a JSON object in which a high-level glance is provided.
+``/api/v2/monitor/health``. It will return a JSON object in which a high-level glance is provided.
 
 .. code-block:: JSON
 
@@ -79,7 +79,7 @@ To check the health status of your Airflow instance, you can simply access the e
     Note that the ``status`` and ``latest_dag_processor_heartbeat`` fields in the health check response will be null for
     deployments that do not include a ``dag_processor`` component.
 
-Please keep in mind that the HTTP response code of ``/health`` endpoint **should not** be used to determine the health
+Please keep in mind that the HTTP response code of ``/api/v2/monitor/health`` endpoint **should not** be used to determine the health
 status of the application. The return code is only indicative of the state of the rest call (200 for success).
 
 Served by the web server, this health check endpoint is independent of the newer :ref:`Scheduler Health Check Server <check-health/scheduler-health-check-server>`, which optionally runs on each scheduler.

--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -136,7 +136,7 @@ services:
     <<: *airflow-common
     command: scheduler
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8974/api/v2/monitor/health"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -78,7 +78,7 @@ Non-authenticated UI users
 ..........................
 
 Airflow doesn't support unauthenticated users by default. If allowed, potential vulnerabilities
-must be assessed and addressed by the Deployment Manager. However, there are exceptions to this. The ``/health`` endpoint responsible to get health check updates should be publicly accessible. This is because other systems would want to retrieve that information. Another exception is the ``/login`` endpoint, as the users are expected to be unauthenticated to use it.
+must be assessed and addressed by the Deployment Manager. However, there are exceptions to this. The ``/api/v2/monitor/health`` endpoint responsible to get health check updates should be publicly accessible. This is because other systems would want to retrieve that information. Another exception is the ``/login`` endpoint, as the users are expected to be unauthenticated to use it.
 
 Capabilities of authenticated UI users
 --------------------------------------

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2088,7 +2088,7 @@ scheduler:
       description: |
         If the last scheduler heartbeat happened more than ``[scheduler] scheduler_health_check_threshold``
         ago (in seconds), scheduler is considered unhealthy.
-        This is used by the health check in the **/health** endpoint and in ``airflow jobs check`` CLI
+        This is used by the health check in the **/api/v2/monitor/health** endpoint and in ``airflow jobs check`` CLI
         for SchedulerJob.
       version_added: 1.10.2
       type: integer
@@ -2323,7 +2323,7 @@ triggerer:
       description: |
         If the last triggerer heartbeat happened more than ``[triggerer] triggerer_health_check_threshold``
         ago (in seconds), triggerer is considered unhealthy.
-        This is used by the health check in the **/health** endpoint and in ``airflow jobs check`` CLI
+        This is used by the health check in the **/api/v2/monitor/health** endpoint and in ``airflow jobs check`` CLI
         for TriggererJob.
       version_added: 2.7.0
       type: float


### PR DESCRIPTION
Fixed all `/health` endpoint instances in the docs with v3 endpoint of `/api/v2/monitor/health`. This done because in Airflow 3, the `/health` endpoint is replaced by `/api/v2/monitor/health`.

Closes: #49683

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


related: #49683

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
