### PR TITLE
Added `last_asset_event_id` and `last_asset_event_timestamp` to the `/assets` endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -55,6 +55,8 @@ class AssetResponse(BaseModel):
     consuming_dags: list[DagScheduleAssetReference]
     producing_tasks: list[TaskOutletAssetReference]
     aliases: list[AssetAliasResponse]
+    last_asset_event_id: int | None
+    last_asset_event_timestamp: datetime | None
 
     @field_validator("extra", mode="after")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -7082,6 +7082,17 @@ components:
             $ref: '#/components/schemas/AssetAliasResponse'
           type: array
           title: Aliases
+        last_asset_event_id:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Last Asset Event Id
+        last_asset_event_timestamp:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Asset Event Timestamp
       type: object
       required:
       - id
@@ -7093,6 +7104,8 @@ components:
       - consuming_dags
       - producing_tasks
       - aliases
+      - last_asset_event_id
+      - last_asset_event_timestamp
       title: AssetResponse
       description: Asset serializer for responses.
     BackfillCollectionResponse:

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -160,6 +160,13 @@ class AssetManager(LoggingMixin):
         session.add(asset_event)
         session.flush()  # Ensure the event is written earlier than DDRQ entries below.
 
+        # Once the asset event has been written, go ahead and update the Asset endpoint to include the latest
+        # AssetEvent ID, as well as the timestamp
+        asset_model.last_asset_event_id = asset_event.id
+        asset_model.last_asset_event_timestamp = asset_event.timestamp
+        # session.add(asset_model)
+        # session.flush()  # Make sure Asset is updated
+
         dags_to_queue_from_asset = {
             ref.dag for ref in asset_model.consuming_dags if not ref.dag.is_stale and not ref.dag.is_paused
         }

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -276,6 +276,19 @@ class AssetModel(Base):
     producing_tasks = relationship("TaskOutletAssetReference", back_populates="asset")
     triggers = relationship("Trigger", secondary=asset_trigger_association_table, back_populates="assets")
 
+    # ForeignKey("asset_event.id") -> this was originally in the last_asset_event_id definition
+    # The default value should be None. When an Asset is defined, it is not yet tied to an AssetEvent
+    last_asset_event_id = Column(Integer, default=None)
+    last_asset_event_timestamp = Column(UtcDateTime, default=None)
+
+    last_event = relationship(
+        "AssetEvent",
+        primaryjoin="AssetModel.last_asset_event_id == foreign(AssetEvent.id)",
+        viewonly=True,
+        lazy="select",
+        uselist=False,
+    )
+
     __tablename__ = "asset"
     __table_args__ = (
         Index("idx_asset_name_uri_unique", name, uri, unique=True),

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -342,6 +342,29 @@ export const $AssetResponse = {
       type: "array",
       title: "Aliases",
     },
+    last_asset_event_id: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Asset Event Id",
+    },
+    last_asset_event_timestamp: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Asset Event Timestamp",
+    },
   },
   type: "object",
   required: [
@@ -354,6 +377,8 @@ export const $AssetResponse = {
     "consuming_dags",
     "producing_tasks",
     "aliases",
+    "last_asset_event_id",
+    "last_asset_event_timestamp",
   ],
   title: "AssetResponse",
   description: "Asset serializer for responses.",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -90,6 +90,8 @@ export type AssetResponse = {
   consuming_dags: Array<DagScheduleAssetReference>;
   producing_tasks: Array<TaskOutletAssetReference>;
   aliases: Array<AssetAliasResponse>;
+  last_asset_event_id: number | null;
+  last_asset_event_timestamp: string | null;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -259,6 +259,8 @@ class TestGetAssets(TestAssets):
                     "consuming_dags": [],
                     "producing_tasks": [],
                     "aliases": [],
+                    "last_asset_event_id": None,
+                    "last_asset_event_timestamp": None,
                 },
                 {
                     "id": asset2.id,
@@ -271,6 +273,8 @@ class TestGetAssets(TestAssets):
                     "consuming_dags": [],
                     "producing_tasks": [],
                     "aliases": [],
+                    "last_asset_event_id": None,  # Defaults to None, since there is no asset event
+                    "last_asset_event_timestamp": None,
                 },
             ],
             "total_entries": 2,
