### PR TITLE
Add delete_by_property method in weaviate hook

### DIFF
--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -30,7 +30,7 @@ from tenacity import Retrying, retry, retry_if_exception, retry_if_exception_typ
 from weaviate import WeaviateClient
 from weaviate.auth import Auth
 from weaviate.classes.query import Filter
-from weaviate.exceptions import ObjectAlreadyExistsException
+from weaviate.exceptions import ObjectAlreadyExistsException, UnexpectedStatusCodeError
 from weaviate.util import generate_uuid5
 
 from airflow.hooks.base import BaseHook
@@ -194,6 +194,7 @@ class WeaviateHook(BaseHook):
 
     def delete_by_property(
         self,
+        *,
         collection_names: list[str] | str,
         filter_criteria: _Filters,
         if_error: str = "stop",
@@ -241,7 +242,7 @@ class WeaviateHook(BaseHook):
                         self.log.info(attempt)
                         collection = self.get_collection(collection_name)
                         collection.data.delete_many(where=filter_criteria, verbose=verbose, dry_run=dry_run)
-            except Exception as e:
+            except UnexpectedStatusCodeError as e:
                 if if_error == "continue":
                     self.log.error(e)
                     failed_collection_list.append(collection_name)

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -190,6 +190,78 @@ class WeaviateHook(BaseHook):
         """
         client = self.conn
         return client.collections.get(name)
+    
+    def delete_by_properties(
+        self,
+        collection_names: list[str] | str,
+        property_names: list[str] | str,
+        operator: str,
+        value: Any,
+        if_error: str = "stop"
+    ) -> bool:
+        """
+        Delete objects from a collection using dynamic filtering with retry logic and error handling.
+
+        :param collection_name: The name of the collection to delete from.
+        :param property_name: The property to filter by.
+        :param operator: The filter operator (e.g., 'equal', 'like', 'greater_than').
+        :param value: The value for the filter operation.
+        :param if_error: define the actions to be taken if there is an error while deleting a collection, possible
+         options are `stop` and `continue`
+        :return: if `if_error=continue` return list of collections which we failed to delete.
+            if `if_error=stop` returns None.
+        """
+        client = self.get_conn()
+
+        collection_names = (
+            [collection_names] if collection_names and isinstance(collection_names, str) else collection_names
+        )
+        property_names = (
+            [property_names] if property_names and isinstance(property_names, str) else property_names
+        )
+
+        failed_collection_list = []
+        for collection_name in collection_names:
+            for property_name in property_names:
+                try:
+                    # dynamically get the filter method to allow deleting objects in collections based on various filtering criteria,
+                    # when there is a filter criteria added/removed from the API, this should adapt to that change.
+                    filter_obj = Filter.by_property(property_name)
+                    if not hasattr(filter_obj, operator):
+                        raise ValueError(
+                            f"Unsupported filter operator '{operator}'. Expected one of: "
+                            f"{', '.join([m for m in dir(filter_obj) if not m.startswith('_')])}"
+                        )
+                    filter_method = getattr(filter_obj, operator)
+                    filter_criteria = filter_method(value)
+
+                    # Log the deletion attempt
+                    self.log.info(
+                        f"Attempting to delete from '{collection_name}' where '{property_name}' {operator} '{value}'"
+                    )
+
+                    # Retry logic
+                    for attempt in Retrying(
+                        stop=stop_after_attempt(3),
+                        retry=(
+                            retry_if_exception(lambda exc: check_http_error_is_retryable(exc))
+                            | retry_if_exception_type(REQUESTS_EXCEPTIONS_TYPES)
+                        ),
+                    ):
+                        with attempt:
+                            self.log.info(attempt)
+                            collection = client.collections.get(collection_name)
+                            collection.data.delete_many(where=filter_criteria)
+                except Exception as e:
+                    if if_error == "continue":
+                        self.log.error(e)
+                        failed_collection_list.append(collection_name)
+                    elif if_error == "stop":
+                        raise e
+
+        if if_error == "continue":
+            return failed_collection_list
+        return None
 
     def delete_collections(
         self, collection_names: list[str] | str, if_error: str = "stop"

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from weaviate.collections import Collection
     from weaviate.collections.classes.batch import ErrorReference
     from weaviate.collections.classes.config import CollectionConfig, CollectionConfigSimple
+    from weaviate.collections.classes.filters import _Filters
     from weaviate.collections.classes.internal import (
         Object,
         QueryReturnType,
@@ -194,7 +195,7 @@ class WeaviateHook(BaseHook):
     def delete_by_property(
         self,
         collection_names: list[str] | str,
-        filter_criteria: Filter,
+        filter_criteria: _Filters,
         if_error: str = "stop",
         dry_run: bool = False,
         verbose: bool = False,
@@ -222,8 +223,6 @@ class WeaviateHook(BaseHook):
         >>>     if_error="stop"
         >>> )
         """
-        client = self.get_conn()
-
         collection_names = [collection_names] if isinstance(collection_names, str) else collection_names
 
         failed_collection_list = []
@@ -240,8 +239,8 @@ class WeaviateHook(BaseHook):
                 ):
                     with attempt:
                         self.log.info(attempt)
