### PR TITLE
Skip NoneType start/end times when computing data interval for events

### DIFF
--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -214,8 +214,10 @@ class DatasetTriggeredTimetable(_TrivialTimetable):
         start_dates, end_dates = [], []
         for event in events:
             if event.source_dag_run is not None:
-                start_dates.append(event.source_dag_run.data_interval_start)
-                end_dates.append(event.source_dag_run.data_interval_end)
+                if event.source_dag_run.data_interval_start is not None:
+                    start_dates.append(event.source_dag_run.data_interval_start)
+                if event.source_dag_run.data_interval_end is not None:
+                    end_dates.append(event.source_dag_run.data_interval_end)
             else:
                 start_dates.append(event.timestamp)
                 end_dates.append(event.timestamp)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Apache Airflow version
2.10.2 (GCP Composer v2)

What happened?
During DAG execution, especially under out-of-capacity conditions, the `start_date` and `end_date` fields may be missing. This causes the Airflow Scheduler on GCP to fail during recovery, resulting in the following error:

```
File ".../airflow/timetables/simple.py, ... in data_interval_for_events"
"TypeError: '<' not supported between instances of 'datetime.datetime' and 'NoneType'"
```

What you think should happen instead?
The function should validate the presence of both start_date and end_date before attempting to compute the minimum and maximum timestamps. Missing values should be skipped to prevent scheduler crashes.

How to reproduce:
Create a DAG run entry in the Airflow metadata database with a NULL (empty) start_date or end_date. When this DAG run is processed, the scheduler will raise a TypeError.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
