### PR TITLE
Change the tag format for Python client release

### DIFF
--- a/dev/README_RELEASE_PYTHON_CLIENT.md
+++ b/dev/README_RELEASE_PYTHON_CLIENT.md
@@ -148,8 +148,8 @@ Then open a PR and merge it into main.
 
 ```shell script
 cd ${AIRFLOW_REPO_ROOT}
-git tag -s python-client-${VERSION}${VERSION_SUFFIX} -m "Airflow Python Client ${VERSION}${VERSION_SUFFIX}"
-git push apache python-client-${VERSION}${VERSION_SUFFIX}
+git tag -s python-client/${VERSION}${VERSION_SUFFIX} -m "Airflow Python Client ${VERSION}${VERSION_SUFFIX}"
+git push apache python-client/${VERSION}${VERSION_SUFFIX}
 cd ${CLIENT_REPO_ROOT}
 git tag -s ${VERSION}${VERSION_SUFFIX} -m "Airflow Python Client ${VERSION}${VERSION_SUFFIX}"
 git push apache tag ${VERSION}${VERSION_SUFFIX}
@@ -329,7 +329,7 @@ you are checking):
 
 ```shell script
 VERSION=X.Y.Zrc1
-git checkout python-client-${VERSION}
+git checkout python-client/${VERSION}
 export AIRFLOW_REPO_ROOT=$(pwd)
 rm -rf dist/*
 breeze release-management prepare-python-client --distribution-format both
@@ -602,9 +602,9 @@ twine upload -r pypi *.tar.gz *.whl
 
 ```shell script
 cd ${AIRFLOW_REPO_ROOT}
-git checkout python-client-${VERSION}${VERSION_SUFFIX}
-git tag -s python-client-${VERSION} -m "Airflow Python Client ${VERSION}"
-git push apache tag python-client-${VERSION}
+git checkout python-client/${VERSION}${VERSION_SUFFIX}
+git tag -s python-client/${VERSION} -m "Airflow Python Client ${VERSION}"
+git push apache tag python-client/${VERSION}
 cd ${CLIENT_REPO_ROOT}
 git checkout ${VERSION}${VERSION_SUFFIX}
 git tag -s ${VERSION} -m ${VERSION}


### PR DESCRIPTION
Changes it from `python-client-3.0.0rc1` to `python-client/3.0.0rc1` to be consistent with our other distributions

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
