### PR TITLE
Fix version validation script for building docker images

### DIFF
--- a/scripts/ci/airflow_version_check.py
+++ b/scripts/ci/airflow_version_check.py
@@ -31,7 +31,7 @@ import sys
 from pathlib import Path
 
 import requests
-from packaging.version import Version
+from packaging.version import Version, parse
 from rich.console import Console
 
 console = Console(color_system="standard", stderr=True, width=400)
@@ -46,18 +46,19 @@ def check_airflow_version(airflow_version: Version) -> tuple[str, bool]:
     """
     latest = False
     url = "https://pypi.org/pypi/apache-airflow/json"
-    max_versions_shown = 30
     try:
         response = requests.get(url)
         response.raise_for_status()
         data = response.json()
         latest_version = Version(data["info"]["version"])
-        valid_versions = list(reversed(data["releases"].keys()))[:max_versions_shown]
-        if str(airflow_version) not in valid_versions:
-            console.print(f"[red]Version {airflow_version} is not a valid Airflow version")
-            console.print(
-                f"Available versions: (first available {max_versions_shown} versions):", valid_versions
-            )
+        all_versions = sorted(
+            (parse(v) for v in data["releases"].keys()),
+            reverse=True,
+        )
+        if airflow_version not in all_versions:
+            console.print(f"[red]Version {airflow_version} is not a valid Airflow release version.")
+            console.print("[yellow]Available versions (latest 30 shown):")
+            console.print([str(v) for v in all_versions[:30]])
             sys.exit(1)
         if airflow_version == latest_version:
             latest = True


### PR DESCRIPTION
Example failure: https://github.com/apache/airflow/actions/runs/15053245013/job/42312930970

Previously, the script used string-based sorting of PyPI releases, which caused versions like 2.11.0 to be incorrectly excluded (e.g. sorted behind 2.9.x). This commit updates the logic to use semantic versioning via `packaging.version.Version`.

Before:

```
❯ uv  run scripts/ci/airflow_version_check.py 2.11.0rc1
Version 2.11.0rc1 is not a valid Airflow version
Available versions: (first available 30 versions):
['3.0.1rc1', '3.0.1', '3.0.0rc4', '3.0.0rc3', '3.0.0rc2', '3.0.0rc1.post4', '3.0.0rc1.post3', '3.0.0rc1.post2', '3.0.0rc1.post1', '3.0.0rc1', '3.0.0b4', '3.0.0', '2.9.3rc1', '2.9.3', '2.9.2rc1', '2.9.2', '2.9.1rc2', '2.9.1rc1', '2.9.1', '2.9.0rc3', '2.9.0rc2', '2.9.0rc1', '2.9.0b2', '2.9.0b1', '2.9.0', '2.8.4rc1', '2.8.4', '2.8.3rc1', '2.8.3', '2.8.2rc3']
```

After:

```
❯ uv  run scripts/ci/airflow_version_check.py 2.11.0rc1
Checking constraints file: https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0rc1/constraints-3.9.txt
Constraints file found for version 2.11.0rc1, Python 3.9
airflowVersion=2.11.0rc1
airflowVersion=2.11.0rc1
skipLatest=true
skipLatest=true
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