@@ -310,6 +314,8 @@ class TestGetAssets(TestAssets):
                     "consuming_dags": [],
                     "producing_tasks": [],
                     "aliases": [],
+                    "last_asset_event_id": None,
+                    "last_asset_event_timestamp": None,
                 },
                 {
                     "id": asset2.id,
@@ -322,6 +328,8 @@ class TestGetAssets(TestAssets):
                     "consuming_dags": [],
                     "producing_tasks": [],
                     "aliases": [],
+                    "last_asset_event_id": None,
+                    "last_asset_event_timestamp": None,
                 },
                 {
                     "id": asset3.id,
@@ -334,6 +342,8 @@ class TestGetAssets(TestAssets):
                     "consuming_dags": [],
                     "producing_tasks": [],
                     "aliases": [],
+                    "last_asset_event_id": None,
+                    "last_asset_event_timestamp": None,
                 },
             ],
             "total_entries": 3,
@@ -897,6 +907,8 @@ class TestGetAssetEndpoint(TestAssets):
             "consuming_dags": [],
             "producing_tasks": [],
             "aliases": [],
+            "last_asset_event_id": None,  # Defaults to None, since there is no asset event
+            "last_asset_event_timestamp": None,
         }
 
     def test_should_respond_401(self, unauthenticated_test_client):
@@ -930,6 +942,8 @@ class TestGetAssetEndpoint(TestAssets):
             "consuming_dags": [],
             "producing_tasks": [],
             "aliases": [],
+            "last_asset_event_id": None,  # Defaults to None, since there is no asset event
+            "last_asset_event_timestamp": None,
         }
 
 
@@ -1114,6 +1128,17 @@ class TestPostAssetEvents(TestAssets):
             "created_dagruns": [],
             "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
         }
+
+    def test_should_update_asset_endpoint(self, test_client, session):
+        (asset,) = self.create_assets(session, num=1)
+        event_payload = {"asset_id": asset.id, "extra": {"foo": "bar"}}
+        asset_event_response = test_client.post("/assets/events", json=event_payload)
+
+        # Now, pull the Asset, and get the response
+        asset_response = test_client.get(f"/assets/{asset.id}")
+
+        assert asset_response.json()["last_asset_event_id"] == asset_event_response.json()["id"]
+        assert asset_response.json()["last_asset_event_timestamp"] == asset_event_response.json()["timestamp"]
 
 
 @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/cli/commands/test_asset_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_asset_command.py
@@ -100,6 +100,8 @@ def test_cli_assets_details(parser: ArgumentParser) -> None:
         "group": "asset",
         "extra": {},
         "aliases": [],
+        "last_asset_event_id": None,
+        "last_asset_event_timestamp": None,
     }
 
 

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -973,6 +973,8 @@ class AssetResponse(BaseModel):
     consuming_dags: Annotated[list[DagScheduleAssetReference], Field(title="Consuming Dags")]
     producing_tasks: Annotated[list[TaskOutletAssetReference], Field(title="Producing Tasks")]
     aliases: Annotated[list[AssetAliasResponse], Field(title="Aliases")]
+    last_asset_event_id: Annotated[int | None, Field(title="Last Asset Event Id")] = None
+    last_asset_event_timestamp: Annotated[datetime | None, Field(title="Last Asset Event Timestamp")] = None
 
 
 class BackfillPostBody(BaseModel):


### PR DESCRIPTION
This pull request adds the `last_asset_event_id` and `last_asset_event_timestamp` fields to the `/assets` endpoint. The original use-case was to make the Asset list view sortable by the last Asset Event. However, there is a much larger use-case at play here; **the ability to easily determine the timestamp for the last Asset Event for a certain Asset**. This is especially applicable for Asset Watchers.

By default, the `last_asset_event_id` and `last_asset_event_timestamp` fields are set as `null`. It's not until the first Asset Event that these fields are populated. This is done in the `AssetManager.register_asset_change` method. 

Unit-tests were added/updated for all changes made.

related: #47164 
