### PR TITLE
Deserialize should work while retrieving variables with secrets backend

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -176,6 +176,10 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
         try:
             var_val = secrets_backend.get_variable(key=key)  # type: ignore[assignment]
             if var_val is not None:
+                if deserialize_json:
+                    import json
+
+                    var_val = json.loads(var_val)
                 return var_val
         except Exception:
             log.exception(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/50666

## Problem

As reported in https://github.com/apache/airflow/issues/50666, `deserialize_json` option wasn't working when trying to use it with Variable.get with AWS secrets manager.

But this problem on further investigation revealed to be not just for AWS secrets backend but a bug in the `Variable` module itself. The bug didn't honor the `deserialize_json` flag at all when it was passed for secrets backend which shouldn't be the case at all.

To prove this, did the following:

Set up a `airflow.secrets.local_filesystem.LocalFilesystemBackend` and checked with both Airflow 2 and Airflow 3.

var.json
```
{
    "A": "{\"num1\": 23, \"num2\": 42}"
}
```

Dag used:
```
from __future__ import annotations

from airflow.models import Variable
from airflow.models.baseoperator import BaseOperator
from airflow import DAG
# from airflow.sdk import Variable

class CustomOperator(BaseOperator):
    def execute(self, context):
        v = Variable.get(key="A")
        print("Got value", v, type(v))


        v1 = Variable.get(key="A", deserialize_json=True)
        print("Got value from deser", v1, type(v1))


with DAG("get-var-sdk", schedule=None, catchup=False) as dag:
    CustomOperator(task_id="set_var")
```

Airflow 2:
```
# With secrets backned
# [2025-05-20, 16:38:47 IST] {logging_mixin.py:190} INFO - Got value {"num1": 23, "num2": 42} <class 'str'>
# [2025-05-20, 16:38:47 IST] {logging_mixin.py:190} INFO - Got value from deser {'num1': 23, 'num2': 42} <class 'dict'>
```

Airflow 3:
```
[2025-05-21, 15:35:41] INFO - Got value {"num1": 23, "num2": 42} <class 'str'>: chan="stdout": source="task"
[2025-05-21, 15:35:41] INFO - Got value from deser {"num1": 23, "num2": 42} <class 'str'>: chan="stdout": source="task"
```

As observed the second print for Airflow 3 is a string when it should really be a dictionary.


## Testing

Set up a `airflow.secrets.local_filesystem.LocalFilesystemBackend` and checked with both Airflow 2 and Airflow 3.

var.json
```
{
    "A": "{\"num1\": 23, \"num2\": 42}"
}
```

And exporting these variables in init.sh of breeze:
```
export AIRFLOW__SECRETS__BACKEND="airflow.secrets.local_filesystem.LocalFilesystemBackend"
export AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_file_path": "/files/conn.json", "variables_file_path": "/files/var.json"}'
```

Dag used:
```
from __future__ import annotations

from airflow.models import Variable
from airflow.models.baseoperator import BaseOperator
from airflow import DAG
# from airflow.sdk import Variable

class CustomOperator(BaseOperator):
    def execute(self, context):
        v = Variable.get(key="A")
        print("Got value", v, type(v))


        v1 = Variable.get(key="A", deserialize_json=True)
        print("Got value from deser", v1, type(v1))


with DAG("get-var-sdk", schedule=None, catchup=False) as dag:
    CustomOperator(task_id="set_var")
```



Before changes:

![image](https://github.com/user-attachments/assets/efac9849-f815-4ead-8d9d-16ab93c7edf0)


After changes:

![image](https://github.com/user-attachments/assets/136bf1a3-3836-4304-ace8-8dd9332520ce)




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
