### PR TITLE
Move map index column

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -22,6 +22,7 @@ import { useParams } from "react-router-dom";
 import {
   useDagRunServiceGetDagRun,
   useDagServiceGetDagDetails,
+  useTaskInstanceServiceGetMappedTaskInstance,
   useTaskServiceGetTask,
 } from "openapi/queries";
 import { BreadcrumbStats } from "src/components/BreadcrumbStats";
@@ -51,6 +52,12 @@ export const DagBreadcrumb = () => {
   );
 
   const { data: task } = useTaskServiceGetTask({ dagId, taskId }, undefined, { enabled: Boolean(taskId) });
+
+  const { data: mappedTaskInstance } = useTaskInstanceServiceGetMappedTaskInstance(
+    { dagId, dagRunId: runId ?? "", mapIndex: parseInt(mapIndex, 10), taskId: taskId ?? "" },
+    undefined,
+    { enabled: Boolean(runId) && Boolean(taskId) && mapIndex !== "-1" },
+  );
 
   const links: Array<{ label: ReactNode | string; labelExtra?: ReactNode; title?: string; value?: string }> =
     [
@@ -101,7 +108,7 @@ export const DagBreadcrumb = () => {
   }
 
   if (mapIndex !== "-1") {
-    links.push({ label: mapIndex, title: "Map Index" });
+    links.push({ label: mappedTaskInstance?.rendered_map_index ?? mapIndex, title: "Map Index" });
   }
 
   return <BreadcrumbStats links={links} />;

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -98,6 +98,10 @@ const taskInstanceColumns = (
         },
       ]),
   {
+    accessorKey: "rendered_map_index",
+    header: "Map Index",
+  },
+  {
     accessorKey: "state",
     cell: ({
       row: {
@@ -124,10 +128,6 @@ const taskInstanceColumns = (
     accessorKey: "end_date",
     cell: ({ row: { original } }) => <Time datetime={original.end_date} />,
     header: "End Date",
-  },
-  {
-    accessorKey: "rendered_map_index",
-    header: "Map Index",
   },
   {
     accessorKey: "try_number",


### PR DESCRIPTION
Move the map_index column to be in line with dag_id, run_id, task_id, and to appear first when viewing a summary mapped tasks on a run.

Also, show the rendered_map_index in the breadcrumb

<img width="1260" alt="Screenshot 2025-05-07 at 9 12 56 AM" src="https://github.com/user-attachments/assets/845a3bf0-1650-49d9-8bb3-273209e43c64" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
