### PR TITLE
Fixing fab doc generation on main

### DIFF
--- a/devel-common/src/sphinx_exts/includes/sections-and-options.rst
+++ b/devel-common/src/sphinx_exts/includes/sections-and-options.rst
@@ -20,6 +20,7 @@
    :depth: 1
 
 .. jinja:: config_ctx
+    {% set seen_labels = [] %}
 
     {% for section_name, section in configs.items() %}
 
@@ -37,7 +38,11 @@
     {% endif %}
 
     {% for option_name, option in section["options"].items() %}
-    .. _config:{{ section_name }}__{{ option_name }}:
+    {% set label = section_name ~ '__' ~ option_name %}
+    {% if label not in seen_labels %}
+    .. _config:{{ label }}:
+    {% do seen_labels.append(label) %}
+    {% endif %}
 
     {{ option_name }}
     {{ "-" * option_name|length }}
@@ -95,7 +100,12 @@
     {% if section_name in deprecated_options %}
 
     {% for deprecated_option_name, (new_section_name, new_option_name, since_version) in deprecated_options[section_name].items() %}
-    .. _config:{{ section_name }}__{{ deprecated_option_name }}:
+    {% set label = section_name ~ '__' ~ deprecated_option_name %}
+    {% if label not in seen_labels %}
+    .. _config:{{ label }}:
+    {% do seen_labels.append(label) %}
+    {% endif %}
+
 
     {{ deprecated_option_name }} (Deprecated)
     {{ "-" * (deprecated_option_name + " (Deprecated)")|length }}

--- a/providers/fab/docs/configurations-ref.rst
+++ b/providers/fab/docs/configurations-ref.rst
@@ -17,7 +17,7 @@
 
 .. include:: /../../../devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
 
-.. _config:fab__access_denied_message:
-.. _config:fab__expose_hostname:
+- .. _config:fab__access_denied_message:
+- .. _config:fab__expose_hostname:
 
 .. include:: /../../../devel-common/src/sphinx_exts/includes/sections-and-options.rst


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Looks like its coming from the above linkages and hence duplicate reports. Letting that own the defintions

Example: https://github.com/apache/airflow/actions/runs/15015528137/job/42192911871?pr=50531#step:6:2188

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
