### PR TITLE
Always Show Trendcount in Dag Overview

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -63,7 +63,7 @@ export const AssetEvents = ({
   });
 
   return (
-    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1} ml={2}>
+    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1}>
       <Flex justify="space-between" mr={1} mt={0} pl={3} pt={1}>
         <HStack>
           <StateBadge colorPalette="blue" fontSize="md" variant="solid">

--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { Box, Heading, Flex, HStack, Skeleton } from "@chakra-ui/react";
-import type { BoxProps } from "@chakra-ui/react";
 import { createListCollection } from "@chakra-ui/react/collection";
 import { FiDatabase } from "react-icons/fi";
 
@@ -41,9 +40,9 @@ type AssetEventProps = {
   readonly assetId?: number;
   readonly data?: AssetEventCollectionResponse;
   readonly isLoading?: boolean;
+  readonly [key: string]: unknown;
   readonly setOrderBy?: (order: string) => void;
   readonly setTableUrlState?: (state: TableState) => void;
-  readonly sx?: BoxProps;
   readonly tableUrlState?: TableState;
   readonly title?: string;
 };
@@ -54,9 +53,9 @@ export const AssetEvents = ({
   isLoading,
   setOrderBy,
   setTableUrlState,
-  sx,
   tableUrlState,
   title,
+  ...rest
 }: AssetEventProps) => {
   const assetSortOptions = createListCollection({
     items: [
@@ -66,7 +65,7 @@ export const AssetEvents = ({
   });
 
   return (
-    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1} ml={2} {...sx}>
+    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1} ml={2} {...rest}>
       <Flex justify="space-between" mr={1} mt={0} pl={3} pt={1}>
         <HStack>
           <StateBadge colorPalette="blue" fontSize="md" variant="solid">

--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Box, Heading, Flex, HStack, Skeleton } from "@chakra-ui/react";
+import type { BoxProps } from "@chakra-ui/react";
 import { createListCollection } from "@chakra-ui/react/collection";
 import { FiDatabase } from "react-icons/fi";
 
@@ -42,6 +43,7 @@ type AssetEventProps = {
   readonly isLoading?: boolean;
   readonly setOrderBy?: (order: string) => void;
   readonly setTableUrlState?: (state: TableState) => void;
+  readonly sx?: BoxProps;
   readonly tableUrlState?: TableState;
   readonly title?: string;
 };
@@ -52,6 +54,7 @@ export const AssetEvents = ({
   isLoading,
   setOrderBy,
   setTableUrlState,
+  sx,
   tableUrlState,
   title,
 }: AssetEventProps) => {
@@ -63,7 +66,7 @@ export const AssetEvents = ({
   });
 
   return (
-    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1}>
+    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1} ml={2} {...sx}>
       <Flex justify="space-between" mr={1} mt={0} pl={3} pt={1}>
         <HStack>
           <StateBadge colorPalette="blue" fontSize="md" variant="solid">

--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Box, Heading, Flex, HStack, Skeleton } from "@chakra-ui/react";
+import type { BoxProps } from "@chakra-ui/react";
 import { createListCollection } from "@chakra-ui/react/collection";
 import { FiDatabase } from "react-icons/fi";
 
@@ -40,7 +41,6 @@ type AssetEventProps = {
   readonly assetId?: number;
   readonly data?: AssetEventCollectionResponse;
   readonly isLoading?: boolean;
-  readonly [key: string]: unknown;
   readonly setOrderBy?: (order: string) => void;
   readonly setTableUrlState?: (state: TableState) => void;
   readonly tableUrlState?: TableState;
@@ -56,7 +56,7 @@ export const AssetEvents = ({
   tableUrlState,
   title,
   ...rest
-}: AssetEventProps) => {
+}: AssetEventProps & BoxProps) => {
   const assetSortOptions = createListCollection({
     items: [
       { label: "Newest first", value: "-timestamp" },

--- a/airflow-core/src/airflow/ui/src/components/TrendCountButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TrendCountButton.tsx
@@ -43,12 +43,8 @@ export const TrendCountButton = ({
   label,
   route,
   startDate,
-}: Props) => {
-  if (count === 0 && !isLoading) {
-    return undefined;
-  }
-
-  return isLoading ? (
+}: Props) =>
+  isLoading ? (
     <Skeleton borderRadius={4} height="45px" width="350px" />
   ) : (
     <Link to={route}>
@@ -63,4 +59,3 @@ export const TrendCountButton = ({
       </HStack>
     </Link>
   );
-};

--- a/airflow-core/src/airflow/ui/src/components/TrendCountChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TrendCountChart.tsx
@@ -101,20 +101,42 @@ export const TrendCountChart = ({ endDate, events, startDate }: Props) => {
   const chartRef = useRef<ChartJS<"line">>();
 
   // Get raw color values instead of CSS variables
-  const [bgLight, bgDark, lineLight, lineDark] = useToken("colors", [
+  const [bgLightGreen, bgDarkGreen, lineLightGreen, lineDarkGreen] = useToken("colors", [
+    "green.100",
+    "green.800",
+    "green.500",
+    "green.400",
+  ]);
+
+  const [bgLightRed, bgDarkRed, lineLightRed, lineDarkRed] = useToken("colors", [
     "red.100",
     "red.800",
     "red.500",
     "red.400",
   ]);
 
-  const backgroundColor = colorMode === "light" ? bgLight : bgDark;
-  const lineColor = colorMode === "light" ? lineLight : lineDark;
-
   const intervalData = useMemo(
     () => aggregateEventsIntoIntervals(events, startDate, endDate),
     [events, startDate, endDate],
   );
+
+  const backgroundColor =
+    colorMode === "light"
+      ? intervalData.some((value) => value > 0)
+        ? bgLightRed
+        : bgLightGreen
+      : intervalData.some((value) => value > 0)
+        ? bgDarkRed
+        : bgDarkGreen;
+
+  const lineColor =
+    colorMode === "light"
+      ? intervalData.some((value) => value > 0)
+        ? lineLightRed
+        : lineLightGreen
+      : intervalData.some((value) => value > 0)
+        ? lineDarkRed
+        : lineDarkGreen;
 
   // Cleanup chart instance on unmount
   useEffect(

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -138,8 +138,8 @@ export const Overview = () => {
           <AssetEvents
             data={assetEventsData}
             isLoading={isLoadingAssetEvents}
+            ml={0}
             setOrderBy={setAssetSortBy}
-            sx={{ ml: 0 }} // Override margin left
             title="Created Asset Event"
           />
         ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -139,6 +139,7 @@ export const Overview = () => {
             data={assetEventsData}
             isLoading={isLoadingAssetEvents}
             setOrderBy={setAssetSortBy}
+            sx={{ ml: 0 }} // Override margin left
             title="Created Asset Event"
           />
         ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -84,7 +84,7 @@ export const Overview = () => {
   });
 
   return (
-    <Box m={4}>
+    <Box m={4} spaceY={4}>
       <Box my={2}>
         <TimeRangeSelector
           defaultValue={defaultHour}
@@ -96,7 +96,7 @@ export const Overview = () => {
       </Box>
       <HStack flexWrap="wrap">
         <TrendCountButton
-          colorPalette="failed"
+          colorPalette={(failedTasks?.total_entries ?? 0) === 0 ? "green" : "failed"}
           count={failedTasks?.total_entries ?? 0}
           endDate={endDate}
           events={(failedTasks?.task_instances ?? []).map((ti) => ({
@@ -111,7 +111,7 @@ export const Overview = () => {
           startDate={startDate}
         />
         <TrendCountButton
-          colorPalette="failed"
+          colorPalette={(failedRuns?.total_entries ?? 0) === 0 ? "green" : "failed"}
           count={failedRuns?.total_entries ?? 0}
           endDate={endDate}
           events={(failedRuns?.dag_runs ?? []).map((dr) => ({

--- a/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -65,7 +65,7 @@ export const Overview = () => {
   );
 
   return (
-    <Box m={4}>
+    <Box m={4} spaceY={4}>
       <Box my={2}>
         <TimeRangeSelector
           defaultValue={defaultHour}
@@ -77,7 +77,7 @@ export const Overview = () => {
       </Box>
       <HStack flexWrap="wrap">
         <TrendCountButton
-          colorPalette="failed"
+          colorPalette={(failedTaskInstances?.total_entries ?? 0) === 0 ? "green" : "red"}
           count={failedTaskInstances?.total_entries ?? 0}
           endDate={endDate}
           events={(failedTaskInstances?.task_instances ?? []).map((ti) => ({


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Im not sure if we hide TrendCount when failed counts == 0 on purpose. 
Im thinking would it be better to show more summary info, starting with trendCount first. Just my proposal. Thanks!

## Previous
Not showing trendcount when nothing failed.
<img width="813" alt="Screenshot 2025-05-05 at 10 40 00 AM" src="https://github.com/user-attachments/assets/ca05852b-eb8c-41ac-9573-365fa251d7da" />

<img width="1161" alt="Screenshot 2025-05-05 at 10 42 12 AM" src="https://github.com/user-attachments/assets/189e76af-4610-4789-956f-fecbd086336f" />

## New 
We can show trendcount by default.
<img width="785" alt="Screenshot 2025-05-05 at 10 40 25 AM" src="https://github.com/user-attachments/assets/a52af6ef-d5eb-4812-a988-86a264b94b6b" />

On failed, change back to "failed" color.
<img width="777" alt="Screenshot 2025-05-05 at 10 41 21 AM" src="https://github.com/user-attachments/assets/bbcb4528-782a-48a5-80a1-c9dce6d07e79" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
