### PR TITLE
AIP-84: alias `dag_display_name` for `dag_version`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import computed_field
+from pydantic import AliasPath, Field, computed_field
 
 from airflow.api_fastapi.core_api.base import BaseModel
 from airflow.dag_processing.bundles.manager import DagBundlesManager
@@ -34,6 +34,7 @@ class DagVersionResponse(BaseModel):
     bundle_name: str | None
     bundle_version: str | None
     created_at: datetime
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))
 
     # Mypy issue https://github.com/python/mypy/issues/1362
     @computed_field  # type: ignore[misc]

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -193,7 +193,7 @@ class DAGDetailsResponse(DAGResponse):
     @property
     def latest_dag_version(self) -> DagVersionResponse | None:
         """Return the latest DagVersion."""
-        latest_dag_version = DagVersion.get_latest_version(self.dag_id)
+        latest_dag_version = DagVersion.get_latest_version(self.dag_id, load_dag_model=True)
         if latest_dag_version is None:
             return latest_dag_version
         return DagVersionResponse.model_validate(latest_dag_version)

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1285,6 +1285,9 @@ components:
           type: string
           format: date-time
           title: Created At
+        dag_display_name:
+          type: string
+          title: Dag Display Name
         bundle_url:
           anyOf:
           - type: string
@@ -1299,6 +1302,7 @@ components:
       - bundle_name
       - bundle_version
       - created_at
+      - dag_display_name
       - bundle_url
       title: DagVersionResponse
       description: Dag Version serializer for responses.

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v1-rest-api-generated.yaml
@@ -8843,6 +8843,9 @@ components:
           type: string
           format: date-time
           title: Created At
+        dag_display_name:
+          type: string
+          title: Dag Display Name
         bundle_url:
           anyOf:
           - type: string
@@ -8857,6 +8860,7 @@ components:
       - bundle_name
       - bundle_version
       - created_at
+      - dag_display_name
       - bundle_url
       title: DagVersionResponse
       description: Dag Version serializer for responses.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
@@ -20,6 +20,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
@@ -59,7 +60,11 @@ def get_dag_version(
     session: SessionDep,
 ) -> DagVersionResponse:
     """Get one Dag Version."""
