### PR TITLE
Add webserver_config.py file to api-server

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -582,6 +582,17 @@ server_tls_key_file = /etc/pgbouncer/server.key
   readOnly: True
 {{- end }}
 
+{{- define "airflow_api_server_config_configmap_name" -}}
+  {{- default (printf "%s-api-server-config" .Release.Name) .Values.webserver.webserverConfigConfigMapName }}
+{{- end }}
+
+{{- define "airflow_api_server_config_mount" -}}
+- name: api-server-config
+  mountPath: {{ template "airflow_webserver_config_path" . }}
+  subPath: webserver_config.py
+  readOnly: True
+{{- end }}
+
 {{- define "airflow_local_setting_path" -}}
   {{- printf "%s/config/airflow_local_settings.py" .Values.airflowHome | quote }}
 {{- end }}

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -170,6 +170,9 @@ spec:
           resources: {{- toYaml .Values.apiServer.resources | nindent 12 }}
           volumeMounts:
             {{- include "airflow_config_mount" . | nindent 12 }}
+            {{- if or .Values.apiServer.apiServerConfig .Values.apiServer.apiServerConfigConfigMapName }}
+              {{- include "airflow_api_server_config_mount" . | nindent 12 }}
+            {{- end }}
             {{- if .Values.logs.persistence.enabled }}
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
@@ -225,6 +228,11 @@ spec:
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}
+        {{- if or .Values.apiServer.apiServerConfig .Values.apiServer.apiServerConfigConfigMapName }}
+        - name: api-server-config
+          configMap:
+            name: {{ template "airflow_api_server_config_configmap_name" . }}
+        {{- end }}
         {{- if (semverCompare "<2.0.0" .Values.airflowVersion) }}
         {{- end }}
         {{- if .Values.logs.persistence.enabled }}

--- a/chart/templates/configmaps/api-server-configmap.yaml
+++ b/chart/templates/configmaps/api-server-configmap.yaml
@@ -1,0 +1,46 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow ConfigMap
+#################################
+{{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+{{- if and .Values.apiServer.apiServerConfig (not .Values.apiServer.apiServerConfigConfigMapName) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "airflow_api_server_config_configmap_name" . }}
+  labels:
+    tier: airflow
+    component: config
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.apiServer.configMapAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  webserver_config.py: |-
+    {{- tpl .Values.apiServer.apiServerConfig . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5065,6 +5065,30 @@
                     ],
                     "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
+                "apiServerConfig": {
+                    "description": "This string (templated) will be mounted into the Airflow API Server as a custom `webserver_config.py`. You can bake a `webserver_config.py` in to your image instead or specify a configmap containing the webserver_config.py.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "x-docsSection": "Common",
+                    "default": null,
+                    "examples": [
+                        "from airflow import configuration as conf\n\n# The SQLAlchemy connection string.\nSQLALCHEMY_DATABASE_URI = conf.get('database', 'SQL_ALCHEMY_CONN')\n\n# Flask-WTF flag for CSRF\nCSRF_ENABLED = True"
+                    ]
+                },
+                "apiServerConfigConfigMapName": {
+                    "description": "The configmap name containing the webserver_config.py.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "x-docsSection": "Common",
+                    "default": null,
+                    "examples": [
+                        "my-webserver-configmap"
+                    ]
+                },
                 "defaultUser": {
                     "description": "Optional default Airflow user information",
                     "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5086,7 +5086,7 @@
                     "x-docsSection": "Common",
                     "default": null,
                     "examples": [
-                        "my-webserver-configmap"
+                        "my-api-server-configmap"
                     ]
                 },
                 "defaultUser": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1382,6 +1382,24 @@ apiServer:
   #     cpu: 100m
   #     memory: 128Mi
 
+  # Add custom annotations to the apiServer configmap
+  configMapAnnotations: {}
+
+  # This string (templated) will be mounted into the Airflow API Server
+  # as a custom webserver_config.py. You can bake a webserver_config.py in to
+  # your image instead or specify a configmap containing the
+  # webserver_config.py.
+  apiServerConfig: ~
+  # apiServerConfig: |
+  #   from airflow import configuration as conf
+
+  #   # The SQLAlchemy connection string.
+  #   SQLALCHEMY_DATABASE_URI = conf.get('database', 'SQL_ALCHEMY_CONN')
+
+  #   # Flask-WTF flag for CSRF
+  #   CSRF_ENABLED = True
+  apiServerConfigConfigMapName: ~
+
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5

--- a/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestAPIServerDeployment:
+    """Tests API Server deployment."""
+
+    def test_airflow_2(self):
+        """
+        API Server only supports Airflow 3.0.0 and later.
+        """
+        docs = render_chart(
+            values={"airflowVersion": "2.10.5"},
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_not_create_api_server_configmap_when_lower_than_3(self):
+        """
+        API Server configmap is only created for Airflow 3.0.0 and later.
+        """
+        docs = render_chart(
+            values={"airflowVersion": "2.10.5"},
+            show_only=["templates/configmaps/api-server-configmap.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_add_annotations_to_api_server_configmap(self):
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.0",
+                "apiServer": {
+                    "apiServerConfig": "CSRF_ENABLED = True  # {{ .Release.Name }}",
+                    "configMapAnnotations": {"test_annotation": "test_annotation_value"},
+                },
+            },
+            show_only=["templates/configmaps/api-server-configmap.yaml"],
+        )
+
+        assert "annotations" in jmespath.search("metadata", docs[0])
+        assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
+
+    def test_should_add_volume_and_volume_mount_when_exist_api_server_config(self):
+        docs = render_chart(
+            values={"apiServer": {"apiServerConfig": "CSRF_ENABLED = True"}, "airflowVersion": "3.0.0"},
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+
+        assert {
+            "name": "api-server-config",
+            "configMap": {"name": "release-name-api-server-config"},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
+        assert {
+            "name": "api-server-config",
+            "mountPath": "/opt/airflow/webserver_config.py",
+            "subPath": "webserver_config.py",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Previously, the api-server component did not include webserver_config.py, making it impossible to configure settings such as LDAP or OAuth2 authentication.

This implementation references the existing method used by the webserver component.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
