### PR TITLE
Add bundle root to sys.path in dag processor

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -67,8 +67,6 @@ ToDagProcessor = Annotated[
 
 
 def _parse_file_entrypoint():
-    import os
-
     import structlog
 
     from airflow.sdk.execution_time import task_runner
@@ -86,6 +84,11 @@ def _parse_file_entrypoint():
 
     task_runner.SUPERVISOR_COMMS = comms_decoder
     log = structlog.get_logger(logger_name="task")
+
+    # Put bundle root on sys.path if needed. This allows the dag bundle to add
+    # code in util modules to be shared between files within the same bundle.
+    if (bundle_root := os.fspath(msg.bundle_path)) not in sys.path:
+        sys.path.append(bundle_root)
 
     result = _parse_file(msg, log)
     if result is not None:

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -563,12 +563,6 @@ def prepare_syspath_for_config_and_plugins():
         sys.path.append(PLUGINS_FOLDER)
 
 
-def prepare_syspath_for_dags_folder():
-    """Update sys.path to include the DAGs folder."""
-    if DAGS_FOLDER not in sys.path:
-        sys.path.append(DAGS_FOLDER)
-
-
 def import_local_settings():
     """Import airflow_local_settings.py files to allow overriding any configs in settings.py file."""
     try:
@@ -615,7 +609,6 @@ def initialize():
     # in airflow_local_settings to take precendec
     load_policy_plugins(POLICY_PLUGIN_MANAGER)
     import_local_settings()
-    prepare_syspath_for_dags_folder()
     global LOGGING_CLASS_PATH
     LOGGING_CLASS_PATH = configure_logging()
 

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -91,16 +91,9 @@ class TestLocalSettings:
 
     @mock.patch("airflow.settings.prepare_syspath_for_config_and_plugins")
     @mock.patch("airflow.settings.import_local_settings")
-    @mock.patch("airflow.settings.prepare_syspath_for_dags_folder")
-    def test_initialize_order(
-        self,
-        mock_prepare_syspath_for_dags_folder,
-        mock_import_local_settings,
-        mock_prepare_syspath_for_config_and_plugins,
-    ):
+    def test_initialize_order(self, mock_import_local_settings, mock_prepare_syspath_for_config_and_plugins):
         """
-        Tests that import_local_settings is called between prepare_syspath_for_config_and_plugins
-        and prepare_syspath_for_dags_folder
+        Tests that import_local_settings is called after prepare_syspath_for_config_and_plugins
         """
         mock_local_settings = mock.Mock()
 
@@ -108,9 +101,6 @@ class TestLocalSettings:
             mock_prepare_syspath_for_config_and_plugins, "prepare_syspath_for_config_and_plugins"
         )
         mock_local_settings.attach_mock(mock_import_local_settings, "import_local_settings")
-        mock_local_settings.attach_mock(
-            mock_prepare_syspath_for_dags_folder, "prepare_syspath_for_dags_folder"
-        )
 
         import airflow.settings
 
@@ -119,7 +109,6 @@ class TestLocalSettings:
         expected_calls = [
             call.prepare_syspath_for_config_and_plugins(),
             call.import_local_settings(),
-            call.prepare_syspath_for_dags_folder(),
         ]
 
         mock_local_settings.assert_has_calls(expected_calls)


### PR DESCRIPTION
Instead of adding the dags folder into `sys.path` globally, each dag file parser now _only_ adds the dag bundle’s root path to `sys.path` for that specific parsing job.

Fix #49838.