### PR TITLE
Add audit log extra to table and improve UX

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
@@ -42,6 +42,43 @@ const eventsColumn = (
       skeletonWidth: 10,
     },
   },
+  {
+    accessorKey: "event",
+    enableSorting: true,
+    header: "Event",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "owner",
+    enableSorting: true,
+    header: "User",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "extra",
+    cell: ({ row: { original } }) => {
+      if (original.extra !== null) {
+        try {
+          const parsed = JSON.parse(original.extra) as Record<string, unknown>;
+
+          return <RenderedJsonField content={parsed} jsonProps={{ collapsed: true }} />;
+        } catch {
+          return <Code>{original.extra}</Code>;
+        }
+      }
+
+      return undefined;
+    },
+    enableSorting: false,
+    header: "Extra",
+    meta: {
+      skeletonWidth: 200,
+    },
+  },
   ...(Boolean(dagId)
     ? []
     : [
@@ -92,43 +129,6 @@ const eventsColumn = (
     header: "Try Number",
     meta: {
       skeletonWidth: 10,
-    },
-  },
-  {
-    accessorKey: "event",
-    enableSorting: true,
-    header: "Event",
-    meta: {
-      skeletonWidth: 10,
-    },
-  },
-  {
-    accessorKey: "owner",
-    enableSorting: true,
-    header: "User",
-    meta: {
-      skeletonWidth: 10,
-    },
-  },
-  {
-    accessorKey: "extra",
-    cell: ({ row: { original } }) => {
-      if (original.extra !== null) {
-        try {
-          const parsed = JSON.parse(original.extra) as Record<string, unknown>;
-
-          return <RenderedJsonField content={parsed} jsonProps={{ collapsed: true }} />;
-        } catch {
-          return <Code>{original.extra}</Code>;
-        }
-      }
-
-      return undefined;
-    },
-    enableSorting: false,
-    header: "Extra",
-    meta: {
-      skeletonWidth: 200,
     },
   },
 ];


### PR DESCRIPTION
We were missing the `extra` field on the Audit Log, which is fairly critical. Now we will try to see if it is valid json, if so, render it as such, with the option to expand/collapse the json field.

<img width="825" alt="Screenshot 2025-05-01 at 3 54 53 PM" src="https://github.com/user-attachments/assets/80512149-15e3-415b-a642-d388beae66ec" />


Also, added a title to the page to reinforce that these are Audit Log Events.
Rearrange the columns to put any dag/run/task info at the end, because for many events they are blank.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
