### PR TITLE
Fix callbacks docs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/callbacks.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/callbacks.rst
@@ -83,13 +83,13 @@ In the following example, failures in any task call the ``task_failure_alert`` f
         start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
         dagrun_timeout=datetime.timedelta(minutes=60),
         catchup=False,
-        on_success_callback=None,
-        on_failure_callback=task_failure_alert,
+        on_success_callback=dag_success_alert,
+        on_failure_callback=None,
         tags=["example"],
     ):
         task1 = EmptyOperator(task_id="task1")
         task2 = EmptyOperator(task_id="task2")
-        task3 = EmptyOperator(task_id="task3", on_success_callback=[dag_success_alert])
+        task3 = EmptyOperator(task_id="task3", on_failure_callback=[task_failure_alert])
         task1 >> task2 >> task3
 
 .. note::


### PR DESCRIPTION
The task callback was assigned to dag and vice versa

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
