### PR TITLE
Simplify GridTI links

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -69,65 +69,34 @@ const Instance = ({ dagId, isGroup, isMapped, runId, search, state, taskId }: Pr
       transition="background-color 0.2s"
       zIndex={1}
     >
-      {isGroup ? (
-        <Link
-          replace
-          to={{
-            pathname: `/dags/${dagId}/runs/${runId}/tasks/group/${taskId}`,
-            search,
-          }}
+      <Link
+        replace
+        to={{
+          pathname: `/dags/${dagId}/runs/${runId}/tasks/${isGroup ? "group/" : ""}${taskId}${isMapped ? "/mapped" : ""}`,
+          search,
+        }}
+      >
+        <Badge
+          borderRadius={4}
+          colorPalette={state === null ? "none" : state}
+          height="14px"
+          minH={0}
+          opacity={state === "success" ? 0.6 : 1}
+          p={0}
+          variant="solid"
+          width="14px"
         >
-          <Badge
-            borderRadius={4}
-            colorPalette={state === null ? "none" : state}
-            height="14px"
-            minH={0}
-            opacity={state === "success" ? 0.6 : 1}
-            p={0}
-            variant="solid"
-            width="14px"
-          >
-            {state === undefined ? undefined : (
-              <StateIcon
-                size={10}
-                state={state}
-                style={{
-                  marginLeft: "2px",
-                }}
-              />
-            )}
-          </Badge>
-        </Link>
-      ) : (
-        <Link
-          replace
-          to={{
-            pathname: `/dags/${dagId}/runs/${runId}/tasks/${taskId}${isMapped ? "/mapped" : ""}`,
-            search,
-          }}
-        >
-          <Badge
-            borderRadius={4}
-            colorPalette={state === null ? "none" : state}
-            height="14px"
-            minH={0}
-            opacity={state === "success" ? 0.6 : 1}
-            p={0}
-            variant="solid"
-            width="14px"
-          >
-            {state === undefined ? undefined : (
-              <StateIcon
-                size={10}
-                state={state}
-                style={{
-                  marginLeft: "2px",
-                }}
-              />
-            )}
-          </Badge>
-        </Link>
-      )}
+          {state === undefined ? undefined : (
+            <StateIcon
+              size={10}
+              state={state}
+              style={{
+                marginLeft: "2px",
+              }}
+            />
+          )}
+        </Badge>
+      </Link>
     </Flex>
   );
 };


### PR DESCRIPTION
After we added the ability to select a task group, we can now simplify the GridTI component.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
