### PR TITLE
Fix log streaming when EXECUTE_TASKS_NEW_PYTHON_INTERPRETER is enabled in Celery executor

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -27,6 +27,7 @@ import logging
 import math
 import os
 import subprocess
+import sys
 import traceback
 import warnings
 from collections.abc import Mapping, MutableMapping
@@ -240,7 +241,7 @@ def _execute_in_subprocess(command_to_exec: CommandType, celery_task_id: str | N
     if celery_task_id:
         env["external_executor_id"] = celery_task_id
     try:
-        subprocess.check_output(command_to_exec, stderr=subprocess.STDOUT, close_fds=True, env=env)
+        subprocess.run(command_to_exec, stderr=sys.__stderr__, stdout=sys.__stdout__, close_fds=True, env=env)
     except subprocess.CalledProcessError as e:
         log.exception("[%s] execute_command encountered a CalledProcessError", celery_task_id)
         log.error(e.output)


### PR DESCRIPTION
Elasticsearch (when configured to output json to stdout) requires, naturally, that the logs are sent as json to stdout.

Currently when running with EXECUTE_TASKS_NEW_PYTHON_INTERPRETER set to true, we use check_output, and we do nothing with the output. This PR implements @dstandish suggestion mentioned in https://github.com/apache/airflow/issues/47420

**TESTING**
Before, logs were not coming with with ES when `EXECUTE_TASKS_NEW_PYTHON_INTERPRETER =True`
<img width="1703" alt="image" src="https://github.com/user-attachments/assets/9633c4ca-8f56-44ab-8ee5-30af79daaad9" />

**After** 
Logs are coming fine now
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a1e4b666-f6bc-4885-9f14-d75bd8f6636b" />



Also, I have verified in AWS there is no regression after this fix
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b11a44e3-b098-430d-bfd5-f311f75e3f20" />


closes: https://github.com/apache/airflow/issues/47420




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
