### PR TITLE
Port `task.test` to Task SDK

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -177,11 +177,6 @@ ARG_OUTPUT_PATH = Arg(
     type=str,
     default="[CWD]" if BUILD_DOCS else os.getcwd(),
 )
-ARG_DRY_RUN = Arg(
-    ("-n", "--dry-run"),
-    help="Perform a dry run for each task. Only renders Template Fields for each task, nothing else",
-    action="store_true",
-)
 ARG_PID = Arg(("--pid",), help="PID file location", nargs="?")
 ARG_DAEMON = Arg(
     ("-D", "--daemon"), help="Daemonize instead of running in the foreground", action="store_true"
@@ -1270,7 +1265,6 @@ TASKS_COMMANDS = (
             ARG_TASK_ID,
             ARG_LOGICAL_DATE_OR_RUN_ID_OPTIONAL,
             ARG_BUNDLE_NAME,
-            ARG_DRY_RUN,
             ARG_TASK_PARAMS,
             ARG_POST_MORTEM,
             ARG_ENV_VARS,

--- a/airflow-core/src/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow-core/src/airflow/example_dags/example_passing_params_via_test_command.py
@@ -46,15 +46,14 @@ def my_py_command(params, test_mode=None, task=None):
 
 
 @task(task_id="env_var_test_task")
-def print_env_vars(test_mode=None):
+def print_env_vars():
     """
     Print out the "foo" param passed in via
     `airflow tasks test example_passing_params_via_test_command env_var_test_task <date>
     --env-vars '{"foo":"bar"}'`
     """
-    if test_mode:
-        print(f"foo={os.environ.get('foo')}")
-        print(f"AIRFLOW_TEST_MODE={os.environ.get('AIRFLOW_TEST_MODE')}")
+    print(f"foo={os.environ.get('foo')}")
+    print(f"AIRFLOW_TEST_MODE={os.environ.get('AIRFLOW_TEST_MODE')}")
 
 
 with DAG(

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -159,10 +159,9 @@ class TestCliTasks:
         args = self.parser.parse_args(["tasks", "test", self.dag_id, task_id, DEFAULT_DATE.isoformat()])
         with caplog.at_level("INFO", logger="airflow.task"):
             task_command.task_test(args)
-        assert (
-            f"Marking task as SUCCESS. dag_id={self.dag_id}, task_id={task_id}, run_id={self.run_id}, "
-            in caplog.text
-        )
+        ti = self.dag_run.get_task_instance(task_id=task_id)
+        assert ti is not None
+        assert ti.state == State.SUCCESS
 
     @pytest.mark.enable_redact
     def test_test_filters_secrets(self, capsys):
@@ -177,12 +176,16 @@ class TestCliTasks:
             ["tasks", "test", "example_python_operator", "print_the_context", "2018-01-01"],
         )
 
-        with mock.patch("airflow.models.TaskInstance.run", side_effect=lambda *_, **__: print(password)):
+        with mock.patch(
+            "airflow.cli.commands.task_command._run_task", side_effect=lambda *_, **__: print(password)
+        ):
             task_command.task_test(args)
         assert capsys.readouterr().out.endswith("***\n")
 
         not_password = "!4321drowssapemos"
-        with mock.patch("airflow.models.TaskInstance.run", side_effect=lambda *_, **__: print(not_password)):
+        with mock.patch(
+            "airflow.cli.commands.task_command._run_task", side_effect=lambda *_, **__: print(not_password)
+        ):
             task_command.task_test(args)
         assert capsys.readouterr().out.endswith(f"{not_password}\n")
 
@@ -234,7 +237,9 @@ class TestCliTasks:
         assert "AIRFLOW_TEST_MODE=True" in output
 
     @mock.patch("airflow.providers.standard.triggers.file.os.path.getmtime", return_value=0)
-    @mock.patch("airflow.providers.standard.triggers.file.glob", return_value=["/tmp/test"])
+    @mock.patch(
+        "airflow.providers.standard.triggers.file.glob", return_value=["/tmp/temporary_file_for_testing"]
+    )
     @mock.patch("airflow.providers.standard.triggers.file.os")
     @mock.patch("airflow.providers.standard.sensors.filesystem.FileSensor.poke", return_value=False)
     def test_cli_test_with_deferrable_operator(self, mock_pock, mock_os, mock_glob, mock_getmtime, caplog):
@@ -252,7 +257,7 @@ class TestCliTasks:
                 )
             )
             output = caplog.text
