### PR TITLE
Fix Edge Worker Remove when in unknown state

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -245,7 +245,11 @@ def remove_worker(worker_name: str, session: Session = NEW_SESSION) -> None:
     """Remove a worker that is offline or just gone from DB."""
     query = select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name)
     worker: EdgeWorkerModel = session.scalar(query)
-    if worker.state in (EdgeWorkerState.OFFLINE, EdgeWorkerState.OFFLINE_MAINTENANCE):
+    if worker.state in (
+        EdgeWorkerState.OFFLINE,
+        EdgeWorkerState.OFFLINE_MAINTENANCE,
+        EdgeWorkerState.UNKNOWN,
+    ):
         session.execute(delete(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name))
     else:
         error_message = f"Cannot remove edge worker {worker_name} as it is in {worker.state} state!"


### PR DESCRIPTION
I noticed that due to addition of validation in #49915 it was not possible anymore to remove a Edge Worker that is in "Unknown" state. This PR adds the missing state to validation.

Note, even though there is atm the edge 1.1.0rc1 release being cut, this bug is minimal, should not block release efforts.