### PR TITLE
Fix get_task_instances typing: allow single items

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -874,7 +874,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         self,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
-        state: list[TaskInstanceState] | None = None,
+        state: TaskInstanceState | Sequence[TaskInstanceState] | None = None,
         session: Session = NEW_SESSION,
     ) -> list[TaskInstance]:
         if not start_date:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

The current implementation uses this argument in one place:
- https://github.com/apache/airflow/blob/c86a4e1582fde083a4c93ea81955f586009177d1/airflow-core/src/airflow/models/dag.py#L890
- This invokes one of the three functions [[1](https://github.com/apache/airflow/blob/c86a4e1582fde083a4c93ea81955f586009177d1/airflow-core/src/airflow/models/dag.py#L899)], [[2](https://github.com/apache/airflow/blob/c86a4e1582fde083a4c93ea81955f586009177d1/airflow-core/src/airflow/models/dag.py#L915)], [[3](https://github.com/apache/airflow/blob/c86a4e1582fde083a4c93ea81955f586009177d1/airflow-core/src/airflow/models/dag.py#L934)], with the following type: `state: TaskInstanceState | Sequence[TaskInstanceState]`


In other parts of the codebase, it's already used by passing a single item rather than a list. [REF](https://github.com/apache/airflow/blob/c86a4e1582fde083a4c93ea81955f586009177d1/airflow-core/src/airflow/ti_deps/dep_context.py#L96)

PS: This is my first time contributing here, please let me know if the format of the PR or the commit message should look different.
