### PR TITLE
[v3-0-test] Move access_denied_message webserver config to fab (#50208)

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -380,6 +380,10 @@ CONFIGS_CHANGES = [
         renamed_to=ConfigParameter("fab", "session_lifetime_minutes"),
     ),
     ConfigChange(
+        config=ConfigParameter("webserver", "access_denied_message"),
+        renamed_to=ConfigParameter("fab", "access_denied_message"),
+    ),
+    ConfigChange(
         config=ConfigParameter("webserver", "base_url"),
         renamed_to=ConfigParameter("api", "base_url"),
     ),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1727,13 +1727,6 @@ operators:
 webserver:
   description: ~
   options:
-    access_denied_message:
-      description: |
-        The message displayed when a user attempts to execute actions beyond their authorised privileges.
-      version_added: 2.7.0
-      type: string
-      example: ~
-      default: "Access is Denied"
     secret_key:
       description: |
         Secret key used to run your api server. It should be as random as possible. However, when running

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -356,6 +356,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "access_logfile"): ("webserver", "access_logfile", "3.0"),
         ("triggerer", "capacity"): ("triggerer", "default_capacity", "3.0"),
         ("api", "expose_config"): ("webserver", "expose_config", "3.0.1"),
+        ("fab", "access_denied_message"): ("webserver", "access_denied_message", "3.0.2"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -264,8 +264,8 @@ def test_validate_provider_info_with_schema():
 @pytest.mark.parametrize(
     "provider_id, min_version",
     [
-        ("amazon", "2.9.0"),
-        ("fab", "3.0.0"),
+        ("amazon", "2.10.0"),
+        ("fab", "3.0.2"),
     ],
 )
 def test_get_min_airflow_version(provider_id: str, min_version: str):

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -264,7 +264,7 @@ def test_validate_provider_info_with_schema():
 @pytest.mark.parametrize(
     "provider_id, min_version",
     [
-        ("amazon", "2.10.0"),
+        ("amazon", "2.9.0"),
         ("fab", "3.0.2"),
     ],
 )

--- a/devel-common/src/sphinx_exts/includes/sections-and-options.rst
+++ b/devel-common/src/sphinx_exts/includes/sections-and-options.rst
@@ -101,7 +101,11 @@
     {{ "-" * (deprecated_option_name + " (Deprecated)")|length }}
 
     .. deprecated:: {{ since_version }}
+    {% if new_section_name in configs %}
      The option has been moved to :ref:`{{ new_section_name }}.{{ new_option_name }} <config:{{ new_section_name }}__{{ new_option_name }}>`
+    {% else %}
+     The option has been moved to ``{{ new_section_name }}.{{ new_option_name }}``
+    {% endif %}
     {% endfor %}
     {% endif %}
 

--- a/providers/fab/docs/configurations-ref.rst
+++ b/providers/fab/docs/configurations-ref.rst
@@ -16,4 +16,8 @@
     under the License.
 
 .. include:: /../../../devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
+
+.. _config:fab__access_denied_message:
+.. _config:fab__expose_hostname:
+
 .. include:: /../../../devel-common/src/sphinx_exts/includes/sections-and-options.rst

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -60,7 +60,7 @@ config:
       access_denied_message:
         description: |
           The message displayed when a user attempts to execute actions beyond their authorised privileges.
-        version_added: 2.0.2
+        version_added: 2.0.3
         type: string
         example: ~
         default: "Access is Denied"

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -32,6 +32,8 @@ source-date-epoch: 1741121873
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 2.0.3
+  - 2.0.2
   - 2.0.1
   - 2.0.0
   - 1.5.2
@@ -55,6 +57,13 @@ config:
   fab:
     description: This section contains configs specific to FAB provider.
     options:
+      access_denied_message:
+        description: |
+          The message displayed when a user attempts to execute actions beyond their authorised privileges.
+        version_added: 2.0.2
+        type: string
+        example: ~
+        default: "Access is Denied"
       auth_rate_limited:
         description: |
           Boolean for enabling rate limiting on authentication endpoints.

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-fab"
-version = "2.0.1"
+version = "2.0.3"
 description = "Provider package apache-airflow-providers-fab for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -57,7 +57,7 @@ license-files = ["NOTICE", "*/LICENSE*"]
 # Make sure to run ``breeze static-checks --type update-providers-dependencies --all-files``
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
-    "apache-airflow>=3.0.0",
+    "apache-airflow>=3.0.2",
     "apache-airflow-providers-common-compat>=1.2.1",
     # Blinker use for signals in Flask, this is an optional dependency in Flask 2.2 and lower.
     # In Flask 2.3 it becomes a mandatory dependency, and flask signals are always available.
@@ -127,8 +127,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.1"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.1/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.3"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.3/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/fab/src/airflow/providers/fab/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/__init__.py
@@ -29,11 +29,11 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "2.0.1"
+__version__ = "2.0.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "3.0.0"
+    "3.0.2"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-fab:{__version__}` needs Apache Airflow 3.0.0+"
+        f"The package `apache-airflow-providers-fab:{__version__}` needs Apache Airflow 3.0.2+"
     )

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -30,6 +30,13 @@ def get_provider_info():
             "fab": {
                 "description": "This section contains configs specific to FAB provider.",
                 "options": {
+                    "access_denied_message": {
+                        "description": "The message displayed when a user attempts to execute actions beyond their authorised privileges.\n",
+                        "version_added": "2.0.2",
+                        "type": "string",
+                        "example": None,
+                        "default": "Access is Denied",
+                    },
                     "auth_rate_limited": {
                         "description": "Boolean for enabling rate limiting on authentication endpoints.\n",
                         "version_added": "1.0.2",

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -32,7 +32,7 @@ def get_provider_info():
                 "options": {
                     "access_denied_message": {
                         "description": "The message displayed when a user attempts to execute actions beyond their authorised privileges.\n",
-                        "version_added": "2.0.2",
+                        "version_added": "2.0.3",
                         "type": "string",
                         "example": None,
                         "default": "Access is Denied",

--- a/providers/fab/src/airflow/providers/fab/www/auth.py
+++ b/providers/fab/src/airflow/providers/fab/www/auth.py
@@ -61,7 +61,7 @@ log = logging.getLogger(__name__)
 
 
 def get_access_denied_message():
-    return conf.get("webserver", "access_denied_message")
+    return conf.get("fab", "access_denied_message")
 
 
 def has_access_with_pk(f):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,7 @@ packages = []
     "apache-airflow-providers-openfaas>=3.7.0"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage>=2.3.0" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-openlineage>=2.1.3" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "opensearch" = [
     "apache-airflow-providers-opensearch>=1.5.0"
@@ -441,7 +441,7 @@ packages = []
     "apache-airflow-providers-odbc>=4.8.0",
     "apache-airflow-providers-openai>=1.5.0",
     "apache-airflow-providers-openfaas>=3.7.0",
-    "apache-airflow-providers-openlineage>=2.3.0", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-openlineage>=2.1.3", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-opensearch>=1.5.0",
     "apache-airflow-providers-opsgenie>=5.8.0",
     "apache-airflow-providers-oracle>=3.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ packages = []
     "apache-airflow-providers-exasol>=4.6.1"
 ]
 "fab" = [
-    "apache-airflow-providers-fab>=2.0.2" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-fab>=2.0.3" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "facebook" = [
     "apache-airflow-providers-facebook>=3.7.0"
@@ -278,7 +278,7 @@ packages = []
     "apache-airflow-providers-openfaas>=3.7.0"
 ]
 "openlineage" = [
-    "apache-airflow-providers-openlineage>=2.1.3" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-openlineage>=2.3.0" # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
 ]
 "opensearch" = [
     "apache-airflow-providers-opensearch>=1.5.0"
@@ -418,7 +418,7 @@ packages = []
     "apache-airflow-providers-edge3>=1.0.0",
     "apache-airflow-providers-elasticsearch>=5.5.2",
     "apache-airflow-providers-exasol>=4.6.1",
-    "apache-airflow-providers-fab>=2.0.2", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-fab>=2.0.3", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-facebook>=3.7.0",
     "apache-airflow-providers-ftp>=3.12.0",
     "apache-airflow-providers-git>=0.0.2", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
@@ -441,7 +441,7 @@ packages = []
     "apache-airflow-providers-odbc>=4.8.0",
     "apache-airflow-providers-openai>=1.5.0",
     "apache-airflow-providers-openfaas>=3.7.0",
-    "apache-airflow-providers-openlineage>=2.1.3", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
+    "apache-airflow-providers-openlineage>=2.3.0", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-opensearch>=1.5.0",
     "apache-airflow-providers-opsgenie>=5.8.0",
     "apache-airflow-providers-oracle>=3.12.0",

--- a/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
+++ b/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
@@ -56,8 +56,8 @@ CUT_OFF_TIMEDELTA = timedelta(days=6 * 30)
 # minimum versions for compatibility with Airflow 3
 MIN_VERSION_OVERRIDE: dict[str, Version] = {
     "amazon": parse_version("2.1.3"),
-    "fab": parse_version("2.0.2"),
-    "openlineage": parse_version("2.1.3"),
+    "fab": parse_version("2.0.3"),
+    "openlineage": parse_version("2.3.0"),
     "git": parse_version("0.0.2"),
     "common.messaging": parse_version("1.0.1"),
 }

--- a/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
+++ b/scripts/ci/pre_commit/update_airflow_pyproject_toml.py
@@ -57,7 +57,7 @@ CUT_OFF_TIMEDELTA = timedelta(days=6 * 30)
 MIN_VERSION_OVERRIDE: dict[str, Version] = {
     "amazon": parse_version("2.1.3"),
     "fab": parse_version("2.0.3"),
-    "openlineage": parse_version("2.3.0"),
+    "openlineage": parse_version("2.1.3"),
     "git": parse_version("0.0.2"),
     "common.messaging": parse_version("1.0.1"),
 }


### PR DESCRIPTION
* Move access_denied_message webserver config to fab

* Fix CI

* Update to fab 2.0.3

* Change core to 3.0.2

* fab depends on apache-airflow 3.0.2

* Fix CI

(cherry picked from commit a18a1df03eeb773f5b87dc54663e1f58733f1a63)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
