### PR TITLE
Migrate `ElasticsearchSQLHook` to use `get_df`

### DIFF
--- a/providers/elasticsearch/README.rst
+++ b/providers/elasticsearch/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                              Version required
 =======================================  ==================
 ``apache-airflow``                       ``>=2.10.0``
-``apache-airflow-providers-common-sql``  ``>=1.26.0``
+``apache-airflow-providers-common-sql``  ``>=1.27.0``
 ``elasticsearch``                        ``>=8.10,<9``
 =======================================  ==================
 

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.27.0",
     "elasticsearch>=8.10,<9",
 ]
 

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -225,6 +225,9 @@ class ElasticsearchSQLHook(DbApiHook):
         parameters: list | tuple | Mapping[str, Any] | None = None,
         **kwargs,
     ):
+        # TODO: Custom ElasticsearchSQLCursor is incompatible with polars.read_database.
+        # To support: either adapt cursor to polars._executor interface or create custom polars reader.
+        # https://github.com/apache/airflow/pull/50454
         raise NotImplementedError("Polars is not supported for Elasticsearch")
 
 

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -219,6 +219,14 @@ class ElasticsearchSQLHook(DbApiHook):
 
         return uri
 
+    def _get_polars_df(
+        self,
+        sql,
+        parameters: list | tuple | Mapping[str, Any] | None = None,
+        **kwargs,
+    ):
+        raise NotImplementedError("Polars is not supported for Elasticsearch")
+
 
 class ElasticsearchPythonHook(BaseHook):
     """

--- a/providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py
@@ -177,6 +177,10 @@ class TestElasticsearchSQLHook:
         self.spy_agency.assert_spy_called(self.cur.close)
         self.spy_agency.assert_spy_called(self.cur.execute)
 
+    def test_get_df_polars(self):
+        with pytest.raises(NotImplementedError):
+            self.db_hook.get_df("SQL", df_type="polars")
+
     def test_run(self):
         statement = "SELECT * FROM hollywood.actors"
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- #49334
cc: @eladkal

## Why 

`get_pandas_df` deprecated in https://github.com/apache/airflow/pull/48875, which would be replaced by `get_df`. Thus, we need to migrate them in providers.

## How

After investigation, I found that `ElasticsearchSQLHook` has its own `ElasticsearchSQLCursor` which is not compatable with polars cursor execution since there is a abstraction for cursor execution when calling `polars.read_database`.  

reference: [polars.read_database](https://github.com/pola-rs/polars/blob/5c114f0f32a62bf796629e4ccf01b93146ae22c4/py-polars/polars/io/database/functions.py#L247-L256) and the abstraction called _executor [_executor](https://github.com/pola-rs/polars/blob/main/py-polars/polars/io/database/_executor.py)

Also there is nothing about the integration info on [polars IO document](https://docs.pola.rs/user-guide/io/) and [Elasticsearch document](https://search.elastic.co/?q=polars) thus I thought it would be better to raise `NotImplementedError` for it like we did in #50017.

Minor change: migrate to `common-sql` 1.27.0 to have better `get_df` type def

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
