### PR TITLE
Set Automatic Notice for providers CHANGELOG when there's a min airflow bump

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -854,13 +854,15 @@ def prepare_provider_documentation(
             ):
                 if not only_min_version_update and not reapply_templates_only:
                     get_console().print("Updating documentation for the latest release version.")
-                    with_breaking_changes, maybe_with_new_features = update_release_notes(
-                        provider_id,
-                        reapply_templates_only=reapply_templates_only,
-                        base_branch=base_branch,
-                        regenerate_missing_docs=reapply_templates_only,
-                        non_interactive=non_interactive,
-                        only_min_version_update=only_min_version_update,
+                    with_breaking_changes, maybe_with_new_features, with_min_airflow_version_bump = (
+                        update_release_notes(
+                            provider_id,
+                            reapply_templates_only=reapply_templates_only,
+                            base_branch=base_branch,
+                            regenerate_missing_docs=reapply_templates_only,
+                            non_interactive=non_interactive,
+                            only_min_version_update=only_min_version_update,
+                        )
                     )
                 update_min_airflow_version_and_build_files(
                     provider_id=provider_id,
@@ -880,6 +882,7 @@ def prepare_provider_documentation(
                         with_breaking_changes=with_breaking_changes,
                         maybe_with_new_features=maybe_with_new_features,
                         only_min_version_update=only_min_version_update,
+                        with_min_airflow_version_bump=with_min_airflow_version_bump,
                     )
         except PrepareReleaseDocsNoChangesException:
             no_changes_packages.append(provider_id)

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -744,6 +744,7 @@ def update_release_notes(
     maybe_with_new_features = False
     original_provider_yaml_content: str | None = None
     marked_for_release = False
+    with_min_airflow_version_bump = False
     if not reapply_templates_only:
         if proceed:
             if non_interactive:
@@ -775,7 +776,6 @@ def update_release_notes(
             table_iter = 0
             global SHORT_HASH_TO_TYPE_DICT
             type_of_current_package_changes: list[TypeOfChange] = []
-            with_min_airflow_version_bump = False
             while table_iter < change_table_len:
                 get_console().print()
                 formatted_message = format_message_for_classification(

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -722,7 +722,7 @@ def update_release_notes(
     regenerate_missing_docs: bool,
     non_interactive: bool,
     only_min_version_update: bool,
-) -> tuple[bool, bool]:
+) -> tuple[bool, bool, bool]:
     """Updates generated files.
 
     This includes the readme, changes, and provider.yaml files.
@@ -732,7 +732,7 @@ def update_release_notes(
     :param base_branch: base branch to check changes in apache remote for changes
     :param regenerate_missing_docs: whether to regenerate missing docs
     :param non_interactive: run in non-interactive mode (useful for CI)
-    :return: tuple of two bools: (with_breaking_change, maybe_with_new_features)
+    :return: tuple of three bools: (with_breaking_change, maybe_with_new_features, with_min_airflow_version_bump)
     """
     proceed, list_of_list_of_changes, changes_as_table = _get_all_changes_for_package(
         provider_id=provider_id,
@@ -770,11 +770,12 @@ def update_release_notes(
             answer = user_confirm(f"Does the provider: {provider_id} have any changes apart from 'doc-only'?")
             if answer == Answer.NO:
                 _mark_latest_changes_as_documentation_only(provider_id, list_of_list_of_changes)
-                return with_breaking_changes, maybe_with_new_features
+                return with_breaking_changes, maybe_with_new_features, False
             change_table_len = len(list_of_list_of_changes[0])
             table_iter = 0
             global SHORT_HASH_TO_TYPE_DICT
             type_of_current_package_changes: list[TypeOfChange] = []
+            with_min_airflow_version_bump = False
             while table_iter < change_table_len:
                 get_console().print()
                 formatted_message = format_message_for_classification(
@@ -786,6 +787,10 @@ def update_release_notes(
                     f" by referring to the above table[/]"
                 )
                 type_of_change = _ask_the_user_for_the_type_of_changes(non_interactive=non_interactive)
+
+                if type_of_change == TypeOfChange.MIN_AIRFLOW_VERSION_BUMP:
+                    with_min_airflow_version_bump = True
+
                 change_hash = list_of_list_of_changes[0][table_iter].short_hash
                 SHORT_HASH_TO_TYPE_DICT[change_hash] = type_of_change
                 type_of_current_package_changes.append(type_of_change)
@@ -899,7 +904,7 @@ def update_release_notes(
         provider_details.documentation_provider_distribution_path,
         regenerate_missing_docs,
     )
-    return with_breaking_changes, maybe_with_new_features
+    return with_breaking_changes, maybe_with_new_features, with_min_airflow_version_bump
 
 
 def _find_insertion_index_for_version(content: list[str], version: str) -> tuple[int, bool]:
@@ -970,6 +975,7 @@ def _generate_new_changelog(
     context: dict[str, Any],
     with_breaking_changes: bool,
     maybe_with_new_features: bool,
+    with_min_airflow_version_bump: bool = False,
 ):
     latest_version = provider_details.versions[0]
     current_changelog = provider_details.changelog_path.read_text()
@@ -1012,6 +1018,7 @@ def _generate_new_changelog(
                 "version": latest_version,
                 "version_header": "." * len(latest_version),
                 "classified_changes": classified_changes,
+                "min_airflow_version_bump": with_min_airflow_version_bump,
             }
         )
         generated_new_changelog = render_template(
@@ -1082,6 +1089,7 @@ def update_changelog(
     with_breaking_changes: bool,
     maybe_with_new_features: bool,
     only_min_version_update: bool,
+    with_min_airflow_version_bump: bool,
 ):
     """Internal update changelog method.
 
@@ -1091,6 +1099,7 @@ def update_changelog(
     :param with_breaking_changes: whether there are any breaking changes
     :param maybe_with_new_features: whether there are any new features
     :param only_min_version_update: whether to only update the min version
+    :param with_min_airflow_version_bump: whether there is a min airflow version bump anywhere
     """
     provider_details = get_provider_details(package_id)
     jinja_context = get_provider_documentation_jinja_context(
@@ -1120,6 +1129,7 @@ def update_changelog(
             context=jinja_context,
             with_breaking_changes=with_breaking_changes,
             maybe_with_new_features=maybe_with_new_features,
+            with_min_airflow_version_bump=with_min_airflow_version_bump,
         )
     get_console().print(f"\n[info]Update index.rst for {package_id}\n")
     _update_index_rst(jinja_context, package_id, provider_details.documentation_provider_distribution_path)

--- a/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
@@ -20,6 +20,16 @@
 {{ version }}
 {{ version_header }}
 
+
+{%- if min_airflow_version_bump %}
+
+.. note::
+    This release of provider is only available for Airflow X.X+ as explained in the
+    Apache Airflow providers support policy <https://github.com/apache/airflow/blob/main/PROVIDERS.rst#minimum-supported-version-of-airflow-for-community-managed-providers>_.
+
+{%- endif %}
+
+
 {%- if WITH_BREAKING_CHANGES and classified_changes.breaking_changes %}
 
 Breaking changes


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/50475

We can now classify commits in providers wave to be "v" (min airflow version bump).

For such cases, the changelog should be robust enough to help with that.

I am adding a new feature that helps with this classification. If there's a `v` classified, we passdown a flag that will update the changelog for us.

I am not updating any global jinja context, just keeping it local to changelog generation: `_generate_new_changelog`

Testing results:

```
NEXT VERSION AFTER + 5.0.2
..........................

Latest change: 2025-05-06

==================================================================================================  ===========  =============================================================
Commit                                                                                              Committed    Subject
==================================================================================================  ===========  =============================================================
`4728fffc5f <https://github.com/apache/airflow/commit/4728fffc5f38ddf1577aace5049046d5e5b07b1f>`__  2025-05-06   ``Update description of provider.yaml dependencies (#50231)``
`34073abbd7 <https://github.com/apache/airflow/commit/34073abbd782ad5fdddf7880bf5e11f73196d0ec>`__  2025-04-29   ``update airbyte changelog (#49934)``
`c761353ce1 <https://github.com/apache/airflow/commit/c761353ce11bb90eb64ebb0ebb9e7b5d16c0949b>`__  2025-04-28   ``Avoid committing history for providers (#49907)``
`0f573ee40b <https://github.com/apache/airflow/commit/0f573ee40bfb7d9145328afd55bc16ca8598d008>`__  2025-04-28   ``Bump min Airflow version in providers to 2.10 (#49843)``
==================================================================================================  ===========  =============================================================

Does the provider: airbyte have any changes apart from 'doc-only'? 
Press y/N/q: y

Define the type of change for `Update description of provider.yaml dependencies (https://github.com/apache/airflow/pull/50231)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)isc, (s)kip, airflow_min_(v)ersion_bump (q)uit ? v


Define the type of change for `update airbyte changelog (https://github.com/apache/airflow/pull/49934)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)isc, (s)kip, airflow_min_(v)ersion_bump (q)uit ? b


Define the type of change for `Avoid committing history for providers (https://github.com/apache/airflow/pull/49907)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)isc, (s)kip, airflow_min_(v)ersion_bump (q)uit ? x


Define the type of change for `Bump min Airflow version in providers to 2.10 (https://github.com/apache/airflow/pull/49843)` by referring to the above table
Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking change, (m)isc, (s)kip, airflow_min_(v)ersion_bump (q)uit ? x

The version will be bumped because of TypeOfChange.BREAKING_CHANGE kind of change
Provider airbyte has been classified as:

Breaking changes - bump in MAJOR version needed

Bumped version to 6.0.0

Updated source-date-epoch to 1747033767

New version of the 'airbyte' package is ready to be released!


Do you want to leave the version for airbyte with version: 6.0.0 as is for the release? 
Press y/N/q: y
 Proceeding with provider: airbyte version as 6.0.0

Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/docs/commits.rst file for the airbyte provider

33c33
< For high-level changelog, see :doc:`changelog <changelog>`.
---
> For high-level changelog, see :doc:`package information including changelog <index>`.
Checking for backticks correctly generated in: /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/docs/commits.rst
Linting: /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/docs/commits.rst
Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/docs/commits.rst for airbyte is OK
Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/README.rst for the airbyte provider

Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/docs/conf.py for the airbyte provider

Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/pyproject.toml for the airbyte provider

Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/src/airflow/providers/airbyte/get_provider_info.py for the airbyte provider


Updates changelog for last release of package 'airbyte'

New version of the 'airbyte' package is ready to be released!

***                                                                                                                                                                                                       
                                                                                                                                                                                                          
---                                                                                                                                                                                                       
                                                                                                                                                                                                          
***************                                                                                                                                                                                           
                                                                                                                                                                                                          
*** 24,33 ****                                                                                                                                                                                            
                                                                                                                                                                                                          
--- 24,59 ----                                                                                                                                                                                            
                                                                                                                                                                                                          
  ``apache-airflow-providers-airbyte``                                                                                                                                                                    
                                                                                                                                                                                                          
  Changelog                                                                                                                                                                                               
  ---------                                                                                                                                                                                               
                                                                                                                                                                                                          
+                                                                                                                                                                                                         
+ 6.0.0                                                                                                                                                                                                   
+ .....                                                                                                                                                                                                   
+                                                                                                                                                                                                         
+ .. note::                                                                                                                                                                                               
+     This release of provider is only available for Airflow X.X+ as explained in the                                                                                                                     
+     Apache Airflow providers support policy <https://github.com/apache/airflow/blob/main/PROVIDERS.rst#minimum-supported-version-of-airflow-for-community-managed-providers>_.                          
+                                                                                                                                                                                                         
+ Breaking changes                                                                                                                                                                                        
+ ~~~~~~~~~~~~~~~~                                                                                                                                                                                        
+                                                                                                                                                                                                         
+ * ``Avoid committing history for providers (#49907)``                                                                                                                                                   
+ * ``Bump min Airflow version in providers to 2.10 (#49843)``                                                                                                                                            
+                                                                                                                                                                                                         
+ Bug Fixes                                                                                                                                                                                               
+ ~~~~~~~~~                                                                                                                                                                                               
+                                                                                                                                                                                                         
+ * ``update airbyte changelog (#49934)``                                                                                                                                                                 
+                                                                                                                                                                                                         
+ Misc                                                                                                                                                                                                    
+ ~~~~                                                                                                                                                                                                    
+                                                                                                                                                                                                         
+ * ``Update description of provider.yaml dependencies (#50231)``                                                                                                                                         
+                                                                                                                                                                                                         
+ .. Below changes are excluded from the changelog. Move them to                                                                                                                                          
+    appropriate section above if needed. Do not delete the lines(!):                                                                                                                                     
                                                                                                                                                                                                          
  5.0.2                                                                                                                                                                                                   
  .....                                                                                                                                                                                                   
                                                                                                                                                                                                          
  .. note::                                                                                                                                                                                               
The provider airbyte changelog for `6.0.0` version is missing. Generating fresh changelog.

Update index.rst for airbyte


Generated /Users/amoghdesai/Documents/OSS/repos/airflow/providers/airbyte/docs/index.rst file for the airbyte provider

79c79
< Release: 5.0.2
---
> Release: 6.0.0
97c97
< The minimum Apache Airflow version supported by this provider distribution is ``2.9.0``.
---
> The minimum Apache Airflow version supported by this provider distribution is ``2.10.0``.
102c102
< ``apache-airflow``  ``>=2.9.0``
---
> ``apache-airflow``  ``>=2.10.0``


Summary of prepared documentation:

Success: 1

airbyte


Successfully prepared documentation for packages!



Please review the updated files, classify the changelog entries and commit the changes.
```

![image](https://github.com/user-attachments/assets/efb169bf-301b-4e23-ae78-c4788961f063)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
