### PR TITLE
Fetch only the most recent dagrun value to be used in dag header.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -59,7 +59,7 @@ export const Dag = () => {
     data: runsData,
     error: runsError,
     isLoading: isLoadingRuns,
-  } = useDagsServiceRecentDagRuns({ dagIds: [dagId] }, undefined, {
+  } = useDagsServiceRecentDagRuns({ dagIds: [dagId], dagRunsLimit: 1 }, undefined, {
     enabled: Boolean(dagId),
     refetchInterval: (query) =>
       query.state.data?.dags


### PR DESCRIPTION
The API by default fetches 10 recent dag runs but only the latest run is used in the header information. Passing the limit as 1 saves data and query output. On an example dag with several dag runs it reduces the data from 8kb to 1kb . This is more useful when there is a pending dagrun and makes autorefresh to be more efficient.

https://github.com/apache/airflow/blob/d176113630d6b7d4bc36511fe3f8cb013060d675/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx#L45