### PR TITLE
[v3-0-test] Update config endpoint to use the get interface (#50902)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -48,9 +48,7 @@ WEBSERVER_CONFIG_KEYS = [
 )
 def get_configs() -> ConfigResponse:
     """Get configs for UI."""
-    conf_dict = conf.as_dict()
-
-    config = {key: conf_dict["webserver"].get(key) for key in WEBSERVER_CONFIG_KEYS}
+    config = {key: conf.get("webserver", key) for key in WEBSERVER_CONFIG_KEYS}
 
     additional_config: dict[str, Any] = {
         "instance_name": conf.get("webserver", "instance_name", fallback="Airflow"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -16,9 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
+
+from tests_common.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
 
@@ -44,23 +44,22 @@ def mock_config_data():
     """
     Mock configuration settings used in the endpoint.
     """
-    with patch("airflow.configuration.conf.as_dict") as mock_conf:
-        mock_conf.return_value = {
-            "webserver": {
-                "page_size": "100",
-                "auto_refresh_interval": "3",
-                "hide_paused_dags_by_default": "false",
-                "instance_name": "Airflow",
-                "instance_name_has_markup": "false",
-                "enable_swagger_ui": "true",
-                "require_confirmation_dag_change": "false",
-                "default_wrap": "false",
-                "warn_deployment_exposure": "false",
-                "audit_view_excluded_events": "",
-                "audit_view_included_events": "",
-            }
+    with conf_vars(
+        {
+            ("webserver", "page_size"): "100",
+            ("webserver", "auto_refresh_interval"): "3",
+            ("webserver", "hide_paused_dags_by_default"): "false",
+            ("webserver", "instance_name"): "Airflow",
+            ("webserver", "instance_name_has_markup"): "false",
+            ("webserver", "enable_swagger_ui"): "true",
+            ("webserver", "require_confirmation_dag_change"): "false",
+            ("webserver", "default_wrap"): "false",
+            ("webserver", "audit_view_excluded_events"): "",
+            ("webserver", "audit_view_included_events"): "",
+            ("webserver", "warn_deployment_exposure"): "false",
         }
-        yield mock_conf
+    ):
+        yield
 
 
 class TestGetConfig:


### PR DESCRIPTION
(cherry picked from commit 0486e6e5a344384d9e98dc60c4e7f19b584c3b40)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
