### PR TITLE
Fixes validation error and adds error indicator

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
@@ -91,7 +91,9 @@ const ConfigForm = <T extends FieldValues = FieldValues>({
         setError={setFormError}
       />
       <Accordion.Item key="advancedOptions" value="advancedOptions">
-        <Accordion.ItemTrigger cursor="button">Advanced Options</Accordion.ItemTrigger>
+        <Accordion.ItemTrigger cursor="button" marginY="2">
+          Advanced Options
+        </Accordion.ItemTrigger>
         <Accordion.ItemContent>
           <Box p={4}>
             {children}

--- a/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
@@ -91,9 +91,7 @@ const ConfigForm = <T extends FieldValues = FieldValues>({
         setError={setFormError}
       />
       <Accordion.Item key="advancedOptions" value="advancedOptions">
-        <Accordion.ItemTrigger cursor="button" marginY="2">
-          Advanced Options
-        </Accordion.ItemTrigger>
+        <Accordion.ItemTrigger cursor="button">Advanced Options</Accordion.ItemTrigger>
         <Accordion.ItemContent>
           <Box p={4}>
             {children}

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Stack, StackSeparator, Text, VStack } from "@chakra-ui/react";
+import { Box, Icon, Stack, StackSeparator, Text } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
+import { MdError } from "react-icons/md";
 
 import type { ParamsSpec } from "src/queries/useDagParams";
 import { useParamStore } from "src/queries/useParamStore";
@@ -103,15 +104,13 @@ export const FlexibleForm = ({
 
           return (
             <Accordion.Item key={currentSection} value={currentSection}>
-              <Accordion.ItemTrigger alignItems="start" cursor="button">
-                <VStack alignItems="start">
-                  <Text marginY="2">{currentSection}</Text>
-                  {sectionError.get(currentSection) ? (
-                    <Text color="red" fontSize="xs" mb="-3" mt="-6">
-                      Error in this section
-                    </Text>
-                  ) : undefined}
-                </VStack>
+              <Accordion.ItemTrigger cursor="button">
+                <Text color={sectionError.get(currentSection) ? "red" : undefined}>{currentSection}</Text>
+                {sectionError.get(currentSection) ? (
+                  <Icon color="red" margin="-1">
+                    <MdError />
+                  </Icon>
+                ) : undefined}
               </Accordion.ItemTrigger>
               <Accordion.ItemContent paddingTop={0}>
                 <Box p={5}>

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Stack, StackSeparator } from "@chakra-ui/react";
+import { Box, Stack, StackSeparator, Text, VStack } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ParamsSpec } from "src/queries/useDagParams";
@@ -74,12 +74,14 @@ export const FlexibleForm = ({
     [setParamsDict, setinitialParamDict],
   );
 
-  useEffect(
-    () => () => {
-      recheckSection();
-    },
-    [params, recheckSection],
-  );
+  useEffect(() => {
+    recheckSection();
+    if (sectionError.size === 0) {
+      setError(false);
+    } else {
+      setError(true);
+    }
+  }, [params, setError, recheckSection, sectionError]);
 
   const onUpdate = (_value?: string, error?: unknown) => {
     recheckSection();
@@ -101,11 +103,15 @@ export const FlexibleForm = ({
 
           return (
             <Accordion.Item key={currentSection} value={currentSection}>
-              <Accordion.ItemTrigger
-                color={sectionError.get(currentSection) ? "red" : undefined}
-                cursor="button"
-              >
-                {currentSection}
+              <Accordion.ItemTrigger alignItems="start" cursor="button">
+                <VStack alignItems="start">
+                  <Text marginY="2">{currentSection}</Text>
+                  {sectionError.get(currentSection) ? (
+                    <Text color="red" fontSize="xs" mb="-3" mt="-6">
+                      Error in this section
+                    </Text>
+                  ) : undefined}
+                </VStack>
               </Accordion.ItemTrigger>
               <Accordion.ItemContent paddingTop={0}>
                 <Box p={5}>


### PR DESCRIPTION
Fixes validation failing on first load and
adds a textual indicator of error

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
