### PR TITLE
add readiness and liveliness support for git sync relay sidecars

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -309,6 +309,12 @@ If release name contains chart name it will be used as a full name.
     {{- toYaml . | nindent 4 }}
     {{- end }}
   resources: {{ toYaml .Values.dags.gitSync.resources | nindent 4 }}
+  {{- if and .Values.dags.gitSync.livenessProbe (not .is_init) }}
+  livenessProbe: {{ tpl (toYaml .Values.dags.gitSync.livenessProbe) . | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.dags.gitSync.readinessProbe (not .is_init) }}
+  readinessProbe: {{ tpl (toYaml .Values.dags.gitSync.readinessProbe) . | nindent 4 }}
+  {{- end }}
   volumeMounts:
   - name: dags
     mountPath: /git

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -8814,6 +8814,16 @@
                                 }
                             ]
                         },
+                        "livenessProbe": {
+                           "description": "Liveness probe configuration for git sync container.",
+                           "type": "object",
+                           "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "readinessProbe": {
+                           "description": "Readiness probe configuration for git sync container.",
+                           "type": "object",
+                           "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+                        },
                         "emptyDirConfig": {
                             "description": "Configuration for dags empty dir volume.",
                             "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -8815,14 +8815,14 @@
                             ]
                         },
                         "livenessProbe": {
-                           "description": "Liveness probe configuration for git sync container.",
-                           "type": "object",
-                           "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+                            "description": "Liveness probe configuration for git sync container.",
+                            "type": "object",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
                         },
                         "readinessProbe": {
-                           "description": "Readiness probe configuration for git sync container.",
-                           "type": "object",
-                           "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+                            "description": "Readiness probe configuration for git sync container.",
+                            "type": "object",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
                         },
                         "emptyDirConfig": {
                             "description": "Configuration for dags empty dir volume.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2899,6 +2899,9 @@ dags:
     # container level lifecycle hooks
     containerLifecycleHooks: {}
 
+    readinessProbe: {}
+    livenessProbe: {}
+
     # Mount additional volumes into git-sync. It can be templated like in the following example:
     #   extraVolumeMounts:
     #     - name: my-templated-extra-volume

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -435,7 +435,7 @@ class TestGitSyncSchedulerTest:
                         "livenessProbe": livenessProbe,
                         "readinessProbe": readinessProbe,
                     },
-                }
+                },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -428,6 +428,7 @@ class TestGitSyncSchedulerTest:
         }
         docs = render_chart(
             values={
+                "airflowVersion": "2.10.5",
                 "dags": {
                     "gitSync": {
                         "enabled": True,

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -408,3 +408,45 @@ class TestGitSyncSchedulerTest:
             jmespath.search("spec.template.spec.containers[1].resources.requests.memory", docs[0]) == "169Mi"
         )
         assert jmespath.search("spec.template.spec.containers[1].resources.requests.cpu", docs[0]) == "300m"
+
+    def test_liveliness_and_readiness_probes_are_configurable(self):
+        livenessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        readinessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "livenessProbe": livenessProbe,
+                        "readinessProbe": readinessProbe,
+                    },
+                }
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        container_search_result = jmespath.search(
+            "spec.template.spec.containers[?name == 'git-sync']", docs[0]
+        )
+        init_container_search_result = jmespath.search(
+            "spec.template.spec.initContainers[?name == 'git-sync-init']", docs[0]
+        )
+        assert "livenessProbe" in container_search_result[0]
+        assert "readinessProbe" in container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert livenessProbe == container_search_result[0]["livenessProbe"]
+        assert readinessProbe == container_search_result[0]["readinessProbe"]

--- a/helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py
@@ -76,3 +76,45 @@ class TestGitSyncTriggerer:
             "name": "git-sync-ssh-key",
             "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
+
+    def test_liveliness_and_readiness_probes_are_configurable(self):
+        livenessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        readinessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "livenessProbe": livenessProbe,
+                        "readinessProbe": readinessProbe,
+                    },
+                }
+            },
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+        container_search_result = jmespath.search(
+            "spec.template.spec.containers[?name == 'git-sync']", docs[0]
+        )
+        init_container_search_result = jmespath.search(
+            "spec.template.spec.initContainers[?name == 'git-sync-init']", docs[0]
+        )
+        assert "livenessProbe" in container_search_result[0]
+        assert "readinessProbe" in container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert livenessProbe == container_search_result[0]["livenessProbe"]
+        assert readinessProbe == container_search_result[0]["readinessProbe"]

