### PR TITLE
update recommendation for Airflow 3 upgrade

### DIFF
--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -23,7 +23,7 @@ Apache Airflow 3 is a major release and contains :ref:`breaking changes<breaking
 Step 1: Take care of prerequisites
 ----------------------------------
 
-- Make sure that you are on Airflow 2.7 or later.
+- Make sure that you are on Airflow 2.7 or later. It is recommended to upgrade to latest 2.x and then to Airflow 3.
 - Make sure that your Python version is in the supported list. Airflow 3.0.0 supports the following Python versions: Python 3.9, 3.10, 3.11 and 3.12.
 - Ensure that you are not using any features or functionality that have been :ref:`removed in Airflow 3<breaking-changes>`.
 


### PR DESCRIPTION
Clarify recommendation to upgrade from latest 2.x if possible.
The idea is that there is less risk of hitting breaking changes on providers.