### PR TITLE
Mask variable values in task logs only if the variable key is sensitive

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1034,7 +1034,7 @@ class ActivitySubprocess(WatchedSubprocess):
             var = self.client.variables.get(msg.key)
             if isinstance(var, VariableResponse):
                 if var.value:
-                    mask_secret(var.value)
+                    mask_secret(var.value, var.key)
                 var_result = VariableResult.from_variable_response(var)
                 resp = var_result
                 dump_opts = {"exclude_unset": True}

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -995,7 +995,7 @@ class TestHandleRequest:
                 ("test_conn",),
                 {},
                 ConnectionResult(conn_id="test_conn", conn_type="mysql"),
-                [],
+                None,
                 id="get_connection",
             ),
             pytest.param(
@@ -1015,7 +1015,7 @@ class TestHandleRequest:
                 ("test_conn",),
                 {},
                 ConnectionResult(conn_id="test_conn", conn_type="mysql", schema="mysql"),  # type: ignore[call-arg]
-                [],
+                None,
                 id="get_connection_with_alias",
             ),
             pytest.param(
@@ -1035,7 +1035,7 @@ class TestHandleRequest:
                 ("test_key", "test_value", "test_description"),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="set_variable",
             ),
             pytest.param(
@@ -1045,7 +1045,7 @@ class TestHandleRequest:
                 ("test_key",),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="delete_variable",
             ),
             pytest.param(
@@ -1055,7 +1055,7 @@ class TestHandleRequest:
                 (TI_ID, DeferTask(next_method="execute_callback", classpath="my-classpath")),
                 {},
                 "",
-                [],
+                None,
                 id="patch_task_instance_to_deferred",
             ),
             pytest.param(
@@ -1074,7 +1074,7 @@ class TestHandleRequest:
                 ),
                 {},
                 "",
-                [],
+                None,
                 id="patch_task_instance_to_up_for_reschedule",
             ),
             pytest.param(
@@ -1084,7 +1084,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", None, False),
                 {},
                 XComResult(key="test_key", value="test_value"),
-                [],
+                None,
                 id="get_xcom",
             ),
             pytest.param(
@@ -1096,7 +1096,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", 2, False),
                 {},
                 XComResult(key="test_key", value="test_value"),
-                [],
+                None,
                 id="get_xcom_map_index",
             ),
             pytest.param(
@@ -1106,7 +1106,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", None, False),
                 {},
                 XComResult(key="test_key", value=None, type="XComResult"),
-                [],
+                None,
                 id="get_xcom_not_found",
             ),
             pytest.param(
@@ -1122,7 +1122,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", None, True),
                 {},
                 XComResult(key="test_key", value=None, type="XComResult"),
-                [],
+                None,
                 id="get_xcom_include_prior_dates",
             ),
             pytest.param(
@@ -1146,7 +1146,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="set_xcom",
             ),
             pytest.param(
@@ -1171,7 +1171,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="set_xcom_with_map_index",
             ),
             pytest.param(
@@ -1197,7 +1197,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="set_xcom_with_map_index_and_mapped_length",
             ),
             pytest.param(
@@ -1219,7 +1219,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="delete_xcom",
             ),
             # we aren't adding all states under TaskInstanceState here, because this test's scope is only to check
@@ -1231,7 +1231,7 @@ class TestHandleRequest:
                 (),
                 {},
                 "",
-                [],
+                None,
                 id="patch_task_instance_to_skipped",
             ),
             pytest.param(
@@ -1247,7 +1247,7 @@ class TestHandleRequest:
                     "rendered_map_index": "test retry task",
                 },
                 "",
