### PR TITLE
docs: conditionally render section‐move links in sections‐and‐options include

### DIFF
--- a/devel-common/src/sphinx_exts/includes/sections-and-options.rst
+++ b/devel-common/src/sphinx_exts/includes/sections-and-options.rst
@@ -101,7 +101,11 @@
     {{ "-" * (deprecated_option_name + " (Deprecated)")|length }}
 
     .. deprecated:: {{ since_version }}
+    {% if new_section_name in configs %}
      The option has been moved to :ref:`{{ new_section_name }}.{{ new_option_name }} <config:{{ new_section_name }}__{{ new_option_name }}>`
+    {% else %}
+     The option has been moved to ``{{ new_section_name }}.{{ new_option_name }}``
+    {% endif %}
     {% endfor %}
     {% endif %}
 

--- a/providers/fab/docs/configurations-ref.rst
+++ b/providers/fab/docs/configurations-ref.rst
@@ -16,4 +16,8 @@
     under the License.
 
 .. include:: /../../../devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
+
+.. _config:fab__access_denied_message:
+.. _config:fab__expose_hostname:
+
 .. include:: /../../../devel-common/src/sphinx_exts/includes/sections-and-options.rst


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This [PR](https://github.com/apache/airflow/pull/50208/) is breaking the docs in main with following error:
```

============================== apache-airflow ==============================
------------------------------ Error   1 --------------------
 WARNING: undefined label: 'config:fab__access_denied_message'

File path: /opt/airflow/airflow-core/docs/<unknown>
------------------------------ Error   2 --------------------
 WARNING: undefined label: 'config:fab__expose_hostname'

File path: /opt/airflow/airflow-core/docs/<unknown>
```

I’ve updated the Jinja include for the core configuration reference so that it only emits a `Sphinx :ref:` link when the target section is part of the core docs.  For provider‐only options (the new fab ones), it now falls back to plain text rather than linking to an undefined `config:fab` label.  This removes the `“undefined label”` warnings for `fab__access_denied_message` and `fab__expose_hostname`. 

As part of [PR](https://github.com/apache/airflow/pull/50208/) we missed adding Sphinx anchors for `access_denied_message` and `expose_hostname` config options:

Also added two new Sphinx reference labels in `providers/fab/docs/configurations-ref.rst`:
- `config:fab__access_denied_message`
- `config:fab__expose_hostname`


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
