### PR TITLE
Do not flood worker logs with secrets backend loading logs

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1450,14 +1450,6 @@ def ensure_secrets_backend_loaded() -> list[BaseSecretsBackend]:
 
     backends = ensure_secrets_loaded(default_backends=DEFAULT_SECRETS_SEARCH_PATH_WORKERS)
 
-    log = structlog.get_logger(logger_name="supervisor")
-
-    log.info(
-        "Secrets backends loaded for worker",
-        count=len(backends),
-        backend_classes=[type(b).__name__ for b in backends],
-    )
-
     return backends
 
 
@@ -1520,7 +1512,12 @@ def supervise(
         processors = logging_processors(enable_pretty_log=pretty_logs)[0]
         logger = structlog.wrap_logger(underlying_logger, processors=processors, logger_name="task").bind()
 
-    ensure_secrets_backend_loaded()
+    backends = ensure_secrets_backend_loaded()
+    log.info(
+        "Secrets backends loaded for worker",
+        count=len(backends),
+        backend_classes=[type(b).__name__ for b in backends],
+    )
 
     reset_secrets_masker()
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


closes: https://github.com/apache/airflow/issues/50517


The info logs for loading of secrets backend was present in `ensure_secrets_backend_loaded` which is called every time `Variable.get` or `Connection.get` is called. This lead to flooding of worker logs with these logs finding it hard to locate the important ones.

Instead, since this is a debugging log, moving it up the ladder to every time a worker is fired up makes sense to get just enough information about the secrets backned loaded.

Example DAG this was tested with:
```
```


Logs in the worker:
```
2025-05-14 07:20:47.936410 [info     ] Task execute_workload[d8eaf207-2106-44ee-8100-16e5fb915f7c] received [celery.worker.strategy]
2025-05-14 07:20:48.045088 [info     ] [d8eaf207-2106-44ee-8100-16e5fb915f7c] Executing workload in Celery: token='eyJ***' ti=TaskInstance(id=UUID('0196cdaa-d590-75e3-a1ef-b13ca77a67bb'), task_id='test_task', dag_id='variable_flooding', run_id='manual__2025-05-14T07:20:47.238678+00:00', try_number=1, map_index=-1, pool_slots=1, queue='default', priority_weight=1, executor_config=None, parent_context_carrier={}, context_carrier={}, queued_dttm=None) dag_rel_path=PurePosixPath('dags/flooding.py') bundle_info=BundleInfo(name='dags-folder', version=None) log_path='dag_id=variable_flooding/run_id=manual__2025-05-14T07:20:47.238678+00:00/task_id=test_task/attempt=1.log' type='ExecuteTask' [airflow.providers.celery.executors.celery_executor_utils]
2025-05-14 07:20:48.061952 [info     ] Secrets backends loaded for worker [supervisor] backend_classes=['MetastoreBackend', 'EnvironmentVariablesBackend'] count=2
2025-05-14 07:20:48.521795 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'TIME_ZONE' not found"}}
2025-05-14 07:20:48.521948 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'TIME_ZONE' not found"}} key=TIME_ZONE status_code=404
2025-05-14 07:20:48.544115 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_0' not found"}}
2025-05-14 07:20:48.544230 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_0' not found"}} key=var_0 status_code=404
2025-05-14 07:20:48.547425 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_1' not found"}}
2025-05-14 07:20:48.547524 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_1' not found"}} key=var_1 status_code=404
2025-05-14 07:20:48.551086 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_2' not found"}}
2025-05-14 07:20:48.551248 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_2' not found"}} key=var_2 status_code=404
2025-05-14 07:20:48.554392 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_3' not found"}}
2025-05-14 07:20:48.554483 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_3' not found"}} key=var_3 status_code=404
2025-05-14 07:20:48.557760 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_4' not found"}}
2025-05-14 07:20:48.557871 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'var_4' not found"}} key=var_4 status_code=404
```

Compared to earlier:
```
[2025-05-09, 15:03:48] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:03:48] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:05:00] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:05:00] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:05:41] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:05:41] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:06:21] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:06:21] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:03] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:03] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:55] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:55] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:55] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:55] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:55] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:07:55] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:08:06] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:08:06] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:09:15] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:09:15] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:10:11] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:10:11] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:10:20] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:10:20] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:10:33] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
[2025-05-09, 15:10:33] INFO - Secrets backends loaded for worker: count=1: backend_classes=["EnvironmentVariablesBackend"]: source="supervisor"
```




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
