### PR TITLE
Ensure singleton use of `DagBag` across all API requests

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -24,6 +24,7 @@ from urllib.parse import urlsplit
 from fastapi import FastAPI
 from starlette.routing import Mount
 
+from airflow.api_fastapi.common.dagbag import create_dag_bag
 from airflow.api_fastapi.core_api.app import (
     init_config,
     init_error_handlers,
@@ -79,12 +80,16 @@ def create_app(apps: str = "all") -> FastAPI:
         version="2",
     )
 
+    dag_bag = create_dag_bag()
+
     if "execution" in apps_list or "all" in apps_list:
         task_exec_api_app = create_task_execution_api_app()
+        task_exec_api_app.state.dag_bag = dag_bag
         init_error_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 
     if "core" in apps_list or "all" in apps_list:
+        app.state.dag_bag = dag_bag
         init_plugins(app)
         init_auth_manager(app)
         init_flask_plugins(app)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -24,8 +24,8 @@ from fastapi import Depends, HTTPException, status
 from sqlalchemy import and_, delete, func, select
 from sqlalchemy.orm import joinedload, subqueryload
 
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import (
     BaseParam,
     FilterParam,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -32,8 +32,8 @@ from airflow.api.common.mark_tasks import (
     set_dag_run_state_to_success,
 )
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
@@ -22,8 +22,8 @@ from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import (
     FilterParam,
     QueryLimit,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -25,12 +25,12 @@ from pydantic import ValidationError
 from sqlalchemy import select, update
 
 from airflow.api.common import delete_dag as delete_dag_module
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
 )
 from airflow.api_fastapi.common.db.dags import generate_dag_with_latest_run_query
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/extra_links.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/extra_links.py
@@ -22,8 +22,8 @@ from typing import TYPE_CHECKING
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.sql import select
 
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.extra_links import ExtraLinkCollectionResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
@@ -26,8 +26,8 @@ from pydantic import PositiveInt
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.headers import HeaderAcceptJsonOrText
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.common.types import Mimetype

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -29,8 +29,8 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.selectable import Select
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -23,7 +23,7 @@ from typing import cast
 from fastapi import Depends, HTTPException, status
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
-from airflow.api_fastapi.common.deps import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.tasks import TaskCollectionResponse, TaskResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -24,8 +24,8 @@ from sqlalchemy import and_, select
 from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import QueryLimit, QueryOffset
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.xcom import (

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import and_, func, select
 
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.security import requires_access_asset, requires_access_dag
 from airflow.models import DagModel

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -28,8 +28,8 @@ from sqlalchemy.orm import joinedload
 
 from airflow import DAG
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.parameters import (
     QueryDagRunRunTypesFilter,
     QueryDagRunStateFilter,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -33,8 +33,8 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep
-from airflow.api_fastapi.common.deps import DagBagDep
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
     PrevSuccessfulDagRunResponse,

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.api_fastapi.app import purge_cached_app
+from airflow.sdk import BaseOperator
+
+from tests_common.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
+
+pytestmark = pytest.mark.db_test
+
+
+class TestDagBagSingleton:
+    """Tests to ensure that DagBag is instantiated only once per app lifecycle."""
+
+    dagbag_call_counter = {"count": 0}
+
+    def setup(self):
+        clear_db_runs()
+        clear_db_dags()
+        clear_db_serialized_dags()
+
+    def teardown(self):
+        clear_db_runs()
+        clear_db_dags()
+        clear_db_serialized_dags()
+
+    @pytest.fixture(autouse=True)
+    def patch_dagbag_once_before_app(self):
+        """Patch DagBag once before app is created, and reset counter."""
+        self.dagbag_call_counter["count"] = 0
+
+        from airflow.models.dagbag import DagBag as RealDagBag
+
+        def factory(*args, **kwargs):
+            self.dagbag_call_counter["count"] += 1
+            return RealDagBag(*args, **kwargs)
+
+        with mock.patch("airflow.api_fastapi.common.dagbag.DagBag", side_effect=factory):
+            purge_cached_app()
+            yield
+
+    def test_dagbag_used_as_singleton_in_dependency(self, session, dag_maker, test_client):
+        """
+        Ensure DagBag is created only once and reused across multiple API requests.
+
+        This test sets up a single DAG, patches the DagBag constructor to track instantiation count,
+        and verifies that two calls to the `/api/v2/dags/{dag_id}` endpoint both return 200 OK,
+        while only one DagBag instance is created.
+
+        This validates that the FastAPI DagBag dependency correctly resolves to app.state.dag_bag,
+        maintaining singleton behavior instead of creating a new DagBag per request.
+        """
+        dag_id = "dagbag_singleton_test"
+
+        with dag_maker(dag_id=dag_id, session=session, serialized=True):
+            BaseOperator(task_id="test_task")
+        session.commit()
+
+        resp1 = test_client.get(f"/api/v2/dags/{dag_id}")
+        assert resp1.status_code == 200
+
+        resp2 = test_client.get(f"/api/v2/dags/{dag_id}")
+        assert resp2.status_code == 200
+
+        assert self.dagbag_call_counter["count"] == 1

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -20,7 +20,7 @@ import os
 
 import pytest
 
-from airflow.api_fastapi.common.deps import _get_dag_bag
+from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.api_fastapi.core_api.datamodels.extra_links import ExtraLinkCollectionResponse
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models.dagbag import DagBag
@@ -96,7 +96,7 @@ class TestGetExtraLinks:
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {self.dag.dag_id: self.dag}
 
-        test_client.app.dependency_overrides[_get_dag_bag] = lambda: dag_bag
+        test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
         dag_bag.sync_to_db("dags-folder", None)
 
         self.dag.create_dagrun(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -27,7 +27,7 @@ import pytest
 from itsdangerous.url_safe import URLSafeSerializer
 from uuid6 import uuid7
 
-from airflow.api_fastapi.common.deps import _get_dag_bag
+from airflow.api_fastapi.common.dagbag import create_dag_bag, dag_bag_from_app
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models.dag import DAG
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -109,10 +109,10 @@ class TestTaskInstancesLog:
             session.flush()
         session.flush()
 
-        dagbag = _get_dag_bag()
+        dagbag = create_dag_bag()
         dagbag.bag_dag(dag)
         dagbag.bag_dag(dummy_dag)
-        test_client.app.dependency_overrides[_get_dag_bag] = lambda: dagbag
+        test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dagbag
 
     @pytest.fixture
     def configure_loggers(self, tmp_path, create_log_template):
@@ -266,11 +266,11 @@ class TestTaskInstancesLog:
         expected_filename = expected_filename.replace("LOG_DIR", str(self.log_dir))
 
         # Recreate DAG without tasks
-        dagbag = _get_dag_bag()
+        dagbag = create_dag_bag()
         dag = DAG(self.DAG_ID, schedule=None, start_date=timezone.parse(self.default_time))
         dagbag.bag_dag(dag=dag)
 
-        self.app.dependency_overrides[_get_dag_bag] = lambda: dagbag
+        self.app.dependency_overrides[dag_bag_from_app] = lambda: dagbag
 
         key = self.app.state.secret_key
         serializer = URLSafeSerializer(key)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 import pytest
 
-from airflow.api_fastapi.common.deps import _get_dag_bag
+from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.models.serialized_dag import SerializedDagModel
@@ -70,7 +70,7 @@ class TestTaskEndpoint:
             mapped_dag.dag_id: mapped_dag,
             unscheduled_dag.dag_id: unscheduled_dag,
         }
-        test_client.app.dependency_overrides[_get_dag_bag] = lambda: dag_bag
+        test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
     @staticmethod
     def clear_db():
@@ -240,7 +240,7 @@ class TestGetTask(TestTaskEndpoint):
         SerializedDagModel.write_dag(dag, bundle_name="test_bundle")
 
         dag_bag = DagBag(os.devnull, include_examples=False, read_dags_from_db=True)
-        test_client.app.dependency_overrides[_get_dag_bag] = lambda: dag_bag
+        test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
         expected = {
             "class_ref": {

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1277,7 +1277,7 @@ class InProcessTestSupervisor(ActivitySubprocess):
 
         api = in_process_api_server()
         if dag is not None:
-            from airflow.api_fastapi.common.deps import _get_dag_bag
+            from airflow.api_fastapi.common.dagbag import dag_bag_from_app
             from airflow.serialization.serialized_objects import SerializedDAG
 
             # This is needed since the Execution API server uses the DagBag in its "state".
@@ -1286,7 +1286,7 @@ class InProcessTestSupervisor(ActivitySubprocess):
 
             # Mimic the behavior of the DagBag in the API server by converting the DAG to a SerializedDAG
             dag_bag.dags[dag.dag_id] = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
-            api.app.dependency_overrides[_get_dag_bag] = lambda: dag_bag
+            api.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
         client = Client(base_url=None, token="", dry_run=True, transport=api.transport)
         # Mypy is wrong -- the setter accepts a string on the property setter! `URLType = URL | str`


### PR DESCRIPTION
Previously, DagBag was injected via onlyFastAPI dependency as part of the refactor in https://github.com/apache/airflow/pull/50372, but a new instance was created for each request. This change updates the dependency to resolve DagBag from `app.state`, ensuring it is only instantiated once at startup while keeping benefits of FastAPI dependency.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