-                        collection = client.collections.get(collection_name)
-                        collection.data.delete_many(where=filter_criteria, dry_run=dry_run, verbose=verbose)
+                        collection = self.get_collection(collection_name)
+                        collection.data.delete_many(where=filter_criteria, verbose=verbose, dry_run=dry_run)
             except Exception as e:
                 if if_error == "continue":
                     self.log.error(e)

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -246,10 +246,10 @@ class WeaviateHook(BaseHook):
                         )
                         if dry_run:
                             self.log.info(delete_many_return)
-            except (
-                weaviate.exceptions.UnexpectedStatusCodeException,
-                weaviate.exceptions.WeaviateDeleteManyError,
-            ) as e:
+            except Exception as e:
+                # Capture generic exception to avoid missing any error, but we could anticipate the following errors:
+                # 1. weaviate.exceptions.UnexpectedStatusCodeException
+                # 2. weaviate.exceptions.WeaviateDeleteManyError
                 if if_error == "continue":
                     self.log.error(e)
                     failed_collection_list.append(collection_name)

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -30,7 +30,7 @@ from tenacity import Retrying, retry, retry_if_exception, retry_if_exception_typ
 from weaviate import WeaviateClient
 from weaviate.auth import Auth
 from weaviate.classes.query import Filter
-from weaviate.exceptions import ObjectAlreadyExistsException, UnexpectedStatusCodeError
+from weaviate.exceptions import ObjectAlreadyExistsException
 from weaviate.util import generate_uuid5
 
 from airflow.hooks.base import BaseHook
@@ -242,7 +242,10 @@ class WeaviateHook(BaseHook):
                         self.log.info(attempt)
                         collection = self.get_collection(collection_name)
                         collection.data.delete_many(where=filter_criteria, verbose=verbose, dry_run=dry_run)
-            except UnexpectedStatusCodeError as e:
+            except (
+                weaviate.exceptions.UnexpectedStatusCodeException,
+                weaviate.exceptions.WeaviateDeleteManyError,
+            ) as e:
                 if if_error == "continue":
                     self.log.error(e)
                     failed_collection_list.append(collection_name)

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -197,6 +197,7 @@ class WeaviateHook(BaseHook):
         property_name: str,
         operator: str,
         value: Any,
