### PR TITLE
Update `WorkflowTrigger` to forward failed_stat

### DIFF
--- a/providers/standard/src/airflow/providers/standard/exceptions.py
+++ b/providers/standard/src/airflow/providers/standard/exceptions.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Exceptions used by Standard Provider."""
+
+from __future__ import annotations
+
+from airflow.exceptions import AirflowException
+
+
+class AirflowExternalTaskSensorException(AirflowException):
+    """Base exception for all ExternalTaskSensor related errors."""
+
+
+class ExternalDagNotFoundError(AirflowExternalTaskSensorException):
+    """Raised when the external DAG does not exist."""
+
+
+class ExternalDagDeletedError(AirflowExternalTaskSensorException):
+    """Raised when the external DAG was deleted."""
+
+
+class ExternalTaskNotFoundError(AirflowExternalTaskSensorException):
+    """Raised when the external task does not exist."""
+
+
+class ExternalTaskGroupNotFoundError(AirflowExternalTaskSensorException):
+    """Raised when the external task group does not exist."""
+
+
+class ExternalTaskFailedError(AirflowExternalTaskSensorException):
+    """Raised when the external task failed."""
+
+
+class ExternalTaskGroupFailedError(AirflowExternalTaskSensorException):
+    """Raised when the external task group failed."""
+
+
+class ExternalDagFailedError(AirflowExternalTaskSensorException):
+    """Raised when the external DAG failed."""
+
+
+class DuplicateStateError(AirflowExternalTaskSensorException):
+    """Raised when duplicate states are provided across allowed, skipped and failed states."""

--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -475,6 +475,10 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         if self.external_task_ids:
             refreshed_dag_info = DagBag(dag_to_wait.fileloc).get_dag(self.external_dag_id)
+            if not refreshed_dag_info:
+                raise ExternalDagNotFoundError(
+                    f"The external DAG {self.external_dag_id} could not be loaded."
+                )
             for external_task_id in self.external_task_ids:
                 if not refreshed_dag_info.has_task(external_task_id):
                     raise ExternalTaskNotFoundError(
@@ -483,6 +487,10 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         if self.external_task_group_id:
             refreshed_dag_info = DagBag(dag_to_wait.fileloc).get_dag(self.external_dag_id)
+            if not refreshed_dag_info:
+                raise ExternalDagNotFoundError(
+                    f"The external DAG {self.external_dag_id} could not be loaded."
+                )
             if not refreshed_dag_info.has_task_group(self.external_task_group_id):
                 raise ExternalTaskGroupNotFoundError(
                     f"The external task group '{self.external_task_group_id}' in "

--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -24,9 +23,19 @@ from collections.abc import Collection, Iterable
 from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowSkipException
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
+from airflow.providers.standard.exceptions import (
+    DuplicateStateError,
+    ExternalDagDeletedError,
+    ExternalDagFailedError,
+    ExternalDagNotFoundError,
+    ExternalTaskFailedError,
+    ExternalTaskGroupFailedError,
+    ExternalTaskGroupNotFoundError,
+    ExternalTaskNotFoundError,
+)
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.external_task import WorkflowTrigger
 from airflow.providers.standard.utils.sensor_helper import _get_count, _get_external_task_group_task_ids
@@ -190,7 +199,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         total_states = set(self.allowed_states + self.skipped_states + self.failed_states)
 
         if len(total_states) != len(self.allowed_states) + len(self.skipped_states) + len(self.failed_states):
-            raise AirflowException(
+            raise DuplicateStateError(
                 "Duplicate values provided across allowed_states, skipped_states and failed_states."
             )
 
@@ -356,7 +365,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                         f"Some of the external tasks {self.external_task_ids} "
                         f"in DAG {self.external_dag_id} failed. Skipping due to soft_fail."
                     )
-                raise AirflowException(
+                raise ExternalTaskFailedError(
                     f"Some of the external tasks {self.external_task_ids} "
                     f"in DAG {self.external_dag_id} failed."
                 )
@@ -366,7 +375,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                         f"The external task_group '{self.external_task_group_id}' "
                         f"in DAG '{self.external_dag_id}' failed. Skipping due to soft_fail."
                     )
-                raise AirflowException(
+                raise ExternalTaskGroupFailedError(
                     f"The external task_group '{self.external_task_group_id}' "
                     f"in DAG '{self.external_dag_id}' failed."
                 )
@@ -374,7 +383,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                 raise AirflowSkipException(
                     f"The external DAG {self.external_dag_id} failed. Skipping due to soft_fail."
                 )
-            raise AirflowException(f"The external DAG {self.external_dag_id} failed.")
+            raise ExternalDagFailedError(f"The external DAG {self.external_dag_id} failed.")
 
     def _handle_skipped_states(self, count_skipped: float | int) -> None:
         """Handle skipped states and raise appropriate exceptions."""
@@ -443,10 +452,14 @@ class ExternalTaskSensor(BaseSensorOperator):
             self.log.info("External tasks %s has executed successfully.", self.external_task_ids)
         elif event["status"] == "skipped":
             raise AirflowSkipException("External job has skipped skipping.")
+        elif event["status"] == "failed":
+            if self.soft_fail:
+                raise AirflowSkipException("External job has failed skipping.")
+            raise ExternalDagFailedError("External job has failed.")
         else:
             if self.soft_fail:
                 raise AirflowSkipException("External job has failed skipping.")
-            raise AirflowException(
+            raise ExternalTaskNotFoundError(
                 "Error occurred while trying to retrieve task status. Please, check the "
                 "name of executed task and Dag."
             )
@@ -455,23 +468,23 @@ class ExternalTaskSensor(BaseSensorOperator):
         dag_to_wait = DagModel.get_current(self.external_dag_id, session)
 
         if not dag_to_wait:
-            raise AirflowException(f"The external DAG {self.external_dag_id} does not exist.")
+            raise ExternalDagNotFoundError(f"The external DAG {self.external_dag_id} does not exist.")
 
         if not os.path.exists(correct_maybe_zipped(dag_to_wait.fileloc)):
-            raise AirflowException(f"The external DAG {self.external_dag_id} was deleted.")
+            raise ExternalDagDeletedError(f"The external DAG {self.external_dag_id} was deleted.")
 
         if self.external_task_ids:
             refreshed_dag_info = DagBag(dag_to_wait.fileloc).get_dag(self.external_dag_id)
             for external_task_id in self.external_task_ids:
                 if not refreshed_dag_info.has_task(external_task_id):
-                    raise AirflowException(
+                    raise ExternalTaskNotFoundError(
                         f"The external task {external_task_id} in DAG {self.external_dag_id} does not exist."
                     )
 
         if self.external_task_group_id:
             refreshed_dag_info = DagBag(dag_to_wait.fileloc).get_dag(self.external_dag_id)
             if not refreshed_dag_info.has_task_group(self.external_task_group_id):
-                raise AirflowException(
+                raise ExternalTaskGroupNotFoundError(
                     f"The external task group '{self.external_task_group_id}' in "
                     f"DAG '{self.external_dag_id}' does not exist."
                 )

--- a/providers/standard/src/airflow/providers/standard/triggers/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/external_task.py
@@ -115,9 +115,7 @@ class WorkflowTrigger(BaseTrigger):
                 if failed_count > 0:
                     yield TriggerEvent({"status": "failed"})
                     return
-                else:
-                    yield TriggerEvent({"status": "success"})
-                    return
+
             if self.skipped_states:
                 skipped_count = await get_count_func(self.skipped_states)
                 if skipped_count > 0:

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -26,12 +26,26 @@ from unittest import mock
 import pytest
 
 from airflow import settings
-from airflow.exceptions import AirflowException, AirflowSensorTimeout, AirflowSkipException, TaskDeferred
+from airflow.exceptions import (
+    AirflowSensorTimeout,
+    AirflowSkipException,
+    TaskDeferred,
+)
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.xcom_arg import XComArg
+from airflow.providers.standard.exceptions import (
+    DuplicateStateError,
+    ExternalDagDeletedError,
+    ExternalDagFailedError,
+    ExternalDagNotFoundError,
+    ExternalTaskFailedError,
+    ExternalTaskGroupFailedError,
+    ExternalTaskGroupNotFoundError,
+    ExternalTaskNotFoundError,
+)
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -226,7 +240,7 @@ class TestExternalTaskSensorV2:
             dag=self.dag,
             poke_interval=0.1,
         )
-        with pytest.raises(AirflowException, match="Sensor has timed out"):
+        with pytest.raises(AirflowSensorTimeout, match="Sensor has timed out"):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_external_task_group_sensor_success(self):
@@ -253,13 +267,13 @@ class TestExternalTaskSensorV2:
             dag=self.dag,
         )
         with pytest.raises(
-            AirflowException,
+            ExternalTaskGroupFailedError,
             match=f"The external task_group '{TEST_TASK_GROUP_ID}' in DAG '{TEST_DAG_ID}' failed.",
         ):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_catch_overlap_allowed_failed_state(self):
-        with pytest.raises(AirflowException):
+        with pytest.raises(DuplicateStateError):
             ExternalTaskSensor(
                 task_id="test_external_task_sensor_check",
                 external_dag_id=TEST_DAG_ID,
@@ -303,7 +317,7 @@ class TestExternalTaskSensorV2:
         error_message = rf"Some of the external tasks \['{TEST_TASK_ID}'\] in DAG {TEST_DAG_ID} failed\."
         with caplog.at_level(logging.INFO, logger=op.log.name):
             caplog.clear()
-            with pytest.raises(AirflowException, match=error_message):
+            with pytest.raises(ExternalTaskFailedError, match=error_message):
                 op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
         assert (
             f"Poking for tasks ['{TEST_TASK_ID}'] in dag {TEST_DAG_ID} on {DEFAULT_DATE.isoformat()} ... "
@@ -404,7 +418,7 @@ class TestExternalTaskSensorV2:
         )
         with caplog.at_level(logging.INFO, logger=op.log.name):
             caplog.clear()
-            with pytest.raises(AirflowException, match=error_message):
+            with pytest.raises(ExternalTaskFailedError, match=error_message):
                 op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
         assert (
             f"Poking for tasks ['{TEST_TASK_ID}', '{TEST_TASK_ID_ALTERNATE}'] "
@@ -552,12 +566,12 @@ exit 0
             dag=dag,
         )
 
-        # We need to test for an AirflowException explicitly since
+        # We need to test for an ExternalTaskFailedError explicitly since
         # AirflowSensorTimeout is a subclass that will be raised if this does
         # not execute properly.
-        with pytest.raises(AirflowException) as ex_ctx:
+        with pytest.raises(ExternalTaskFailedError) as ex_ctx:
             task_chain_with_failure.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        assert type(ex_ctx.value) is AirflowException
+        assert type(ex_ctx.value) is ExternalTaskFailedError
 
     def test_external_task_sensor_delta(self):
         self.add_time_sensor()
@@ -753,7 +767,7 @@ exit 0
             dag=self.dag,
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ExternalTaskNotFoundError):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_external_task_sensor_waits_for_dag_check_existence(self):
@@ -765,7 +779,7 @@ exit 0
             dag=self.dag,
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ExternalDagNotFoundError):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_external_task_group_with_mapped_tasks_sensor_success(self):
@@ -791,7 +805,7 @@ exit 0
             dag=self.dag,
         )
         with pytest.raises(
-            AirflowException,
+            ExternalTaskGroupFailedError,
             match=f"The external task_group '{TEST_TASK_GROUP_ID}' in DAG '{TEST_DAG_ID}' failed.",
         ):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
@@ -846,7 +860,7 @@ exit 0
         (
             (
                 False,
-                AirflowException,
+                ExternalTaskFailedError,
             ),
             (
                 True,
@@ -870,8 +884,24 @@ exit 0
             deferrable=False,
             **kwargs,
         )
-        with pytest.raises(expected_exception, match=expected_message):
-            op.execute(context={})
+
+        # We need to handle the specific exception types based on kwargs
+        if not soft_fail:
+            expected_exc = expected_exception
+            if "external_task_ids" in kwargs:
+                expected_exc = ExternalTaskFailedError
+            elif "external_task_group_id" in kwargs:
+                expected_exc = ExternalTaskGroupFailedError
+            elif "failed_states" in kwargs and not any(
+                k in kwargs for k in ["external_task_ids", "external_task_group_id"]
+            ):
+                expected_exc = ExternalDagFailedError
+
+            with pytest.raises(expected_exc, match=expected_message):
+                op.execute(context={})
+        else:
+            with pytest.raises(expected_exception, match=expected_message):
+                op.execute(context={})
 
     @pytest.mark.parametrize(
         "response_get_current, response_exists, kwargs, expected_message",
@@ -903,11 +933,11 @@ exit 0
         (
             (
                 False,
-                AirflowException,
+                ExternalDagNotFoundError,
             ),
             (
                 True,
-                AirflowException,
+                ExternalDagNotFoundError,
             ),
         ),
     )
@@ -946,7 +976,17 @@ exit 0
         )
         if not hasattr(op, "never_fail"):
             expected_message = "Skipping due to soft_fail is set to True." if soft_fail else expected_message
-        with pytest.raises(expected_exception, match=expected_message):
+        specific_exception = expected_exception
+        if response_get_current is None:
+            specific_exception = ExternalDagNotFoundError
+        elif not response_exists:
+            specific_exception = ExternalDagDeletedError
+        elif "external_task_ids" in kwargs:
+            specific_exception = ExternalTaskNotFoundError
+        elif "external_task_group_id" in kwargs:
+            specific_exception = ExternalTaskGroupNotFoundError
+
+        with pytest.raises(specific_exception, match=expected_message):
             op.execute(context={})
 
 
@@ -1002,7 +1042,7 @@ class TestExternalTaskSensorV3:
 
         self.context["ti"].get_ti_count.return_value = 1
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ExternalTaskFailedError):
             op.execute(context=self.context)
 
         self.context["ti"].get_ti_count.assert_called_once_with(
@@ -1227,7 +1267,7 @@ class TestExternalTaskSensorV3:
 
         self.context["ti"].get_task_states.return_value = {"run_id": {"test_group.task_id": State.FAILED}}
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ExternalTaskGroupFailedError):
             op.execute(context=self.context)
 
         self.context["ti"].get_task_states.assert_called_once_with(
@@ -1261,7 +1301,7 @@ class TestExternalTaskAsyncSensor:
         assert isinstance(exc.value.trigger, WorkflowTrigger), "Trigger is not a WorkflowTrigger"
 
     def test_defer_and_fire_failed_state_trigger(self):
-        """Tests that an AirflowException is raised in case of error event"""
+        """Tests that an ExternalTaskNotFoundError is raised in case of error event"""
         sensor = ExternalTaskSensor(
             task_id=TASK_ID,
             external_task_id=EXTERNAL_TASK_ID,
@@ -1269,13 +1309,13 @@ class TestExternalTaskAsyncSensor:
             deferrable=True,
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ExternalTaskNotFoundError):
             sensor.execute_complete(
                 context=mock.MagicMock(), event={"status": "error", "message": "test failure message"}
             )
 
     def test_defer_and_fire_timeout_state_trigger(self):
-        """Tests that an AirflowException is raised in case of timeout event"""
+        """Tests that an ExternalTaskNotFoundError is raised in case of timeout event"""
         sensor = ExternalTaskSensor(
             task_id=TASK_ID,
             external_task_id=EXTERNAL_TASK_ID,
@@ -1283,7 +1323,7 @@ class TestExternalTaskAsyncSensor:
             deferrable=True,
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ExternalTaskNotFoundError):
             sensor.execute_complete(
                 context=mock.MagicMock(),
                 event={"status": "timeout", "message": "Dag was not started within 1 minute, assuming fail."},
@@ -1304,6 +1344,55 @@ class TestExternalTaskAsyncSensor:
                 event={"status": "success"},
             )
         mock_log_info.assert_called_with("External tasks %s has executed successfully.", [EXTERNAL_TASK_ID])
+
+    def test_defer_execute_check_failed_status(self):
+        """Tests that the execute_complete method properly handles the 'failed' status from WorkflowTrigger"""
+        sensor = ExternalTaskSensor(
+            task_id=TASK_ID,
+            external_task_id=EXTERNAL_TASK_ID,
+            external_dag_id=EXTERNAL_DAG_ID,
+            deferrable=True,
+        )
+
+        with pytest.raises(ExternalDagFailedError, match="External job has failed."):
+            sensor.execute_complete(
+                context=mock.MagicMock(),
+                event={"status": "failed"},
+            )
+
+    def test_defer_execute_check_failed_status_soft_fail(self):
+        """Tests that the execute_complete method properly handles the 'failed' status with soft_fail=True"""
+        sensor = ExternalTaskSensor(
+            task_id=TASK_ID,
+            external_task_id=EXTERNAL_TASK_ID,
+            external_dag_id=EXTERNAL_DAG_ID,
+            deferrable=True,
+            soft_fail=True,
+        )
+
+        with pytest.raises(AirflowSkipException, match="External job has failed skipping."):
+            sensor.execute_complete(
+                context=mock.MagicMock(),
+                event={"status": "failed"},
+            )
+
+    def test_defer_with_failed_states(self):
+        """Tests that failed_states are properly passed to the WorkflowTrigger when the sensor is deferred"""
+        failed_states = ["failed", "upstream_failed"]
+        sensor = ExternalTaskSensor(
+            task_id=TASK_ID,
+            external_task_id=EXTERNAL_TASK_ID,
+            external_dag_id=EXTERNAL_DAG_ID,
+            deferrable=True,
+            failed_states=failed_states,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            sensor.execute(context=mock.MagicMock())
+
+        trigger = exc.value.trigger
+        assert isinstance(trigger, WorkflowTrigger), "Trigger is not a WorkflowTrigger"
+        assert trigger.failed_states == failed_states, "failed_states not properly passed to WorkflowTrigger"
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Needs Flask app context fixture for AF 2")
@@ -1648,7 +1737,7 @@ def test_external_task_marker_future(dag_bag_ext):
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Different test for 3.0+")
 def test_external_task_marker_exception(dag_bag_ext):
     """
