### PR TITLE
Fix changelog categorisation when commits are classified into min airflow bump

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -948,7 +948,7 @@ def _get_changes_classified(
 
         if type_of_change == TypeOfChange.BUGFIX:
             classified_changes.fixes.append(change)
-        elif type_of_change == TypeOfChange.MISC:
+        elif type_of_change == TypeOfChange.MISC or type_of_change == TypeOfChange.MIN_AIRFLOW_VERSION_BUMP:
             classified_changes.misc.append(change)
         elif type_of_change == TypeOfChange.FEATURE and maybe_with_new_features:
             classified_changes.features.append(change)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


### Case 1: Using `v` + `f`:

```
Does the provider: common.messaging have any changes apart from 'doc-only'? 
Press y/N/q: y

Define the type of change for `Avoid committing history for providers (https://github.com/apache/airflow/pull/49907)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? v


Define the type of change for `Prepare docs for Apr 3rd wave of providers (https://github.com/apache/airflow/pull/49338)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? f

The version will be bumped because of TypeOfChange.FEATURE kind of change
Provider common.messaging has been classified as:

Feature changes - bump in MINOR version needed

Bumped version to 1.1.0

Updated source-date-epoch to 1745910992
```

The `v` should be classified under misc

![image](https://github.com/user-attachments/assets/a6688f0e-5210-4252-905b-a8207a0e6358)


### Case 2: Using `x` + `v`

```
Define the type of change for `Avoid committing history for providers (https://github.com/apache/airflow/pull/49907)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? v


Define the type of change for `Prepare docs for Apr 3rd wave of providers (https://github.com/apache/airflow/pull/49338)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? x

The version will be bumped because of TypeOfChange.BREAKING_CHANGE kind of change
Provider common.messaging has been classified as:

Breaking changes - bump in MAJOR version needed

Bumped version to 2.0.0
```

`v` should again go into misc:

![image](https://github.com/user-attachments/assets/2e7ba29e-4f29-4c33-abf2-08eb422474d8)

### Case 3: Using `m` + `v`:
```
Define the type of change for `Avoid committing history for providers (https://github.com/apache/airflow/pull/49907)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Prepare docs for Apr 3rd wave of providers (https://github.com/apache/airflow/pull/49338)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? v

The version will be bumped because of TypeOfChange.MIN_AIRFLOW_VERSION_BUMP kind of change
Provider common.messaging has been classified as:

Airflow version bump change - bump in MINOR version needed

Bumped version to 1.1.0
```


Both should be under misc:
![image](https://github.com/user-attachments/assets/57c3124d-ef7e-434a-a245-aba41b432c50)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
