### PR TITLE
feat: Add OpenLineage support for DatabricksSqlHook

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -2029,7 +2029,7 @@ def test_expected_output_push(
             ),
             {
                 "selected-providers-list-as-string": "amazon common.compat common.io common.sql "
-                "dbt.cloud ftp google microsoft.mssql mysql "
+                "databricks dbt.cloud ftp google microsoft.mssql mysql "
                 "openlineage postgres sftp snowflake trino",
                 "all-python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
                 "all-python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
@@ -2040,7 +2040,7 @@ def test_expected_output_push(
                 "skip-providers-tests": "false",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow amazon common.compat common.io common.sql "
-                "dbt.cloud ftp google microsoft.mssql mysql "
+                "databricks dbt.cloud ftp google microsoft.mssql mysql "
                 "openlineage postgres sftp snowflake trino",
                 "skip-pre-commits": ALL_SKIPPED_COMMITS_ON_NO_CI_IMAGE,
                 "run-kubernetes-tests": "false",
@@ -2051,7 +2051,7 @@ def test_expected_output_push(
                         {
                             "description": "amazon...google",
                             "test_types": "Providers[amazon] Providers[common.compat,common.io,common.sql,"
-                            "dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,"
+                            "databricks,dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,"
                             "postgres,sftp,snowflake,trino] Providers[google]",
                         }
                     ]

--- a/devel-common/src/sphinx_exts/providers_extensions.py
+++ b/devel-common/src/sphinx_exts/providers_extensions.py
@@ -284,7 +284,8 @@ def _render_openlineage_supported_classes_content():
         }
     )
 
-    # These excluded classes will be included in docs directly
+    # Excluding these classes from auto-detection, and any subclasses, to prevent detection of methods
+    # from abstract base classes (which need explicit OL support). Will be included in docs manually
     class_registry.pop("airflow.providers.common.sql.hooks.sql.DbApiHook")
     class_registry.pop("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator")
 
@@ -314,7 +315,12 @@ def _render_openlineage_supported_classes_content():
                 method_names=openlineage_db_hook_methods,
                 class_registry=class_registry,
             ):
-                db_type = class_name.replace("SqlApiHook", "").replace("Hook", "")
+                db_type = (  # Extract db type from hook name
+                    class_name.replace("RedshiftSQL", "Redshift")  # for RedshiftSQLHook
+                    .replace("DatabricksSql", "Databricks")  # for DatabricksSqlHook
+                    .replace("SnowflakeSqlApi", "Snowflake")  # for SnowflakeSqlApiHook
+                    .replace("Hook", "")  # for others like MySqlHook, TrinoHook etc.
+                )
                 db_hooks.append((db_type, class_path))
 
             elif info["methods_with_hook_level_lineage"]:

--- a/devel-common/src/sphinx_exts/templates/openlineage.rst.jinja2
+++ b/devel-common/src/sphinx_exts/templates/openlineage.rst.jinja2
@@ -62,11 +62,21 @@ apache-airflow-providers-google
     - Transport Information (only HTTP transport is supported for now (with api_key auth, if any))
 
 
-:class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`
-============================================================================
+:class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator` and derivatives
+=============================================================================================
 
-uses SQL parsing for lineage extraction. To extract unique data from each database type,
-a dedicated Hook implementing OpenLineage methods is required. Currently, the following databases are supported:
+These operators are using SQL parsing and may query DB for lineage extraction.
+To extract unique data from each database type, a dedicated Hook implementing OpenLineage methods is required.
+
+.. note::
+  Not all subclasses of :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator` are automatically
+  supported, only those also using a supported Hook (e.g., one of supported operators is
+  :class:`~airflow.providers.databricks.operators.databricks_sql.DatabricksSqlOperator`).
+  Due to the automatic generation of this documentation, some supported operators inheriting from
+  :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator` may not appear in the ``Providers``
+  section below - to prevent false positives. Please check your operator's code to confirm OpenLineage support.
+
+Currently, the following databases (hooks) are supported:
 
 {% for db_type, hook in db_hooks %}
 - {{ db_type }} (via :class:`~{{ hook }}`)

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -58,9 +58,11 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.6.0",
     "apache-airflow-providers-common-sql>=1.21.0",
     "requests>=2.31.0,<3",
     "databricks-sql-connector>=3.0.0",
+    "databricks-sqlalchemy>=1.0.2",
     "aiohttp>=3.9.2, <4",
     "mergedeep>=1.3.4",
     "pandas>=2.1.2,<2.2",
