### PR TITLE
Stop streaming task logs if end of log mark is missing

### DIFF
--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -44,6 +44,8 @@ class TaskLogReader:
 
     STREAM_LOOP_SLEEP_SECONDS = 1
     """Time to sleep between loops while waiting for more logs"""
+    STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS = 5
+    """Number of empty loop iterations before stopping the stream"""
 
     def read_log_chunks(
         self, ti: TaskInstance, try_number: int | None, metadata
@@ -81,6 +83,7 @@ class TaskLogReader:
 
         for key in ("end_of_log", "max_offset", "offset", "log_pos"):
             metadata.pop(key, None)
+        empty_iterations = 0
 
         while True:
             logs, out_metadata = self.read_log_chunks(ti, try_number, metadata)
@@ -96,10 +99,15 @@ class TaskLogReader:
                 TaskInstanceState.RUNNING,
                 TaskInstanceState.DEFERRED,
             ):
-                if not logs[0]:
+                if not logs:
                     # we did not receive any logs in this loop
                     # sleeping to conserve resources / limit requests on external services
                     time.sleep(self.STREAM_LOOP_SLEEP_SECONDS)
+                    empty_iterations += 1
+                    if empty_iterations >= self.STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS:
+                        # we have not received any logs for a while, so we stop the stream
+                        yield "(Log stream stopped - End of log marker not found, so logs may be incomplete)\n"
+                        break
             else:
                 metadata.clear()
                 metadata.update(out_metadata)

--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -109,11 +109,11 @@ class TaskLogReader:
                     if empty_iterations >= self.STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS:
                         # we have not received any logs for a while, so we stop the stream
                         yield "(Log stream stopped - End of log marker not found, so logs may be incomplete)\n"
-                        break
+                        return
             else:
                 metadata.clear()
                 metadata.update(out_metadata)
-                break
+                return
 
     @cached_property
     def log_handler(self):

--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -99,7 +99,9 @@ class TaskLogReader:
                 TaskInstanceState.RUNNING,
                 TaskInstanceState.DEFERRED,
             ):
-                if not logs:
+                if logs:
+                    empty_iterations = 0
+                else:
                     # we did not receive any logs in this loop
                     # sleeping to conserve resources / limit requests on external services
                     time.sleep(self.STREAM_LOOP_SLEEP_SECONDS)

--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -108,7 +108,7 @@ class TaskLogReader:
                     empty_iterations += 1
                     if empty_iterations >= self.STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS:
                         # we have not received any logs for a while, so we stop the stream
-                        yield "(Log stream stopped - End of log marker not found, so logs may be incomplete)\n"
+                        yield "(Log stream stopped - End of log marker not found; logs may be incomplete.)\n"
                         return
             else:
                 metadata.clear()

--- a/airflow-core/tests/unit/utils/log/test_log_reader.py
+++ b/airflow-core/tests/unit/utils/log/test_log_reader.py
@@ -235,7 +235,7 @@ class TestLogView:
         log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
         assert list(log_stream) == [
             "hello\n",
-            "(Log stream stopped - End of log marker not found, so logs may be incomplete)\n",
+            "(Log stream stopped - End of log marker not found; logs may be incomplete.)\n",
         ]
         assert mock_read.call_count == 6
 

--- a/airflow-core/tests/unit/utils/log/test_log_reader.py
+++ b/airflow-core/tests/unit/utils/log/test_log_reader.py
@@ -218,6 +218,27 @@ class TestLogView:
             any_order=False,
         )
 
+    @mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read")
+    def test_read_log_stream_no_end_of_log_marker(self, mock_read):
+        mock_read.side_effect = [
+            (["hello"], {"end_of_log": False}),
+            ([], {"end_of_log": False}),
+            ([], {"end_of_log": False}),
+            ([], {"end_of_log": False}),
+            ([], {"end_of_log": False}),
+            ([], {"end_of_log": False}),
+        ]
+
+        self.ti.state = TaskInstanceState.SUCCESS
+        task_log_reader = TaskLogReader()
+        task_log_reader.STREAM_LOOP_SLEEP_SECONDS = 0.001  # to speed up the test
+        log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
+        assert list(log_stream) == [
+            "hello\n",
+            "(Log stream stopped - End of log marker not found, so logs may be incomplete)\n",
+        ]
+        assert mock_read.call_count == 6
+
     def test_supports_external_link(self):
         task_log_reader = TaskLogReader()
 


### PR DESCRIPTION
Sometimes, somehow, the end of log mark can be missing, and when that happens the streaming log reader enters an infinite loop. Instead, if the task is in a non-running state and we stop receiving log lines but never get the end of log mark, we assume we won't and stop trying. We do tell emit that we are stopping though.

Closes #39323