### PR TITLE
[KubernetesPodOperator] Reads Kubernetes events and writes them into log

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -110,6 +111,12 @@ def mock_get_connection():
 @pytest.mark.execution_timeout(180)
 @pytest.mark.usefixtures("mock_get_connection")
 class TestKubernetesPodOperatorSystem:
+    @pytest.fixture(autouse=True)
+    def event_loop(self):
+        loop = asyncio.new_event_loop()
+        yield loop
+        loop.close()
+
     @pytest.fixture(autouse=True)
     def setup_tests(self, test_label):
         self.api_client = ApiClient()

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -1219,6 +1220,11 @@ class TestKubernetesPodOperatorSystem:
 
         # recreate op just to ensure we're not relying on any statefulness
         k = get_op()
+
+        # Before next attempt we need to re-create event loop if it is closed.
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            asyncio.set_event_loop(asyncio.new_event_loop())
 
         # `create_pod` should be called because though there's still a pod to be found,
         # it will be `already_checked`

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -620,7 +620,7 @@ class KubernetesPodOperator(BaseOperator):
         except PodLaunchFailedException:
             if self.log_events_on_failure:
                 self._read_pod_events(pod, reraise=False)
-        raise
+            raise
 
     def extract_xcom(self, pod: k8s.V1Pod) -> dict[Any, Any] | None:
         """Retrieve xcom value and kill xcom sidecar container."""

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -620,7 +620,7 @@ class KubernetesPodOperator(BaseOperator):
         except PodLaunchFailedException:
             if self.log_events_on_failure:
                 self._read_pod_events(pod, reraise=False)
-            raise
+        raise
 
     def extract_xcom(self, pod: k8s.V1Pod) -> dict[Any, Any] | None:
         """Retrieve xcom value and kill xcom sidecar container."""

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import json
 import math
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
     from kubernetes.client.models.v1_container_state import V1ContainerState
     from kubernetes.client.models.v1_container_state_waiting import V1ContainerStateWaiting
     from kubernetes.client.models.v1_container_status import V1ContainerStatus
+    from kubernetes.client.models.v1_object_reference import V1ObjectReference
     from kubernetes.client.models.v1_pod import V1Pod
     from kubernetes.client.models.v1_pod_condition import V1PodCondition
     from urllib3.response import HTTPResponse
@@ -377,7 +379,21 @@ class PodManager(LoggingMixin):
         """Launch the pod asynchronously."""
         return self.run_pod_async(pod)
 