-                [],
+                None,
                 id="up_for_retry",
             ),
             pytest.param(
@@ -1257,7 +1257,7 @@ class TestHandleRequest:
                 (TI_ID, {"field1": "rendered_value1", "field2": "rendered_value2"}),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="set_rtif",
             ),
             pytest.param(
@@ -1267,7 +1267,7 @@ class TestHandleRequest:
                 [],
                 {"name": "asset"},
                 AssetResult(name="asset", uri="s3://bucket/obj", group="asset"),
-                [],
+                None,
                 id="get_asset_by_name",
             ),
             pytest.param(
@@ -1277,7 +1277,7 @@ class TestHandleRequest:
                 [],
                 {"uri": "s3://bucket/obj"},
                 AssetResult(name="asset", uri="s3://bucket/obj", group="asset"),
-                [],
+                None,
                 id="get_asset_by_uri",
             ),
             pytest.param(
@@ -1300,7 +1300,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
-                [],
+                None,
                 id="get_asset_events_by_uri_and_name",
             ),
             pytest.param(
@@ -1323,7 +1323,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
-                [],
+                None,
                 id="get_asset_events_by_uri",
             ),
             pytest.param(
@@ -1346,7 +1346,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
-                [],
+                None,
                 id="get_asset_events_by_name",
             ),
             pytest.param(
@@ -1369,7 +1369,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
-                [],
+                None,
                 id="get_asset_events_by_asset_alias",
             ),
             pytest.param(
@@ -1387,7 +1387,7 @@ class TestHandleRequest:
                     "rendered_map_index": "test success task",
                 },
                 "",
-                [],
+                None,
                 id="succeed_task",
             ),
             pytest.param(
@@ -1406,7 +1406,7 @@ class TestHandleRequest:
                     data_interval_start=timezone.parse("2025-01-10T12:00:00Z"),
                     data_interval_end=timezone.parse("2025-01-10T14:00:00Z"),
                 ),
-                [],
+                None,
                 id="get_prev_successful_dagrun",
             ),
             pytest.param(
@@ -1422,7 +1422,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", {"key": "value"}, timezone.datetime(2025, 1, 1), True),
                 {},
                 OKResponse(ok=True),
-                [],
+                None,
                 id="dag_run_trigger",
             ),
             pytest.param(
@@ -1432,7 +1432,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", None, None, False),
                 {},
                 ErrorResponse(error=ErrorType.DAGRUN_ALREADY_EXISTS),
-                [],
+                None,
                 id="dag_run_trigger_already_exists",
             ),
             pytest.param(
@@ -1442,7 +1442,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run"),
                 {},
                 DagRunStateResult(state=DagRunState.RUNNING),
-                [],
+                None,
                 id="get_dag_run_state",
             ),
             pytest.param(
@@ -1452,7 +1452,7 @@ class TestHandleRequest:
                 (TI_ID, 1),
                 {},
                 TaskRescheduleStartDate(start_date=timezone.parse("2024-10-31T12:00:00Z")),
-                [],
+                None,
                 id="get_task_reschedule_start_date",
             ),
             pytest.param(
@@ -1470,7 +1470,7 @@ class TestHandleRequest:
                     "task_ids": ["task1", "task2"],
                 },
                 TICount(count=2),
-                [],
+                None,
                 id="get_ti_count",
             ),
             pytest.param(
@@ -1485,7 +1485,7 @@ class TestHandleRequest:
                     "states": ["success", "failed"],
                 },
                 DRCount(count=2),
-                [],
+                None,
                 id="get_dr_count",
             ),
             pytest.param(
@@ -1502,7 +1502,7 @@ class TestHandleRequest:
                     "task_group_id": "test_group",
                 },
                 TaskStatesResult(task_states={"run_id": {"task1": "success", "task2": "failed"}}),
