### PR TITLE
AIP-81:Check if the user is logged in before loading credentials

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -110,11 +110,13 @@ class Credentials:
         self,
         api_url: str | None = None,
         api_token: str | None = None,
+        client_kind: ClientKind | None = None,
         api_environment: str = "production",
     ):
         self.api_url = api_url
         self.api_token = api_token
         self.api_environment = os.getenv("AIRFLOW_CLI_ENVIRONMENT") or api_environment
+        self.client_kind = client_kind
 
     @property
     def input_cli_config_file(self) -> str:
@@ -137,12 +139,15 @@ class Credentials:
         """Load the credentials from keyring and URL from disk file."""
         default_config_dir = user_config_path("airflow", "Apache Software Foundation")
         credential_path = os.path.join(default_config_dir, self.input_cli_config_file)
-        if os.path.exists(credential_path):
+        if os.path.exists(credential_path) and self.client_kind == ClientKind.CLI:
             with open(credential_path) as f:
                 credentials = json.load(f)
                 self.api_url = credentials["api_url"]
                 self.api_token = keyring.get_password("airflowctl", f"api_token-{self.api_environment}")
             return self
+        if self.client_kind == ClientKind.AUTH:
+            credentials = Credentials()
+            return credentials
         raise AirflowCtlCredentialNotFoundException(f"No credentials found in {default_config_dir}")
 
 
@@ -264,10 +269,8 @@ def get_client(kind: ClientKind = ClientKind.CLI):
     api_client = None
     try:
         # API URL always loaded from the config file, please save with it if you are using other than ClientKind.CLI
-        if isinstance(Credentials().load(),Credentials):
-            credentials = Credentials().load()
-        else : 
-            credentials = Credentials(api_url=None,api_client=None,api_environment="production")
+
+        credentials = Credentials(client_kind=kind).load()
         api_client = Client(
             base_url=credentials.api_url or "http://localhost:8080",
             limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -264,7 +264,10 @@ def get_client(kind: ClientKind = ClientKind.CLI):
     api_client = None
     try:
         # API URL always loaded from the config file, please save with it if you are using other than ClientKind.CLI
-        credentials = Credentials().load()
+        if isinstance(Credentials().load(),Credentials):
+            credentials = Credentials().load()
+        else : 
+            credentials = Credentials(api_url=None,api_client=None,api_environment="production")
         api_client = Client(
             base_url=credentials.api_url or "http://localhost:8080",
             limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -93,7 +93,7 @@ class TestCredentials:
 
         assert os.path.exists(self.default_config_dir)
         with open(os.path.join(self.default_config_dir, f"{env}.json")) as f:
-            credentials = Credentials().load()
+            credentials = Credentials(client_kind=cli_client).load()
             assert json.load(f) == {
                 "api_url": credentials.api_url,
             }
@@ -111,20 +111,19 @@ class TestCredentials:
         )
         credentials.save()
         with open(os.path.join(self.default_config_dir, f"{env}.json")) as f:
-            credentials = Credentials().load()
+            credentials = Credentials(client_kind=cli_client).load()
             assert json.load(f) == {
-                "api_url": credential.api_url,
+                "api_url": credentials.api_url,
             }
 
     @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_LOAD"})
     @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
     @patch("airflowctl.api.client.keyring")
-    def test_load_auth_kind(self,mock_keyring):
+    def test_load_auth_kind(self, mock_keyring):
         mock_keyring.set_password.return_value = MagicMock()
         mock_keyring.get_password.return_value = "NO_TOKEN"
-        env = "TEST_LOAD"
         auth_client = ClientKind.AUTH
-        credentials = Credentials(client_kind = auth_client)
+        credentials = Credentials(client_kind=auth_client)
         assert credentials.api_url is None
 
     @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_NO_CREDENTIALS"})

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -26,7 +26,7 @@ import httpx
 import pytest
 from platformdirs import user_config_path
 
-from airflowctl.api.client import Client, Credentials
+from airflowctl.api.client import Client, ClientKind, Credentials
 from airflowctl.api.operations import ServerResponseError
 from airflowctl.exceptions import AirflowCtlNotFoundException
 
@@ -85,8 +85,10 @@ class TestCredentials:
     def test_save(self, mock_keyring):
         mock_keyring.set_password.return_value = MagicMock()
         env = "TEST_SAVE"
-
-        credentials = Credentials(api_url="http://localhost:8080", api_token="NO_TOKEN", api_environment=env)
+        cli_client = ClientKind.CLI
+        credentials = Credentials(
+            api_url="http://localhost:8080", api_token="NO_TOKEN", api_environment=env, client_kind=cli_client
+        )
         credentials.save()
 
         assert os.path.exists(self.default_config_dir)
@@ -99,26 +101,40 @@ class TestCredentials:
     @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_LOAD"})
     @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
     @patch("airflowctl.api.client.keyring")
-    def test_load(self, mock_keyring):
+    def test_load_cli_kind(self, mock_keyring):
         mock_keyring.set_password.return_value = MagicMock()
         mock_keyring.get_password.return_value = "NO_TOKEN"
         env = "TEST_LOAD"
-
-        credentials = Credentials(api_url="http://localhost:8080", api_token="NO_TOKEN", api_environment=env)
+        cli_client = ClientKind.CLI
+        credentials = Credentials(
+            api_url="http://localhost:8080", api_token="NO_TOKEN", api_environment=env, client_kind=cli_client
+        )
         credentials.save()
         with open(os.path.join(self.default_config_dir, f"{env}.json")) as f:
             credentials = Credentials().load()
             assert json.load(f) == {
-                "api_url": credentials.api_url,
+                "api_url": credential.api_url,
             }
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_LOAD"})
+    @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_load_auth_kind(self,mock_keyring):
+        mock_keyring.set_password.return_value = MagicMock()
+        mock_keyring.get_password.return_value = "NO_TOKEN"
+        env = "TEST_LOAD"
+        auth_client = ClientKind.AUTH
+        credentials = Credentials(client_kind = auth_client)
+        assert credentials.api_url is None
 
     @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_NO_CREDENTIALS"})
     @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
     @patch("airflowctl.api.client.keyring")
     def test_load_no_credentials(self, mock_keyring):
+        cli_client = ClientKind.CLI
         if os.path.exists(self.default_config_dir):
             shutil.rmtree(self.default_config_dir)
         with pytest.raises(AirflowCtlNotFoundException):
-            Credentials().load()
+            Credentials(client_kind=cli_client).load()
 
         assert not os.path.exists(self.default_config_dir)


### PR DESCRIPTION
A small bug is introduced here: #50135. Credentials are being loaded before the user is logged in, causing an exception. 
This PR aims to fix that bug by ensuring the user logs in first before loading credentials.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
