### PR TITLE
fix: wrap overflowing texts of asset events

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvent.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvent.tsx
@@ -51,7 +51,9 @@ export const AssetEvent = ({
       </Text>
       {Boolean(assetId) ? undefined : (
         <HStack>
-          <FiDatabase />
+          <Box>
+            <FiDatabase />
+          </Box>
           <Tooltip
             content={
               <div>
@@ -62,18 +64,22 @@ export const AssetEvent = ({
             showArrow
           >
             <Link to={`/assets/${event.asset_id}`}>
-              <Text color="fg.info"> {event.name ?? ""} </Text>
+              <Box color="fg.info" overflowWrap="anywhere" padding={0} wordWrap="break-word">
+                {event.name ?? ""}
+              </Box>
             </Link>
           </Tooltip>
         </HStack>
       )}
       <HStack>
-        <Text>Source: </Text>
+        <Box>Source: </Box>
         {source === "" ? (
           <Link
             to={`/dags/${event.source_dag_id}/runs/${event.source_run_id}/tasks/${event.source_task_id}${event.source_map_index > -1 ? `/mapped/${event.source_map_index}` : ""}`}
           >
-            <Text color="fg.info"> {event.source_dag_id} </Text>
+            <Box color="fg.info" overflowWrap="anywhere" padding={0} wordWrap="break-word">
+              {event.source_dag_id}
+            </Box>
           </Link>
         ) : (
           source


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #50022 

## Why 
Long asset or dag names were overflowing their containers in "Asset Events" on the home page.
<img width="425" alt="unwrapped_text" src="https://github.com/user-attachments/assets/fb58de3d-5c82-43b9-91c6-f637b5751237" />


## How 
Replaced `Text` with `Box` that supports word wrapping to make sure names break properly within the section.
<img width="311" alt="wrapped_text" src="https://github.com/user-attachments/assets/6b6750f5-4903-4bc6-8e8a-f717518aff11" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
