### PR TITLE
Fix reading number of dags from direct system providers path

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_report.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_report.py
@@ -23,7 +23,7 @@ import pytest
 
 from airflow.utils.file import list_py_file_paths
 
-import system.standard
+from tests_common.pytest_plugin import AIRFLOW_ROOT_PATH
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, parse_and_sync_to_db
 
@@ -34,6 +34,10 @@ TEST_DAG_FOLDER_WITH_SUBDIR = f"{TEST_DAG_FOLDER}/subdir2"
 TEST_DAG_FOLDER_INVALID = "/invalid/path"
 TEST_DAG_FOLDER_INVALID_2 = "/root/airflow/tests/dags/"
 
+STANDARD_PROVIDER_SYSTEM_TESTS_PATH = (
+    AIRFLOW_ROOT_PATH / "providers" / "standard" / "tests" / "system" / "standard"
+)
+
 
 def get_corresponding_dag_file_count(dir: str, include_examples: bool = True) -> int:
     from airflow import example_dags
@@ -41,7 +45,7 @@ def get_corresponding_dag_file_count(dir: str, include_examples: bool = True) ->
     return (
         len(list_py_file_paths(directory=dir))
         + (len(list_py_file_paths(next(iter(example_dags.__path__)))) if include_examples else 0)
-        + (len(list_py_file_paths(next(iter(system.standard.__path__)))) if include_examples else 0)
+        + (len(list_py_file_paths(STANDARD_PROVIDER_SYSTEM_TESTS_PATH.as_posix())) if include_examples else 0)
     )
 
 


### PR DESCRIPTION
The original PR #49978 that fixed generation of proper documentation for standard provider examples added retrieval of the path by checking import location for the standard provider. Instead we are now using direct path to the provider.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
