### PR TITLE
Show last asset event in assets list

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -27,6 +27,7 @@ import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
+import Time from "src/components/Time";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { CreateAssetEvent } from "src/pages/Asset/CreateAssetEvent";
 import { pluralize } from "src/utils";
@@ -44,6 +45,24 @@ const columns: Array<ColumnDef<AssetResponse>> = [
       </Link>
     ),
     header: () => "Name",
+  },
+  {
+    accessorKey: "last_asset_event",
+    cell: ({ row: { original } }: AssetRow) => {
+      const assetEvent = "last_asset_event" in original ? original.last_asset_event : undefined;
+      const timestamp =
+        assetEvent !== undefined && assetEvent !== null && "timestamp" in assetEvent
+          ? assetEvent.timestamp
+          : undefined;
+
+      if (timestamp === null || timestamp === undefined) {
+        return undefined;
+      }
+
+      return <Time datetime={timestamp} />;
+    },
+    enableSorting: false,
+    header: () => "Last Asset Event",
   },
   {
     accessorKey: "group",

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -49,11 +49,8 @@ const columns: Array<ColumnDef<AssetResponse>> = [
   {
     accessorKey: "last_asset_event",
     cell: ({ row: { original } }: AssetRow) => {
-      const assetEvent = "last_asset_event" in original ? original.last_asset_event : undefined;
-      const timestamp =
-        assetEvent !== undefined && assetEvent !== null && "timestamp" in assetEvent
-          ? assetEvent.timestamp
-          : undefined;
+      const assetEvent = original.last_asset_event;
+      const timestamp = assetEvent?.timestamp;
 
       if (timestamp === null || timestamp === undefined) {
         return undefined;


### PR DESCRIPTION
UI portion to https://github.com/apache/airflow/issues/47164


<img width="636" alt="Screenshot 2025-05-06 at 4 27 46 PM" src="https://github.com/user-attachments/assets/149fa22b-9f28-420e-bbf2-6a232bfb249b" />


When the API supports it, we will add sorting and filtering too



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
