### PR TITLE
Make test_scheduler_job work locally after moving examples

### DIFF
--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -74,7 +74,7 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.thread_safe_dict import ThreadSafeDict
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
-from system import standard
+from tests_common.pytest_plugin import AIRFLOW_ROOT_PATH
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars, env_vars
 from tests_common.test_utils.db import (
@@ -97,14 +97,11 @@ from unit.utils.test_timezone import UTC
 
 pytestmark = pytest.mark.db_test
 
-ROOT_FOLDER = os.path.realpath(
-    os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir)
-)
-PERF_DAGS_FOLDER = os.path.join(ROOT_FOLDER, "tests", "test_utils", "perf", "dags")
+PERF_DAGS_FOLDER = AIRFLOW_ROOT_PATH / "dev" / "airflow_perf" / "dags"
 ELASTIC_DAG_FILE = os.path.join(PERF_DAGS_FOLDER, "elastic_dag.py")
 
 TEST_DAG_FOLDER = os.environ["AIRFLOW__CORE__DAGS_FOLDER"]
-EXAMPLE_STANDARD_DAGS_FOLDER = standard.__path__[0]
+EXAMPLE_STANDARD_DAGS_FOLDER = AIRFLOW_ROOT_PATH / "providers" / "standard" / "tests" / "system" / "standard"
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 DEFAULT_LOGICAL_DATE = timezone.coerce_datetime(DEFAULT_DATE)
 TRY_NUMBER = 1
@@ -5715,7 +5712,7 @@ class TestSchedulerJob:
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_find_and_purge_task_instances_without_heartbeats(self, session, create_dagrun):
-        dagfile = os.path.join(EXAMPLE_STANDARD_DAGS_FOLDER, "example_branch_operator.py")
+        dagfile = EXAMPLE_STANDARD_DAGS_FOLDER / "example_branch_operator.py"
         dagbag = DagBag(dagfile)
         dag = dagbag.get_dag("example_branch_operator")
         dm = LazyDeserializedDAG(data=SerializedDAG.to_dict(dag))
@@ -5781,7 +5778,7 @@ class TestSchedulerJob:
         """
         Check that the task instance heartbeat timeout message comes out as expected
         """
-        dagfile = os.path.join(EXAMPLE_STANDARD_DAGS_FOLDER, "example_branch_operator.py")
+        dagfile = EXAMPLE_STANDARD_DAGS_FOLDER / "example_branch_operator.py"
         dagbag = DagBag(dagfile)
         dag = dagbag.get_dag("example_branch_operator")
         dm = LazyDeserializedDAG(data=SerializedDAG.to_dict(dag))
@@ -6487,7 +6484,7 @@ class TestSchedulerJobQueriesCount:
         [
             (21, 1, 1),  # One DAG with one task per DAG file.
             (21, 1, 5),  # One DAG with five tasks per DAG file.
-            (93, 10, 10),  # 10 DAGs with 10 tasks per DAG file.
+            (148, 10, 10),  # 10 DAGs with 10 tasks per DAG file.
         ],
     )
     def test_execute_queries_count_with_harvested_dags(
@@ -6528,7 +6525,9 @@ class TestSchedulerJobQueriesCount:
                 dr = dag.create_dagrun(
                     state=State.RUNNING,
                     run_id=f"{DagRunType.MANUAL.value}__{i}",
-                    dag_hash=dagbag.dags_hash[dag.dag_id],
+                    run_after=pendulum.datetime(2025, 1, 1, tz="UTC"),
+                    run_type=DagRunType.MANUAL,
+                    triggered_by=DagRunTriggeredByType.TEST,
                 )
                 dagruns.append(dr)
                 for ti in dr.get_task_instances():
@@ -6574,13 +6573,13 @@ class TestSchedulerJobQueriesCount:
             # 10 DAGs with 10 tasks per DAG file.
             ([10, 10, 10, 10], 10, 10, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 10, 10, "1d", "None", "linear"),
-            ([105, 38, 38, 38], 10, 10, "1d", "@once", "no_structure"),
-            ([115, 51, 51, 51], 10, 10, "1d", "@once", "linear"),
-            ([105, 119, 119, 119], 10, 10, "1d", "30m", "no_structure"),
-            ([115, 145, 145, 145], 10, 10, "1d", "30m", "linear"),
-            ([115, 139, 139, 139], 10, 10, "1d", "30m", "binary_tree"),
-            ([115, 139, 139, 139], 10, 10, "1d", "30m", "star"),
-            ([115, 139, 139, 139], 10, 10, "1d", "30m", "grid"),
+            ([218, 69, 69, 69], 10, 10, "1d", "@once", "no_structure"),
+            ([228, 84, 84, 84], 10, 10, "1d", "@once", "linear"),
+            ([217, 119, 119, 119], 10, 10, "1d", "30m", "no_structure"),
+            ([2227, 145, 145, 145], 10, 10, "1d", "30m", "linear"),
+            ([227, 139, 139, 139], 10, 10, "1d", "30m", "binary_tree"),
+            ([227, 139, 139, 139], 10, 10, "1d", "30m", "star"),
+            ([227, 259, 259, 259], 10, 10, "1d", "30m", "grid"),
         ],
     )
     def test_process_dags_queries_count(


### PR DESCRIPTION
There was an issue with the test after migrating standard provider examples to ... standard provider (#49978) that made the test work only in Breeze and not in local env.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
