### PR TITLE
fix(snowflake): infinite loop via moving the _get_conn_params call to drive class

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -200,11 +200,8 @@ class SnowflakeHook(DbApiHook):
 
         return account_identifier
 
-    def get_oauth_token(self, conn_config: dict | None = None) -> str:
+    def get_oauth_token(self, conn_config: dict) -> str:
         """Generate temporary OAuth access token using refresh token in connection details."""
-        if conn_config is None:
-            conn_config = self._get_conn_params
-
         url = f"{self.account_identifier}.snowflakecomputing.com/oauth/token-request"
 
         data = {

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -225,10 +225,13 @@ class SnowflakeSqlApiHook(SnowflakeHook):
     def get_oauth_token(self, conn_config: dict[str, Any] | None = None) -> str:
         """Generate temporary OAuth access token using refresh token in connection details."""
         warnings.warn(
-            "This method is deprecated. Please use `get_oauth_token` method from `SnowflakeHook` instead. ",
+            "This method is deprecated. Please use `get_oauth_token` method from `SnowflakeHook` instead.",
             AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
+        if conn_config is None:
+            conn_config = self._get_conn_params
+
         return super().get_oauth_token(conn_config=conn_config)
 
     def get_request_url_header_params(self, query_id: str) -> tuple[dict[str, Any], dict[str, Any], str]:


### PR DESCRIPTION
Bug introduced in: #49482
Moved the `_get_conn_params` call to the drive class (`SnowflakeSqlApiHook`)  since it was there in the first place. Now `SnowflakeSqlApiHook` is calling the `_get_conn_params`, but it is `_get_conn_params` calls from `super().get_oauth_token()` again, so it shouldn't do any infinite loops. The original method was added without None in the conn_config parameter, so converting that back since it isn't needed and is backwards compatible. At the worst case, it should call `super().get_oauth_token()` twice.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
