### PR TITLE
[v3-0-test] Set proper limits for task-sdk in v3-0-test branch

### DIFF
--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "apache-airflow-core<=3.1.0,>=3.0.0",
+    "apache-airflow-core<3.1.0,>=3.0.0",
     "aiologic>=0.14.0",
     "attrs>=24.2.0, !=25.2.0",
     "fsspec>=2023.10.0",


### PR DESCRIPTION
The task SDK we have currently is not yet fully decoupled from the Airflow version we are going to have. It is simply not "future compatible" yet.

The "true" decoupling will come when we have Airflow 3.1, for now the task-sdk we have is really tied with 3.1.* version of Airflow - and for now we should have the limits set properly for core:

* Lower >= 3.0.0 -> the main version of task-sdk will only work with airflow 3.0.* (including pre-releases)
* Upper < 3.1.0 -> the task-sdk from main (1.1.0) will not work with Airflow 3.0.* and it's not going to be installable for Airflow 3.0 as well.

Related to #50163

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
