### PR TITLE
feat(provider/azure): Add Power BI triggers, operators and tests for dataset and workspace operations

### DIFF
--- a/providers/microsoft/azure/docs/operators/powerbi.rst
+++ b/providers/microsoft/azure/docs/operators/powerbi.rst
@@ -40,6 +40,33 @@ To trigger a refresh for the specified dataset from the specified workspace, use
     :start-after: [START howto_operator_powerbi_refresh_async]
     :end-before: [END howto_operator_powerbi_refresh_async]
 
+.. _howto/operator:PowerBIDatasetListOperator:
+
+PowerBIDatasetListOperator
+----------------------------------
+
+To list all available and discoverable datasets from the specified workspace, use the :class:`~airflow.providers.microsoft.azure.operators.powerbi.PowerBIDatasetListOperator`.
+
+
+.. exampleinclude:: /../tests/system/microsoft/azure/example_powerbi_dataset_list.py
+    :language: python
+    :dedent: 0
+    :start-after: [START howto_operator_powerbi_dataset_list_async]
+    :end-before: [END howto_operator_powerbi_dataset_list_async]
+
+.. _howto/operator:PowerBIWorkspaceListOperator:
+
+PowerBIWorkspaceListOperator
+----------------------------------
+
+To list all available and discoverable workspaces for the tenant, use the :class:`~airflow.providers.microsoft.azure.operators.powerbi.PowerBIWorkspaceListOperator`.
+
+.. exampleinclude:: /../tests/system/microsoft/azure/example_powerbi_workspace_list.py
+    :language: python
+    :dedent: 0
+    :start-after: [START howto_operator_powerbi_workspace_list_async]
+    :end-before: [END howto_operator_powerbi_workspace_list_async]
+
 Reference
 ---------
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -230,3 +230,165 @@ class PowerBITrigger(BaseTrigger):
                     "dataset_refresh_id": self.dataset_refresh_id,
                 }
             )
