### PR TITLE
docs(ruff): fix outdated content and add airflow rule list, ruff configuration links

### DIFF
--- a/airflow-core/docs/best-practices.rst
+++ b/airflow-core/docs/best-practices.rst
@@ -303,11 +303,7 @@ Code Quality and Linting
 
 Maintaining high code quality is essential for the reliability and maintainability of your Airflow workflows. Utilizing linting tools can help identify potential issues and enforce coding standards. One such tool is ``ruff``, a fast Python linter that now includes specific rules for Airflow.
 
-ruff assists in detecting deprecated features and patterns that may affect your migration to Airflow 3.0. For instance, it includes rules prefixed with ``AIR`` to flag potential issues:
-
-- **AIR301**: Flags DAGs without an explicit ``schedule`` argument.
-- **AIR302**: Identifies usage of deprecated ``schedule_interval`` parameter.
-- **AIR303**: Detects imports from modules that have been relocated or removed in Airflow 3.0.
+ruff assists in detecting deprecated features and patterns that may affect your migration to Airflow 3.0. For instance, it includes rules prefixed with ``AIR`` to flag potential issues. The full list is detailed in `Airflow (AIR) <https://docs.astral.sh/ruff/rules/#airflow-air>`_.
 
 Installing and Using ruff
 -------------------------
@@ -316,13 +312,13 @@ Installing and Using ruff
 
    .. code-block:: bash
 
-      pip install "ruff>=0.9.5"
+      pip install "ruff>=0.11.6"
 
 2. **Running ruff**: Execute ``ruff`` to check your dags for potential issues:
 
    .. code-block:: bash
 
-      ruff check dags/ --select AIR301,AIR302,AIR303
+      ruff check dags/ --select AIR3 --preview
 
    This command will analyze your dags located in the ``dags/`` directory and report any issues related to the specified rules.
 

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -70,6 +70,9 @@ Some changes can be automatically fixed. To do so, run the following command:
 
     ruff check dag/ --select AIR301 --fix --preview
 
+
+You can also configure these flags through configuration files. See `Configuring Ruff <Configuring Ruff>`_ for details.
+
 Step 4: Install the Standard Providers
 --------------------------------------
 


### PR DESCRIPTION
## Why
Some of the ruff related content is outdated or missing.

## What
Update the outdated content and point those information to ruff pages

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
