### PR TITLE
Fix duration charts

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -34,7 +34,7 @@ import { Bar } from "react-chartjs-2";
 
 import type { TaskInstanceResponse, DAGRunResponse } from "openapi/requests/types.gen";
 import { system } from "src/theme";
-import { pluralize, getDuration } from "src/utils";
+import { pluralize } from "src/utils";
 
 ChartJS.register(
   CategoryScale,
@@ -54,6 +54,8 @@ const average = (ctx: PartialEventContext, index: number) => {
 };
 
 type RunResponse = DAGRunResponse | TaskInstanceResponse;
+
+const getDuration = (start: string, end: string | null) => dayjs.duration(dayjs(end).diff(start)).asSeconds();
 
 export const DurationChart = ({
   entries,


### PR DESCRIPTION
I broke the task instance and dag run duration charts by accident.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
