### PR TITLE
Fix index to sort by last parsing duration.

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -710,7 +710,7 @@ class DagFileProcessorManager(LoggingMixin):
                 )
 
         # Sort by longest last runtime. (Can't sort None values in python3)
-        rows.sort(key=lambda x: x[5] or 0.0, reverse=True)
+        rows.sort(key=lambda x: x[6] or 0.0, reverse=True)
 
         formatted_rows = []
         for (


### PR DESCRIPTION
It looks `bundle_name` got added as an extra entry in 3b27a4b17849be4fb13da4cae57d7c94a5b72d7f but the sort index was not updated to match this change.

https://github.com/apache/airflow/commit/3b27a4b17849be4fb13da4cae57d7c94a5b72d7f#diff-827b7a469438ffd1b172ae295134a84c8a914c9ea4c9ea2a7d3de1f1d5aa6bb6L629