### PR TITLE
Support macros defined via plugins in Airflow 3

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -171,8 +171,7 @@ definitions in Airflow.
     from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
 
 
-    # Will show up under airflow.sdk.macros.test_plugin.plugin_macro
-    # and in templates through {{ macros.test_plugin.plugin_macro }}
+    # Will show up in templates through {{ macros.test_plugin.plugin_macro }}
     def plugin_macro():
         pass
 

--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -171,7 +171,7 @@ definitions in Airflow.
     from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
 
 
-    # Will show up under airflow.macros.test_plugin.plugin_macro
+    # Will show up under airflow.sdk.macros.test_plugin.plugin_macro
     # and in templates through {{ macros.test_plugin.plugin_macro }}
     def plugin_macro():
         pass

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -507,7 +507,7 @@ def integrate_macros_plugins() -> None:
     global plugins
     global macros_modules
 
-    from airflow import macros
+    from airflow.sdk.definitions import macros
 
     if macros_modules is not None:
         return
@@ -525,7 +525,7 @@ def integrate_macros_plugins() -> None:
         if plugin.name is None:
             raise AirflowPluginException("Invalid plugin name")
 
-        macros_module = make_module(f"airflow.macros.{plugin.name}", plugin.macros)
+        macros_module = make_module(f"airflow.sdk.definitions.{plugin.name}", plugin.macros)
 
         if macros_module:
             macros_modules.append(macros_module)

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -507,7 +507,7 @@ def integrate_macros_plugins() -> None:
     global plugins
     global macros_modules
 
-    from airflow.sdk.definitions import macros
+    from airflow.sdk import macros
 
     if macros_modules is not None:
         return

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -525,7 +525,7 @@ def integrate_macros_plugins() -> None:
         if plugin.name is None:
             raise AirflowPluginException("Invalid plugin name")
 
-        macros_module = make_module(f"airflow.sdk.definitions.{plugin.name}", plugin.macros)
+        macros_module = make_module(f"airflow.sdk.macros.{plugin.name}", plugin.macros)
 
         if macros_module:
             macros_modules.append(macros_module)

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -507,7 +507,7 @@ def integrate_macros_plugins() -> None:
     global plugins
     global macros_modules
 
-    from airflow.sdk import macros
+    from airflow.sdk.definitions import macros
 
     if macros_modules is not None:
         return
@@ -525,7 +525,7 @@ def integrate_macros_plugins() -> None:
         if plugin.name is None:
             raise AirflowPluginException("Invalid plugin name")
 
-        macros_module = make_module(f"airflow.sdk.macros.{plugin.name}", plugin.macros)
+        macros_module = make_module(f"airflow.sdk.definitions.macros.{plugin.name}", plugin.macros)
 
         if macros_module:
             macros_modules.append(macros_module)

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -228,17 +228,20 @@ class TestPluginsManager:
         """
         Tests whether macros that originate from plugins are being registered correctly.
         """
-        from airflow import macros
         from airflow.plugins_manager import integrate_macros_plugins
+        from airflow.sdk import macros
 
         def cleanup_macros():
-            """Reloads the airflow.macros module such that the symbol table is reset after the test."""
+            """Reloads the macros module such that the symbol table is reset after the test."""
             # We're explicitly deleting the module from sys.modules and importing it again
             # using import_module() as opposed to using importlib.reload() because the latter
-            # does not undo the changes to the airflow.macros module that are being caused by
+            # does not undo the changes to the airflow.sdk.definitions.macros module that are being caused by
             # invoking integrate_macros_plugins()
-            del sys.modules["airflow.macros"]
-            importlib.import_module("airflow.macros")
+
+            # Note: When we import airflow.sdk macros, ot resolves the actual path into sys.modules using
+            # lazy import.
+            del sys.modules["airflow.sdk.definitions.macros"]
+            importlib.import_module("airflow.sdk.definitions.macros")
 
         request.addfinalizer(cleanup_macros)
 
@@ -253,12 +256,12 @@ class TestPluginsManager:
             # Ensure the macros for the plugin have been integrated.
             integrate_macros_plugins()
             # Test whether the modules have been created as expected.
-            plugin_macros = importlib.import_module(f"airflow.macros.{MacroPlugin.name}")
+            plugin_macros = importlib.import_module(f"airflow.sdk.macros.{MacroPlugin.name}")
             for macro in MacroPlugin.macros:
                 # Verify that the macros added by the plugin are being set correctly
                 # on the plugin's macro module.
                 assert hasattr(plugin_macros, macro.__name__)
-            # Verify that the symbol table in airflow.macros has been updated with an entry for
+            # Verify that the symbol table in airflow.sdk.macros has been updated with an entry for
             # this plugin, this is necessary in order to allow the plugin's macros to be used when
             # rendering templates.
             assert hasattr(macros, MacroPlugin.name)

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -238,8 +238,6 @@ class TestPluginsManager:
             # does not undo the changes to the airflow.sdk.definitions.macros module that are being caused by
             # invoking integrate_macros_plugins()
 
