### PR TITLE
Fix edit port for connections

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
@@ -91,7 +91,8 @@ export const useEditConnection = (
         ...requestBody,
         conn_type: requestBody.conn_type,
         connection_id: initialConnection.connection_id,
-        port: Number(requestBody.port),
+        // eslint-disable-next-line unicorn/no-null
+        port: requestBody.port === "" ? null : Number(requestBody.port),
       },
       updateMask,
     });


### PR DESCRIPTION
When connection is edited, and port is not set, it defaults to 0. It should be null.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
