### PR TITLE
Adding backcompat shim for BaseNotifier

### DIFF
--- a/airflow-core/src/airflow/notifications/__init__.py
+++ b/airflow-core/src/airflow/notifications/__init__.py
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,16 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-"""Re exporting the new notifier module from Task SDK for backward compatibility."""
+"""Airflow Notifiers."""
 
 from __future__ import annotations
 
-from airflow.sdk.bases.notifier import BaseNotifier as BaseNotifier
 from airflow.utils.deprecation_tools import add_deprecated_classes
 
 __deprecated_classes = {
-    "base": {
+    "basenotifier": {
         "BaseNotifier": "airflow.sdk.bases.notifier.BaseNotifier",
     },
 }

--- a/airflow-core/src/airflow/notifications/basenotifier.py
+++ b/airflow-core/src/airflow/notifications/basenotifier.py
@@ -20,3 +20,11 @@
 from __future__ import annotations
 
 from airflow.sdk.bases.notifier import BaseNotifier as BaseNotifier
+from airflow.utils.deprecation_tools import add_deprecated_classes
+
+__deprecated_classes = {
+    "base": {
+        "BaseNotifier": "airflow.sdk.bases.notifier.BaseNotifier",
+    },
+}
+add_deprecated_classes(__deprecated_classes, __name__)

--- a/airflow-core/src/airflow/notifications/basenotifier.py
+++ b/airflow-core/src/airflow/notifications/basenotifier.py
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Re exporting the new notifier module from Task SDK for backward compatibility."""
+
+from __future__ import annotations
+
+from airflow.sdk.bases.notifier import BaseNotifier as BaseNotifier

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -84,7 +84,7 @@ __lazy_imports: dict[str, str] = {
     "AssetAll": ".definitions.asset",
     "AssetAny": ".definitions.asset",
     "AssetWatcher": ".definitions.asset",
-    "BaseNotifier": ".definitions.notifier",
+    "BaseNotifier": ".bases.notifier",
     "BaseOperator": ".bases.operator",
     "BaseOperatorLink": ".bases.operatorlink",
     "BaseSensorOperator": ".bases.sensor",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Trying to import BaseNotifier from the older path in core reported in
```
(link_name, task.get_extra_links(ti, link_name)) for link_name in task.extra_links
  File "/opt/airflow/airflow-core/src/airflow/models/mappedoperator.py", line 177, in get_extra_links
    return link.get_link(self.unmap(None), ti_key=ti.key)
  File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/mappedoperator.py", line 772, in unmap
    SerializedBaseOperator.populate_operator(op, self.operator_class)
  File "/opt/airflow/airflow-core/src/airflow/serialization/serialized_objects.py", line 1348, in populate_operator
    and operator.__module__ == encoded_op["_task_module"]
KeyError: '_task_module'
```

We should maintain backcompat to allow seamless migration for end users.

Also interestingly the shorthand `from airflow.sdk import BaseNotifier` didn;t work. Fixed it in the PR too

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
