### PR TITLE
Fix XCom deserialization for mapped tasks with custom backend

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/lazy_sequence.py
+++ b/task-sdk/src/airflow/sdk/execution_time/lazy_sequence.py
@@ -140,10 +140,9 @@ class LazyXComSequence(Sequence[T]):
         #     if not reverse:
         #         rows.reverse()
         # return rows
-
-        from airflow.sdk.bases.xcom import BaseXCom
         from airflow.sdk.execution_time.comms import GetXComSequenceItem, XComResult
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+        from airflow.sdk.execution_time.xcom import XCom
 
         with SUPERVISOR_COMMS.lock:
             source = (xcom_arg := self._xcom_arg).operator
@@ -161,7 +160,7 @@ class LazyXComSequence(Sequence[T]):
 
         if not isinstance(msg, XComResult):
             raise IndexError(key)
-        return BaseXCom.deserialize_value(msg)
+        return XCom.deserialize_value(msg)
 
 
 def _coerce_index(value: Any) -> int | None:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/50636


## What the problem is?

While using a dag that has tasks consuming xcoms from upstream tasks which are mapped and a custom xcom backend is configured, the downstream tasks would not get the "data" of the xcom or the value of the xcom, but would instead get the reference of it.

In case of object store backend, the downstream tasks were suffering with the "path" on the store of the xcom.

![image](https://github.com/user-attachments/assets/4efea128-8d4f-4564-9b2c-4a6b609524f2)


## Problem

Due to some recent refactoring done by: #50011, the deserialize function on the custom xcom backend was not consumed and "BaseXcom" was consumed always leading to it doing the most basic deserialize -- (serde deser) and hence the retrurned object remained equal to the reference of it. 


## Testing

DAG used (same as the reported one)
```
from airflow.decorators import dag, task
from airflow.models.xcom import XCom

@task
def generate_data():
    print("XCom.__name__ --->", XCom.__name__)
    return [1, 2, 3]


@task
def filter_item_from_mapped_task(item):
    print("filter_item_from_mapped_task item --->", item)
    if item==1:
        return None
    return item


@task
def print_item(item):
    print("print_item item --->", item)


@dag(
    dag_id='test_bug_dag',
)
def test_bug_dag():
    data = generate_data()
    filtered_data = filter_item_from_mapped_task.expand(item=data)
    print_item.expand(item=filtered_data)

test_bug_dag()
```

`generate_data` pushes right stuff:

![image](https://github.com/user-attachments/assets/fd9b8dc7-baec-40ab-870d-ad2b9108a5b6)


`filter_item_from_mapped_task` pushes right stuff:

map index 0:

![image](https://github.com/user-attachments/assets/b5103024-b76a-45a8-8fa9-de3700217972)


map index 1:

![image](https://github.com/user-attachments/assets/a96e4490-9775-4907-ad29-a3982ffcb90f)


map index 2:

![image](https://github.com/user-attachments/assets/2ae117f0-e569-419c-b3ae-f2432d2e7723)


Push on s3 is as expected:
![image](https://github.com/user-attachments/assets/ec3f24d4-8124-4154-8013-c152041ca64a)


Consumed rightly by the `print_item` task now:

map index 0:

![image](https://github.com/user-attachments/assets/6c751df3-b856-47fd-94d6-6227a374ee39)

map index 1:
![image](https://github.com/user-attachments/assets/d8d6bd41-ce1a-4cf0-8be9-5e94b2d46ec7)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
