### PR TITLE
fix(#46978) - kubernetes cleanup-pods CLI command only available in KubernetesExecutor

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Cleanup Pods CronJob
 #################################
-{{- if .Values.cleanup.enabled }}
+{{- if and .Values.cleanup.enabled (contains "KubernetesExecutor" .Values.executor) }}
 {{- $nodeSelector := or .Values.cleanup.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.cleanup.affinity .Values.affinity }}
 {{- $tolerations := or .Values.cleanup.tolerations .Values.tolerations }}

--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Cleanup ServiceAccount
 #################################
-{{- if and .Values.cleanup.serviceAccount.create .Values.cleanup.enabled }}
+{{- if and .Values.cleanup.serviceAccount.create .Values.cleanup.enabled (contains "KubernetesExecutor" .Values.executor) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.cleanup.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #46978
related: #ISSUE



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

fix(#46978) - kubernetes cleanup-pods CLI command only available in KubernetesExecutor

Error log when using Celery:
```bash
+ airflow-cleanup-29107800-sqlxx › airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods [2025-05-05T18:00:08.641+0000] {stats.py:42} ERROR - Could not configure StatsClient: [Errno -3] Temporary failure in name resolution, using NoStatsLogger instead.
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods Usage: airflow [-h] GROUP_OR_COMMAND ...
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods Positional Arguments:
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods   GROUP_OR_COMMAND
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods     Groups
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       assets            Manage assets
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       backfill          Manage backfills
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       celery            Celery components
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       config            View configuration
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       connections       Manage connections
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       dags              Manage DAGs
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       db                Database operations
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       fab-db            Manage FAB
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       jobs              Manage jobs
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       pools             Manage pools
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       providers         Display providers
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       roles             Manage roles
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       tasks             Manage tasks
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       users             Manage users
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       variables         Manage variables
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods     Commands:
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       api-server        Start an Airflow API server instance
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       cheat-sheet       Display cheat sheet
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       dag-processor     Start a dag processor instance
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       info              Show information about current Airflow and environment
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       kerberos          Start a kerberos ticket renewer
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       plugins           Dump information about loaded plugins
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       rotate-fernet-key
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods                         Rotate encrypted connection credentials and variables
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       scheduler         Start a scheduler instance
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       standalone        Run an all-in-one copy of Airflow
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       sync-perm         Update permissions for existing roles and optionally
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods                         DAGs
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       triggerer         Start a triggerer instance
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods       version           Show the version
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods Options:
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods   -h, --help            show this help message and exit
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods
airflow-cleanup-29107800-sqlxx airflow-cleanup-pods airflow command error: argument GROUP_OR_COMMAND: invalid choice: 'kubernetes' (choose from api-server, assets, backfill, celery, cheat-sheet, config, connections, dag-processor, dags, db, fab-db, info, jobs, kerberos, plugins, pools, providers, roles, rotate-fernet-key, scheduler, standalone, sync-perm, tasks, triggerer, users, variables, version), see help above.
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
