### PR TITLE
Mask secrets when retrieving variables from secrets backend

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -181,7 +181,8 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
                     import json
 
                     var_val = json.loads(var_val)
-                mask_secret(var_val, key)  # type: ignore[arg-type]
+                if isinstance(var_val, str):
+                    mask_secret(var_val, key)
                 return var_val
         except Exception:
             log.exception(

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -39,6 +39,7 @@ from airflow.sdk.definitions.asset import (
     BaseAssetUniqueKey,
 )
 from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.execution_time.secrets_masker import mask_secret
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -180,6 +181,7 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
                     import json
 
                     var_val = json.loads(var_val)
+                mask_secret(var_val, key)  # type: ignore[arg-type]
                 return var_val
         except Exception:
             log.exception(

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
@@ -131,6 +132,27 @@ class TestVariableFromSecrets:
 
             retrieved_var_deser = Variable.get(key="VAR_A", deserialize_json=True)
             assert retrieved_var_deser == dict_data
+
+    @patch("airflow.sdk.execution_time.context.mask_secret")
+    def test_var_get_from_secrets_sensitive_key(self, mock_mask_secret, mock_supervisor_comms, tmp_path):
+        """Tests getting a variable from secrets backend when deserialize_json is provided."""
+        path = tmp_path / "var.json"
+        data = {"secret": "super-secret"}
+        path.write_text(json.dumps(data, indent=4))
+
+        with conf_vars(
+            {
+                (
+                    "workers",
+                    "secrets_backend",
+                ): "airflow.secrets.local_filesystem.LocalFilesystemBackend",
+                ("workers", "secrets_backend_kwargs"): f'{{"variables_file_path": "{path}"}}',
+            }
+        ):
+            retrieved_var = Variable.get(key="secret")
+            assert retrieved_var == "super-secret"
+
+            mock_mask_secret.assert_called_with("super-secret", "secret")
 
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_variable")
     def test_get_variable_env_var(self, mock_env_get, mock_supervisor_comms):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Follow up to this: https://github.com/apache/airflow/pull/50880#discussion_r2099958752





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
