### PR TITLE
Fix node selections

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/DagNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/DagNode.tsx
@@ -36,13 +36,14 @@ export const DagNode = ({
     <NodeWrapper>
       <Flex
         bg={isOpen ? "bg.muted" : "bg"}
+        borderColor={isSelected ? "border.inverted" : "border"}
         borderRadius={5}
-        borderWidth={isSelected ? 6 : 2}
+        borderWidth={isSelected ? 4 : 2}
         cursor="default"
         flexDirection="column"
         height={`${height}px`}
         px={3}
-        py={isSelected ? 0 : 1}
+        py={1}
         width={`${width}px`}
       >
         <HStack alignItems="center" justifyContent="space-between">

--- a/airflow-core/src/airflow/ui/src/components/Graph/DefaultNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/DefaultNode.tsx
@@ -28,6 +28,7 @@ export const DefaultNode = ({ data: { height, label, width } }: NodeProps<NodeTy
       bg="bg"
       borderRadius={5}
       borderWidth={2}
+      cursor="auto"
       flexDirection="column"
       height={`${height}px`}
       p={2}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -144,7 +144,7 @@ export const Graph = () => {
       ...node,
       data: {
         ...node.data,
-        isSelected: node.id === taskId,
+        isSelected: node.id === taskId || node.id === `dag:${dagId}`,
         taskInstance,
       },
     };

--- a/airflow-core/src/airflow/ui/src/pages/Asset/AssetGraph.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/AssetGraph.tsx
@@ -42,7 +42,7 @@ export const AssetGraph = ({ asset }: { readonly asset?: AssetResponse }) => {
   });
 
   const nodes = graphData?.nodes.map((node) =>
-    node.data.label === asset?.name ? { ...node, data: { ...node.data, isSelected: true } } : node,
+    node.id === `asset:${assetId}` ? { ...node, data: { ...node.data, isSelected: true } } : node,
   );
 
   const [selectedDarkColor, selectedLightColor] = useToken("colors", ["gray.200", "gray.800"]);


### PR DESCRIPTION
Fix a few bugs:

- For "All Dag Dependencies" the dag node selection was broken (make sure to check dagId for `isSelected`)
- If you had an asset and a dag with the same name, we would show both as selected (isSelected now checks `asset:{id}`)
- Cursor on an invalid asset ref made it look like it should be clickable (change cursor)


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
