### PR TITLE
Minor typo-fix in doc

### DIFF
--- a/airflow-core/src/airflow/cli/commands/daemon_utils.py
+++ b/airflow-core/src/airflow/cli/commands/daemon_utils.py
@@ -45,7 +45,7 @@ def run_command_with_daemon_option(
     :param callback: the actual command to run with or without daemon context
     :param should_setup_logging: if true, then a log file handler for the daemon process will be created
     :param umask: file access creation mask ("umask") to set for the process on daemon start
-    :param pid_file: if specified, this file path us used to store daemon process PID.
+    :param pid_file: if specified, this file path is used to store daemon process PID.
         If not specified, a file path is generated with the default pattern.
     """
     if args.daemon:


### PR DESCRIPTION
Found minor typo in daemon params documentation