-    Clearing across multiple DAGs should raise AirflowException if more levels are being cleared
+    Clearing across multiple DAGs should raise ExternalDagFailedError if more levels are being cleared
     than allowed by the recursion_depth of the first ExternalTaskMarker being cleared.
     """
     run_tasks(dag_bag_ext)
@@ -1656,7 +1745,7 @@ def test_external_task_marker_exception(dag_bag_ext):
     task_a_0 = dag_0.get_task("task_a_0")
     task_b_0 = dag_0.get_task("task_b_0")
     task_b_0.recursion_depth = 2
-    with pytest.raises(AirflowException, match="Maximum recursion depth 2"):
+    with pytest.raises(ExternalDagFailedError, match="Maximum recursion depth 2"):
         clear_tasks(dag_bag_ext, dag_0, task_a_0)
 
 
@@ -1736,14 +1825,14 @@ def dag_bag_cyclic():
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Different test for 3.0+")
 def test_external_task_marker_cyclic_deep(dag_bag_cyclic):
     """
-    Tests clearing across multiple DAGs that have cyclic dependencies. AirflowException should be
+    Tests clearing across multiple DAGs that have cyclic dependencies. ExternalDagFailedError should be
     raised.
     """
     dag_bag = dag_bag_cyclic(10)
     run_tasks(dag_bag)
     dag_0 = dag_bag.get_dag("dag_0")
     task_a_0 = dag_0.get_task("task_a_0")
-    with pytest.raises(AirflowException, match="Maximum recursion depth 3"):
+    with pytest.raises(ExternalDagFailedError, match="Maximum recursion depth 3"):
         clear_tasks(dag_bag, dag_0, task_a_0)
 
 

--- a/providers/standard/tests/unit/standard/test_exceptions.py
+++ b/providers/standard/tests/unit/standard/test_exceptions.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.standard.exceptions import (
+    AirflowExternalTaskSensorException,
+    DuplicateStateError,
+    ExternalDagDeletedError,
+    ExternalDagFailedError,
+    ExternalDagNotFoundError,
+    ExternalTaskFailedError,
+    ExternalTaskGroupFailedError,
+    ExternalTaskGroupNotFoundError,
+    ExternalTaskNotFoundError,
+)
+
+
+def test_external_task_sensor_exception():
+    """Test if AirflowExternalTaskSensorException can be raised correctly."""
+    with pytest.raises(AirflowExternalTaskSensorException, match="Task execution failed"):
+        raise AirflowExternalTaskSensorException("Task execution failed")
+
+
+def test_external_dag_not_found_error():
+    """Test if ExternalDagNotFoundError can be raised correctly."""
+    with pytest.raises(ExternalDagNotFoundError, match="External DAG not found"):
+        raise ExternalDagNotFoundError("External DAG not found")
+
+    # Verify it's a subclass of AirflowExternalTaskSensorException
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalDagNotFoundError("External DAG not found")
+
+
+def test_external_dag_deleted_error():
+    """Test if ExternalDagDeletedError can be raised correctly."""
+    with pytest.raises(ExternalDagDeletedError, match="External DAG was deleted"):
+        raise ExternalDagDeletedError("External DAG was deleted")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalDagDeletedError("External DAG was deleted")
+
+
+def test_external_task_not_found_error():
+    """Test if ExternalTaskNotFoundError can be raised correctly."""
+    with pytest.raises(ExternalTaskNotFoundError, match="External task not found"):
+        raise ExternalTaskNotFoundError("External task not found")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalTaskNotFoundError("External task not found")
+
+
+def test_external_task_group_not_found_error():
+    """Test if ExternalTaskGroupNotFoundError can be raised correctly."""
+    with pytest.raises(ExternalTaskGroupNotFoundError, match="External task group not found"):
+        raise ExternalTaskGroupNotFoundError("External task group not found")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalTaskGroupNotFoundError("External task group not found")
+
+
+def test_external_task_failed_error():
+    """Test if ExternalTaskFailedError can be raised correctly."""
+    with pytest.raises(ExternalTaskFailedError, match="External task failed"):
+        raise ExternalTaskFailedError("External task failed")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalTaskFailedError("External task failed")
+
+
+def test_external_task_group_failed_error():
+    """Test if ExternalTaskGroupFailedError can be raised correctly."""
+    with pytest.raises(ExternalTaskGroupFailedError, match="External task group failed"):
+        raise ExternalTaskGroupFailedError("External task group failed")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalTaskGroupFailedError("External task group failed")
+
+
+def test_external_dag_failed_error():
+    """Test if ExternalDagFailedError can be raised correctly."""
+    with pytest.raises(ExternalDagFailedError, match="External DAG failed"):
+        raise ExternalDagFailedError("External DAG failed")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise ExternalDagFailedError("External DAG failed")
+
+
+def test_duplicate_state_error():
+    """Test if DuplicateStateError can be raised correctly."""
+    with pytest.raises(DuplicateStateError, match="Duplicate state provided"):
+        raise DuplicateStateError("Duplicate state provided")
+
+    with pytest.raises(AirflowExternalTaskSensorException):
+        raise DuplicateStateError("Duplicate state provided")

--- a/providers/standard/tests/unit/standard/triggers/test_external_task.py
+++ b/providers/standard/tests/unit/standard/triggers/test_external_task.py
@@ -153,14 +153,8 @@ class TestWorkflowTrigger:
                     run_ids=[self.RUN_ID],
                     states=["success", "fail"],
                 ),
-                mock.call(
-                    dag_id="external_task",
-                    task_ids=["external_task_op"],
-                    logical_dates=[self.LOGICAL_DATE],
-                    run_ids=[self.RUN_ID],
-                    states=["success", "fail"],
-                ),
             ]
+            * 2
         )
 
         # test that it returns after yielding
@@ -519,14 +513,8 @@ class TestWorkflowTriggerAF2:
                     external_dag_id="external_task",
                     states=["success", "fail"],
                 ),
-                mock.call(
-                    dttm_filter=value,
-                    external_task_ids=["external_task_op"],
-                    external_task_group_id=None,
-                    external_dag_id="external_task",
-                    states=["success", "fail"],
-                ),
             ]
+            * 2
         )
 
         mock_sleep.assert_not_called()

--- a/providers/standard/tests/unit/standard/triggers/test_external_task.py
+++ b/providers/standard/tests/unit/standard/triggers/test_external_task.py
@@ -122,7 +122,7 @@ class TestWorkflowTrigger:
     @pytest.mark.asyncio
     @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
     async def test_task_workflow_trigger_fail_count_eq_0(self, mock_get_count):
-        mock_get_count.return_value = 0
+        mock_get_count.side_effect = [0, 1]  # First 0 for failed_states, then 1 for allowed_states
 
         trigger = WorkflowTrigger(
             external_dag_id=self.DAG_ID,
@@ -130,6 +130,7 @@ class TestWorkflowTrigger:
             run_ids=[self.RUN_ID],
             external_task_ids=[self.TASK_ID],
             failed_states=self.STATES,
+            allowed_states=self.STATES,
             poke_interval=0.2,
         )
 
@@ -140,13 +141,28 @@ class TestWorkflowTrigger:
         result = trigger_task.result()
         assert isinstance(result, TriggerEvent)
         assert result.payload == {"status": "success"}
-        mock_get_count.assert_called_once_with(
-            dag_id="external_task",
-            task_ids=["external_task_op"],
-            logical_dates=[self.LOGICAL_DATE],
-            run_ids=[self.RUN_ID],
-            states=["success", "fail"],
+
+        # Verify both calls were made
+        assert mock_get_count.call_count == 2
+        mock_get_count.assert_has_calls(
+            [
+                mock.call(
+                    dag_id="external_task",
+                    task_ids=["external_task_op"],
+                    logical_dates=[self.LOGICAL_DATE],
+                    run_ids=[self.RUN_ID],
+                    states=["success", "fail"],
+                ),
+                mock.call(
+                    dag_id="external_task",
+                    task_ids=["external_task_op"],
+                    logical_dates=[self.LOGICAL_DATE],
+                    run_ids=[self.RUN_ID],
+                    states=["success", "fail"],
+                ),
+            ]
         )
+
         # test that it returns after yielding
         with pytest.raises(StopAsyncIteration):
             await gen.__anext__()
@@ -468,15 +484,20 @@ class TestWorkflowTriggerAF2:
             await gen.__anext__()
 
     @mock.patch("airflow.providers.standard.triggers.external_task._get_count")
+    @mock.patch("asyncio.sleep")
     @pytest.mark.asyncio
-    async def test_task_workflow_trigger_fail_count_eq_0(self, mock_get_count):
-        mock_get_count.return_value = 0
+    async def test_task_workflow_trigger_fail_count_eq_0(self, mock_sleep, mock_get_count):
+        mock_get_count.side_effect = [
+            0,
+            1,
+        ]
 
         trigger = WorkflowTrigger(
             external_dag_id=self.DAG_ID,
             **_DATES,
             external_task_ids=[self.TASK_ID],
             failed_states=self.STATES,
+            allowed_states=self.STATES,
             poke_interval=0.2,
         )
 
@@ -487,14 +508,29 @@ class TestWorkflowTriggerAF2:
         result = trigger_task.result()
         assert isinstance(result, TriggerEvent)
         assert result.payload == {"status": "success"}
-        mock_get_count.assert_called_once_with(
-            dttm_filter=value,
-            external_task_ids=["external_task_op"],
-            external_task_group_id=None,
-            external_dag_id="external_task",
-            states=["success", "fail"],
+
+        assert mock_get_count.call_count == 2
+        mock_get_count.assert_has_calls(
+            [
+                mock.call(
+                    dttm_filter=value,
+                    external_task_ids=["external_task_op"],
+                    external_task_group_id=None,
+                    external_dag_id="external_task",
+                    states=["success", "fail"],
+                ),
+                mock.call(
+                    dttm_filter=value,
+                    external_task_ids=["external_task_op"],
+                    external_task_group_id=None,
+                    external_dag_id="external_task",
+                    states=["success", "fail"],
+                ),
+            ]
         )
-        # test that it returns after yielding
+
+        mock_sleep.assert_not_called()
+
         with pytest.raises(StopAsyncIteration):
             await gen.__anext__()
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

closes #41140
cc @eladkal 

## Why

- prevents infinite polling when monitored failure
- correctly propagates failure status back to calling workflow

## How

- fix `WorkflowTrigger` to continue checking allowed_states when no failed states are found
- update `ExternalTaskSensor.execute_complete` to properly handle "failed" status
- add tests to verify behaviors

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
