### PR TITLE
Improve testing for context serialization

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -31,6 +31,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, Container, Iterable, Mapping, Sequence
 from functools import cache
+from itertools import chain
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, cast
@@ -859,14 +860,7 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             # If we're using system packages, assume both are present
             found_airflow = found_pendulum = True
         else:
-            requirements_iterable = []
-            if isinstance(self.requirements, str):
-                requirements_iterable = self.requirements.splitlines()
-            else:
-                for item in self.requirements:
-                    requirements_iterable.extend(item.splitlines())
-
-            for raw_str in requirements_iterable:
+            for raw_str in chain.from_iterable(req.splitlines() for req in self.requirements):
                 line = raw_str.strip()
                 # Skip blank lines and full‐line comments
                 if not line or line.startswith("#"):

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1480,6 +1480,10 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
             (["", "pendulum"], False, False, True),
             # indented comment + requirement
             (["  # comment", "pendulum~=2.1.0"], False, False, True),
+            # requirements passed as multi-line strings
+            ("funcsigs==0.4\nattrs==23.1.0", False, False, False),
+            (["funcsigs==0.4\nattrs==23.1.0"], False, False, False),
+            ("pendulum==2.1.2  # pinned version\nattrs==23.1.0  # optional", False, False, True),
         ],
     )
     def test_iter_serializable_context_keys(self, requirements, system_site, want_airflow, want_pendulum):


### PR DESCRIPTION
Follow-up to #50446 and #50521:

- Clean up requirements-flattening logic.
- Add tests for requirements passed as multi-line strings.

Following @shahar1 PR (#50521), I cleaned up a little bit the flattening logic of
`_iter_serializable_context_keys`, in connection with this part of the `__init__` function
of `PythonVirtualenvOperator` class:
```python
        if not requirements:
            self.requirements: list[str] = []
        elif isinstance(requirements, str):
            self.requirements = [requirements]
```
As `self.requirements` is always a list starting from there, it simplifies the way we can process it later. I also add the use cases detailed in #50521 to the relevant test. Sorry for my initial over-simplification 🙏🏻
