### PR TITLE
Additional validation of whether constraints are available for images

### DIFF
--- a/scripts/ci/airflow_version_check.py
+++ b/scripts/ci/airflow_version_check.py
@@ -26,7 +26,9 @@
 # ///
 from __future__ import annotations
 
+import re
 import sys
+from pathlib import Path
 
 import requests
 from packaging.version import Version
@@ -59,6 +61,28 @@ def check_airflow_version(airflow_version: Version) -> tuple[str, bool]:
             sys.exit(1)
         if airflow_version == latest_version:
             latest = True
+        # find requires-python = "~=VERSION" in pyproject.toml file of airflow
+        pyproject_toml_conntent = (Path(__file__).parents[2] / "pyproject.toml").read_text()
+        matched_version = re.search('requires-python = "~=([0-9]+.[0-9]+)', pyproject_toml_conntent)
+        if matched_version:
+            min_version = matched_version.group(1)
+        else:
+            console.print("[red]Error: requires-python version not found in pyproject.toml")
+            sys.exit(1)
+        constraints_url = (
+            f"https://raw.githubusercontent.com/apache/airflow/"
+            f"constraints-{airflow_version}/constraints-{min_version}.txt"
+        )
+        console.print(f"[bright_blue]Checking constraints file: {constraints_url}")
+        response = requests.head(constraints_url)
+        if response.status_code == 404:
+            console.print(
+                f"[red]Error: Constraints file not found for version {airflow_version}. "
+                f"Please set appropriate tag."
+            )
+            sys.exit(1)
+        response.raise_for_status()
+        console.print(f"[green]Constraints file found for version {airflow_version}, Python {min_version}")
         return str(airflow_version), latest
     except Exception as e:
         console.print(f"[red]Error fetching latest version: {e}")


### PR DESCRIPTION
When releasing the images, we are supposed to use constraints to release the images - and when the constraints are not present, we should not even attempt to do so.

This additional check verifies that constraints for the airflow version which we use to release the image is present in the repo.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