+
+
+class PowerBIWorkspaceListTrigger(BaseTrigger):
+    """
+    Triggers a call to the API to request the available workspace IDs.
+
+    :param conn_id: The connection Id to connect to PowerBI.
+    :param timeout: The HTTP timeout being used by the `KiotaRequestAdapter`. Default is 1 week (60s * 60m * 24h * 7d).
+        When no timeout is specified or set to None then there is no HTTP timeout on each request.
+    :param proxies: A dict defining the HTTP proxies to be used (default is None).
+    :param api_version: The API version of the Microsoft Graph API to be used (default is v1).
+        You can pass an enum named APIVersion which has 2 possible members v1 and beta,
+        or you can pass a string as `v1.0` or `beta`.
+    """
+
+    def __init__(
+        self,
+        conn_id: str,
+        workspace_ids: list[str] | None = None,
+        timeout: float = 60 * 60 * 24 * 7,
+        proxies: dict | None = None,
+        api_version: APIVersion | str | None = None,
+    ):
+        super().__init__()
+        self.hook = PowerBIHook(conn_id=conn_id, proxies=proxies, api_version=api_version, timeout=timeout)
+        self.timeout = timeout
+        self.workspace_ids = workspace_ids
+
+    def serialize(self):
+        """Serialize the trigger instance."""
+        return (
+            "airflow.providers.microsoft.azure.triggers.powerbi.PowerBIWorkspaceListTrigger",
+            {
+                "conn_id": self.conn_id,
+                "proxies": self.proxies,
+                "api_version": self.api_version,
+                "timeout": self.timeout,
+                "workspace_ids": self.workspace_ids,
+            },
+        )
+
+    @property
+    def conn_id(self) -> str:
+        return self.hook.conn_id
+
+    @property
+    def proxies(self) -> dict | None:
+        return self.hook.proxies
+
+    @property
+    def api_version(self) -> APIVersion | str:
+        return self.hook.api_version
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """Make async connection to the PowerBI and polls for the list of workspace IDs."""
+        if not self.workspace_ids:
+            # Trigger the API to get the workspace list
+            workspace_ids = await self.hook.get_workspace_list()
+
+            if workspace_ids:
+                self.log.info("Triggered request to get workspace list.")
+                yield TriggerEvent(
+                    {
+                        "status": "success",
+                        "message": "The workspace list get request has been successful.",
+                        "workspace_ids": workspace_ids,
+                    }
+                )
+                return
+
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "message": "Error grabbing the workspace list.",
+                    "workspace_ids": None,
+                }
+            )
+            return
+
+
+class PowerBIDatasetListTrigger(BaseTrigger):
+    """
+    Triggers a call to the API to request the available dataset IDs.
+
+    :param conn_id: The connection Id to connect to PowerBI.
+    :param group_id: The group Id to list discoverable datasets.
+    :param timeout: The HTTP timeout being used by the `KiotaRequestAdapter`. Default is 1 week (60s * 60m * 24h * 7d).
+        When no timeout is specified or set to None then there is no HTTP timeout on each request.
+    :param proxies: A dict defining the HTTP proxies to be used (default is None).
+    :param api_version: The API version of the Microsoft Graph API to be used (default is v1).
+        You can pass an enum named APIVersion which has 2 possible members v1 and beta,
+        or you can pass a string as `v1.0` or `beta`.
+    """
+
+    def __init__(
+        self,
+        conn_id: str,
+        group_id: str,
+        dataset_ids: list[str] | None = None,
+        timeout: float = 60 * 60 * 24 * 7,
+        proxies: dict | None = None,
+        api_version: APIVersion | str | None = None,
+    ):
+        super().__init__()
+        self.hook = PowerBIHook(conn_id=conn_id, proxies=proxies, api_version=api_version, timeout=timeout)
+        self.timeout = timeout
+        self.group_id = group_id
+        self.dataset_ids = dataset_ids
+
+    def serialize(self):
+        """Serialize the trigger instance."""
+        return (
+            "airflow.providers.microsoft.azure.triggers.powerbi.PowerBIDatasetListTrigger",
+            {
+                "conn_id": self.conn_id,
+                "proxies": self.proxies,
+                "api_version": self.api_version,
+                "timeout": self.timeout,
+                "group_id": self.group_id,
+                "dataset_ids": self.dataset_ids,
+            },
+        )
+
+    @property
+    def conn_id(self) -> str:
+        return self.hook.conn_id
+
+    @property
+    def proxies(self) -> dict | None:
+        return self.hook.proxies
+
+    @property
+    def api_version(self) -> APIVersion | str:
+        return self.hook.api_version
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """Make async connection to the PowerBI and polls for the list of dataset IDs."""
+        if not self.dataset_ids:
+            # Trigger the API to get the dataset list
+            dataset_ids = await self.hook.get_dataset_list(
+                group_id=self.group_id,
+            )
+
+            if dataset_ids:
+                self.log.info("Triggered request to get dataset list.")
+                yield TriggerEvent(
+                    {
+                        "status": "success",
+                        "message": f"The dataset list get request from workspace {self.group_id} has been successful.",
+                        "dataset_ids": dataset_ids,
+                    }
+                )
+                return
+
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "message": "Error grabbing the dataset list.",
+                    "dataset_ids": None,
+                }
+            )
+            return

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -285,29 +285,28 @@ class PowerBIWorkspaceListTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make async connection to the PowerBI and polls for the list of workspace IDs."""
-        if not self.workspace_ids:
-            # Trigger the API to get the workspace list
-            workspace_ids = await self.hook.get_workspace_list()
+        # Trigger the API to get the workspace list
+        workspace_ids = await self.hook.get_workspace_list()
 
-            if workspace_ids:
-                self.log.info("Triggered request to get workspace list.")
-                yield TriggerEvent(
-                    {
-                        "status": "success",
-                        "message": "The workspace list get request has been successful.",
-                        "workspace_ids": workspace_ids,
-                    }
-                )
-                return
-
+        if workspace_ids:
+            self.log.info("Triggered request to get workspace list.")
             yield TriggerEvent(
                 {
-                    "status": "error",
-                    "message": "Error grabbing the workspace list.",
-                    "workspace_ids": None,
+                    "status": "success",
+                    "message": "The workspace list get request has been successful.",
+                    "workspace_ids": workspace_ids,
                 }
             )
             return
+
+        yield TriggerEvent(
+            {
+                "status": "error",
+                "message": "Error grabbing the workspace list.",
+                "workspace_ids": None,
+            }
+        )
+        return
 
 
 class PowerBIDatasetListTrigger(BaseTrigger):
@@ -367,28 +366,27 @@ class PowerBIDatasetListTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make async connection to the PowerBI and polls for the list of dataset IDs."""
-        if not self.dataset_ids:
-            # Trigger the API to get the dataset list
-            dataset_ids = await self.hook.get_dataset_list(
-                group_id=self.group_id,
-            )
+        # Trigger the API to get the dataset list
+        dataset_ids = await self.hook.get_dataset_list(
+            group_id=self.group_id,
+        )
 
