### PR TITLE
Adding deprecation notice for get_current_context in std provider

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import textwrap
 import types
+import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, Container, Iterable, Mapping, Sequence
 from functools import cache
@@ -38,6 +39,7 @@ import lazy_object_proxy
 from airflow.exceptions import (
     AirflowConfigException,
     AirflowException,
+    AirflowProviderDeprecationWarning,
     AirflowSkipException,
     DeserializingResultError,
 )
@@ -1113,6 +1115,13 @@ def get_current_context() -> Mapping[str, Any]:
     was starting to execute.
     """
     if AIRFLOW_V_3_0_PLUS:
+        warnings.warn(
+            "Using get_current_context from standard provider is deprecated and will be removed."
+            "Please import `from airflow.sdk import get_current_context` and use it instead.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
+
         from airflow.sdk import get_current_context
 
         return get_current_context()

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1811,14 +1811,21 @@ class TestBranchExternalPythonOperator(BaseTestBranchPythonVirtualenvOperator):
 
 class TestCurrentContext:
     def test_current_context_no_context_raise(self):
-        with pytest.warns(AirflowProviderDeprecationWarning):
+        if AIRFLOW_V_3_0_PLUS:
+            with pytest.warns(AirflowProviderDeprecationWarning):
+                with pytest.raises(RuntimeError):
+                    get_current_context()
+        else:
             with pytest.raises(RuntimeError):
                 get_current_context()
 
     def test_current_context_roundtrip(self):
         example_context = {"Hello": "World"}
         with set_current_context(example_context):
-            with pytest.warns(AirflowProviderDeprecationWarning):
+            if AIRFLOW_V_3_0_PLUS:
+                with pytest.warns(AirflowProviderDeprecationWarning):
+                    assert get_current_context() == example_context
+            else:
                 assert get_current_context() == example_context
 
     def test_context_removed_after_exit(self):
@@ -1826,7 +1833,11 @@ class TestCurrentContext:
 
         with set_current_context(example_context):
             pass
-        with pytest.warns(AirflowProviderDeprecationWarning):
+        if AIRFLOW_V_3_0_PLUS:
+            with pytest.warns(AirflowProviderDeprecationWarning):
+                with pytest.raises(RuntimeError):
+                    get_current_context()
+        else:
             with pytest.raises(RuntimeError):
                 get_current_context()
 
@@ -1845,7 +1856,15 @@ class TestCurrentContext:
             ctx_obj = set_current_context(new_context)
             ctx_obj.__enter__()
             ctx_list.append(ctx_obj)
-        with pytest.warns(AirflowProviderDeprecationWarning):
+        if AIRFLOW_V_3_0_PLUS:
+            with pytest.warns(AirflowProviderDeprecationWarning):
+                for i in reversed(range(max_stack_depth)):
+                    # Iterate over contexts in reverse order - stack is LIFO
+                    ctx = get_current_context()
+                    assert ctx["ContextId"] == i
+                    # End of with statement
+                    ctx_list[i].__exit__(None, None, None)
+        else:
             for i in reversed(range(max_stack_depth)):
                 # Iterate over contexts in reverse order - stack is LIFO
                 ctx = get_current_context()
@@ -1893,13 +1912,19 @@ class TestCurrentContextRuntime:
     def test_context_in_task(self):
         with DAG(dag_id="assert_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = MyContextAssertOperator(task_id="assert_context")
-            with pytest.warns(AirflowProviderDeprecationWarning):
+            if AIRFLOW_V_3_0_PLUS:
+                with pytest.warns(AirflowProviderDeprecationWarning):
+                    op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+            else:
                 op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
 
     def test_get_context_in_old_style_context_task(self):
         with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = PythonOperator(python_callable=get_all_the_context, task_id="get_all_the_context")
-            with pytest.warns(AirflowProviderDeprecationWarning):
+            if AIRFLOW_V_3_0_PLUS:
+                with pytest.warns(AirflowProviderDeprecationWarning):
+                    op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+            else:
                 op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
 
 

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1893,12 +1893,14 @@ class TestCurrentContextRuntime:
     def test_context_in_task(self):
         with DAG(dag_id="assert_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = MyContextAssertOperator(task_id="assert_context")
-            op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+            with pytest.warns(AirflowProviderDeprecationWarning):
+                op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
 
     def test_get_context_in_old_style_context_task(self):
         with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = PythonOperator(python_callable=get_all_the_context, task_id="get_all_the_context")
-            op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+            with pytest.warns(AirflowProviderDeprecationWarning):
+                op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
 
 
 @pytest.mark.need_serialized_dag(False)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Ideally, we should be nuking this away from the provider in the next provider wave (major) and use it from task SDK. This will eventually go away when we decouple sdk and core and providers can truly depend on sdk.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
