### PR TITLE
Ability to request shutdown of a remote edge worker

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -114,7 +114,7 @@ _worker_queue_doc = Body(
 
 
 def redefine_state(worker_state: EdgeWorkerState, body_state: EdgeWorkerState) -> EdgeWorkerState:
-    """Redefine the state of the worker based on maintenance request."""
+    """Redefine the state of the worker based on maintenance or shutdown request."""
     if (
         worker_state == EdgeWorkerState.MAINTENANCE_REQUEST
         and body_state
@@ -132,6 +132,14 @@ def redefine_state(worker_state: EdgeWorkerState, body_state: EdgeWorkerState) -
             return EdgeWorkerState.RUNNING
         if body_state == EdgeWorkerState.MAINTENANCE_MODE:
             return EdgeWorkerState.IDLE
+
+    if worker_state == EdgeWorkerState.SHUTDOWN_REQUEST:
+        if body_state not in (
+            EdgeWorkerState.OFFLINE_MAINTENANCE,
+            EdgeWorkerState.OFFLINE,
+            EdgeWorkerState.UNKNOWN,
+        ):
+            return EdgeWorkerState.SHUTDOWN_REQUEST
 
     return body_state
 


### PR DESCRIPTION
When running on distributed clusters, there is often a need to shutdown certain edge workers running on remote hosts. Today this requires you to ssh to the host, identify the pid file and run `airflow edge stop`. This PR addresses the inconvenience by adding the ability to request a safe shutdown of the remote worker. 

You should now be able run `airflow edge shutdown-remote-edge-worker -H worker_name` and the worker will automatically enter the shutdown routine
