### PR TITLE
Remove external icon for Manage Pools link

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Heading, Flex, Skeleton, Link, Text } from "@chakra-ui/react";
+import { Box, Heading, Flex, Skeleton, Link } from "@chakra-ui/react";
 import { BiTargetLock } from "react-icons/bi";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -75,10 +75,8 @@ export const PoolSummary = () => {
           </Heading>
         </Flex>
         {hasPoolsAccess ? (
-          <Link asChild color="fg.info" display="flex" gap={1}>
-            <RouterLink to="/pools">
-              <Text fontSize="xs">Manage Pools</Text>
-            </RouterLink>
+          <Link asChild color="fg.info" display="flex" fontSize="xs" gap={1}>
+            <RouterLink to="/pools">Manage Pools</RouterLink>
           </Link>
         ) : undefined}
       </Flex>

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -18,7 +18,6 @@
  */
 import { Box, Heading, Flex, Skeleton, Link, Text } from "@chakra-ui/react";
 import { BiTargetLock } from "react-icons/bi";
-import { FiExternalLink } from "react-icons/fi";
 import { Link as RouterLink } from "react-router-dom";
 
 import { useAuthLinksServiceGetAuthMenus } from "openapi/queries";
@@ -79,7 +78,6 @@ export const PoolSummary = () => {
           <Link asChild color="fg.info" display="flex" gap={1}>
             <RouterLink to="/pools">
               <Text fontSize="xs">Manage Pools</Text>
-              <FiExternalLink size={12} />
             </RouterLink>
           </Link>
         ) : undefined}


### PR DESCRIPTION
Pools is an internal, not external, link. So we shouldn't use the external link icon


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
