### PR TITLE
Add keyboard shortcut for fullscreen and wrap in logs.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, Button, Heading, HStack, Link } from "@chakra-ui/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useParams } from "react-router-dom";
 import { createElement, PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
@@ -33,7 +34,7 @@ import type { DAGSourceResponse } from "openapi/requests/types.gen";
 import { DagVersionSelect } from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardButton } from "src/components/ui";
+import { ClipboardRoot, ClipboardButton, Tooltip } from "src/components/ui";
 import { ProgressBar } from "src/components/ui";
 import { useColorMode } from "src/context/colorMode";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
@@ -79,6 +80,8 @@ export const Code = () => {
   const toggleWrap = () => setWrap(!wrap);
   const { colorMode } = useColorMode();
 
+  useHotkeys("w", toggleWrap);
+
   const style = colorMode === "dark" ? oneDark : oneLight;
 
   // wrapLongLines wasn't working with the prsim styles so we have to manually apply the style
@@ -123,9 +126,16 @@ export const Code = () => {
           <ClipboardRoot value={code?.content ?? ""}>
             <ClipboardButton />
           </ClipboardRoot>
-          <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
-            {wrap ? "Unwrap" : "Wrap"}
-          </Button>
+          <Tooltip closeDelay={100} content="Press w for wrap" openDelay={100}>
+            <Button
+              aria-label={wrap ? "Unwrap" : "Wrap"}
+              bg="bg.panel"
+              onClick={toggleWrap}
+              variant="outline"
+            >
+              {wrap ? "Unwrap" : "Wrap"}
+            </Button>
+          </Tooltip>
         </HStack>
       </HStack>
       {/* We want to show an empty state on 404 instead of an error */}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -126,7 +126,7 @@ export const Code = () => {
           <ClipboardRoot value={code?.content ?? ""}>
             <ClipboardButton />
           </ClipboardRoot>
-          <Tooltip closeDelay={100} content="Press w for wrap" openDelay={100}>
+          <Tooltip closeDelay={100} content="Press w to toggle wrap" openDelay={100}>
             <Button
               aria-label={wrap ? "Unwrap" : "Wrap"}
               bg="bg.panel"

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
@@ -48,7 +48,7 @@ const FailedLogs = ({
     <Flex flexDirection="column" gap={3}>
       <Flex alignItems="center" justifyContent="space-between">
         <Heading size="md">Recent Failed Task Logs</Heading>
-        <Tooltip closeDelay={100} content="Press w for wrap" openDelay={100}>
+        <Tooltip closeDelay={100} content="Press w to toggle wrap" openDelay={100}>
           <Button
             aria-label={wrap ? "Unwrap" : "Wrap"}
             bg="bg.panel"

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/FailedLogs.tsx
@@ -18,8 +18,10 @@
  */
 import { Flex, Heading, Button } from "@chakra-ui/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import type { TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
+import { Tooltip } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig";
 
 import { TaskLogPreview } from "./TaskLogPreview";
@@ -36,6 +38,8 @@ const FailedLogs = ({
 
   const toggleWrap = () => setWrap(!wrap);
 
+  useHotkeys("w", toggleWrap);
+
   if (taskLogs === undefined || taskLogs.length <= 0) {
     return undefined;
   }
@@ -44,16 +48,18 @@ const FailedLogs = ({
     <Flex flexDirection="column" gap={3}>
       <Flex alignItems="center" justifyContent="space-between">
         <Heading size="md">Recent Failed Task Logs</Heading>
-        <Button
-          aria-label={wrap ? "Unwrap" : "Wrap"}
-          bg="bg.panel"
-          fontSize="sm"
-          onClick={toggleWrap}
-          size="sm"
-          variant="outline"
-        >
-          {wrap ? "Unwrap" : "Wrap"}
-        </Button>
+        <Tooltip closeDelay={100} content="Press w for wrap" openDelay={100}>
+          <Button
+            aria-label={wrap ? "Unwrap" : "Wrap"}
+            bg="bg.panel"
+            fontSize="sm"
+            onClick={toggleWrap}
+            size="sm"
+            variant="outline"
+          >
+            {wrap ? "Unwrap" : "Wrap"}
+          </Button>
+        </Tooltip>
       </Flex>
       {taskLogs.map((taskInstance) => (
         <TaskLogPreview key={taskInstance.id} taskInstance={taskInstance} wrap={wrap} />

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, Heading, VStack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
@@ -67,6 +68,9 @@ export const Logs = () => {
 
   const toggleWrap = () => setWrap(!wrap);
   const toggleFullscreen = () => setFullscreen(!fullscreen);
+
+  useHotkeys("w", toggleWrap);
+  useHotkeys("f", toggleFullscreen);
 
   const onOpenChange = () => {
     setFullscreen(false);

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -30,7 +30,7 @@ import { useSearchParams } from "react-router-dom";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
-import { Button, Select } from "src/components/ui";
+import { Button, Select, Tooltip } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { system } from "src/theme";
 import { type LogLevel, logLevelColorMapping, logLevelOptions } from "src/utils/logs";
@@ -179,13 +179,22 @@ export const TaskLogHeader = ({
           </Select.Root>
         ) : undefined}
         <HStack>
-          <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
-            {wrap ? "Unwrap" : "Wrap"}
-          </Button>
+          <Tooltip closeDelay={100} content="Press w for wrap" openDelay={100}>
+            <Button
+              aria-label={wrap ? "Unwrap" : "Wrap"}
+              bg="bg.panel"
+              onClick={toggleWrap}
+              variant="outline"
+            >
+              {wrap ? "Unwrap" : "Wrap"}
+            </Button>
+          </Tooltip>
           {!isFullscreen && (
-            <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
-              <MdOutlineOpenInFull />
-            </IconButton>
+            <Tooltip closeDelay={100} content="Press f for fullscreen" openDelay={100}>
+              <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
+                <MdOutlineOpenInFull />
+              </IconButton>
+            </Tooltip>
           )}
         </HStack>
       </HStack>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -179,7 +179,7 @@ export const TaskLogHeader = ({
           </Select.Root>
         ) : undefined}
         <HStack>
-          <Tooltip closeDelay={100} content="Press w for wrap" openDelay={100}>
+          <Tooltip closeDelay={100} content="Press w to toggle wrap" openDelay={100}>
             <Button
               aria-label={wrap ? "Unwrap" : "Wrap"}
               bg="bg.panel"


### PR DESCRIPTION
Press "f" for fullscreen and "w" for wrap. A tooltip is with 100ms delay added for better discoverability. I have also validated when the user is in the log tab and is editing a dagrun note the keypress "f"/"w" while typing the note are not captured.

Closes #50006