-            if dataset_ids:
-                self.log.info("Triggered request to get dataset list.")
-                yield TriggerEvent(
-                    {
-                        "status": "success",
-                        "message": f"The dataset list get request from workspace {self.group_id} has been successful.",
-                        "dataset_ids": dataset_ids,
-                    }
-                )
-                return
-
+        if dataset_ids:
+            self.log.info("Triggered request to get dataset list.")
             yield TriggerEvent(
                 {
-                    "status": "error",
-                    "message": "Error grabbing the dataset list.",
-                    "dataset_ids": None,
+                    "status": "success",
+                    "message": f"The dataset list get request from workspace {self.group_id} has been successful.",
+                    "dataset_ids": dataset_ids,
                 }
             )
             return
+
+        yield TriggerEvent(
+            {
+                "status": "error",
+                "message": "Error grabbing the dataset list.",
+                "dataset_ids": None,
+            }
+        )
+        return

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_list.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_list.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from airflow import DAG, settings
+from airflow.decorators import task
+from airflow.models import Connection
+from airflow.models.baseoperator import chain
+from airflow.providers.microsoft.azure.operators.powerbi import PowerBIDatasetListOperator
+
+DAG_ID = "example_powerbi_dataset_list"
+CONN_ID = "powerbi_default"
+
+# Before running this system test, you should set following environment variables:
+GROUP_ID = os.environ.get("GROUP_ID", "None")
+CLIENT_ID = os.environ.get("CLIENT_ID", None)
+CLIENT_SECRET = os.environ.get("CLIENT_SECRET", None)
+TENANT_ID = os.environ.get("TENANT_ID", None)
+
+
+@task
+def create_connection(conn_id_name: str):
+    conn = Connection(
+        conn_id=conn_id_name,
+        conn_type="powerbi",
+        login=CLIENT_ID,
+        password=CLIENT_SECRET,
+        extra={"tenant_id": TENANT_ID},
+    )
+    session = settings.Session()
+    session.add(conn)
+    session.commit()
+
+
+with DAG(
+    dag_id=DAG_ID,
+    start_date=datetime(2021, 1, 1),
+    schedule=None,
+    tags=["example"],
+) as dag:
+    set_up_connection = create_connection(CONN_ID)
+
+    # [START howto_operator_powerbi_dataset_list_async]
+    get_powerbi_dataset_list = PowerBIDatasetListOperator(
+        conn_id="powerbi_default",
+        task_id="get_powerbi_dataset_list",
+        group_id=GROUP_ID,
+        timeout=120,
+    )
+    # [END howto_operator_powerbi_dataset_list_async]
+
+    chain(
+        # TEST SETUP
+        set_up_connection,
+        # TEST BODY
+        get_powerbi_dataset_list,
+    )
+
+    from tests_common.test_utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "tearDown" task with trigger rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_workspace_list.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_workspace_list.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from airflow import DAG, settings
+from airflow.decorators import task
+from airflow.models import Connection
+from airflow.models.baseoperator import chain
+from airflow.providers.microsoft.azure.operators.powerbi import PowerBIWorkspaceListOperator
+
+DAG_ID = "example_powerbi_workspace_list"
+CONN_ID = "powerbi_default"
+
+# Before running this system test, you should set following environment variables:
+CLIENT_ID = os.environ.get("CLIENT_ID", None)
+CLIENT_SECRET = os.environ.get("CLIENT_SECRET", None)
+TENANT_ID = os.environ.get("TENANT_ID", None)
+
+
+@task
+def create_connection(conn_id_name: str):
+    conn = Connection(
+        conn_id=conn_id_name,
+        conn_type="powerbi",
+        login=CLIENT_ID,
+        password=CLIENT_SECRET,
+        extra={"tenant_id": TENANT_ID},
+    )
+    session = settings.Session()
+    session.add(conn)
+    session.commit()
+
+
+with DAG(
+    dag_id=DAG_ID,
+    start_date=datetime(2021, 1, 1),
+    schedule=None,
+    tags=["example"],
+) as dag:
+    set_up_connection = create_connection(CONN_ID)
+
+    # [START howto_operator_powerbi_workspace_list_async]
+    get_powerbi_workspace_list = PowerBIWorkspaceListOperator(
+        conn_id="powerbi_default",
+        task_id="get_powerbi_workspace_list",
+        timeout=120,
+    )
+    # [END howto_operator_powerbi_workspace_list_async]
+
+    chain(
+        # TEST SETUP
+        set_up_connection,
+        # TEST BODY
+        get_powerbi_workspace_list,
+    )
+
+    from tests_common.test_utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "tearDown" task with trigger rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_powerbi_list.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_powerbi_list.py
@@ -1,0 +1,227 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.providers.microsoft.azure.operators.powerbi import (
+    PowerBIDatasetListOperator,
+    PowerBIWorkspaceListOperator,
+)
+from airflow.providers.microsoft.azure.triggers.powerbi import (
+    PowerBIDatasetListTrigger,
+    PowerBIWorkspaceListTrigger,
+)
+from airflow.utils import timezone
+
+from unit.microsoft.azure.base import Base
+from unit.microsoft.azure.test_utils import get_airflow_connection
+
+DEFAULT_CONNECTION_CLIENT_SECRET = "powerbi_conn_id"
+TASK_ID = "run_powerbi_operators"
+GROUP_ID = "group_id"
+
+DATASET_LIST_ID = ["5e2d9921-e91b-491f-b7e1-e7d8db49194c"]
+WORKSPACE_LIST_ID = ["5e2d9921-e91b-491f-b7e1-e7d8db49194c"]
+
+CONFIG_DATASETS = {
+    "task_id": TASK_ID,
+    "conn_id": DEFAULT_CONNECTION_CLIENT_SECRET,
+    "group_id": GROUP_ID,
+}
+CONFIG_WORKSPACES = {
+    "task_id": TASK_ID,
+    "conn_id": DEFAULT_CONNECTION_CLIENT_SECRET,
+}
+
+SUCCESS_LIST_EVENT_DATASETS = {
+    "status": "success",
+    "message": "success",
+    "dataset_ids": DATASET_LIST_ID,
+}
+
+SUCCESS_LIST_EVENT_WORKSPACES = {
+    "status": "success",
+    "message": "success",
+    "workspace_ids": WORKSPACE_LIST_ID,
+}
+
+DEFAULT_DATE = timezone.datetime(2021, 1, 1)
+
+
+class TestPowerBIDatasetListOperator(Base):
+    @mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection)
+    def test_powerbi_operator_async_get_dataset_list_success(self, connection):
+        """Assert that get_dataset_list log success message"""
+        operator = PowerBIDatasetListOperator(
+            **CONFIG_DATASETS,
+        )
+        context = {"ti": MagicMock()}
+        context["ti"].task_id = TASK_ID
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(
+                context=context,
+            )
+
+        assert isinstance(exc.value.trigger, PowerBIDatasetListTrigger)
+        assert exc.value.trigger.dataset_ids is None
+        assert str(exc.value.trigger.group_id) == GROUP_ID
+
+    def test_powerbi_operator_async_execute_complete_success(self):
+        """Assert that execute_complete log success message"""
+        operator = PowerBIDatasetListOperator(
+            **CONFIG_DATASETS,
+        )
+        context = {"ti": MagicMock()}
+        operator.execute_complete(
+            context=context,
+            event=SUCCESS_LIST_EVENT_DATASETS,
+        )
+        assert context["ti"].xcom_push.call_count == 1
+
+    def test_powerbi_operator_async_execute_complete_fail(self):
+        """Assert that execute_complete raise exception on error"""
+        operator = PowerBIDatasetListOperator(
+            **CONFIG_DATASETS,
+        )
+        context = {"ti": MagicMock()}
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(
+                context=context,
+                event={
+                    "status": "error",
+                    "message": "error",
+                    "dataset_ids": None,
+                },
+            )
+        assert context["ti"].xcom_push.call_count == 1
+        assert str(exc.value) == "error"
+
+    def test_powerbi_operator_dataset_list_fail(self):
+        """Assert that execute_complete raise exception on dataset list fail"""
+        operator = PowerBIDatasetListOperator(
+            **CONFIG_DATASETS,
+        )
+        context = {"ti": MagicMock()}
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(
+                context=context,
+                event={
+                    "status": "error",
+                    "message": "error message",
+                    "dataset_ids": None,
+                },
+            )
+        assert context["ti"].xcom_push.call_count == 1
+        assert str(exc.value) == "error message"
+
+    def test_execute_complete_no_event(self):
+        """Test execute_complete when event is None or empty."""
+        operator = PowerBIDatasetListOperator(
+            **CONFIG_DATASETS,
+        )
+        context = {"ti": MagicMock()}
+        operator.execute_complete(
+            context=context,
+            event=None,
+        )
+        assert context["ti"].xcom_push.call_count == 0
+
+
+class TestPowerBIWorkspaceListOperator(Base):
+    @mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection)
+    def test_powerbi_operator_async_get_workspace_list_success(self, connection):
+        """Assert that get_workspace_list log success message"""
+        operator = PowerBIWorkspaceListOperator(
+            **CONFIG_WORKSPACES,
+        )
+        context = {"ti": MagicMock()}
+        context["ti"].task_id = TASK_ID
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(
+                context=context,
+            )
+
+        assert isinstance(exc.value.trigger, PowerBIWorkspaceListTrigger)
+        assert exc.value.trigger.workspace_ids is None
+
+    def test_powerbi_operator_async_execute_complete_success(self):
+        """Assert that execute_complete log success message"""
+        operator = PowerBIWorkspaceListOperator(
+            **CONFIG_WORKSPACES,
+        )
+        context = {"ti": MagicMock()}
+        operator.execute_complete(
+            context=context,
+            event=SUCCESS_LIST_EVENT_WORKSPACES,
+        )
+        assert context["ti"].xcom_push.call_count == 1
+
+    def test_powerbi_operator_async_execute_complete_fail(self):
+        """Assert that execute_complete raise exception on error"""
+        operator = PowerBIWorkspaceListOperator(
+            **CONFIG_WORKSPACES,
+        )
+        context = {"ti": MagicMock()}
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(
+                context=context,
+                event={
+                    "status": "error",
+                    "message": "error",
+                    "workspace_ids": None,
+                },
+            )
+        assert context["ti"].xcom_push.call_count == 1
+        assert str(exc.value) == "error"
+
+    def test_powerbi_operator_workspace_list_fail(self):
+        """Assert that execute_complete raise exception on workspace list fail"""
+        operator = PowerBIWorkspaceListOperator(
+            **CONFIG_WORKSPACES,
+        )
+        context = {"ti": MagicMock()}
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(
+                context=context,
+                event={
+                    "status": "error",
+                    "message": "error message",
+                    "workspace_ids": None,
+                },
+            )
+        assert context["ti"].xcom_push.call_count == 1
+        assert str(exc.value) == "error message"
+
+    def test_execute_complete_no_event(self):
+        """Test execute_complete when event is None or empty."""
+        operator = PowerBIWorkspaceListOperator(
+            **CONFIG_WORKSPACES,
+        )
+        context = {"ti": MagicMock()}
+        operator.execute_complete(
+            context=context,
+            event=None,
+        )
+        assert context["ti"].xcom_push.call_count == 0

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
@@ -26,7 +26,11 @@ from airflow.providers.microsoft.azure.hooks.powerbi import (
     PowerBIDatasetRefreshException,
     PowerBIDatasetRefreshStatus,
 )
