### PR TITLE
Bumping pinecone sdk to 7.0.0 to improve podspec handling

### DIFF
--- a/providers/pinecone/pyproject.toml
+++ b/providers/pinecone/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "pinecone>=3.1.0",
+    "pinecone>=7.0.0",
 ]
 
 [dependency-groups]

--- a/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -24,7 +24,8 @@ import os
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from pinecone import Pinecone, PodSpec, PodType, ServerlessSpec
+from pinecone import Pinecone, PodSpec, ServerlessSpec
+from pinecone.db_control.enums import PodType
 
 from airflow.hooks.base import BaseHook
 

--- a/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -24,8 +24,7 @@ import os
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from pinecone import Pinecone, PodSpec, ServerlessSpec
-from pinecone.db_control.enums import PodType
+from pinecone import Pinecone, PodSpec, PodType, ServerlessSpec
 
 from airflow.hooks.base import BaseHook
 

--- a/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -182,7 +182,7 @@ class PineconeHook(BaseHook):
         replicas: int | None = None,
         shards: int | None = None,
         pods: int | None = None,
-        pod_type: str | None = "p1.x1",
+        pod_type: str = "p1.x1",
         metadata_config: dict | None = None,
         source_collection: str | None = None,
         environment: str | None = None,
@@ -203,7 +203,7 @@ class PineconeHook(BaseHook):
             replicas=replicas,
             shards=shards,
             pods=pods,
-            pod_type=pod_type,
+            pod_type=pod_type,  # type: ignore[arg-type]
             metadata_config=metadata_config,
             source_collection=source_collection,
         )

--- a/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -24,7 +24,7 @@ import os
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from pinecone import Pinecone, PodSpec, ServerlessSpec
+from pinecone import Pinecone, PodSpec, PodType, ServerlessSpec
 
 from airflow.hooks.base import BaseHook
 
@@ -182,7 +182,7 @@ class PineconeHook(BaseHook):
         replicas: int | None = None,
         shards: int | None = None,
         pods: int | None = None,
-        pod_type: str = "p1.x1",
+        pod_type: str | PodType = PodType.P1_X1,
         metadata_config: dict | None = None,
         source_collection: str | None = None,
         environment: str | None = None,
@@ -203,7 +203,7 @@ class PineconeHook(BaseHook):
             replicas=replicas,
             shards=shards,
             pods=pods,
-            pod_type=pod_type,  # type: ignore[arg-type]
+            pod_type=pod_type if isinstance(pod_type, PodType) else PodType(pod_type),
             metadata_config=metadata_config,
             source_collection=source_collection,
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Due to pinecone bump to 7.0.0 as in https://github.com/apache/airflow/actions/runs/15151908599/job/42599727921, the argument type has changed leading to failures like:
```
providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py:206: error:
Argument "pod_type" to "PodSpec" has incompatible type "Optional[str]"; expected
"Union[PodType, str]"  [arg-type]
                pod_type=pod_type,
                         ^~~~~~~~
Found 1 error in 1 file (checked 3787 source files)
```

Removing Optional[str] and making it str with a default. Also adding type[ignore]

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
