### PR TITLE
Support running `airflow dags test` from local files

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -355,6 +355,13 @@ ARG_TREAT_DAG_ID_AS_REGEX = Arg(
 )
 
 # test_dag
+ARG_DAGFILE_PATH = Arg(
+    (
+        "-f",
+        "--dagfile-path",
+    ),
+    help="Path to the DAG file. Can be absolute or relative to current directory",
+)
 ARG_SHOW_DAGRUN = Arg(
     ("--show-dagrun",),
     help=(
@@ -1124,6 +1131,16 @@ DAGS_COMMANDS = (
         description=(
             "Execute one single DagRun for a given DAG and logical date.\n"
             "\n"
+            "You can test a DAG in three ways:\n"
+            "1. Using default bundle:\n"
+            "   airflow dags test <DAG_ID>\n"
+            "\n"
+            "2. Using a specific bundle if multiple DAG bundles are configured:\n"
+            "   airflow dags test <DAG_ID> --bundle-name <BUNDLE_NAME> (or -B <BUNDLE_NAME>)\n"
+            "\n"
+            "3. Using a specific DAG file:\n"
+            "   airflow dags test <DAG_ID> --dagfile-path <PATH> (or -f <PATH>)\n"
+            "\n"
             "The --imgcat-dagrun option only works in iTerm.\n"
             "\n"
             "For more information, see: https://www.iterm2.com/documentation-images.html\n"
@@ -1144,6 +1161,8 @@ DAGS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_LOGICAL_DATE_OPTIONAL,
+            ARG_BUNDLE_NAME,
+            ARG_DAGFILE_PATH,
             ARG_CONF,
             ARG_SHOW_DAGRUN,
             ARG_IMGCAT_DAGRUN,

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -360,7 +360,7 @@ ARG_DAGFILE_PATH = Arg(
         "-f",
         "--dagfile-path",
     ),
-    help="Path to the DAG file. Can be absolute or relative to current directory",
+    help="Path to the dag file. Can be absolute or relative to current directory",
 )
 ARG_SHOW_DAGRUN = Arg(
     ("--show-dagrun",),

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -24,11 +24,9 @@ import errno
 import json
 import logging
 import operator
-import os
 import re
 import subprocess
 import sys
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select
@@ -41,10 +39,8 @@ from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowException
 from airflow.jobs.job import Job
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
-from airflow.models.dag import DAG
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils import cli as cli_utils, timezone
 from airflow.utils.cli import get_dag, suppress_logs_and_warning, validate_dag_bundle_arg
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
@@ -57,6 +53,7 @@ if TYPE_CHECKING:
     from graphviz.dot import Dot
     from sqlalchemy.orm import Session
 
+    from airflow.models.dag import DAG
     from airflow.timetables.base import DataInterval
 
 DAG_DETAIL_FIELDS = {*DAGResponse.model_fields, *DAGResponse.model_computed_fields}
@@ -591,29 +588,6 @@ def dag_list_dag_runs(args, dag: DAG | None = None, session: Session = NEW_SESSI
     AirflowConsole().print_as(data=dag_runs, output=args.output, mapper=_render_dagrun)
 
 
-def _parse_and_get_dag(dag_id: str) -> DAG | None:
-    """Given a dag_id, determine the bundle and relative fileloc from the db, then parse and return the DAG."""
-    db_dag = get_dag(bundle_names=None, dag_id=dag_id, from_db=True)
-    bundle_name = db_dag.get_bundle_name()
-    if bundle_name is None:
-        raise AirflowException(
-            f"Bundle name for DAG {dag_id!r} is not found in the database. This should not happen."
-        )
-    if db_dag.relative_fileloc is None:
-        raise AirflowException(
-            f"Relative fileloc for DAG {dag_id!r} is not found in the database. This should not happen."
-        )
-    bundle = DagBundlesManager().get_bundle(bundle_name)
-    bundle.initialize()
-    dag_absolute_path = os.fspath(Path(bundle.path, db_dag.relative_fileloc))
-
-    with _airflow_parsing_context_manager(dag_id=dag_id):
-        bag = DagBag(
-            dag_folder=dag_absolute_path, include_examples=False, safe_mode=False, load_op_links=False
-        )
-        return bag.dags.get(dag_id)
-
-
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -632,13 +606,12 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
         re.compile(args.mark_success_pattern) if args.mark_success_pattern is not None else None
     )
 
-    dag = dag or _parse_and_get_dag(args.dag_id)
+    dag = dag or get_dag(bundle_names=args.bundle_name, dag_id=args.dag_id, dagfile_path=args.dagfile_path)
     if not dag:
         raise AirflowException(
             f"Dag {args.dag_id!r} could not be found; either it does not exist or it failed to parse."
         )
 
-    dag = DAG.from_sdk_dag(dag)
     dr: DagRun = dag.test(
         logical_date=logical_date,
         run_conf=run_conf,

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Callable, TypeVar, cast
 from airflow import settings
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowException
+from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.sdk.execution_time.secrets_masker import should_hide_value_for_key
 from airflow.utils import cli_action_loggers, timezone
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
@@ -258,7 +259,9 @@ def _search_for_dag_file(val: str | None) -> str | None:
     return None
 
 
-def get_dag(bundle_names: list | None, dag_id: str, from_db: bool = False) -> DAG:
+def get_dag(
+    bundle_names: list | None, dag_id: str, from_db: bool = False, dagfile_path: str | None = None
+) -> DAG:
     """
     Return DAG of a given dag_id.
 
@@ -277,7 +280,10 @@ def get_dag(bundle_names: list | None, dag_id: str, from_db: bool = False) -> DA
         manager = DagBundlesManager()
         for bundle_name in bundle_names:
             bundle = manager.get_bundle(bundle_name)
-            dagbag = DagBag(dag_folder=bundle.path, bundle_path=bundle.path, include_examples=False)
+            with _airflow_parsing_context_manager(dag_id=dag_id):
+                dagbag = DagBag(
+                    dag_folder=dagfile_path or bundle.path, bundle_path=bundle.path, include_examples=False
+                )
             dag = dagbag.dags.get(dag_id)
             if dag:
                 break
@@ -287,7 +293,10 @@ def get_dag(bundle_names: list | None, dag_id: str, from_db: bool = False) -> DA
         manager = DagBundlesManager()
         all_bundles = list(manager.get_all_dag_bundles())
         for bundle in all_bundles:
-            dag_bag = DagBag(dag_folder=bundle.path, bundle_path=bundle.path)
+            with _airflow_parsing_context_manager(dag_id=dag_id):
+                dag_bag = DagBag(
+                    dag_folder=dagfile_path or bundle.path, bundle_path=bundle.path, include_examples=False
+                )
             dag = dag_bag.dags.get(dag_id)
             if dag:
                 break

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -374,6 +374,7 @@ Dagbag
 dagbag
 dagbags
 DagCallbackRequest
+dagfile
 DagFileProcessorManager
 dagfolder
 dagmodel


### PR DESCRIPTION
Currently, we can't run `airflow dags test` in isolation with a local dag file. We need to first run `airflow dags reserialize`, so DAGs are parsed and stored in DB, because the `airflow dags test` currently loads it from DB.

The change in this PR/commit allows testing DAGs from different sources:
- Using bundle configuration (`--bundle-name`)
- Using direct file path (`--dagfile-path`/`-f`)
- Using default behavior (from DB)

This speeds up the process too since we don't have to load the entire DagBag to run a single file.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
