### PR TITLE
Add default ordering by map_index to patch TI API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -753,6 +753,8 @@ def _patch_ti_validate_request(
     )
     if map_index is not None:
         query = query.where(TI.map_index == map_index)
+    else:
+        query = query.order_by(TI.map_index)
 
     tis = session.scalars(query).all()
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -3682,10 +3682,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         response_data = response.json()
 
         assert response_data["total_entries"] == 3
-        # Sort by map index for a more predictable order of accessing in the loop below
-        response_data["task_instances"] = sorted(
-            response_data["task_instances"], key=lambda x: x["map_index"]
-        )
+
         for map_index in range(1, 3):
             response_ti = response_data["task_instances"][map_index]
             assert response_ti == {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -3682,7 +3682,10 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         response_data = response.json()
 
         assert response_data["total_entries"] == 3
-
+        # Sort by map index for a more predictable order of accessing in the loop below
+        response_data["task_instances"] = sorted(
+            response_data["task_instances"], key=lambda x: x["map_index"]
+        )
         for map_index in range(1, 3):
             response_ti = response_data["task_instances"][map_index]
             assert response_ti == {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Failure like this:
```
FAILED airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py::TestPatchTaskInstance::test_set_note_should_respond_200_mapped_task_summary_with_rtif - AssertionError: assert equals failed
  {                                {                               
    'dag_display_name': 'example_    'dag_display_name': 'example_ 
  python_operator',                python_operator',               
    'dag_id': 'example_python_ope    'dag_id': 'example_python_ope 
  rator',                          rator',                         
    'dag_run_id': 'TEST_DAG_RUN_I    'dag_run_id': 'TEST_DAG_RUN_I 
  D',                              D',                             
    'dag_version': None,             'dag_version': None,          
    'duration': 10000.0,             'duration': 10000.0,          
    'end_date': '2020-01-03T00:00    'end_date': '2020-01-03T00:00 
  :00Z',                           :00Z',                          
    'executor': None,                'executor': None,             
    'executor_config': '{}',         'executor_config': '{}',      
    'hostname': '',                  'hostname': '',               
    'id': '0196ddae-891d-7e95-8c7    'id': <ANY>,                  
  9-b7b71b913ba4',                                                 
    'logical_date': '2020-01-01T0    'logical_date': '2020-01-01T0 
  0:00:00Z',                       0:00:00Z',                      
    'map_index': 2,                  'map_index': 1,               
    'max_tries': 0,                  'max_tries': 0,               
    'note': 'My super cool TaskIn    'note': 'My super cool TaskIn 
  stance note',                    stance note',                   
    'operator': 'PythonOperator',    'operator': 'PythonOperator', 
    'pid': 100,                      'pid': 100,                   
    'pool': 'default_pool',          'pool': 'default_pool',       
    'pool_slots': 1,                 'pool_slots': 1,              
    'priority_weight': 9,            'priority_weight': 9,         
    'queue': 'default_queue',        'queue': 'default_queue',     
    'queued_when': None,             'queued_when': None,          
    'rendered_fields': {             'rendered_fields': {          
      'op_args': [],                   'op_args': [],              
      'op_kwargs': {},                 'op_kwargs': {},            
      'templates_dict': None,          'templates_dict': None,     
    },                               },                            
    'rendered_map_index': '2',       'rendered_map_index': '1',    
    'run_after': '2020-01-01T00:0    'run_after': '2020-01-01T00:0 
  0:00Z',                          0:00Z',                         
    'scheduled_when': None,          'scheduled_when': None,       
    'start_date': '2020-01-02T00:    'start_date': '2020-01-02T00: 
  00:00Z',                         00:00Z',                        
    'state': 'running',              'state': 'running',           
    'task_display_name': 'print_t    'task_display_name': 'print_t 
  he_context',                     he_context',                    
    'task_id': 'print_the_context    'task_id': 'print_the_context 
  ',                               ',                              
    'trigger': None,                 'trigger': None,              
    'triggerer_job': None,           'triggerer_job': None,        
    'try_number': 0,                 'try_number': 0,              
    'unixname': 'root',              'unixname': 'root',           
  }                                }
= 1 failed, 1372 passed, 195 skipped, 1 xfailed, 1 warning in 768.55s (0:12:48) =
```

Example: https://github.com/apache/airflow/actions/runs/15083900155/job/42404215412

Revealed that we have a "kinda" bug in the way our API responds. All API calls must return predictable results as some users might rely on ordering for their logic.


Adding a ordering by "map_index" to `_patch_ti_validate_request` => and only adding it for the cases when more than one TI is returned. For cases when we perform patch on a TI in a mapped task instance with None mapping.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
