### PR TITLE
Move access_denied_message webserver config to fab

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -380,6 +380,10 @@ CONFIGS_CHANGES = [
         renamed_to=ConfigParameter("fab", "session_lifetime_minutes"),
     ),
     ConfigChange(
+        config=ConfigParameter("webserver", "access_denied_message"),
+        renamed_to=ConfigParameter("fab", "access_denied_message"),
+    ),
+    ConfigChange(
         config=ConfigParameter("webserver", "base_url"),
         renamed_to=ConfigParameter("api", "base_url"),
     ),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1693,13 +1693,6 @@ operators:
 webserver:
   description: ~
   options:
-    access_denied_message:
-      description: |
-        The message displayed when a user attempts to execute actions beyond their authorised privileges.
-      version_added: 2.7.0
-      type: string
-      example: ~
-      default: "Access is Denied"
     secret_key:
       description: |
         Secret key used to run your api server. It should be as random as possible. However, when running

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -356,6 +356,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "access_logfile"): ("webserver", "access_logfile", "3.0"),
         ("triggerer", "capacity"): ("triggerer", "default_capacity", "3.0"),
         ("api", "expose_config"): ("webserver", "expose_config", "3.0.1"),
+        ("fab", "access_denied_message"): ("webserver", "access_denied_message", "3.0.1"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -356,7 +356,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "access_logfile"): ("webserver", "access_logfile", "3.0"),
         ("triggerer", "capacity"): ("triggerer", "default_capacity", "3.0"),
         ("api", "expose_config"): ("webserver", "expose_config", "3.0.1"),
-        ("fab", "access_denied_message"): ("webserver", "access_denied_message", "3.0.1"),
+        ("fab", "access_denied_message"): ("webserver", "access_denied_message", "3.0.2"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -250,7 +250,7 @@ def test_validate_provider_info_with_schema():
     "provider_id, min_version",
     [
         ("amazon", "2.10.0"),
-        ("fab", "3.0.0"),
+        ("fab", "3.0.2"),
     ],
 )
 def test_get_min_airflow_version(provider_id: str, min_version: str):

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -59,6 +59,13 @@ config:
   fab:
     description: This section contains configs specific to FAB provider.
     options:
+      access_denied_message:
+        description: |
+          The message displayed when a user attempts to execute actions beyond their authorised privileges.
+        version_added: 2.0.3
+        type: string
+        example: ~
+        default: "Access is Denied"
       auth_rate_limited:
         description: |
           Boolean for enabling rate limiting on authentication endpoints.

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -35,6 +35,7 @@ source-date-epoch: 1745478857
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 2.0.3
   - 2.0.2
   - 2.0.1
   - 2.0.0

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -62,7 +62,7 @@ config:
       access_denied_message:
         description: |
           The message displayed when a user attempts to execute actions beyond their authorised privileges.
-        version_added: 2.0.3
+        version_added: 2.0.2
         type: string
         example: ~
         default: "Access is Denied"

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-fab"
-version = "2.0.2"
+version = "2.0.3"
 description = "Provider package apache-airflow-providers-fab for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -127,8 +127,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.2"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.2/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.3"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.3/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -57,7 +57,7 @@ license-files = ["NOTICE", "*/LICENSE*"]
 # Make sure to run ``breeze static-checks --type update-providers-dependencies --all-files``
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
-    "apache-airflow>=3.0.0",
+    "apache-airflow>=3.0.2",
     "apache-airflow-providers-common-compat>=1.2.1",
     # Blinker use for signals in Flask, this is an optional dependency in Flask 2.2 and lower.
     # In Flask 2.3 it becomes a mandatory dependency, and flask signals are always available.

--- a/providers/fab/src/airflow/providers/fab/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.0.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "3.0.0"
+    "3.0.2"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-fab:{__version__}` needs Apache Airflow 3.0.0+"
+        f"The package `apache-airflow-providers-fab:{__version__}` needs Apache Airflow 3.0.2+"
     )

--- a/providers/fab/src/airflow/providers/fab/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "3.0.0"

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -30,6 +30,13 @@ def get_provider_info():
             "fab": {
                 "description": "This section contains configs specific to FAB provider.",
                 "options": {
+                    "access_denied_message": {
+                        "description": "The message displayed when a user attempts to execute actions beyond their authorised privileges.\n",
+                        "version_added": "2.0.3",
+                        "type": "string",
+                        "example": None,
+                        "default": "Access is Denied",
+                    },
                     "auth_rate_limited": {
                         "description": "Boolean for enabling rate limiting on authentication endpoints.\n",
                         "version_added": "1.0.2",

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -32,7 +32,7 @@ def get_provider_info():
                 "options": {
                     "access_denied_message": {
                         "description": "The message displayed when a user attempts to execute actions beyond their authorised privileges.\n",
-                        "version_added": "2.0.3",
+                        "version_added": "2.0.2",
                         "type": "string",
                         "example": None,
                         "default": "Access is Denied",

--- a/providers/fab/src/airflow/providers/fab/www/auth.py
+++ b/providers/fab/src/airflow/providers/fab/www/auth.py
@@ -61,7 +61,7 @@ log = logging.getLogger(__name__)
 
 
 def get_access_denied_message():
-    return conf.get("webserver", "access_denied_message")
+    return conf.get("fab", "access_denied_message")
 
 
 def has_access_with_pk(f):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ packages = []
     "apache-airflow-providers-exasol>=4.6.1"
 ]
 "fab" = [
-    "apache-airflow-providers-fab>=2.0.2" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-fab>=2.0.3" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "facebook" = [
     "apache-airflow-providers-facebook>=3.7.0"
@@ -422,7 +422,7 @@ packages = []
     "apache-airflow-providers-edge3>=1.0.0",
     "apache-airflow-providers-elasticsearch>=5.5.2",
     "apache-airflow-providers-exasol>=4.6.1",
-    "apache-airflow-providers-fab>=2.0.2", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-fab>=2.0.3", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-facebook>=3.7.0",
     "apache-airflow-providers-ftp>=3.12.0",
     "apache-airflow-providers-git>=0.0.2", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py

--- a/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
+++ b/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
@@ -56,7 +56,7 @@ CUT_OFF_TIMEDELTA = timedelta(days=6 * 30)
 # minimum versions for compatibility with Airflow 3
 MIN_VERSION_OVERRIDE: dict[str, Version] = {
     "amazon": parse_version("2.1.3"),
-    "fab": parse_version("2.0.2"),
+    "fab": parse_version("2.0.3"),
     "openlineage": parse_version("2.3.0"),
     "git": parse_version("0.0.2"),
     "common.messaging": parse_version("1.0.1"),


### PR DESCRIPTION
Part of: https://github.com/apache/airflow/issues/49896

This is still needed by the fab provider. Just confirming how things articulate between the provider / core dependency (provider requirements) on a minimal example,  before moving on with other webserver config params.