### PR TITLE
Port `dag.test` to Task SDK

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -225,7 +225,11 @@ class InProcessExecutionAPI:
     def app(self):
         if not self._app:
             from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
-            from airflow.api_fastapi.execution_api.deps import JWTBearerDep, JWTRefresherDep
+            from airflow.api_fastapi.execution_api.deps import (
+                JWTBearerDep,
+                JWTBearerTIPathDep,
+                JWTRefresherDep,
+            )
             from airflow.api_fastapi.execution_api.routes.connections import has_connection_access
             from airflow.api_fastapi.execution_api.routes.variables import has_variable_access
             from airflow.api_fastapi.execution_api.routes.xcoms import has_xcom_access
@@ -235,6 +239,7 @@ class InProcessExecutionAPI:
             async def always_allow(): ...
 
             self._app.dependency_overrides[JWTBearerDep.dependency] = always_allow
+            self._app.dependency_overrides[JWTBearerTIPathDep.dependency] = always_allow
             self._app.dependency_overrides[JWTRefresherDep.dependency] = always_allow
             self._app.dependency_overrides[has_connection_access] = always_allow
             self._app.dependency_overrides[has_variable_access] = always_allow

--- a/airflow-core/src/airflow/api_fastapi/execution_api/deps.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/deps.py
@@ -96,6 +96,9 @@ class JWTBearer(HTTPBearer):
 
 JWTBearerDep: TIToken = Depends(JWTBearer())
 
+# This checks that the UUID in the url matches the one in the token for us.
+JWTBearerTIPathDep = Depends(JWTBearer(path_param_name="task_instance_id"))
+
 
 class JWTReissuer:
     """Re-issue JWTs to requests when they are about to run out."""

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -25,7 +25,7 @@ from uuid import UUID
 
 import structlog
 from cadwyn import VersionedAPIRouter
-from fastapi import Body, Depends, HTTPException, Query, status
+from fastapi import Body, HTTPException, Query, status
 from pydantic import JsonValue
 from sqlalchemy import func, or_, tuple_, update
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
@@ -50,7 +50,7 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
     TISuccessStatePayload,
     TITerminalStatePayload,
 )
-from airflow.api_fastapi.execution_api.deps import JWTBearer
+from airflow.api_fastapi.execution_api.deps import JWTBearerTIPathDep
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun as DR
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
@@ -70,7 +70,7 @@ router = VersionedAPIRouter()
 ti_id_router = VersionedAPIRouter(
     dependencies=[
         # This checks that the UUID in the url matches the one in the token for us.
-        Depends(JWTBearer(path_param_name="task_instance_id")),
+        JWTBearerTIPathDep
     ]
 )
 

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -644,7 +644,6 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
         run_conf=run_conf,
         use_executor=use_executor,
         mark_success_pattern=mark_success_pattern,
-        session=session,
     )
     show_dagrun = args.show_dagrun
     imgcat = args.imgcat_dagrun

--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -33,8 +33,9 @@ from airflow.cli.simple_table import AirflowConsole
 from airflow.cli.utils import fetch_dag_run_from_run_id_or_logical_date_string
 from airflow.exceptions import DagRunNotFound, TaskDeferred, TaskInstanceNotFound
 from airflow.models import TaskInstance
-from airflow.models.dag import DAG, _run_inline_trigger
+from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
+from airflow.sdk.definitions.dag import _run_inline_trigger
 from airflow.sdk.definitions.param import ParamsDict
 from airflow.sdk.execution_time.secrets_masker import RedactedIO
 from airflow.ti_deps.dep_context import DepContext

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -161,7 +161,11 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
 
     callbacks = callbacks if isinstance(callbacks, list) else [callbacks]
     # TODO:We need a proper context object!
