### PR TITLE
Turn releasing images in two stages - AMD only first and AMD/ARM second

### DIFF
--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -58,7 +58,6 @@ jobs:
           echo "Input parameters summary"
           echo "========================="
           echo "Airflow version: '${AIRFLOW_VERSION}'"
-          echo "Skip latest: '${SKIP_LATEST}'"
           echo "AMD only: '${AMD_ONLY}'"
       - name: "Cleanup repo"
         shell: bash
@@ -146,6 +145,8 @@ jobs:
           sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt install docker-buildx-plugin
+      - name: "Install emulation support"
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: "Install regctl"
         # yamllint disable rule:line-length
         run: |
@@ -153,40 +154,20 @@ jobs:
           curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >${HOME}/bin/regctl
           chmod 755 ${HOME}/bin/regctl
           echo "${HOME}/bin" >>${GITHUB_PATH}
-      - name: "Install emulation support"
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: "Create airflow_cache builder"
         run: docker buildx create --name airflow_cache
       - name: >
-          Release regular images: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
+          Release regular images AMD64 first: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
         env:
           COMMIT_SHA: ${{ github.sha }}
           REPOSITORY: ${{ github.repository }}
           PYTHON_VERSION: ${{ matrix.python-version }}
           AIRFLOW_VERSION: ${{ github.event.inputs.airflowVersion }}
           SKIP_LATEST: ${{ needs.build-info.outputs.skipLatest == 'true' && '--skip-latest' || '' }}
-          LIMIT_PLATFORM: >
-            ${{ (github.repository == 'apache/airflow' || github.event.inputs.amdOnly == 'true')
-            && '--limit-platform linux/amd64' || '' }}
         run: >
           breeze release-management release-prod-images --dockerhub-repo "${REPOSITORY}"
-          --airflow-version "${AIRFLOW_VERSION}" ${SKIP_LATEST} ${LIMIT_PLATFORM}
-          --limit-python ${PYTHON_VERSION}
-      - name: >
-          Release slim images: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          REPOSITORY: ${{ github.repository }}
-          PYTHON_VERSION: ${{ matrix.python-version }}
-          AIRFLOW_VERSION: ${{ github.event.inputs.airflowVersion }}
-          SKIP_LATEST: ${{ needs.build-info.outputs.skipLatest == 'true' && '--skip-latest' || '' }}
-          LIMIT_PLATFORM: >
-            ${{ (github.repository == 'apache/airflow' || github.event.inputs.amdOnly == 'true')
-            && '--limit-platform linux/amd64' || '' }}
-        run: >
-          breeze release-management release-prod-images --dockerhub-repo "${REPOSITORY}"
-          --airflow-version "${AIRFLOW_VERSION}" ${SKIP_LATEST} ${LIMIT_PLATFORM}
-          --limit-python ${PYTHON_VERSION} --slim-images
+          --airflow-version "${AIRFLOW_VERSION}" ${SKIP_LATEST}
+          --limit-python ${PYTHON_VERSION} --limit-platform linux/amd64
       - name: >
           Verify regular AMD64 image: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
         env:
@@ -199,6 +180,18 @@ jobs:
           --image-name
           ${REPOSITORY}:${AIRFLOW_VERSION}-python${PYTHON_VERSION}
       - name: >
+          Release slim images AMD64 first: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          AIRFLOW_VERSION: ${{ github.event.inputs.airflowVersion }}
+          SKIP_LATEST: ${{ needs.build-info.outputs.skipLatest == 'true' && '--skip-latest' || '' }}
+        run: >
+          breeze release-management release-prod-images --dockerhub-repo "${REPOSITORY}"
+          --airflow-version "${AIRFLOW_VERSION}" ${SKIP_LATEST}
+          --limit-python ${PYTHON_VERSION} --slim-images --limit-platform linux/amd64
+      - name: >
           Verify slim AMD64 image: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
@@ -210,6 +203,32 @@ jobs:
           --slim-image
           --image-name
           ${REPOSITORY}:slim-${AIRFLOW_VERSION}-python${PYTHON_VERSION}
+      - name: >
+          Release regular images for both AMD / ARM: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          AIRFLOW_VERSION: ${{ github.event.inputs.airflowVersion }}
+          SKIP_LATEST: ${{ needs.build-info.outputs.skipLatest == 'true' && '--skip-latest' || '' }}
+        run: >
+          breeze release-management release-prod-images --dockerhub-repo "${REPOSITORY}"
+          --airflow-version "${AIRFLOW_VERSION}" ${SKIP_LATEST}
+          --limit-python ${PYTHON_VERSION}
+        if: github.event.inputs.amdOnly != 'true'
+      - name: >
+          Release slim images for both AMD / ARM: ${{ github.event.inputs.airflowVersion }}, ${{ matrix.python-version }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          AIRFLOW_VERSION: ${{ github.event.inputs.airflowVersion }}
+          SKIP_LATEST: ${{ needs.build-info.outputs.skipLatest == 'true' && '--skip-latest' || '' }}
+        run: >
+          breeze release-management release-prod-images --dockerhub-repo "${REPOSITORY}"
+          --airflow-version "${AIRFLOW_VERSION}" ${SKIP_LATEST}
+          --limit-python ${PYTHON_VERSION} --slim-images
+        if: github.event.inputs.amdOnly != 'true'
       - name: "Docker logout"
         run: docker logout
         if: always()


### PR DESCRIPTION
When building release images, we build a multi-platform images - however for now we are not yet using ARM-hardware support for building ARM images, we are using simulation, that is **slow** (very slow) - this means that 90% of the build time the AMD images are ready but the ARM images are being built.

This PR changes the approach (until we have hardware ARM support) - we first build (and push) AMD images - which should takes < 10 minutes and then we run second build that shoudl additionally build the ARM images and pushes the images again - this time as multi-platform images.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
