### PR TITLE
Migrate `BigQueryHook` to use `get_df`

### DIFF
--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -62,7 +62,7 @@ PIP package                                  Version required
 ===========================================  ======================================
 ``apache-airflow``                           ``>=2.10.0``
 ``apache-airflow-providers-common-compat``   ``>=1.4.0``
-``apache-airflow-providers-common-sql``      ``>=1.20.0``
+``apache-airflow-providers-common-sql``      ``>=1.27.0``
 ``asgiref``                                  ``>=3.5.2``
 ``dill``                                     ``>=0.2.3``
 ``gcloud-aio-auth``                          ``>=5.2.0``

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.4.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.27.0",
     "asgiref>=3.5.2",
     "dill>=0.2.3",
     "gcloud-aio-auth>=5.2.0",
@@ -129,11 +129,6 @@ dependencies = [
     # See https://github.com/looker-open-source/sdk-codegen/issues/1518
     "looker-sdk>=22.4.0,!=24.18.0",
     "pandas-gbq>=0.7.0",
-    # In pandas 2.2 minimal version of the sqlalchemy is 2.0
-    # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies
-    # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723
-    # In addition FAB also limit sqlalchemy to < 2.0
-    "pandas>=2.1.2,<2.2",
     # A transient dependency of google-cloud-bigquery-datatransfer, but we
     # further constrain it since older versions are buggy.
     "proto-plus>=1.19.6",
@@ -233,6 +228,7 @@ dev = [
     "apache-airflow-providers-trino",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-apache-kafka",
+    "apache-airflow-providers-common-sql[pandas,polars]",
 ]
 
 # To build docs:

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -57,6 +57,7 @@ from googleapiclient.discovery import build
 from pandas_gbq import read_gbq
 from pandas_gbq.gbq import GbqConnector  # noqa: F401 used in ``airflow.contrib.hooks.bigquery``
 from sqlalchemy import create_engine
+from typing_extensions import Literal
 
 from airflow.exceptions import (
     AirflowException,
@@ -81,6 +82,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     import pandas as pd
+    import polars as pl
     from google.api_core.page_iterator import HTTPIterator
     from google.api_core.retry import Retry
     from requests import Session
@@ -286,8 +288,39 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         dialect: str | None = None,
         **kwargs,
     ) -> pd.DataFrame:
+        if dialect is None:
+            dialect = "legacy" if self.use_legacy_sql else "standard"
+
+        credentials, project_id = self.get_credentials_and_project_id()
+
+        return read_gbq(sql, project_id=project_id, dialect=dialect, credentials=credentials, **kwargs)
+
+    def _get_polars_df(self, sql, parameters=None, dialect=None, **kwargs) -> pl.DataFrame:
+        try:
+            import polars as pl
+        except ImportError:
+            raise AirflowOptionalProviderFeatureException(
+                "Polars is not installed. Please install it with `pip install polars`."
+            )
+
+        if dialect is None:
+            dialect = "legacy" if self.use_legacy_sql else "standard"
+
+        credentials, project_id = self.get_credentials_and_project_id()
+
+        pandas_df = read_gbq(sql, project_id=project_id, dialect=dialect, credentials=credentials, **kwargs)
+        return pl.from_pandas(pandas_df)
+
+    def get_df(
+        self,
+        sql,
+        parameters=None,
+        dialect=None,
+        df_type: Literal["pandas", "polars"] = "pandas",
+        **kwargs,
+    ) -> pd.DataFrame | pl.DataFrame:
         """
-        Get a Pandas DataFrame for the BigQuery results.
+        Get a DataFrame for the BigQuery results.
 
         The DbApiHook method must be overridden because Pandas doesn't support
         PEP 249 connections, except for SQLite.
@@ -303,24 +336,11 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             defaults to use `self.use_legacy_sql` if not specified
         :param kwargs: (optional) passed into pandas_gbq.read_gbq method
         """
-        if dialect is None:
-            dialect = "legacy" if self.use_legacy_sql else "standard"
+        if df_type == "polars":
+            return self._get_polars_df(sql, parameters, dialect, **kwargs)
 
-        credentials, project_id = self.get_credentials_and_project_id()
-
-        return read_gbq(sql, project_id=project_id, dialect=dialect, credentials=credentials, **kwargs)
-
-    async def _get_polars_df(self, sql, parameters=None, dialect=None, **kwargs):
-        try:
-            import polars as pl
-        except ImportError:
-            raise AirflowOptionalProviderFeatureException(
-                "Polars is not installed. Please install it with `pip install polars`."
-            )
-
-        client = self.get_client()
-        rows = await client.query(sql).result()
-        return pl.from_arrow(rows.to_arrow())
+        if df_type == "pandas":
+            return self._get_pandas_df(sql, parameters, dialect, **kwargs)
 
     @deprecated(
         planned_removal_date="November 30, 2025",

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -32,7 +32,6 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, NoReturn, Union, cast
 
 from aiohttp import ClientSession as ClientSession
-from deprecated import deprecated as airflow_providers_deprecated
 from gcloud.aio.bigquery import Job, Table as Table_async
 from google.cloud.bigquery import (
     DEFAULT_RETRY,
@@ -323,10 +322,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         rows = await client.query(sql).result()
         return pl.from_arrow(rows.to_arrow())
 
-    @airflow_providers_deprecated(
-        reason="Replaced by function `get_df_by_chunks`.",
+    @deprecated(
+        planned_removal_date="November 30, 2025",
+        use_instead="airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_df",
         category=AirflowProviderDeprecationWarning,
-        action="ignore",
     )
     def get_pandas_df(self, sql, parameters=None, dialect=None, **kwargs):
         return self._get_pandas_df(sql, parameters, dialect, **kwargs)

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -29,7 +29,7 @@ import uuid
 from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, NoReturn, Union, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Union, cast, overload
 
 from aiohttp import ClientSession as ClientSession
 from gcloud.aio.bigquery import Job, Table as Table_async
@@ -311,11 +311,22 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         pandas_df = read_gbq(sql, project_id=project_id, dialect=dialect, credentials=credentials, **kwargs)
         return pl.from_pandas(pandas_df)
 
+    @overload
+    def get_df(
+        self, sql, parameters=None, dialect=None, *, df_type: Literal["pandas"] = "pandas", **kwargs
+    ) -> pd.DataFrame: ...
+
+    @overload
+    def get_df(
+        self, sql, parameters=None, dialect=None, *, df_type: Literal["polars"], **kwargs
+    ) -> pl.DataFrame: ...
+
     def get_df(
         self,
         sql,
         parameters=None,
         dialect=None,
+        *,
         df_type: Literal["pandas", "polars"] = "pandas",
         **kwargs,
     ) -> pd.DataFrame | pl.DataFrame:

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -153,8 +153,8 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         assert result is False
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.read_gbq")
-    def test_get_pandas_df(self, mock_read_gbq):
-        self.hook.get_pandas_df("select 1")
+    def test_get_df(self, mock_read_gbq):
+        self.hook.get_df("select 1", df_type="pandas")
 
         mock_read_gbq.assert_called_once_with(
             "select 1", credentials=CREDENTIALS, dialect="legacy", project_id=PROJECT_ID

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -153,12 +153,16 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         assert result is False
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.read_gbq")
-    def test_get_df(self, mock_read_gbq):
-        self.hook.get_df("select 1", df_type="pandas")
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_get_df(self, mock_read_gbq, mock_get_client, df_type):
+        self.hook.get_df("select 1", df_type=df_type)
 
-        mock_read_gbq.assert_called_once_with(
-            "select 1", credentials=CREDENTIALS, dialect="legacy", project_id=PROJECT_ID
-        )
+        if df_type == "pandas":
+            mock_read_gbq.assert_called_once_with(
+                "select 1", credentials=CREDENTIALS, dialect="legacy", project_id=PROJECT_ID
+            )
+        else:
+            mock_read_gbq.assert_not_called()
 
     def test_validate_value(self):
         with pytest.raises(

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -154,7 +154,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.read_gbq")
     @pytest.mark.parametrize("df_type", ["pandas", "polars"])
-    def test_get_df(self, mock_read_gbq, mock_get_client, df_type):
+    def test_get_df(self, mock_read_gbq, df_type):
         self.hook.get_df("select 1", df_type=df_type)
 
         if df_type == "pandas":

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery_system.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery_system.py
@@ -36,23 +36,23 @@ class TestBigQueryDataframeResultsSystem(GoogleSystemTest):
     def test_output_is_dataframe_with_valid_query(self):
         import pandas as pd
 
-        df = self.instance.get_pandas_df("select 1")
+        df = self.instance.get_df("select 1", df_type="pandas")
         assert isinstance(df, pd.DataFrame)
 
     def test_throws_exception_with_invalid_query(self):
         with pytest.raises(Exception) as ctx:
-            self.instance.get_pandas_df("from `1`")
+            self.instance.get_df("from `1`", df_type="pandas")
         assert "Reason: " in str(ctx.value), ""
 
     def test_succeeds_with_explicit_legacy_query(self):
-        df = self.instance.get_pandas_df("select 1", dialect="legacy")
+        df = self.instance.get_df("select 1", df_type="pandas")
         assert df.iloc(0)[0][0] == 1
 
     def test_succeeds_with_explicit_std_query(self):
-        df = self.instance.get_pandas_df("select * except(b) from (select 1 a, 2 b)", dialect="standard")
+        df = self.instance.get_df("select * except(b) from (select 1 a, 2 b)", df_type="pandas")
         assert df.iloc(0)[0][0] == 1
 
     def test_throws_exception_with_incompatible_syntax(self):
         with pytest.raises(Exception) as ctx:
-            self.instance.get_pandas_df("select * except(b) from (select 1 a, 2 b)", dialect="legacy")
+            self.instance.get_df("select * except(b) from (select 1 a, 2 b)", df_type="pandas")
         assert "Reason: " in str(ctx.value), ""

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery_system.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery_system.py
@@ -33,26 +33,31 @@ class TestBigQueryDataframeResultsSystem(GoogleSystemTest):
     def setup_method(self):
         self.instance = hook.BigQueryHook()
 
-    def test_output_is_dataframe_with_valid_query(self):
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_output_is_dataframe_with_valid_query(self, df_type):
         import pandas as pd
 
-        df = self.instance.get_df("select 1", df_type="pandas")
+        df = self.instance.get_df("select 1", df_type=df_type)
         assert isinstance(df, pd.DataFrame)
 
-    def test_throws_exception_with_invalid_query(self):
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_throws_exception_with_invalid_query(self, df_type):
         with pytest.raises(Exception) as ctx:
-            self.instance.get_df("from `1`", df_type="pandas")
+            self.instance.get_df("from `1`", df_type=df_type)
         assert "Reason: " in str(ctx.value), ""
 
-    def test_succeeds_with_explicit_legacy_query(self):
-        df = self.instance.get_df("select 1", df_type="pandas")
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_succeeds_with_explicit_legacy_query(self, df_type):
+        df = self.instance.get_df("select 1", df_type=df_type)
         assert df.iloc(0)[0][0] == 1
 
-    def test_succeeds_with_explicit_std_query(self):
-        df = self.instance.get_df("select * except(b) from (select 1 a, 2 b)", df_type="pandas")
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_succeeds_with_explicit_std_query(self, df_type):
+        df = self.instance.get_df("select * except(b) from (select 1 a, 2 b)", df_type=df_type)
         assert df.iloc(0)[0][0] == 1
 
-    def test_throws_exception_with_incompatible_syntax(self):
+    @pytest.mark.parametrize("df_type", ["pandas", "polars"])
+    def test_throws_exception_with_incompatible_syntax(self, df_type):
         with pytest.raises(Exception) as ctx:
-            self.instance.get_df("select * except(b) from (select 1 a, 2 b)", df_type="pandas")
+            self.instance.get_df("select * except(b) from (select 1 a, 2 b)", df_type=df_type)
         assert "Reason: " in str(ctx.value), ""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- #49334

## Why 

`get_pandas_df` deprecated in https://github.com/apache/airflow/pull/48875, which would be replaced by `get_df`. Thus, we need to migrate them in providers.

## How

- This PR is focus on migration of `BigQueryHook`
- Migrate unit test

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
