### PR TITLE
Use non-deprecated context in tests for Airflow 3

### DIFF
--- a/airflow-core/src/airflow/example_dags/tutorial_taskflow_templates.py
+++ b/airflow-core/src/airflow/example_dags/tutorial_taskflow_templates.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 # [START import_module]
 import pendulum
 
-from airflow.providers.standard.operators.python import get_current_context
-from airflow.sdk import dag, task
+from airflow.sdk import dag, get_current_context, task
 
 # [END import_module]
 

--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -334,7 +334,7 @@ def _create_mapped_with_name_template_classic(*, task_id, map_names, template):
 
 
 def _create_mapped_with_name_template_taskflow(*, task_id, map_names, template):
-    from airflow.providers.standard.operators.python import get_current_context
+    from airflow.sdk import get_current_context
 
     @task(task_id=task_id, map_index_template=template)
     def task1(map_name):
@@ -360,7 +360,7 @@ def _create_named_map_index_renders_on_failure_classic(*, task_id, map_names, te
 
 
 def _create_named_map_index_renders_on_failure_taskflow(*, task_id, map_names, template):
-    from airflow.providers.standard.operators.python import get_current_context
+    from airflow.sdk import get_current_context
 
     @task(task_id=task_id, map_index_template=template)
     def task1(map_name):

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -3713,7 +3713,7 @@ class TestTaskInstance:
 
     def test_get_current_context_works_in_template(self, dag_maker):
         def user_defined_macro():
-            from airflow.providers.standard.operators.python import get_current_context
+            from airflow.sdk import get_current_context
 
             get_current_context()
 

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker.py
@@ -52,7 +52,6 @@ from airflow.providers.amazon.aws.sensors.sagemaker import (
     SageMakerTransformSensor,
     SageMakerTuningSensor,
 )
-from airflow.providers.standard.operators.python import get_current_context
 from airflow.utils.trigger_rule import TriggerRule
 
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder, prune_logs
@@ -419,6 +418,13 @@ def set_up(env_id, role_arn):
     )
     _install_aws_cli_if_needed()
     _build_and_upload_docker_image(preprocess_script, ecr_repository_uri)
+
+    from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS
+
+    if AIRFLOW_V_3_0_PLUS:
+        from airflow.sdk import get_current_context
+    else:
+        from airflow.providers.standard.utils import get_current_context
 
     ti = get_current_context()["ti"]
     ti.xcom_push(key="docker_image", value=ecr_repository_uri)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker.py
@@ -424,7 +424,7 @@ def set_up(env_id, role_arn):
     if AIRFLOW_V_3_0_PLUS:
         from airflow.sdk import get_current_context
     else:
-        from airflow.providers.standard.utils import get_current_context
+        from airflow.providers.standard.operators.python import get_current_context
 
     ti = get_current_context()["ti"]
     ti.xcom_push(key="docker_image", value=ecr_repository_uri)

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Collection, Mapping, Sequence
 from typing import Any, Callable
 
-from airflow.providers.common.compat.standard.operators import PythonOperator, get_current_context
+from airflow.providers.common.compat.standard.operators import PythonOperator
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.providers.snowflake.utils.snowpark import inject_session_into_op_kwargs
 
@@ -115,6 +115,14 @@ class SnowparkOperator(PythonOperator):
             session_parameters=self.session_parameters,
         )
         session = hook.get_snowpark_session()
+
+        from airflow.providers.snowflake.version_compat import AIRFLOW_V_3_0_PLUS
+
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk import get_current_context
+        else:
+            from airflow.providers.standard.utils import get_current_context
+
         context = get_current_context()
         session.update_query_tag(
             {

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark.py
@@ -121,7 +121,7 @@ class SnowparkOperator(PythonOperator):
         if AIRFLOW_V_3_0_PLUS:
             from airflow.sdk import get_current_context
         else:
-            from airflow.providers.standard.utils import get_current_context
+            from airflow.providers.standard.operators.python import get_current_context
 
         context = get_current_context()
         session.update_query_tag(


### PR DESCRIPTION
The #50301 deprecated using get_current_context in standard provider in favour of the task.sdk call, but some core tests are still using the provider's one.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
