### PR TITLE
Update `useTableURLState` hook for sticky table sort

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/useTableUrlState.ts
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/useTableUrlState.ts
@@ -18,6 +18,8 @@
  */
 import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { useLocalStorage } from "usehooks-ts";
 
 import { useConfig } from "src/queries/useConfig";
 
@@ -26,6 +28,13 @@ import type { TableState } from "./types";
 
 export const useTableURLState = (defaultState?: Partial<TableState>) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const pageName = location.pathname;
+
+  const [sorting, setSorting] = useLocalStorage<TableState["sorting"]>(
+    `${pageName.replaceAll("/", "-").slice(1)}-table-sort`,
+    [],
+  );
 
   const pageSize = useConfig("page_size") as number;
 
@@ -34,7 +43,7 @@ export const useTableURLState = (defaultState?: Partial<TableState>) => {
       pageIndex: 0,
       pageSize,
     },
-    sorting: [],
+    sorting,
   } as const satisfies TableState;
 
   const handleStateChange = useCallback(
@@ -42,8 +51,9 @@ export const useTableURLState = (defaultState?: Partial<TableState>) => {
       setSearchParams(stateToSearchParams(state, defaultTableState), {
         replace: true,
       });
+      setSorting(state.sorting);
     },
-    [setSearchParams, defaultTableState],
+    [setSearchParams, defaultTableState, setSorting],
   );
 
   const tableURLState = useMemo(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related PR

as a following PR for #50600
cc: @bbovenzi @pierrejeambrun 

## Why

since different people may want different sort order in the same instance. Make the sort be sticky would rather a good choice than be a global config

## How

Update `useTableURLState` to store the sort into localStorage for pages using the table and use it as a default value. This solution could not only support for dag list pages but for all pages with sortable table.

local storage may look like 

<img width="679" alt="image" src="https://github.com/user-attachments/assets/6a6371f9-5c80-4ac7-8ac5-5c5d994ef869" />

current ui

https://github.com/user-attachments/assets/9fcb734d-fde3-4dbf-98fa-736aaa1a5ba3

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
