### PR TITLE
Fix operator overflow in graph

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -63,7 +63,7 @@ export const TaskNode = ({
           }}
           taskInstance={taskInstance}
         >
-          <Flex
+          <Box
             // Alternate background color for nested open groups
             bg={isOpen && depth !== undefined && depth % 2 === 0 ? "bg.muted" : "bg"}
             borderColor={
@@ -73,51 +73,58 @@ export const TaskNode = ({
             borderWidth={isSelected ? 4 : 2}
             height={`${height + (isSelected ? 4 : 0)}px`}
             justifyContent="space-between"
+            overflow="hidden"
+            position="relative"
             px={isSelected ? 1 : 2}
             py={isSelected ? 0 : 1}
             width={`${width + (isSelected ? 4 : 0)}px`}
           >
-            <Box>
-              <LinkOverlay asChild>
-                <TaskLink
-                  childCount={taskInstance?.task_count}
-                  id={id}
-                  isGroup={isGroup}
-                  isMapped={isMapped}
-                  isOpen={isOpen}
-                  label={label}
-                  setupTeardownType={setupTeardownType}
-                />
-              </LinkOverlay>
-              <Text color="fg.muted" fontSize="sm" textTransform="capitalize">
-                {isGroup ? "Task Group" : operator}
-              </Text>
-              {taskInstance === undefined ? undefined : (
-                <HStack>
-                  <StateBadge fontSize="xs" state={taskInstance.state}>
-                    {taskInstance.state}
-                  </StateBadge>
-                  {taskInstance.try_number > 1 ? <CgRedo /> : undefined}
-                </HStack>
-              )}
-            </Box>
-            <Box>
-              {isGroup ? (
-                <Button
-                  colorPalette="blue"
-                  cursor="pointer"
-                  height="inherit"
-                  onClick={onClick}
-                  pb={2}
-                  pr={0}
-                  variant="plain"
-                >
-                  {isOpen ? "- " : "+ "}
-                  {pluralize("task", childCount, undefined, false)}
-                </Button>
-              ) : undefined}
-            </Box>
-          </Flex>
+            <LinkOverlay asChild>
+              <TaskLink
+                childCount={taskInstance?.task_count}
+                id={id}
+                isGroup={isGroup}
+                isMapped={isMapped}
+                isOpen={isOpen}
+                label={label}
+                setupTeardownType={setupTeardownType}
+              />
+            </LinkOverlay>
+            <Text
+              color="fg.muted"
+              fontSize="sm"
+              overflow="hidden"
+              textOverflow="ellipsis"
+              textTransform="capitalize"
+              whiteSpace="nowrap"
+            >
+              {isGroup ? "Task Group" : operator}
+            </Text>
+            {taskInstance === undefined ? undefined : (
+              <HStack>
+                <StateBadge fontSize="xs" state={taskInstance.state}>
+                  {taskInstance.state}
+                </StateBadge>
+                {taskInstance.try_number > 1 ? <CgRedo /> : undefined}
+              </HStack>
+            )}
+            {isGroup ? (
+              <Button
+                colorPalette="blue"
+                cursor="pointer"
+                height={8}
+                onClick={onClick}
+                position="absolute"
+                px={1}
+                right={0}
+                top={0}
+                variant="plain"
+              >
+                {isOpen ? "- " : "+ "}
+                {pluralize("task", childCount, undefined, false)}
+              </Button>
+            ) : undefined}
+          </Box>
         </TaskInstanceTooltip>
         {Boolean(isMapped) || Boolean(isGroup && !isOpen) ? (
           <>


### PR DESCRIPTION
Really long operator names were overflowing outside their Task node. Instead, let's make an ellipsis and users can click on a task to see the full name in the details panel.

<img width="573" alt="Screenshot 2025-05-06 at 10 04 07 AM" src="https://github.com/user-attachments/assets/f22803b4-8c31-4a15-8532-d3bd6619d637" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
