### PR TITLE
fix react ui datetime utils and time component test

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Time.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Time.test.tsx
@@ -29,9 +29,14 @@ describe("Test Time and TimezoneProvider", () => {
   it("Displays a UTC time correctly", () => {
     const now = new Date();
 
-    render(<Time datetime={now.toISOString()} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <TimezoneContext.Provider value={{ selectedTimezone: "UTC", setSelectedTimezone: vi.fn() }}>
+        <Time datetime={now.toISOString()} />
+      </TimezoneContext.Provider>,
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     const utcTime = screen.getByText(dayjs.utc(now).format(defaultFormat));
 

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -24,7 +24,7 @@ dayjs.extend(dayjsDuration);
 export const getDuration = (startDate?: string | null, endDate?: string | null) => {
   const seconds = dayjs.duration(dayjs(endDate ?? undefined).diff(startDate ?? undefined)).asSeconds();
 
-  if (!seconds) {
+  if (isNaN(seconds) || seconds <= 0) {
     return "00:00:00";
   }
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

datetimeUtils wasn't handling null or defined dates properly

current UTC time test wasn't providing any context so selectedTimezone was probably defaulting to local timezone, not UTC