### PR TITLE
Add basic json check to variable value

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Field, HStack, Input, Spacer, Textarea } from "@chakra-ui/react";
+import { Box, Field, HStack, Input, Spacer, Textarea, Text } from "@chakra-ui/react";
 import { Controller, useForm } from "react-hook-form";
 import { FiSave } from "react-icons/fi";
 
@@ -27,6 +27,16 @@ export type VariableBody = {
   description: string | undefined;
   key: string;
   value: string;
+};
+
+const isJsonString = (string: string) => {
+  try {
+    JSON.parse(string);
+  } catch {
+    return false;
+  }
+
+  return true;
 };
 
 type VariableFormProps = {
@@ -80,14 +90,28 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
       <Controller
         control={control}
         name="value"
-        render={({ field }) => (
-          <Field.Root mt={4}>
-            <Field.Label fontSize="md">
-              Value <Field.RequiredIndicator />
-            </Field.Label>
-            <Textarea {...field} size="sm" />
-          </Field.Root>
-        )}
+        render={({ field, fieldState }) => {
+          const showJsonWarning =
+            field.value.startsWith("{") || field.value.startsWith("[") ? !isJsonString(field.value) : false;
+
+          return (
+            <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
+              <Field.Label fontSize="md">
+                Value <Field.RequiredIndicator />
+              </Field.Label>
+              <Textarea {...field} size="sm" />
+              {showJsonWarning ? (
+                <Text color="fg.warning" fontSize="xs">
+                  Invalid JSON
+                </Text>
+              ) : undefined}
+              {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
+            </Field.Root>
+          );
+        }}
+        rules={{
+          required: "Value is required",
+        }}
       />
 
       <Controller


### PR DESCRIPTION
We don't know if a Variable value is going to be json, but if it starts with `{` or `[` we can at least try to check and show the user a warning they can choose to listen to or not.

Also, made sure the value was actually a required field.

Closes https://github.com/apache/airflow/issues/27157

See the difference between an error and a warning:
<img width="898" alt="Screenshot 2025-05-06 at 3 30 50 PM" src="https://github.com/user-attachments/assets/801c823a-8564-49cb-9ae4-08f34829d7d5" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
