### PR TITLE
Make dag_run.conf nullable in Details page

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -73,7 +73,7 @@ class DAGRunResponse(BaseModel):
     run_type: DagRunType
     state: DagRunState
     triggered_by: DagRunTriggeredByType | None
-    conf: dict
+    conf: dict | None
     note: str | None
     dag_versions: list[DagVersionResponse]
     bundle_version: str | None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -955,8 +955,10 @@ components:
           - $ref: '#/components/schemas/DagRunTriggeredByType'
           - type: 'null'
         conf:
-          additionalProperties: true
-          type: object
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
           title: Conf
         note:
           anyOf:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -8464,8 +8464,10 @@ components:
           - $ref: '#/components/schemas/DagRunTriggeredByType'
           - type: 'null'
         conf:
-          additionalProperties: true
-          type: object
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
           title: Conf
         note:
           anyOf:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2275,8 +2275,15 @@ export const $DAGRunResponse = {
       ],
     },
     conf: {
-      additionalProperties: true,
-      type: "object",
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Conf",
     },
     note: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -582,7 +582,7 @@ export type DAGRunResponse = {
   triggered_by: DagRunTriggeredByType | null;
   conf: {
     [key: string]: unknown;
-  };
+  } | null;
   note: string | null;
   dag_versions: Array<DagVersionResponse>;
   bundle_version: string | null;

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -151,7 +151,7 @@ export const Details = () => {
             <Table.Row>
               <Table.Cell>Run Config</Table.Cell>
               <Table.Cell>
-                <RenderedJsonField content={dagRun.conf} />
+                <RenderedJsonField content={dagRun.conf ?? {}} />
               </Table.Cell>
             </Table.Row>
           </Table.Body>

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1245,7 +1245,7 @@ class DAGRunResponse(BaseModel):
     run_type: DagRunType
     state: DagRunState
     triggered_by: DagRunTriggeredByType | None = None
-    conf: Annotated[dict[str, Any], Field(title="Conf")]
+    conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     note: Annotated[str | None, Field(title="Note")] = None
     dag_versions: Annotated[list[DagVersionResponse], Field(title="Dag Versions")]
     bundle_version: Annotated[str | None, Field(title="Bundle Version")] = None


### PR DESCRIPTION
Fixes #50386

As part of Airflow 2 to 3 migration we noticed dag_run.json became a JSON field. Since we don't need this in non-production we deleted the column and added new one with JSON type which is nullable as per the migration. But it's not nullable in the pydantic definition thus causing API error when a dagrun with null conf is present.


This PR changed schema conf as nullable and generated files for the change