### PR TITLE
[v3-0-test] Avoid pushing images in test canary runs (#49950)

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -116,7 +116,9 @@ jobs:
       include-success-outputs: ${{ inputs.include-success-outputs }}
       docker-cache: ${{ inputs.docker-cache }}
       disable-airflow-repo-cache: ${{ inputs.disable-airflow-repo-cache }}
-    if: inputs.branch == 'main'
+    if: >
+      inputs.canary-run == 'true' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
 
   # Check that after earlier cache push, breeze command will build quickly
   check-that-image-builds-quickly:

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -324,7 +324,9 @@ jobs:
       INCLUDE_SUCCESS_OUTPUTS: "${{ inputs.include-success-outputs }}"
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
       VERBOSE: "true"
-    if: inputs.canary-run == 'true' && inputs.branch == 'main'
+    if: >
+      inputs.canary-run == 'true' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
       - name: "Cleanup repo"
         shell: bash

--- a/.github/workflows/finalize-tests.yml
+++ b/.github/workflows/finalize-tests.yml
@@ -127,7 +127,9 @@ jobs:
         run: ./scripts/ci/constraints/ci_commit_constraints.sh
         if: inputs.canary-run == 'true'
       - name: "Push changes"
-        if: inputs.canary-run == 'true'
+        if: >
+          inputs.canary-run == 'true' &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         working-directory: "constraints"
         run:
           git push
@@ -138,6 +140,8 @@ jobs:
     uses: ./.github/workflows/push-image-cache.yml
     permissions:
       contents: read
+      # This write is only given here for `push` events from "apache/airflow" repo. It is not given for PRs
+      # from forks. This is to prevent malicious PRs from creating images in the "apache/airflow" repo.
       packages: write
     with:
       runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
@@ -153,7 +157,9 @@ jobs:
       include-success-outputs: ${{ inputs.include-success-outputs }}
       docker-cache: ${{ inputs.docker-cache }}
       disable-airflow-repo-cache: ${{ inputs.disable-airflow-repo-cache }}
-    if: inputs.canary-run == 'true'
+    if: >
+      inputs.canary-run == 'true' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
 
   #  push-buildx-cache-to-github-registry-arm:
   #    name: Push Regular ARM Image Cache
@@ -175,7 +181,9 @@ jobs:
   #      use-uv: "true"
   #      include-success-outputs: ${{ inputs.include-success-outputs }}
   #      docker-cache: ${{ inputs.docker-cache }}
-  #    if: inputs.canary-run == 'true'
+  #    if: >
+  #      inputs.canary-run == 'true' &&
+  #      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
 
   summarize-warnings:
     timeout-minutes: 15


### PR DESCRIPTION
When testing canary runs from PRs, we cannot push to the image registry because there is no permission to push the images from a fork. This leads to misleading "forbidden" error when you set "canary" label on a PR.

We limit pushing to registry only to "schedule"  and "workflow-dispatch" only - which means that the push will only happen when we either the scheduled run runs or when committers will trigger the run via the "workflow-dispatch" mechanism
(cherry picked from commit af97463ee66571eadc0c8a04eb73321acfa9d316)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
