### PR TITLE
Move in-process API Client creation to ``DagFileProcessorManager``

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -147,6 +147,7 @@ class TestDagFileProcessorManager:
             stdin=write_end,
             requests_fd=123,
             logger_filehandle=logger_filehandle,
+            client=MagicMock(),
         )
         if start_time:
             ret.start_time = start_time
@@ -899,6 +900,7 @@ class TestDagFileProcessorManager:
                     selector=mock.ANY,
                     logger=mock_logger,
                     logger_filehandle=mock_filehandle,
+                    client=mock.ANY,
                 ),
                 mock.call(
                     id=mock.ANY,
@@ -908,6 +910,7 @@ class TestDagFileProcessorManager:
                     selector=mock.ANY,
                     logger=mock_logger,
                     logger_filehandle=mock_filehandle,
+                    client=mock.ANY,
                 ),
             ]
             # And removed from the queue


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/50097
closes https://github.com/apache/airflow/issues/49887

Previously, each `DagFileProcessorProcess` created its own `InProcessExecutionAPI` client instance, leading to unnecessary thread creation and memory build up.

This commit ensures that a single `Client` backed by `InProcessExecutionAPI` is created and owned by `DagFileProcessorManager`, and passed into all DAG file processor subprocesses.


## Reproduction

Use following DAG:

```py
from airflow.sdk import Variable, dag, task

@dag
def xample_simplest_dag():

    Variable.get("my_variable", "d")

    @task
    def my_task():
        print("hellooo")

    my_task()


xample_simplest_dag()
```

Run the dag-processor with following command for quicker reproduction:

```bash
AIRFLOW__DAG_PROCESSOR__MIN_FILE_PROCESS_INTERVAL=2 \
AIRFLOW__CORE__LOAD_EXAMPLES=False \
AIRFLOW__DAG_PROCESSOR__DAG_FILE_PROCESSOR_TIMEOUT=2 \
AIRFLOW__DAG_PROCESSOR__BUNDLE_REFRESH_CHECK_INTERVAL=1 \
airflow dag-processor
```


Check the number of threads grow as the dag is parsed:
![thread-leak](https://github.com/user-attachments/assets/0aa0e187-51c9-4ef5-9dfa-3f5cbd70509c)


Add following diff to check in logs:

```diff
diff --git a/task-sdk/src/airflow/sdk/api/client.py b/task-sdk/src/airflow/sdk/api/client.py
index 5f76e8360b..cbee5c2609 100644
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -102,6 +102,11 @@ __all__ = [
 def get_json_error(response: httpx.Response):
     """Raise a ServerResponseError if we can extract error info from the error."""
     err = ServerResponseError.from_response(response)
+    import os;
+    import threading
+    log.exception(f"Total threads at runtime: {len(threading.enumerate())}")
+    for t in threading.enumerate():
+        log.exception(f"  - {t.name}")
     if err:
         log.warning("Server error", detail=err.detail)
         raise err

```
![May-14-2025 00-13-53](https://github.com/user-attachments/assets/fea12bc2-c9dd-43e3-b669-69781bdae4f8)


Another easy way to reproduce, thanks to @tirkarthi in https://github.com/apache/airflow/issues/49887#issuecomment-2868630859


Command:

```bash
watch -n 2 "pgrep -f dag-processor | xargs -I{} ls -l /proc/{}/fd/ 2>/dev/null | grep -i socket | wc -l"
```

![May-14-2025 00-35-05](https://github.com/user-attachments/assets/1697b9c3-d758-4824-a252-bc9fbdef83e4)


---

**Before**:

![image](https://github.com/user-attachments/assets/f9682395-bb7b-41f0-96fb-a7faf616345e)


**After**:

![image](https://github.com/user-attachments/assets/d7e05c56-7d31-466c-9488-d0c464db369e)


In a follow-up, I will add some cleanup to `InProcessExecutionAPI` itself so our test have no side-effects when used with `dag.test`. 

The Triggerer is the other thing that uses it but because it is a long-running process that doesn't spawn any other processes like DAG File processor, it remains unaffected.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
