### PR TITLE
docs: Update oauth keycloak example with new security manager

### DIFF
--- a/providers/fab/docs/auth-manager/webserver-authentication.rst
+++ b/providers/fab/docs/auth-manager/webserver-authentication.rst
@@ -288,7 +288,7 @@ Here is an example of what you might have in your webserver_config.py:
       def get_oauth_user_info(self, provider, response):
           if provider == "keycloak":
               token = response["access_token"]
-              me = jwt.decode(token, public_key, algorithms=["HS256", "RS256"])
+              me = jwt.decode(token, public_key, algorithms=["HS256", "RS256"], audience="account")
 
               # Extract roles from resource access
               realm_access = me.get("realm_access", {})

--- a/providers/fab/docs/auth-manager/webserver-authentication.rst
+++ b/providers/fab/docs/auth-manager/webserver-authentication.rst
@@ -232,15 +232,15 @@ Here is an example of what you might have in your webserver_config.py:
 
 .. code-block:: python
 
-  import os
-  import jwt
-  import requests
   import logging
   from base64 import b64decode
+
+  import jwt
+  import requests
   from cryptography.hazmat.primitives import serialization
-  from flask_appbuilder.security.manager import AUTH_DB, AUTH_OAUTH
-  from airflow import configuration as conf
-  from airflow.www.security import AirflowSecurityManager
+  from flask_appbuilder.security.manager import AUTH_OAUTH
+
+  from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
   log = logging.getLogger(__name__)
 
@@ -284,7 +284,7 @@ Here is an example of what you might have in your webserver_config.py:
   public_key = serialization.load_der_public_key(key_der)
 
 
-  class CustomSecurityManager(AirflowSecurityManager):
+  class CustomSecurityManager(FabAirflowSecurityManagerOverride):
       def get_oauth_user_info(self, provider, response):
           if provider == "keycloak":
               token = response["access_token"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

When trying to setup Airflow 3.0.0 with OAuth through keycloak locally, I noticed that the relevant code example in the documentation has not been updated for the new security manager introduced with Airflow 3.0.0. This MR should fix this. The proposed changes have been tested successfully.

I will make a separate MR to add the `webserver_config.py` to the api server in the helm chart as this is a bigger set of changes.