-                [],
+                None,
                 id="get_task_states",
             ),
             pytest.param(
@@ -1518,7 +1518,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", 0),
                 {},
                 XComResult(key="test_key", value="test_value"),
-                [],
+                None,
                 id="get_xcom_seq_item",
             ),
             pytest.param(
@@ -1534,7 +1534,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", 2),
                 {},
                 ErrorResponse(error=ErrorType.XCOM_NOT_FOUND),
-                [],
+                None,
                 id="get_xcom_seq_item_not_found",
             ),
         ],

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -978,7 +978,15 @@ class TestHandleRequest:
 
     @patch("airflow.sdk.execution_time.supervisor.mask_secret")
     @pytest.mark.parametrize(
-        ["message", "expected_buffer", "client_attr_path", "method_arg", "method_kwarg", "mock_response"],
+        [
+            "message",
+            "expected_buffer",
+            "client_attr_path",
+            "method_arg",
+            "method_kwarg",
+            "mock_response",
+            "mask_secret_args",
+        ],
         [
             pytest.param(
                 GetConnection(conn_id="test_conn"),
@@ -987,7 +995,18 @@ class TestHandleRequest:
                 ("test_conn",),
                 {},
                 ConnectionResult(conn_id="test_conn", conn_type="mysql"),
+                [],
                 id="get_connection",
+            ),
+            pytest.param(
+                GetConnection(conn_id="test_conn"),
+                b'{"conn_id":"test_conn","conn_type":"mysql","password":"password","type":"ConnectionResult"}\n',
+                "connections.get",
+                ("test_conn",),
+                {},
+                ConnectionResult(conn_id="test_conn", conn_type="mysql", password="password"),
+                ["password"],
+                id="get_connection_with_password",
             ),
             pytest.param(
                 GetConnection(conn_id="test_conn"),
@@ -996,6 +1015,7 @@ class TestHandleRequest:
                 ("test_conn",),
                 {},
                 ConnectionResult(conn_id="test_conn", conn_type="mysql", schema="mysql"),  # type: ignore[call-arg]
+                [],
                 id="get_connection_with_alias",
             ),
             pytest.param(
@@ -1005,6 +1025,7 @@ class TestHandleRequest:
                 ("test_key",),
                 {},
                 VariableResult(key="test_key", value="test_value"),
+                ["test_value", "test_key"],
                 id="get_variable",
             ),
             pytest.param(
@@ -1014,6 +1035,7 @@ class TestHandleRequest:
                 ("test_key", "test_value", "test_description"),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="set_variable",
             ),
             pytest.param(
@@ -1023,6 +1045,7 @@ class TestHandleRequest:
                 ("test_key",),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="delete_variable",
             ),
             pytest.param(
@@ -1032,6 +1055,7 @@ class TestHandleRequest:
                 (TI_ID, DeferTask(next_method="execute_callback", classpath="my-classpath")),
                 {},
                 "",
+                [],
                 id="patch_task_instance_to_deferred",
             ),
             pytest.param(
@@ -1050,6 +1074,7 @@ class TestHandleRequest:
                 ),
                 {},
                 "",
+                [],
                 id="patch_task_instance_to_up_for_reschedule",
             ),
             pytest.param(
@@ -1059,6 +1084,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", None, False),
                 {},
                 XComResult(key="test_key", value="test_value"),
+                [],
                 id="get_xcom",
             ),
             pytest.param(
@@ -1070,6 +1096,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", 2, False),
                 {},
                 XComResult(key="test_key", value="test_value"),
+                [],
                 id="get_xcom_map_index",
             ),
             pytest.param(
@@ -1079,6 +1106,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", None, False),
                 {},
                 XComResult(key="test_key", value=None, type="XComResult"),
+                [],
                 id="get_xcom_not_found",
             ),
             pytest.param(
@@ -1094,6 +1122,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", None, True),
                 {},
                 XComResult(key="test_key", value=None, type="XComResult"),
+                [],
                 id="get_xcom_include_prior_dates",
             ),
             pytest.param(
@@ -1117,6 +1146,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="set_xcom",
             ),
             pytest.param(
@@ -1141,6 +1171,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="set_xcom_with_map_index",
             ),
             pytest.param(
@@ -1166,6 +1197,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="set_xcom_with_map_index_and_mapped_length",
             ),
             pytest.param(
@@ -1187,6 +1219,7 @@ class TestHandleRequest:
                 ),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="delete_xcom",
             ),
             # we aren't adding all states under TaskInstanceState here, because this test's scope is only to check
