### PR TITLE
Migrate `HiveToDynamoDBOperator` and `SqlToS3Operator` to use `get_df`

### DIFF
--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -55,7 +55,7 @@ PIP package                                 Version required
 ==========================================  =====================
 ``apache-airflow``                          ``>=2.10.0``
 ``apache-airflow-providers-common-compat``  ``>=1.6.1``
-``apache-airflow-providers-common-sql``     ``>=1.20.0``
+``apache-airflow-providers-common-sql``     ``>=1.27.0``
 ``apache-airflow-providers-http``
 ``boto3``                                   ``>=1.37.0``
 ``botocore``                                ``>=1.37.0``

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.6.1",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.27.0",
     "apache-airflow-providers-http",
     # We should update minimum version of boto3 and here regularly to avoid `pip` backtracking with the number
     # of candidates to consider. Make sure to configure boto3 version here as well as in all the tools below
@@ -88,13 +88,6 @@ dependencies = [
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
-"pandas" = [
-    # In pandas 2.2 minimal version of the sqlalchemy is 2.0
-    # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies
-    # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723
-    # In addition FAB also limit sqlalchemy to < 2.0
-    "pandas>=2.1.2,<2.2",
-]
 # There is conflict between boto3 and aiobotocore dependency botocore.
 # TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
 # boto3 have native async support and we move away from aio aiobotocore
@@ -187,6 +180,7 @@ dev = [
     "openapi-spec-validator>=0.7.1",
     "opensearch-py>=2.2.0",
     "responses>=0.25.0",
+    "apache-airflow-providers-common-sql[pandas,polars]",
 ]
 
 # To build docs:

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
@@ -93,7 +93,7 @@ class HiveToDynamoDBOperator(BaseOperator):
         self.log.info("Extracting data from Hive")
         self.log.info(self.sql)
 
-        data = hive.get_pandas_df(self.sql, schema=self.schema)
+        data = hive.get_df(self.sql, schema=self.schema, df_type="pandas")
         dynamodb = DynamoDBHook(
             aws_conn_id=self.aws_conn_id,
             table_name=self.table_name,

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -187,7 +187,7 @@ class SqlToS3Operator(BaseOperator):
     def execute(self, context: Context) -> None:
         sql_hook = self._get_hook()
         s3_conn = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        data_df = sql_hook.get_pandas_df(sql=self.query, parameters=self.parameters)
+        data_df = sql_hook.get_df(sql=self.query, parameters=self.parameters, df_type="pandas")
         self.log.info("Data from SQL obtained")
         self._fix_dtypes(data_df, self.file_format)
         file_options = FILE_OPTIONS_MAP[self.file_format]
@@ -233,8 +233,6 @@ class SqlToS3Operator(BaseOperator):
         self.log.debug("Get connection for %s", self.sql_conn_id)
         conn = BaseHook.get_connection(self.sql_conn_id)
         hook = conn.get_hook(hook_params=self.sql_hook_params)
-        if not callable(getattr(hook, "get_pandas_df", None)):
-            raise AirflowException(
-                "This hook is not supported. The hook class must have get_pandas_df method."
-            )
+        if not callable(getattr(hook, "get_df", None)):
+            raise AirflowException("This hook is not supported. The hook class must have get_df method.")
         return hook

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_hive_to_dynamodb.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_hive_to_dynamodb.py
@@ -51,11 +51,11 @@ class TestHiveToDynamoDBOperator:
         assert hook.get_conn() is not None
 
     @mock.patch(
-        "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook.get_pandas_df",
+        "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook.get_df",
         return_value=pd.DataFrame(data=[("1", "sid")], columns=["id", "name"]),
     )
     @mock_aws
-    def test_get_records_with_schema(self, mock_get_pandas_df):
+    def test_get_records_with_schema(self, mock_get_df):
         # this table needs to be created in production
         self.hook.get_conn().create_table(
             TableName="test_airflow",
@@ -81,11 +81,11 @@ class TestHiveToDynamoDBOperator:
         assert table.item_count == 1
 
     @mock.patch(
-        "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook.get_pandas_df",
+        "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook.get_df",
         return_value=pd.DataFrame(data=[("1", "sid"), ("1", "gupta")], columns=["id", "name"]),
     )
     @mock_aws
-    def test_pre_process_records_with_schema(self, mock_get_pandas_df):
+    def test_pre_process_records_with_schema(self, mock_get_df):
         # this table needs to be created in production
         self.hook.get_conn().create_table(
             TableName="test_airflow",

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_sql_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_sql_to_s3.py
@@ -38,8 +38,8 @@ class TestSqlToS3Operator:
 
         mock_dbapi_hook = mock.Mock()
         test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
-        get_pandas_df_mock = mock_dbapi_hook.return_value.get_pandas_df
-        get_pandas_df_mock.return_value = test_df
+        get_df_mock = mock_dbapi_hook.return_value.get_df
+        get_df_mock.return_value = test_df
         with NamedTemporaryFile() as f:
             temp_mock.return_value.__enter__.return_value.name = f.name
 
@@ -58,7 +58,7 @@ class TestSqlToS3Operator:
             op.execute(None)
             mock_s3_hook.assert_called_once_with(aws_conn_id="aws_conn_id", verify=None)
 
-            get_pandas_df_mock.assert_called_once_with(sql=query, parameters=None)
+            get_df_mock.assert_called_once_with(sql=query, parameters=None, df_type="pandas")
 
             temp_mock.assert_called_once_with(mode="r+", suffix=".csv")
             mock_s3_hook.return_value.load_file.assert_called_once_with(
@@ -78,8 +78,8 @@ class TestSqlToS3Operator:
         mock_dbapi_hook = mock.Mock()
 
         test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
-        get_pandas_df_mock = mock_dbapi_hook.return_value.get_pandas_df
-        get_pandas_df_mock.return_value = test_df
+        get_df_mock = mock_dbapi_hook.return_value.get_df
+        get_df_mock.return_value = test_df
         with NamedTemporaryFile() as f:
             temp_mock.return_value.__enter__.return_value.name = f.name
 
@@ -98,7 +98,7 @@ class TestSqlToS3Operator:
             op.execute(None)
             mock_s3_hook.assert_called_once_with(aws_conn_id="aws_conn_id", verify=None)
 
-            get_pandas_df_mock.assert_called_once_with(sql=query, parameters=None)
+            get_df_mock.assert_called_once_with(sql=query, parameters=None, df_type="pandas")
 
             temp_mock.assert_called_once_with(mode="rb+", suffix=".parquet")
             mock_s3_hook.return_value.load_file.assert_called_once_with(
@@ -114,8 +114,8 @@ class TestSqlToS3Operator:
 
         mock_dbapi_hook = mock.Mock()
         test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
-        get_pandas_df_mock = mock_dbapi_hook.return_value.get_pandas_df
-        get_pandas_df_mock.return_value = test_df
+        get_df_mock = mock_dbapi_hook.return_value.get_df
+        get_df_mock.return_value = test_df
         with NamedTemporaryFile() as f:
             temp_mock.return_value.__enter__.return_value.name = f.name
 
@@ -135,7 +135,7 @@ class TestSqlToS3Operator:
             op.execute(None)
             mock_s3_hook.assert_called_once_with(aws_conn_id="aws_conn_id", verify=None)
 
-            get_pandas_df_mock.assert_called_once_with(sql=query, parameters=None)
+            get_df_mock.assert_called_once_with(sql=query, parameters=None, df_type="pandas")
 
             temp_mock.assert_called_once_with(mode="r+", suffix=".json")
             mock_s3_hook.return_value.load_file.assert_called_once_with(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- #49334
cc: @potiuk @eladkal 

## Why 

`get_pandas_df` deprecated in https://github.com/apache/airflow/pull/48875, which would be replaced by `get_df`. Thus, we need to migrate them in providers.

## How

- This PR is focus on migration of `Amazon/transfer`
- Migrate unit test
- Refine the common-sql type

## Note

There is some workaround for type here. It should be removed after the common-sql bundle the refined type definition. I've added the TODO in the comment and would get back here after the release.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
