### PR TITLE
fix(snowflake_oauth): Fix infinite recursive call of _get_conn_params while getting oauth token from snowflake

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -189,8 +189,10 @@ class SnowflakeHook(DbApiHook):
             return extra_dict[field_name] or None
         return extra_dict.get(backcompat_key) or None
 
-    def _get_account_identifier(self, conn_config: dict) -> str:
+    @property
+    def account_identifier(self) -> str:
         """Get snowflake account identifier."""
+        conn_config = self._get_conn_params
         account_identifier = f"https://{conn_config['account']}"
 
         if conn_config["region"]:
@@ -203,8 +205,7 @@ class SnowflakeHook(DbApiHook):
         if conn_config is None:
             conn_config = self._get_conn_params
 
-        account_identifier = self._get_account_identifier(conn_config=conn_config)
-        url = f"{account_identifier}.snowflakecomputing.com/oauth/token-request"
+        url = f"{conn_config['account']}.snowflakecomputing.com/oauth/token-request"
 
         data = {
             "grant_type": "refresh_token",

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -189,10 +189,8 @@ class SnowflakeHook(DbApiHook):
             return extra_dict[field_name] or None
         return extra_dict.get(backcompat_key) or None
 
-    @property
-    def account_identifier(self) -> str:
-        """Returns snowflake account identifier."""
-        conn_config = self._get_conn_params
+    def _get_account_identifier(self, conn_config: dict) -> str:
+        """Get snowflake account identifier."""
         account_identifier = f"https://{conn_config['account']}"
 
         if conn_config["region"]:
@@ -205,7 +203,8 @@ class SnowflakeHook(DbApiHook):
         if conn_config is None:
             conn_config = self._get_conn_params
 
-        url = f"{self.account_identifier}.snowflakecomputing.com/oauth/token-request"
+        account_identifier = self._get_account_identifier(conn_config=conn_config)
+        url = f"{account_identifier}.snowflakecomputing.com/oauth/token-request"
 
         data = {
             "grant_type": "refresh_token",

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -205,7 +205,7 @@ class SnowflakeHook(DbApiHook):
         if conn_config is None:
             conn_config = self._get_conn_params
 
-        url = f"{conn_config['account']}.snowflakecomputing.com/oauth/token-request"
+        url = f"https://{conn_config['account']}.snowflakecomputing.com/oauth/token-request"
 
         data = {
             "grant_type": "refresh_token",

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
@@ -908,7 +908,7 @@ class TestPytestSnowflakeHook:
         hook = SnowflakeHook(snowflake_conn_id="mock_conn_id")
         hook.get_oauth_token(conn_config=CONN_PARAMS_OAUTH)
         requests_post.assert_called_once_with(
-            f"https://{CONN_PARAMS_OAUTH['account']}.{CONN_PARAMS_OAUTH['region']}.snowflakecomputing.com/oauth/token-request",
+            f"https://{CONN_PARAMS_OAUTH['account']}.snowflakecomputing.com/oauth/token-request",
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": CONN_PARAMS_OAUTH["refresh_token"],

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -368,7 +368,7 @@ class TestSnowflakeSqlApiHook:
         with pytest.warns(expected_warning=AirflowProviderDeprecationWarning):
             hook.get_oauth_token(CONN_PARAMS_OAUTH)
         requests_post.assert_called_once_with(
-            f"https://{CONN_PARAMS_OAUTH['account']}.{CONN_PARAMS_OAUTH['region']}.snowflakecomputing.com/oauth/token-request",
+            f"https://{CONN_PARAMS_OAUTH['account']}.snowflakecomputing.com/oauth/token-request",
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": CONN_PARAMS_OAUTH["refresh_token"],


### PR DESCRIPTION
Bug introduced in: https://github.com/apache/airflow/pull/49482
The infinite loop was caused by calling the property self._get_conn_params in the property self.account_identifier. The self.account_identifier was used in the get_oauth_token function, thus resulting in the infinite loop of calls to self._get_conn_params

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

---

