### PR TITLE
Fix aws_conn_id defaulting after dag.test was updated to use TaskSDK.

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -607,9 +607,14 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         """Get the Airflow Connection object and wrap it in helper (cached)."""
         connection = None
         if self.aws_conn_id:
+            possible_exceptions = (
+                (AirflowNotFoundException, AirflowRuntimeError)
+                if AIRFLOW_V_3_0_PLUS
+                else (AirflowNotFoundException,)
+            )
             try:
                 connection = self.get_connection(self.aws_conn_id)
-            except (AirflowNotFoundException, AirflowRuntimeError) as e:
+            except possible_exceptions as e:
                 if isinstance(
                     e, AirflowNotFoundException
                 ) or f"Connection with ID {self.aws_conn_id} not found" in str(e):

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -607,11 +607,13 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         """Get the Airflow Connection object and wrap it in helper (cached)."""
         connection = None
         if self.aws_conn_id:
-            possible_exceptions = (
-                (AirflowNotFoundException, AirflowRuntimeError)
-                if AIRFLOW_V_3_0_PLUS
-                else (AirflowNotFoundException,)
-            )
+            possible_exceptions: tuple[type[Exception], ...]
+
+            if AIRFLOW_V_3_0_PLUS:
+                possible_exceptions = (AirflowNotFoundException, AirflowRuntimeError)
+            else:
+                possible_exceptions = (AirflowNotFoundException,)
+
             try:
                 connection = self.get_connection(self.aws_conn_id)
             except possible_exceptions as e:

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -58,12 +58,15 @@ from airflow.hooks.base import BaseHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 from airflow.providers.amazon.aws.utils.identifiers import generate_uuid
 from airflow.providers.amazon.aws.utils.suppress import return_on_error
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.providers_manager import ProvidersManager
-from airflow.sdk.exceptions import AirflowRuntimeError
 from airflow.utils.helpers import exactly_one
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 BaseAwsConnection = TypeVar("BaseAwsConnection", bound=Union[boto3.client, boto3.resource])
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk.exceptions import AirflowRuntimeError
 
 if TYPE_CHECKING:
     from aiobotocore.session import AioSession


### PR DESCRIPTION
The Task API raises an AirflowRuntimeError which we need to catch now as well.   In an effort to not accidentally swallow any other RuntimeErrors that may pop up, I added a message match on it and re-raise if it doesn't have the expected "connection not found" message.

Related slack discussion:  https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1746835026272909?thread_ts=1746819752.521919&cid=C06K9Q5G2UA

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
