### PR TITLE
Limit Celery to not include 5.5.2

### DIFF
--- a/providers/celery/pyproject.toml
+++ b/providers/celery/pyproject.toml
@@ -62,7 +62,10 @@ dependencies = [
     # Uses Celery for CeleryExecutor, and we also know that Kubernetes Python client follows SemVer
     # (https://docs.celeryq.dev/en/stable/contributing.html?highlight=semver#versions).
     # Updating min version to 5.5.0 to avoid redis import bug https://github.com/apache/airflow/issues/41359
-    "celery[redis]>=5.5.0,<6",
+    # The 5.5.2 version released 25 April 2025 introduced some stability issues that cause our
+    # integration tests to fail occasionally and latest boto tests hanging frequently
+    # tracked in https://github.com/apache/airflow/issues/49937
+    "celery[redis]>=5.5.0,<6,!=5.5.2",
     "flower>=1.0.0",
 ]
 


### PR DESCRIPTION
The Latest boto and celery integration tests started to randomly hang or fail recently and one of the suspects is Celery 5.5.2

This is tracked in https://github.com/apache/airflow/issues/49937

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
