### PR TITLE
Check `is_mapped` to prevent `operator_extra_links` property failing for Airflow 3.

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
@@ -32,7 +32,6 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.models.mappedoperator import MappedOperator
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.providers.amazon.aws.links.batch import (
     BatchJobDefinitionLink,
@@ -145,7 +144,7 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
     def operator_extra_links(self):
         op_extra_links = [BatchJobDetailsLink()]
 
-        if isinstance(self, MappedOperator):
+        if self.is_mapped:
             wait_for_completion = self.partial_kwargs.get(
                 "wait_for_completion"
             ) or self.expand_input.value.get("wait_for_completion")


### PR DESCRIPTION
Add missing `airflow.sdk.definitions.mappedoperator.MappedOperator` import to prevent `operator_extra_links` property failing for Airflow 3.


closes: [#50535](https://github.com/apache/airflow/issues/50535)

