### PR TITLE
AIP-84: alias `dag_display_name` for `DagRun`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from pydantic import AwareDatetime, Field, NonNegativeInt, model_validator
+from pydantic import AliasPath, AwareDatetime, Field, NonNegativeInt, model_validator
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
@@ -77,6 +77,7 @@ class DAGRunResponse(BaseModel):
     note: str | None
     dag_versions: list[DagVersionResponse]
     bundle_version: str | None
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))
 
 
 class DAGRunCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -945,6 +945,9 @@ components:
           - type: string
           - type: 'null'
           title: Bundle Version
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - dag_run_id
@@ -964,6 +967,7 @@ components:
       - note
       - dag_versions
       - bundle_version
+      - dag_display_name
       title: DAGRunResponse
       description: DAG Run serializer for responses.
     DAGRunStates:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -8342,6 +8342,9 @@ components:
           - type: string
           - type: 'null'
           title: Bundle Version
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - dag_run_id
@@ -8361,6 +8364,7 @@ components:
       - note
       - dag_versions
       - bundle_version
+      - dag_display_name
       title: DAGRunResponse
       description: DAG Run serializer for responses.
     DAGRunsBatchBody:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2266,6 +2266,10 @@ export const $DAGRunResponse = {
       ],
       title: "Bundle Version",
     },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
+    },
   },
   type: "object",
   required: [
@@ -2286,6 +2290,7 @@ export const $DAGRunResponse = {
     "note",
     "dag_versions",
     "bundle_version",
+    "dag_display_name",
   ],
   title: "DAGRunResponse",
   description: "DAG Run serializer for responses.",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -578,6 +578,7 @@ export type DAGRunResponse = {
   note: string | null;
   dag_versions: Array<DagVersionResponse>;
   bundle_version: string | null;
+  dag_display_name: string;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1145,6 +1145,7 @@ class TestPostAssetMaterialize(TestAssets):
         assert response.status_code == 200
         assert response.json() == {
             "bundle_version": None,
+            "dag_display_name": self.DAG_ASSET1_ID,
             "dag_run_id": mock.ANY,
             "dag_id": self.DAG_ASSET1_ID,
             "dag_versions": mock.ANY,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.db_test
 
 DAG1_ID = "test_dag1"
+DAG1_DISPLAY_NAME = "test_dag1"
 DAG2_ID = "test_dag2"
 DAG1_RUN1_ID = "dag_run_1"
 DAG1_RUN2_ID = "dag_run_2"
@@ -168,6 +169,7 @@ def get_dag_versions_dict(dag_versions: list[DagVersion]) -> list[dict]:
 def get_dag_run_dict(run: DagRun):
     return {
         "bundle_version": None,
+        "dag_display_name": run.dag_model.dag_display_name,
         "dag_run_id": run.run_id,
         "dag_id": run.dag_id,
         "logical_date": from_datetime_to_zulu_without_ms(run.logical_date),
@@ -1306,6 +1308,7 @@ class TestTriggerDagRun:
         expected_response_json = {
             "bundle_version": None,
             "conf": {},
+            "dag_display_name": DAG1_DISPLAY_NAME,
             "dag_id": DAG1_ID,
             "dag_run_id": expected_dag_run_id,
             "dag_versions": get_dag_versions_dict(run.dag_versions),
@@ -1495,6 +1498,7 @@ class TestTriggerDagRun:
         assert response_1.status_code == 200
         assert response_1.json() == {
             "bundle_version": None,
+            "dag_display_name": DAG1_DISPLAY_NAME,
             "dag_run_id": RUN_ID_1,
             "dag_id": DAG1_ID,
             "dag_versions": mock.ANY,
@@ -1580,6 +1584,7 @@ class TestTriggerDagRun:
         assert response.status_code == 200
         assert response.json() == {
             "bundle_version": None,
+            "dag_display_name": DAG1_DISPLAY_NAME,
             "dag_run_id": mock.ANY,
             "dag_id": DAG1_ID,
             "dag_versions": mock.ANY,

--- a/airflow-core/tests/unit/cli/commands/test_asset_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_asset_command.py
@@ -142,6 +142,7 @@ def test_cli_assets_materialize(parser: ArgumentParser) -> None:
     assert run_list[0] | undeterministic == undeterministic | {
         "conf": {},
         "bundle_version": None,
+        "dag_display_name": "asset1_producer",
         "dag_id": "asset1_producer",
         "end_date": None,
         "last_scheduling_decision": None,

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1220,6 +1220,7 @@ class DAGRunResponse(BaseModel):
     note: Annotated[str | None, Field(title="Note")] = None
     dag_versions: Annotated[list[DagVersionResponse], Field(title="Dag Versions")]
     bundle_version: Annotated[str | None, Field(title="Bundle Version")] = None
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
 
 
 class DAGRunsBatchBody(BaseModel):

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -444,6 +444,7 @@ class TestDagRunOperations:
     dag_id = "dag_id"
     dag_run_id = "dag_run_id"
     dag_run_response = DAGRunResponse(
+        dag_display_name=dag_run_id,
         dag_run_id=dag_run_id,
         dag_id=dag_id,
         logical_date=datetime.datetime(2025, 1, 1, 0, 0, 0),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730
cc: @pierrejeambrun @jason810496 

## How

- alias the `dag_display_name` for `DagRun`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
