### PR TITLE
Flattening the `requirements` input for python venv operators

### DIFF
--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -323,7 +323,12 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         )
 
         mock_get.assert_called_once_with(project_id=PROJECT_ID, dataset_id=DATASET_ID)
-        assert view_access in dataset.access_entries
+        assert any(
+            entry.role == view_access.role
+            and entry.entity_type == view_access.entity_type
+            and entry.entity_id == view_access.entity_id
+            for entry in dataset.access_entries
+        ), f"View access entry not found in {dataset.access_entries}"
         mock_update.assert_called_once_with(
             fields=["access"],
             dataset_resource=dataset.to_api_repr(),

--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -859,7 +859,14 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             # If we're using system packages, assume both are present
             found_airflow = found_pendulum = True
         else:
-            for raw_str in self.requirements:
+            requirements_iterable = []
+            if isinstance(self.requirements, str):
+                requirements_iterable = self.requirements.splitlines()
+            else:
+                for item in self.requirements:
+                    requirements_iterable.extend(item.splitlines())
+
+            for raw_str in requirements_iterable:
                 line = raw_str.strip()
                 # Skip blank lines and full‐line comments
                 if not line or line.startswith("#"):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/50446 did some rework on the way requirements are parsed. This was leading to some of the traditional ways of passing requirements to the venv operators to break. 

Tested with:
```
'funcsigs==0.4\nattrs==23.1.0'

['funcsigs==0.4', 'attrs==23.1.0']

['funcsigs==0.4\nattrs==23.1.0']

'pendulum==2.1.2  # pinned version\nattrs==23.1.0  # optional'

['   pendulum==2.1.2   ', '# comment only', 'attrs==23.1.0   # inline comment']

['apache-airflow==2.8.0', 'something==1.0']
```

All good now.

Example failures: https://github.com/apache/airflow/actions/runs/14986598214

```
FAILED providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py::TestPythonVirtualenvDecorator::test_with_requirements_file[pickle] - ValueError: Invalid requirement 'funcsigs==0.4
attrs==23.1.0': Expected end or semicolon (after version specifier)
    funcsigs==0.4
attrs==23.1.0
            ~~~~~^
FAILED providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py::TestPythonVirtualenvDecorator::test_with_requirements_file[dill] - ValueError: Invalid requirement 'funcsigs==0.4
attrs==23.1.0': Expected end or semicolon (after version specifier)
    funcsigs==0.4
attrs==23.1.0
            ~~~~~^
FAILED providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py::TestPythonVirtualenvDecorator::test_with_requirements_file[cloudpickle] - ValueError: Invalid requirement 'funcsigs==0.4
attrs==23.1.0': Expected end or semicolon (after version specifier)
    funcsigs==0.4
attrs==23.1.0
            ~~~~~^
FAILED providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py::TestPythonVirtualenvDecorator::test_with_requirements_file[default] - ValueError: Invalid requirement 'funcsigs==0.4
attrs==23.1.0': Expected end or semicolon (after version specifier)
    funcsigs==0.4
attrs==23.1.0
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