@@ -83,14 +85,19 @@ dependencies = [
 "standard" = [
     "apache-airflow-providers-standard"
 ]
+"openlineage" = [
+    "apache-airflow-providers-openlineage>=2.3.0"
+]
 
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-fab",
+    "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "deltalake>=0.12.0",
     "apache-airflow-providers-microsoft-azure",

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     from databricks.sql.client import Connection
 
     from airflow.models.connection import Connection as AirflowConnection
+    from airflow.providers.openlineage.extractors import OperatorLineage
+    from airflow.providers.openlineage.sqlparser import DatabaseInfo
 
 
 LIST_SQL_ENDPOINTS_ENDPOINT = ("GET", "api/2.0/sql/endpoints")
@@ -108,6 +110,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         self.catalog = catalog
         self.schema = schema
         self.additional_params = kwargs
+        self.query_ids: list[str] = []
 
     def _get_extra_config(self) -> dict[str, Any | None]:
         extra_params = copy(self.databricks_conn.extra_dejson)
@@ -227,6 +230,8 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
             it will raise and fail.
         """
         self.descriptions = []
+        self.query_ids = []
+
         if isinstance(sql, str):
             if split_statements:
                 sql_list = [self.strip_sql_string(s) for s in self.split_sql_string(sql)]
@@ -266,6 +271,10 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
                     finally:
                         if t is not None:
                             t.cancel()
+
+                    if query_id := cur.query_id:
+                        self.log.info("Databricks query id: %s", query_id)
+                        self.query_ids.append(query_id)
 
                     if handler is not None:
                         raw_result = handler(cur)
@@ -309,3 +318,80 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
     def bulk_load(self, table, tmp_file):
         raise NotImplementedError()
+
+    def get_openlineage_database_info(self, connection) -> DatabaseInfo:
+        from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
+        return DatabaseInfo(
+            scheme=self.get_openlineage_database_dialect(connection),
+            authority=self.host,
+            database=self.catalog,
+            information_schema_columns=[
+                "table_schema",
+                "table_name",
+                "column_name",
+                "ordinal_position",
+                "data_type",
+                "table_catalog",
+            ],
+            is_information_schema_cross_db=True,
+        )
+
+    def get_openlineage_database_dialect(self, _) -> str:
+        return "databricks"
+
+    def get_openlineage_default_schema(self) -> str | None:
+        return self.schema or "default"
+
+    def get_openlineage_database_specific_lineage(self, task_instance) -> OperatorLineage | None:
+        """
+        Generate OpenLineage metadata for a Databricks task instance based on executed query IDs.
+
+        If a single query ID is present, attach an `ExternalQueryRunFacet` to the lineage metadata.
+        If multiple query IDs are present, emits separate OpenLineage events for each query instead.
+
+        Note that `get_openlineage_database_specific_lineage` is usually called after task's execution,
+        so if multiple query IDs are present, both START and COMPLETE event for each query will be emitted
+        after task's execution. If we are able to query Databricks for query execution metadata,
+        query event times will correspond to actual query's start and finish times.
+
+        Args:
+            task_instance: The Airflow TaskInstance object for which lineage is being collected.
+
+        Returns:
+            An `OperatorLineage` object if a single query ID is found; otherwise `None`.
+        """
+        from airflow.providers.common.compat.openlineage.facet import ExternalQueryRunFacet
+        from airflow.providers.databricks.utils.openlineage import (
+            emit_openlineage_events_for_databricks_queries,
+        )
+        from airflow.providers.openlineage.extractors import OperatorLineage
+        from airflow.providers.openlineage.sqlparser import SQLParser
+
+        if not self.query_ids:
+            self.log.debug("openlineage: no databricks query ids found.")
+            return None
+
+        self.log.debug("openlineage: getting connection to get database info")
+        connection = self.get_connection(self.get_conn_id())
+        namespace = SQLParser.create_namespace(self.get_openlineage_database_info(connection))
+
+        if len(self.query_ids) == 1:
+            self.log.debug("Attaching ExternalQueryRunFacet with single query_id to OpenLineage event.")
+            return OperatorLineage(
+                run_facets={
+                    "externalQuery": ExternalQueryRunFacet(
+                        externalQueryId=self.query_ids[0], source=namespace
+                    )
+                }
+            )
+
+        self.log.info("Multiple query_ids found. Separate OpenLineage event will be emitted for each query.")
+        emit_openlineage_events_for_databricks_queries(
+            query_ids=self.query_ids,
+            query_source_namespace=namespace,
+            task_instance=task_instance,
+            hook=self,
+        )
+
+        return None

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import csv
 import json
 from collections.abc import Sequence
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from databricks.sql.utils import ParamEscaper
@@ -106,7 +107,8 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
         self.catalog = catalog
         self.schema = schema
 
-    def get_db_hook(self) -> DatabricksSqlHook:
+    @cached_property
+    def _hook(self) -> DatabricksSqlHook:
         hook_params = {
             "http_path": self.http_path,
             "session_configuration": self.session_configuration,
@@ -119,6 +121,9 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
             **self.hook_params,
         }
         return DatabricksSqlHook(self.databricks_conn_id, **hook_params)
+
+    def get_db_hook(self) -> DatabricksSqlHook:
+        return self._hook
 
     def _should_run_output_processing(self) -> bool:
         return self.do_xcom_push or bool(self._output_path)

--- a/providers/databricks/src/airflow/providers/databricks/utils/openlineage.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/openlineage.py
@@ -1,0 +1,336 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import requests
+
+from airflow.providers.common.compat.openlineage.check import require_openlineage_version
+from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.utils import timezone
+
+if TYPE_CHECKING:
+    from openlineage.client.event_v2 import RunEvent
+    from openlineage.client.facet_v2 import JobFacet
+
+    from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
+
+log = logging.getLogger(__name__)
+
+
+def _get_logical_date(task_instance):
+    # todo: remove when min airflow version >= 3.0
+    if AIRFLOW_V_3_0_PLUS:
+        dagrun = task_instance.get_template_context()["dag_run"]
+        return dagrun.logical_date or dagrun.run_after
+
+    if hasattr(task_instance, "logical_date"):
+        date = task_instance.logical_date
+    else:
+        date = task_instance.execution_date
+
+    return date
+
+
+def _get_dag_run_clear_number(task_instance):
+    # todo: remove when min airflow version >= 3.0
+    if AIRFLOW_V_3_0_PLUS:
+        dagrun = task_instance.get_template_context()["dag_run"]
+        return dagrun.clear_number
+    return task_instance.dag_run.clear_number
+
+
+# todo: move this run_id logic into OpenLineage's listener to avoid differences
+def _get_ol_run_id(task_instance) -> str:
+    """
+    Get OpenLineage run_id from TaskInstance.
+
+    It's crucial that the task_instance's run_id creation logic matches OpenLineage's listener implementation.
+    Only then can we ensure that the generated run_id aligns with the Airflow task,
+    enabling a proper connection between events.
+    """
+    from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
+
+    # Generate same OL run id as is generated for current task instance
+    return OpenLineageAdapter.build_task_instance_run_id(
+        dag_id=task_instance.dag_id,
+        task_id=task_instance.task_id,
+        logical_date=_get_logical_date(task_instance),
+        try_number=task_instance.try_number,
+        map_index=task_instance.map_index,
+    )
+
+
+# todo: move this run_id logic into OpenLineage's listener to avoid differences
+def _get_ol_dag_run_id(task_instance) -> str:
+    from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
+
+    return OpenLineageAdapter.build_dag_run_id(
+        dag_id=task_instance.dag_id,
+        logical_date=_get_logical_date(task_instance),
+        clear_number=_get_dag_run_clear_number(task_instance),
+    )
+
+
+def _get_parent_run_facet(task_instance):
+    """
+    Retrieve the ParentRunFacet associated with a specific Airflow task instance.
+
+    This facet helps link OpenLineage events of child jobs - such as queries executed within
+    external systems (e.g., Databricks) by the Airflow task - to the original Airflow task execution.
+    Establishing this connection enables better lineage tracking and observability.
+    """
+    from openlineage.client.facet_v2 import parent_run
+
+    from airflow.providers.openlineage.conf import namespace
+
+    parent_run_id = _get_ol_run_id(task_instance)
+    root_parent_run_id = _get_ol_dag_run_id(task_instance)
+
+    return parent_run.ParentRunFacet(
+        run=parent_run.Run(runId=parent_run_id),
+        job=parent_run.Job(
+            namespace=namespace(),
+            name=f"{task_instance.dag_id}.{task_instance.task_id}",
+        ),
+        root=parent_run.Root(
+            run=parent_run.RootRun(runId=root_parent_run_id),
+            job=parent_run.RootJob(
+                name=task_instance.dag_id,
+                namespace=namespace(),
+            ),
+        ),
+    )
+
+
+def _run_api_call(hook: DatabricksSqlHook, query_ids: list[str]) -> list[dict]:
+    """Retrieve execution details for specific queries from Databricks's query history API."""
+    if not hook._token:
+        # This has logic for token initialization
+        hook.get_conn()
+
+    # https://docs.databricks.com/api/azure/workspace/queryhistory/list
+    try:
+        response = requests.get(
+            url=f"https://{hook.host}/api/2.0/sql/history/queries",
+            headers={"Authorization": f"Bearer {hook._token}"},
+            data=json.dumps({"filter_by": {"statement_ids": query_ids}}),
+            timeout=2,
+        )
+    except Exception as e:
+        log.warning(
+            "OpenLineage could not retrieve Databricks queries details. Error received: `%s`.",
+            e,
+        )
+        return []
+
+    if response.status_code != 200:
+        log.warning(
+            "OpenLineage could not retrieve Databricks queries details. API error received: `%s`: `%s`",
+            response.status_code,
+            response.text,
+        )
+        return []
+
+    return response.json()["res"]
+
+
+def _get_queries_details_from_databricks(
+    hook: DatabricksSqlHook, query_ids: list[str]
+) -> dict[str, dict[str, Any]]:
+    if not query_ids:
+        return {}
+
+    queries_info_from_api = _run_api_call(hook=hook, query_ids=query_ids)
+
+    query_details = {}
+    for query_info in queries_info_from_api:
+        if not query_info.get("query_id"):
+            log.debug("Databricks query ID not found in API response.")
+            continue
+
+        q_start_time = None
+        q_end_time = None
+        if query_info.get("query_start_time_ms") and query_info.get("query_end_time_ms"):
+            q_start_time = datetime.datetime.fromtimestamp(
+                query_info["query_start_time_ms"] / 1000, tz=datetime.timezone.utc
+            )
+            q_end_time = datetime.datetime.fromtimestamp(
+                query_info["query_end_time_ms"] / 1000, tz=datetime.timezone.utc
+            )
+
+        query_details[query_info["query_id"]] = {
+            "status": query_info.get("status"),
+            "start_time": q_start_time,
+            "end_time": q_end_time,
+            "query_text": query_info.get("query_text"),
+            "error_message": query_info.get("error_message"),
+        }
+
+    return query_details
+
+
+def _create_ol_event_pair(
+    job_namespace: str,
+    job_name: str,
+    start_time: datetime.datetime,
+    end_time: datetime.datetime,
+    is_successful: bool,
+    run_facets: dict | None = None,
+    job_facets: dict | None = None,
+) -> tuple[RunEvent, RunEvent]:
+    """Create a pair of OpenLineage RunEvents representing the start and end of a query execution."""
+    from openlineage.client.event_v2 import Job, Run, RunEvent, RunState
+    from openlineage.client.uuid import generate_new_uuid
+
+    run = Run(runId=str(generate_new_uuid()), facets=run_facets or {})
+    job = Job(namespace=job_namespace, name=job_name, facets=job_facets or {})
+
+    start = RunEvent(
+        eventType=RunState.START,
+        eventTime=start_time.isoformat(),
+        run=run,
+        job=job,
+    )
+    end = RunEvent(
+        eventType=RunState.COMPLETE if is_successful else RunState.FAIL,
+        eventTime=end_time.isoformat(),
+        run=run,
+        job=job,
+    )
+    return start, end
+
+
+@require_openlineage_version(provider_min_version="2.3.0")
+def emit_openlineage_events_for_databricks_queries(
+    query_ids: list[str],
+    query_source_namespace: str,
+    task_instance,
+    hook: DatabricksSqlHook | None = None,
+    additional_run_facets: dict | None = None,
+    additional_job_facets: dict | None = None,
+) -> None:
+    """
+    Emit OpenLineage events for executed Databricks queries.
+
+    Metadata retrieval from Databricks is attempted only if a `DatabricksSqlHook` is provided.
+    If metadata is available, execution details such as start time, end time, execution status,
+    error messages, and SQL text are included in the events. If no metadata is found, the function
+    defaults to using the Airflow task instance's state and the current timestamp.
+
+    Note that both START and COMPLETE event for each query will be emitted at the same time.
+    If we are able to query Databricks for query execution metadata, event times
+    will correspond to actual query execution times.
+
+    Args:
+        query_ids: A list of Databricks query IDs to emit events for.
+        query_source_namespace: The namespace to be included in ExternalQueryRunFacet.
+        task_instance: The Airflow task instance that run these queries.
+        hook: A hook instance used to retrieve query metadata if available.
+        additional_run_facets: Additional run facets to include in OpenLineage events.
+        additional_job_facets: Additional job facets to include in OpenLineage events.
+    """
+    from openlineage.client.facet_v2 import job_type_job
+
+    from airflow.providers.common.compat.openlineage.facet import (
+        ErrorMessageRunFacet,
+        ExternalQueryRunFacet,
+        RunFacet,
+        SQLJobFacet,
+    )
+    from airflow.providers.openlineage.conf import namespace
+    from airflow.providers.openlineage.plugins.listener import get_openlineage_listener
+
+    if not query_ids:
+        log.debug("No Databricks query IDs provided; skipping OpenLineage event emission.")
+        return
+
+    query_ids = [q for q in query_ids]  # Make a copy to make sure it does not change
+
+    if hook:
+        log.debug("Retrieving metadata for %s queries from Databricks.", len(query_ids))
+        databricks_metadata = _get_queries_details_from_databricks(hook, query_ids)
+    else:
+        log.debug("DatabricksSqlHook not provided. No extra metadata fill be fetched from Databricks.")
+        databricks_metadata = {}
+
+    # If real metadata is unavailable, we send events with eventTime=now
+    default_event_time = timezone.utcnow()
+    # If no query metadata is provided, we use task_instance's state when checking for success
+    # Adjust state for DBX logic, where "finished" means "success"
+    default_state = task_instance.state.value if hasattr(task_instance, "state") else ""
+    default_state = "finished" if default_state == "success" else default_state
+
+    log.debug("Generating OpenLineage facets")
+    common_run_facets = {"parent": _get_parent_run_facet(task_instance)}
+    common_job_facets: dict[str, JobFacet] = {
+        "jobType": job_type_job.JobTypeJobFacet(
+            jobType="QUERY",
+            integration="DATABRICKS",
+            processingType="BATCH",
+        )
+    }
+    additional_run_facets = additional_run_facets or {}
+    additional_job_facets = additional_job_facets or {}
+
+    events: list[RunEvent] = []
+    for counter, query_id in enumerate(query_ids, 1):
+        query_metadata = databricks_metadata.get(query_id, {})
+        log.debug(
+            "Metadata for query no. %s, (ID `%s`): `%s`",
+            counter,
+            query_id,
+            query_metadata if query_metadata else "not found",
+        )
+
+        query_specific_run_facets: dict[str, RunFacet] = {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId=query_id, source=query_source_namespace)
+        }
+        if query_metadata.get("error_message"):
+            query_specific_run_facets["error"] = ErrorMessageRunFacet(
+                message=query_metadata["error_message"],
+                programmingLanguage="SQL",
+            )
+
+        query_specific_job_facets = {}
+        if query_metadata.get("query_text"):
+            query_specific_job_facets["sql"] = SQLJobFacet(query=query_metadata["query_text"])
+
+        log.debug("Creating OpenLineage event pair for query ID: %s", query_id)
+        event_batch = _create_ol_event_pair(
+            job_namespace=namespace(),
+            job_name=f"{task_instance.dag_id}.{task_instance.task_id}.query.{counter}",
+            start_time=query_metadata.get("start_time", default_event_time),  # type: ignore[arg-type]
+            end_time=query_metadata.get("end_time", default_event_time),  # type: ignore[arg-type]
+            # Only finished status means it completed without failures
+            is_successful=query_metadata.get("status", default_state).lower() == "finished",
+            run_facets={**query_specific_run_facets, **common_run_facets, **additional_run_facets},
+            job_facets={**query_specific_job_facets, **common_job_facets, **additional_job_facets},
+        )
+        events.extend(event_batch)
+
+    log.debug("Generated %s OpenLineage events; emitting now.", len(events))
+    adapter = get_openlineage_listener().adapter
+    for event in events:
+        adapter.emit(event)
+
+    log.info("OpenLineage has successfully finished processing information about Databricks queries.")
+    return

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -27,7 +27,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from databricks.sql.types import Row
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowOptionalProviderFeatureException
 from airflow.models import Connection
 from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook, create_timeout_thread
