### PR TITLE
Add Airflow 2.10.5 to Back-Compat tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -690,6 +690,12 @@ DEFAULT_EXTRAS = [
 PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
     {
         "python-version": "3.9",
+        "airflow-version": "2.10.5",
+        "remove-providers": "cloudant common.messaging fab git",
+        "run-tests": "true",
+    },
+    {
+        "python-version": "3.9",
         "airflow-version": "2.11.0",
         "remove-providers": "cloudant common.messaging fab git",
         "run-tests": "true",


### PR DESCRIPTION
Just realized in support-ci-cd channel in Slack that the changes for Releae of Airflow 2.11 remioved 2.10.5 from back-compat tests, This PR re-adds it to ensure that all providers are compatibl with 2.10.5 - even when we know 2.11 is minimal functional difference.