### PR TITLE
fix: Use source hook instead of destination hook when reading records in non-paginated mode in GenericTransfer

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/operators/generic_transfer.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/generic_transfer.py
@@ -162,7 +162,7 @@ class GenericTransfer(BaseOperator):
             self.log.info("Extracting data from %s", self.source_conn_id)
             self.log.info("Executing: \n %s", self.sql)
 
-            results = self.destination_hook.get_records(self.sql)
+            results = self.source_hook.get_records(self.sql)
 
             self.log.info("Inserting rows into %s", self.destination_conn_id)
             self.destination_hook.insert_rows(table=self.destination_table, rows=results, **self.insert_args)

--- a/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
@@ -24,6 +24,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from more_itertools import flatten
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.connection import Connection
@@ -34,7 +35,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils import timezone
 
 from tests_common.test_utils.compat import GenericTransfer
-from tests_common.test_utils.operators.run_deferrable import execute_operator
+from tests_common.test_utils.operators.run_deferrable import execute_operator, mock_context
 from tests_common.test_utils.providers import get_provider_min_airflow_version
 
 pytestmark = pytest.mark.db_test
@@ -43,6 +44,12 @@ DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 TEST_DAG_ID = "unit_test_dag"
+INSERT_ARGS = {
+    "commit_every": 1000,  # Number of rows inserted in each batch
+    "executemany": True,  # Enable batch inserts
+    "fast_executemany": True,  # Boost performance for MSSQL inserts
+    "replace": True,  # Used for upserts/merges if needed
+}
 counter = 0
 
 
@@ -175,6 +182,46 @@ class TestPostgres:
 
 
 class TestGenericTransfer:
+    @classmethod
+    def setup_class(cls):
+        cls.mocked_source_hook = MagicMock(conn_name_attr="my_source_conn_id", spec=DbApiHook)
+        cls.mocked_destination_hook = MagicMock(conn_name_attr="my_destination_conn_id", spec=DbApiHook)
+        cls.mocked_hooks = {
+            "my_source_conn_id": cls.mocked_source_hook,
+            "my_destination_conn_id": cls.mocked_destination_hook,
+        }
+
+    @classmethod
+    def get_hook(cls, conn_id: str, hook_params: dict | None = None):
+        return cls.mocked_hooks[conn_id]
+
+    @classmethod
+    def get_connection(cls, conn_id: str):
+        mocked_hook = cls.get_hook(conn_id=conn_id)
+        mocked_conn = MagicMock(conn_id=conn_id, spec=Connection)
+        mocked_conn.get_hook.return_value = mocked_hook
+        return mocked_conn
+
+    def setup_method(self):
+        # Reset mock states before each test
+        self.mocked_source_hook.reset_mock()
+        self.mocked_destination_hook.reset_mock()
+
+        # Set up the side effect for paginated read
+        records = [
+            [[1, 2], [11, 12], [3, 4], [13, 14]],
+            [[3, 4], [13, 14]],
+        ]
+
+        def get_records_side_effect(sql: str):
+            if records:
+                if "LIMIT" not in sql:
+                    return list(flatten(records))
+                return records.pop(0)
+            return []
+
+        self.mocked_source_hook.get_records.side_effect = get_records_side_effect
+
     def test_templated_fields(self):
         dag = DAG(
             "test_dag",
@@ -209,40 +256,37 @@ class TestGenericTransfer:
         assert operator.preoperator == "my_preoperator"
         assert operator.insert_args == {"commit_every": 5000, "executemany": True, "replace": True}
 
+    def test_non_paginated_read(self):
+        with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=self.get_connection):
+            with mock.patch("airflow.hooks.base.BaseHook.get_hook", side_effect=self.get_hook):
+                operator = GenericTransfer(
+                    task_id="transfer_table",
+                    source_conn_id="my_source_conn_id",
+                    destination_conn_id="my_destination_conn_id",
+                    sql="SELECT * FROM HR.EMPLOYEES",
+                    destination_table="NEW_HR.EMPLOYEES",
+                    insert_args=INSERT_ARGS,
+                    execution_timeout=timedelta(hours=1),
+                )
+
+                operator.execute(context=mock_context(task=operator))
+
+        assert self.mocked_source_hook.get_records.call_count == 1
+        assert self.mocked_source_hook.get_records.call_args_list[0].args[0] == "SELECT * FROM HR.EMPLOYEES"
+        assert self.mocked_destination_hook.insert_rows.call_count == 1
+        assert self.mocked_destination_hook.insert_rows.call_args_list[0].kwargs == {
+            **INSERT_ARGS,
+            **{"rows": [[1, 2], [11, 12], [3, 4], [13, 14], [3, 4], [13, 14]], "table": "NEW_HR.EMPLOYEES"},
+        }
+
     def test_paginated_read(self):
         """
         This unit test is based on the example described in the medium article:
         https://medium.com/apache-airflow/transfering-data-from-sap-hana-to-mssql-using-the-airflow-generictransfer-d29f147a9f1f
         """
 
