### PR TITLE
AIP-38 feat: add Korean language UI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,6 @@
 
 # Translations
 airflow-core/src/airflow/ui/src/i18n/locales/zh_TW/ @Lee-W
-airflow-core/src/airflow/ui/src/i18n/locales/ko/ @choo121600
 
 # Security/Permissions
 /airflow-core/src/airflow/security/permissions.py @vincbeck

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@
 
 # Translations
 airflow-core/src/airflow/ui/src/i18n/locales/zh_TW/ @Lee-W
+airflow-core/src/airflow/ui/src/i18n/locales/ko/ @choo121600
 
 # Security/Permissions
 /airflow-core/src/airflow/security/permissions.py @vincbeck

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -22,6 +22,8 @@ import { initReactI18next } from "react-i18next";
 
 import enCommon from "./locales/en/common.json";
 import enDashboard from "./locales/en/dashboard.json";
+import koCommon from "./locales/ko/common.json";
+import koDashboard from "./locales/ko/dashboard.json";
 import zhTWCommon from "./locales/zh_TW/common.json";
 import zhTWDashboard from "./locales/zh_TW/dashboard.json";
 
@@ -30,6 +32,7 @@ import zhTWDashboard from "./locales/zh_TW/dashboard.json";
 
 export const supportedLanguages = [
   { code: "en", name: "English" },
+  { code: "ko", name: "한국어" },
   { code: "zh_TW", name: "繁體中文" },
 ] as const;
 
@@ -40,6 +43,10 @@ const resources = {
   en: {
     common: enCommon,
     dashboard: enDashboard,
+  },
+  ko: {
+    common: koCommon,
+    dashboard: koDashboard,
   },
   zh_TW: {
     common: zhTWCommon,

--- a/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
@@ -10,6 +10,7 @@
     "chinese": "중국어 번체",
     "english": "영어",
     "korean": "한국어",
+    "german": "독일어",
     "select": "언어 선택"
   },
   "nav": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
@@ -1,0 +1,78 @@
+{
+  "defaultToGraphView": "그래프 뷰 기본 보기",
+  "defaultToGridView": "그리드 뷰 기본 보기",
+  "logout": "로그아웃",
+  "switchToDarkMode": "다크 모드로 전환",
+  "switchToLightMode": "라이트 모드로 전환",
+  "timezone": "시간대",
+  "user": "사용자",
+  "language": {
+    "chinese": "중국어 번체",
+    "english": "영어",
+    "korean": "한국어",
+    "select": "언어 선택"
+  },
+  "nav": {
+    "home": "홈",
+    "assets": "에셋",
+    "browse": "탐색",
+    "admin": "관리자",
+    "docs": "문서",
+    "plugins": "플러그인"
+  },
+  "browse": {
+    "auditLog": "감사 로그",
+    "xcoms": "XComs"
+  },
+  "admin": {
+    "Variables": "변수들",
+    "Pools": "Pools",
+    "Providers": "제공자들",
+    "Plugins": "플러그인들",
+    "Connections": "연결들",
+    "Config": "설정"
+  },
+  "timeRange": {
+    "duration": "지속 시간",
+    "lastHour": "지난 1시간",
+    "last12Hours": "지난 12 시간",
+    "last24Hours": "지난 24 시간",
+    "pastWeek": "지난 주"
+  },
+  "docs": {
+    "documentation": "문서",
+    "githubRepo": "GitHub 저장소",
+    "restApiReference": "REST API 참조"
+  },
+  "states": {
+    "queued": "대기 중",
+    "running": "실행 중",
+    "success": "성공",
+    "failed": "실패",
+    "skipped": "건너뜀",
+    "removed": "제거됨",
+    "scheduled": "예약됨",
+    "restarting": "다시 시작 중",
+    "up_for_retry": "재시도 대기 중",
+    "up_for_reschedule": "재예약 대기 중",
+    "upstream_failed": "업스트림 실패",
+    "deferred": "연기됨",
+    "no_status": "상태 없음"
+  },
+  "dagRun_one": "Dag 실행",
+  "dagRun_other": "Dag 실행들",
+  "taskInstance_one": "작업 인스턴스",
+  "taskInstance_other": "작업 인스턴스들",
+  "assetEvent_one": "에셋 이벤트",
+  "assetEvent_other": "에셋 이벤트들",
+  "triggered": "트리거됨",
+  "pools": {
+    "open": "열림",
+    "running": "실행 중",
+    "queued": "대기 중",
+    "scheduled": "예약됨",
+    "deferred": "연기됨",
+    "pools_one": "pool",
+    "pools_other": "pools"
+  }
+}

--- a/airflow-core/src/airflow/ui/src/i18n/locales/ko/dashboard.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/ko/dashboard.json
@@ -1,0 +1,38 @@
+{
+  "welcome": "환영합니다",
+  "stats": {
+    "stats": "통계",
+    "failedDags": "실패한 Dags",
+    "runningDags": "실행 중인 Dags",
+    "activeDags": "활성 Dags",
+    "queuedDags": "대기 중인 Dags"
+  },
+  "health": {
+    "health": "상태",
+    "metaDatabase": "메타데이터베이스",
+    "scheduler": "스케줄러",
+    "triggerer": "트리거러",
+    "dagProcessor": "Dag 프로세서",
+    "status": "상태",
+    "lastHeartbeat": "마지막 Heartbeat",
+    "healthy": "정상",
+    "unhealthy": "비정상"
+  },
+  "importErrors": {
+    "searchByFile": "파일로 검색",
+    "dagImportError_one": "Dag 가져오기 오류",
+    "dagImportError_other": "Dag 가져오기 오류들",
+    "timestamp": "타임스탬프"
+  },
+  "poolSlots": "Pool 슬롯",
+  "managePools": "Pools 관리",
+  "history": "기록",
+  "sortBy": {
+    "newestFirst": "최신순",
+    "oldestFirst": "오래된 순"
+  },
+  "source": "소스",
+  "group": "그룹",
+  "uri": "Uri",
+  "noAssetEvents": "자산 이벤트를 찾을 수 없습니다."
+}


### PR DESCRIPTION
Follow up to #50626 & #50863 - added Korean UI string translations.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
