### PR TITLE
[v3-0-test] Pre-release distributions documentation links use `staged…

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/pyproject_TEMPLATE.toml.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/pyproject_TEMPLATE.toml.jinja2
@@ -124,8 +124,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/{{ PACKAGE_PIP_NAME }}/{{RELEASE}}"
-"Changelog" = "https://airflow.apache.org/docs/{{ PACKAGE_PIP_NAME }}/{{RELEASE}}/changelog.html"
+"Documentation" = "{{ AIRFLOW_DOC_URL }}/docs/{{ PACKAGE_PIP_NAME }}/{{RELEASE}}"
+"Changelog" = "{{ AIRFLOW_DOC_URL }}/docs/{{ PACKAGE_PIP_NAME }}/{{RELEASE}}/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -886,6 +886,9 @@ def regenerate_pyproject_toml(
             new_optional_dependencies.append(modified_dependency)
         optional_dependencies = new_optional_dependencies
     context["INSTALL_REQUIREMENTS"] = "\n".join(required_dependencies)
+    context["AIRFLOW_DOC_URL"] = (
+        "https://airflow.staged.apache.org" if version_suffix else "https://airflow.apache.org"
+    )
     cross_provider_ids = set(PROVIDER_DEPENDENCIES.get(provider_details.provider_id)["cross-providers-deps"])
     cross_provider_dependencies = []
     # Add cross-provider dependencies to the optional dependencies if they are missing
@@ -1055,6 +1058,9 @@ def update_version_suffix_in_non_provider_pyproject_toml(version_suffix: str, py
         if base_line.startswith("version = "):
             get_console().print(f"[info]Updating version suffix to {version_suffix} for {line}.")
             base_line = base_line.rstrip('"') + f'{version_suffix}"'
+        if "https://airflow.apache.org/" in base_line and version_suffix:
+            get_console().print(f"[info]Updating documentation link to staging for {line}.")
+            base_line = base_line.replace("https://airflow.apache.org/", "https://airflow.staged.apache.org/")
         # do not modify references for .post prefixes
         if not version_suffix.startswith(".post"):
             if base_line.strip().startswith('"apache-airflow-') and ">=" in base_line:


### PR DESCRIPTION
….apache.org` (#50536)

(cherry picked from commit 0c712387d497ae80470289ef94ce86d8e9b66f06)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
