### PR TITLE
Refine type overload for `HiveServer2Hook`

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -28,7 +28,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 
 from deprecated import deprecated
-from typing_extensions import Literal
+from typing_extensions import Literal, overload
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -1070,6 +1070,28 @@ class HiveServer2Hook(DbApiHook):
         res = self.get_results(sql, schema=schema, hive_conf=hive_conf)
         df = pl.DataFrame(res["data"], schema=[c[0] for c in res["header"]], orient="row", **kwargs)
         return df
+
+    @overload  # type: ignore[override]
+    def get_df(
+        self,
+        sql: str,
+        schema: str = "default",
+        hive_conf: dict[Any, Any] | None = None,
+        *,
+        df_type: Literal["pandas"] = "pandas",
+        **kwargs: Any,
+    ) -> pd.DataFrame: ...
+
+    @overload  # type: ignore[override]
+    def get_df(
+        self,
+        sql: str,
+        schema: str = "default",
+        hive_conf: dict[Any, Any] | None = None,
+        *,
+        df_type: Literal["polars"],
+        **kwargs: Any,
+    ) -> pl.DataFrame: ...
 
     def get_df(  # type: ignore
         self,

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -23,6 +23,7 @@ from collections import namedtuple
 from unittest import mock
 
 import pandas as pd
+import polars as pl
 import pytest
 from hmsclient import HMSClient
 
@@ -737,8 +738,10 @@ class TestHiveServer2Hook:
         assert len(df) == 2
         if df_type == "pandas":
             assert df["hive_server_hook.a"].values.tolist() == [1, 2]
+            assert isinstance(df, pd.DataFrame)
         elif df_type == "polars":
             assert df["hive_server_hook.a"].to_list() == [1, 2]
+            assert isinstance(df, pl.DataFrame)
         date_key = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
         hook.get_conn.assert_called_with(self.database)
         hook.mock_cursor.execute.assert_any_call("set airflow.ctx.dag_id=test_dag_id")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why

Since `HiveServer2Hook`'s `get_df` has its own overwrite which would be used by `Amazon/transfer`, we need a more precise overload like previously added in `common-sql` to prevent the union type issue.

## How

- add overload for `get_df`
- add type assertion in unit test


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
