### PR TITLE
Fix dropdowns in accordion and error text colors

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Icon, Stack, StackSeparator, Text } from "@chakra-ui/react";
+import { Icon, Stack, StackSeparator, Text } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { MdError } from "react-icons/md";
 
@@ -39,7 +39,7 @@ export const FlexibleForm = ({
   initialParamsDict,
   setError,
 }: FlexibleFormProps) => {
-  const { paramsDict: params, setinitialParamDict, setParamsDict } = useParamStore();
+  const { paramsDict: params, setInitialParamDict, setParamsDict } = useParamStore();
   const processedSections = new Map();
   const [sectionError, setSectionError] = useState<Map<string, boolean>>(new Map());
 
@@ -62,17 +62,17 @@ export const FlexibleForm = ({
       const paramsCopy = structuredClone(initialParamsDict.paramsDict);
 
       setParamsDict(paramsCopy);
-      setinitialParamDict(initialParamsDict.paramsDict);
+      setInitialParamDict(initialParamsDict.paramsDict);
     }
-  }, [initialParamsDict, params, setParamsDict, setinitialParamDict]);
+  }, [initialParamsDict, params, setParamsDict, setInitialParamDict]);
 
   useEffect(
     () => () => {
       // Clear paramsDict and initialParamDict when the component is unmounted or modal closes
       setParamsDict({});
-      setinitialParamDict({});
+      setInitialParamDict({});
     },
-    [setParamsDict, setinitialParamDict],
+    [setParamsDict, setInitialParamDict],
   );
 
   useEffect(() => {
@@ -103,7 +103,16 @@ export const FlexibleForm = ({
           processedSections.set(currentSection, true);
 
           return (
-            <Accordion.Item key={currentSection} overflow="visible" value={currentSection}>
+            <Accordion.Item
+              // We need to make the item content overflow visible for dropdowns to work, but directly applying the style does not work
+              css={{
+                "& > :nth-child(2)": {
+                  overflow: "visible",
+                },
+              }}
+              key={currentSection}
+              value={currentSection}
+            >
               <Accordion.ItemTrigger cursor="button">
                 <Text color={sectionError.get(currentSection) ? "fg.error" : undefined}>
                   {currentSection}
@@ -114,8 +123,9 @@ export const FlexibleForm = ({
                   </Icon>
                 ) : undefined}
               </Accordion.ItemTrigger>
-              <Accordion.ItemContent paddingTop={0}>
-                <Box p={5}>
+
+              <Accordion.ItemContent pt={0}>
+                <Accordion.ItemBody>
                   <Stack separator={<StackSeparator />}>
                     {Object.entries(params)
                       .filter(
@@ -127,7 +137,7 @@ export const FlexibleForm = ({
                         <Row key={name} name={name} onUpdate={onUpdate} />
                       ))}
                   </Stack>
-                </Box>
+                </Accordion.ItemBody>
               </Accordion.ItemContent>
             </Accordion.Item>
           );

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -103,11 +103,13 @@ export const FlexibleForm = ({
           processedSections.set(currentSection, true);
 
           return (
-            <Accordion.Item key={currentSection} value={currentSection}>
+            <Accordion.Item key={currentSection} overflow="visible" value={currentSection}>
               <Accordion.ItemTrigger cursor="button">
-                <Text color={sectionError.get(currentSection) ? "red" : undefined}>{currentSection}</Text>
+                <Text color={sectionError.get(currentSection) ? "fg.error" : undefined}>
+                  {currentSection}
+                </Text>
                 {sectionError.get(currentSection) ? (
-                  <Icon color="red" margin="-1">
+                  <Icon color="fg.error" margin="-1">
                     <MdError />
                   </Icon>
                 ) : undefined}

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
@@ -47,7 +47,7 @@ type FormStore = {
   initialParamDict: ParamsSpec;
   paramsDict: ParamsSpec;
   setConf: (confString: string) => void;
-  setinitialParamDict: (newParamsDict: ParamsSpec) => void;
+  setInitialParamDict: (newParamsDict: ParamsSpec) => void;
   setParamsDict: (newParamsDict: ParamsSpec) => void;
 };
 
@@ -83,7 +83,7 @@ export const useParamStore = create<FormStore>((set) => ({
       return { conf: confString, paramsDict: updatedParamsDict };
     }),
 
-  setinitialParamDict: (newParamsDict: ParamsSpec) => set(() => ({ initialParamDict: newParamsDict })),
+  setInitialParamDict: (newParamsDict: ParamsSpec) => set(() => ({ initialParamDict: newParamsDict })),
 
   setParamsDict: (newParamsDict: ParamsSpec) =>
     set((state) => {


### PR DESCRIPTION
Make select dropdowns overflow accordions.
Match accordion error text with our other error text colors
Fix naming of some variables
<img width="890" alt="Screenshot 2025-05-20 at 11 58 32 AM" src="https://github.com/user-attachments/assets/bfb96331-d1a4-4cec-986b-0b34055f70d6" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
