### PR TITLE
Use `pytest.param.id` in connection, pool, and variable bulk tests

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -921,8 +921,7 @@ class TestBulkConnections(TestConnectionEndpoint):
     @pytest.mark.parametrize(
         "actions, expected_results",
         [
-            # Test successful create
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -943,9 +942,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_successful_create",
             ),
-            # Test successful create with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -970,9 +969,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_successful_create_with_skip",
             ),
-            # Test create with overwrite
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -994,9 +993,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_create_with_overwrite",
             ),
-            # Test create conflict
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1026,9 +1025,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         ],
                     }
                 },
+                id="test_create_conflict",
             ),
-            # Test successful update
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1050,9 +1049,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_successful_update",
             ),
-            # Test update with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1073,9 +1072,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_update_with_skip",
             ),
-            # Test update with fail
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1101,9 +1100,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         ],
                     }
                 },
+                id="test_update_with_fail",
             ),
-            # Test successful delete
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1118,9 +1117,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_successful_delete",
             ),
-            # Test delete with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1136,9 +1135,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     }
                 },
+                id="test_delete_with_skip",
             ),
-            # Test delete not found
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1159,9 +1158,9 @@ class TestBulkConnections(TestConnectionEndpoint):
                         ],
                     }
                 },
+                id="test_delete_not_found",
             ),
-            # Test Create, Update, Delete
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -1206,6 +1205,7 @@ class TestBulkConnections(TestConnectionEndpoint):
                         "errors": [],
                     },
                 },
+                id="test_create_update_delete",
             ),
         ],
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -427,8 +427,7 @@ class TestBulkPools(TestPoolsEndpoint):
     @pytest.mark.parametrize(
         "actions, expected_results",
         [
-            # Test successful create
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -442,9 +441,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     ]
                 },
                 {"create": {"success": ["pool3", "pool4"], "errors": []}},
+                id="test_successful_create",
             ),
-            # Test successful create with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -458,9 +457,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     ]
                 },
                 {"create": {"success": ["pool3"], "errors": []}},
+                id="test_successful_create_with_skip",
             ),
-            # Test successful create with overwrite
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -474,9 +473,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     ]
                 },
                 {"create": {"success": ["pool3", "pool2"], "errors": []}},
+                id="test_successful_create_with_overwrite",
             ),
-            # Test create conflict
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -497,9 +496,9 @@ class TestBulkPools(TestPoolsEndpoint):
                         ],
                     }
                 },
+                id="test_create_conflict",
             ),
-            # Test successful update
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -510,9 +509,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     ]
                 },
                 {"update": {"success": ["pool2"], "errors": []}},
+                id="test_successful_update",
             ),
-            # Test update with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -523,9 +522,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     ]
                 },
                 {"update": {"success": [], "errors": []}},
+                id="test_update_with_skip",
             ),
-            # Test update not found
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -546,19 +545,19 @@ class TestBulkPools(TestPoolsEndpoint):
                         ],
                     }
                 },
+                id="test_update_not_found",
             ),
-            # Test successful delete
-            (
+            pytest.param(
                 {"actions": [{"action": "delete", "entities": ["pool1"], "action_on_non_existence": "skip"}]},
                 {"delete": {"success": ["pool1"], "errors": []}},
+                id="test_successful_delete",
             ),
-            # Test delete with skip
-            (
+            pytest.param(
                 {"actions": [{"action": "delete", "entities": ["pool3"], "action_on_non_existence": "skip"}]},
                 {"delete": {"success": [], "errors": []}},
+                id="test_delete_with_skip",
             ),
-            # Test delete not found
-            (
+            pytest.param(
                 {"actions": [{"action": "delete", "entities": ["pool4"], "action_on_non_existence": "fail"}]},
                 {
                     "delete": {
@@ -571,9 +570,9 @@ class TestBulkPools(TestPoolsEndpoint):
                         ],
                     }
                 },
+                id="test_delete_not_found",
             ),
-            # Test Create, Update, and Delete combined
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -594,9 +593,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     "update": {"success": ["pool1"], "errors": []},
                     "delete": {"success": ["pool2"], "errors": []},
                 },
+                id="test_create_update_delete",
             ),
-            # Test Fail on conflicting create and handle others
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -625,9 +624,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     "update": {"success": ["pool1"], "errors": []},
                     "delete": {"success": [], "errors": []},
                 },
