### PR TITLE
Move AWS auth dependencies to python3-saml extra

### DIFF
--- a/airflow-core/docs/extra-packages-ref.rst
+++ b/airflow-core/docs/extra-packages-ref.rst
@@ -114,6 +114,8 @@ other packages that can be used by airflow or some of its providers.
 +=====================+=====================================================+============================================================================+
 | aiobotocore         | ``pip install 'apache-airflow[aiobotocore]'``       | Support for asynchronous (deferrable) operators for Amazon integration     |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
+| amazon-aws-auth     | ``pip install apache-airflow[amazon-aws-auth]``     | Amazon-aws-auth AWS authentication                                         |
++---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 | cloudpickle         | ``pip install apache-airflow[cloudpickle]``         | Cloudpickle hooks and operators                                            |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 | github-enterprise   | ``pip install 'apache-airflow[github-enterprise]'`` | GitHub Enterprise auth backend                                             |

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -76,11 +76,6 @@ dependencies = [
     "asgiref>=2.3.0",
     "PyAthena>=3.10.0",
     "jmespath>=0.7.0",
-    "python3-saml>=1.16.0",
-    # python3-saml is dependent on xmlsec and seems they do not pin it, pinning here would be needed
-    # We can remove it after https://github.com/xmlsec/python-xmlsec/issues/344 is fixed
-    "xmlsec!=1.3.15,>=1.3.14",
-    "lxml<5.4.0,>=5.3.2",
     "sagemaker-studio>=1.0.9",
     "marshmallow>=3",
 ]
@@ -102,6 +97,10 @@ dependencies = [
 ]
 "python3-saml" = [
     "python3-saml>=1.16.0",
+    # python3-saml is dependent on xmlsec and seems they do not pin it, pinning here would be needed
+    # We can remove it after https://github.com/xmlsec/python-xmlsec/issues/344 is fixed
+    "xmlsec!=1.3.15,>=1.3.14",
+    "lxml<5.4.0,>=5.3.2",
 ]
 "apache.hive" = [
     "apache-airflow-providers-apache-hive"

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/routes/test_login.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/routes/test_login.py
@@ -26,12 +26,18 @@ if not AIRFLOW_V_3_0_PLUS:
     pytest.skip("AWS auth manager is only compatible with Airflow >= 3.0.0", allow_module_level=True)
 
 from fastapi.testclient import TestClient
-from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX, create_app
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.mock_plugins import mock_plugin_manager
+
+# onelogin is optional dependency from apache-airflow-providers-amazon[python3-saml]
+# we want to skip it for the lowest dependency checks as it does not install extra dependencies
+# https://github.com/apache/airflow/pull/50449#issuecomment-2897572327
+OneLogin_Saml2_IdPMetadataParser = pytest.importorskip(
+    "onelogin.saml2.idp_metadata_parser"
+).OneLogin_Saml2_IdPMetadataParser
 
 SAML_METADATA_URL = "/saml/metadata"
 SAML_METADATA_PARSED = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,7 +380,7 @@ packages = []
     "apache-airflow-providers-zendesk>=4.9.0"
 ]
 "all" = [
-    "apache-airflow[aiobotocore,apache-atlas,apache-webhdfs,async,cloudpickle,github-enterprise,google-auth,graphviz,kerberos,ldap,otel,pandas,polars,rabbitmq,s3fs,sentry,statsd,uv]",
+    "apache-airflow[aiobotocore,amazon-aws-auth,apache-atlas,apache-webhdfs,async,cloudpickle,github-enterprise,google-auth,graphviz,kerberos,ldap,otel,pandas,polars,rabbitmq,s3fs,sentry,statsd,uv]",
     "apache-airflow-core[all]",
     "apache-airflow-providers-airbyte>=5.0.0",
     "apache-airflow-providers-alibaba>=3.0.0",
@@ -492,6 +492,9 @@ packages = []
 ]
 "apache-webhdfs" = [
     "apache-airflow-providers-apache-hdfs",
+]
+"amazon-aws-auth" = [
+   "apache-airflow-providers-amazon[python3-saml]",
 ]
 "cloudpickle" = [
     "cloudpickle>=2.2.1",


### PR DESCRIPTION
The workaround of set xmlsec and lxml is relevant only for aws auth manager thus we need these as part of the python3-saml extra rather than as direct dependency of the provider