+        by_property_length: bool = False,
         if_error: str = "stop"
     ) -> bool:
         """
@@ -204,8 +205,9 @@ class WeaviateHook(BaseHook):
 
         :param collection_name: The name of the collection to delete from.
         :param property_name: The property to filter by.
-        :param operator: The filter operator (e.g., 'equal', 'like', 'greater_than').
+        :param operator: The filter operator (contains_all, contains_any, equal, greater_or_equal, greater_than, is_none, less_or_equal, less_than, like, not_equal, within_geo_range)
         :param value: The value for the filter operation.
+        :param by_property_length: True to filter by the length of the property. This filter requires the property length to be indexed.
         :param if_error: define the actions to be taken if there is an error while deleting a collection, possible
          options are `stop` and `continue`
         :return: if `if_error=continue` return list of collections which we failed to delete.
@@ -222,7 +224,7 @@ class WeaviateHook(BaseHook):
             try:
                 # dynamically get the filter method to allow deleting objects in collections based on various filtering criteria,
                 # when there is a filter criteria added/removed from the API, this should adapt to that change.
-                filter_obj = Filter.by_property(property_name)
+                filter_obj = Filter.by_property(property_name, length=by_property_length)
                 if not hasattr(filter_obj, operator):
                     raise ValueError(
                         f"Unsupported filter operator '{operator}'. Expected one of: "

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -206,7 +206,7 @@ class WeaviateHook(BaseHook):
         :param filter_criteria: A `Filter` object defining the filter criteria for deletion.
         :param if_error: define the actions to be taken if there is an error while deleting objects, possible
          options are `stop` and `continue`
-        :param dry_run: Use dryRun to check how many objects would be deleted, without actually performing the deletion.
+        :param dry_run: Use 'dry_run' to check how many objects would be deleted, without actually performing the deletion.
         :param verbose: Set output to 'verbose' to see more details (ID and deletion status) for each deletion
         :return: If `if_error="continue"`, returns list of failed collection names. Else, returns None.
 

--- a/providers/weaviate/tests/unit/weaviate/hooks/test_weaviate.py
+++ b/providers/weaviate/tests/unit/weaviate/hooks/test_weaviate.py
@@ -599,7 +599,9 @@ def test_batch_data_retry(weaviate_hook):
 
 
 @mock.patch("airflow.providers.weaviate.hooks.weaviate.WeaviateHook.get_conn")
-def test_delete_by_properties_retry(get_conn, weaviate_hook):
+def test_delete_by_property_retry(get_conn, weaviate_hook):
+    from weaviate.classes.query import Filter
+
     mock_collection = MagicMock()
     weaviate_hook.get_collection = MagicMock(return_value=mock_collection)
 
@@ -613,15 +615,19 @@ def test_delete_by_properties_retry(get_conn, weaviate_hook):
 
     mock_collection.data.delete_many.side_effect = side_effect
 
-    weaviate_hook.delete_by_properties(collection_names="collection_a", property_name="title", operator="equal", value="Object", if_error="continue")
-
-    assert mock_collection.data.delete_many.call_count == len(
-        side_effect
+    weaviate_hook.delete_by_property(
+        collection_names="collection_a",
+        filter_criteria=Filter.by_property("name").equal("John"),
+        if_error="continue",
     )
+
+    assert mock_collection.data.delete_many.call_count == len(side_effect)
 
 
 @mock.patch("airflow.providers.weaviate.hooks.weaviate.WeaviateHook.get_conn")
-def test_delete_by_properties_get_exception(get_conn, weaviate_hook):
+def test_delete_by_property_get_exception(get_conn, weaviate_hook):
+    from weaviate.classes.query import Filter
+
     collection_names = ["collection_a", "collection_b"]
 
     mock_collection = MagicMock()
@@ -632,15 +638,23 @@ def test_delete_by_properties_get_exception(get_conn, weaviate_hook):
         weaviate.UnexpectedStatusCodeException("something failed", requests.Response()),
         mock_collection,
     ]
-    
-    error_list = weaviate_hook.delete_by_properties(collection_names=collection_names, property_name="title", operator="equal", value="Object", if_error="continue")
+
+    error_list = weaviate_hook.delete_by_property(
+        collection_names=collection_names,
+        filter_criteria=Filter.by_property("name").equal("John"),
+        if_error="continue",
+    )
     assert error_list == ["collection_a"]
 
     get_conn.return_value.collections.get.side_effect = weaviate.UnexpectedStatusCodeException(
         "something failed", requests.Response()
     )
     with pytest.raises(weaviate.UnexpectedStatusCodeException):
-        weaviate_hook.delete_by_properties(collection_names="collection_a", property_name="title", operator="equal", value="Object", if_error="stop")
+        weaviate_hook.delete_by_property(
+            collection_names="collection_a",
+            filter_criteria=Filter.by_property("name").equal("John"),
+            if_error="stop",
+        )
 
 
 @mock.patch("airflow.providers.weaviate.hooks.weaviate.WeaviateHook.get_conn")


### PR DESCRIPTION
### Motivation

By adding the `delete_by_property` method, users can delete multiple objects in multiple collections based on various filtering criteria, making data management more targeted and efficient.

Close #42565 

### Reference

https://weaviate.io/developers/weaviate/search/filters
https://weaviate.io/developers/weaviate/manage-data/delete#delete-multiple-objects

### Testing
1. Two unit tests are created to capture failure scenarios
2. Various filtering criteria have been tested in Jupyter notebook environment to connect to Weaviate and delete objects in collection.
3. Failure scenarios also tested in notebook environment.

### Testing Code Sample
```python
import os
os.environ["WEAVIATE_URL"] = "<REST_ENDPOINT>"
os.environ["WEAVIATE_API_KEY"] = "<API Key>"

import weaviate
from weaviate.classes.init import Auth
from weaviate.classes.query import Filter

weaviate_url = os.environ["WEAVIATE_URL"]
weaviate_api_key = os.environ["WEAVIATE_API_KEY"]

# Connect to Weaviate Cloud
client = weaviate.connect_to_weaviate_cloud(
    cluster_url=weaviate_url,
    auth_credentials=Auth.api_key(weaviate_api_key),
)

def delete_by_property(...): ...

# create collection and add data.
data_rows = [
    {"title": f"Object {i+1}"} for i in range(5)
]

collection = client.collections.get("collection_a")

with collection.batch.fixed_size(batch_size=200) as batch:
    for data_row in data_rows:
        batch.add_object(
            properties=data_row,
        )
        if batch.number_errors > 10:
            print("Batch import stopped due to excessive errors.")
            break

failed_objects = collection.batch.failed_objects
if failed_objects:
    print(f"Number of failed imports: {len(failed_objects)}")
    print(f"First failed object: {failed_objects[0]}")

# Execute the deletion
delete_by_property(
    collection_names="collection_a",
    filter_criteria=Filter.by_property("title").equal("Object 1"),
    if_error="continue"
)
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
