### PR TITLE
nit: Switch to using json instead of str when casting collections in OpenLineage

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -298,7 +298,7 @@ class InfoJsonEncodable(dict):
         if isinstance(value, datetime.timedelta):
             return f"{value.total_seconds()} seconds"
         if isinstance(value, (set, list, tuple)):
-            return str(list(value))
+            return json.dumps(list(value))
         return value
 
     def _rename_fields(self):

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -208,7 +208,7 @@ def test_info_json_encodable_list_does_flatten():
 
     obj = Test(["a", "b", "c"])
 
-    assert json.loads(json.dumps(TestInfo(obj))) == {"alist": "['a', 'b', 'c']"}
+    assert json.loads(json.dumps(TestInfo(obj))) == {"alist": '["a", "b", "c"]'}
 
 
 def test_info_json_encodable_list_does_include_nonexisting():

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -176,7 +176,7 @@ def test_get_airflow_dag_run_facet():
         "owner": "airflow",
         "timetable": {},
         "start_date": "2024-06-01T00:00:00+00:00",
-        "tags": "['test']",
+        "tags": '["test"]',
         "owner_links": {},
     }
     if hasattr(dag, "schedule_interval"):  # Airflow 2 compat.
@@ -823,7 +823,7 @@ class TestDagInfoAirflow2:
             "fileloc": pathlib.Path(__file__).resolve().as_posix(),
             "schedule_interval": "@once",
             "start_date": "2024-06-01T00:00:00+00:00",
-            "tags": "['test']",
+            "tags": '["test"]',
             "timetable": {},
             "owner_links": {"some_owner": "https://airflow.apache.org"},
         }
@@ -1071,7 +1071,7 @@ class TestDagInfoAirflow3:
             "description": "test desc",
             "fileloc": pathlib.Path(__file__).resolve().as_posix(),
             "start_date": "2024-06-01T00:00:00+00:00",
-            "tags": "['test']",
+            "tags": '["test"]',
             "timetable": {},
             "timetable_summary": "@once",
             "owner_links": {"some_owner": "https://airflow.apache.org"},
@@ -1562,7 +1562,7 @@ def test_task_info_af3():
     tg_info = TaskGroupInfo(tg)
     assert dict(tg_info) == {
         "downstream_group_ids": "[]",
-        "downstream_task_ids": "['task_1']",
+        "downstream_task_ids": '["task_1"]',
         "group_id": "section_1",
         "prefix_group_id": True,
         "tooltip": "",
@@ -1572,13 +1572,13 @@ def test_task_info_af3():
     assert dict(result) == {
         "deferrable": True,
         "depends_on_past": False,
-        "downstream_task_ids": "['task_1']",
+        "downstream_task_ids": '["task_1"]',
         "execution_timeout": None,
         "executor_config": {},
         "external_dag_id": "external_dag_id",
         "external_task_id": "external_task_id",
         "ignore_first_depends_on_past": False,
-        "inlets": "[{'uri': 'uri1', 'extra': {'a': 1}}]",
+        "inlets": '[{"uri": "uri1", "extra": {"a": 1}}]',
         "mapped": False,
         "max_active_tis_per_dag": None,
         "max_active_tis_per_dagrun": None,
@@ -1586,7 +1586,7 @@ def test_task_info_af3():
         "multiple_outputs": False,
         "operator_class": "CustomOperator",
         "operator_class_path": get_fully_qualified_class_name(task_10),
-        "outlets": "[{'uri': 'uri2', 'extra': {'b': 2}}, {'uri': 'uri3', 'extra': {'c': 3}}]",
+        "outlets": '[{"uri": "uri2", "extra": {"b": 2}}, {"uri": "uri3", "extra": {"c": 3}}]',
         "owner": "airflow",
         "priority_weight": 1,
         "queue": "default",
@@ -1597,7 +1597,7 @@ def test_task_info_af3():
         "task_id": "section_1.task_3",
         "trigger_dag_id": "trigger_dag_id",
         "trigger_rule": "all_success",
-        "upstream_task_ids": "['task_0']",
+        "upstream_task_ids": '["task_0"]',
         "wait_for_downstream": False,
         "wait_for_past_depends_before_skipping": False,
     }
@@ -1636,7 +1636,7 @@ def test_task_info_af2():
     tg_info = TaskGroupInfo(tg)
     assert dict(tg_info) == {
         "downstream_group_ids": "[]",
-        "downstream_task_ids": "['task_1']",
+        "downstream_task_ids": '["task_1"]',
         "group_id": "section_1",
         "prefix_group_id": True,
         "tooltip": "",
@@ -1646,7 +1646,7 @@ def test_task_info_af2():
     assert dict(result) == {
         "deferrable": True,
         "depends_on_past": False,
-        "downstream_task_ids": "['task_1']",
+        "downstream_task_ids": '["task_1"]',
         "execution_timeout": None,
         "executor_config": {},
         "external_dag_id": "external_dag_id",
@@ -1655,7 +1655,7 @@ def test_task_info_af2():
         "is_setup": False,
         "is_teardown": False,
         "sla": None,
-        "inlets": "[{'uri': 'uri1', 'extra': {'a': 1}}]",
+        "inlets": '[{"uri": "uri1", "extra": {"a": 1}}]',
         "mapped": False,
         "max_active_tis_per_dag": None,
         "max_active_tis_per_dagrun": None,
@@ -1663,7 +1663,7 @@ def test_task_info_af2():
         "multiple_outputs": False,
         "operator_class": "CustomOperator",
         "operator_class_path": get_fully_qualified_class_name(task_10),
-        "outlets": "[{'uri': 'uri2', 'extra': {'b': 2}}, {'uri': 'uri3', 'extra': {'c': 3}}]",
+        "outlets": '[{"uri": "uri2", "extra": {"b": 2}}, {"uri": "uri3", "extra": {"c": 3}}]',
         "owner": "airflow",
         "priority_weight": 1,
         "queue": "default",
@@ -1674,7 +1674,7 @@ def test_task_info_af2():
         "task_id": "section_1.task_3",
         "trigger_dag_id": "trigger_dag_id",
         "trigger_rule": "all_success",
-        "upstream_task_ids": "['task_0']",
+        "upstream_task_ids": '["task_0"]',
         "wait_for_downstream": False,
         "wait_for_past_depends_before_skipping": False,
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Using json when casting collections to string in OL can be helpful for consumers, especially for things like DAG tags that are now casted with `str()` which can sometimes be hard to reverse. This is still compliant with the spec, we keep it as string, only changing the quotes for consistent ones really.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