-        assert "wait_for_file_async completed successfully as /tmp/temporary_file_for_testing found" in output
+        assert "Found File /tmp/temporary_file_for_testing" in output
 
     def test_task_render(self):
         """

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1244,8 +1244,9 @@ def _run_task(*, ti):
             )
 
             msg = taskrun_result.msg
+            ti.set_state(taskrun_result.ti.state)
 
-            if taskrun_result.ti.state == State.DEFERRED and isinstance(msg, DeferTask):
+            if ti.state == State.DEFERRED and isinstance(msg, DeferTask):
                 # API Server expects the task instance to be in QUEUED state before
                 # resuming from deferral.
                 ti.set_state(State.QUEUED)


### PR DESCRIPTION
Follow-up of https://github.com/apache/airflow/pull/50300 for running a single task.

Post this, the next is to modify / remove `ti.run` usage in tests


Dag used to test:

```py
from airflow.sdk import Variable, dag, task

@dag
def ample_simplest_dag():

    @task
    def my_task():
        print("hellooo")
        import os
        os.environ["AIRFLOW_VAR_MY_VARIABLE"] = "my_value"
        assert Variable.get("my_variable") == "my_value"

    my_task()


d = ample_simplest_dag()
```

and then ran:

```shell
root@75043446567f:/opt/airflow# airflow tasks test ample_simplest_dag my_task
```

Logs:

```py
root@75043446567f:/opt/airflow# airflow tasks test ample_simplest_dag my_task
[2025-05-20T18:00:14.130+0000] {manager.py:147} INFO - DAG bundles loaded: dags-folder, example_dags, example_standard_dags
[2025-05-20T18:00:14.996+0000] {dagbag.py:573} INFO - Filling up the DagBag from /files/dags
[2025-05-20T18:00:16.315+0000] {dag.py:2321} INFO - created dagrun <DagRun ample_simplest_dag @ None: __airflow_temporary_run_2025-05-20T18:00:16.238529+00:00__, state:running, queued_at: None. run_type: manual>
[2025-05-20T18:00:16.336+0000] {dag.py:1221} INFO - [DAG TEST] starting task_id=my_task map_index=-1
[2025-05-20T18:00:16.336+0000] {dag.py:1224} INFO - [DAG TEST] running task <TaskInstance: ample_simplest_dag.my_task __airflow_temporary_run_2025-05-20T18:00:16.238529+00:00__ [None]>
2025-05-20 18:00:17 [debug    ] Starting task instance run     hostname=75043446567f pid=147 ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4 unixname=root
2025-05-20 18:00:17 [debug    ] Retrieved task instance details dag_id=ample_simplest_dag state=queued task_id=my_task ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
2025-05-20 18:00:17 [info     ] Task started                   hostname=75043446567f previous_state=queued ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
2025-05-20 18:00:17 [info     ] Task instance state updated    rows_affected=1 ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
[2025-05-20T18:00:17.055+0000] {_client.py:1026} INFO - HTTP Request: PATCH http://in-process.invalid./task-instances/0196eeda-74bb-7bd0-8013-23f704571fd4/run "HTTP/1.1 200 OK"
2025-05-20 18:00:17 [debug    ] Sending request                [task] msg=SetRenderedFields(rendered_fields={'templates_dict': None, 'op_args': [], 'op_kwargs': {}}, type='SetRenderedFields')
2025-05-20 18:00:17 [debug    ] Received message from task runner [task] msg=SetRenderedFields(rendered_fields={'templates_dict': None, 'op_args': [], 'op_kwargs': {}}, type='SetRenderedFields')
2025-05-20 18:00:17 [info     ] Updating RenderedTaskInstanceFields field_count=3 ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
2025-05-20 18:00:17 [debug    ] RenderedTaskInstanceFields updated successfully ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
[2025-05-20T18:00:17.082+0000] {_client.py:1026} INFO - HTTP Request: PUT http://in-process.invalid./task-instances/0196eeda-74bb-7bd0-8013-23f704571fd4/rtif "HTTP/1.1 201 Created"
Task instance is in running state
 Previous state of the Task instance: TaskInstanceState.QUEUED
Current task name:my_task
Dag name:ample_simplest_dag
hellooo
[2025-05-20T18:00:17.086+0000] {python.py:219} INFO - Done. Returned value was: None
2025-05-20 18:00:17 [debug    ] Sending request                [task] msg=SucceedTask(state='success', end_date=datetime.datetime(2025, 5, 20, 18, 0, 17, 86745, tzinfo=datetime.timezone.utc), task_outlets=[], outlet_events=[], rendered_map_index=None, type='SucceedTask')
2025-05-20 18:00:17 [debug    ] Received message from task runner [task] msg=SucceedTask(state='success', end_date=datetime.datetime(2025, 5, 20, 18, 0, 17, 86745, tzinfo=datetime.timezone.utc), task_outlets=[], outlet_events=[], rendered_map_index=None, type='SucceedTask')
2025-05-20 18:00:17 [debug    ] Updating task instance state   new_state=success ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
2025-05-20 18:00:17 [debug    ] Retrieved current task instance state max_tries=0 previous_state=running ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4 try_number=0
2025-05-20 18:00:17 [info     ] Task instance state updated    new_state=success rows_affected=1 ti_id=0196eeda-74bb-7bd0-8013-23f704571fd4
[2025-05-20T18:00:17.106+0000] {_client.py:1026} INFO - HTTP Request: PATCH http://in-process.invalid./task-instances/0196eeda-74bb-7bd0-8013-23f704571fd4/state "HTTP/1.1 204 No Content"
2025-05-20 18:00:17 [debug    ] Running finalizers             [task] ti=RuntimeTaskInstance(id=UUID('0196eeda-74bb-7bd0-8013-23f704571fd4'), task_id='my_task', dag_id='ample_simplest_dag', run_id='__airflow_temporary_run_2025-05-20T18:00:16.238529+00:00__', try_number=0, map_index=-1, hostname='75043446567f', context_carrier=None, task=<Task(_PythonDecoratedOperator): my_task>, max_tries=0, start_date=datetime.datetime(2025, 5, 20, 18, 0, 16, 632534, tzinfo=datetime.timezone.utc), end_date=None, state=<TaskInstanceState.SUCCESS: 'success'>, is_mapped=False, rendered_map_index=None, log_url=None)
Task instance in success state
 Previous state of the Task instance: TaskInstanceState.RUNNING
Task operator:<Task(_PythonDecoratedOperator): my_task>
[2025-05-20T18:00:17.118+0000] {dag.py:1270} INFO - [DAG TEST] end task task_id=my_task map_index=-1
```

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/f94ec79d-dbac-4c4f-a530-055b373d203e" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
