### PR TITLE
Remove occupied slots from PoolBar

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -38,7 +38,6 @@ export const PoolSummary = () => {
   const totalSlots = pools?.reduce((sum, pool) => sum + pool.slots, 0) ?? 0;
   const aggregatePool: Slots = {
     deferred_slots: 0,
-    occupied_slots: 0,
     open_slots: 0,
     queued_slots: 0,
     running_slots: 0,
@@ -47,7 +46,6 @@ export const PoolSummary = () => {
 
   const poolsWithSlotType: Slots = {
     deferred_slots: 0,
-    occupied_slots: 0,
     open_slots: 0,
     queued_slots: 0,
     running_slots: 0,

--- a/airflow-core/src/airflow/ui/src/utils/slots.tsx
+++ b/airflow-core/src/airflow/ui/src/utils/slots.tsx
@@ -18,12 +18,13 @@
  */
 
 /* eslint-disable perfectionist/sort-objects */
-import { FiXCircle } from "react-icons/fi";
-
 import type { PoolResponse } from "openapi/requests/types.gen";
 import { StateIcon } from "src/components/StateIcon";
 
-export type Slots = Omit<PoolResponse, "description" | "include_deferred" | "name" | "slots">;
+export type Slots = Omit<
+  PoolResponse,
+  "description" | "include_deferred" | "name" | "occupied_slots" | "slots"
+>;
 export type SlotConfig = {
   color: string;
   icon: JSX.Element;
@@ -35,11 +36,6 @@ export const slotConfigs: Array<SlotConfig> = [
     key: "open_slots",
     color: "success",
     icon: <StateIcon color="white" state="success" />,
-  },
-  {
-    key: "occupied_slots",
-    color: "up_for_retry",
-    icon: <FiXCircle color="white" />,
   },
   {
     key: "running_slots",
@@ -65,7 +61,6 @@ export const slotConfigs: Array<SlotConfig> = [
 
 export const slotKeys: Array<keyof Slots> = [
   "deferred_slots",
-  "occupied_slots",
   "open_slots",
   "queued_slots",
   "running_slots",


### PR DESCRIPTION
Occupied slots were redundant with queued, running, deferred. The UI was then counting every occupied slot twice, instead we should just show queued/running/deferred slots.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
