### PR TITLE
Add TIs tab to mapped task details

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/MappedTaskInstance.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/MappedTaskInstance.tsx
@@ -30,8 +30,6 @@ import { isStatePending, useAutoRefresh } from "src/utils";
 
 import { Header } from "./Header";
 
-const tabs = [{ icon: <MdOutlineTask />, label: "Task Instances", value: "" }];
-
 export const MappedTaskInstance = () => {
   const { dagId = "", runId = "", taskId = "" } = useParams();
   const refetchInterval = useAutoRefresh({ dagId });
@@ -73,6 +71,10 @@ export const MappedTaskInstance = () => {
   const taskInstance = data?.dag_runs
     .find((dr) => dr.dag_run_id === runId)
     ?.task_instances.find((ti) => ti.task_id === taskId);
+
+  const tabs = [
+    { icon: <MdOutlineTask />, label: `Task Instances [${taskInstance?.task_count}]`, value: "" },
+  ];
 
   return (
     <ReactFlowProvider>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -22,7 +22,11 @@ import { MdDetails, MdOutlineEventNote, MdOutlineTask, MdReorder, MdSyncAlt } fr
 import { PiBracketsCurlyBold } from "react-icons/pi";
 import { useParams } from "react-router-dom";
 
-import { useDagServiceGetDagDetails, useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
+import {
+  useDagServiceGetDagDetails,
+  useGridServiceGridData,
+  useTaskInstanceServiceGetMappedTaskInstance,
+} from "openapi/queries";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -67,6 +71,25 @@ export const TaskInstance = () => {
     },
   );
 
+  // Filter grid data to get only a single dag run
+  const { data } = useGridServiceGridData(
+    {
+      dagId,
+      limit: 1,
+      offset: 0,
+      runAfterGte: taskInstance?.run_after,
+      runAfterLte: taskInstance?.run_after,
+    },
+    undefined,
+    {
+      enabled: taskInstance !== undefined,
+    },
+  );
+
+  const mappedTaskInstance = data?.dag_runs
+    .find((dr) => dr.dag_run_id === runId)
+    ?.task_instances.find((ti) => ti.task_id === taskId);
+
   let newTabs = tabs;
 
   if (taskInstance && taskInstance.map_index > -1) {
@@ -74,7 +97,7 @@ export const TaskInstance = () => {
       ...tabs.slice(0, 1),
       {
         icon: <MdOutlineTask />,
-        label: `Task Instances [${taskInstance.rendered_map_index}]`,
+        label: `Task Instances [${mappedTaskInstance?.task_count ?? ""}]`,
         value: "task_instances",
       },
       ...tabs.slice(1),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -18,7 +18,7 @@
  */
 import { ReactFlowProvider } from "@xyflow/react";
 import { FiCode } from "react-icons/fi";
-import { MdDetails, MdOutlineEventNote, MdReorder, MdSyncAlt } from "react-icons/md";
+import { MdDetails, MdOutlineEventNote, MdOutlineTask, MdReorder, MdSyncAlt } from "react-icons/md";
 import { PiBracketsCurlyBold } from "react-icons/pi";
 import { useParams } from "react-router-dom";
 
@@ -67,9 +67,23 @@ export const TaskInstance = () => {
     },
   );
 
+  let newTabs = tabs;
+
+  if (taskInstance && taskInstance.map_index > -1) {
+    newTabs = [
+      ...tabs.slice(0, 1),
+      {
+        icon: <MdOutlineTask />,
+        label: `Task Instances [${taskInstance.rendered_map_index}]`,
+        value: "task_instances",
+      },
+      ...tabs.slice(1),
+    ];
+  }
+
   return (
     <ReactFlowProvider>
-      <DetailsLayout dag={dag} error={error ?? dagError} isLoading={isLoading || isDagLoading} tabs={tabs}>
+      <DetailsLayout dag={dag} error={error ?? dagError} isLoading={isLoading || isDagLoading} tabs={newTabs}>
         {taskInstance === undefined ? undefined : (
           <Header
             isRefreshing={Boolean(isStatePending(taskInstance.state) && Boolean(refetchInterval))}


### PR DESCRIPTION
Add `Task Instances [{map_index}]` tab to a mapped task's detail page. This makes it easier to switch between mapped tasks to see logs, xcoms, etc

Closes https://github.com/apache/airflow/issues/34489

<img width="1011" alt="Screenshot 2025-05-01 at 11 57 26 AM" src="https://github.com/user-attachments/assets/e5edb793-3a04-46b9-b115-bc80d60c0f6b" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
