### PR TITLE
Fetch only the most recent dagrun value for list display.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -163,6 +163,7 @@ const DAGS_LIST_DISPLAY = "dags_list_display";
 export const DagsList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [display, setDisplay] = useLocalStorage<"card" | "table">(DAGS_LIST_DISPLAY, "card");
+  const dagRunsLimit = display === "card" ? 14 : 1;
 
   const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
   const defaultShowPaused = hidePausedDagsByDefault ? false : undefined;
@@ -206,7 +207,7 @@ export const DagsList = () => {
     paused = false;
   }
 
-  const { data, error, isLoading } = useDags({
+  const { data, error, isLoading } = useDags(dagRunsLimit, {
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? `${dagDisplayNamePattern}` : undefined,
     lastDagRunState,
     limit: pagination.pageSize,

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -25,6 +25,7 @@ export type DagWithLatest = {
 } & DAGWithLatestDagRunsResponse;
 
 export const useDags = (
+  dagRunsLimit: number,
   searchParams: {
     dagDisplayNamePattern?: string;
     dagIdPattern?: string;
@@ -51,7 +52,7 @@ export const useDags = (
   } = useDagsServiceRecentDagRuns(
     {
       ...runsParams,
-      dagRunsLimit: 14,
+      dagRunsLimit,
     },
     undefined,
     {


### PR DESCRIPTION
Similar to #50767 when table view is selected then only the most recent dagrun is required instead of fetching 14 entries making the query more efficient. `dagRunsLimit` could be passed as part of `searchParams` but it was not part of query parameters.