### PR TITLE
Prioritize min airflow bump over bugfix during provider doc prep

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -114,13 +114,15 @@ class TypeOfChange(Enum):
 
 
 # defines the precedence order for provider version bumps
-# BREAKING_CHANGE > FEATURE > BUGFIX > MIN_AIRFLOW_VERSION_BUMP > MISC > DOCUMENTATION > SKIP
+# BREAKING_CHANGE > FEATURE > MIN_AIRFLOW_VERSION_BUMP > BUGFIX > MISC > DOCUMENTATION > SKIP
+
+# When MIN_AIRFLOW_VERSION_BUMP is provided, it means that the bump is at least feature
 precedence_order = {
     TypeOfChange.SKIP: 0,
     TypeOfChange.DOCUMENTATION: 1,
     TypeOfChange.MISC: 2,
-    TypeOfChange.MIN_AIRFLOW_VERSION_BUMP: 2.5,
     TypeOfChange.BUGFIX: 3,
+    TypeOfChange.MIN_AIRFLOW_VERSION_BUMP: 3.5,
     TypeOfChange.FEATURE: 4,
     TypeOfChange.BREAKING_CHANGE: 5,
 }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Before: 
```
Does the provider: airbyte have any changes apart from 'doc-only'? 
Press y/N/q: y

Define the type of change for `update airbyte changelog (https://github.com/apache/airflow/pull/49934)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip,(v)airflow_min_version_bump (q)uit ? v


Define the type of change for `Avoid committing history for providers (https://github.com/apache/airflow/pull/49907)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip,(v)airflow_min_version_bump (q)uit ? b


Define the type of change for `Bump min Airflow version in providers to 2.10 (https://github.com/apache/airflow/pull/49843)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip,(v)airflow_min_version_bump (q)uit ? v

The version will be bumped because of TypeOfChange.BUGFIX kind of change
Provider airbyte has been classified as:

Bugfix changes only - bump in PATCHLEVEL version needed

Bumped version to 5.0.3

Updated source-date-epoch to 1746448531

New version of the 'airbyte' package is ready to be released!
```

After: 
```
Does the provider: airbyte have any changes apart from 'doc-only'? 
Press y/N/q: y

Define the type of change for `update airbyte changelog (https://github.com/apache/airflow/pull/49934)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip,(v)airflow_min_version_bump (q)uit ? v


Define the type of change for `Avoid committing history for providers (https://github.com/apache/airflow/pull/49907)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip,(v)airflow_min_version_bump (q)uit ? b


Define the type of change for `Bump min Airflow version in providers to 2.10 (https://github.com/apache/airflow/pull/49843)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip,(v)airflow_min_version_bump (q)uit ? m

The version will be bumped because of TypeOfChange.MIN_AIRFLOW_VERSION_BUMP kind of change
Provider airbyte has been classified as:

Airflow version bump change - bump in MINOR version needed

Bumped version to 5.1.0

Updated source-date-epoch to 1746448780

New version of the 'airbyte' package is ready to be released!
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
