### PR TITLE
Clean-up /mnt disk in case it is not empty

### DIFF
--- a/scripts/ci/prepare_and_cleanup_runner.sh
+++ b/scripts/ci/prepare_and_cleanup_runner.sh
@@ -21,6 +21,10 @@ function prepare_and_cleanup_runner {
     local target_docker_volume_location="/mnt/var-lib-docker"
     echo "Checking free space!"
     df -H
+    echo "Cleaning /mnt just in case it is not empty"
+    sudo rm -rf /mnt/*
+    echo "Checking free space!"
+    df -H
     echo "Making sure that /mnt is writeable"
     sudo chown -R "${USER}" /mnt
     # This is faster than docker prune
@@ -31,6 +35,7 @@ function prepare_and_cleanup_runner {
     sudo mkdir -p "${target_docker_volume_location}" /var/lib/docker
     sudo mount --bind "${target_docker_volume_location}" /var/lib/docker
     sudo chown -R 0:0 "${target_docker_volume_location}"
+
     sudo systemctl start docker
 }
 


### PR DESCRIPTION
Recently some of our jobs started to get runners with completely filled /mnt volume and failed on "no space left on device".

We opened a support ticket to GitHub but as a mitigation we attempt to clean-up the volume and see if the space is freed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
