### PR TITLE
[v3-0-test] Remove unecessary breaking flag in config command (#50781)

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -161,7 +161,6 @@ CONFIGS_CHANGES = [
         old_default="SequentialExecutor",
         new_default="LocalExecutor",
         was_removed=False,
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("core", "hostname"),
@@ -394,17 +393,14 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_host"),
         renamed_to=ConfigParameter("api", "host"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_port"),
         renamed_to=ConfigParameter("api", "port"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "workers"),
         renamed_to=ConfigParameter("api", "workers"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_worker_timeout"),
@@ -413,17 +409,14 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_ssl_cert"),
         renamed_to=ConfigParameter("api", "ssl_cert"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "web_server_ssl_key"),
         renamed_to=ConfigParameter("api", "ssl_key"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "access_logfile"),
         renamed_to=ConfigParameter("api", "access_logfile"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "error_logfile"),
@@ -476,32 +469,26 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("webserver", "enable_proxy_fix"),
         renamed_to=ConfigParameter("fab", "enable_proxy_fix"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_for"),
         renamed_to=ConfigParameter("fab", "proxy_fix_x_for"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_proto"),
         renamed_to=ConfigParameter("fab", "proxy_fix_x_proto"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_host"),
         renamed_to=ConfigParameter("fab", "proxy_fix_x_host"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_port"),
         renamed_to=ConfigParameter("fab", "proxy_fix_x_port"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "proxy_fix_x_prefix"),
         renamed_to=ConfigParameter("fab", "proxy_fix_x_prefix"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("webserver", "expose_config"),
@@ -587,7 +574,6 @@ CONFIGS_CHANGES = [
         "If your DAGs rely on catchup behavior, not explicitly defined in the DAG definition, "
         "set this configuration parameter to `True` in the `scheduler` section of your `airflow.cfg` "
         "to enable the behavior from Airflow 2.x.",
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "create_cron_data_intervals"),
@@ -595,7 +581,6 @@ CONFIGS_CHANGES = [
         old_default="True",
         new_default="False",
         was_removed=False,
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "create_delta_data_intervals"),
@@ -603,7 +588,6 @@ CONFIGS_CHANGES = [
         old_default="True",
         new_default="False",
         was_removed=False,
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "processor_poll_interval"),
@@ -683,7 +667,6 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("scheduler", "dag_dir_list_interval"),
         renamed_to=ConfigParameter("dag_processor", "refresh_interval"),
-        breaking=True,
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "local_task_job_heartbeat_sec"),
@@ -740,7 +723,6 @@ CONFIGS_CHANGES = [
     ConfigChange(
         config=ConfigParameter("triggerer", "default_capacity"),
         renamed_to=ConfigParameter("triggerer", "capacity"),
-        breaking=True,
     ),
     # email
     ConfigChange(


### PR DESCRIPTION
(cherry picked from commit 8b5f0cf6666343f4c61bf67dc4d5d8a17f865ca8)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
