### PR TITLE
Migrate `Hive` provider to use `get_df`

### DIFF
--- a/providers/apache/druid/pyproject.toml
+++ b/providers/apache/druid/pyproject.toml
@@ -77,7 +77,7 @@ dev = [
     "apache-airflow-providers-apache-hive",
     "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    "apache-airflow-providers-common-sql[polars]",
+    "apache-airflow-providers-common-sql[pandas,polars]",
 ]
 
 # To build docs:

--- a/providers/apache/hive/README.rst
+++ b/providers/apache/hive/README.rst
@@ -54,9 +54,8 @@ Requirements
 PIP package                              Version required
 =======================================  ==================
 ``apache-airflow``                       ``>=2.10.0``
-``apache-airflow-providers-common-sql``  ``>=1.20.0``
+``apache-airflow-providers-common-sql``  ``>=1.26.0``
 ``hmsclient``                            ``>=0.1.0``
-``pandas``                               ``>=2.1.2,<2.2``
 ``pyhive[hive_pure_sasl]``               ``>=0.7.0``
 ``thrift``                               ``>=0.11.0``
 ``jmespath``                             ``>=0.7.0``

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -58,13 +58,8 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.26.0",
     "hmsclient>=0.1.0",
-    # In pandas 2.2 minimal version of the sqlalchemy is 2.0
-    # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies
-    # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723
-    # In addition FAB also limit sqlalchemy to < 2.0
-    "pandas>=2.1.2,<2.2",
     "pyhive[hive_pure_sasl]>=0.7.0",
     "thrift>=0.11.0",
     "jmespath>=0.7.0",
@@ -109,6 +104,7 @@ dev = [
     "apache-airflow-providers-samba",
     "apache-airflow-providers-vertica",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
+    "apache-airflow-providers-common-sql[pandas,polars]",
 ]
 
 # To build docs:

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -715,7 +715,8 @@ class TestHiveServer2Hook:
         hook.mock_cursor.execute.assert_any_call("set airflow.ctx.dag_owner=airflow")
         hook.mock_cursor.execute.assert_any_call("set airflow.ctx.dag_email=test@airflow.com")
 
-    def test_get_pandas_df(self):
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_get_df(self, df_type):
         hook = MockHiveServer2Hook()
         query = f"SELECT * FROM {self.table}"
 
@@ -731,10 +732,13 @@ class TestHiveServer2Hook:
                 "AIRFLOW_CTX_DAG_EMAIL": "test@airflow.com",
             },
         ):
-            df = hook.get_pandas_df(query, schema=self.database)
+            df = hook.get_df(query, schema=self.database, df_type=df_type)
 
         assert len(df) == 2
-        assert df["hive_server_hook.a"].values.tolist() == [1, 2]
+        if df_type == "pandas":
+            assert df["hive_server_hook.a"].values.tolist() == [1, 2]
+        elif df_type == "polars":
+            assert df["hive_server_hook.a"].to_list() == [1, 2]
         date_key = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
         hook.get_conn.assert_called_with(self.database)
         hook.mock_cursor.execute.assert_any_call("set airflow.ctx.dag_id=test_dag_id")
@@ -747,7 +751,7 @@ class TestHiveServer2Hook:
         hook = MockHiveServer2Hook(connection_cursor=EmptyMockConnectionCursor())
         query = f"SELECT * FROM {self.table}"
 
-        df = hook.get_pandas_df(query, schema=self.database)
+        df = hook.get_df(query, schema=self.database, df_type=df_type)
 
         assert len(df) == 0
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- #49334

## Why 

`get_pandas_df` deprecated in https://github.com/apache/airflow/pull/48875, which would be replaced by `get_df`. Thus, we need to migrate them in providers.

## How

- This PR is focus on migration of Hive provider.
- Migrate unit test to test pandas and polars
- since pandas and polars is only used by `get_df`, thus move them to extra
- update missing extra in `Drill`

cc: @eladkal @potiuk 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