@@ -1198,6 +1231,7 @@ class TestHandleRequest:
                 (),
                 {},
                 "",
+                [],
                 id="patch_task_instance_to_skipped",
             ),
             pytest.param(
@@ -1213,6 +1247,7 @@ class TestHandleRequest:
                     "rendered_map_index": "test retry task",
                 },
                 "",
+                [],
                 id="up_for_retry",
             ),
             pytest.param(
@@ -1222,6 +1257,7 @@ class TestHandleRequest:
                 (TI_ID, {"field1": "rendered_value1", "field2": "rendered_value2"}),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="set_rtif",
             ),
             pytest.param(
@@ -1231,6 +1267,7 @@ class TestHandleRequest:
                 [],
                 {"name": "asset"},
                 AssetResult(name="asset", uri="s3://bucket/obj", group="asset"),
+                [],
                 id="get_asset_by_name",
             ),
             pytest.param(
@@ -1240,6 +1277,7 @@ class TestHandleRequest:
                 [],
                 {"uri": "s3://bucket/obj"},
                 AssetResult(name="asset", uri="s3://bucket/obj", group="asset"),
+                [],
                 id="get_asset_by_uri",
             ),
             pytest.param(
@@ -1262,6 +1300,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
+                [],
                 id="get_asset_events_by_uri_and_name",
             ),
             pytest.param(
@@ -1284,6 +1323,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
+                [],
                 id="get_asset_events_by_uri",
             ),
             pytest.param(
@@ -1306,6 +1346,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
+                [],
                 id="get_asset_events_by_name",
             ),
             pytest.param(
@@ -1328,6 +1369,7 @@ class TestHandleRequest:
                         )
                     ]
                 ),
+                [],
                 id="get_asset_events_by_asset_alias",
             ),
             pytest.param(
@@ -1345,6 +1387,7 @@ class TestHandleRequest:
                     "rendered_map_index": "test success task",
                 },
                 "",
+                [],
                 id="succeed_task",
             ),
             pytest.param(
@@ -1363,6 +1406,7 @@ class TestHandleRequest:
                     data_interval_start=timezone.parse("2025-01-10T12:00:00Z"),
                     data_interval_end=timezone.parse("2025-01-10T14:00:00Z"),
                 ),
+                [],
                 id="get_prev_successful_dagrun",
             ),
             pytest.param(
@@ -1378,6 +1422,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", {"key": "value"}, timezone.datetime(2025, 1, 1), True),
                 {},
                 OKResponse(ok=True),
+                [],
                 id="dag_run_trigger",
             ),
             pytest.param(
@@ -1387,6 +1432,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", None, None, False),
                 {},
                 ErrorResponse(error=ErrorType.DAGRUN_ALREADY_EXISTS),
+                [],
                 id="dag_run_trigger_already_exists",
             ),
             pytest.param(
@@ -1396,6 +1442,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run"),
                 {},
                 DagRunStateResult(state=DagRunState.RUNNING),
+                [],
                 id="get_dag_run_state",
             ),
             pytest.param(
@@ -1405,6 +1452,7 @@ class TestHandleRequest:
                 (TI_ID, 1),
                 {},
                 TaskRescheduleStartDate(start_date=timezone.parse("2024-10-31T12:00:00Z")),
+                [],
                 id="get_task_reschedule_start_date",
             ),
             pytest.param(
@@ -1422,6 +1470,7 @@ class TestHandleRequest:
                     "task_ids": ["task1", "task2"],
                 },
                 TICount(count=2),
+                [],
                 id="get_ti_count",
             ),
             pytest.param(
@@ -1436,6 +1485,7 @@ class TestHandleRequest:
                     "states": ["success", "failed"],
                 },
                 DRCount(count=2),
