### PR TITLE
Fix selective checks when only pyproject.toml or provider.yaml modified

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -891,6 +891,84 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             id="Providers tests run including amazon tests if amazon provider files changed",
         ),
         pytest.param(
+            ("providers/amazon/src/airflow/providers/amazon/pyproject.toml",),
+            {
+                "selected-providers-list-as-string": "amazon apache.hive cncf.kubernetes "
+                "common.compat common.messaging common.sql exasol ftp google http imap microsoft.azure "
+                "mongo mysql openlineage postgres salesforce ssh teradata",
+                "all-python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
+                "all-python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
+                "python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
+                "python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
+                "ci-image-build": "true",
+                "prod-image-build": "false",
+                "needs-helm-tests": "false",
+                "run-tests": "true",
+                "docs-build": "true",
+                # no python files changed so flynt should not run
+                "skip-pre-commits": "flynt," + ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
+                "run-kubernetes-tests": "false",
+                "upgrade-to-newer-dependencies": "false",
+                "run-amazon-tests": "true",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "amazon...google",
+                            "test_types": "Providers[amazon] Providers[apache.hive,cncf.kubernetes,"
+                            "common.compat,common.messaging,common.sql,exasol,ftp,http,imap,"
+                            "microsoft.azure,mongo,mysql,openlineage,postgres,salesforce,ssh,teradata] "
+                            "Providers[google]",
+                        }
+                    ]
+                ),
+                "needs-mypy": "true",
+                "mypy-checks": "['mypy-providers']",
+            },
+            id="Providers tests run including amazon tests if only amazon pyproject.toml files changed",
+        ),
+        pytest.param(
+            ("providers/amazon/src/airflow/providers/amazon/provider.yaml",),
+            {
+                "selected-providers-list-as-string": "amazon apache.hive cncf.kubernetes "
+                "common.compat common.messaging common.sql exasol ftp google http imap microsoft.azure "
+                "mongo mysql openlineage postgres salesforce ssh teradata",
+                "all-python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
+                "all-python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
+                "python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
+                "python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
+                "ci-image-build": "true",
+                "prod-image-build": "false",
+                "needs-helm-tests": "false",
+                "run-tests": "true",
+                "docs-build": "true",
+                # no python files changed so flynt should not run
+                "skip-pre-commits": "flynt," + ALL_SKIPPED_COMMITS_IF_NO_UI_AND_HELM_TESTS,
+                "run-kubernetes-tests": "false",
+                "upgrade-to-newer-dependencies": "false",
+                "run-amazon-tests": "true",
+                "core-test-types-list-as-strings-in-json": json.dumps(
+                    [{"description": "Always", "test_types": "Always"}]
+                ),
+                "providers-test-types-list-as-strings-in-json": json.dumps(
+                    [
+                        {
+                            "description": "amazon...google",
+                            "test_types": "Providers[amazon] Providers[apache.hive,cncf.kubernetes,"
+                            "common.compat,common.messaging,common.sql,exasol,ftp,http,imap,"
+                            "microsoft.azure,mongo,mysql,openlineage,postgres,salesforce,ssh,teradata] "
+                            "Providers[google]",
+                        }
+                    ]
+                ),
+                "needs-mypy": "true",
+                "mypy-checks": "['mypy-providers']",
+            },
+            id="Providers tests run including amazon tests if only amazon provider.yaml files changed",
+        ),
+        pytest.param(
             ("providers/airbyte/tests/airbyte/__init__.py",),
             {
                 "selected-providers-list-as-string": "airbyte",


### PR DESCRIPTION
The tests for providers were not triggered when only provider.yaml or pyproject.toml of provider has been modified. This PR fixes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
