### PR TITLE
Fix backward compatibility for timeout in defer() with Airflow 2.11

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
@@ -127,12 +127,7 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
                 raise AirflowSkipException("Skipping due to soft_fail is set to True.") from e
             raise
 
-        # todo: remove backcompat when min airflow version greater than 2.11
-        timeout: int | float | timedelta
-        if _get_airflow_version() >= Version("2.11.0"):
-            timeout = self.timeout
-        else:
-            timeout = timedelta(seconds=self.timeout)
+        timeout = timedelta(seconds=self.timeout)
 
         self.defer(
             trigger=trigger,

--- a/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
@@ -127,7 +127,13 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
                 raise AirflowSkipException("Skipping due to soft_fail is set to True.") from e
             raise
 
-        timeout = timedelta(seconds=self.timeout)
+        # todo: remove backcompat when min airflow version greater than 2.11
+        timeout: int | float | timedelta
+        if AIRFLOW_V_3_0_PLUS:
+            timeout = self.timeout
+        else:
+            # <=2.11 requires timedelta
+            timeout = timedelta(seconds=self.timeout)
 
         self.defer(
             trigger=trigger,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Main is failing with errors like these:
```
_ TestTimeDeltaSensorAsync.test_timedelta_sensor_async_run_after_vs_interval[run_after0-interval_end0] _
providers/standard/tests/unit/standard/sensors/test_time_delta.py:185: in test_timedelta_sensor_async_run_after_vs_interval
    op.execute(context)
/usr/local/lib/python3.9/site-packages/airflow/models/baseoperator.py:424: in wrapper
    return func(self, *args, **kwargs)
/usr/local/lib/python3.9/site-packages/airflow/providers/standard/sensors/time_delta.py:137: in execute
    self.defer(
/usr/local/lib/python3.9/site-packages/airflow/models/baseoperator.py:1800: in defer
    raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
/usr/local/lib/python3.9/site-packages/airflow/exceptions.py:431: in __init__
    raise ValueError("Timeout value must be a timedelta")
E   ValueError: Timeout value must be a timedelta
```

- In 2.11, timeout must be a `timedelta | None`

- In 3.0, timeout can be `timedelta | int | float | None`

It seems the conditional is wrong and should be flipped

Example failures: https://github.com/apache/airflow/actions/runs/15152977665/job/42602642810


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
