### PR TITLE
Fix the version for generated client

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3147,7 +3147,7 @@ def _generate_python_client_sources(python_client_version: str) -> None:
             "--git-repo-id",
             "airflow-client-python",
             "--additional-properties",
-            f'packageVersion="{python_client_version}"',
+            f"packageVersion={python_client_version}",
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
The command that was generated before:

```shell
docker run --rm -u 501:20 \
  -v ~/airflow/clients/python/v2.yaml:/spec.yaml \
  -v ~/airflow/clients/python/tmp:/output \
  openapitools/openapi-generator-cli:v7.13.0 generate \
  --input-spec /spec.yaml \
  --generator-name python \
  --git-user-id None \
  --git-repo-id airflow-client-python \
  --output /output \
  --package-name airflow_client.client \
  --additional-properties packageVersion="3.0.0"
```

which caused things like `__version__ = "&quot;2.10.0&quot;"` ( [here](https://github.com/apache/airflow-client-python/blob/4bd5b2544e30b05bd8cd03502dc99bd6784a20d6/airflow_client/client/__init__.py) ) or

`__version__ = "&quot;3.0.0&quot;"` in [here](https://github.com/apache/airflow-client-python/blob/38367b1158b777c87f51fe4d6283273031a4fb60/airflow_client/client/__init__.py#L17)

While this does not cause error the user-agent and things are weird:

```py
self.user_agent = 'OpenAPI-Generator/"3.0.0"/python'
```

vs

```py
self.user_agent = 'OpenAPI-Generator/3.0.0/python'
```

The command generated now:

```shell
docker run --rm -u 501:20 \
  -v ~/airflow/clients/python/v2.yaml:/spec.yaml \
  -v ~/airflow/clients/python/tmp:/output \
  openapitools/openapi-generator-cli:v7.13.0 generate \
  --input-spec /spec.yaml \
  --generator-name python \
  --git-user-id None \
  --git-repo-id airflow-client-python \
  --output /output \
  --package-name airflow_client.client \
  --additional-properties packageVersion=3.0.0
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