--- a/helm-tests/tests/helm_tests/other/test_git_sync_webserver.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_webserver.py
@@ -196,3 +196,45 @@ class TestGitSyncWebserver:
             "name": "git-sync-ssh-key",
             "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
+
+    def test_liveliness_and_readiness_probes_are_configurable(self):
+        livenessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        readinessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "livenessProbe": livenessProbe,
+                        "readinessProbe": readinessProbe,
+                    },
+                }
+            },
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+        container_search_result = jmespath.search(
+            "spec.template.spec.containers[?name == 'git-sync']", docs[0]
+        )
+        init_container_search_result = jmespath.search(
+            "spec.template.spec.initContainers[?name == 'git-sync-init']", docs[0]
+        )
+        assert "livenessProbe" in container_search_result[0]
+        assert "readinessProbe" in container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert livenessProbe == container_search_result[0]["livenessProbe"]
+        assert readinessProbe == container_search_result[0]["readinessProbe"]

--- a/helm-tests/tests/helm_tests/other/test_git_sync_webserver.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_webserver.py
@@ -224,7 +224,7 @@ class TestGitSyncWebserver:
                         "livenessProbe": livenessProbe,
                         "readinessProbe": readinessProbe,
                     },
-                }
+                },
             },
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )

--- a/helm-tests/tests/helm_tests/other/test_git_sync_webserver.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_webserver.py
@@ -198,6 +198,7 @@ class TestGitSyncWebserver:
         } in jmespath.search("spec.template.spec.volumes", docs[0])
 
     def test_liveliness_and_readiness_probes_are_configurable(self):
+        """If Airflow < 2.0.0 - test git sync related containers, volume mounts & volumes are created."""
         livenessProbe = {
             "failureThreshold": 10,
             "exec": {"command": ["/bin/true"]},
@@ -216,6 +217,7 @@ class TestGitSyncWebserver:
         }
         docs = render_chart(
             values={
+                "airflowVersion": "1.10.14",
                 "dags": {
                     "gitSync": {
                         "enabled": True,

--- a/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
@@ -201,6 +201,7 @@ class TestGitSyncWorker:
             },
             "preStop": {"exec": {"command": ["/bin/sh", "-c", "echo preStop handler > /git/message_start"]}},
         }
+
     def test_liveliness_and_readiness_probes_are_configurable(self):
         livenessProbe = {
             "failureThreshold": 10,

--- a/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
@@ -201,3 +201,44 @@ class TestGitSyncWorker:
             },
             "preStop": {"exec": {"command": ["/bin/sh", "-c", "echo preStop handler > /git/message_start"]}},
         }
+    def test_liveliness_and_readiness_probes_are_configurable(self):
+        livenessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        readinessProbe = {
+            "failureThreshold": 10,
+            "exec": {"command": ["/bin/true"]},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "timeoutSeconds": 5,
+        }
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "livenessProbe": livenessProbe,
+                        "readinessProbe": readinessProbe,
+                    },
+                }
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        container_search_result = jmespath.search(
+            "spec.template.spec.containers[?name == 'git-sync']", docs[0]
+        )
+        init_container_search_result = jmespath.search(
+            "spec.template.spec.initContainers[?name == 'git-sync-init']", docs[0]
+        )
+        assert "livenessProbe" in container_search_result[0]
+        assert "readinessProbe" in container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert "readinessProbe" not in init_container_search_result[0]
+        assert livenessProbe == container_search_result[0]["livenessProbe"]
+        assert readinessProbe == container_search_result[0]["readinessProbe"]


### PR DESCRIPTION
**PR Description**

This PR adds support for liveliness and readiness probe configuration to airflow sidecar container when gitsync is enabled  and additional adds a skip condition for git sync initContainers which does not support probes as per kubernetes schema

Motivation
This is quite useful in places where companies has strict requirement of defining probes in all containers