### PR TITLE
AIP-84: alias `dag_display_name` for `dag_source`, `log`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_sources.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_sources.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from pydantic import AliasPath, Field
+
 from airflow.api_fastapi.core_api.base import BaseModel
 
 
@@ -25,3 +27,4 @@ class DAGSourceResponse(BaseModel):
     content: str | None
     dag_id: str
     version_number: int | None
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import Field
+from pydantic import AliasPath, Field
 
 from airflow.api_fastapi.core_api.base import BaseModel
 
@@ -38,6 +38,9 @@ class EventLogResponse(BaseModel):
     logical_date: datetime | None
     owner: str | None
     extra: str | None
+    dag_display_name: str | None = Field(
+        validation_alias=AliasPath("dag_model", "dag_display_name"), default=None
+    )
 
 
 class EventLogCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -8478,11 +8478,15 @@ components:
           - type: integer
           - type: 'null'
           title: Version Number
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - content
       - dag_id
       - version_number
+      - dag_display_name
       title: DAGSourceResponse
       description: DAG Source serializer for responses.
     DAGTagCollectionResponse:
@@ -8894,6 +8898,11 @@ components:
           - type: string
           - type: 'null'
           title: Extra
+        dag_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Display Name
       type: object
       required:
       - event_log_id

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_sources.py
@@ -73,6 +73,7 @@ def get_dag_source(
         dag_id=dag_id,
         content=dag_version.dag_code.source_code,
         version_number=dag_version.version_number,
+        dag_display_name=dag_version.dag_model.dag_display_name,
     )
 
     if accept == Mimetype.TEXT:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
@@ -112,6 +112,7 @@ def get_log(
         )
         .join(TaskInstance.dag_run)
         .options(joinedload(TaskInstance.trigger).joinedload(Trigger.triggerer_job))
+        .options(joinedload(TaskInstance.dag_model))
     )
     ti = session.scalar(query)
     if ti is None:
@@ -173,11 +174,15 @@ def get_external_log_url(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Task log handler does not support external logs.")
 
     # Fetch the task instance
-    query = select(TaskInstance).where(
-        TaskInstance.task_id == task_id,
-        TaskInstance.dag_id == dag_id,
-        TaskInstance.run_id == dag_run_id,
-        TaskInstance.map_index == map_index,
+    query = (
+        select(TaskInstance)
+        .where(
+            TaskInstance.task_id == task_id,
+            TaskInstance.dag_id == dag_id,
+            TaskInstance.run_id == dag_run_id,
+            TaskInstance.map_index == map_index,
+        )
+        .options(joinedload(TaskInstance.dag_model))
     )
     ti = session.scalar(query)
 

--- a/airflow-core/src/airflow/models/log.py
+++ b/airflow-core/src/airflow/models/log.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Column, Index, Integer, String, Text
+from sqlalchemy.orm import relationship
 
 from airflow.models.base import Base, StringID
 from airflow.utils import timezone
@@ -47,6 +48,13 @@ class Log(Base):
     owner_display_name = Column(String(500))
     extra = Column(Text)
     try_number = Column(Integer)
+
+    dag_model = relationship(
+        "DagModel",
+        viewonly=True,
+        foreign_keys=[dag_id],
+        primaryjoin="Log.dag_id == DagModel.dag_id",
+    )
 
     __table_args__ = (
         Index("idx_log_dttm", dttm),

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2505,9 +2505,13 @@ export const $DAGSourceResponse = {
       ],
       title: "Version Number",
     },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
+    },
   },
   type: "object",
-  required: ["content", "dag_id", "version_number"],
+  required: ["content", "dag_id", "version_number", "dag_display_name"],
   title: "DAGSourceResponse",
   description: "DAG Source serializer for responses.",
 } as const;
@@ -3062,6 +3066,17 @@ export const $EventLogResponse = {
         },
       ],
       title: "Extra",
+    },
+    dag_display_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Dag Display Name",
     },
   },
   type: "object",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -611,6 +611,7 @@ export type DAGSourceResponse = {
   content: string | null;
   dag_id: string;
   version_number: number | null;
+  dag_display_name: string;
 };
 
 /**
@@ -796,6 +797,7 @@ export type EventLogResponse = {
   logical_date: string | null;
   owner: string | null;
   extra: string | null;
+  dag_display_name?: string | null;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -42,6 +42,7 @@ EXAMPLE_DAG_FILE = (
     AIRFLOW_REPO_ROOT_PATH / "airflow-core" / "src" / "airflow" / "example_dags" / "example_simplest_dag.py"
 )
 TEST_DAG_ID = "example_simplest_dag"
+TEST_DAG_DISPLAY_NAME = "example_simplest_dag"
 
 
 @pytest.fixture
@@ -106,6 +107,7 @@ class TestGetDAGSource:
             "content": dag_content,
             "dag_id": TEST_DAG_ID,
             "version_number": 1,
+            "dag_display_name": TEST_DAG_DISPLAY_NAME,
         }
         assert response.headers["Content-Type"].startswith("application/json")
 
@@ -153,6 +155,7 @@ class TestGetDAGSource:
                 "content": dag_content2,
                 "dag_id": TEST_DAG_ID,
                 "version_number": 2,
+                "dag_display_name": TEST_DAG_DISPLAY_NAME,
             }
 
     def test_should_respond_406_unsupport_mime_type(self, test_client, test_dag):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -29,6 +29,7 @@ from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_
 pytestmark = pytest.mark.db_test
 
 DAG_ID = "TEST_DAG_ID"
+DAG_DISPLAY_NAME = "TEST_DAG_ID"
 DAG_RUN_ID = "TEST_DAG_RUN_ID"
 TASK_ID = "TEST_TASK_ID"
 DAG_EXECUTION_DATE = datetime(2024, 6, 15, 0, 0, tzinfo=timezone.utc)
@@ -128,6 +129,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                 200,
                 {
                     "dag_id": DAG_ID,
+                    "dag_display_name": DAG_DISPLAY_NAME,
                     "event": TASK_INSTANCE_EVENT,
                     "map_index": -1,
                     "owner": OWNER_AIRFLOW,
@@ -140,6 +142,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                 200,
                 {
                     "dag_id": DAG_ID,
+                    "dag_display_name": DAG_DISPLAY_NAME,
                     "event": EVENT_WITH_OWNER_AND_TASK_INSTANCE,
                     "map_index": -1,
                     "owner": OWNER,
@@ -162,6 +165,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
         expected_json = {
             "event_log_id": event_log_id,
             "when": from_datetime_to_zulu(event_log.dttm) if event_log.dttm else None,
+            "dag_display_name": expected_body.get("dag_display_name"),
             "dag_id": expected_body.get("dag_id"),
             "task_id": expected_body.get("task_id"),
             "run_id": expected_body.get("run_id"),

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -319,6 +319,7 @@ class DAGSourceResponse(BaseModel):
     content: Annotated[str | None, Field(title="Content")] = None
     dag_id: Annotated[str, Field(title="Dag Id")]
     version_number: Annotated[int | None, Field(title="Version Number")] = None
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
 
 
 class DAGTagCollectionResponse(BaseModel):
@@ -481,6 +482,7 @@ class EventLogResponse(BaseModel):
     logical_date: Annotated[datetime | None, Field(title="Logical Date")] = None
     owner: Annotated[str | None, Field(title="Owner")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
+    dag_display_name: Annotated[str | None, Field(title="Dag Display Name")] = None
 
 
 class ExternalLogUrlResponse(BaseModel):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `dag_display_name` for `dag_source` and `log`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