@@ -435,3 +435,72 @@ def test_create_timeout_thread_no_timeout(
     thread = create_timeout_thread(cur=cur, execution_timeout=None)
     mock_timer.assert_not_called()
     assert thread is None
+
+
+def test_get_openlineage_default_schema_with_no_schema_set():
+    hook = DatabricksSqlHook()
+    assert hook.get_openlineage_default_schema() == "default"
+
+
+def test_get_openlineage_default_schema_with_schema_set():
+    hook = DatabricksSqlHook(schema="my-schema")
+    assert hook.get_openlineage_default_schema() == "my-schema"
+
+
+def test_get_openlineage_database_specific_lineage_with_no_query_id():
+    hook = DatabricksSqlHook()
+    hook.query_ids = []
+
+    result = hook.get_openlineage_database_specific_lineage(None)
+    assert result is None
+
+
+def test_get_openlineage_database_specific_lineage_with_single_query_id():
+    from airflow.providers.common.compat.openlineage.facet import ExternalQueryRunFacet
+    from airflow.providers.openlineage.extractors import OperatorLineage
+
+    hook = DatabricksSqlHook()
+    hook.query_ids = ["query1"]
+    hook.get_connection = mock.MagicMock()
+    hook.get_openlineage_database_info = lambda x: mock.MagicMock(authority="auth", scheme="scheme")
+
+    result = hook.get_openlineage_database_specific_lineage(None)
+    assert result == OperatorLineage(
+        run_facets={"externalQuery": ExternalQueryRunFacet(externalQueryId="query1", source="scheme://auth")}
+    )
+
+
+@mock.patch("airflow.providers.databricks.utils.openlineage.emit_openlineage_events_for_databricks_queries")
+def test_get_openlineage_database_specific_lineage_with_multiple_query_ids(mock_emit):
+    hook = DatabricksSqlHook()
+    hook.query_ids = ["query1", "query2"]
+    hook.get_connection = mock.MagicMock()
+    hook.get_openlineage_database_info = lambda x: mock.MagicMock(authority="auth", scheme="scheme")
+
+    ti = mock.MagicMock()
+
+    result = hook.get_openlineage_database_specific_lineage(ti)
+    mock_emit.assert_called_once_with(
+        **{
+            "hook": hook,
+            "query_ids": ["query1", "query2"],
+            "query_source_namespace": "scheme://auth",
+            "task_instance": ti,
+        }
+    )
+    assert result is None
+
+
+@mock.patch("importlib.metadata.version", return_value="1.99.0")
+def test_get_openlineage_database_specific_lineage_with_old_openlineage_provider(mock_version):
+    hook = DatabricksSqlHook()
+    hook.query_ids = ["query1", "query2"]
+    hook.get_connection = mock.MagicMock()
+    hook.get_openlineage_database_info = lambda x: mock.MagicMock(authority="auth", scheme="scheme")
+
+    expected_err = (
+        "OpenLineage provider version `1.99.0` is lower than required `2.3.0`, "
+        "skipping function `emit_openlineage_events_for_databricks_queries` execution"
+    )
+    with pytest.raises(AirflowOptionalProviderFeatureException, match=expected_err):
+        hook.get_openlineage_database_specific_lineage(mock.MagicMock())

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
@@ -307,3 +307,10 @@ def test_exec_write_file(
             return_last=return_last,
             split_statements=split_statements,
         )
+
+
+def test_hook_is_cached():
+    op = DatabricksSqlOperator(task_id=TASK_ID, sql="SELECT 42")
+    hook = op.get_db_hook()
+    hook2 = op.get_db_hook()
+    assert hook is hook2

--- a/providers/databricks/tests/unit/databricks/utils/test_openlineage.py
+++ b/providers/databricks/tests/unit/databricks/utils/test_openlineage.py
@@ -1,0 +1,617 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import copy
+import datetime
+from unittest import mock
+
+import pytest
+from openlineage.client.event_v2 import Job, Run, RunEvent, RunState
+from openlineage.client.facet_v2 import job_type_job, parent_run
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+from airflow.providers.common.compat.openlineage.facet import (
+    ErrorMessageRunFacet,
+    ExternalQueryRunFacet,
+    SQLJobFacet,
+)
+from airflow.providers.databricks.utils.openlineage import (
+    _create_ol_event_pair,
+    _get_ol_run_id,
+    _get_parent_run_facet,
+    _get_queries_details_from_databricks,
+    _run_api_call,
+    emit_openlineage_events_for_databricks_queries,
+)
+from airflow.providers.openlineage.conf import namespace
+from airflow.utils import timezone
+from airflow.utils.state import TaskInstanceState
+
+
+def test_get_ol_run_id_ti_success():
+    logical_date = timezone.datetime(2025, 1, 1)
+    mock_ti = mock.MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        map_index=1,
+        try_number=1,
+        logical_date=logical_date,
+        state=TaskInstanceState.SUCCESS,
+    )
+    mock_ti.get_template_context.return_value = {"dag_run": mock.MagicMock(logical_date=logical_date)}
+
+    result = _get_ol_run_id(mock_ti)
+    assert result == "01941f29-7c00-7087-8906-40e512c257bd"
+
+
+def test_get_ol_run_id_ti_failed():
+    logical_date = timezone.datetime(2025, 1, 1)
+    mock_ti = mock.MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        map_index=1,
+        try_number=1,
+        logical_date=logical_date,
+        state=TaskInstanceState.FAILED,
+    )
+    mock_ti.get_template_context.return_value = {"dag_run": mock.MagicMock(logical_date=logical_date)}
+
+    result = _get_ol_run_id(mock_ti)
+    assert result == "01941f29-7c00-7087-8906-40e512c257bd"
+
+
+def test_get_parent_run_facet():
+    logical_date = timezone.datetime(2025, 1, 1)
+    mock_ti = mock.MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        map_index=1,
+        try_number=1,
+        logical_date=logical_date,
+        state=TaskInstanceState.SUCCESS,
+    )
+    mock_ti.get_template_context.return_value = {"dag_run": mock.MagicMock(logical_date=logical_date)}
+
+    result = _get_parent_run_facet(mock_ti)
+
+    assert result.run.runId == "01941f29-7c00-7087-8906-40e512c257bd"
+    assert result.job.namespace == namespace()
+    assert result.job.name == "dag_id.task_id"
+
+
+def test_run_api_call_success():
+    mock_hook = mock.MagicMock()
+    mock_hook._token = "mock_token"
+    mock_hook.host = "mock_host"
+
+    mock_response = mock.MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"res": [{"query_id": "123", "status": "success"}]}
+
+    with mock.patch("requests.get", return_value=mock_response):
+        result = _run_api_call(mock_hook, ["123"])
+
+    assert result == [{"query_id": "123", "status": "success"}]
+
+
+def test_run_api_call_error():
+    mock_hook = mock.MagicMock()
+    mock_hook._token = "mock_token"
+    mock_hook.host = "mock_host"
+
+    mock_response = mock.MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+
+    with mock.patch("requests.get", return_value=mock_response):
+        result = _run_api_call(mock_hook, ["123"])
+
+    assert result == []
+
+
+def test_get_queries_details_from_databricks_empty_query_ids():
+    details = _get_queries_details_from_databricks(None, [])
+    assert details == {}
+
+
+@mock.patch("airflow.providers.databricks.utils.openlineage._run_api_call")
+def test_get_queries_details_from_databricks(mock_api_call):
+    hook = mock.MagicMock()
+    query_ids = ["ABC"]
+    fake_result = [
+        {
+            "query_id": "ABC",
+            "status": "FINISHED",
+            "query_start_time_ms": 1595357086200,
+            "query_end_time_ms": 1595357087200,
+            "query_text": "SELECT * FROM table1;",
+            "error_message": "Error occurred",
+        }
+    ]
+    mock_api_call.return_value = fake_result
+
+    details = _get_queries_details_from_databricks(hook, query_ids)
+    mock_api_call.assert_called_once_with(hook=hook, query_ids=query_ids)
+    assert details == {
+        "ABC": {
+            "status": "FINISHED",
+            "start_time": datetime.datetime(2020, 7, 21, 18, 44, 46, 200000, tzinfo=datetime.timezone.utc),
+            "end_time": datetime.datetime(2020, 7, 21, 18, 44, 47, 200000, tzinfo=datetime.timezone.utc),
+            "query_text": "SELECT * FROM table1;",
+            "error_message": "Error occurred",
+        }
+    }
+
+
+@mock.patch("airflow.providers.databricks.utils.openlineage._run_api_call")
+def test_get_queries_details_from_databricks_no_data_found(mock_api_call):
+    hook = mock.MagicMock()
+    query_ids = ["ABC", "DEF"]
+    mock_api_call.return_value = []
+
+    details = _get_queries_details_from_databricks(hook, query_ids)
+    mock_api_call.assert_called_once_with(hook=hook, query_ids=query_ids)
+    assert details == {}
+
+
+@pytest.mark.parametrize("is_successful", [True, False])
+@mock.patch("openlineage.client.uuid.generate_new_uuid")
+def test_create_ol_event_pair_success(mock_generate_uuid, is_successful):
+    fake_uuid = "01941f29-7c00-7087-8906-40e512c257bd"
+    mock_generate_uuid.return_value = fake_uuid
+
+    job_namespace = "test_namespace"
+    job_name = "test_job"
+    start_time = timezone.datetime(2021, 1, 1, 10, 0, 0)
+    end_time = timezone.datetime(2021, 1, 1, 10, 30, 0)
+    run_facets = {"run_key": "run_value"}
+    job_facets = {"job_key": "job_value"}
+
+    start_event, end_event = _create_ol_event_pair(
+        job_namespace,
+        job_name,
+        start_time,
+        end_time,
+        is_successful=is_successful,
+        run_facets=run_facets,
+        job_facets=job_facets,
+    )
+
+    assert start_event.eventType == RunState.START
+    assert start_event.eventTime == start_time.isoformat()
+    assert end_event.eventType == RunState.COMPLETE if is_successful else RunState.FAIL
+    assert end_event.eventTime == end_time.isoformat()
+
+    assert start_event.run.runId == fake_uuid
+    assert start_event.run.facets == run_facets
+
+    assert start_event.job.namespace == job_namespace
+    assert start_event.job.name == job_name
+    assert start_event.job.facets == job_facets
+
+    assert start_event.run is end_event.run
+    assert start_event.job == end_event.job
+
+
+@mock.patch("importlib.metadata.version", return_value="2.3.0")
+@mock.patch("openlineage.client.uuid.generate_new_uuid")
+@mock.patch("airflow.utils.timezone.utcnow")
+def test_emit_openlineage_events_for_databricks_queries(mock_now, mock_generate_uuid, mock_version):
+    fake_uuid = "01958e68-03a2-79e3-9ae9-26865cc40e2f"
+    mock_generate_uuid.return_value = fake_uuid
+
+    default_event_time = timezone.datetime(2025, 1, 5, 0, 0, 0)
+    mock_now.return_value = default_event_time
+
+    query_ids = ["query1", "query2", "query3"]
+    original_query_ids = copy.deepcopy(query_ids)
+    logical_date = timezone.datetime(2025, 1, 1)
+    mock_dagrun = mock.MagicMock(logical_date=logical_date, clear_number=0)
+    mock_ti = mock.MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        map_index=1,
+        try_number=1,
+        logical_date=logical_date,
+        state=TaskInstanceState.FAILED,  # This will be query default state if no metadata found
+        dag_run=mock_dagrun,
+    )
+    mock_ti.get_template_context.return_value = {"dag_run": mock_dagrun}
+
+    fake_metadata = {
+        "query1": {
+            "status": "FINISHED",
+            "start_time": datetime.datetime(2020, 7, 21, 18, 44, 46, 200000, tzinfo=datetime.timezone.utc),
+            "end_time": datetime.datetime(2020, 7, 21, 18, 44, 47, 200000, tzinfo=datetime.timezone.utc),
+            "query_text": "SELECT * FROM table1",
+            # No error for query1
+        },
+        "query2": {
+            "status": "CANCELED",
+            "start_time": datetime.datetime(2020, 7, 21, 18, 44, 48, 200000, tzinfo=datetime.timezone.utc),
+            "end_time": datetime.datetime(2020, 7, 21, 18, 44, 49, 200000, tzinfo=datetime.timezone.utc),
+            "query_text": "SELECT * FROM table2",
+            "error_message": "Error occurred",
+        },
+        # No metadata for query3
+    }
+
+    additional_run_facets = {"custom_run": "value_run"}
+    additional_job_facets = {"custom_job": "value_job"}
+
+    fake_adapter = mock.MagicMock()
+    fake_adapter.emit = mock.MagicMock()
+    fake_listener = mock.MagicMock()
+    fake_listener.adapter = fake_adapter
+
+    with (
+        mock.patch(
+            "airflow.providers.databricks.utils.openlineage._get_queries_details_from_databricks",
+            return_value=fake_metadata,
+        ),
+        mock.patch(
+            "airflow.providers.openlineage.plugins.listener.get_openlineage_listener",
+            return_value=fake_listener,
+        ),
+    ):
+        emit_openlineage_events_for_databricks_queries(
+            query_ids=query_ids,
+            query_source_namespace="databricks_ns",
+            task_instance=mock_ti,
+            hook=mock.MagicMock(),
+            additional_run_facets=additional_run_facets,
+            additional_job_facets=additional_job_facets,
+        )
+
+        assert query_ids == original_query_ids  # Verify that the input query_ids list is unchanged.
+        assert fake_adapter.emit.call_count == 6  # Expect two events per query.
+
+        expected_common_job_facets = {
+            "jobType": job_type_job.JobTypeJobFacet(
+                jobType="QUERY",
+                processingType="BATCH",
+                integration="DATABRICKS",
+            ),
+            "custom_job": "value_job",
+        }
+        expected_common_run_facets = {
+            "parent": parent_run.ParentRunFacet(
+                run=parent_run.Run(runId="01941f29-7c00-7087-8906-40e512c257bd"),
+                job=parent_run.Job(namespace=namespace(), name="dag_id.task_id"),
+                root=parent_run.Root(
+                    run=parent_run.RootRun(runId="01941f29-7c00-743e-b109-28b18d0a19c5"),
+                    job=parent_run.RootJob(namespace=namespace(), name="dag_id"),
+                ),
+            ),
+            "custom_run": "value_run",
+        }
+
+        expected_calls = [
+            mock.call(  # Query1: START event
+                RunEvent(
+                    eventTime="2020-07-21T18:44:46.200000+00:00",
+                    eventType=RunState.START,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query1", source="databricks_ns"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.1",
+                        facets={
+                            "sql": SQLJobFacet(query="SELECT * FROM table1"),
+                            **expected_common_job_facets,
+                        },
+                    ),
+                )
+            ),
+            mock.call(  # Query1: COMPLETE event
+                RunEvent(
+                    eventTime="2020-07-21T18:44:47.200000+00:00",
+                    eventType=RunState.COMPLETE,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query1", source="databricks_ns"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.1",
+                        facets={
+                            "sql": SQLJobFacet(query="SELECT * FROM table1"),
+                            **expected_common_job_facets,
+                        },
+                    ),
+                )
+            ),
+            mock.call(  # Query2: START event
+                RunEvent(
+                    eventTime="2020-07-21T18:44:48.200000+00:00",
+                    eventType=RunState.START,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query2", source="databricks_ns"
+                            ),
+                            "error": ErrorMessageRunFacet(
+                                message="Error occurred", programmingLanguage="SQL"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.2",
+                        facets={
+                            "sql": SQLJobFacet(query="SELECT * FROM table2"),
+                            **expected_common_job_facets,
+                        },
+                    ),
+                )
+            ),
+            mock.call(  # Query2: FAIL event
+                RunEvent(
+                    eventTime="2020-07-21T18:44:49.200000+00:00",
+                    eventType=RunState.FAIL,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query2", source="databricks_ns"
+                            ),
+                            "error": ErrorMessageRunFacet(
+                                message="Error occurred", programmingLanguage="SQL"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.2",
+                        facets={
+                            "sql": SQLJobFacet(query="SELECT * FROM table2"),
+                            **expected_common_job_facets,
+                        },
+                    ),
+                )
+            ),
+            mock.call(  # Query3: START event (no metadata)
+                RunEvent(
+                    eventTime=default_event_time.isoformat(),  # no metadata for query3
+                    eventType=RunState.START,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query3", source="databricks_ns"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.3",
+                        facets=expected_common_job_facets,
+                    ),
+                )
+            ),
+            mock.call(  # Query3: FAIL event (no metadata)
+                RunEvent(
+                    eventTime=default_event_time.isoformat(),  # no metadata for query3
+                    eventType=RunState.FAIL,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query3", source="databricks_ns"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.3",
+                        facets=expected_common_job_facets,
+                    ),
+                )
+            ),
+        ]
+
+        assert fake_adapter.emit.call_args_list == expected_calls
+
+
+@mock.patch("importlib.metadata.version", return_value="2.3.0")
+@mock.patch("openlineage.client.uuid.generate_new_uuid")
+@mock.patch("airflow.utils.timezone.utcnow")
+def test_emit_openlineage_events_for_databricks_queries_without_metadata_found(
+    mock_now, mock_generate_uuid, mock_version
+):
+    fake_uuid = "01958e68-03a2-79e3-9ae9-26865cc40e2f"
+    mock_generate_uuid.return_value = fake_uuid
+
+    default_event_time = timezone.datetime(2025, 1, 5, 0, 0, 0)
+    mock_now.return_value = default_event_time
+
+    query_ids = ["query1"]
+    original_query_ids = copy.deepcopy(query_ids)
+    logical_date = timezone.datetime(2025, 1, 1)
+    mock_ti = mock.MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        map_index=1,
+        try_number=1,
+        logical_date=logical_date,
+        state=TaskInstanceState.SUCCESS,  # This will be query default state if no metadata found
+        dag_run=mock.MagicMock(logical_date=logical_date, clear_number=0),
+    )
+    mock_ti.get_template_context.return_value = {
+        "dag_run": mock.MagicMock(logical_date=logical_date, clear_number=0)
+    }
+
+    additional_run_facets = {"custom_run": "value_run"}
+    additional_job_facets = {"custom_job": "value_job"}
+
+    fake_adapter = mock.MagicMock()
+    fake_adapter.emit = mock.MagicMock()
+    fake_listener = mock.MagicMock()
+    fake_listener.adapter = fake_adapter
+
+    with mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_openlineage_listener",
+        return_value=fake_listener,
+    ):
+        emit_openlineage_events_for_databricks_queries(
+            query_ids=query_ids,
+            query_source_namespace="databricks_ns",
+            task_instance=mock_ti,
+            hook=None,  # None so metadata retrieval is not triggered
+            additional_run_facets=additional_run_facets,
+            additional_job_facets=additional_job_facets,
+        )
+
+        assert query_ids == original_query_ids  # Verify that the input query_ids list is unchanged.
+        assert fake_adapter.emit.call_count == 2  # Expect two events per query.
+
+        expected_common_job_facets = {
+            "jobType": job_type_job.JobTypeJobFacet(
+                jobType="QUERY",
+                processingType="BATCH",
+                integration="DATABRICKS",
+            ),
+            "custom_job": "value_job",
+        }
+        expected_common_run_facets = {
+            "parent": parent_run.ParentRunFacet(
+                run=parent_run.Run(runId="01941f29-7c00-7087-8906-40e512c257bd"),
+                job=parent_run.Job(namespace=namespace(), name="dag_id.task_id"),
+                root=parent_run.Root(
+                    run=parent_run.RootRun(runId="01941f29-7c00-743e-b109-28b18d0a19c5"),
+                    job=parent_run.RootJob(namespace=namespace(), name="dag_id"),
+                ),
+            ),
+            "custom_run": "value_run",
+        }
+
+        expected_calls = [
+            mock.call(  # Query1: START event (no metadata)
+                RunEvent(
+                    eventTime=default_event_time.isoformat(),
+                    eventType=RunState.START,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query1", source="databricks_ns"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.1",
+                        facets=expected_common_job_facets,
+                    ),
+                )
+            ),
+            mock.call(  # Query1: COMPLETE event (no metadata)
+                RunEvent(
+                    eventTime=default_event_time.isoformat(),
+                    eventType=RunState.COMPLETE,
+                    run=Run(
+                        runId=fake_uuid,
+                        facets={
+                            "externalQuery": ExternalQueryRunFacet(
+                                externalQueryId="query1", source="databricks_ns"
+                            ),
+                            **expected_common_run_facets,
+                        },
+                    ),
+                    job=Job(
+                        namespace=namespace(),
+                        name="dag_id.task_id.query.1",
+                        facets=expected_common_job_facets,
+                    ),
+                )
+            ),
+        ]
+
+        assert fake_adapter.emit.call_args_list == expected_calls
+
+
+@mock.patch("importlib.metadata.version", return_value="2.3.0")
+def test_emit_openlineage_events_for_databricks_queries_without_query_ids(mock_version):
+    query_ids = []
+    original_query_ids = copy.deepcopy(query_ids)
+
+    fake_adapter = mock.MagicMock()
+    fake_adapter.emit = mock.MagicMock()
+    fake_listener = mock.MagicMock()
+    fake_listener.adapter = fake_adapter
+
+    with mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_openlineage_listener",
+        return_value=fake_listener,
+    ):
+        emit_openlineage_events_for_databricks_queries(
+            query_ids=query_ids,
+            query_source_namespace="databricks_ns",
+            task_instance=None,
+        )
+
+        assert query_ids == original_query_ids  # Verify that the input query_ids list is unchanged.
+        fake_adapter.emit.assert_not_called()  # No events should be emitted
+
+
+# emit_openlineage_events_for_databricks_queries requires OL provider 2.3.0
+@mock.patch("importlib.metadata.version", return_value="1.99.0")
+def test_emit_openlineage_events_with_old_openlineage_provider(mock_version):
+    query_ids = ["q1", "q2"]
+    original_query_ids = copy.deepcopy(query_ids)
+
+    fake_adapter = mock.MagicMock()
+    fake_adapter.emit = mock.MagicMock()
+    fake_listener = mock.MagicMock()
+    fake_listener.adapter = fake_adapter
+
+    with mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_openlineage_listener",
+        return_value=fake_listener,
+    ):
+        expected_err = (
+            "OpenLineage provider version `1.99.0` is lower than required `2.3.0`, "
+            "skipping function `emit_openlineage_events_for_databricks_queries` execution"
+        )
+
+        with pytest.raises(AirflowOptionalProviderFeatureException, match=expected_err):
+            emit_openlineage_events_for_databricks_queries(
+                query_ids=query_ids,
+                query_source_namespace="databricks_ns",
+                task_instance=None,
+            )
+        assert query_ids == original_query_ids  # Verify that the input query_ids list is unchanged.
+        fake_adapter.emit.assert_not_called()  # No events should be emitted


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds OpenLineage support for `DatabricksSqlHook` and therefore `DatabricksSqlOperator`. It also introduces caching the hook on the operator level and gathering Databricks query_ids in the Hook when executing queries.

The OpenLineage logic implemented in `DatabricksSqlHook` is very similar to all other database Hooks already supported, and implementing a common interface from `DbApiHook`:

- Snowflake implementation [url](https://github.com/apache/airflow/blob/main/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py#L562). 
- Redshift implementation [url](https://github.com/apache/airflow/blob/main/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py#L205).
- All supported hooks [url](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/supported_classes.html#sqlexecutequeryoperator)

This PR also implements a very similar logic as in [Snowflake provider](https://github.com/apache/airflow/blob/main/providers/snowflake/src/airflow/providers/snowflake/utils/openlineage.py) on how to deal with multiple query_ids - we are sending pair of OpenLineage events for each query run, if there are more than one per operator run.

I've also updated the OpenLineage documentation to make it clear for the users how the support works for operators that inherit from SqlExecuteQueryOperator.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
