### PR TITLE
Remove special case for building PROD image in non-main branch

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -37,7 +37,7 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
       branch:
-        description: "Branch used to run the CI jobs in (main/v2_*_test)."
+        description: "Branch used to run the CI jobs in (main/v*_*_test)."
         required: true
         type: string
       constraints-branch:

--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -68,7 +68,6 @@ jobs:
       default-python-version: ${{ inputs.default-python-version }}
       branch: ${{ inputs.default-branch }}
       use-uv: "false"
-      build-provider-distributions: ${{ inputs.default-branch == 'main' }}
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ inputs.constraints-branch }}
       docker-cache: ${{ inputs.docker-cache }}
@@ -84,7 +83,6 @@ jobs:
       default-python-version: ${{ inputs.default-python-version }}
       branch: ${{ inputs.default-branch }}
       use-uv: "false"
-      build-provider-distributions: ${{ inputs.default-branch == 'main' }}
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ inputs.constraints-branch }}
       docker-cache: ${{ inputs.docker-cache }}

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -77,7 +77,7 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
       branch:
-        description: "Branch used to run the CI jobs in (main/v2_*_test)."
+        description: "Branch used to run the CI jobs in (main/v*_*_test)."
         required: true
         type: string
       constraints-branch:

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -41,7 +41,7 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
       branch:
-        description: "Branch used to run the CI jobs in (main/v2_*_test)."
+        description: "Branch used to run the CI jobs in (main/v*_*_test)."
         required: true
         type: string
       canary-run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,7 +689,6 @@ jobs:
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
       branch: ${{ needs.build-info.outputs.default-branch }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
-      build-provider-distributions: ${{ needs.build-info.outputs.default-branch == 'main' }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -85,15 +85,11 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
       branch:
-        description: "Branch used to run the CI jobs in (main/v2_*_test)."
+        description: "Branch used to run the CI jobs in (main/v*_*_test)."
         required: true
         type: string
       constraints-branch:
         description: "Branch used to construct constraints URL from."
-        required: true
-        type: string
-      build-provider-distributions:
-        description: "Whether to build provider distributions (true/false). If false providers are from PyPI"
         required: true
         type: string
       upgrade-to-newer-dependencies:
@@ -143,14 +139,22 @@ jobs:
         with:
           use-uv: ${{ inputs.use-uv }}
         if: inputs.upload-package-artifact == 'true'
-      - name: "Prepare providers packages"
+      - name: "Prepare providers packages - all providers built from sources"
         shell: bash
         run: >
           breeze release-management prepare-provider-distributions
           --distributions-list-file ./prod_image_installed_providers.txt
           --distribution-format wheel --include-not-ready-providers --skip-tag-check
         if: >
-          inputs.upload-package-artifact == 'true' && inputs.build-provider-distributions == 'true'
+          inputs.upload-package-artifact == 'true' && inputs.branch == 'main'
+      - name: "Prepare providers packages with only new versions of providers"
+        shell: bash
+        run: >
+          breeze release-management prepare-provider-distributions
+          --distributions-list-file ./prod_image_installed_providers.txt
+          --distribution-format wheel --include-not-ready-providers
+        if: >
+          inputs.upload-package-artifact == 'true' && inputs.branch != 'main'
       - name: "Prepare airflow package"
         shell: bash
         run: >
@@ -262,25 +266,6 @@ jobs:
           INSTALL_MYSQL_CLIENT_TYPE: ${{ inputs.install-mysql-client-type }}
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ inputs.upgrade-to-newer-dependencies }}
           INCLUDE_NOT_READY_PROVIDERS: "true"
-        if: inputs.build-provider-distributions == 'true'
-      - name: "Build PROD images with PyPi providers ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
-        shell: bash
-        run: >
-          breeze prod-image build
-          --builder airflow_cache
-          --commit-sha "${{ github.sha }}"
-          --install-distributions-from-context
-          --airflow-constraints-mode constraints
-          --use-constraints-for-context-distributions
-        env:
-          PUSH: ${{ inputs.push-image }}
-          DOCKER_CACHE: ${{ inputs.docker-cache }}
-          DISABLE_AIRFLOW_REPO_CACHE: ${{ inputs.disable-airflow-repo-cache }}
-          DEBIAN_VERSION: ${{ inputs.debian-version }}
-          INSTALL_MYSQL_CLIENT_TYPE: ${{ inputs.install-mysql-client-type }}
-          UPGRADE_TO_NEWER_DEPENDENCIES: ${{ inputs.upgrade-to-newer-dependencies }}
-          INCLUDE_NOT_READY_PROVIDERS: "true"
-        if: inputs.build-provider-distributions != 'true'
       - name: "Verify PROD image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"
         run: breeze prod-image verify
       - name: "Export PROD docker image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}"

--- a/.github/workflows/prod-image-extra-checks.yml
+++ b/.github/workflows/prod-image-extra-checks.yml
@@ -33,15 +33,11 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
       branch:
-        description: "Branch used to run the CI jobs in (main/v2_*_test)."
+        description: "Branch used to run the CI jobs in (main/v*_*_test)."
         required: true
         type: string
       use-uv:
         description: "Whether to use uv to build the image (true/false)"
-        required: true
-        type: string
-      build-provider-distributions:
-        description: "Whether to build provider distributions (true/false). If false providers are from PyPI"
         required: true
         type: string
       upgrade-to-newer-dependencies:
@@ -78,7 +74,6 @@ jobs:
       # Always build images during the extra checks and never push them
       push-image: "false"
       use-uv: ${{ inputs.use-uv }}
-      build-provider-distributions: ${{ inputs.build-provider-distributions }}
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ inputs.constraints-branch }}
       docker-cache: ${{ inputs.docker-cache }}
@@ -87,8 +82,6 @@ jobs:
 
   pip-image:
     uses: ./.github/workflows/prod-image-build.yml
-    # Skip testing PIP image on release branches as all images there are built with pip
-    if: ${{ inputs.use-uv == 'true' }}
     with:
       runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
       build-type: "pip"
@@ -102,7 +95,6 @@ jobs:
       # Always build images during the extra checks and never push them
       push-image: "false"
       use-uv: "false"
-      build-provider-distributions: ${{ inputs.build-provider-distributions }}
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ inputs.constraints-branch }}
       docker-cache: ${{ inputs.docker-cache }}

--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -57,7 +57,7 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
       branch:
-        description: "Branch used to run the CI jobs in (main/v2_*_test)."
+        description: "Branch used to run the CI jobs in (main/v*_*_test)."
         required: true
         type: string
       constraints-branch:


### PR DESCRIPTION
When we removed "chicken-egg-providers" from the build in #49799 we should be able now to build PROD image in v3*test branch without special case of only using PyPI providers. This should work because in v3-*test branch we automatically detect (by presence of relesed tag) whether we should build provider from sources or use it from PyPI. In normal circumstances, we would need use providers fro PyPI, but sometimes (For example for 3.0.1) we need to use some providers from sources before they get released (for example common.messaging 1.0.1 that is the lowest possible common.messaging for Airflow 3.0.1.

This PR removes that special case and switches to the same method of building PROD image in main and in release branch.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
