### PR TITLE
Add shortcut to clear and mark state for taskinstance and dagrun.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -17,33 +17,46 @@
  * under the License.
  */
 import { Box, useDisclosure } from "@chakra-ui/react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { CgRedo } from "react-icons/cg";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
+import { Tooltip } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
 
 import ClearRunDialog from "./ClearRunDialog";
 
 type Props = {
   readonly dagRun: DAGRunResponse;
+  readonly hasHotKey?: boolean;
   readonly withText?: boolean;
 };
 
-const ClearRunButton = ({ dagRun, withText = true }: Props) => {
+const ClearRunButton = ({ dagRun, hasHotKey = false, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
-  return (
-    <Box>
-      <ActionButton
-        actionName="Clear Dag Run"
-        icon={<CgRedo />}
-        onClick={onOpen}
-        text="Clear Run"
-        withText={withText}
-      />
+  useHotkeys(
+    "shift+c",
+    () => {
+      onOpen();
+    },
+    { enabled: hasHotKey },
+  );
 
-      {open ? <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} /> : undefined}
-    </Box>
+  return (
+    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!hasHotKey} openDelay={100}>
+      <Box>
+        <ActionButton
+          actionName="Clear Dag Run"
+          icon={<CgRedo />}
+          onClick={onOpen}
+          text="Clear Run"
+          withText={withText}
+        />
+
+        {open ? <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} /> : undefined}
+      </Box>
+    </Tooltip>
   );
 };
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -28,11 +28,11 @@ import ClearRunDialog from "./ClearRunDialog";
 
 type Props = {
   readonly dagRun: DAGRunResponse;
-  readonly hasHotKey?: boolean;
+  readonly isHotkeyEnabled?: boolean;
   readonly withText?: boolean;
 };
 
-const ClearRunButton = ({ dagRun, hasHotKey = false, withText = true }: Props) => {
+const ClearRunButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   useHotkeys(
@@ -40,11 +40,11 @@ const ClearRunButton = ({ dagRun, hasHotKey = false, withText = true }: Props) =
     () => {
       onOpen();
     },
-    { enabled: hasHotKey },
+    { enabled: isHotkeyEnabled },
   );
 
   return (
-    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!hasHotKey} openDelay={100}>
+    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!isHotkeyEnabled} openDelay={100}>
       <Box>
         <ActionButton
           actionName="Clear Dag Run"

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -27,12 +27,12 @@ import ActionButton from "src/components/ui/ActionButton";
 import ClearTaskInstanceDialog from "./ClearTaskInstanceDialog";
 
 type Props = {
-  readonly hasHotKey?: boolean;
+  readonly isHotkeyEnabled?: boolean;
   readonly taskInstance: TaskInstanceResponse;
   readonly withText?: boolean;
 };
 
