### PR TITLE
fix(airflow.datasets): Fix DatasetAny fallback typo

### DIFF
--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -86,7 +86,7 @@ __lazy_imports: dict[str, tuple[str, str, bool]] = {
     "version": (".version", "", False),
     # Deprecated lazy imports
     "AirflowException": (".exceptions", "AirflowException", True),
-    "Dataset": (".sdk.definitions.asset", "Dataset", True),
+    "Dataset": (".sdk.definitions.asset", "Asset", True),
 }
 if TYPE_CHECKING:
     # These objects are imported by PEP-562, however, static analyzers and IDE's

--- a/airflow-core/src/airflow/datasets/__init__.py
+++ b/airflow-core/src/airflow/datasets/__init__.py
@@ -32,7 +32,7 @@ import warnings
 _names_moved = {
     "DatasetAlias": ("airflow.sdk.definitions.asset", "AssetAlias"),
     "DatasetAll": ("airflow.sdk.definitions.asset", "AssetAll"),
-    "DatasetAny": ("airflow.sdk.definitions.asset", "DatasetAny"),
+    "DatasetAny": ("airflow.sdk.definitions.asset", "AssetAny"),
     "Dataset": ("airflow.sdk.definitions.asset", "Asset"),
     "expand_alias_to_datasets": ("airflow.models.asset", "expand_alias_to_assets"),
 }

--- a/airflow-core/tests/unit/datasets/test_dataset.py
+++ b/airflow-core/tests/unit/datasets/test_dataset.py
@@ -22,19 +22,21 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "module_path, attr_name, warning_message",
+    "module_path, attr_name, expected_value, warning_message",
     (
         (
             "airflow",
             "Dataset",
+            "airflow.sdk.definitions.asset.Asset",
             (
                 "Import 'Dataset' directly from the airflow module is deprecated and will be removed in the future. "
-                "Please import it from 'airflow.sdk.definitions.asset.Dataset'."
+                "Please import it from 'airflow.sdk.definitions.asset.Asset'."
             ),
         ),
         (
             "airflow.datasets",
             "Dataset",
+            "airflow.sdk.definitions.asset.Asset",
             (
                 "Import 'airflow.dataset.Dataset' is deprecated and "
                 "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset.Asset'."
@@ -43,6 +45,7 @@ import pytest
         (
             "airflow.datasets",
             "DatasetAlias",
+            "airflow.sdk.definitions.asset.AssetAlias",
             (
                 "Import 'airflow.dataset.DatasetAlias' is deprecated and "
                 "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset.AssetAlias'."
@@ -51,6 +54,7 @@ import pytest
         (
             "airflow.datasets",
             "expand_alias_to_datasets",
+            "airflow.models.asset.expand_alias_to_assets",
             (
                 "Import 'airflow.dataset.expand_alias_to_datasets' is deprecated and "
                 "will be removed in the Airflow 3.2. Please import it from 'airflow.models.asset.expand_alias_to_assets'."
@@ -59,6 +63,7 @@ import pytest
         (
             "airflow.datasets.metadata",
             "Metadata",
+            "airflow.sdk.definitions.asset.metadata.Metadata",
             (
                 "Import from the airflow.dataset module is deprecated and "
                 "will be removed in the Airflow 3.2. Please import it from "
@@ -67,12 +72,13 @@ import pytest
         ),
     ),
 )
-def test_backward_compat_import_before_airflow_3_2(module_path, attr_name, warning_message):
+def test_backward_compat_import_before_airflow_3_2(module_path, attr_name, expected_value, warning_message):
     with pytest.warns() as record:
         import importlib
 
         mod = importlib.import_module(module_path, __name__)
-        getattr(mod, attr_name)
+        attr = getattr(mod, attr_name)
+        assert f"{attr.__module__}.{attr.__name__}" == expected_value
 
     assert record[0].category is DeprecationWarning
     assert str(record[0].message) == warning_message


### PR DESCRIPTION
## Why
`airflow.datasets.DatasetAny` should fallback to `airflow.sdk.definitions.asset.AssetAny` instead of `airflow.sdk.definitions.asset.DatasetAny` which does not exists 

## What
* Update fallback value as `airflow.sdk.definitions.asset.AssetAny`
* Change the fallback value of `airflow.Dataset` as `airflow.sdk.definitions.asset.Asset` (It doesn't really matter whether it's `Asset` or `Dataset` (it's a subclass of `Asset`); just to unify it with `airflow.datasets.Dataset`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
