### PR TITLE
Upgrade `DatabricksSqlHook` to support `polars`

### DIFF
--- a/providers/databricks/README.rst
+++ b/providers/databricks/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                              Version required
 =======================================  ==================
 ``apache-airflow``                       ``>=2.10.0``
-``apache-airflow-providers-common-sql``  ``>=1.21.0``
+``apache-airflow-providers-common-sql``  ``>=1.27.0``
 ``requests``                             ``>=2.31.0,<3``
 ``databricks-sql-connector``             ``>=3.0.0``
 ``aiohttp``                              ``>=3.9.2,<4``

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.6.0",
-    "apache-airflow-providers-common-sql>=1.21.0",
+    "apache-airflow-providers-common-sql>=1.27.0",
     "requests>=2.31.0,<3",
     "databricks-sql-connector>=3.0.0",
     "databricks-sqlalchemy>=1.0.2",
@@ -101,6 +101,7 @@ dev = [
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "deltalake>=0.12.0",
     "apache-airflow-providers-microsoft-azure",
+    "apache-airflow-providers-common-sql[pandas,polars]",
 ]
 
 # To build docs:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- #49334

## Why 

We supported `polars` in https://github.com/apache/airflow/pull/48875.

## How

- This PR is focus on upgrade of `DatabricksSqlHook`
- Migrate common-sql to 1.27.0
- Add unit test for pandas and polars

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
