### PR TITLE
Bugfix for un versioned docs S3 publishing

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -35,7 +35,7 @@ on:  # yamllint disable-line rule:truthy
         default: "s3://staging-docs-airflow-apache-org/docs"
         type: string
       docs-list-as-string:
-        description: "Comma separated list of docs to build"
+        description: "Space separated list of docs to build"
         required: false
         default: ""
         type: string

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
@@ -128,33 +128,41 @@ class S3DocsPublish:
         """
 
         for doc in self.get_all_eligible_docs:
-            stable_file_path = f"{self.source_dir_path}/{doc}/stable.txt"
-            if os.path.exists(stable_file_path):
-                with open(stable_file_path) as stable_file:
-                    stable_version = stable_file.read()
-                    get_console().print(f"[info]Stable version: {stable_version} for {doc}\n")
-            else:
-                get_console().print(
-                    f"[info]Skipping, stable version file not found for {doc} in {stable_file_path}\n"
-                )
-                continue
-
-            dest_doc_versioned_folder = f"{self.destination_location}/{doc}/{stable_version}/"
-            dest_doc_stable_folder = f"{self.destination_location}/{doc}/stable/"
-
-            if self.doc_exists(dest_doc_versioned_folder):
-                if self.overwrite:
-                    get_console().print(f"[info]Overwriting existing version {stable_version} for {doc}\n")
+            # PACKAGES_METADATA_EXCLUDE_NAMES has no stable versions so we copy them directly
+            if doc not in PACKAGES_METADATA_EXCLUDE_NAMES:
+                stable_file_path = f"{self.source_dir_path}/{doc}/stable.txt"
+                if os.path.exists(stable_file_path):
+                    with open(stable_file_path) as stable_file:
+                        stable_version = stable_file.read()
+                        get_console().print(f"[info]Stable version: {stable_version} for {doc}\n")
                 else:
                     get_console().print(
-                        f"[info]Skipping doc publish for {doc} as version {stable_version} already exists\n"
+                        f"[info]Skipping, stable version file not found for {doc} in {stable_file_path}\n"
                     )
                     continue
 
-            source_dir_doc_path = f"{self.source_dir_path}/{doc}/{stable_version}/"
+                dest_doc_versioned_folder = f"{self.destination_location}/{doc}/{stable_version}/"
+                dest_doc_stable_folder = f"{self.destination_location}/{doc}/stable/"
 
-            self.source_dest_mapping.append((source_dir_doc_path, dest_doc_versioned_folder))
-            self.source_dest_mapping.append((source_dir_doc_path, dest_doc_stable_folder))
+                if self.doc_exists(dest_doc_versioned_folder):
+                    if self.overwrite:
+                        get_console().print(
+                            f"[info]Overwriting existing version {stable_version} for {doc}\n"
+                        )
+                    else:
+                        get_console().print(
+                            f"[info]Skipping doc publish for {doc} as version {stable_version} already exists\n"
+                        )
+                        continue
+
+                source_dir_doc_path = f"{self.source_dir_path}/{doc}/{stable_version}/"
+
+                self.source_dest_mapping.append((source_dir_doc_path, dest_doc_versioned_folder))
+                self.source_dest_mapping.append((source_dir_doc_path, dest_doc_stable_folder))
+            else:
+                source_dir_doc_path = f"{self.source_dir_path}/{doc}/"
+                dest_doc_versioned_folder = f"{self.destination_location}/{doc}/"
+                self.source_dest_mapping.append((source_dir_doc_path, dest_doc_versioned_folder))
 
         if self.source_dest_mapping:
             self.run_publish()


### PR DESCRIPTION
"docker-stack", "apache-airflow-providers" are un versioned we can copy them directly instead of checking version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
