### PR TITLE
Eager upgrade strategy when building pre-release images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -462,7 +462,7 @@ function common::get_packaging_tool() {
         UV_CONCURRENT_DOWNLOADS=$(nproc --all)
         export UV_CONCURRENT_DOWNLOADS
         if [[ ${INCLUDE_PRE_RELEASE=} == "true" ]]; then
-            EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS} --prerelease if-necessary"
+            EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS} --prerelease allow"
         fi
     else
         echo
@@ -960,6 +960,26 @@ function install_from_external_spec() {
             ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
             set +x
         fi
+        if [[ ${INCLUDE_PRE_RELEASE=} == "true" && ${AIRFLOW_USE_UV} != "true" ]]; then
+            echo
+            echo "${COLOR_YELLOW}Additionally upgrading with highest resolution for pre-release builds.${COLOR_RESET}"
+            echo
+            # With pre-release and pip we need to run additional upgrade step with --upgrade-strategy eager
+            # because by default `pip` will only resolve non-pre releases when it does not have to only eager
+            # upgrade after the initial install will actually install potentially pre-released RC candidates for providers
+            if ! ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} \
+               ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
+                set +x
+                echo
+                echo "${COLOR_YELLOW}Likely pyproject.toml has new dependencies conflicting with constraints.${COLOR_RESET}"
+                echo
+                echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
+                echo
+                set -x
+                ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
+                set +x
+            fi
+         fi
     fi
 }
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -401,7 +401,7 @@ function common::get_packaging_tool() {
         UV_CONCURRENT_DOWNLOADS=$(nproc --all)
         export UV_CONCURRENT_DOWNLOADS
         if [[ ${INCLUDE_PRE_RELEASE=} == "true" ]]; then
-            EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS} --prerelease if-necessary"
+            EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS} --prerelease allow"
         fi
     else
         echo
@@ -713,6 +713,26 @@ function install_from_external_spec() {
             ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
             set +x
         fi
+        if [[ ${INCLUDE_PRE_RELEASE=} == "true" && ${AIRFLOW_USE_UV} != "true" ]]; then
+            echo
+            echo "${COLOR_YELLOW}Additionally upgrading with highest resolution for pre-release builds.${COLOR_RESET}"
+            echo
+            # With pre-release and pip we need to run additional upgrade step with --upgrade-strategy eager
+            # because by default `pip` will only resolve non-pre releases when it does not have to only eager
+            # upgrade after the initial install will actually install potentially pre-released RC candidates for providers
+            if ! ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} \
+               ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
+                set +x
+                echo
+                echo "${COLOR_YELLOW}Likely pyproject.toml has new dependencies conflicting with constraints.${COLOR_RESET}"
+                echo
+                echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
+                echo
+                set -x
+                ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
+                set +x
+            fi
+         fi
     fi
 }
 

--- a/scripts/docker/common.sh
+++ b/scripts/docker/common.sh
@@ -49,7 +49,7 @@ function common::get_packaging_tool() {
         UV_CONCURRENT_DOWNLOADS=$(nproc --all)
         export UV_CONCURRENT_DOWNLOADS
         if [[ ${INCLUDE_PRE_RELEASE=} == "true" ]]; then
-            EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS} --prerelease if-necessary"
+            EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS} --prerelease allow"
         fi
     else
         echo


### PR DESCRIPTION
Seems that the default strategy when --pre is specified is to use pre-releases only when necessary. However in our case we are supposed to use latest pre-releases when building pre-release image, because only the providers we want to install as pre-releases are not limited by constraints, so we can safely upgrade them.

This PR adds the `eager` upgrade strategy to force that.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