+                id="test_create_update_delete_with_fail",
             ),
-            # Test all skipping actions
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -648,9 +647,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     "update": {"success": [], "errors": []},
                     "delete": {"success": [], "errors": []},
                 },
+                id="test_create_update_delete_with_skip",
             ),
-            # Test Dependent actions
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -673,9 +672,9 @@ class TestBulkPools(TestPoolsEndpoint):
                     "update": {"success": ["pool5"], "errors": []},
                     "delete": {"success": ["pool5"], "errors": []},
                 },
+                id="test_dependent_actions",
             ),
-            # Test Repeated actions
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -748,6 +747,7 @@ class TestBulkPools(TestPoolsEndpoint):
                     },
                     "delete": {"success": ["pool2"], "errors": []},
                 },
+                id="test_repeated_actions",
             ),
         ],
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -502,8 +502,7 @@ class TestBulkVariables(TestVariableEndpoint):
     @pytest.mark.parametrize(
         "actions, expected_results",
         [
-            # Test successful create
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -517,9 +516,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"create": {"success": ["new_var1", "new_var2"], "errors": []}},
+                id="test_successful_create",
             ),
-            # Test successful create with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -537,9 +536,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"create": {"success": ["new_var2"], "errors": []}},
+                id="test_successful_create_with_skip",
             ),
-            # Test successful create with overwrite
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -557,9 +556,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"create": {"success": ["test_variable_key", "new_var2"], "errors": []}},
+                id="test_successful_create_with_overwrite",
             ),
-            # Test create conflict
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -586,9 +585,9 @@ class TestBulkVariables(TestVariableEndpoint):
                         ],
                     }
                 },
+                id="test_create_conflict",
             ),
-            # Test successful update
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -605,9 +604,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"update": {"success": ["test_variable_key"], "errors": []}},
+                id="test_successful_update",
             ),
-            # Test update with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -624,9 +623,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"update": {"success": [], "errors": []}},
+                id="test_update_with_skip",
             ),
-            # Test update not found
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -653,9 +652,9 @@ class TestBulkVariables(TestVariableEndpoint):
                         ],
                     }
                 },
+                id="test_update_not_found",
             ),
-            # Test successful delete
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -666,9 +665,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"delete": {"success": ["test_variable_key"], "errors": []}},
+                id="test_successful_delete",
             ),
-            # Test delete with skip
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -679,9 +678,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     ]
                 },
                 {"delete": {"success": [], "errors": []}},
+                id="test_delete_with_skip",
             ),
-            # Test delete not found
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -702,9 +701,9 @@ class TestBulkVariables(TestVariableEndpoint):
                         ],
                     }
                 },
+                id="test_delete_not_found",
             ),
-            # Test Create, Update, and Delete combined
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -744,9 +743,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     "update": {"success": ["test_variable_key"], "errors": []},
                     "delete": {"success": ["dictionary_password"], "errors": []},
                 },
+                id="test_create_update_delete_combined",
             ),
-            # Test Fail on conflicting create and handle others
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -791,9 +790,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     "update": {"success": ["dictionary_password"], "errors": []},
                     "delete": {"success": [], "errors": []},
                 },
+                id="test_fail_on_conflicting_create_and_handle_others",
             ),
-            # Test all skipping actions
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -830,9 +829,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     "update": {"success": [], "errors": []},
                     "delete": {"success": [], "errors": []},
                 },
+                id="test_all_skipping_actions",
             ),
-            # Test Dependent actions
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -869,9 +868,9 @@ class TestBulkVariables(TestVariableEndpoint):
                     "update": {"success": ["new_variable_key"], "errors": []},
                     "delete": {"success": ["new_variable_key"], "errors": []},
                 },
+                id="test_dependent_actions",
             ),
-            # Test Repeated actions
-            (
+            pytest.param(
                 {
                     "actions": [
                         {
@@ -972,6 +971,7 @@ class TestBulkVariables(TestVariableEndpoint):
                     },
                     "delete": {"success": ["dictionary_password"], "errors": []},
                 },
+                id="test_repeated_actions",
             ),
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Why

I found that the bulk tests have comments for test cases but not using it as `pytest.param.id` when implementing #50443

How 

- use `pytest.param.id` instead of comments


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
