### PR TITLE
Access deprecated expose_config from core

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/config.py
@@ -70,11 +70,11 @@ text_example_response_for_get_config = {
 
 def _check_expose_config() -> bool:
     display_sensitive: bool | None = None
-    if conf.get("api", "expose_config").lower() == "non-sensitive-only":
+    if conf.get("webserver", "expose_config").lower() == "non-sensitive-only":
         expose_config = True
         display_sensitive = False
     else:
-        expose_config = conf.getboolean("api", "expose_config")
+        expose_config = conf.getboolean("webserver", "expose_config")
         display_sensitive = True
 
     if not expose_config:


### PR DESCRIPTION
Follow up of: https://github.com/apache/airflow/pull/50209

Access the deprecated conf from core. (api section might not be in the conf yet)