### PR TITLE
Fix Breeze unit test

### DIFF
--- a/providers/common/compat/src/airflow/providers/common/compat/standard/operators.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/standard/operators.py
@@ -39,8 +39,12 @@ else:
             _SERIALIZERS,
             PythonOperator,
             ShortCircuitOperator,
-            get_current_context,
         )
+
+    try:
+        from airflow.sdk import get_current_context
+    except (ImportError, ModuleNotFoundError):
+        from airflow.providers.standard.operators.python import get_current_context
 
 
 __all__ = ["PythonOperator", "_SERIALIZERS", "ShortCircuitOperator", "get_current_context"]

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Collection, Mapping, Sequence
 from typing import Any, Callable
 
-from airflow.providers.common.compat.standard.operators import PythonOperator
+from airflow.providers.common.compat.standard.operators import PythonOperator, get_current_context
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.providers.snowflake.utils.snowpark import inject_session_into_op_kwargs
 
@@ -115,14 +115,6 @@ class SnowparkOperator(PythonOperator):
             session_parameters=self.session_parameters,
         )
         session = hook.get_snowpark_session()
-
-        from airflow.providers.snowflake.version_compat import AIRFLOW_V_3_0_PLUS
-
-        if AIRFLOW_V_3_0_PLUS:
-            from airflow.sdk import get_current_context
-        else:
-            from airflow.providers.standard.operators.python import get_current_context
-
         context = get_current_context()
         session.update_query_tag(
             {


### PR DESCRIPTION
This fixes broken breeze unit test:

```
FAILED tests/test_selective_checks.py::test_expected_output_pull_request_main[Only Python tests] - AssertionError: Correct value for 'providers-test-types-list-as-strings-in-json'
assert '[{"description": "common.compat...standard", "test_types": "Providers[common.compat,snowflake] Providers[standard]"}]' == '[{"description": "common.compat...standard", "test_types": "Providers[common.compat] Providers[standard]"}]'
  
  - [{"description": "common.compat...standard", "test_types": "Providers[common.compat] Providers[standard]"}]
  + [{"description": "common.compat...standard", "test_types": "Providers[common.compat,snowflake] Providers[standard]"}]
  ?                                                                                    ++++++++++
FAILED tests/test_selective_checks.py::test_expected_output_pull_request_main[Providers standard tests and Serialization tests to run when airflow bash.py changed] - AssertionError: Correct value for 'selected-providers-list-as-string'
assert 'common.compat snowflake standard' == 'common.compat standard'
  
  - common.compat standard
  + common.compat snowflake standard
  ?               ++++++++++
FAILED tests/test_selective_checks.py::test_expected_output_pull_request_main[Force Core and Serialization tests to run when tests bash changed] - AssertionError: Correct value for 'providers-test-types-list-as-strings-in-json'
assert '[{"description": "common.compat...standard", "test_types": "Providers[common.compat,snowflake] Providers[standard]"}]' == '[{"description": "common.compat...standard", "test_types": "Providers[common.compat] Providers[standard]"}]'
  
  - [{"description": "common.compat...standard", "test_types": "Providers[common.compat] Providers[standard]"}]
  + [{"description": "common.compat...standard", "test_types": "Providers[common.compat,snowflake] Providers[standard]"}]
  ?                                                                                    ++++++++++
```

Example failure: https://github.com/apache/airflow/actions/runs/14929336405/job/41941407161?pr=50300 -- this was due to change in https://github.com/apache/airflow/pull/50391

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
