### PR TITLE
Add user-defined macros warning to Plugins doc page

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -20,6 +20,10 @@
 Plugins
 ========
 
+.. warning::
+
+    As of Airflow version 3.0.0, support for user-defined macros is pending.
+
 Airflow has a simple plugin manager built-in that can integrate external
 features to its core by simply dropping files in your
 ``$AIRFLOW_HOME/plugins`` folder.

--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -22,7 +22,7 @@ Plugins
 
 .. warning::
 
-    As of Airflow version 3.0.0, support for user-defined macros is pending.
+    As part of Airflow 3.0.0 development, support for user-defined macros is pending. This will be added soon in one of the 3.0.0 patch version or 3.1
 
 Airflow has a simple plugin manager built-in that can integrate external
 features to its core by simply dropping files in your

--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -22,7 +22,7 @@ Plugins
 
 .. warning::
 
-    As part of Airflow 3.0.0 development, support for user-defined macros is pending. This will be added soon in one of the 3.0.0 patch version or 3.1
+    As part of Airflow 3.0.0 development, support for user-defined macros is pending. This will be added soon in an upcoming release. See `#48476 <https://github.com/apache/airflow/issues/48476>`__ for further support updates on this feature.
 
 Airflow has a simple plugin manager built-in that can integrate external
 features to its core by simply dropping files in your


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


<!-- Please keep an empty line above the dashes. -->
---

related: https://github.com/apache/airflow/issues/48476

Adds a clarification that user-defined macros are currently not supported in Airflow 3.0.0. Prior to this, this doc mentioned some caveats related to Flask plugins, but didn't explicitly mention the state of user-defined macros.

## Testing
Tested locally via:
```shell
cd airflow-core
uv run --group docs build-docs --autobuild
```
Screenshot of locally rendered page below:
![Screenshot 2025-05-08 at 1 03 28 PM](https://github.com/user-attachments/assets/b552aed8-de30-4288-8a45-fbfcbe35fa46)