-const ClearTaskInstanceButton = ({ hasHotKey = false, taskInstance, withText = true }: Props) => {
+const ClearTaskInstanceButton = ({ isHotkeyEnabled = false, taskInstance, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   useHotkeys(
@@ -40,11 +40,11 @@ const ClearTaskInstanceButton = ({ hasHotKey = false, taskInstance, withText = t
     () => {
       onOpen();
     },
-    { enabled: hasHotKey },
+    { enabled: isHotkeyEnabled },
   );
 
   return (
-    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!hasHotKey} openDelay={100}>
+    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!isHotkeyEnabled} openDelay={100}>
       <Box>
         <ActionButton
           actionName="Clear Task Instance"

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -17,35 +17,48 @@
  * under the License.
  */
 import { Box, useDisclosure } from "@chakra-ui/react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { CgRedo } from "react-icons/cg";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import { Tooltip } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
 
 import ClearTaskInstanceDialog from "./ClearTaskInstanceDialog";
 
 type Props = {
+  readonly hasHotKey?: boolean;
   readonly taskInstance: TaskInstanceResponse;
   readonly withText?: boolean;
 };
 
-const ClearTaskInstanceButton = ({ taskInstance, withText = true }: Props) => {
+const ClearTaskInstanceButton = ({ hasHotKey = false, taskInstance, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
-  return (
-    <Box>
-      <ActionButton
-        actionName="Clear Task Instance"
-        icon={<CgRedo />}
-        onClick={onOpen}
-        text="Clear Task Instance"
-        withText={withText}
-      />
+  useHotkeys(
+    "shift+c",
+    () => {
+      onOpen();
+    },
+    { enabled: hasHotKey },
+  );
 
-      {open ? (
-        <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
-      ) : undefined}
-    </Box>
+  return (
+    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!hasHotKey} openDelay={100}>
+      <Box>
+        <ActionButton
+          actionName="Clear Task Instance"
+          icon={<CgRedo />}
+          onClick={onOpen}
+          text="Clear Task Instance"
+          withText={withText}
+        />
+
+        {open ? (
+          <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
+        ) : undefined}
+      </Box>
+    </Tooltip>
   );
 };
 

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -31,11 +31,11 @@ import MarkRunAsDialog from "./MarkRunAsDialog";
 
 type Props = {
   readonly dagRun: DAGRunResponse;
-  readonly hasHotKey?: boolean;
+  readonly isHotkeyEnabled?: boolean;
   readonly withText?: boolean;
 };
 
-const MarkRunAsButton = ({ dagRun, hasHotKey = false, withText = true }: Props) => {
+const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
   const [state, setState] = useState<DAGRunPatchStates>("success");
 
@@ -45,7 +45,7 @@ const MarkRunAsButton = ({ dagRun, hasHotKey = false, withText = true }: Props) 
       setState("failed");
       onOpen();
     },
-    { enabled: hasHotKey && dagRun.state !== "failed" },
+    { enabled: isHotkeyEnabled && dagRun.state !== "failed" },
   );
 
   useHotkeys(
@@ -54,7 +54,7 @@ const MarkRunAsButton = ({ dagRun, hasHotKey = false, withText = true }: Props) 
       setState("success");
       onOpen();
     },
-    { enabled: hasHotKey && dagRun.state !== "success" },
+    { enabled: isHotkeyEnabled && dagRun.state !== "success" },
   );
 
   return (
@@ -80,7 +80,7 @@ const MarkRunAsButton = ({ dagRun, hasHotKey = false, withText = true }: Props) 
               <Tooltip
                 closeDelay={100}
                 content={content}
-                disabled={!hasHotKey || dagRun.state === menuState}
+                disabled={!isHotkeyEnabled || dagRun.state === menuState}
                 key={menuState}
                 openDelay={100}
               >

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -18,11 +18,12 @@
  */
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { MdArrowDropDown } from "react-icons/md";
 
 import type { DAGRunPatchStates, DAGRunResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
-import { Menu } from "src/components/ui";
+import { Menu, Tooltip } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
 
 import { allowedStates } from "../utils";
@@ -30,12 +31,31 @@ import MarkRunAsDialog from "./MarkRunAsDialog";
 
 type Props = {
   readonly dagRun: DAGRunResponse;
+  readonly hasHotKey?: boolean;
   readonly withText?: boolean;
 };
 
-const MarkRunAsButton = ({ dagRun, withText = true }: Props) => {
+const MarkRunAsButton = ({ dagRun, hasHotKey = false, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
   const [state, setState] = useState<DAGRunPatchStates>("success");
+
+  useHotkeys(
+    "shift+f",
+    () => {
+      setState("failed");
+      onOpen();
+    },
+    { enabled: hasHotKey && dagRun.state !== "failed" },
+  );
+
+  useHotkeys(
+    "shift+s",
+    () => {
+      setState("success");
+      onOpen();
+    },
+    { enabled: hasHotKey && dagRun.state !== "success" },
+  );
 
   return (
     <Box>
@@ -50,24 +70,39 @@ const MarkRunAsButton = ({ dagRun, withText = true }: Props) => {
           />
         </Menu.Trigger>
         <Menu.Content>
-          {allowedStates.map((menuState) => (
-            <Menu.Item
-              asChild
-              disabled={dagRun.state === menuState}
-              key={menuState}
-              onClick={() => {
-                if (dagRun.state !== menuState) {
-                  setState(menuState);
-                  onOpen();
-                }
-              }}
-              value={menuState}
-            >
-              <StateBadge my={1} state={menuState}>
-                {menuState}
-              </StateBadge>
-            </Menu.Item>
-          ))}
+          {allowedStates.map((menuState) => {
+            const content =
+              menuState === "success"
+                ? "Press shift+s to mark as success"
+                : "Press shift+f to mark as failed";
+
+            return (
+              <Tooltip
+                closeDelay={100}
+                content={content}
+                disabled={!hasHotKey || dagRun.state === menuState}
+                key={menuState}
+                openDelay={100}
+              >
+                <Menu.Item
+                  asChild
+                  disabled={dagRun.state === menuState}
+                  key={menuState}
+                  onClick={() => {
+                    if (dagRun.state !== menuState) {
+                      setState(menuState);
+                      onOpen();
+                    }
+                  }}
+                  value={menuState}
+                >
+                  <StateBadge my={1} state={menuState}>
+                    {menuState}
+                  </StateBadge>
+                </Menu.Item>
+              </Tooltip>
+            );
+          })}
         </Menu.Content>
       </Menu.Root>
 

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -18,25 +18,45 @@
  */
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { MdArrowDropDown } from "react-icons/md";
 
 import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
-import { Menu } from "src/components/ui";
+import { Menu, Tooltip } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
 
 import { allowedStates } from "../utils";
 import MarkTaskInstanceAsDialog from "./MarkTaskInstanceAsDialog";
 
 type Props = {
+  readonly hasHotKey?: boolean;
   readonly taskInstance: TaskInstanceResponse;
   readonly withText?: boolean;
 };
 
-const MarkTaskInstanceAsButton = ({ taskInstance, withText = true }: Props) => {
+const MarkTaskInstanceAsButton = ({ hasHotKey = false, taskInstance, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   const [state, setState] = useState<TaskInstanceState>("success");
+
+  useHotkeys(
+    "shift+f",
+    () => {
+      setState("failed");
+      onOpen();
+    },
+    { enabled: hasHotKey && taskInstance.state !== "failed" },
+  );
+
+  useHotkeys(
+    "shift+s",
+    () => {
+      setState("success");
+      onOpen();
+    },
+    { enabled: hasHotKey && taskInstance.state !== "success" },
+  );
 
   return (
     <Box>
@@ -51,24 +71,39 @@ const MarkTaskInstanceAsButton = ({ taskInstance, withText = true }: Props) => {
           />
         </Menu.Trigger>
         <Menu.Content>
-          {allowedStates.map((menuState) => (
-            <Menu.Item
-              asChild
-              disabled={taskInstance.state === menuState}
-              key={menuState}
-              onClick={() => {
-                if (taskInstance.state !== menuState) {
-                  setState(menuState);
-                  onOpen();
-                }
-              }}
-              value={menuState}
-            >
-              <StateBadge my={1} state={menuState}>
-                {menuState}
-              </StateBadge>
-            </Menu.Item>
-          ))}
+          {allowedStates.map((menuState) => {
+            const content =
+              menuState === "success"
+                ? "Press shift+s to mark as success"
+                : "Press shift+f to mark as failed";
+
+            return (
+              <Tooltip
+                closeDelay={100}
+                content={content}
+                disabled={!hasHotKey || taskInstance.state === menuState}
+                key={menuState}
+                openDelay={100}
+              >
+                <Menu.Item
+                  asChild
+                  disabled={taskInstance.state === menuState}
+                  key={menuState}
+                  onClick={() => {
+                    if (taskInstance.state !== menuState) {
+                      setState(menuState);
+                      onOpen();
+                    }
+                  }}
+                  value={menuState}
+                >
+                  <StateBadge my={1} state={menuState}>
+                    {menuState}
+                  </StateBadge>
+                </Menu.Item>
+              </Tooltip>
+            );
+          })}
         </Menu.Content>
       </Menu.Root>
 

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -30,12 +30,12 @@ import { allowedStates } from "../utils";
 import MarkTaskInstanceAsDialog from "./MarkTaskInstanceAsDialog";
 
 type Props = {
-  readonly hasHotKey?: boolean;
+  readonly isHotkeyEnabled?: boolean;
   readonly taskInstance: TaskInstanceResponse;
   readonly withText?: boolean;
 };
 
-const MarkTaskInstanceAsButton = ({ hasHotKey = false, taskInstance, withText = true }: Props) => {
+const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   const [state, setState] = useState<TaskInstanceState>("success");
@@ -46,7 +46,7 @@ const MarkTaskInstanceAsButton = ({ hasHotKey = false, taskInstance, withText = 
       setState("failed");
       onOpen();
     },
-    { enabled: hasHotKey && taskInstance.state !== "failed" },
+    { enabled: isHotkeyEnabled && taskInstance.state !== "failed" },
   );
 
   useHotkeys(
@@ -55,7 +55,7 @@ const MarkTaskInstanceAsButton = ({ hasHotKey = false, taskInstance, withText = 
       setState("success");
       onOpen();
     },
-    { enabled: hasHotKey && taskInstance.state !== "success" },
+    { enabled: isHotkeyEnabled && taskInstance.state !== "success" },
   );
 
   return (
@@ -81,7 +81,7 @@ const MarkTaskInstanceAsButton = ({ hasHotKey = false, taskInstance, withText = 
               <Tooltip
                 closeDelay={100}
                 content={content}
-                disabled={!hasHotKey || taskInstance.state === menuState}
+                disabled={!isHotkeyEnabled || taskInstance.state === menuState}
                 key={menuState}
                 openDelay={100}
               >

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -77,8 +77,8 @@ export const Header = ({
               text={Boolean(dagRun.note) ? "Note" : "Add a note"}
               withText={containerWidth > 700}
             />
-            <ClearRunButton dagRun={dagRun} hasHotKey withText={containerWidth > 700} />
-            <MarkRunAsButton dagRun={dagRun} hasHotKey withText={containerWidth > 700} />
+            <ClearRunButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />
+            <MarkRunAsButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />
           </>
         }
         icon={<FiBarChart />}

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -77,8 +77,8 @@ export const Header = ({
               text={Boolean(dagRun.note) ? "Note" : "Add a note"}
               withText={containerWidth > 700}
             />
-            <ClearRunButton dagRun={dagRun} withText={containerWidth > 700} />
-            <MarkRunAsButton dagRun={dagRun} withText={containerWidth > 700} />
+            <ClearRunButton dagRun={dagRun} hasHotKey withText={containerWidth > 700} />
+            <MarkRunAsButton dagRun={dagRun} hasHotKey withText={containerWidth > 700} />
           </>
         }
         icon={<FiBarChart />}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -98,8 +98,16 @@ export const Header = ({
               text={Boolean(taskInstance.note) ? "Note" : "Add a note"}
               withText={containerWidth > 700}
             />
-            <ClearTaskInstanceButton hasHotKey taskInstance={taskInstance} withText={containerWidth > 700} />
-            <MarkTaskInstanceAsButton hasHotKey taskInstance={taskInstance} withText={containerWidth > 700} />
+            <ClearTaskInstanceButton
+              isHotkeyEnabled
+              taskInstance={taskInstance}
+              withText={containerWidth > 700}
+            />
+            <MarkTaskInstanceAsButton
+              isHotkeyEnabled
+              taskInstance={taskInstance}
+              withText={containerWidth > 700}
+            />
           </>
         }
         icon={<MdOutlineTask />}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -98,8 +98,8 @@ export const Header = ({
               text={Boolean(taskInstance.note) ? "Note" : "Add a note"}
               withText={containerWidth > 700}
             />
-            <ClearTaskInstanceButton taskInstance={taskInstance} withText={containerWidth > 700} />
-            <MarkTaskInstanceAsButton taskInstance={taskInstance} withText={containerWidth > 700} />
+            <ClearTaskInstanceButton hasHotKey taskInstance={taskInstance} withText={containerWidth > 700} />
+            <MarkTaskInstanceAsButton hasHotKey taskInstance={taskInstance} withText={containerWidth > 700} />
           </>
         }
         icon={<MdOutlineTask />}


### PR DESCRIPTION
* `shift+s` to mark task instance/dagrun as success only when the it is not in success state. 
* `shift+f` to mark task instance/dagrun as failed only when the task is not in failed state. 
* `shift+c` to clear task instance/dagrun.
* Hotkey enabled only in details page and not in list page to avoid ambiguity of multiple modals opened.

Closes https://github.com/apache/airflow/issues/50884
 