### PR TITLE
Update pipeline.rst

### DIFF
--- a/docs/apache-airflow/tutorial/pipeline.rst
+++ b/docs/apache-airflow/tutorial/pipeline.rst
@@ -36,7 +36,7 @@ The steps below should be sufficient, but see the quick-start documentation for 
 .. code-block:: bash
 
   # Download the docker-compose.yaml file
-  curl -LfO 'https://airflow.apache.org/docs/apache-airflow/stable/docker-compose.yaml'
+  curl -LfO 'https://airflow.apache.org/docs/apache-airflow/2.10.5/docker-compose.yaml'
 
   # Make expected directories and set an expected environment variable
   mkdir -p ./dags ./logs ./plugins


### PR DESCRIPTION
Your download statement is for stable when this tutorial is for 2.10.5.  If you select stable you will get Airflow 3.0.0

