### PR TITLE
add jwt-secret

### DIFF
--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -62,6 +62,7 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
+    AIRFLOW__API_AUTH__JWT_SECRET: 'KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp'
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server


### PR DESCRIPTION
build Docker-compose file, you will get an error to enter ValueError: The value api_auth/jwt_secret must be set!. 
To solve this problem, you entered the temporary secret key of AIRFLOW_API_AUTH_JWT_SECRET in the Docker-compose.yml file.

Closes: https://github.com/apache/airflow/issues/49992