### PR TITLE
Use Github API to fetch K8S schemas to fix rate limiting

### DIFF
--- a/helm-tests/tests/chart_utils/helm_template_generator.py
+++ b/helm-tests/tests/chart_utils/helm_template_generator.py
@@ -37,7 +37,7 @@ CHART_DIR = Path(__file__).resolve().parents[3] / "chart"
 
 DEFAULT_KUBERNETES_VERSION = "1.29.1"
 BASE_URL_SPEC = (
-    f"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
+    f"https://api.github.com/repos/yannh/kubernetes-json-schema/contents/"
     f"v{DEFAULT_KUBERNETES_VERSION}-standalone-strict"
 )
 
@@ -63,14 +63,17 @@ def get_schema_k8s(api_version, kind, kubernetes_version):
     else:
         url = f"{BASE_URL_SPEC}/{kind}-{api_version}.json"
 
-    headers = {}
+    headers = {
+        "Accept": "application/vnd.github.v3.raw",
+    }
     if GITHUB_TOKEN:
         headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
         headers["X-GitHub-Api-Version"] = "2022-11-28"
-    request = requests.get(url, headers=headers)
-    request.raise_for_status()
+
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
     schema = json.loads(
-        request.text.replace(
+        response.text.replace(
             "kubernetesjsonschema.dev", "raw.githubusercontent.com/yannh/kubernetes-json-schema/master"
         )
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Similar to #50716


Updating the K8s schema fetch logic to use the Github API instead of using the raw.githubuser.com, which had limited support for GH tokens. Hence it was running into rate limiting errors like:

```
........................................................................ [ 25%]
............F........................................................... [ 51%]
........................................................................ [ 76%]
..................................................................       [100%]
=================================== FAILURES ===================================
_ TestGitSyncWorker.test_should_add_dags_volume_to_the_worker_if_git_sync_and_persistence_is_enabled _
[gw3] linux -- Python 3.9.22 /usr/local/bin/python3

self = <helm_tests.other.test_git_sync_worker.TestGitSyncWorker object at 0xffdf80633b20>

    def test_should_add_dags_volume_to_the_worker_if_git_sync_and_persistence_is_enabled(self):
>       docs = render_chart(
            values={
                "executor": "CeleryExecutor",
                "dags": {"persistence": {"enabled": True}, "gitSync": {"enabled": True}},
            },
            show_only=["templates/workers/worker-deployment.yaml"],
        )

helm-tests/tests/helm_tests/other/test_git_sync_worker.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
helm-tests/tests/chart_utils/helm_template_generator.py:165: in render_chart
    validate_k8s_object(k8s_object, kubernetes_version)
helm-tests/tests/chart_utils/helm_template_generator.py:116: in validate_k8s_object
    validate = create_validator(instance.get("apiVersion"), instance.get("kind"), kubernetes_version)
helm-tests/tests/chart_utils/helm_template_generator.py:99: in create_validator
    schema = get_schema_k8s(api_version, kind, kubernetes_version)
helm-tests/tests/chart_utils/helm_template_generator.py:71: in get_schema_k8s
    request.raise_for_status()
```

Example: https://github.com/apache/airflow/actions/runs/15086622656/job/42410644771


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
