### PR TITLE
Fix permission check on the ui config endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -23,7 +23,7 @@ from fastapi import Depends, status
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.config import ConfigResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import requires_access_configuration
+from airflow.api_fastapi.core_api.security import requires_authenticated
 from airflow.configuration import conf
 from airflow.settings import DASHBOARD_UIALERTS
 from airflow.utils.log.log_reader import TaskLogReader
@@ -49,7 +49,7 @@ WEBSERVER_CONFIG_KEYS = [
 @config_router.get(
     "/config",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
-    dependencies=[Depends(requires_access_configuration("GET"))],
+    dependencies=[Depends(requires_authenticated())],
 )
 def get_configs() -> ConfigResponse:
     """Get configs for UI."""

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -327,7 +327,7 @@ def requires_authenticated() -> Callable:
 
     def inner(
         request: Request,
-        user: Annotated[BaseUser | None, Depends(get_user)] = None,
+        user: GetUserDep,
     ) -> None:
         pass
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -322,6 +322,18 @@ def requires_access_asset_alias(method: ResourceMethod) -> Callable:
     return inner
 
 
+def requires_authenticated() -> Callable:
+    """Just ensure the user is authenticated - no need to check any specific permissions."""
+
+    def inner(
+        request: Request,
+        user: Annotated[BaseUser | None, Depends(get_user)] = None,
+    ) -> None:
+        pass
+
+    return inner
+
+
 def _requires_access(
     *,
     is_authorized_callback: Callable[[], bool],

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -87,6 +87,8 @@ class TestGetConfig:
         response = unauthenticated_test_client.get("/config")
         assert response.status_code == 401
 
-    def test_get_config_should_response_403(self, unauthorized_test_client):
+    def test_get_config_just_authenticated(self, mock_config_data, unauthorized_test_client):
+        """Just being authenticated is enough to access the endpoint."""
         response = unauthorized_test_client.get("/config")
-        assert response.status_code == 403
+        assert response.status_code == 200
+        assert response.json() == mock_config_response


### PR DESCRIPTION
This is just config for the UI, not the whole Airflow instances config, which is what the config permission for users controls. If the user doesn't have the config permission, without this change, the user cannot use the UI at all.

So, instead we just check that the user is authenticated at all.

You can reproduce the issue by using this auth manager:
```
class NoConfigSimpleAuthManager(SimpleAuthManager):
    def is_authorized_configuration(
        self,
        *,
        method: ResourceMethod,
        user: SimpleAuthManagerUser,
        details: ConfigurationDetails | None = None,
    ) -> bool:
        return False
```