-        def create_get_records_side_effect():
-            records = [
-                [[1, 2], [11, 12], [3, 4], [13, 14]],
-                [[3, 4], [13, 14]],
-            ]
-
-            def side_effect(sql: str):
-                if records:
-                    return records.pop(0)
-                return []
-
-            return side_effect
-
-        get_records_side_effect = create_get_records_side_effect()
-
-        def get_hook(conn_id: str, hook_params: dict | None = None):
-            mocked_hook = MagicMock(conn_name_attr=conn_id, spec=DbApiHook)
-            mocked_hook.get_records.side_effect = get_records_side_effect
-            return mocked_hook
-
-        def get_connection(conn_id: str):
-            mocked_hook = get_hook(conn_id=conn_id)
-            mocked_conn = MagicMock(conn_id=conn_id, spec=Connection)
-            mocked_conn.get_hook.return_value = mocked_hook
-            return mocked_conn
-
-        with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_connection):
-            with mock.patch("airflow.hooks.base.BaseHook.get_hook", side_effect=get_hook):
+        with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=self.get_connection):
+            with mock.patch("airflow.hooks.base.BaseHook.get_hook", side_effect=self.get_hook):
                 operator = GenericTransfer(
                     task_id="transfer_table",
                     source_conn_id="my_source_conn_id",
@@ -250,12 +294,7 @@ class TestGenericTransfer:
                     sql="SELECT * FROM HR.EMPLOYEES",
                     destination_table="NEW_HR.EMPLOYEES",
                     page_size=1000,  # Fetch data in chunks of 1000 rows for pagination
-                    insert_args={
-                        "commit_every": 1000,  # Number of rows inserted in each batch
-                        "executemany": True,  # Enable batch inserts
-                        "fast_executemany": True,  # Boost performance for MSSQL inserts
-                        "replace": True,  # Used for upserts/merges if needed
-                    },
+                    insert_args=INSERT_ARGS,
                     execution_timeout=timedelta(hours=1),
                 )
 
@@ -266,6 +305,21 @@ class TestGenericTransfer:
                 assert events[0].payload["results"] == [[1, 2], [11, 12], [3, 4], [13, 14]]
                 assert events[1].payload["results"] == [[3, 4], [13, 14]]
                 assert not events[2].payload["results"]
+
+        assert self.mocked_source_hook.get_records.call_count == 3
+        assert (
+            self.mocked_source_hook.get_records.call_args_list[0].args[0]
+            == "SELECT * FROM HR.EMPLOYEES LIMIT 1000 OFFSET 0"
+        )
+        assert self.mocked_destination_hook.insert_rows.call_count == 2
+        assert self.mocked_destination_hook.insert_rows.call_args_list[0].kwargs == {
+            **INSERT_ARGS,
+            **{"rows": [[1, 2], [11, 12], [3, 4], [13, 14]], "table": "NEW_HR.EMPLOYEES"},
+        }
+        assert self.mocked_destination_hook.insert_rows.call_args_list[1].kwargs == {
+            **INSERT_ARGS,
+            **{"rows": [[3, 4], [13, 14]], "table": "NEW_HR.EMPLOYEES"},
+        }
 
     def test_when_provider_min_airflow_version_is_3_0_or_higher_remove_obsolete_method(self):
         """

--- a/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
@@ -182,14 +182,12 @@ class TestPostgres:
 
 
 class TestGenericTransfer:
-    @classmethod
-    def setup_class(cls):
-        cls.mocked_source_hook = MagicMock(conn_name_attr="my_source_conn_id", spec=DbApiHook)
-        cls.mocked_destination_hook = MagicMock(conn_name_attr="my_destination_conn_id", spec=DbApiHook)
-        cls.mocked_hooks = {
-            "my_source_conn_id": cls.mocked_source_hook,
-            "my_destination_conn_id": cls.mocked_destination_hook,
-        }
+    mocked_source_hook = MagicMock(conn_name_attr="my_source_conn_id", spec=DbApiHook)
+    mocked_destination_hook = MagicMock(conn_name_attr="my_destination_conn_id", spec=DbApiHook)
+    mocked_hooks = {
+        "my_source_conn_id": mocked_source_hook,
+        "my_destination_conn_id": mocked_destination_hook,
+    }
 
     @classmethod
     def get_hook(cls, conn_id: str, hook_params: dict | None = None):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: https://github.com/apache/airflow/issues/49731
related:  [#49731](https://github.com/apache/airflow/issues/49731)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/49731  reported by @Baptistouille
replaces: https://github.com/apache/airflow/pull/49783

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
