### PR TITLE
feat: Add OpenLineage support for DatabricksSQLStatementsOperator

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/utils/mixins.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/mixins.py
@@ -170,10 +170,11 @@ class DatabricksSQLStatementsMixin:
     def execute_complete(self: ExecuteCompleteHasFields, context: Context, event: dict):
         statement_state = SQLStatementState.from_json(event["state"])
         error = event["error"]
-        statement_id = event["statement_id"]
+        # Save as instance attribute again after coming back from defer (e.g., for later use in listeners)
+        self.statement_id = event["statement_id"]
 
         if statement_state.is_successful:
-            self.log.info("SQL Statement with ID %s completed successfully.", statement_id)
+            self.log.info("SQL Statement with ID %s completed successfully.", self.statement_id)
             return
 
         error_message = f"SQL Statement execution failed with terminal state: {statement_state} and with the error {error}"

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -27,6 +27,11 @@ import pytest
 
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models import DAG
+from airflow.providers.common.compat.openlineage.facet import (
+    Dataset,
+    ExternalQueryRunFacet,
+    SQLJobFacet,
+)
 from airflow.providers.databricks.hooks.databricks import RunState, SQLStatementState
 from airflow.providers.databricks.operators.databricks import (
     DatabricksCreateJobsOperator,
@@ -2117,6 +2122,155 @@ class TestDatabricksSQLStatementsOperator:
 
         with pytest.raises(AirflowException, match="^SQL Statement execution failed with terminal state: .*"):
             op.execute_complete(context=None, event=event)
+
+    def test_execute_complete_sets_statement_id(self):
+        """
+        Test `execute_complete` function is setting statement_id as operator attribute.
+        """
+        event = {
+            "statement_id": STATEMENT_ID,
+            "state": SQLStatementState("SUCCEEDED").to_json(),
+            "error": {},
+        }
+
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement="select * from test.test;",
+            warehouse_id=WAREHOUSE_ID,
+            deferrable=True,
+        )
+        assert op.statement_id is None
+        op.execute_complete(context=None, event=event)
+        assert op.statement_id == STATEMENT_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_get_openlineage_facets(self, db_mock_class):
+        query = "insert into dest_schema.dest_table select * from source_schema.source_table"
+        op = DatabricksSQLStatementsOperator(task_id=TASK_ID, statement=query, warehouse_id=WAREHOUSE_ID)
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.host = "host"
+
+        op.execute(None)
+
+        result = op.get_openlineage_facets_on_complete(None)
+        assert result.inputs == [Dataset(namespace="databricks://host", name="source_schema.source_table")]
+        assert result.outputs == [Dataset(namespace="databricks://host", name="dest_schema.dest_table")]
+        assert result.run_facets == {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId=STATEMENT_ID, source="databricks://host")
+        }
+        assert result.job_facets == {"sql": SQLJobFacet(query=query)}
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_get_openlineage_facets_with_parametrized_query(self, db_mock_class):
+        query = "insert into dest_schema.:dest select * from source_schema.:src"
+        filled_query = "insert into dest_schema.dest_table select * from source_schema.source_table"
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement=query,
+            warehouse_id=WAREHOUSE_ID,
+            parameters=[{"name": "dest", "value": "dest_table"}, {"name": "src", "value": "source_table"}],
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.host = "host"
+
+        op.execute(None)
+
+        result = op.get_openlineage_facets_on_complete(None)
+        assert result.inputs == [Dataset(namespace="databricks://host", name="source_schema.source_table")]
+        assert result.outputs == [Dataset(namespace="databricks://host", name="dest_schema.dest_table")]
+        assert result.run_facets == {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId=STATEMENT_ID, source="databricks://host")
+        }
+        assert result.job_facets == {"sql": SQLJobFacet(query=filled_query)}
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_get_openlineage_facets_with_default_catalog_and_schema(self, db_mock_class):
+        query = "insert into dest_cat.dest_schema.dest_table select * from source_table"
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement=query,
+            warehouse_id=WAREHOUSE_ID,
+            catalog="default_catalog",
+            schema="default_schema",
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.host = "host"
+
+        op.execute(None)
+
+        result = op.get_openlineage_facets_on_complete(None)
+        assert result.inputs == [
+            Dataset(namespace="databricks://host", name="default_catalog.default_schema.source_table")
+        ]
+        assert result.outputs == [
+            Dataset(namespace="databricks://host", name="dest_cat.dest_schema.dest_table")
+        ]
+        assert result.run_facets == {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId=STATEMENT_ID, source="databricks://host")
+        }
+        assert result.job_facets == {"sql": SQLJobFacet(query=query)}
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_get_openlineage_facets_without_statement_id(self, db_mock_class):
+        """Test missing statement_id, even though that should not happen."""
+        query = "insert into dest_cat.dest_schema.dest_table select * from source_table"
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement=query,
+            warehouse_id=WAREHOUSE_ID,
+            catalog="default_catalog",
+            schema="default_schema",
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.host = "host"
+
+        op.execute(None)
+        op.statement_id = None
+
+        result = op.get_openlineage_facets_on_complete(None)
+        assert result.inputs == [
+            Dataset(namespace="databricks://host", name="default_catalog.default_schema.source_table")
+        ]
+        assert result.outputs == [
+            Dataset(namespace="databricks://host", name="dest_cat.dest_schema.dest_table")
+        ]
+        assert result.run_facets == {}
+        assert result.job_facets == {"sql": SQLJobFacet(query=query)}
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    @mock.patch("airflow.providers.openlineage.sqlparser.SQLParser")
+    def test_get_openlineage_facets_with_sql_parser_error(self, mock_sql_parser, db_mock_class):
+        def raise_func():
+            raise ValueError("sql parsing error")
+
+        query = (
+            "insert into dest_cat.dest_schema.dest_table select * from source_cat.source_schema.source_table"
+        )
+        op = DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement=query,
+            warehouse_id=WAREHOUSE_ID,
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.host = "host"
+        mock_sql_parser().generate_openlineage_metadata_from_sql.side_effect = raise_func
+        mock_sql_parser().create_namespace.return_value = "dbx_namespace"
+        mock_sql_parser.normalize_sql.side_effect = lambda x: "normalized" + x
+
+        op.execute(None)
+
+        result = op.get_openlineage_facets_on_complete(None)
+        assert result.inputs == []
+        assert result.outputs == []
+        assert result.run_facets == {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId=STATEMENT_ID, source="dbx_namespace")
+        }
+        assert result.job_facets == {"sql": SQLJobFacet(query="normalized" + query)}
 
 
 class TestDatabricksNotebookOperator:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds OpenLineage support for DatabricksSQLStatementsOperator. Apart from including Databricks Query ID in OL event, that can be used to get more details about a query from the API later, I've added some offline SQL parsing to possibly extract inputs and outputs.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
