### PR TITLE
Resurrect fab related configs

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -467,27 +467,33 @@ CONFIGS_CHANGES = [
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "enable_proxy_fix"),
-        was_deprecated=False,
+        renamed_to=ConfigParameter("fab", "enable_proxy_fix"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_for"),
-        was_deprecated=False,
+        renamed_to=ConfigParameter("fab", "proxy_fix_x_for"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_proto"),
-        was_deprecated=False,
+        renamed_to=ConfigParameter("fab", "proxy_fix_x_proto"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_host"),
-        was_deprecated=False,
+        renamed_to=ConfigParameter("fab", "proxy_fix_x_host"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_port"),
-        was_deprecated=False,
+        renamed_to=ConfigParameter("fab", "proxy_fix_x_port"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_prefix"),
-        was_deprecated=False,
+        renamed_to=ConfigParameter("fab", "proxy_fix_x_prefix"),
+        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "cookie_secure"),

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2707,7 +2707,10 @@ config:
     statsd_port: 9125
     statsd_prefix: airflow
     statsd_host: '{{ printf "%s-statsd" (include "airflow.fullname" .) }}'
+  fab:
+    enable_proxy_fix: 'True'
   webserver:
+    # For Airflow 2.X
     enable_proxy_fix: 'True'
     # For Airflow 1.10
     rbac: 'True'


### PR DESCRIPTION
The following configs in section `webserver` have been removed while working on Airflow 3:
- enable_proxy_fix
- proxy_fix_x_for
- proxy_fix_x_proto
- proxy_fix_x_host
- proxy_fix_x_port
- proxy_fix_x_prefix

These configs were used by the main Flask application. Recently, we found out that we need these configs back because the FAB provider Flask application needs these ones. See #49942. As part of the same PR, we decided to move them from `webserver` to `fab`.

This PR updates the `airflow config lint` command to rename these configs. For those who already migrated, I think they will have to add back these configs manually (or there is another solution?).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
