### PR TITLE
Improve grid endpoint response time

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -133,7 +133,8 @@ def grid_data(
     tis_of_dag_runs, _ = paginated_select(
         statement=select(TaskInstance)
         .join(TaskInstance.task_instance_note, isouter=True)
-        .where(TaskInstance.dag_id == dag.dag_id),
+        .where(TaskInstance.dag_id == dag.dag_id)
+        .where(TaskInstance.run_id.in_([dag_run.run_id for dag_run in dag_runs])),
         filters=[],
         order_by=SortParam(allowed_attrs=["task_id", "run_id"], model=TaskInstance).set_value("task_id"),
         offset=offset,


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/49800

I realized that we were considering 'all' TIs of all DagRuns, I don't think there is a reason to do so. Limiting the TI considered to the queried DagRun.

Tested on a DAG with 5600 DagRuns:
- Before 9s
- After 500ms

That's about 20x improvement, but most importantly the response time should stop increasing linearly with the size of the TI table.