### PR TITLE
Add breeze to the main workspace of the apache-airflow-project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1217,6 +1217,7 @@ ignore_errors = true
 [dependency-groups]
 dev = [
     "apache-airflow[all]",
+    "apache-airflow-breeze",
     "apache-airflow-dev",
     "apache-airflow-devel-common[no-doc]",
     "apache-airflow-docker-tests",
@@ -1258,6 +1259,7 @@ no-build-isolation-package = ["sphinx-redoc"]
 # These names must match the names as defined in the pyproject.toml of the workspace items,
 # *not* the workspace folder paths
 apache-airflow = {workspace = true}
+apache-airflow-breeze = {workspace = true}
 apache-airflow-dev = {workspace = true}
 apache-airflow-core = {workspace = true}
 apache-airflow-ctl = {workspace = true}
@@ -1371,6 +1373,7 @@ apache-airflow-providers-zendesk = { workspace = true }
 members = [
     ".",
     "airflow-core",
+    "dev/breeze",
     "airflow-ctl",
     "dev",
     "devel-common",


### PR DESCRIPTION
With #50059 it turned out that we need to add breeze also as part of the workspace. With the current ".idea" setup - all our projects share the same `.venv` environment and when someone wants to run `breeze` tests using that `.venv`, it is great if `uv sync` installs all that is needed to run breeze tests as well. The #50059 added `awswrangler` that was not part of any other project and even after `uv sync` in the main repo, `breeze` tests could not be run.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
