### PR TITLE
Fix `ResolutionTooDeep` error on pip 25.1

### DIFF
--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -80,8 +80,8 @@ dependencies = [
     # Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed
     "google-cloud-aiplatform[evaluation,ray]>=1.73.0;python_version < '3.12'",
     "google-cloud-aiplatform[evaluation]>=1.73.0;python_version >= '3.12'",
-    "ray[default]==2.42.0 ; python_version >= '3.12'",
-    "google-cloud-bigquery-storage==2.31.0; python_version >= '3.12'",
+    "ray[default]>=2.42.0 ; python_version >= '3.12'",
+    "google-cloud-bigquery-storage>=2.31.0; python_version >= '3.12'",
     "google-cloud-alloydb>=0.4.0",
     "google-cloud-automl>=2.12.0",
     # Excluded versions contain bug https://github.com/apache/airflow/issues/39541 which is resolved in 3.24.0


### PR DESCRIPTION
Sorry, I couldn't get any of the contribution infrastructure working quickly, so I have no idea if this PR will pass checks, I also have no problem with someone editing this PR or making a new PR based on it.

I took a look at the [reported](https://github.com/pypa/pip/issues/13281) `ResolutionTooDeep` errors in pip 25.1, I found that two pinnings in particular were causing pip to struggle to resolve, I have a high level explanation about why such pins can cause pip problems: https://github.com/pypa/pip/issues/13281#issuecomment-2843881861

I took a look at the history of these requirements and it wasn't clear to me why either of them were pinned to a specific version, but it's sufficient to just unpin `google-cloud-bigquery-storage`. Also the comment "Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed" seems to have drifted away from what it's commenting on, but I wasn't going to fix that.

Let me know if you have any questions, I will be using these `ResolutionTooDeep` errors as a test bed for future ideas to improve the pip resolver.

cc: @potiuk




