### PR TITLE
Migrate `Exasol` provider to use `get_df`

### DIFF
--- a/providers/exasol/README.rst
+++ b/providers/exasol/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                              Version required
 =======================================  ==================
 ``apache-airflow``                       ``>=2.10.0``
-``apache-airflow-providers-common-sql``  ``>=1.21.0``
+``apache-airflow-providers-common-sql``  ``>=1.26.0``
 ``pyexasol``                             ``>=0.5.1``
 ``pandas``                               ``>=2.1.2,<2.2``
 =======================================  ==================

--- a/providers/exasol/pyproject.toml
+++ b/providers/exasol/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-sql>=1.21.0",
+    "apache-airflow-providers-common-sql>=1.26.0",
     "pyexasol>=0.5.1",
     # In pandas 2.2 minimal version of the sqlalchemy is 2.0
     # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies

--- a/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
@@ -171,3 +171,23 @@ class TestExasolHook:
             query_params=query_params,
             export_params=export_params,
         )
+
+    def test_get_df_pandas(self):
+        statement = "SQL"
+        column = "col"
+        result_sets = [("row1",), ("row2",)]
+        mock_df = mock.MagicMock()
+        mock_df.columns = [column]
+        mock_df.values.tolist.return_value = result_sets
+        self.conn.export_to_pandas.return_value = mock_df
+
+        df = self.db_hook.get_df(statement, df_type="pandas")
+
+        assert column == df.columns[0]
+
+        assert result_sets[0][0] == df.values.tolist()[0][0]
+        assert result_sets[1][0] == df.values.tolist()[1][0]
+
+    def test_get_df_polars(self):
+        with pytest.raises(NotImplementedError):
+            self.db_hook.get_df("SQL", df_type="polars")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- #49334

## Why 

`get_pandas_df` deprecated in https://github.com/apache/airflow/pull/48875, which would be replaced by `get_df`. Thus, we need to migrate them in providers.

## How

- This PR is focus on migration of Exasol provider.
- Currently polars is not supported see https://github.com/exasol/pyexasol/issues/102, thus I raise `NotImplementedError` for it.
- Add missing test for get_df

cc: @eladkal @potiuk 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
