### PR TITLE
Pass mapIndex to clear the relevant task instances similar to dry run.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -131,7 +131,7 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
                     include_past: past,
                     include_upstream: upstream,
                     only_failed: onlyFailed,
-                    task_ids: [taskId],
+                    task_ids: [[taskId, mapIndex]],
                   },
                 });
                 if (note !== taskInstance.note) {

--- a/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
@@ -60,15 +60,14 @@ export const useClearTaskInstances = ({
         (variables.requestBody.task_ids ?? [])
           .filter((taskId) => typeof taskId === "string" || Array.isArray(taskId))
           .map((taskId) => {
-            const actualTaskId = Array.isArray(taskId) ? taskId[0] : taskId;
+            const [actualTaskId, mapIndex] = Array.isArray(taskId) ? taskId : [taskId, undefined];
             const runId = variables.requestBody.dag_run_id;
 
             if (runId === null || runId === undefined) {
               return undefined;
             }
 
-            // TODO: update mapIndex when the endpoint supports clearing mapped tasks
-            const params = { dagId, dagRunId: runId, mapIndex: -1, taskId: actualTaskId };
+            const params = { dagId, dagRunId: runId, mapIndex: mapIndex ?? -1, taskId: actualTaskId };
 
             return UseTaskInstanceServiceGetMappedTaskInstanceKeyFn(params);
           })


### PR DESCRIPTION
In #49307 `mapIndex` was passed to `dry_run` to filter the relevant mapped task. But the actual clearing of the tasks was missing `mapIndex` thus the dry_run returned correct information for confirmation yet the confirmation cleared all mapped instances of the task. This patch passes the `mapIndex` to clearing too and also clears the relevant query cache for refresh.