### PR TITLE
Default 'once' start_date to 'now' when None

### DIFF
--- a/airflow-core/newsfragments/50374.feature.rst
+++ b/airflow-core/newsfragments/50374.feature.rst
@@ -1,0 +1,1 @@
+When a dag specifies ``schedule="@once"`` without an explicit ``start_date``, run it as soon as convenient. (Previously, the dag would never run.)

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -101,12 +101,11 @@ class OnceTimetable(_TrivialTimetable):
     ) -> DagRunInfo | None:
         if last_automated_data_interval is not None:
             return None  # Already run, no more scheduling.
-        if restriction.earliest is None:  # No start date, won't run.
-            return None
+        # If the user does not specify an explicit start_date, the dag is ready.
+        run_after = restriction.earliest or timezone.coerce_datetime(timezone.utcnow())
         # "@once" always schedule to the start_date determined by the DAG and
         # tasks, regardless of catchup or not. This has been the case since 1.10
         # and we're inheriting it.
-        run_after = restriction.earliest
         if restriction.latest is not None and run_after > restriction.latest:
             return None
         return DagRunInfo.exact(run_after)

--- a/airflow-core/tests/unit/timetables/test_once_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_once_timetable.py
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+import time_machine
+
+from airflow.timetables.base import DagRunInfo, TimeRestriction
+from airflow.timetables.simple import OnceTimetable
+from airflow.utils import timezone
+
+FROZEN_NOW = timezone.coerce_datetime(datetime.datetime(2025, 3, 4, 5, 6, 7, 8))
+
+PREVIOUS_INFO = DagRunInfo.exact(FROZEN_NOW - datetime.timedelta(days=1))
+
+
+@pytest.mark.parametrize(
+    "prev_info, end_date, expected_next_info",
+    [
+        (None, None, DagRunInfo.exact(FROZEN_NOW)),
+        (None, FROZEN_NOW + datetime.timedelta(days=1), DagRunInfo.exact(FROZEN_NOW)),
+        (None, FROZEN_NOW - datetime.timedelta(days=1), None),
+        (PREVIOUS_INFO, None, None),
+        (PREVIOUS_INFO, FROZEN_NOW + datetime.timedelta(days=1), None),
+        (PREVIOUS_INFO, FROZEN_NOW - datetime.timedelta(days=1), None),
+    ],
+)
+@pytest.mark.parametrize("catchup", [True, False])  # Irrelevant for @once.
+@time_machine.travel(FROZEN_NOW)
+def test_no_start_date_means_now(catchup, prev_info, end_date, expected_next_info):
+    timetable = OnceTimetable()
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=prev_info,
+        restriction=TimeRestriction(earliest=None, latest=end_date, catchup=catchup),
+    )
+    assert next_info == expected_next_info


### PR DESCRIPTION
Previously, when a dag does not have start_date, 'once' would never run because the scheduler does not know when to do that one run. This was not particularly problematic in Airflow 2 since you almost always are expected to provide an explicit start_date to a dag.

In Airflow 3, however, since start_date=None is the implicit default, it is more common for people to forget about the start_date, and be surprised when the dag never runs. After some brief discussion, it's decided that it's more intuitive for this argument combination to run the dag 'as soon as convenient' instead.

See also: https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1747371756970659

Close #50374.