### PR TITLE
[v3-0-test] Move webserver expose_hostname config to fab (#50269)

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -384,6 +384,10 @@ CONFIGS_CHANGES = [
         renamed_to=ConfigParameter("fab", "access_denied_message"),
     ),
     ConfigChange(
+        config=ConfigParameter("webserver", "expose_hostname"),
+        renamed_to=ConfigParameter("fab", "expose_hostname"),
+    ),
+    ConfigChange(
         config=ConfigParameter("webserver", "base_url"),
         renamed_to=ConfigParameter("api", "base_url"),
     ),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1741,13 +1741,6 @@ webserver:
       sensitive: true
       example: ~
       default: "{SECRET_KEY}"
-    expose_hostname:
-      description: |
-        Expose hostname in the web server
-      version_added: 1.10.8
-      type: string
-      example: ~
-      default: "False"
     grid_view_sorting_order:
       description: |
         Sorting order in grid view. Valid values are: ``topological``, ``hierarchical_alphabetical``

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -357,6 +357,7 @@ class AirflowConfigParser(ConfigParser):
         ("triggerer", "capacity"): ("triggerer", "default_capacity", "3.0"),
         ("api", "expose_config"): ("webserver", "expose_config", "3.0.1"),
         ("fab", "access_denied_message"): ("webserver", "access_denied_message", "3.0.2"),
+        ("fab", "expose_hostname"): ("webserver", "expose_hostname", "3.0.2"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -64,6 +64,13 @@ config:
         type: string
         example: ~
         default: "Access is Denied"
+      expose_hostname:
+        description: |
+          Expose hostname in the web server
+        version_added: 2.0.3
+        type: string
+        example: ~
+        default: "False"
       auth_rate_limited:
         description: |
           Boolean for enabling rate limiting on authentication endpoints.

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -37,6 +37,13 @@ def get_provider_info():
                         "example": None,
                         "default": "Access is Denied",
                     },
+                    "expose_hostname": {
+                        "description": "Expose hostname in the web server\n",
+                        "version_added": "2.0.3",
+                        "type": "string",
+                        "example": None,
+                        "default": "False",
+                    },
                     "auth_rate_limited": {
                         "description": "Boolean for enabling rate limiting on authentication endpoints.\n",
                         "version_added": "1.0.2",

--- a/providers/fab/src/airflow/providers/fab/www/auth.py
+++ b/providers/fab/src/airflow/providers/fab/www/auth.py
@@ -145,7 +145,7 @@ def _has_access(*, is_authorized: bool, func: Callable, args, kwargs):
         return (
             render_template(
                 "airflow/no_roles_permissions.html",
-                hostname=get_hostname() if conf.getboolean("webserver", "EXPOSE_HOSTNAME") else "",
+                hostname=get_hostname() if conf.getboolean("fab", "EXPOSE_HOSTNAME") else "",
                 logout_url=get_fab_auth_manager().get_url_logout(),
             ),
             403,
@@ -217,7 +217,7 @@ def has_access_dag(method: ResourceMethod, access_entity: DagAccessEntity | None
                 return (
                     render_template(
                         "airflow/no_roles_permissions.html",
-                        hostname=get_hostname() if conf.getboolean("webserver", "EXPOSE_HOSTNAME") else "",
+                        hostname=get_hostname() if conf.getboolean("fab", "EXPOSE_HOSTNAME") else "",
                         logout_url=get_auth_manager().get_url_logout(),
                     ),
                     403,

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_jinja_globals.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_jinja_globals.py
@@ -37,7 +37,7 @@ def init_jinja_globals(app, enable_plugins: bool):
     elif server_timezone == "utc":
         server_timezone = "UTC"
 
-    expose_hostname = conf.getboolean("webserver", "EXPOSE_HOSTNAME")
+    expose_hostname = conf.getboolean("fab", "EXPOSE_HOSTNAME")
     hostname = get_hostname() if expose_hostname else "redact"
 
     try:


### PR DESCRIPTION
(cherry picked from commit 7c292141cb69ee37c5b2bd621cae85526b828b03)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