-    context: Context = {}  # type: ignore[assignment]
+    context: Context = {  # type: ignore[assignment]
+        "dag": dag,
+        "run_id": request.run_id,
+        "reason": request.msg,
+    }
 
     for callback in callbacks:
         log.info(

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -17,20 +17,14 @@
 # under the License.
 from __future__ import annotations
 
-import asyncio
 import copy
 import functools
 import logging
 import re
-import sys
-import time
 from collections import defaultdict
 from collections.abc import Collection, Generator, Iterable, Sequence
-from contextlib import ExitStack
 from datetime import datetime, timedelta
 from functools import cache
-from pathlib import Path
-from re import Pattern
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -70,14 +64,12 @@ from sqlalchemy.sql import Select, expression
 
 from airflow import settings, utils
 from airflow.assets.evaluation import AssetEvaluator
-from airflow.configuration import conf as airflow_conf, secrets_backend_list
+from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import (
     AirflowException,
-    TaskDeferred,
     UnknownExecutorException,
 )
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.executors.workloads import BundleInfo
 from airflow.models.asset import (
     AssetDagRunQueue,
     AssetModel,
@@ -95,9 +87,7 @@ from airflow.models.tasklog import LogTemplate
 from airflow.sdk import TaskGroup
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, BaseAsset
 from airflow.sdk.definitions.dag import DAG as TaskSDKDag, dag as task_sdk_dag_decorator
-from airflow.secrets.local_filesystem import LocalFilesystemBackend
 from airflow.settings import json
-from airflow.stats import Stats
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
 from airflow.timetables.simple import (
@@ -111,7 +101,7 @@ from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, lock_rows, with_row_locks
-from airflow.utils.state import DagRunState, State, TaskInstanceState
+from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
@@ -121,7 +111,6 @@ if TYPE_CHECKING:
 
     from airflow.models.dagbag import DagBag
     from airflow.models.operator import Operator
-    from airflow.sdk.definitions._internal.abstractoperator import TaskStateChangeCallback
     from airflow.serialization.serialized_objects import MaybeSerializedDAG
     from airflow.typing_compat import Literal
 
@@ -776,89 +765,6 @@ class DAG(TaskSDKDag, LoggingMixin):
     def get_serialized_fields(cls):
         """Stringified DAGs and operators contain exactly these fields."""
         return TaskSDKDag.get_serialized_fields() | {"_processor_dags_folder"}
-
-    @staticmethod
-    @provide_session
-    def fetch_callback(
-        dag: DAG,
-        run_id: str,
-        success: bool = True,
-        reason: str | None = None,
-        *,
-        session: Session = NEW_SESSION,
-    ) -> tuple[list[TaskStateChangeCallback], Context] | None:
-        """
-        Fetch the appropriate callbacks depending on the value of success.
-
-        This method gets the context of a single TaskInstance part of this DagRun and returns it along
-        the list of callbacks.
-
-        :param dag: DAG object
-        :param run_id: The DAG run ID
-        :param success: Flag to specify if failure or success callback should be called
-        :param reason: Completion reason
-        :param session: Database session
-        """
-        callbacks = dag.on_success_callback if success else dag.on_failure_callback
-        if callbacks:
-            dagrun = DAG.fetch_dagrun(dag_id=dag.dag_id, run_id=run_id, session=session)
-            callbacks = callbacks if isinstance(callbacks, list) else [callbacks]
-            tis = dagrun.get_task_instances(session=session)
-            # tis from a dagrun may not be a part of dag.partial_subset,
-            # since dag.partial_subset is a subset of the dag.
-            # This ensures that we will only use the accessible TI
-            # context for the callback.
-            if dag.partial:
-                tis = [ti for ti in tis if not ti.state == State.NONE]
-            # filter out removed tasks
-            tis = [ti for ti in tis if ti.state != TaskInstanceState.REMOVED]
-            ti = tis[-1]  # get first TaskInstance of DagRun
-            ti.task = dag.get_task(ti.task_id)
-            context = ti.get_template_context(session=session)
-            context["reason"] = reason
-            return callbacks, context
-        return None
-
-    @provide_session
-    def handle_callback(self, dagrun: DagRun, success=True, reason=None, session=NEW_SESSION):
-        """
-        Triggers on_failure_callback or on_success_callback as appropriate.
-
-        This method gets the context of a single TaskInstance part of this DagRun
-        and passes that to the callable along with a 'reason', primarily to
-        differentiate DagRun failures.
-
-        .. note: The logs end up in
-            ``$AIRFLOW_HOME/logs/scheduler/latest/PROJECT/DAG_FILE.py.log``
-
-        :param dagrun: DagRun object
-        :param success: Flag to specify if failure or success callback should be called
-        :param reason: Completion reason
-        :param session: Database session
-        """
-        callbacks, context = DAG.fetch_callback(
-            dag=self, run_id=dagrun.run_id, success=success, reason=reason, session=session
-        ) or (None, None)
-
-        DAG.execute_callback(callbacks, context, self.dag_id)
-
-    @classmethod
-    def execute_callback(cls, callbacks: list[Callable] | None, context: Context | None, dag_id: str):
-        """
-        Triggers the callbacks with the given context.
-
-        :param callbacks: List of callbacks to call
-        :param context: Context to pass to all callbacks
-        :param dag_id: The dag_id of the DAG to find.
-        """
-        if callbacks and context:
-            for callback in callbacks:
-                cls.logger().info("Executing dag callback function: %s", callback)
-                try:
-                    callback(context)
-                except Exception:
-                    cls.logger().exception("failed to invoke dag state update callback")
-                    Stats.incr("dag.callback_exceptions", tags={"dag_id": dag_id})
 
     def get_active_runs(self):
         """
@@ -1602,188 +1508,6 @@ class DAG(TaskSDKDag, LoggingMixin):
         parser = cli_parser.get_parser(dag_parser=True)
         args = parser.parse_args()
         args.func(args, self)
-
-    @provide_session
-    def test(
-        self,
-        run_after: datetime | None = None,
-        logical_date: datetime | None = None,
-        run_conf: dict[str, Any] | None = None,
-        conn_file_path: str | None = None,
-        variable_file_path: str | None = None,
-        use_executor: bool = False,
-        mark_success_pattern: Pattern | str | None = None,
-        session: Session = NEW_SESSION,
-    ) -> DagRun:
-        """
-        Execute one single DagRun for a given DAG and logical date.
-
-        :param run_after: the datetime before which to Dag cannot run.
-        :param logical_date: logical date for the DAG run
-        :param run_conf: configuration to pass to newly created dagrun
-        :param conn_file_path: file path to a connection file in either yaml or json
-        :param variable_file_path: file path to a variable file in either yaml or json
-        :param use_executor: if set, uses an executor to test the DAG
-        :param mark_success_pattern: regex of task_ids to mark as success instead of running
-        :param session: database connection (optional)
-        """
-        from airflow.serialization.serialized_objects import SerializedDAG
-
-        def add_logger_if_needed(ti: TaskInstance):
-            """
-            Add a formatted logger to the task instance.
-
-            This allows all logs to surface to the command line, instead of into
-            a task file. Since this is a local test run, it is much better for
-            the user to see logs in the command line, rather than needing to
-            search for a log file.
-
-            :param ti: The task instance that will receive a logger.
-            """
-            format = logging.Formatter("[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s")
-            handler = logging.StreamHandler(sys.stdout)
-            handler.level = logging.INFO
-            handler.setFormatter(format)
-            # only add log handler once
-            if not any(isinstance(h, logging.StreamHandler) for h in ti.log.handlers):
-                self.log.debug("Adding Streamhandler to taskinstance %s", ti.task_id)
-                ti.log.addHandler(handler)
-
-        exit_stack = ExitStack()
-        if conn_file_path or variable_file_path:
-            local_secrets = LocalFilesystemBackend(
-                variables_file_path=variable_file_path, connections_file_path=conn_file_path
-            )
-            secrets_backend_list.insert(0, local_secrets)
-            exit_stack.callback(lambda: secrets_backend_list.pop(0))
-
-        with exit_stack:
-            self.validate()
-            self.log.debug("Clearing existing task instances for logical date %s", logical_date)
-            self.clear(
-                start_date=logical_date,
-                end_date=logical_date,
-                dag_run_state=False,  # type: ignore
-                session=session,
-            )
-            self.log.debug("Getting dagrun for dag %s", self.dag_id)
-            logical_date = timezone.coerce_datetime(logical_date)
-            run_after = timezone.coerce_datetime(run_after) or timezone.coerce_datetime(timezone.utcnow())
-            data_interval = (
-                self.timetable.infer_manual_data_interval(run_after=logical_date) if logical_date else None
-            )
-            scheduler_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(self))
-
-            dr: DagRun = _get_or_create_dagrun(
-                dag=scheduler_dag,
-                start_date=logical_date or run_after,
-                logical_date=logical_date,
-                data_interval=data_interval,
-                run_after=run_after,
-                run_id=DagRun.generate_run_id(
-                    run_type=DagRunType.MANUAL,
-                    logical_date=logical_date,
-                    run_after=run_after,
-                ),
-                session=session,
-                conf=run_conf,
-                triggered_by=DagRunTriggeredByType.TEST,
-            )
-            # Start a mock span so that one is present and not started downstream. We
-            # don't care about otel in dag.test and starting the span during dagrun update
-            # is not functioning properly in this context anyway.
-            dr.start_dr_spans_if_needed(tis=[])
-
-            tasks = self.task_dict
-            self.log.debug("starting dagrun")
-            # Instead of starting a scheduler, we run the minimal loop possible to check
-            # for task readiness and dependency management.
-
-            # ``Dag.test()`` works in two different modes depending on ``use_executor``:
-            # - if ``use_executor`` is False, runs the task locally with no executor using ``_run_task``
-            # - if ``use_executor`` is True, sends the task instances to the executor with
-            #   ``BaseExecutor.queue_task_instance``
-            if use_executor:
-                from airflow.models.dagbag import DagBag
-
-                dag_bag = DagBag()
-                dag_bag.bag_dag(self)
-
-                executor = ExecutorLoader.get_default_executor()
-                executor.start()
-
-            while dr.state == DagRunState.RUNNING:
-                session.expire_all()
-                schedulable_tis, _ = dr.update_state(session=session)
-                for s in schedulable_tis:
-                    if s.state != TaskInstanceState.UP_FOR_RESCHEDULE:
-                        s.try_number += 1
-                    s.state = TaskInstanceState.SCHEDULED
-                    s.scheduled_dttm = timezone.utcnow()
-                session.commit()
-                # triggerer may mark tasks scheduled so we read from DB
-                all_tis = set(dr.get_task_instances(session=session))
-                scheduled_tis = {x for x in all_tis if x.state == TaskInstanceState.SCHEDULED}
-                ids_unrunnable = {x for x in all_tis if x.state not in State.finished} - scheduled_tis
-                if not scheduled_tis and ids_unrunnable:
-                    self.log.warning("No tasks to run. unrunnable tasks: %s", ids_unrunnable)
-                    time.sleep(1)
-
-                triggerer_running = _triggerer_is_healthy(session)
-                for ti in scheduled_tis:
-                    ti.task = tasks[ti.task_id]
-
-                    mark_success = (
-                        re.compile(mark_success_pattern).fullmatch(ti.task_id) is not None
-                        if mark_success_pattern is not None
-                        else False
-                    )
-
-                    if use_executor:
-                        if executor.has_task(ti):
-                            continue
-                        # TODO: Task-SDK: This check is transitionary. Remove once all executors are ported over.
-                        from airflow.executors import workloads
-                        from airflow.executors.base_executor import BaseExecutor
-
-                        if executor.queue_workload.__func__ is not BaseExecutor.queue_workload:  # type: ignore[attr-defined]
-                            workload = workloads.ExecuteTask.make(
-                                ti,
-                                dag_rel_path=Path(self.fileloc),
-                                generator=executor.jwt_generator,
-                                # For the system test/debug purpose, we use the default bundle which uses
-                                # local file system. If it turns out to be a feature people want, we could
-                                # plumb the Bundle to use as a parameter to dag.test
-                                bundle_info=BundleInfo(name="dags-folder"),
-                            )
-                            executor.queue_workload(workload, session=session)
-                            ti.state = TaskInstanceState.QUEUED
-                            session.commit()
-                        else:
-                            # Send the task to the executor
-                            executor.queue_task_instance(ti, ignore_ti_state=True)
-                    else:
-                        # Run the task locally
-                        try:
-                            add_logger_if_needed(ti)
-                            _run_task(
-                                ti=ti,
-                                inline_trigger=not triggerer_running,
-                                session=session,
-                                mark_success=mark_success,
-                            )
-                        except Exception:
-                            self.log.exception("Task failed; ti=%s", ti)
-                if use_executor:
-                    executor.heartbeat()
-                    from airflow.jobs.scheduler_job_runner import SchedulerDagBag, SchedulerJobRunner
-
-                    SchedulerJobRunner.process_executor_events(
-                        executor=executor, job_id=None, scheduler_dag_bag=SchedulerDagBag(), session=session
-                    )
-            if use_executor:
-                executor.end()
-        return dr
 
     @provide_session
     def create_dagrun(
@@ -2533,47 +2257,6 @@ if STATICA_HACK:  # pragma: no cover
 
     DagModel.serialized_dag = relationship(SerializedDagModel)
     """:sphinx-autoapi-skip:"""
-
-
-def _run_inline_trigger(trigger):
-    async def _run_inline_trigger_main():
-        # We can replace it with `return await anext(trigger.run(), default=None)`
-        # when we drop support for Python 3.9
-        try:
-            return await trigger.run().__anext__()
-        except StopAsyncIteration:
-            return None
-
-    return asyncio.run(_run_inline_trigger_main())
-
-
-def _run_task(
-    *, ti: TaskInstance, inline_trigger: bool = False, mark_success: bool = False, session: Session
-):
-    """
-    Run a single task instance, and push result to Xcom for downstream tasks.
-
-    Bypasses a lot of extra steps used in `task.run` to keep our local running as fast as
-    possible.  This function is only meant for the `dag.test` function as a helper function.
-
-    Args:
-        ti: TaskInstance to run
-    """
-    log.info("[DAG TEST] starting task_id=%s map_index=%s", ti.task_id, ti.map_index)
-    while True:
-        try:
-            log.info("[DAG TEST] running task %s", ti)
-            ti._run_raw_task(session=session, raise_on_defer=inline_trigger, mark_success=mark_success)
-            break
-        except TaskDeferred as e:
-            log.info("[DAG TEST] running trigger in line")
-            event = _run_inline_trigger(e.trigger)
-            ti.next_method = e.method_name
-            ti.next_kwargs = {"event": event.payload} if event else e.kwargs
-            log.info("[DAG TEST] Trigger completed")
-        session.merge(ti)
-        session.commit()
-    log.info("[DAG TEST] end task task_id=%s map_index=%s", ti.task_id, ti.map_index)
 
 
 def _get_or_create_dagrun(

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -1031,7 +1031,7 @@ class TestDag:
         assert dag_run.state == State.RUNNING
         assert dag_run.run_type != DagRunType.MANUAL
 
-    @patch("airflow.models.dag.Stats")
+    @patch("airflow.models.dagrun.Stats")
     def test_dag_handle_callback_crash(self, mock_stats):
         """
         Tests avoid crashes from calling dag callbacks exceptions
@@ -1062,8 +1062,8 @@ class TestDag:
             )
 
             # should not raise any exception
-            dag.handle_callback(dag_run, success=False)
-            dag.handle_callback(dag_run, success=True)
+        dag_run.handle_dag_callback(dag=dag, success=False)
+        dag_run.handle_dag_callback(dag=dag, success=True)
 
         mock_stats.incr.assert_called_with(
             "dag.callback_exceptions",
@@ -1102,8 +1102,8 @@ class TestDag:
             assert dag_run.get_task_instance(task_removed.task_id).state == TaskInstanceState.REMOVED
 
             # should not raise any exception
-            dag.handle_callback(dag_run, success=True)
-            dag.handle_callback(dag_run, success=False)
+            dag_run.handle_dag_callback(dag=dag, success=False)
+            dag_run.handle_dag_callback(dag=dag, success=True)
 
     @pytest.mark.parametrize("catchup,expected_next_dagrun", [(True, DEFAULT_DATE), (False, None)])
     def test_next_dagrun_after_fake_scheduled_previous(self, catchup, expected_next_dagrun):
@@ -1507,8 +1507,8 @@ class TestDag:
             mock_handle_object_1(f"task {ti.task_id} failed...")
 
         def handle_dag_failure(context):
-            ti = context["task_instance"]
-            mock_handle_object_2(f"dag {ti.dag_id} run failed...")
+            dag_id = context["dag"].dag_id
+            mock_handle_object_2(f"dag {dag_id} run failed...")
 
         dag = DAG(
             dag_id="test_local_testing_conn_file",

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -835,7 +835,7 @@ def run(
                 return state, msg, error
 
             try:
-                result = _execute_task(context, ti, log)
+                result = _execute_task(context=context, ti=ti, log=log)
             except Exception:
                 import jinja2
 
@@ -886,7 +886,7 @@ def run(
         )
         state = TaskInstanceState.FAILED
         error = e
-    except (AirflowTaskTimeout, AirflowException) as e:
+    except (AirflowTaskTimeout, AirflowException, AirflowRuntimeError) as e:
         # We should allow retries if the task has defined it.
         log.exception("Task failed with exception")
         msg, state = _handle_current_task_failed(ti)


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/45549

### DAGs used to test

Filename: `example_simplest_dag.py`
```py
from airflow.sdk import Variable, dag, task

@dag
def example_simplest_dag():
    @task
    def my_task():
        print("hellooo")
        assert Variable.get("my_variabe") == "my_value"

    my_task()


d = example_simplest_dag()

if __name__ == "__main__":
    d.test()
```

Result:

<img width="1720" alt="image" src="https://github.com/user-attachments/assets/8d17e6ba-17ee-4b8d-aceb-4f085c08a307" />


Async DAG:

Filename: `example_time_delta_sensor_async.py`
```py
import datetime
import pendulum

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.providers.standard.sensors.time_delta import TimeDeltaSensorAsync
from airflow.sdk import DAG

with DAG(
    dag_id="example_time_delta_sensor_async",
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
) as dag:
    wait = TimeDeltaSensorAsync(task_id="wait", delta=datetime.timedelta(seconds=5))
    finish = EmptyOperator(task_id="finish")
    wait >> finish

if __name__ == "__main__":
    dag.test()

```

Result:
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/dd3838f9-5730-47fd-bff0-e13ecfe011b2" />

 ### Testing

I will add some more tests, but the existing tests (that use dag.test) are sufficient and catch most of the issues. Longer-term we should have Task SDK Integration/system tests that allow accessing DB. The current Task SDK unit test does not allow any DB interaction so tests can't go there.

 ### TODO

- [x] Support `use_executor` on `dag.test`. It is used in system tests (based on https://github.com/apache/airflow/pull/48699)
- [x] Handle DAG level callbacks
- [x] Handle `fail_fast`, which currently relies on the DAG being present in the `serialized_dag` table.  
      Since we skip `task_runner.parse` in `dag.test()`, the DAG is not auto-serialized.
      https://github.com/apache/airflow/blob/952a004a6bb2c68d8d2743a3d96b5ce184889dd7/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py#L374-L378
      Possible fix to add the following in `dag.test()`:

     ```py
      from airflow.models.serialized_dag import SerializedDagModel as SDM
      SDM.write_dag(dag=self, bundle_name="test")
     ```

 ### Future Enhancements

1. Replace `ti.run` & `TI._run_raw_task` implementation to use this code so we can nuke a lot of code in models.TaskInstance to completely remove a separate execution pathlogs, API server logs etc
2. Better logging format to differentiate between Task 
3. Not have to rely on DB access entirely

I will do (1) in the next few weeks as that is a big change too (affecting all providers) and (1) and (2) will be deferred for later.
