### PR TITLE
Fix useCreateBackfillDryRun cache key

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useCreateBackfillDryRun.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useCreateBackfillDryRun.ts
@@ -48,13 +48,16 @@ const validateHeaderName = (requestBody: CreateBackfillDryRunData) => {
 export const useCreateBackfillDryRun = <TData = DryRunBackfillCollectionResponse, TError = unknown>({
   options,
   requestBody,
-}: Props<TData, TError>) =>
-  useQuery<TData, TError>({
+}: Props<TData, TError>) => {
+  const { max_active_runs: maxActiveRuns, ...bodyForKey } = requestBody.requestBody;
+
+  return useQuery<TData, TError>({
     ...options,
     enabled: validateHeaderName(requestBody),
     queryFn: () =>
       BackfillService.createBackfillDryRun({
         ...requestBody,
       }) as TData,
-    queryKey: [useCreateBackfillDryRunKey, requestBody],
+    queryKey: [useCreateBackfillDryRunKey, bodyForKey],
   });
+};


### PR DESCRIPTION
Remove the `max_active_runs` from the cache key. 

The dry run request can be pretty long, and it's annoying just before submitting, when editing the `Max Active Runs
` input to have other request emitted. The number of run won't depend on that and can safely be omitted from the dry_run cache.