### PR TITLE
Add Key to default meta keys in S3KeySensor

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/s3.py
@@ -107,7 +107,7 @@ class S3KeySensor(AwsBaseSensor[S3Hook]):
         self.verify = verify
         self.deferrable = deferrable
         self.use_regex = use_regex
-        self.metadata_keys = metadata_keys if metadata_keys else ["Size"]
+        self.metadata_keys = metadata_keys if metadata_keys else ["Size", "Key"]
 
     def _check_key(self, key, context: Context):
         bucket_name, key = self.hook.get_s3_bucket_key(self.bucket_name, key, "bucket_name", "bucket_key")
@@ -116,7 +116,8 @@ class S3KeySensor(AwsBaseSensor[S3Hook]):
         """
         Set variable `files` which contains a list of dict which contains attributes defined by the user
         Format: [{
-            'Size': int
+            'Size': int,
+            'Key': str,
         }]
         """
         if self.wildcard_match:

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
@@ -320,11 +320,19 @@ class TestS3KeySensor:
         with pytest.raises(AirflowException, match=message):
             op.execute_complete(context={}, event={"status": "error", "message": message})
 
+    @pytest.mark.parametrize(
+        "metadata_keys, expected",
+        [
+            (["Size", "Key"], True),
+            (["Content"], False),
+            (None, True),
+        ],
+    )
     @mock_aws
-    def test_custom_metadata_default_return_vals(self):
+    def test_custom_metadata_default_return_vals(self, metadata_keys, expected):
         def check_fn(files: list) -> bool:
             for f in files:
-                if "Size" not in f:
+                if "Size" not in f or "Key" not in f:
                     return False
             return True
 
@@ -335,31 +343,14 @@ class TestS3KeySensor:
             key="test-key",
             string_data="test-body",
         )
-
         op = S3KeySensor(
             task_id="test-metadata",
             bucket_key="test-key",
             bucket_name="test-bucket",
-            metadata_keys=["Size"],
+            metadata_keys=metadata_keys,
             check_fn=check_fn,
         )
-        assert op.poke(None) is True
-        op = S3KeySensor(
-            task_id="test-metadata",
-            bucket_key="test-key",
-            bucket_name="test-bucket",
-            metadata_keys=["Content"],
-            check_fn=check_fn,
-        )
-        assert op.poke(None) is False
-
-        op = S3KeySensor(
-            task_id="test-metadata",
-            bucket_key="test-key",
-            bucket_name="test-bucket",
-            check_fn=check_fn,
-        )
-        assert op.poke(None) is True
+        assert op.poke(None) is expected
 
     @mock_aws
     def test_custom_metadata_default_custom_vals(self):
@@ -391,7 +382,7 @@ class TestS3KeySensor:
         def check_fn(files: list) -> bool:
             hook = S3Hook()
             metadata_keys = set(hook.head_object(bucket_name="test-bucket", key="test-key").keys())
-            test_data_keys = set(files[0].keys())
+            test_data_keys = set(files[0].keys()) - {"Key"}
 
             return test_data_keys == metadata_keys
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
closes: #44896
Added 'Key' as default argument in metadata_keys for Amazon S3 provider (S3KeySensor).
Updated tests for compatibility with new code.
