### PR TITLE
Fix a bug where Kube config "worker_pod_pending_fatal_container_state_reasons" is parsed wrongly

### DIFF
--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -241,8 +241,8 @@ config:
         version_added: 8.1.0
         type: string
         example: ~
-        default: 'CreateContainerConfigError,ErrImagePull,CreateContainerError,ImageInspectError,
-        InvalidImageName'
+        default: "CreateContainerConfigError,ErrImagePull,CreateContainerError,ImageInspectError,\
+        InvalidImageName"
       worker_pods_creation_batch_size:
         description: |
           Number of Kubernetes Worker Pod creation calls per scheduler loop.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -169,7 +169,7 @@ def get_provider_info():
                         "version_added": "8.1.0",
                         "type": "string",
                         "example": None,
-                        "default": "CreateContainerConfigError,ErrImagePull,CreateContainerError,ImageInspectError, InvalidImageName",
+                        "default": "CreateContainerConfigError,ErrImagePull,CreateContainerError,ImageInspectError,InvalidImageName",
                     },
                     "worker_pods_creation_batch_size": {
                         "description": 'Number of Kubernetes Worker Pod creation calls per scheduler loop.\nNote that the current default of "1" will only launch a single pod\nper-heartbeat. It is HIGHLY recommended that users increase this\nnumber to match the tolerance of their kubernetes cluster for\nbetter performance.\n',

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
@@ -42,9 +42,11 @@ class KubeConfig:
         )
         self.worker_pod_pending_fatal_container_state_reasons = []
         if conf.get(self.kubernetes_section, "worker_pod_pending_fatal_container_state_reasons", fallback=""):
-            self.worker_pod_pending_fatal_container_state_reasons = conf.get(
-                self.kubernetes_section, "worker_pod_pending_fatal_container_state_reasons"
-            ).split(",")
+            self.worker_pod_pending_fatal_container_state_reasons = [
+                r.strip() for r in conf.get(
+                    self.kubernetes_section, "worker_pod_pending_fatal_container_state_reasons"
+                ).split(",")
+            ]
 
         self.worker_pods_creation_batch_size = conf.getint(
             self.kubernetes_section, "worker_pods_creation_batch_size"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
@@ -43,7 +43,8 @@ class KubeConfig:
         self.worker_pod_pending_fatal_container_state_reasons = []
         if conf.get(self.kubernetes_section, "worker_pod_pending_fatal_container_state_reasons", fallback=""):
             self.worker_pod_pending_fatal_container_state_reasons = [
-                r.strip() for r in conf.get(
+                r.strip()
+                for r in conf.get(
                     self.kubernetes_section, "worker_pod_pending_fatal_container_state_reasons"
                 ).split(",")
             ]

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1818,9 +1818,7 @@ class TestKubernetesJobWatcher:
         ],
     )
     def test_kube_config_parse_worker_pod_pending_fatal_container_state_reasons(
-        self,
-        state_reasons,
-        expected_result
+        self, state_reasons, expected_result
     ):
         config = {
             ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): state_reasons,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1415,29 +1415,6 @@ class TestKubernetesExecutor:
         finally:
             get_logs_task_metadata.cache_clear()
 
-    @pytest.mark.parametrize(
-        "state_reasons, expected_result",
-        [
-            pytest.param("e1,e2,e3", ["e1", "e2", "e3"]),
-            pytest.param("e1, e2,e3", ["e1", "e2", "e3"]),
-            pytest.param(" e1,e2, e3", ["e1", "e2", "e3"]),
-            pytest.param("e1", ["e1"]),
-            pytest.param("e1 ", ["e1"]),
-        ],
-    )
-    def test_kube_config_parse_worker_pod_pending_fatal_container_state_reasons(
-        self,
-        state_reasons,
-        expected_result
-    ):
-        config = {
-            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): state_reasons,
-        }
-        with conf_vars(config):
-            executor = KubernetesExecutor()
-
-        assert executor.kube_config.worker_pod_pending_fatal_container_state_reasons == expected_result
-
 
 class TestKubernetesJobWatcher:
     test_namespace = "airflow"
@@ -1829,3 +1806,26 @@ class TestKubernetesJobWatcher:
                 self.watcher.run()
 
             mock_underscore_run.assert_called_once_with(mock.ANY, "0", mock.ANY, mock.ANY)
+
+    @pytest.mark.parametrize(
+        "state_reasons, expected_result",
+        [
+            pytest.param("e1,e2,e3", ["e1", "e2", "e3"]),
+            pytest.param("e1, e2,e3", ["e1", "e2", "e3"]),
+            pytest.param(" e1,e2, e3", ["e1", "e2", "e3"]),
+            pytest.param("e1", ["e1"]),
+            pytest.param("e1 ", ["e1"]),
+        ],
+    )
+    def test_kube_config_parse_worker_pod_pending_fatal_container_state_reasons(
+        self,
+        state_reasons,
+        expected_result
+    ):
+        config = {
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): state_reasons,
+        }
+        with conf_vars(config):
+            executor = KubernetesExecutor()
+
+        assert executor.kube_config.worker_pod_pending_fatal_container_state_reasons == expected_result

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1415,6 +1415,29 @@ class TestKubernetesExecutor:
         finally:
             get_logs_task_metadata.cache_clear()
 
+    @pytest.mark.parametrize(
+        "state_reasons, expected_result",
+        [
+            pytest.param("e1,e2,e3", ["e1", "e2", "e3"]),
+            pytest.param("e1, e2,e3", ["e1", "e2", "e3"]),
+            pytest.param(" e1,e2, e3", ["e1", "e2", "e3"]),
+            pytest.param("e1", ["e1"]),
+            pytest.param("e1 ", ["e1"]),
+        ],
+    )
+    def test_kube_config_parse_worker_pod_pending_fatal_container_state_reasons(
+        self,
+        state_reasons,
+        expected_result
+    ):
+        config = {
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): state_reasons,
+        }
+        with conf_vars(config):
+            executor = KubernetesExecutor()
+
+        assert executor.kube_config.worker_pod_pending_fatal_container_state_reasons == expected_result
+
 
 class TestKubernetesJobWatcher:
     test_namespace = "airflow"


### PR DESCRIPTION
## **Impact:**
This issue results in that one container state reason not handled properly.

## **More details:**

<img width="1018" alt="Screenshot 2025-05-20 at 11 07 16 PM" src="https://github.com/user-attachments/assets/75f58bfa-3a4c-42d3-a23f-d4d6451e99f7" />

Note this unexpected space in the result when we try to get this configuration.

It may seem minor, but actually it's impacting the following logics at https://github.com/apache/airflow/blob/967da37479288bf15e48f71644f42248049ebf7f/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py#L248-L251

It will always fail to handle the reason `InvalidImageName`, because `"InvalidImageName" in [..., " InvalidImageName"]` will always be `False`


## **How did this issue happen:**
The issue originated at the code below, where the break-line is introducing the extra space which is not handled properly later
https://github.com/apache/airflow/blob/967da37479288bf15e48f71644f42248049ebf7f/providers/cncf/kubernetes/provider.yaml#L244-L245

## **Changes made here**
- Updated the `airflow/providers/cncf/kubernetes/provider.yaml` to make the default value correct
- add logics to help further ensure the config is parsed correctly and robustly.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
