### PR TITLE
fix: Duplicate region in Snowflake URI no longer breaks OpenLineage

### DIFF
--- a/providers/snowflake/tests/unit/snowflake/utils/test_openlineage.py
+++ b/providers/snowflake/tests/unit/snowflake/utils/test_openlineage.py
@@ -93,6 +93,9 @@ def test_snowflake_sqlite_account_urls(source, target):
         ("xy12345", "xy12345.us-west-1.aws"),  # No '-' or '_' in name
         ("xy12345.us-west-1.aws", "xy12345.us-west-1.aws"),  # Already complete locator
         ("xy12345.us-west-2.gcp", "xy12345.us-west-2.gcp"),  # Already complete locator for GCP
+        ("xy12345.us-west-2.gcp.us-west-2.gcp", "xy12345.us-west-2.gcp"),  # Duplicated region
+        ("xy12345.us-west-2.gcp.us-west-2.gcp.us-west-2.gcp", "xy12345.us-west-2.gcp"),  # Triple region
+        ("xy12345.us-west-2.gcp.some_random_part", "xy12345.us-west-2.gcp"),  # Suffix to locator, ignored
         ("xy12345aws", "xy12345aws.us-west-1.aws"),  # AWS without '-' or '_'
         ("xy12345-aws", "xy12345-aws"),  # AWS with '-'
         ("xy12345_gcp-europe-west1", "xy12345.europe-west1.gcp"),  # GCP with '_'


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When debugging another issue, I came across some examples of Snowflake URI that will still execute the query, but break OpenLineage. Duplicated region in hostname seems to be ignored by Snowflake, but is causing OL to crash as we expect exactly 3 elements - locator, region, cloud. 

This PR adjusts OL behaviour, so that it's consistent with Snowflake. This should only happen when user provides duplicate information in uri (f.e. region in account and also as separate argument). These are some examples of URIs that broke OL but still executed the query:
```
snowflake://user:pass@acc_locator.europe-west3.gcp/PUBLIC?account=acc_locator.europe-west3.gcp&region=europe-west3.gcp&database=TEST&warehouse=COMPUTE_WH&role=custom_role
snowflake://user:pass@acc_locator/PUBLIC?account=acc_locator.europe-west3.gcp&region=europe-west3.gcp&database=TEST&warehouse=COMPUTE_WH&role=custom_role
snowflake://user:pass@acc_locator/PUBLIC?account=acc_locator.europe-west3.gcp.europe-west3.gcp&region=europe-west3.gcp&database=TEST&warehouse=COMPUTE_WH&role=custom_role
snowflake://user:pass@europe-west3.gcp/PUBLIC?account=acc_locator.europe-west3.gcp&region=europe-west3.gcp&database=TEST&warehouse=COMPUTE_WH&role=custom_role
snowflake://user:pass@/PUBLIC?account=acc_locator.europe-west3.gcp&region=europe-west3.gcp&database=TEST&warehouse=COMPUTE_WH&role=custom_role
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