-    dag_version = session.scalar(select(DagVersion).filter_by(dag_id=dag_id, version_number=version_number))
+    dag_version = session.scalar(
+        select(DagVersion)
+        .filter_by(dag_id=dag_id, version_number=version_number)
+        .options(joinedload(DagVersion.dag_model))
+    )
 
     if dag_version is None:
         raise HTTPException(
@@ -104,7 +109,7 @@ def get_dag_versions(
 
     This endpoint allows specifying `~` as the dag_id to retrieve DAG Versions for all DAGs.
     """
-    query = select(DagVersion)
+    query = select(DagVersion).options(joinedload(DagVersion.dag_model))
 
     if dag_id != "~":
         dag: DAG = dag_bag.get_dag(dag_id)

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2890,6 +2890,10 @@ export const $DagVersionResponse = {
       format: "date-time",
       title: "Created At",
     },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
+    },
     bundle_url: {
       anyOf: [
         {
@@ -2904,7 +2908,16 @@ export const $DagVersionResponse = {
     },
   },
   type: "object",
-  required: ["id", "version_number", "dag_id", "bundle_name", "bundle_version", "created_at", "bundle_url"],
+  required: [
+    "id",
+    "version_number",
+    "dag_id",
+    "bundle_name",
+    "bundle_version",
+    "created_at",
+    "dag_display_name",
+    "bundle_url",
+  ],
   title: "DagVersionResponse",
   description: "Dag Version serializer for responses.",
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -749,6 +749,7 @@ export type DagVersionResponse = {
   bundle_name: string | null;
   bundle_version: string | null;
   created_at: string;
+  dag_display_name: string;
   readonly bundle_url: string | null;
 };
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -61,6 +61,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                     "dag_id": "ANOTHER_DAG_ID",
                     "id": mock.ANY,
                     "version_number": 1,
+                    "dag_display_name": "ANOTHER_DAG_ID",
                 },
             ],
             [
@@ -74,6 +75,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
                     "version_number": 1,
+                    "dag_display_name": "dag_with_multiple_versions",
                 },
             ],
             [
@@ -87,6 +89,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
                     "version_number": 2,
+                    "dag_display_name": "dag_with_multiple_versions",
                 },
             ],
             [
@@ -100,6 +103,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
                     "dag_id": "dag_with_multiple_versions",
                     "id": mock.ANY,
                     "version_number": 3,
+                    "dag_display_name": "dag_with_multiple_versions",
                 },
             ],
         ],
@@ -144,6 +148,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "ANOTHER_DAG_ID",
                             "id": mock.ANY,
                             "version_number": 1,
+                            "dag_display_name": "ANOTHER_DAG_ID",
                         },
                         {
                             "bundle_name": "dag_maker",
@@ -153,6 +158,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
                             "version_number": 1,
+                            "dag_display_name": "dag_with_multiple_versions",
                         },
                         {
                             "bundle_name": "dag_maker",
@@ -162,6 +168,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
                             "version_number": 2,
+                            "dag_display_name": "dag_with_multiple_versions",
                         },
                         {
                             "bundle_name": "dag_maker",
@@ -171,6 +178,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
                             "version_number": 3,
+                            "dag_display_name": "dag_with_multiple_versions",
                         },
                     ],
                     "total_entries": 4,
@@ -188,6 +196,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
                             "version_number": 1,
+                            "dag_display_name": "dag_with_multiple_versions",
                         },
                         {
                             "bundle_name": "dag_maker",
@@ -197,6 +206,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
                             "version_number": 2,
+                            "dag_display_name": "dag_with_multiple_versions",
                         },
                         {
                             "bundle_name": "dag_maker",
@@ -206,6 +216,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
                             "dag_id": "dag_with_multiple_versions",
                             "id": mock.ANY,
                             "version_number": 3,
+                            "dag_display_name": "dag_with_multiple_versions",
                         },
                     ],
                     "total_entries": 3,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -448,6 +448,7 @@ class TestDagDetails(TestDagEndpoint):
                 "dag_id": "test_dag2",
                 "id": mock.ANY,
                 "version_number": 1,
+                "dag_display_name": dag_display_name,
             },
             "last_expired": None,
             "last_parsed": last_parsed,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -274,6 +274,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "id": mock.ANY,
                 "version_number": expected_version_number,
                 "dag_id": "dag_with_multiple_versions",
+                "dag_display_name": "dag_with_multiple_versions",
                 "bundle_name": "dag_maker",
                 "bundle_version": f"some_commit_hash{expected_version_number}",
                 "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
@@ -1976,6 +1977,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
                 "bundle_version": f"some_commit_hash{expected_version_number}",
                 "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
+                "dag_display_name": "dag_with_multiple_versions",
             },
         }
 
@@ -3044,6 +3046,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 "bundle_version": f"some_commit_hash{expected_version_number}",
                 "bundle_url": f"fakeprotocol://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
                 "created_at": mock.ANY,
+                "dag_display_name": "dag_with_multiple_versions",
             },
         }
 

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -443,6 +443,7 @@ class DagVersionResponse(BaseModel):
     bundle_name: Annotated[str | None, Field(title="Bundle Name")] = None
     bundle_version: Annotated[str | None, Field(title="Bundle Version")] = None
     created_at: Annotated[datetime, Field(title="Created At")]
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
     bundle_url: Annotated[str | None, Field(title="Bundle Url")] = None
 
 

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -527,6 +527,7 @@ class TestDagRunOperations:
                 bundle_name="bundle_name",
                 bundle_version="1",
                 created_at=datetime.datetime(2025, 1, 1, 0, 0, 0),
+                dag_display_name=dag_id,
             )
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this filea
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `dag_display_name` for `dag_version`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
