### PR TITLE
Fix next asset schedule and dag card UX

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Stat.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Stat.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Heading, type StackProps, VStack } from "@chakra-ui/react";
+import { Center, Heading, type StackProps, VStack } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 
 type Props = {
@@ -25,9 +25,9 @@ type Props = {
 
 export const Stat = ({ children, label, ...rest }: Props) => (
   <VStack align="flex-start" gap={1} {...rest}>
-    <Heading color="fg.muted" fontSize="xs">
+    <Heading color="fg.muted" fontSize="xs" lineHeight="1.25rem">
       {label}
     </Heading>
-    {children}
+    <Center height="100%">{children}</Center>
   </VStack>
 );

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -59,7 +59,7 @@ export const AssetSchedule = ({ dag }: Props) => {
     return (
       <HStack>
         <FiDatabase style={{ display: "inline" }} />
-        <Link asChild color="fg.info" display="block" py={2}>
+        <Link asChild color="fg.info" display="block" fontSize="sm">
           <RouterLink to={`/assets/${asset.id}`}>{asset.name ?? asset.uri}</RouterLink>
         </Link>
       </HStack>
@@ -79,7 +79,10 @@ export const AssetSchedule = ({ dag }: Props) => {
       <Popover.Content css={{ "--popover-bg": "colors.bg.emphasized" }} width="fit-content">
         <Popover.Arrow />
         <Popover.Body>
-          <AssetExpression events={pendingEvents} expression={dag.asset_expression as ExpressionType} />
+          <AssetExpression
+            events={pendingEvents}
+            expression={(nextRun?.asset_expression ?? dag.asset_expression) as ExpressionType}
+          />
         </Popover.Body>
       </Popover.Content>
     </Popover.Root>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -43,7 +43,7 @@ export const DagCard = ({ dag }: Props) => {
 
   return (
     <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden">
-      <Flex alignItems="center" bg="bg.muted" justifyContent="space-between" px={3} py={2}>
+      <Flex alignItems="center" bg="bg.muted" justifyContent="space-between" px={3} py={1}>
         <HStack>
           <Tooltip content={dag.description} disabled={!Boolean(dag.description)}>
             <Link asChild color="fg.info" fontWeight="bold">
@@ -63,7 +63,7 @@ export const DagCard = ({ dag }: Props) => {
           <DeleteDagButton dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} withText={false} />
         </HStack>
       </Flex>
-      <SimpleGrid columns={4} gap={1} height={20} px={3}>
+      <SimpleGrid columns={4} gap={1} height={20} px={3} py={1}>
         <Stat label="Schedule">
           <Schedule dag={dag} />
         </Stat>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 export const Schedule = ({ dag }: Props) =>
   Boolean(dag.timetable_summary) ? (
-    Boolean(dag.asset_expression) ? (
+    Boolean(dag.asset_expression) || dag.timetable_summary === "Asset" ? (
       <AssetSchedule dag={dag} />
     ) : (
       <Tooltip content={dag.timetable_description}>


### PR DESCRIPTION
Sometimes asset_expression on /dags wasn't working even if next run assets did. Added extra checks to always show the asset_expression in the UI.

Also, fixed some spacing in the dag card to make Stats fit better when wrapping.


Closes: https://github.com/apache/airflow/issues/47786


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