+                [],
                 id="get_dr_count",
             ),
             pytest.param(
@@ -1452,6 +1502,7 @@ class TestHandleRequest:
                     "task_group_id": "test_group",
                 },
                 TaskStatesResult(task_states={"run_id": {"task1": "success", "task2": "failed"}}),
+                [],
                 id="get_task_states",
             ),
             pytest.param(
@@ -1467,6 +1518,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", 0),
                 {},
                 XComResult(key="test_key", value="test_value"),
+                [],
                 id="get_xcom_seq_item",
             ),
             pytest.param(
@@ -1482,6 +1534,7 @@ class TestHandleRequest:
                 ("test_dag", "test_run", "test_task", "test_key", 2),
                 {},
                 ErrorResponse(error=ErrorType.XCOM_NOT_FOUND),
+                [],
                 id="get_xcom_seq_item_not_found",
             ),
         ],
@@ -1498,6 +1551,7 @@ class TestHandleRequest:
         method_arg,
         method_kwarg,
         mock_response,
+        mask_secret_args,
     ):
         """
         Test handling of different messages to the subprocess. For any new message type, add a
@@ -1523,8 +1577,8 @@ class TestHandleRequest:
         msg = message.model_dump_json().encode() + b"\n"
         generator.send(msg)
 
-        if isinstance(message, GetVariable):
-            mock_mask_secret.assert_called_with("test_value", "test_key")
+        if mask_secret_args:
+            mock_mask_secret.assert_called_with(*mask_secret_args)
 
         time_machine.move_to(timezone.datetime(2024, 10, 31), tick=False)
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -92,7 +92,6 @@ from airflow.sdk.execution_time.comms import (
     VariableResult,
     XComResult,
 )
-from airflow.sdk.execution_time.secrets_masker import SecretsMasker
 from airflow.sdk.execution_time.supervisor import (
     BUFFER_SIZE,
     ActivitySubprocess,
@@ -978,7 +977,6 @@ class TestHandleRequest:
         return subprocess, read_end
 
     @patch("airflow.sdk.execution_time.supervisor.mask_secret")
-    @patch("airflow.sdk.execution_time.secrets_masker._secrets_masker")
     @pytest.mark.parametrize(
         ["message", "expected_buffer", "client_attr_path", "method_arg", "method_kwarg", "mock_response"],
         [
@@ -1490,7 +1488,6 @@ class TestHandleRequest:
     )
     def test_handle_requests(
         self,
-        mock_secrets_masker,
         mock_mask_secret,
         watched_subprocess,
         mocker,
@@ -1513,7 +1510,6 @@ class TestHandleRequest:
             3. Checks that the buffer is updated with the expected response.
             4. Verifies that the response is correctly decoded.
         """
-        mock_secrets_masker.return_value = SecretsMasker()
         watched_subprocess, read_socket = watched_subprocess
 
         # Mock the client method. E.g. `client.variables.get` or `client.connections.get`
@@ -1528,7 +1524,6 @@ class TestHandleRequest:
         generator.send(msg)
 
         if isinstance(message, GetVariable):
-            mock_mask_secret.assert_called_once()
             mock_mask_secret.assert_called_with("test_value", "test_key")
 
         time_machine.move_to(timezone.datetime(2024, 10, 31), tick=False)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


For a dag like this:

```
from __future__ import annotations

from airflow.models.baseoperator import BaseOperator
from airflow import DAG
from airflow.sdk import Variable

class CustomOperator(BaseOperator):
    def execute(self, context):
        v = Variable.get(key="key1")
        print("Got value", v)


with DAG("get-var-sdk", schedule=None, catchup=False) as dag:
    CustomOperator(task_id="set_var")
```

We shouldn't mask the value of the variable in logs unless the key is sensitive. As of now, we always mask it. This means that irrespective of the value, it will always be masked. This will block users from printing variable values in their tasks.


After changes:
![image](https://github.com/user-attachments/assets/069f9d99-73b3-4e22-bd26-0cdd6151c78e)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
