### PR TITLE
Propagate AssetEvent through context when Consumer DAG triggering on AssetAlias

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -32,7 +32,7 @@ from functools import lru_cache, partial
 from itertools import groupby
 from typing import TYPE_CHECKING, Any, Callable
 
-from sqlalchemy import and_, or_, delete, exists, func, select, text, tuple_, update
+from sqlalchemy import and_, delete, exists, func, or_, select, text, tuple_, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, selectinload
 from sqlalchemy.sql import expression
@@ -54,7 +54,6 @@ from airflow.models.asset import (
     DagScheduleAssetAliasReference,
     DagScheduleAssetReference,
     TaskOutletAssetReference,
-    asset_alias_asset_event_association_table,
 )
 from airflow.models.backfill import Backfill
 from airflow.models.dag import DAG, DagModel
@@ -1583,70 +1582,24 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .cte()
             )
 
-            start_time = func.coalesce(cte.c.previous_dag_run_run_after, date.min)
-
-            #####################################################################
-            # Profiling
-            #####################################################################
-            t0 = time.perf_counter()
-
-            asset_events_query = select(AssetEvent).where(
-                or_(
-                    AssetEvent.asset_id.in_(
-                        select(DagScheduleAssetReference.asset_id).where(
-                            DagScheduleAssetReference.dag_id == dag.dag_id
-                        )
+            asset_events = session.scalars(
+                select(AssetEvent).where(
+                    or_(
+                        AssetEvent.asset_id.in_(
+                            select(DagScheduleAssetReference.asset_id).where(
+                                DagScheduleAssetReference.dag_id == dag.dag_id
+                            )
+                        ),
+                        AssetEvent.source_aliases.any(
+                            AssetAliasModel.consuming_dags.any(
+                                DagScheduleAssetAliasReference.dag_id == dag.dag_id
+                            )
+                        ),
                     ),
-                    AssetEvent.source_aliases.any(
-                        AssetAliasModel.consuming_dags.any(
-                            DagScheduleAssetAliasReference.dag_id == dag.dag_id
-                        )
-                    ),
-                ),
-                AssetEvent.timestamp <= triggered_date,
-                AssetEvent.timestamp > start_time,
-            )
-            asset_events = session.scalars(asset_events_query).all()
-            # asset_events = session.scalars(
-            #     select(AssetEvent)
-            #     .join(
-            #         DagScheduleAssetReference,
-            #         AssetEvent.asset_id == DagScheduleAssetReference.asset_id,
-            #     )
-            #     .where(
-            #         DagScheduleAssetReference.dag_id == dag.dag_id,
-            #         AssetEvent.timestamp <= triggered_date,
-            #         AssetEvent.timestamp > func.coalesce(cte.c.previous_dag_run_run_after, date.min),
-            #     )
-            # ).all()
-            # alias_events = session.scalars(
-            #     select(AssetEvent)
-            #     .join(
-            #         asset_alias_asset_event_association_table,
-            #         asset_alias_asset_event_association_table.c.event_id == AssetEvent.id,
-            #     )
-            #     .join(
-            #         AssetAliasModel,
-            #         asset_alias_asset_event_association_table.c.alias_id == AssetAliasModel.id,
-            #     )
-            #     .join(
-            #         DagScheduleAssetAliasReference,
-            #         DagScheduleAssetAliasReference.alias_id == AssetAliasModel.id,
-            #     )
-            #     .where(
-            #         DagScheduleAssetAliasReference.dag_id == dag.dag_id,
-            #         AssetEvent.timestamp <= triggered_date,
-            #         AssetEvent.timestamp > func.coalesce(cte.c.previous_dag_run_run_after, date.min),
-            #     )
-            # ).all()
-
-            #####################################################################
-            # Profiling
-            #####################################################################
-            t1 = time.perf_counter()
-            self.log.info("[PROFILE] DAG: %s, Fetched %d asset_events (include alias) in %.4f seconds", dag.dag_id, len(asset_events), t1 - t0)
-            self.log.info("[PROFILE] DAG: %s, Number of asset events in set %s", dag.dag_id, len(set(asset_events)))
-            # self.log.info("[PROFILE] DAG: %s, Fetched %d alias_events in %.4f seconds", dag.dag_id, len(alias_events), t1 - t0)
+                    AssetEvent.timestamp <= triggered_date,
+                    AssetEvent.timestamp > func.coalesce(cte.c.previous_dag_run_run_after, date.min),
+                )
+            ).all()
 
             dag_run = dag.create_dagrun(
                 run_id=DagRun.generate_run_id(
@@ -1663,7 +1616,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
             Stats.incr("asset.triggered_dagruns")
             dag_run.consumed_asset_events.extend(asset_events)
-            # dag_run.consumed_asset_events.extend(alias_events)
             session.execute(delete(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == dag_run.dag_id))
 
     def _should_update_dag_next_dagruns(

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -47,12 +47,12 @@ from airflow.jobs.job import Job, perform_heartbeat
 from airflow.models import Log
 from airflow.models.asset import (
     AssetActive,
+    AssetAliasModel,
     AssetDagRunQueue,
     AssetEvent,
     AssetModel,
-    AssetAliasModel,
-    DagScheduleAssetReference,
     DagScheduleAssetAliasReference,
+    DagScheduleAssetReference,
     TaskOutletAssetReference,
     asset_alias_asset_event_association_table,
 )
@@ -1614,7 +1614,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     AssetEvent.timestamp > func.coalesce(cte.c.previous_dag_run_run_after, date.min),
                 )
             ).all()
-            
+
             dag_run = dag.create_dagrun(
                 run_id=DagRun.generate_run_id(
                     run_type=DagRunType.ASSET_TRIGGERED, logical_date=None, run_after=triggered_date

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4004,7 +4004,7 @@ class TestSchedulerJob:
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_asset_alias_with_asset_event_attached(self, session, dag_maker):
         """
-        Test DAG Run trigger on AssetAlias includes the corresponding AssetEvent in `consumed_asset_events`.
+        Test Dag Run trigger on AssetAlias includes the corresponding AssetEvent in `consumed_asset_events`.
         """
 
         # Simulate an Asset created at runtime, and it is not an active asset

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4018,7 +4018,7 @@ class TestSchedulerJob:
 
         asam = AssetAliasModel(name=asset_alias.name, group=asset_alias.group)
 
-        # Simulate a Producer DAG attach an asset event at runtime to an AssetAlias
+        # Simulate a Producer dag attach an asset event at runtime to an AssetAlias
         # Don't use outlets here because the needs to associate an asset alias with an asset event in the association table
         with dag_maker(dag_id="asset-alias-producer", start_date=timezone.utcnow(), session=session):
             BashOperator(task_id="simulate-asset-alias-outlet", bash_command="echo 1")

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -48,7 +48,13 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.executor_utils import ExecutorName
 from airflow.jobs.job import Job, run_job
 from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
-from airflow.models.asset import AssetActive, AssetDagRunQueue, AssetEvent, AssetModel
+from airflow.models.asset import (
+    AssetActive,
+    AssetAliasModel,
+    AssetDagRunQueue,
+    AssetEvent,
+    AssetModel,
+)
 from airflow.models.backfill import Backfill, _create_backfill
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
@@ -63,7 +69,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import task
-from airflow.sdk.definitions.asset import Asset
+from airflow.sdk.definitions.asset import Asset, AssetAlias
 from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.timetables.base import DataInterval
 from airflow.traces.tracer import Trace
@@ -3993,6 +3999,82 @@ class TestSchedulerJob:
         # dag3 ADRQ record should be deleted since the dag run was triggered
         assert session.query(AssetDagRunQueue).filter_by(target_dag_id=dag3.dag_id).one_or_none() is None
 
+        assert created_run.creating_job_id == scheduler_job.id
+
+    @pytest.mark.need_serialized_dag
+    def test_create_dag_runs_asset_alias_with_asset_event_attached(self, session, dag_maker):
+        """
+        Test DAG Run trigger on AssetAlias includes the corresponding AssetEvent in `consumed_asset_events`.
+        """
+
+        # Simulate an Asset created at runtime, and it is not an active asset
+        asset1 = Asset(uri="test://asset1", name="test_asset", group="test_group")
+        # Create an AssetAlias, and the Asset will be attached to this AssetAlias
+        asset_alias = AssetAlias(name="test_asset_alias_with_asset_event", group="test_group")
+
+        # Add it to the DB so the event can be created from this Asset
+        asm = AssetModel(name=asset1.name, uri=asset1.uri, group=asset1.group)
+        session.add(asm)
+
+        asam = AssetAliasModel(name=asset_alias.name, group=asset_alias.group)
+
+        # Simulate a Producer DAG attach an asset event at runtime to an AssetAlias
+        # Don't use outlets here because the needs to associate an asset alias with an asset event in the association table
+        with dag_maker(dag_id="asset-alias-producer", start_date=timezone.utcnow(), session=session):
+            BashOperator(task_id="simulate-asset-alias-outlet", bash_command="echo 1")
+        dr = dag_maker.create_dagrun(run_id="asset-alias-producer-run")
+
+        asset1_id = session.query(AssetModel.id).filter_by(uri=asset1.uri).scalar()
+
+        # Create an AssetEvent, which is associated with the Asset, and it is attached to the AssetAlias
+        event = AssetEvent(
+            asset_id=asset1_id,
+            source_task_id="simulate-asset-alias-outlet",
+            source_dag_id=dr.dag_id,
+            source_run_id=dr.run_id,
+            source_map_index=-1,
+        )
+        # Attach the Asset and the AssetEvent to the Asset Alias
+        asam.assets.append(asm)
+        asam.asset_events.append(event)
+
+        session.add_all([asam, event])
+        session.flush()
+
+        # Create the Consumer DAG and Trigger it with scheduler
+        with dag_maker(dag_id="asset-alias-consumer", schedule=[asset_alias]):
+            pass
+        consumer_dag = dag_maker.dag
+
+        session = dag_maker.session
+        session.add_all(
+            [
+                AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag.dag_id),
+            ]
+        )
+        session.flush()
+
+        scheduler_job = Job(executor=self.null_exec)
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with create_session() as session:
+            self.job_runner._create_dagruns_for_dags(session, session)
+
+        def dict_from_obj(obj):
+            """Get dict of column attrs from SqlAlchemy object."""
+            return {k.key: obj.__dict__.get(k) for k in obj.__mapper__.column_attrs}
+
+        created_run = session.query(DagRun).filter(DagRun.dag_id == consumer_dag.dag_id).one()
+        assert created_run.state == State.QUEUED
+        assert created_run.start_date is None
+
+        # The AssetEvent should be included in the consumed_asset_events when the consumer DAG is
+        # triggered on AssetAlias
+        assert list(map(dict_from_obj, created_run.consumed_asset_events)) == list(
+            map(dict_from_obj, [event])
+        )
+        assert created_run.data_interval_start is None
+        assert created_run.data_interval_end is None
         assert created_run.creating_job_id == scheduler_job.id
 
     @pytest.mark.need_serialized_dag


### PR DESCRIPTION
The motivation of this PR is to approach the request “I would like to have the possibility to have a DAG trigger on ANY dataset matching a wildcard/regex” (#39017). The two main use cases include 1.) Trigger ingestion process on file arrival and 2.) Monitor database updates.

Close #39017 

### Design Solution

Looking at the file arrival use case, the consumer DAG should be triggered on updates to any asset that can be matched to a specific regex pattern. In other words, the consumer DAG will be scheduled on a single Dataset (i.e. Asset) of which the name is some sort of regex string. In this way, the consumer DAG is scheduled on a SINGLE asset and multiple asset events generated by the producer DAG can trigger the consumer DAG.

Considering the concept of AssetAlias, an asset event can be created for any asset that is generated at runtime and be attached to an asset alias. The consumer DAG can be scheduled on a SINGLE asset alias and multiple asset events can be attached to the alias to trigger the consumer DAG. Therefore, utilizing asset aliases can also fulfill the two use cases.

Now, the problem comes. After experimenting with asset aliases, I found that the consumer task within the consumer DAG is not aware of the underlying asset event when it is scheduled on the asset alias. Please check the discussion in the issue for more details.

https://github.com/apache/airflow/issues/39017#issuecomment-2853230727

Therefore, in order to let the consumer task pick up the corresponding asset to process, it needs the access to the underlying asset event that triggers the DAG Run, when the consumer DAG is scheduled on asset aliases (Note: when the consumer DAG is scheduled on Asset, the asset event is propagated to the “triggering_asset_events” in Airflow context and the “inlet_events”, but it is not the case for asset alias in schedule).

The changes made in this PR updates the scheduler code to propagate this information to the “consumed_asset_events” such that the “triggering_asset_events” can include this information when the consumer DAG is scheduled on an asset alias. In this way, the consumer task in the consumer DAG can utilize the information to determine the asset event and pick up the corresponding asset to process, aligning with the use case objective.

### The downsides of using AssetAlias?

When an asset is created at runtime and attached to an asset alias, the asset is not set in the “outlets” or “inlets”, so the created asset will be inactive. This asset will show up in the Airflow UI as well as persist in the Airflow metadata store, even though it will be just used once. Therefore, for use cases that create different assets every time when the producer DAG runs, it generates inactive/orphan/unused assets without being able to clean up.

### A Potential Solution

Probably we can create an API endpoint to clean up those unused assets related to an asset alias.

### Unit tests

The following use case is run to test the scheduler job run. I have created a test case `test_create_dag_runs_asset_alias_with_asset_event_attached` to validate that the AssetEvent will be attached to the context when the consumer DAG is trigger on AssetAlias. 
```
pytest --log-cli-level=DEBUG airflow-core/tests/unit/jobs/test_scheduler_job.py
217 passed, 2 skipped, 1 xpassed, 1 warning
```
Other test suites related to asset-aware scheduling are run.

https://github.com/apache/airflow/pull/50182#issuecomment-2849885150

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
