### PR TITLE
Fix SQLite Lock error in TestTaskInstancesLog setup

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -82,7 +82,8 @@ class TestTaskInstancesLog:
             ti.id = str(uuid7())
             ti.hostname = "localhost"
             session.merge(ti)
-            session.flush()
+        # Commit changes to avoid locks
+        session.commit()
 
         # Add dummy dag for checking picking correct log with same task_id and different dag_id case.
         with dag_maker(
@@ -106,8 +107,9 @@ class TestTaskInstancesLog:
             ti.id = str(uuid7())
             ti.hostname = "localhost"
             session.merge(ti)
-            session.flush()
-        session.flush()
+
+        # Final commit to ensure all changes are persisted
+        session.commit()
 
         dagbag = create_dag_bag()
         dagbag.bag_dag(dag)


### PR DESCRIPTION

related: #50175

## Why

The `TestTaskInstancesLog.setup_attrs` might cause `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked` error.

For example: https://github.com/apache/airflow/actions/runs/15097906931/job/42435158054?pr=50175
