### PR TITLE
Adding upper bound to openlineage in optional dependencies for all providers

### DIFF
--- a/providers/apache/spark/pyproject.toml
+++ b/providers/apache/spark/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "apache-airflow-providers-cncf-kubernetes>=7.4.0",
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]

--- a/providers/common/compat/pyproject.toml
+++ b/providers/common/compat/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 "standard" = [
     "apache-airflow-providers-standard"

--- a/providers/common/io/pyproject.toml
+++ b/providers/common/io/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "apache-airflow-providers-common-compat"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]

--- a/providers/common/sql/pyproject.toml
+++ b/providers/common/sql/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "pandas>=2.1.2,<2.2",
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 "polars" = [
     "polars>=1.26.0"

--- a/providers/ftp/pyproject.toml
+++ b/providers/ftp/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "apache-airflow-providers-common-compat"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -187,7 +187,7 @@ dependencies = [
     "apache-airflow-providers-mysql"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 "postgres" = [
     "apache-airflow-providers-postgres"

--- a/providers/microsoft/mssql/pyproject.toml
+++ b/providers/microsoft/mssql/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]

--- a/providers/mysql/pyproject.toml
+++ b/providers/mysql/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "apache-airflow-providers-amazon"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 "presto" = [
     "apache-airflow-providers-presto"

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "apache-airflow-providers-amazon>=2.6.0",
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]

--- a/providers/sftp/pyproject.toml
+++ b/providers/sftp/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "apache-airflow-providers-common-compat"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]

--- a/providers/trino/pyproject.toml
+++ b/providers/trino/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "apache-airflow-providers-google"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage"
+    "apache-airflow-providers-openlineage>=2.3.0"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Docker build is failing with error:
```
  #57 23.38   Preparing metadata (pyproject.toml): finished with status 'done'
  #57 23.38 INFO: pip is looking at multiple versions of apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv] to determine which version is compatible with other requirements. This could take a while.
  #57 23.39 ERROR: Cannot install apache-airflow-providers-openlineage 2.2.0 (from /docker-context-files/apache_airflow_providers_openlineage-2.2.0-py3-none-any.whl) and apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.0 because these package versions have conflicting dependencies.
  #57 23.39 
  #57 23.39 The conflict is caused by:
  #57 23.39     The user requested apache-airflow-providers-openlineage 2.2.0 (from /docker-context-files/apache_airflow_providers_openlineage-2.2.0-py3-none-any.whl)
  #57 23.39     apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv] 3.1.0 depends on apache-airflow-providers-openlineage>=2.3.0; extra == "openlineage"
  #57 23.39 
  #57 23.39 To fix this you could try to:
  #57 23.39 1. loosen the range of package versions you've specified
  #57 23.39 2. remove package versions to allow pip to attempt to solve the dependency conflict
  #57 23.39 
  #57 23.39 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
  #57 ERROR: process "/bin/bash -o pipefail -o errexit -o nounset -o nolog -c if [[ ${INSTALL_DISTRIBUTIONS_FROM_CONTEXT} == \"true\" ]]; then         bash /scripts/docker/install_from_docker_context_files.sh;     fi;     if ! airflow version 2>/dev/null >/dev/null; then         bash /scripts/docker/install_airflow_when_building_images.sh;     fi;     if [[ -n \"${ADDITIONAL_PYTHON_DEPS}\" ]]; then         bash /scripts/docker/install_additional_dependencies.sh;     fi;     find \"${AIRFLOW_USER_HOME_DIR}/.local/\" -name '*.pyc' -print0 | xargs -0 rm -f || true ;     find \"${AIRFLOW_USER_HOME_DIR}/.local/\" -type d -name '__pycache__' -print0 | xargs -0 rm -rf || true ;     find \"${AIRFLOW_USER_HOME_DIR}/.local\" -executable ! -type l -print0 | xargs --null chmod g+x;     find \"${AIRFLOW_USER_HOME_DIR}/.local\" ! -type l -print0 | xargs --null chmod g+rw" did not complete successfully: exit code: 1
  ------
   > [airflow-build-image 15/16] RUN --mount=type=cache,id=prod-amd64-9,target=/tmp/.cache/,uid=50000     if [[ true == "true" ]]; then         bash /scripts/docker/install_from_docker_context_files.sh;     fi;     if ! airflow version 2>/dev/null >/dev/null; then         bash /scripts/docker/install_airflow_when_building_images.sh;     fi;     if [[ -n "" ]]; then         bash /scripts/docker/install_additional_dependencies.sh;     fi;     find "/home/airflow/.local/" -name '*.pyc' -print0 | xargs -0 rm -f || true ;     find "/home/airflow/.local/" -type d -name '__pycache__' -print0 | xargs -0 rm -rf || true ;     find "/home/airflow/.local" -executable ! -type l -print0 | xargs --null chmod g+x;     find "/home/airflow/.local" ! -type l -print0 | xargs --null chmod g+rw:
  23.39 
  23.39 The conflict is caused by:
  23.39     The user requested apache-airflow-providers-openlineage 2.2.0 (from /docker-context-files/apache_airflow_providers_openlineage-2.2.0-py3-none-any.whl)
  23.39     apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv] 3.1.0 depends on apache-airflow-providers-openlineage>=2.3.0; extra == "openlineage"
```

Added in https://github.com/apache/airflow/pull/49237 but probably not for all providers.

Example: https://github.com/apache/airflow/actions/runs/14852598445/job/41699559748?pr=50224


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
