### PR TITLE
Remove unnecessary noise from CI breeze's output

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -156,7 +156,7 @@ def fix_ownership(use_sudo: bool):
         fix_ownership_without_docker()
         sys.exit(0)
     get_console().print("[info]Fixing ownership using docker.")
-    fix_ownership_using_docker()
+    fix_ownership_using_docker(quiet=False)
     # Always succeed
     sys.exit(0)
 

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -1162,7 +1162,7 @@ def doctor(ctx):
     shell_params.print_badge_info()
 
     perform_environment_checks()
-    fix_ownership_using_docker()
+    fix_ownership_using_docker(quiet=False)
 
     given_answer = user_confirm("Are you sure with the removal of temporary Python files and Python cache?")
     if not get_dry_run() and given_answer == Answer.YES:

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -257,6 +257,7 @@ def _run_test(
                 check=False,
                 env=env,
                 verbose_override=False,
+                quiet=True,
             )
             remove_docker_networks(networks=[f"{compose_project_name}_default"])
     return result.returncode, f"Test: {shell_params.test_type}"

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -561,7 +561,7 @@ OWNERSHIP_CLEANUP_DOCKER_TAG = (
 )
 
 
-def fix_ownership_using_docker(quiet: bool = False):
+def fix_ownership_using_docker(quiet: bool = True):
     if get_host_os() != "linux":
         # no need to even attempt fixing ownership on MacOS/Windows
         return
@@ -585,7 +585,7 @@ def fix_ownership_using_docker(quiet: bool = False):
         OWNERSHIP_CLEANUP_DOCKER_TAG,
         "/opt/airflow/scripts/in_container/run_fix_ownership.py",
     ]
-    run_command(cmd, text=True, check=False, capture_output=quiet)
+    run_command(cmd, text=True, check=False, quiet=quiet)
 
 
 def remove_docker_networks(networks: list[str] | None = None) -> None:
@@ -602,6 +602,7 @@ def remove_docker_networks(networks: list[str] | None = None) -> None:
             ["docker", "network", "prune", "-f", "-a", "--filter", "label=com.docker.compose.project=breeze"],
             check=False,
             stderr=DEVNULL,
+            quiet=True,
         )
     else:
         for network in networks:
@@ -609,6 +610,7 @@ def remove_docker_networks(networks: list[str] | None = None) -> None:
                 ["docker", "network", "rm", network],
                 check=False,
                 stderr=DEVNULL,
+                quiet=True,
             )
 
 
@@ -893,6 +895,7 @@ def is_docker_rootless() -> bool:
             capture_output=True,
             check=False,
             text=True,
+            quiet=True,
         )
         if response.returncode == 0 and "rootless" in response.stdout.strip():
             get_console().print("[info]Docker is running in rootless mode.[/]\n")

--- a/dev/breeze/src/airflow_breeze/utils/host_info_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/host_info_utils.py
@@ -37,7 +37,9 @@ def get_host_user_id() -> str:
     host_user_id = ""
     os = get_host_os()
     if os == "linux" or os == "darwin":
-        host_user_id = run_command(cmd=["id", "-ur"], capture_output=True, text=True).stdout.strip()
+        host_user_id = run_command(
+            cmd=["id", "-ur"], capture_output=True, text=True, quiet=True
+        ).stdout.strip()
     return host_user_id
 
 
@@ -47,7 +49,9 @@ def get_host_group_id() -> str:
     host_group_id = ""
     os = get_host_os()
     if os == "linux" or os == "darwin":
-        host_group_id = run_command(cmd=["id", "-gr"], capture_output=True, text=True).stdout.strip()
+        host_group_id = run_command(
+            cmd=["id", "-gr"], capture_output=True, text=True, quiet=True
+        ).stdout.strip()
     return host_group_id
 
 


### PR DESCRIPTION
CI tests with breeze are running with `--verbose` options in order to get more diagnostics when things fail. However there were a few commmands always executed at the end of every command in breeze which did not add any value for diagnostics and only generated noise:

* id retrievals for users and groups
* fixing ownership
* checking for rootless docker

Those commmands are now silecenced with `quiet=True` of run_command, and the command nicely handles the case where we also capture output of such command.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
