### PR TITLE
Add packages-metadata generation functions to S3 Docs publishing

### DIFF
--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -135,6 +135,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: 51f70f4250bfdb784261fda0981101a53dac6f02a0aada0e08aeb488df16fbd0822b0c01f457d32e166714409bf02c1d97e2cf5e358b87004792d62a2180d82d
+Package config hash: dd1d7af15b5317bee5360566f3351a173ac228415cfd7cf6dc95a9d711907bc9ff7a9f9635b4ae9ccbc91af4ae103de04b2316b229ff32bd8f3def156a66e15a
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -135,6 +135,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: bf3faa4e35a6ee2b2bc45ab87d79b5050d443ebffc00ea95402af12ab5345252ae3e5abb489b6d2f65ef146de4fb66e1c145c6ad48fc27b916782c163cb5db20
+Package config hash: 51f70f4250bfdb784261fda0981101a53dac6f02a0aada0e08aeb488df16fbd0822b0c01f457d32e166714409bf02c1d97e2cf5e358b87004792d62a2180d82d
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -74,7 +74,8 @@ dependencies = [
     "twine>=4.0.2",
     "tqdm>=4.67.1",
     "boto3>=1.34.90",
-    "awswrangler>=3.11.0"
+    "awswrangler>=3.11.0",
+    "semver>=3.0.4"
 ]
 
 [project.scripts]

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -73,7 +73,8 @@ dependencies = [
     "tomli>=2.0.1; python_version < '3.11'",
     "twine>=4.0.2",
     "tqdm>=4.67.1",
-    "boto3>=1.34.90"
+    "boto3>=1.34.90",
+    "awswrangler>=3.11.0"
 ]
 
 [project.scripts]

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
@@ -16,12 +16,15 @@
 # under the License.
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 from functools import cached_property
 
+import awswrangler as wr
 import boto3
+import semver
 
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.parallel import check_async_run_results, run_with_pool
@@ -29,6 +32,8 @@ from airflow_breeze.utils.parallel import check_async_run_results, run_with_pool
 PROVIDER_NAME_FORMAT = "apache-airflow-providers-{}"
 
 NON_SHORT_NAME_PACKAGES = ["docker-stack", "helm-chart", "apache-airflow"]
+
+PACKAGES_METADATA_EXCLUDE_NAMES = ["docker-stack", "apache-airflow-providers"]
 
 s3_client = boto3.client("s3")
 
@@ -98,9 +103,7 @@ class S3DocsPublish:
         return docs_to_process
 
     def doc_exists(self, s3_bucket_doc_location: str) -> bool:
-        parts = s3_bucket_doc_location[5:].split("/", 1)
-        bucket = parts[0]
-        key = parts[1]
+        bucket, key = self.get_bucket_key(s3_bucket_doc_location)
         response = s3_client.list_objects_v2(Bucket=bucket, Prefix=key)
 
         return response["KeyCount"] > 0
@@ -200,3 +203,74 @@ class S3DocsPublish:
             outputs=outputs,
             include_success_outputs=False,
         )
+
+        # Now generate the packages-metadata.json
+        self.generate_packages_metadata()
+
+    def generate_packages_metadata(self):
+        get_console().print("[info]Generating packages-metadata.json file\n")
+
+        if self.dry_run:
+            get_console().print("Dry run enabled, skipping packages-metadata.json generation")
+            return
+
+        package_versions_map = {}
+        s3_docs_path = self.destination_location.rstrip("/") + "/"
+        resp = wr.s3.list_directories(s3_docs_path)
+
+        # package_path: s3://staging-docs-airflow-apache-org/docs/apache-airflow-providers-apache-cassandra/
+        for package_path in resp:
+            package_name = package_path.replace(s3_docs_path, "").rstrip("/")
+
+            if package_name in PACKAGES_METADATA_EXCLUDE_NAMES:
+                continue
+
+            # version_path: s3://staging-docs-airflow-apache-org/docs/apache-airflow-providers-apache-cassandra/1.0.0/
+
+            versions = [
+                version_path.replace(package_path, "").rstrip("/")
+                for version_path in wr.s3.list_directories(package_path)
+                if version_path.replace(package_path, "").rstrip("/") != "stable"
+            ]
+            package_versions_map[package_name] = versions
+
+        all_packages_infos = self.dump_docs_package_metadata(package_versions_map)
+
+        bucket, _ = self.get_bucket_key(self.destination_location)
+
+        # We keep metadata in the same location with constant file name so that
+        # its easy to reference in airflow-site with url
+        # ex: https://staging-docs-airflow-apache-org.s3.us-east-2.amazonaws.com/manifest/packages-metadata.json
+
+        s3_client.put_object(
+            Bucket=bucket,
+            Key="manifest/packages-metadata.json",
+            Body=json.dumps(all_packages_infos, indent=2),
+            ContentType="application/json",
+        )
+
+    def dump_docs_package_metadata(self, package_versions: dict[str, list[str]]):
+        all_packages_infos = [
+            {
+                "package-name": package_name,
+                "all-versions": (all_versions := self.get_all_versions(versions)),
+                "stable-version": all_versions[-1],
+            }
+            for package_name, versions in package_versions.items()
+        ]
+
+        return all_packages_infos
+
+    @staticmethod
+    def get_all_versions(versions: list[str]) -> list[str]:
+        return sorted(
+            versions,
+            key=lambda d: semver.VersionInfo.parse(d),
+        )
+
+    @staticmethod
+    def get_bucket_key(bucket_path: str) -> tuple[str, str]:
+        parts = bucket_path[5:].split("/", 1)
+        bucket = parts[0]
+        key = parts[1]
+        return bucket, key


### PR DESCRIPTION
https://github.com/apache/airflow-site/blob/gh-pages/_gen/packages-metadata.json

We would need the `packages-metadata.json` file to work properly dropdowns in docs. Now that we are going to publishing all the docs to s3, so its best to generate part of doc publishing `packages-metadata` and we can pull this json directly in https://github.com/apache/airflow-site/blob/main/dump-docs-packages-metadata.py here.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
