### PR TITLE
Don't auto activate assets in activation tests

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -239,6 +239,7 @@ class TestAssetModelOperation:
 
 
 @pytest.mark.db_test
+@pytest.mark.want_activate_assets(False)
 class TestAssetModelOperationSyncAssetActive:
     @staticmethod
     def clean_db():


### PR DESCRIPTION
These tests check if activation works correctly, so we should disable auto activation when the assets are created so the tests actually test the activation process correctly.

Fix #50405.