### PR TITLE
Creating `S3KeysUpsertedTrigger` to "Watch" an S3 Asset

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -815,7 +815,7 @@ class S3Hook(AwsBaseHook):
         from_datetime: datetime | None = None,
         to_datetime: datetime | None = None,
         object_filter: Callable[..., list] | None = None,
-        apply_wildcard: bool = False
+        apply_wildcard: bool = False,
     ) -> list:
         """
         List keys in a bucket under prefix and not containing delimiter.
@@ -879,14 +879,12 @@ class S3Hook(AwsBaseHook):
         )
 
         keys: list[str] = []
-
         for page in response:
             if "Contents" in page:
                 new_keys = page["Contents"]
                 if _apply_wildcard:
                     new_keys = (k for k in new_keys if fnmatch.fnmatch(k["Key"], _original_prefix))
                 keys.extend(new_keys)
-
         if object_filter_usr is not None:
             return object_filter_usr(keys, from_datetime, to_datetime)
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -683,13 +683,6 @@ class S3Hook(AwsBaseHook):
                 return False
             return True
 
-        for key in keys:
-            print(f"from_datetime: {from_datetime}")
-            print(f"to_datetime: {to_datetime}")
-            print(f"LastModified (value)  : {key['LastModified']}")
-            print(f"LastModified (type)   : {type(key['LastModified'])}")
-            break
-
         return [k["Key"] for k in keys if _is_in_period(k["LastModified"])]
 
     async def is_keys_unchanged_async(

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -809,6 +809,7 @@ class S3Hook(AwsBaseHook):
         to_datetime: datetime | None = None,
         object_filter: Callable[..., list] | None = None,
         apply_wildcard: bool = False,
+        is_async: bool = False
     ) -> list:
         """
         List keys in a bucket under prefix and not containing delimiter.
@@ -828,6 +829,7 @@ class S3Hook(AwsBaseHook):
         :param object_filter: Function that receives the list of the S3 objects, from_datetime and
             to_datetime and returns the List of matched key.
         :param apply_wildcard: whether to treat '*' as a wildcard or a plain symbol in the prefix.
+        :param is_async: whether to return a list of keys asynchronously
 
         **Example**: Returns the list of S3 object with LastModified attr greater than from_datetime
              and less than to_datetime:
@@ -872,12 +874,31 @@ class S3Hook(AwsBaseHook):
         )
 
         keys: list[str] = []
-        for page in response:
-            if "Contents" in page:
-                new_keys = page["Contents"]
-                if _apply_wildcard:
-                    new_keys = (k for k in new_keys if fnmatch.fnmatch(k["Key"], _original_prefix))
-                keys.extend(new_keys)
+
+        if is_async:
+            async def _filter_keys():
+                # keys_async
+                keys_async: list[str] = []
+                async for page_async in response:
+                    if "Contents" in page_async:
+                        new_keys_async = page_async["Contents"]
+                        if _apply_wildcard:
+                            new_keys_async = (
+                                k for k in new_keys_async if fnmatch.fnmatch(k["Key"], _original_prefix)
+                            )
+                        keys_async.extend(new_keys_async)
+                    return keys_async
+
+            keys.extend(asyncio.run(_filter_keys()))
+
+        else:
+            for page in response:
+                if "Contents" in page:
+                    new_keys = page["Contents"]
+                    if _apply_wildcard:
+                        new_keys = (k for k in new_keys if fnmatch.fnmatch(k["Key"], _original_prefix))
+                    keys.extend(new_keys)
+
         if object_filter_usr is not None:
             return object_filter_usr(keys, from_datetime, to_datetime)
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/s3.py
@@ -285,7 +285,7 @@ class S3KeyUpsertedTrigger(BaseEventTrigger):
                                 # "from_datetime": self.from_datetime.isoformat(),
                             })
 
-                        continue
+                        return  # Since we are persisting state, we can now return
 
                     self.log.info("Sleeping for %s seconds", self.poke_interval)
                     await asyncio.sleep(self.poke_interval)

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/s3.py
@@ -245,7 +245,7 @@ class S3KeyUpsertedTrigger(BaseEventTrigger):
                                 "last_activity_time": self.last_activity_time.isoformat(),
                             })
 
-                        return
+                        continue
 
                     self.log.info("Sleeping for %s seconds", self.poke_interval)
                     await asyncio.sleep(self.poke_interval)


### PR DESCRIPTION
**This description will be changed once it moved out of "Draft" state.*

I'm building a Trigger that would be used to monitor a certain key in S3, waiting for that key to exist or be updated. However, I'm having difficulty persisting state between Trigger runs. Once a Trigger event(s) is yielded and the `run` method completes execution. The `last_activity_time` timestamp is wiped. This means that my Trigger runs in a sort of "infinite loop". 

What is the best way for us to maintain state across "Asset Watches"? I think this is an inherent downside of using Trigger exclusively to build `AssetWatchers`, without the ability to "customize" that logic.

**EDIT:**

**I've removed the `return`, this solves the issue that I previously had, but prevents the `Trigger` `run` from completing.**
 