### PR TITLE
Add test for `common-sql` overload

### DIFF
--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -23,6 +23,8 @@ import logging
 import logging.config
 from unittest.mock import MagicMock
 
+import pandas as pd
+import polars as pl
 import pytest
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
@@ -306,3 +308,16 @@ class TestDbApiHook:
     def test_uri_with_schema(self):
         dbapi_hook = mock_db_hook(DbApiHook, conn_params={"schema": "other_schema"})
         assert dbapi_hook.get_uri() == "//login:password@host:1234/other_schema"
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "df_type, expected_type",
+        [
+            ("pandas", pd.DataFrame),
+            ("polars", pl.DataFrame),
+        ],
+    )
+    def test_get_df_with_df_type(db, df_type, expected_type):
+        dbapi_hook = mock_db_hook(DbApiHook)
+        df = dbapi_hook.get_df("SQL", df_type=df_type)
+        assert isinstance(df, expected_type)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why 

When manually test the overload change for #50189, I think it would be great to add it in test. Since it's hard to be tested in mypy when there is some error, to add it in test is more safe way. 

## How 

Try call func with different `df_type` and check their type

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