-from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
+from airflow.providers.microsoft.azure.triggers.powerbi import (
+    PowerBIDatasetListTrigger,
+    PowerBITrigger,
+    PowerBIWorkspaceListTrigger,
+)
 from airflow.triggers.base import TriggerEvent
 
 from unit.microsoft.azure.test_utils import get_airflow_connection
@@ -35,6 +39,8 @@ POWERBI_CONN_ID = "powerbi_default"
 DATASET_ID = "dataset_id"
 GROUP_ID = "group_id"
 DATASET_REFRESH_ID = "dataset_refresh_id"
+DATASET_IDS = "dataset_ids"
+WORKSPACE_IDS = "workspace_ids"
 TIMEOUT = 5
 MODULE = "airflow.providers.microsoft.azure"
 CHECK_INTERVAL = 1
@@ -53,6 +59,31 @@ def powerbi_trigger(timeout=TIMEOUT, check_interval=CHECK_INTERVAL) -> PowerBITr
         group_id=GROUP_ID,
         check_interval=check_interval,
         wait_for_termination=True,
+        timeout=timeout,
+    )
+
+
+@pytest.fixture
+def powerbi_dataset_list_trigger(timeout=TIMEOUT, group_id=GROUP_ID) -> PowerBIDatasetListTrigger:
+    """Fixture for creating a PowerBIDatasetListTrigger with customizable timeout."""
+    return PowerBIDatasetListTrigger(
+        conn_id=POWERBI_CONN_ID,
+        proxies=None,
+        api_version=API_VERSION,
+        group_id=group_id,
+        dataset_ids=None,
+        timeout=timeout,
+    )
+
+
+@pytest.fixture
+def powerbi_workspace_list_trigger(timeout=TIMEOUT) -> PowerBIWorkspaceListTrigger:
+    """Fixture for creating a PowerBIWorkspaceListTrigger with customizable timeout."""
+    return PowerBIWorkspaceListTrigger(
+        conn_id=POWERBI_CONN_ID,
+        proxies=None,
+        api_version=API_VERSION,
+        workspace_ids=None,
         timeout=timeout,
     )
 


