### PR TITLE
AWS System Test Context: Don't set env_id at parse time

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/utils/__init__.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/__init__.py
@@ -188,7 +188,6 @@ class SystemTestContextBuilder:
 
     def __init__(self):
         self.variables = set()
-        self.env_id = set_env_id()
         self.test_name = _get_test_name()
 
     def add_variable(
@@ -229,7 +228,7 @@ class SystemTestContextBuilder:
 
         @task
         def variable_fetcher(ti=None):
-            ti.xcom_push(ENV_ID_KEY, self.env_id)
+            ti.xcom_push(ENV_ID_KEY, set_env_id())
             for variable in self.variables:
                 ti.xcom_push(variable.name, variable.get_value())
 

--- a/providers/amazon/tests/system/amazon/aws/utils/__init__.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/__init__.py
@@ -113,13 +113,13 @@ def _fetch_from_ssm(key: str, test_name: str | None = None) -> str:
         log.info("No boto credentials found: %s", e)
     except ClientError as e:
         log.info("Client error when connecting to SSM: %s", e)
+    except hook.conn.exceptions.ParameterNotFound as e:
+        log.info("SSM does not contain any parameter for this test: %s", e)
     except KeyError as e:
         log.info(
             "SSM contains one parameter for this test, but not the requested value: %s",
             e,
         )
-    except Exception as e:
-        log.info("SSM does not contain any parameter for this test: %s", e)
     return value
 
 


### PR DESCRIPTION
When building the AWS system context we do not need to set the env_id
at parse time. We can wait to do it during the variable fetcher task.

This means that the SSM code (to fetch parameters for system tests) does
not execute at parse time. This will interfere much less with our docs building,
have fewer side effects and save time when the systems tests are parsed/loaded/imported.

fixes #50506

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
