### PR TITLE
Bump min versions of crucial providers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -889,7 +889,7 @@ repos:
         name: Update Airflow's meta-package pyproject.toml
         language: python
         entry: ./scripts/ci/pre_commit/update_airflow_pyproject_toml.py
-        files: ^pyproject\.toml$
+        files: ^.*/pyproject\.toml$|^scripts/ci/pre_commit/update_airflow_pyproject_toml\.py$
         pass_filenames: false
         require_serial: true
         additional_dependencies: ['rich>=12.4.4', 'tomli>=2.0.1', 'packaging>=23.2' ]

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -1040,22 +1040,27 @@ def update_version_suffix_in_non_provider_pyproject_toml(version_suffix: str, py
     lines = pyproject_toml_path.read_text().splitlines()
     updated_lines = []
     for line in lines:
-        if line.startswith("version = "):
+        base_line, comment = line.split(" #", 1) if " #" in line else (line, "")
+        if comment:
+            comment = " #" + comment
+        if base_line.startswith("version = "):
             get_console().print(f"[info]Updating version suffix to {version_suffix} for {line}.")
-            line = line.rstrip('"') + f'{version_suffix}"'
+            base_line = base_line.rstrip('"') + f'{version_suffix}"'
         # do not modify references for .post prefixes
         if not version_suffix.startswith(".post"):
-            if line.strip().startswith('"apache-airflow-') and ">=" in line:
+            if base_line.strip().startswith('"apache-airflow-') and ">=" in base_line:
                 floored_version_suffix = floor_version_suffix(version_suffix)
-                get_console().print(f"[info]Updating version suffix to {floored_version_suffix} for {line}.")
-                line = line.rstrip('",') + f'{floored_version_suffix}",'
-            if line.strip().startswith('"apache-airflow-core') and "==" in line:
-                get_console().print(f"[info]Updating version suffix to {version_suffix} for {line}.")
-                line = line.rstrip('",') + f'{version_suffix}",'
-            if line.strip().startswith('"apache-airflow-task-sdk') and "==" in line:
-                get_console().print(f"[info]Updating version suffix to {version_suffix} for {line}.")
-                line = line.rstrip('",') + f'{version_suffix}",'
-        updated_lines.append(line)
+                get_console().print(
+                    f"[info]Updating version suffix to {floored_version_suffix} for {base_line}."
+                )
+                base_line = base_line.rstrip('",') + f'{floored_version_suffix}",'
+            if base_line.strip().startswith('"apache-airflow-core') and "==" in base_line:
+                get_console().print(f"[info]Updating version suffix to {version_suffix} for {base_line}.")
+                base_line = base_line.rstrip('",') + f'{version_suffix}",'
+            if base_line.strip().startswith('"apache-airflow-task-sdk') and "==" in base_line:
+                get_console().print(f"[info]Updating version suffix to {version_suffix} for {base_line}.")
+                base_line = base_line.rstrip('",') + f'{version_suffix}",'
+        updated_lines.append(f"{base_line}{comment}")
     new_content = "\n".join(updated_lines) + "\n"
     get_console().print(f"[info]Writing updated content to {pyproject_toml_path}.\n")
     pyproject_toml_path.write_text(new_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ packages = []
     "apache-airflow-providers-exasol>=4.6.1"
 ]
 "fab" = [
-    "apache-airflow-providers-fab>=2.0.0"
+    "apache-airflow-providers-fab>=2.0.2" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "facebook" = [
     "apache-airflow-providers-facebook>=3.7.0"
@@ -221,7 +221,7 @@ packages = []
     "apache-airflow-providers-ftp>=3.12.0"
 ]
 "git" = [
-    "apache-airflow-providers-git>=0.0.1"
+    "apache-airflow-providers-git>=0.0.2" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "github" = [
     "apache-airflow-providers-github>=2.8.0"
@@ -281,7 +281,7 @@ packages = []
     "apache-airflow-providers-openfaas>=3.7.0"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage>=2.1.3"
+    "apache-airflow-providers-openlineage>=2.1.3" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "opensearch" = [
     "apache-airflow-providers-opensearch>=1.5.0"
@@ -422,10 +422,10 @@ packages = []
     "apache-airflow-providers-edge3>=1.0.0",
     "apache-airflow-providers-elasticsearch>=5.5.2",
     "apache-airflow-providers-exasol>=4.6.1",
-    "apache-airflow-providers-fab>=2.0.0",
+    "apache-airflow-providers-fab>=2.0.2", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-facebook>=3.7.0",
     "apache-airflow-providers-ftp>=3.12.0",
-    "apache-airflow-providers-git>=0.0.1",
+    "apache-airflow-providers-git>=0.0.2", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-github>=2.8.0",
     "apache-airflow-providers-google>=10.24.0",
     "apache-airflow-providers-grpc>=3.7.0",
@@ -445,7 +445,7 @@ packages = []
     "apache-airflow-providers-odbc>=4.8.0",
     "apache-airflow-providers-openai>=1.5.0",
     "apache-airflow-providers-openfaas>=3.7.0",
-    "apache-airflow-providers-openlineage>=2.1.3",
+    "apache-airflow-providers-openlineage>=2.1.3", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-opensearch>=1.5.0",
     "apache-airflow-providers-opsgenie>=5.8.0",
     "apache-airflow-providers-oracle>=3.12.0",


### PR DESCRIPTION
There are a few min-versions of providers that should make its way into apache-airflow pyproject.toml - because they contain crucial Airflow 3 fixes and users should not be installng those providers in lower versions.

This PR adds such limits and makes it clearer when updates happen what happens and where to override them.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
