### PR TITLE
Allow breeze to run edge executor

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -513,7 +513,9 @@ class ShellParams:
             _set_var(_env, "AIRFLOW__CORE__EXECUTOR", self.executor)
         if self.executor == EDGE_EXECUTOR:
             _set_var(
-                _env, "AIRFLOW__CORE__EXECUTOR", "airflow.providers.edge.executors.edge_executor.EdgeExecutor"
+                _env,
+                "AIRFLOW__CORE__EXECUTOR",
+                "airflow.providers.edge3.executors.edge_executor.EdgeExecutor",
             )
             _set_var(_env, "AIRFLOW__EDGE__API_ENABLED", "true")
 
@@ -527,11 +529,8 @@ class ShellParams:
                 "attempt={{ try_number|default(ti.try_number) }}.log",
             )
 
-            # Dev Airflow 3 runs API on FastAPI transitional
-            port = 9091
-            if self.use_airflow_version and self.use_airflow_version.startswith("2."):
-                # Airflow 2.10 runs it in the webserver atm
-                port = 8080
+            # Airflow 2.10 runs it in the webserver atm
+            port = 8080
             _set_var(_env, "AIRFLOW__EDGE__API_URL", f"http://localhost:{port}/edge_worker/v1/rpcapi")
         _set_var(_env, "ANSWER", get_forced_answer() or "")
         _set_var(_env, "BACKEND", self.backend)

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -78,7 +78,7 @@ if [[ ${INTEGRATION_CELERY} == "true" && ${CELERY_FLOWER} == "true" ]]; then
     tmux split-window -h
     tmux send-keys 'airflow celery flower' C-m
 fi
-if [[ ${AIRFLOW__CORE__EXECUTOR,,} == "edgeexecutor" ]]; then
+if [[ ${AIRFLOW__CORE__EXECUTOR,,} == *"edgeexecutor" ]]; then
     tmux select-pane -t 0
     tmux split-window -h
 

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -296,7 +296,7 @@ def find_installation_spec(
 
 ALLOWED_PACKAGE_FORMAT = ["wheel", "sdist", "both"]
 ALLOWED_CONSTRAINTS_MODE = ["constraints-source-providers", "constraints", "constraints-no-providers"]
-ALLOWED_MOUNT_SOURCES = ["remove", "tests", "providers-and-tests"]
+ALLOWED_MOUNT_SOURCES = ["remove", "tests", "providers-and-tests", "selected"]
 
 
 @click.command()


### PR DESCRIPTION
While attempting to develop the fix #50560 I realized that breeze on the branch was not able to run EdgeExecutor.

This PR fixes this:
- The package was renamed but the package on the branch name was not adjusted (edge -> edge3)
- The panels were missing to start the worker as the executor name was an exact match
- Port was using 9091 from the state where we had api-server, was wrongly back-ported, needs to be 8080

To test with EdgeExecutor you need to build the dist from main and use it when starting breeze as the edge executor on the v2-11-test branch of course if totally outdated.

So if you want to test:
- `breeze release-management prepare-provider-distributions edge3 --skip-tag-check` on main
- copy the WHL file to the Airflow 2.11 workspace/dist folder
- Then on the v2-11-test branch you can `breeze start-airflow --python 3.12 --load-example-dags --backend postgres --executor EdgeExecutor --answer y --use-packages-from-dist`

FYI @kaxil +1 here :-D

FYI @wolfdn thanks for finding!