### PR DESCRIPTION
## Description
This PR introduces deferrable versions of the Power BI workspace- and dataset-list operators in the Azure provider package. Instead of blocking a worker slot while calling the Power BI REST API, these operators now:

- **Defer** execution using custom `BaseTrigger` implementations  
- **Poll** asynchronously for the full list of workspaces or datasets  
- **Resume** execution once data is available and push IDs into XCom  

### New Hook methods
- `PowerBIHook.get_workspace_list()`  
- `PowerBIHook.get_dataset_list(group_id: str)`

### New Trigger classes
- `PowerBIWorkspaceListTrigger`  
- `PowerBIDatasetListTrigger`

### New Operator classes
- `PowerBIWorkspaceListOperator`  
- `PowerBIDatasetListOperator`

### Unit tests
- Trigger serialization (`serialize()`)  
- Trigger run logic (success and error paths)  
- Operator deferral (`TaskDeferred`)  
- Operator resume handling (`execute_complete`)  
- XCom key/value assertions  

## Motivation and Context
Long-running or paginated API calls can occupy a worker slot for tens of seconds or more, limiting concurrency and throughput. By deferring:

1. We free up the worker while waiting on Power BI.  
2. We align with Airflow’s best practices for asynchronous I/O.  
3. We make scaling in high-volume environments more efficient.

This change complements existing synchronous operators; it does not remove or alter any blocking behavior, giving users the choice.

## How Has This Been Tested?
- 🧪 **Automated tests** under `tests/providers/microsoft/azure/` covering all new code paths.  
- 🔄 **Manual end-to-end DAG** against a real Power BI service principal.  
- ✅ Verified that XCom payloads contain the correct ID lists on resume.  
- ✅ Verified appropriate error handling and retries in failure cases.

## Documentation
- Added `howto/operator:PowerBIWorkspaceListOperator` and `howto/operator:PowerBIDatasetListOperator` pages.  
- Updated Azure provider README to mention the new deferrable operators.

## Backwards-Incompatible Changes?
No. Existing synchronous `PowerBIHook` methods and operators remain unchanged and fully supported.

## New Dependencies?
None. All new code relies on existing Airflow and Azure provider infrastructure.

