### PR TITLE
Update deprecated functions to use stable functions

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -399,7 +399,7 @@ class DbApiHook(BaseHook):
         :param parameters: The parameters to render the SQL query with.
         :param kwargs: (optional) passed into pandas.io.sql.read_sql method
         """
-        return self._get_pandas_df(sql, parameters, **kwargs)
+        return self.get_df(sql, parameters, df_type="pandas", **kwargs)
 
     @deprecated(
         reason="Replaced by function `get_df_by_chunks`.",
@@ -414,7 +414,7 @@ class DbApiHook(BaseHook):
         chunksize: int,
         **kwargs,
     ) -> Generator[PandasDataFrame, None, None]:
-        return self._get_pandas_df_by_chunks(sql, parameters, chunksize=chunksize, **kwargs)
+        return self.get_df_by_chunks(sql, parameters, chunksize=chunksize, df_type="pandas", **kwargs)
 
     @overload
     def get_df(

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -313,11 +313,16 @@ class TestDbApiHook:
     @pytest.mark.parametrize(
         "df_type, expected_type",
         [
+            ("test_default_df_type", pd.DataFrame),
             ("pandas", pd.DataFrame),
             ("polars", pl.DataFrame),
         ],
     )
     def test_get_df_with_df_type(db, df_type, expected_type):
         dbapi_hook = mock_db_hook(DbApiHook)
-        df = dbapi_hook.get_df("SQL", df_type=df_type)
-        assert isinstance(df, expected_type)
+        if df_type == "test_default_df_type":
+            df = dbapi_hook.get_df("SQL")
+            assert isinstance(df, pd.DataFrame)
+        else:
+            df = dbapi_hook.get_df("SQL", df_type=df_type)
+            assert isinstance(df, expected_type)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

https://github.com/apache/airflow/pull/50161

## Why

Since we now have more robust type definition, we could use the public functions instead of private functions without breaking the type check for deprecated functions, which ensures backward compatibility and follows a better coding style.

## How

- replace private functions with public functions for deprecated functions
- minor changes: add default `df_type` test  for `get_df`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