-    def await_pod_start(
+    async def watch_pod_events(self, pod: V1Pod, check_interval: int = 1) -> None:
+        """Read pod events and writes into log."""
+        self.keep_watching_for_events = True
+        num_events = 0
+        while self.keep_watching_for_events:
+            events = self.read_pod_events(pod)
+            for new_event in events.items[num_events:]:
+                involved_object: V1ObjectReference = new_event.involved_object
+                self.log.info(
+                    "The Pod has an Event: %s from %s", new_event.message, involved_object.field_path
+                )
+            num_events = len(events.items)
+            await asyncio.sleep(check_interval)
+
+    async def await_pod_start(
         self, pod: V1Pod, schedule_timeout: int = 120, startup_timeout: int = 120, check_interval: int = 1
     ) -> None:
         """
@@ -439,7 +455,7 @@ class PodManager(LoggingMixin):
                                 f"\n{container_waiting.message}"
                             )
 
-            time.sleep(check_interval)
+            await asyncio.sleep(check_interval)
 
     def fetch_container_logs(
         self,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import base64
 import pickle
 
+import pytest
+
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -71,6 +73,7 @@ class TestKubernetesDecorator(TestKubernetesDecoratorsBase):
         decoded_input = pickle.loads(base64.b64decode(containers[0].env[1].value))
         assert decoded_input == {"args": [], "kwargs": {}}
 
+    @pytest.mark.asyncio
     def test_kubernetes_with_input_output(self):
         """Verify @task.kubernetes will run XCom container if do_xcom_push is set."""
         with self.dag:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
@@ -33,6 +33,7 @@ XCOM_IMAGE = "XCOM_IMAGE"
 
 
 class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "args_only",
         [True, False],
@@ -77,6 +78,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         assert containers[0].command == expected_command
         assert containers[0].args == expected_args
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "func_return, exception",
         [
@@ -117,6 +119,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         with context_manager:
             self.execute_task(k8s_task)
 
+    @pytest.mark.asyncio
     def test_kubernetes_cmd_with_input_output(self):
         """Verify @task.kubernetes_cmd will run XCom container if do_xcom_push is set."""
         with self.dag:
@@ -167,6 +170,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         assert containers[1].image == XCOM_IMAGE
         assert containers[1].volume_mounts[0].mount_path == "/airflow/xcom"
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "cmds",
         [None, ["ignored_cmd"], "ignored_cmd"],
@@ -229,6 +233,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         assert containers[0].command == expected_command
         assert containers[0].args == expected_args
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         argnames=["command", "op_arg", "expected_command"],
         argvalues=[
@@ -278,6 +283,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         assert containers[0].command == expected_command
         assert containers[0].args == []
 
+    @pytest.mark.asyncio
     def test_basic_context_works(self):
         """Test that decorator works with context as kwargs unpcacked in function arguments"""
         with self.dag:
@@ -308,6 +314,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         assert containers[0].command == ["echo", "hello", DAG_ID]
         assert containers[0].args == []
 
+    @pytest.mark.asyncio
     def test_named_context_variables(self):
         """Test that decorator works with specific context variable as kwargs in function arguments"""
         with self.dag:
@@ -338,6 +345,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         assert containers[0].command == ["echo", "hello", DAG_ID]
         assert containers[0].args == []
 
+    @pytest.mark.asyncio
     def test_rendering_kubernetes_cmd_decorator_params(self):
         """Test that templating works in decorator parameters"""
         with self.dag:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import datetime
 import re
 from contextlib import contextmanager, nullcontext
@@ -143,13 +144,25 @@ def create_context(task, persist_to_db=False, map_index=None):
 @pytest.mark.execution_timeout(300)
 class TestKubernetesPodOperator:
     @pytest.fixture(autouse=True)
+    def event_loop(self):
+        loop = asyncio.new_event_loop()
+        yield loop
+        loop.close()
+
+    @pytest.fixture(autouse=True)
     def setup_tests(self, dag_maker):
         self.create_pod_patch = patch(f"{POD_MANAGER_CLASS}.create_pod")
-        self.await_pod_patch = patch(f"{POD_MANAGER_CLASS}.await_pod_start")
+        self.watch_pod_events = patch(f"{POD_MANAGER_CLASS}.watch_pod_events", new_callable=mock.AsyncMock)
+        self.await_pod_patch = patch(f"{POD_MANAGER_CLASS}.await_pod_start", new_callable=mock.AsyncMock)
         self.await_pod_completion_patch = patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
         self._default_client_patch = patch(f"{HOOK_CLASS}._get_default_client")
+        self.watch_pod_events_mock = self.watch_pod_events.start()
+        self.watch_pod_events_mock.return_value = asyncio.Future()
+        self.watch_pod_events_mock.return_value.set_result(None)
         self.create_mock = self.create_pod_patch.start()
         self.await_start_mock = self.await_pod_patch.start()
+        self.await_start_mock.return_value = asyncio.Future()
+        self.await_start_mock.return_value.set_result(None)
         self.await_pod_mock = self.await_pod_completion_patch.start()
         self._default_client_mock = self._default_client_patch.start()
         self.dag_maker = dag_maker

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import copy
 import json
 from datetime import date
@@ -38,6 +39,27 @@ from airflow.utils import db, timezone
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_pod_manager_methods():
+    # Patch watch_pod_events
+    patch_watch_pod_events = mock.patch(f"{POD_MANAGER_CLASS}.watch_pod_events", new_callable=mock.AsyncMock)
+    mock_watch_pod_events = patch_watch_pod_events.start()
+    mock_watch_pod_events.return_value = asyncio.Future()
+    mock_watch_pod_events.return_value.set_result(None)
+
+    # Patch await_pod_start
+    patch_await_pod_start = mock.patch(f"{POD_MANAGER_CLASS}.await_pod_start", new_callable=mock.AsyncMock)
+    mock_await_pod_start = patch_await_pod_start.start()
+    mock_await_pod_start.return_value = asyncio.Future()
+    mock_await_pod_start.return_value.set_result(None)
+
+    yield
+
+    mock.patch.stopall()
 
 
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.KubernetesHook")
@@ -203,7 +225,6 @@ def create_context(task):
 @pytest.mark.db_test
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_requested_container_logs")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-@patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_start")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.client")
 @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.cleanup")
@@ -254,6 +275,7 @@ class TestSparkKubernetesOperatorCreateApplication:
             "version": "v1beta2",
         }
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task_name, application_file_path",
         [
@@ -269,7 +291,6 @@ class TestSparkKubernetesOperatorCreateApplication:
         mock_cleanup,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -294,6 +315,7 @@ class TestSparkKubernetesOperatorCreateApplication:
             **self.call_commons,
         )
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task_name, application_file_path",
         [
@@ -309,7 +331,6 @@ class TestSparkKubernetesOperatorCreateApplication:
         mock_cleanup,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -339,6 +360,7 @@ class TestSparkKubernetesOperatorCreateApplication:
             **self.call_commons,
         )
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task_name, application_file_path",
         [
@@ -354,7 +376,6 @@ class TestSparkKubernetesOperatorCreateApplication:
         mock_cleanup,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -381,6 +402,7 @@ class TestSparkKubernetesOperatorCreateApplication:
             **self.call_commons,
         )
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("random_name_suffix", [True, False])
     def test_new_template_from_yaml(
         self,
@@ -389,7 +411,6 @@ class TestSparkKubernetesOperatorCreateApplication:
         mock_cleanup,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -415,6 +436,7 @@ class TestSparkKubernetesOperatorCreateApplication:
             **self.call_commons,
         )
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("random_name_suffix", [True, False])
     def test_template_spec(
         self,
@@ -423,7 +445,6 @@ class TestSparkKubernetesOperatorCreateApplication:
         mock_cleanup,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -454,7 +475,6 @@ class TestSparkKubernetesOperatorCreateApplication:
 @pytest.mark.db_test
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_requested_container_logs")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-@patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_start")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.client")
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.create_job_name")
@@ -488,6 +508,7 @@ class TestSparkKubernetesOperator:
         op.execute(context)
         return op
 
+    @pytest.mark.asyncio
     def test_env(
         self,
         mock_create_namespaced_crd,
@@ -496,7 +517,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -532,6 +552,7 @@ class TestSparkKubernetesOperator:
         assert op.launcher.body["spec"]["driver"]["envFrom"] == env_from
         assert op.launcher.body["spec"]["executor"]["envFrom"] == env_from
 
+    @pytest.mark.asyncio
     def test_volume(
         self,
         mock_create_namespaced_crd,
@@ -540,7 +561,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -578,6 +598,7 @@ class TestSparkKubernetesOperator:
         assert op.launcher.body["spec"]["driver"]["volumeMounts"] == volume_mounts
         assert op.launcher.body["spec"]["executor"]["volumeMounts"] == volume_mounts
 
+    @pytest.mark.asyncio
     def test_pull_secret(
         self,
         mock_create_namespaced_crd,
@@ -586,7 +607,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -599,6 +619,7 @@ class TestSparkKubernetesOperator:
         exp_secrets = [k8s.V1LocalObjectReference(name=secret) for secret in ["secret1", "secret2"]]
         assert op.launcher.body["spec"]["imagePullSecrets"] == exp_secrets
 
+    @pytest.mark.asyncio
     def test_affinity(
         self,
         mock_create_namespaced_crd,
@@ -607,7 +628,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -653,6 +673,7 @@ class TestSparkKubernetesOperator:
         assert op.launcher.body["spec"]["driver"]["affinity"] == affinity
         assert op.launcher.body["spec"]["executor"]["affinity"] == affinity
 
+    @pytest.mark.asyncio
     def test_toleration(
         self,
         mock_create_namespaced_crd,
@@ -661,7 +682,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -680,6 +700,7 @@ class TestSparkKubernetesOperator:
         assert op.launcher.body["spec"]["driver"]["tolerations"] == [toleration]
         assert op.launcher.body["spec"]["executor"]["tolerations"] == [toleration]
 
+    @pytest.mark.asyncio
     def test_get_logs_from_driver(
         self,
         mock_create_namespaced_crd,
@@ -688,7 +709,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,
@@ -703,6 +723,7 @@ class TestSparkKubernetesOperator:
             follow_logs=True,
         )
 
+    @pytest.mark.asyncio
     def test_find_custom_pod_labels(
         self,
         mock_create_namespaced_crd,
@@ -711,7 +732,6 @@ class TestSparkKubernetesOperator:
         mock_create_job_name,
         mock_get_kube_client,
         mock_create_pod,
-        mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
         data_file,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -160,6 +160,29 @@ class TestPodManager:
             ]
         )
 
+    @pytest.mark.asyncio
+    @mock.patch("asyncio.sleep", new_callable=mock.AsyncMock)
+    async def test_watch_pod_events(self, mock_time_sleep, caplog):
+        events = mock.MagicMock()
+        events.items = []
+        for id in ["event 1", "event 2"]:
+            event = mock.MagicMock()
+            event.message = f"test {id}"
+            event.involved_object.field_path = f"object {id}"
+            events.items.append(event)
+        startup_check_interval = 10
+
+        def mock_read_pod_events(pod):
+            self.pod_manager.keep_watching_for_events = False
+            return events
+
+        with mock.patch.object(self.pod_manager, "read_pod_events", side_effect=mock_read_pod_events):
+            await self.pod_manager.watch_pod_events(pod=None, check_interval=startup_check_interval)
+
+        assert caplog.text.count("The Pod has an Event: test event 1 from object event 1") == 1
+        assert caplog.text.count("The Pod has an Event: test event 2 from object event 2") == 1
+        mock_time_sleep.assert_called_once_with(startup_check_interval)
+
     def test_read_pod_events_successfully_returns_events(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.list_namespaced_event.return_value = mock.sentinel.events
@@ -392,20 +415,22 @@ class TestPodManager:
 
         assert mock_run_pod_async.call_count == 3
 
-    def test_start_pod_raises_informative_error_on_scheduled_timeout(self):
+    @pytest.mark.asyncio
+    async def test_start_pod_raises_informative_error_on_scheduled_timeout(self):
         pod_response = mock.MagicMock()
         pod_response.status.phase = "Pending"
         self.mock_kube_client.read_namespaced_pod.return_value = pod_response
         expected_msg = "Pod took too long to be scheduled on the cluster, giving up. More than 0s. Check the pod events in kubernetes."
         mock_pod = MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
-            self.pod_manager.await_pod_start(
+            await self.pod_manager.await_pod_start(
                 pod=mock_pod,
                 schedule_timeout=0,
                 startup_timeout=0,
             )
 
-    def test_start_pod_raises_informative_error_on_startup_timeout(self):
+    @pytest.mark.asyncio
+    async def test_start_pod_raises_informative_error_on_startup_timeout(self):
         pod_response = mock.MagicMock()
         pod_response.status.phase = "Pending"
         condition = mock.MagicMock()
@@ -417,12 +442,13 @@ class TestPodManager:
         expected_msg = "Pod took too long to start. More than 0s. Check the pod events in kubernetes."
         mock_pod = MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
-            self.pod_manager.await_pod_start(
+            await self.pod_manager.await_pod_start(
                 pod=mock_pod,
                 schedule_timeout=0,
                 startup_timeout=0,
             )
 
+    @pytest.mark.asyncio
     def test_start_pod_raises_fast_error_on_image_error(self):
         pod_response = mock.MagicMock()
         pod_response.status.phase = "Pending"
@@ -437,14 +463,15 @@ class TestPodManager:
         expected_msg = f"Pod docker image cannot be pulled, unable to start: {waiting_state.reason}\n{waiting_state.message}"
         mock_pod = MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
-            self.pod_manager.await_pod_start(
+            await self.pod_manager.await_pod_start(
                 pod=mock_pod,
                 schedule_timeout=60,
                 startup_timeout=60,
             )
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.time.sleep")
-    def test_start_pod_startup_interval_seconds(self, mock_time_sleep, caplog):
+    @pytest.mark.asyncio
+    @mock.patch("asyncio.sleep", new_callable=mock.AsyncMock)
+    async def test_start_pod_startup_interval_seconds(self, mock_time_sleep, caplog):
         condition_scheduled = mock.MagicMock()
         condition_scheduled.type = "PodScheduled"
         condition_scheduled.status = "True"
@@ -467,7 +494,7 @@ class TestPodManager:
         schedule_timeout = 30
         startup_timeout = 60
         mock_pod = MagicMock()
-        self.pod_manager.await_pod_start(
+        await self.pod_manager.await_pod_start(
             pod=mock_pod,
             schedule_timeout=schedule_timeout,  # Never hit, any value is fine, as time.sleep is mocked to do nothing
             startup_timeout=startup_timeout,  # Never hit, any value is fine, as time.sleep is mocked to do nothing
@@ -477,6 +504,7 @@ class TestPodManager:
         assert mock_time_sleep.call_count == 3
         assert f"::group::Waiting until {schedule_timeout}s to get the POD scheduled..." in caplog.text
         assert f"Waiting {startup_timeout}s to get the POD running..." in caplog.text
+        assert not self.pod_manager.keep_watching_for_events
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
     def test_container_is_running(self, container_is_running_mock):


### PR DESCRIPTION
# Overview

The idea is to make the events of the Kubernetes pod visible in the log during start phase of the Pod. The KubenetesPodOperator starts the Pod and pulls the events in parallel and writes new events into log.
This enables the user to see what is happening in the background in Kubernetes.

# Details of change:

* await_pod_start pulls cyclic for new Kubernetes events and writes into log parallel to start phase of the Pod.