-            # Note: When we import airflow.sdk macros, ot resolves the actual path into sys.modules using
-            # lazy import.
             del sys.modules["airflow.sdk.definitions.macros"]
             importlib.import_module("airflow.sdk.definitions.macros")
 
@@ -261,7 +259,7 @@ class TestPluginsManager:
                 # Verify that the macros added by the plugin are being set correctly
                 # on the plugin's macro module.
                 assert hasattr(plugin_macros, macro.__name__)
-            # Verify that the symbol table in airflow.sdk.macros has been updated with an entry for
+            # Verify that the symbol table in airflow.sdk.definitions.macros has been updated with an entry for
             # this plugin, this is necessary in order to allow the plugin's macros to be used when
             # rendering templates.
             assert hasattr(macros, MacroPlugin.name)

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -229,7 +229,7 @@ class TestPluginsManager:
         Tests whether macros that originate from plugins are being registered correctly.
         """
         from airflow.plugins_manager import integrate_macros_plugins
-        from airflow.sdk import macros
+        from airflow.sdk.definitions import macros
 
         def cleanup_macros():
             """Reloads the macros module such that the symbol table is reset after the test."""
@@ -256,7 +256,7 @@ class TestPluginsManager:
             # Ensure the macros for the plugin have been integrated.
             integrate_macros_plugins()
             # Test whether the modules have been created as expected.
-            plugin_macros = importlib.import_module(f"airflow.sdk.macros.{MacroPlugin.name}")
+            plugin_macros = importlib.import_module(f"airflow.sdk.definitions.macros.{MacroPlugin.name}")
             for macro in MacroPlugin.macros:
                 # Verify that the macros added by the plugin are being set correctly
                 # on the plugin's macro module.

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -123,7 +123,7 @@ def __getattr__(name: str):
         import importlib
 
         mod = importlib.import_module(module_path, __name__)
-        val = getattr(mod, name)
+        val = getattr(mod, name, mod)
 
         # Store for next time
         globals()[name] = val

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -53,7 +53,6 @@ __all__ = [
     "task",
     "task_group",
     "teardown",
-    "macros",
 ]
 
 __version__ = "1.1.0"
@@ -63,7 +62,6 @@ if TYPE_CHECKING:
     from airflow.sdk.bases.operator import BaseOperator, chain, chain_linear, cross_downstream
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.bases.sensor import BaseSensorOperator, PokeReturnValue
-    from airflow.sdk.definitions import macros
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher
     from airflow.sdk.definitions.asset.decorators import asset
     from airflow.sdk.definitions.asset.metadata import Metadata

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -114,7 +114,6 @@ __lazy_imports: dict[str, str] = {
     "task": ".definitions.decorators",
     "task_group": ".definitions.decorators",
     "teardown": ".definitions.decorators",
-    "macros": ".definitions.macros",
 }
 
 
@@ -123,7 +122,7 @@ def __getattr__(name: str):
         import importlib
 
         mod = importlib.import_module(module_path, __name__)
-        val = getattr(mod, name, mod)
+        val = getattr(mod, name)
 
         # Store for next time
         globals()[name] = val

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     "task",
     "task_group",
     "teardown",
+    "macros",
 ]
 
 __version__ = "1.1.0"
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     from airflow.sdk.bases.operator import BaseOperator, chain, chain_linear, cross_downstream
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.bases.sensor import BaseSensorOperator, PokeReturnValue
+    from airflow.sdk.definitions import macros
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher
     from airflow.sdk.definitions.asset.decorators import asset
     from airflow.sdk.definitions.asset.metadata import Metadata
@@ -112,6 +114,7 @@ __lazy_imports: dict[str, str] = {
     "task": ".definitions.decorators",
     "task_group": ".definitions.decorators",
     "teardown": ".definitions.decorators",
+    "macros": ".definitions.macros",
 }
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -151,6 +151,9 @@ class RuntimeTaskInstance(TaskInstance):
     def get_template_context(self) -> Context:
         # TODO: Move this to `airflow.sdk.execution_time.context`
         #   once we port the entire context logic from airflow/utils/context.py ?
+        from airflow.plugins_manager import integrate_macros_plugins
+
+        integrate_macros_plugins()
 
         dag_run_conf: dict[str, Any] | None = None
         if from_server := self._ti_context_from_server:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/48476


## What the issue is?

Airflow is supposed to support macros -- both present internally like: `uuid`, `datetime.now`, `ds_add` etc in conjunction with the user defined macros that are registered via plugins.

Check references here: https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html and a usage example here: https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/plugins.html#example.


## Why is it important?

Airflow 2 supported this feature and wouldve built tons of dags around it which would break for those users during if not this is not supported in airflow 3 and would serve as a blocker for those users.

Some examples of callouts: https://apache-airflow.slack.com/archives/CCZRF2U5A/p1746707742015169 which we referred to this issue: https://github.com/apache/airflow/issues/48476.


## Approach

Using the older approach itself where we have a utility: `integrate_macros_plugins` present that registers the user defined and global macros with airflow core by making the module by users under: `airflow.sdk.definitions` and it can be accessed using `MacrosAccessor` in the context: https://github.com/apache/airflow/blob/08cc57d5bba8a045d34bce39b28ac21af691c3a9/task-sdk/src/airflow/sdk/execution_time/task_runner.py#L175

- The macros module in `integrate_macros_plugins` has been updated to refer to the `macros` module in `airflow.sdk.definitions` instead of the older one: `airflow.macros`


## Testing

### Steps

#### 1. Creating few macros:

- `emojiify_macro` that takes some text and converts it into an emoji and returns
- `support_ticket_macro` returns a support ticket link based on dag id and task id

#### 2. Define these in an airflow plugin:
```
from airflow.plugins_manager import AirflowPlugin

def emojiify_macro(text):
    return f"🎉 {text} 🚀"

def support_ticket_macro(dag_id, task_id):
    base_url = "https://support.mycompany.com/tickets"
    ticket_id = f"{dag_id}:{task_id}"
    return f"{base_url}/{ticket_id}"

class MyMacroPlugin(AirflowPlugin):
    name = "amogh_macro_plugin"

    macros = [
        emojiify_macro,
        support_ticket_macro,
    ]
```


#### 3. Ensure that the plugin has been loaded:
<img width="865" alt="image" src="https://github.com/user-attachments/assets/675a4261-33d5-4462-a7ae-ae6de08ec72f" />


#### 4. Now check if the macros are loaded in that plugin:

Run `airflow plugin` in CLI:

```
root@f3dfe327e53c:/opt/airflow# airflow plugins
                   | operator_extra_li |                   |                    |
name               | nks               | macros            | appbuilder_views   | source
===================+===================+===================+====================+===================
amogh_macro_plugin |                   | macros_plugin.emo |                    | $PLUGINS_FOLDER/ma
                   |                   | jiify_macro,macro |                    | cros_plugin.py
                   |                   | s_plugin.support_ |                    |
                   |                   | ticket_macro      |                    |
```

#### 5. Define dags that can check the plugins out

DAG:
```
from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator

def print_macro_examples(**context):
    emoji_message = context["templates_dict"]["emoji_message"]
    ticket_url = context["templates_dict"]["ticket_url"]

    print(emoji_message)
    print(f"If something fails, open a support ticket at: {ticket_url}")

with DAG(
    dag_id="amogh-plugin-dag",
    schedule=None,
    catchup=False,
) as dag:
    task_use_macros = PythonOperator(
        task_id="use_plugin_macros",
        python_callable=print_macro_examples,
        templates_dict={
            "emoji_message": "{{ macros.amogh_macro_plugin.emojiify_macro('The task: `use_plugin_macros` is running!') }}",
            "ticket_url": "{{ macros.amogh_macro_plugin.support_ticket_macro(dag_id='amogh-plugin-dag', task_id='use_plugin_macros') }}",
        },
    )


```


Result:
<img width="865" alt="image" src="https://github.com/user-attachments/assets/5c95ae66-2d06-451b-ad9c-2f1aaf9a107f" />


Logs:
```
Log message source details: sources=["/root/airflow/logs/dag_id=amogh-plugin-dag/run_id=manual__2025-05-15T08:37:03.977081+00:00/task_id=use_plugin_macros/attempt=1.log"]
[[2](http://localhost:28080/dags/amogh-plugin-dag/runs/manual__2025-05-15T08:37:03.977081+00:00/tasks/use_plugin_macros?try_number=1#2)025-05-15, 14:07:04] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-05-15, 14:07:04] INFO - Filling up the DagBag from /files/dags/dags/amogh-plugin-test.py: source="airflow.models.dagbag.DagBag"
[2025-05-15, 1[4](http://localhost:28080/dags/amogh-plugin-dag/runs/manual__2025-05-15T08:37:03.977081+00:00/tasks/use_plugin_macros?try_number=1#4):07:04] INFO - Done. Returned value was: None: source="airflow.task.operators.airflow.providers.standard.operators.python.PythonOperator"
[2025-05-1[5](http://localhost:28080/dags/amogh-plugin-dag/runs/manual__2025-05-15T08:37:03.977081+00:00/tasks/use_plugin_macros?try_number=1#5), 14:07:05] INFO - 🎉 The task: `use_plugin_macros` is running! 🚀: chan="stdout": source="task"
[2025-05-15, 14:07:05] INFO - If something fails, open a support ticket at: https://support.mycompany.com/tickets/amogh-plugin-dag:use_plugin_macros: chan="stdout": source="task"
```


## TODO:

- [x] Write some tests supporting this change in task runner


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
