### PR TITLE
[v2-11-test] Fix Incorrect Log URL

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2274,7 +2274,7 @@ class TaskInstance(Base, LoggingMixin):
     def log_url(self) -> str:
         """Log URL for TaskInstance."""
         run_id = quote(self.run_id)
-        base_date = quote(self.execution_date.strftime("%Y-%m-%dT%H:%M:%S%z"))
+        base_date = quote(self.execution_date.strftime("%Y-%m-%dT%H:%M:%S.%f%z"))
         base_url = conf.get_mandatory_value("webserver", "BASE_URL")
         map_index = f"&map_index={self.map_index}" if self.map_index >= 0 else ""
         return (

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2095,7 +2095,7 @@ class TestTaskInstance:
             "/dags/my_dag/grid"
             "?dag_run_id=test"
             "&task_id=op"
-            "&base_date=2018-01-01T00%3A00%3A00%2B0000"
+            "&base_date=2018-01-01T00%3A00%3A000000%2B0000"
             "&tab=logs"
         )
         assert ti.log_url == expected_url

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2095,7 +2095,7 @@ class TestTaskInstance:
             "/dags/my_dag/grid"
             "?dag_run_id=test"
             "&task_id=op"
-            "&base_date=2018-01-01T00%3A00%3A000000%2B0000"
+            "&base_date=2018-01-01T00%3A00%3A00.000000%2B0000"
             "&tab=logs"
         )
         assert ti.log_url == expected_url


### PR DESCRIPTION

closes: #46547

## What

Fix `TaskInstance. log_url` timestamp format from `"%Y-%m-%dT%H:%M:%S%z"` to `"%Y-%m-%dT%H:%M:%S.%f%z"`
