### PR TITLE
Fix broken cncf.kubernetes for Airflow 2

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/template_rendering.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/template_rendering.py
@@ -19,11 +19,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from jinja2 import TemplateAssertionError, UndefinedError
 from kubernetes.client.api_client import ApiClient
 
+from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
@@ -58,3 +61,17 @@ def render_k8s_pod_yaml(task_instance: TaskInstance) -> dict | None:
     )
     sanitized_pod = ApiClient().sanitize_for_serialization(pod)
     return sanitized_pod
+
+
+@provide_session
+def get_rendered_k8s_spec(task_instance: TaskInstance, session=NEW_SESSION) -> dict | None:
+    """Fetch rendered template fields from DB."""
+    from airflow.models.renderedtifields import RenderedTaskInstanceFields
+
+    rendered_k8s_spec = RenderedTaskInstanceFields.get_k8s_pod_yaml(task_instance, session=session)
+    if not rendered_k8s_spec:
+        try:
+            rendered_k8s_spec = render_k8s_pod_yaml(task_instance)
+        except (TemplateAssertionError, UndefinedError) as e:
+            raise AirflowException(f"Unable to render a k8s spec for this taskinstance: {e}") from e
+    return rendered_k8s_spec

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
@@ -24,8 +24,9 @@ import yaml
 from kubernetes.client import models as k8s
 from sqlalchemy.orm import make_transient
 
-from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
-from airflow.providers.cncf.kubernetes.template_rendering import render_k8s_pod_yaml
+from airflow.models.renderedtifields import RenderedTaskInstanceFields, RenderedTaskInstanceFields as RTIF
+from airflow.providers.cncf.kubernetes.template_rendering import get_rendered_k8s_spec, render_k8s_pod_yaml
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.version import version
@@ -147,6 +148,39 @@ def test_render_k8s_pod_yaml_with_custom_pod_template_and_pod_override(
     # was overridden by the pod_override
     assert ti_pod_yaml["metadata"]["labels"]["custom_label"] == "override"
     assert ti_pod_yaml["metadata"]["annotations"]["test"] == "annotation"
+
+
+@pytest.mark.skipif(
+    AIRFLOW_V_3_0_PLUS,
+    reason="This test is only needed for Airflow 2 - we can remove it after "
+    "only Airflow 3 is supported in providers",
+)
+@mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
+@mock.patch.object(RenderedTaskInstanceFields, "get_k8s_pod_yaml")
+@mock.patch("airflow.providers.cncf.kubernetes.template_rendering.render_k8s_pod_yaml")
+def test_get_rendered_k8s_spec(render_k8s_pod_yaml, rtif_get_k8s_pod_yaml, create_task_instance):
+    # Create new TI for the same Task
+    ti = create_task_instance()
+
+    mock.patch.object(ti, "render_k8s_pod_yaml", autospec=True)
+
+    fake_spec = {"ermagawds": "pods"}
+
+    session = mock.Mock()
+
+    rtif_get_k8s_pod_yaml.return_value = fake_spec
+    assert get_rendered_k8s_spec(ti, session=session) == fake_spec
+
+    rtif_get_k8s_pod_yaml.assert_called_once_with(ti, session=session)
+    render_k8s_pod_yaml.assert_not_called()
+
+    # Now test that when we _dont_ find it in the DB, it calls render_k8s_pod_yaml
+    rtif_get_k8s_pod_yaml.return_value = None
+    render_k8s_pod_yaml.return_value = fake_spec
+
+    assert get_rendered_k8s_spec(session) == fake_spec
+
+    render_k8s_pod_yaml.assert_called_once()
 
 
 @mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})


### PR DESCRIPTION
The #50650 broke cncf.kubernetes for Airflow 2 - it removed a method that was not used in Airflow 3 but it turns out that those methods were also used in Airflow 2. We revert the change but also we add skipif for Airflow 3 to skip the test on Airflow 3 and to mark it essentially for removal when we drop compatibility with Airflow 2.

Revert "Remove unused db method in k8s provider (#49186)"

This reverts commit 0ca0f17996c86efb292cf5b10181944c67e3b862.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
