### PR TITLE
Refine BigQuery test with field-wise comparison of access_entries

### DIFF
--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -323,7 +323,12 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         )
 
         mock_get.assert_called_once_with(project_id=PROJECT_ID, dataset_id=DATASET_ID)
-        assert view_access in dataset.access_entries
+        assert any(
+            entry.role == view_access.role
+            and entry.entity_type == view_access.entity_type
+            and entry.entity_id == view_access.entity_id
+            for entry in dataset.access_entries
+        ), f"View access entry not found in {dataset.access_entries}"
         mock_update.assert_called_once_with(
             fields=["access"],
             dataset_resource=dataset.to_api_repr(),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Due to bigquery version: `google-cloud-bigquery==3.32.0` (https://pypi.org/project/google-cloud-bigquery/), seems that tests fail due to
```
providers/google/tests/unit/google/cloud/hooks/test_bigquery.py:305 (TestBigQueryHookMethods.test_run_grant_dataset_view_access_granting)
<AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}> != [<AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}>]

Expected :[<AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}>]
Actual   :<AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}>
<Click to see difference>

unit/google/cloud/hooks/test_bigquery.py:326: in test_run_grant_dataset_view_access_granting
    assert view_access in dataset.access_entries
E   AssertionError: assert <AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}> in [<AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}>]
E    +  where [<AccessEntry: role=None, view={'projectId': 'bq-project', 'datasetId': 'bq_dataset_view', 'tableId': 'bq_table_view'}>] = Dataset(DatasetReference('bq-project', 'bq_dataset')).access_entries
```

On further digging, seems that the `dataset.access_entries` uses
```
    @classmethod
    def from_api_repr(cls, resource: dict) -> "AccessEntry":
        """Factory: construct an access entry given its API representation

        Args:
            resource (Dict[str, object]):
                Access entry resource representation returned from the API

        Returns:
            google.cloud.bigquery.dataset.AccessEntry:
                Access entry parsed from ``resource``.
        """

        access_entry = cls()
        access_entry._properties = resource.copy()
        return access_entry
```

Which is not turning out too well and retruning: `None` as a key.

As a more resilient fix, comparing by field would be a better thing to do.

Example occurence: https://github.com/apache/airflow/actions/runs/14986598214/job/42104886631


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
