### PR TITLE
Edge worker maintenance state is remembered if worker crashes

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -122,7 +122,12 @@ def redefine_state(worker_state: EdgeWorkerState, body_state: EdgeWorkerState) -
             EdgeWorkerState.MAINTENANCE_PENDING,
             EdgeWorkerState.MAINTENANCE_MODE,
         )
-        or worker_state == EdgeWorkerState.OFFLINE_MAINTENANCE
+        or worker_state
+        in (
+            EdgeWorkerState.OFFLINE_MAINTENANCE,
+            EdgeWorkerState.MAINTENANCE_MODE,
+            EdgeWorkerState.MAINTENANCE_PENDING,
+        )
         and body_state == EdgeWorkerState.STARTING
     ):
         return EdgeWorkerState.MAINTENANCE_REQUEST

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
@@ -143,6 +143,24 @@ class TestWorkerApiRoutes:
                 EdgeWorkerState.MAINTENANCE_REQUEST,
                 id="maintenance_starting",
             ),
+            pytest.param(
+                EdgeWorkerState.MAINTENANCE_MODE,
+                EdgeWorkerState.STARTING,
+                EdgeWorkerState.MAINTENANCE_REQUEST,
+                id="maintenance_crash",
+            ),
+            pytest.param(
+                EdgeWorkerState.MAINTENANCE_PENDING,
+                EdgeWorkerState.STARTING,
+                EdgeWorkerState.MAINTENANCE_REQUEST,
+                id="maintenance_crash_2",
+            ),
+            pytest.param(
+                EdgeWorkerState.MAINTENANCE_REQUEST,
+                EdgeWorkerState.STARTING,
+                EdgeWorkerState.MAINTENANCE_REQUEST,
+                id="maintenance_crash_3",
+            ),
         ],
     )
     def test_redefine_state(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

If the worker is in maintenance mode, and crashes, or shut down NOT gracefully, then the state will remain in MAINTENANCE_MODE and later will be set to UNKNOWN by the executor. So in the end it will not be in OFFLINE_MAINTENANCE, which means, that during startup it will start normally instead of maintenance.
So 2 loigcs were modified to prevent this:

1. The executor will not set to unknown if the dead worker's last state is maintenance, but to OFFLINE_MAINTENANCE.
2. If the worker wants to register the STARTING state, but the previous state was maintenance or offline maintenance, then the state will remain maintenance


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
