### PR TITLE
AIP-84: alias `dag_display_name` for `BackfillResponse`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import NonNegativeInt
+from pydantic import AliasPath, Field, NonNegativeInt
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.models.backfill import ReprocessBehavior
@@ -51,6 +51,7 @@ class BackfillResponse(BaseModel):
     created_at: datetime
     completed_at: datetime | None
     updated_at: datetime
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))
 
 
 class BackfillCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -650,6 +650,9 @@ components:
           type: string
           format: date-time
           title: Updated At
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - id
@@ -663,6 +666,7 @@ components:
       - created_at
       - completed_at
       - updated_at
+      - dag_display_name
       title: BackfillResponse
       description: Base serializer for Backfill.
     BaseEdgeResponse:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -7191,6 +7191,9 @@ components:
           type: string
           format: date-time
           title: Updated At
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - id
@@ -7204,6 +7207,7 @@ components:
       - created_at
       - completed_at
       - updated_at
+      - dag_display_name
       title: BackfillResponse
       description: Base serializer for Backfill.
     BaseInfoResponse:

--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -135,6 +135,13 @@ class Backfill(Base):
 
     backfill_dag_run_associations = relationship("BackfillDagRun", back_populates="backfill")
 
+    dag_model = relationship(
+        "DagModel",
+        primaryjoin="DagModel.dag_id == Backfill.dag_id",
+        viewonly=True,
+        foreign_keys=[dag_id],
+    )
+
     def __repr__(self):
         return f"Backfill({self.dag_id=}, {self.from_date=}, {self.to_date=})"
 
@@ -465,6 +472,7 @@ def _create_backfill(
             max_active_runs=max_active_runs,
             dag_run_conf=dag_run_conf,
             reprocess_behavior=reprocess_behavior,
+            dag_model=dag,
         )
         session.add(br)
         session.commit()

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -482,6 +482,10 @@ export const $BackfillResponse = {
       format: "date-time",
       title: "Updated At",
     },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
+    },
   },
   type: "object",
   required: [
@@ -496,6 +500,7 @@ export const $BackfillResponse = {
     "created_at",
     "completed_at",
     "updated_at",
+    "dag_display_name",
   ],
   title: "BackfillResponse",
   description: "Base serializer for Backfill.",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -132,6 +132,7 @@ export type BackfillResponse = {
   created_at: string;
   completed_at: string | null;
   updated_at: string;
+  dag_display_name: string;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -121,6 +121,7 @@ class TestListBackfills(TestBackfillEndpoint):
                 {
                     "completed_at": mock.ANY,
                     "created_at": mock.ANY,
+                    "dag_display_name": "TEST_DAG_1",
                     "dag_id": "TEST_DAG_1",
                     "dag_run_conf": {},
                     "from_date": to_iso(from_date),
@@ -149,6 +150,7 @@ class TestGetBackfill(TestBackfillEndpoint):
         assert response.json() == {
             "completed_at": mock.ANY,
             "created_at": mock.ANY,
+            "dag_display_name": "TEST_DAG_1",
             "dag_id": "TEST_DAG_1",
             "dag_run_conf": {},
             "from_date": to_iso(from_date),
@@ -214,6 +216,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
         assert response.json() == {
             "completed_at": mock.ANY,
             "created_at": mock.ANY,
+            "dag_display_name": "TEST_DAG_1",
             "dag_id": "TEST_DAG_1",
             "dag_run_conf": {"param1": "val1", "param2": True},
             "from_date": from_date_iso,
@@ -715,6 +718,7 @@ class TestCancelBackfill(TestBackfillEndpoint):
         assert response.json() == {
             "completed_at": mock.ANY,
             "created_at": mock.ANY,
+            "dag_display_name": "TEST_DAG_1",
             "dag_id": "TEST_DAG_1",
             "dag_run_conf": {},
             "from_date": to_iso(from_date),
@@ -793,6 +797,7 @@ class TestPauseBackfill(TestBackfillEndpoint):
         assert response.json() == {
             "completed_at": mock.ANY,
             "created_at": mock.ANY,
+            "dag_display_name": "TEST_DAG_1",
             "dag_id": "TEST_DAG_1",
             "dag_run_conf": {},
             "from_date": to_iso(from_date),
@@ -851,6 +856,7 @@ class TestUnpauseBackfill(TestBackfillEndpoint):
         assert response.json() == {
             "completed_at": mock.ANY,
             "created_at": mock.ANY,
+            "dag_display_name": "TEST_DAG_1",
             "dag_id": "TEST_DAG_1",
             "dag_run_conf": {},
             "from_date": to_iso(from_date),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
@@ -104,6 +104,7 @@ class TestListBackfills(TestBackfillEndpoint):
             "backfill1": {
                 "completed_at": from_datetime_to_zulu(completed_at),
                 "created_at": mock.ANY,
+                "dag_display_name": "TEST_DAG_1",
                 "dag_id": "TEST_DAG_1",
                 "dag_run_conf": {},
                 "from_date": from_datetime_to_zulu(from_date),
@@ -117,6 +118,7 @@ class TestListBackfills(TestBackfillEndpoint):
             "backfill2": {
                 "completed_at": None,
                 "created_at": mock.ANY,
+                "dag_display_name": "TEST_DAG_2",
                 "dag_id": "TEST_DAG_2",
                 "dag_run_conf": {},
                 "from_date": from_datetime_to_zulu(from_date),
@@ -130,6 +132,7 @@ class TestListBackfills(TestBackfillEndpoint):
             "backfill3": {
                 "completed_at": None,
                 "created_at": mock.ANY,
+                "dag_display_name": "TEST_DAG_3",
                 "dag_id": "TEST_DAG_3",
                 "dag_run_conf": {},
                 "from_date": from_datetime_to_zulu(from_date),

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1008,6 +1008,7 @@ class BackfillResponse(BaseModel):
     created_at: Annotated[datetime, Field(title="Created At")]
     completed_at: Annotated[datetime | None, Field(title="Completed At")] = None
     updated_at: Annotated[datetime, Field(title="Updated At")]
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
 
 
 class BulkCreateActionConnectionBody(BaseModel):

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -193,6 +193,7 @@ class TestBackfillOperations:
             created_at=datetime.datetime(2024, 12, 31, 23, 59, 59),
             completed_at=datetime.datetime(2025, 1, 1, 0, 0, 0),
             updated_at=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            dag_display_name="TEST_DAG_1",
         )
 
         def handle_request(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `dag_display_name` for `BackfillResponse`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
