### PR TITLE
CLI: Exclude example dags when a bundle is passed

### DIFF
--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -277,7 +277,7 @@ def get_dag(bundle_names: list | None, dag_id: str, from_db: bool = False) -> DA
         manager = DagBundlesManager()
         for bundle_name in bundle_names:
             bundle = manager.get_bundle(bundle_name)
-            dagbag = DagBag(dag_folder=bundle.path, bundle_path=bundle.path)
+            dagbag = DagBag(dag_folder=bundle.path, bundle_path=bundle.path, include_examples=False)
             dag = dagbag.dags.get(dag_id)
             if dag:
                 break

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -833,6 +833,20 @@ class TestCliDags:
         assert len(mock__execute_task.call_args_list) == 1
         assert mock__execute_task.call_args_list[0].kwargs["ti"].task_id == "dummy_operator"
 
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_get_dag_excludes_examples_with_bundle(self, configure_testing_dag_bundle):
+        """Test that example DAGs are excluded when bundle names are passed."""
+        from airflow.utils.cli import get_dag
+
+        with configure_testing_dag_bundle(TEST_DAGS_FOLDER / "test_sensor.py"):
+            # example DAG should not be found since include_examples=False
+            with pytest.raises(AirflowException, match="could not be found"):
+                get_dag(bundle_names=["testing"], dag_id="example_simplest_dag")
+
+            # However, "test_sensor.py" should exist
+            dag = get_dag(bundle_names=["testing"], dag_id="test_sensor")
+            assert dag.dag_id == "test_sensor"
+
 
 class TestCliDagsReserialize:
     parser = cli_parser.get_parser()


### PR DESCRIPTION
When `bundle_names` is explicitly passed, we shouldn't include example_dags, it just pollutes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
