### PR TITLE
Fixes DagProcessor stats log | process duration changed to use time.monotonic

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -679,7 +679,7 @@ class DagFileProcessorManager(LoggingMixin):
 
         rows = []
         utcnow = timezone.utcnow()
-        now = time.time()
+        now = time.monotonic()
 
         for files in known_files.values():
             for file in files:
@@ -806,7 +806,7 @@ class DagFileProcessorManager(LoggingMixin):
 
             # Collect the DAGS and import errors into the DB, emit metrics etc.
             self._file_stats[file] = process_parse_results(
-                run_duration=time.time() - proc.start_time,
+                run_duration=time.monotonic() - proc.start_time,
                 finish_time=timezone.utcnow(),
                 run_count=self._file_stats[file].run_count,
                 bundle_name=file.bundle_name,


### PR DESCRIPTION
### Fixes #50317
### Why
Log statement 

DAG File Processing stats captured 'Current Duration' and 'Last Duration' and was using `time.time()` to calculate the duration of processing a DAG , [PR ](https://github.com/apache/airflow/pull/49868) changed to `time.monotonic()` for process start_time and then the log statement stated comparing unix timestamp to monotonic counter which gave wrong stats as shown below

<img width="1444" alt="Screenshot 2025-05-06 at 4 07 47 PM" src="https://github.com/user-attachments/assets/94b8102d-d0da-4862-a67a-c05a87b8fcf0" />


### Fix

This Fix changes the `time.time()` calls to use `time.monotonic()` and it fixes the issue as shown below:


<img width="1452" alt="Screenshot 2025-05-07 at 8 54 40 AM" src="https://github.com/user-attachments/assets/beb9a9f8-9feb-4f63-a198-9f81de2b84a5" />

