### PR TITLE
expose OpenLineage's lineage_root_* macros in plugin

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
@@ -90,6 +90,16 @@ def lineage_parent_id(task_instance: TaskInstance):
 
 
 def lineage_root_parent_id(task_instance: TaskInstance):
+    """
+    Macro function which returns a unique identifier of given task that can be used to create root information for ParentRunFacet.
+
+    This identifier is composed of the namespace, dag name, and generated run id for given dag, structured
+    as '{namespace}/{job_name}/{run_id}'.
+
+    .. seealso::
+        For more information take a look at the guide:
+        :ref:`howto/macros:openlineage`
+    """
     return "/".join(
         (
             lineage_job_namespace(),

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/openlineage.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/openlineage.py
@@ -23,6 +23,9 @@ from airflow.providers.openlineage.plugins.macros import (
     lineage_job_name,
     lineage_job_namespace,
     lineage_parent_id,
+    lineage_root_job_name,
+    lineage_root_parent_id,
+    lineage_root_run_id,
     lineage_run_id,
 )
 
@@ -37,7 +40,15 @@ class OpenLineageProviderPlugin(AirflowPlugin):
 
     name = "OpenLineageProviderPlugin"
     if not conf.is_disabled():
-        macros = [lineage_job_namespace, lineage_job_name, lineage_run_id, lineage_parent_id]
+        macros = [
+            lineage_job_namespace,
+            lineage_job_name,
+            lineage_run_id,
+            lineage_parent_id,
+            lineage_root_run_id,
+            lineage_root_job_name,
+            lineage_root_parent_id,
+        ]
         listeners = [get_openlineage_listener()]
         from airflow.lineage.hook import HookLineageReader
 


### PR DESCRIPTION
Those macro methods are used to provide root lineage information that can be exposed to the child jobs that are also instrumented with OpenLineage. 

Follow up to https://github.com/apache/airflow/pull/49237