### PR TITLE
Remove Airflow 2 code path in executors

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -29,12 +29,13 @@ import pendulum
 
 from airflow.cli.cli_config import DefaultHelpParser
 from airflow.configuration import conf
+from airflow.executors import workloads
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models import Log
 from airflow.stats import Stats
 from airflow.traces import NO_TRACE_ID
 from airflow.traces.tracer import Trace, add_span, gen_context
-from airflow.traces.utils import gen_span_id_from_ti_key, gen_trace_id
+from airflow.traces.utils import gen_span_id_from_ti_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.thread_safe_dict import ThreadSafeDict
@@ -51,28 +52,14 @@ if TYPE_CHECKING:
     from airflow.callbacks.base_callback_sink import BaseCallbackSink
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.cli.cli_config import GroupCommand
-    from airflow.executors import workloads
     from airflow.executors.executor_utils import ExecutorName
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
-
-    # Command to execute - list of strings
-    # the first element is always "airflow".
-    # It should be result of TaskInstance.generate_command method.
-    CommandType = Sequence[str]
-
-    # Task that is queued. It contains all the information that is
-    # needed to run the task.
-    #
-    # Tuple of: command, priority, queue name, TaskInstance
-    QueuedTaskInstanceType = tuple[CommandType, int, Optional[str], TaskInstance]
 
     # Event_buffer dict value type
     # Tuple of: state, info
     EventBufferValueType = tuple[Optional[str], Any]
 
-    # Task tuple to send to be executed
-    TaskTuple = tuple[TaskInstanceKey, CommandType, Optional[str], Optional[Any]]
 
 log = logging.getLogger(__name__)
 
@@ -159,7 +146,7 @@ class BaseExecutor(LoggingMixin):
 
         self.parallelism: int = parallelism
         self.team_id: str | None = team_id
-        self.queued_tasks: dict[TaskInstanceKey, QueuedTaskInstanceType] = {}
+        self.queued_tasks: dict[TaskInstanceKey, workloads.ExecuteTask] = {}
         self.running: set[TaskInstanceKey] = set()
         self.event_buffer: dict[TaskInstanceKey, EventBufferValueType] = {}
         self._task_event_logs: deque[Log] = deque()
@@ -192,62 +179,23 @@ class BaseExecutor(LoggingMixin):
         """Add an event to the log table."""
         self._task_event_logs.append(Log(event=event, task_instance=ti_key, extra=extra))
 
-    def queue_command(
-        self,
-        task_instance: TaskInstance,
-        command: CommandType,
-        priority: int = 1,
-        queue: str | None = None,
-    ):
-        """Queues command to task."""
-        if task_instance.key not in self.queued_tasks:
-            self.log.info("Adding to queue: %s", command)
-            self.queued_tasks[task_instance.key] = (command, priority, queue, task_instance)
-        else:
-            self.log.error("could not queue task %s", task_instance.key)
-
     def queue_workload(self, workload: workloads.All, session: Session) -> None:
-        raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
+        if not isinstance(workload, workloads.ExecuteTask):
+            raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
+        ti = workload.ti
+        self.queued_tasks[ti.key] = workload
 
-    def queue_task_instance(
-        self,
-        task_instance: TaskInstance,
-        mark_success: bool = False,
-        ignore_all_deps: bool = False,
-        ignore_depends_on_past: bool = False,
-        wait_for_past_depends_before_skipping: bool = False,
-        ignore_task_deps: bool = False,
-        ignore_ti_state: bool = False,
-        pool: str | None = None,
-        cfg_path: str | None = None,
-    ) -> None:
-        """Queues task instance."""
-        if TYPE_CHECKING:
-            assert task_instance.task
+    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
+        """
+        Process the given workloads.
 
-        pool = pool or task_instance.pool
+        This method must be implemented by subclasses to define how they handle
+        the execution of workloads (e.g., queuing them to workers, submitting to
+        external systems, etc.).
 
-        command_list_to_run = task_instance.command_as_list(
-            local=True,
-            mark_success=mark_success,
-            ignore_all_deps=ignore_all_deps,
-            ignore_depends_on_past=ignore_depends_on_past,
-            wait_for_past_depends_before_skipping=wait_for_past_depends_before_skipping,
-            ignore_task_deps=ignore_task_deps,
-            ignore_ti_state=ignore_ti_state,
-            pool=pool,
-            # cfg_path is needed to propagate the config values if using impersonation
-            # (run_as_user), given that there are different code paths running tasks.
-            # https://github.com/apache/airflow/pull/2991
-            cfg_path=cfg_path,
-        )
-        self.log.debug("created command %s", command_list_to_run)
-        self.queue_command(
-            task_instance,
-            command_list_to_run,
-            priority=task_instance.priority_weight,
-            queue=task_instance.task.queue,
-        )
+        :param workloads: List of workloads to process
+        """
+        raise NotImplementedError(f"{type(self).__name__} must implement _process_workloads()")
 
     def has_task(self, task_instance: TaskInstance) -> bool:
         """
@@ -347,29 +295,19 @@ class BaseExecutor(LoggingMixin):
             tags={"status": "running", "name": name},
         )
 
-    def order_queued_tasks_by_priority(self) -> list[tuple[TaskInstanceKey, QueuedTaskInstanceType]]:
+    def order_queued_tasks_by_priority(self) -> list[tuple[TaskInstanceKey, workloads.ExecuteTask]]:
         """
         Orders the queued tasks by priority.
 
-        :return: List of tuples from the queued_tasks according to the priority.
+        :return: List of workloads from the queued_tasks according to the priority.
         """
-        from airflow.executors import workloads
-
         if not self.queued_tasks:
             return []
 
-        kind = next(iter(self.queued_tasks.values()))
-        if isinstance(kind, workloads.BaseWorkload):
-            # V3 + new executor that supports workloads
-            return sorted(
-                self.queued_tasks.items(),
-                key=lambda x: x[1].ti.priority_weight,
-                reverse=True,
-            )
-
+        # V3 + new executor that supports workloads
         return sorted(
             self.queued_tasks.items(),
-            key=lambda x: x[1][1],
+            key=lambda x: x[1].ti.priority_weight,
             reverse=True,
         )
 
@@ -381,7 +319,6 @@ class BaseExecutor(LoggingMixin):
         :param open_slots: Number of open slots
         """
         sorted_queue = self.order_queued_tasks_by_priority()
-        task_tuples = []
         workload_list = []
 
         for _ in range(min((open_slots, len(self.queued_tasks)))):
@@ -397,103 +334,38 @@ class BaseExecutor(LoggingMixin):
             # deferred task has completed. In this case and for this reason,
             # we make a small number of attempts to see if the task has been
             # removed from the running set in the meantime.
-            if key in self.running:
-                attempt = self.attempts[key]
-                if attempt.can_try_again():
-                    # if it hasn't been much time since first check, let it be checked again next time
-                    self.log.info("queued but still running; attempt=%s task=%s", attempt.total_tries, key)
-                    continue
-
-                # Otherwise, we give up and remove the task from the queue.
-                self.log.error(
-                    "could not queue task %s (still running after %d attempts).",
-                    key,
-                    attempt.total_tries,
-                )
-                self.log_task_event(
-                    event="task launch failure",
-                    extra=(
-                        "Task was in running set and could not be queued "
-                        f"after {attempt.total_tries} attempts."
-                    ),
-                    ti_key=key,
-                )
+            if key in self.attempts:
                 del self.attempts[key]
-                del self.queued_tasks[key]
-            else:
-                if key in self.attempts:
-                    del self.attempts[key]
-                # TODO: TaskSDK: Compat, remove when KubeExecutor is fully moved over to TaskSDK too.
-                # TODO: TaskSDK: We need to minimum version requirements on executors with Airflow 3.
-                # How/where do we do that? Executor loader?
-                from airflow.executors import workloads
 
-                if isinstance(item, workloads.ExecuteTask) and hasattr(item, "ti"):
-                    ti = item.ti
+            if isinstance(item, workloads.ExecuteTask) and hasattr(item, "ti"):
+                ti = item.ti
 
-                    # If it's None, then the span for the current TaskInstanceKey hasn't been started.
-                    if self.active_spans is not None and self.active_spans.get(key) is None:
-                        from airflow.models.taskinstance import SimpleTaskInstance
+                # If it's None, then the span for the current TaskInstanceKey hasn't been started.
+                if self.active_spans is not None and self.active_spans.get(key) is None:
+                    from airflow.models.taskinstance import SimpleTaskInstance
 
-                        if isinstance(ti, (SimpleTaskInstance, workloads.TaskInstance)):
-                            parent_context = Trace.extract(ti.parent_context_carrier)
-                        else:
-                            parent_context = Trace.extract(ti.dag_run.context_carrier)
-                        # Start a new span using the context from the parent.
-                        # Attributes will be set once the task has finished so that all
-                        # values will be available (end_time, duration, etc.).
+                    if isinstance(ti, (SimpleTaskInstance, workloads.TaskInstance)):
+                        parent_context = Trace.extract(ti.parent_context_carrier)
+                    else:
+                        parent_context = Trace.extract(ti.dag_run.context_carrier)
+                    # Start a new span using the context from the parent.
+                    # Attributes will be set once the task has finished so that all
+                    # values will be available (end_time, duration, etc.).
 
-                        span = Trace.start_child_span(
-                            span_name=f"{ti.task_id}",
-                            parent_context=parent_context,
-                            component="task",
-                            start_as_current=False,
-                        )
-                        self.active_spans.set(key, span)
-                        # Inject the current context into the carrier.
-                        carrier = Trace.inject()
-                        ti.context_carrier = carrier
+                    span = Trace.start_child_span(
+                        span_name=f"{ti.task_id}",
+                        parent_context=parent_context,
+                        component="task",
+                        start_as_current=False,
+                    )
+                    self.active_spans.set(key, span)
+                    # Inject the current context into the carrier.
+                    carrier = Trace.inject()
+                    ti.context_carrier = carrier
 
-                if hasattr(self, "_process_workloads"):
-                    workload_list.append(item)
-                else:
-                    (command, _, queue, ti) = item
-                    task_tuples.append((key, command, queue, getattr(ti, "executor_config", None)))
-
-        if task_tuples:
-            self._process_tasks(task_tuples)
-        elif workload_list:
-            self._process_workloads(workload_list)  # type: ignore[attr-defined]
-
-    @add_span
-    def _process_tasks(self, task_tuples: list[TaskTuple]) -> None:
-        for key, command, queue, executor_config in task_tuples:
-            task_instance = self.queued_tasks[key][3]  # TaskInstance in fourth element
-            trace_id = int(gen_trace_id(task_instance.dag_run, as_int=True))
-            span_id = int(gen_span_id_from_ti_key(key, as_int=True))
-            links = [{"trace_id": trace_id, "span_id": span_id}]
-
-            # assuming that the span_id will very likely be unique inside the trace
-            with Trace.start_span(
-                span_name=f"{key.dag_id}.{key.task_id}",
-                component="BaseExecutor",
-                span_id=span_id,
-                links=links,
-            ) as span:
-                span.set_attributes(
-                    {
-                        "dag_id": key.dag_id,
-                        "run_id": key.run_id,
-                        "task_id": key.task_id,
-                        "try_number": key.try_number,
-                        "command": str(command),
-                        "queue": str(queue),
-                        "executor_config": str(executor_config),
-                    }
-                )
-                del self.queued_tasks[key]
-                self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
-                self.running.add(key)
+                workload_list.append(item)
+        if workload_list:
+            self._process_workloads(workload_list)
 
     # TODO: This should not be using `TaskInstanceState` here, this is just "did the process complete, or did
     # it die". It is possible for the task itself to finish with success, but the state of the task to be set
@@ -609,23 +481,6 @@ class BaseExecutor(LoggingMixin):
 
         return cleared_events
 
-    def execute_async(
-        self,
-        key: TaskInstanceKey,
-        command: CommandType,
-        queue: str | None = None,
-        executor_config: Any | None = None,
-    ) -> None:  # pragma: no cover
-        """
-        Execute the command asynchronously.
-
-        :param key: Unique key for the task instance
-        :param command: Command to run
-        :param queue: name of the queue
-        :param executor_config: Configuration passed to the executor.
-        """
-        raise NotImplementedError()
-
     def get_task_log(self, ti: TaskInstance, try_number: int) -> tuple[list[str], list[str]]:
         """
         Return the task logs.
@@ -682,28 +537,6 @@ class BaseExecutor(LoggingMixin):
     def slots_occupied(self):
         """Number of tasks this executor instance is currently managing."""
         return len(self.running) + len(self.queued_tasks)
-
-    @staticmethod
-    def validate_airflow_tasks_run_command(command: Sequence[str]) -> tuple[str | None, str | None]:
-        """
-        Check if the command to execute is airflow command.
-
-        Returns tuple (dag_id,task_id) retrieved from the command (replaced with None values if missing)
-        """
-        if command[0:3] != ["airflow", "tasks", "run"]:
-            raise ValueError('The command must start with ["airflow", "tasks", "run"].')
-        if len(command) > 3 and "--help" not in command:
-            dag_id: str | None = None
-            task_id: str | None = None
-            for arg in command[3:]:
-                if not arg.startswith("--"):
-                    if dag_id is None:
-                        dag_id = arg
-                    else:
-                        task_id = arg
-                        break
-            return dag_id, task_id
-        return None, None
 
     def debug_dump(self):
         """Get called in response to SIGUSR2 by the scheduler."""

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -42,7 +42,6 @@ from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallback
 from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
 from airflow.executors import workloads
-from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import Job, perform_heartbeat
@@ -88,6 +87,7 @@ if TYPE_CHECKING:
     from pendulum.datetime import DateTime
     from sqlalchemy.orm import Query, Session
 
+    from airflow.executors.base_executor import BaseExecutor
     from airflow.executors.executor_utils import ExecutorName
     from airflow.models.taskinstance import TaskInstanceKey
     from airflow.utils.sqlalchemy import (
@@ -698,29 +698,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti.set_state(None, session=session)
                 continue
 
-            # TODO: Task-SDK: This check is transitionary. Remove once all executors are ported over.
-            # Has a real queue_activity implemented
-            if executor.queue_workload.__func__ is not BaseExecutor.queue_workload:  # type: ignore[attr-defined]
-                workload = workloads.ExecuteTask.make(ti, generator=executor.jwt_generator)
-                executor.queue_workload(workload, session=session)
-                continue
-
-            command = ti.command_as_list(
-                local=True,
-            )
-
-            priority = ti.priority_weight
-            queue = ti.queue
-            self.log.info(
-                "Sending %s to %s with priority %s and queue %s", ti.key, executor.name, priority, queue
-            )
-
-            executor.queue_command(
-                ti,
-                command,
-                priority=priority,
-                queue=queue,
-            )
+            workload = workloads.ExecuteTask.make(ti, generator=executor.jwt_generator)
+            executor.queue_workload(workload, session=session)
 
     def _critical_section_enqueue_task_instances(self, session: Session) -> int:
         """

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -27,6 +27,7 @@ import time_machine
 
 from airflow.cli.cli_config import DefaultHelpParser, GroupCommand
 from airflow.cli.cli_parser import AirflowHelpFormatter
+from airflow.executors import workloads
 from airflow.executors.base_executor import BaseExecutor, RunningRetryAttemptType
 from airflow.executors.local_executor import LocalExecutor
 from airflow.models.baseoperator import BaseOperator
@@ -183,149 +184,61 @@ def test_try_adopt_task_instances(dag_maker):
     assert BaseExecutor().try_adopt_task_instances(tis) == tis
 
 
-def enqueue_tasks(executor, dagrun):
-    for task_instance in dagrun.task_instances:
-        executor.queue_command(task_instance, ["airflow"])
-
-
 def setup_trigger_tasks(dag_maker, parallelism=None):
     dagrun = setup_dagrun(dag_maker)
     if parallelism:
         executor = BaseExecutor(parallelism=parallelism)
     else:
         executor = BaseExecutor()
-    executor.execute_async = mock.Mock()
-    enqueue_tasks(executor, dagrun)
+
+    executor._process_workloads = mock.Mock()
+
+    for task_instance in dagrun.task_instances:
+        workload = workloads.ExecuteTask.make(task_instance)
+        executor.queued_tasks[task_instance.key] = workload
+
     return executor, dagrun
 
 
 @pytest.mark.db_test
-@pytest.mark.parametrize("open_slots", [1, 2, 3])
-def test_trigger_queued_tasks(dag_maker, open_slots):
-    executor_parallelism = 10
-    executor, dagrun = setup_trigger_tasks(dag_maker, executor_parallelism)
-    num_tasks = len(dagrun.task_instances)
-
-    # All tasks are queued in setup method
-    assert executor.slots_occupied == num_tasks
-    assert executor.slots_available == executor_parallelism - num_tasks
-    assert len(executor.queued_tasks) == num_tasks
-    assert len(executor.running) == 0
-    executor.trigger_tasks(open_slots)
-    assert executor.slots_available == executor_parallelism - num_tasks
-    assert executor.slots_occupied == num_tasks
-    assert len(executor.queued_tasks) == num_tasks - open_slots
-    # Only open_slots number of tasks are allowed through to running
-    assert len(executor.running) == open_slots
-    assert executor.execute_async.call_count == open_slots
-
-
-@pytest.mark.db_test
-@pytest.mark.parametrize(
-    "can_try_num, change_state_num, second_exec",
-    [
-        (2, 3, False),
-        (3, 3, True),
-        (4, 3, True),
-    ],
-)
-@mock.patch("airflow.executors.base_executor.RunningRetryAttemptType.can_try_again")
-def test_trigger_running_tasks(can_try_mock, dag_maker, can_try_num, change_state_num, second_exec):
-    can_try_mock.side_effect = [True for _ in range(can_try_num)] + [False]
+def test_trigger_queued_tasks(dag_maker):
+    """Test that trigger_tasks() calls _process_workloads() when there are queued workloads."""
     executor, dagrun = setup_trigger_tasks(dag_maker)
-    open_slots = 100
-    executor.trigger_tasks(open_slots)
-    expected_calls = len(dagrun.task_instances)  # initially `execute_async` called for each task
-    assert executor.execute_async.call_count == expected_calls
 
-    # All the tasks are now "running", so while we enqueue them again here,
-    # they won't be executed again until the executor has been notified of a state change.
+    # Verify tasks are queued
+    assert len(executor.queued_tasks) == 3
+
+    # Call trigger_tasks with enough slots
+    executor.trigger_tasks(open_slots=10)
+
+    executor._process_workloads.assert_called_once()
+
+    # Verify it was called with the expected workloads
+    call_args = executor._process_workloads.call_args[0][0]
+    assert len(call_args) == 3
+
+
+@pytest.mark.db_test
+def test_trigger_running_tasks(dag_maker):
+    """Test that trigger_tasks() works when tasks are re-queued."""
+    executor, dagrun = setup_trigger_tasks(dag_maker)
+
+    executor.trigger_tasks(open_slots=10)
+    executor._process_workloads.assert_called_once()
+
+    # Reset mock for second call
+    executor._process_workloads.reset_mock()
+
+    # Re-queue one task (simulates retry scenario)
     ti = dagrun.task_instances[0]
-    assert ti.key in executor.running
-    assert ti.key not in executor.queued_tasks
-    executor.queue_command(ti, ["airflow"])
 
-    # this is the problem we're dealing with: ti.key both queued and running
-    assert ti.key in executor.queued_tasks
-    assert ti.key in executor.running
-    assert len(executor.attempts) == 0
-    executor.trigger_tasks(open_slots)
+    workload = workloads.ExecuteTask.make(ti)
+    executor.queued_tasks[ti.key] = workload
 
-    # first trigger call after queueing again creates an attempt object
-    assert len(executor.attempts) == 1
-    assert ti.key in executor.attempts
+    executor.trigger_tasks(open_slots=10)
 
-    for attempt in range(2, change_state_num + 2):
-        executor.trigger_tasks(open_slots)
-        if attempt <= min(can_try_num, change_state_num):
-            assert ti.key in executor.queued_tasks
-            assert ti.key in executor.running
-        # On the configured attempt, we notify the executor that the task has succeeded.
-        if attempt == change_state_num:
-            executor.change_state(ti.key, State.SUCCESS)
-            assert ti.key not in executor.running
-    # retry was ok when state changed, ti.key will be in running (for the second time)
-    if can_try_num >= change_state_num:
-        assert ti.key in executor.running
-    else:  # otherwise, it won't be
-        assert ti.key not in executor.running
-    # either way, ti.key not in queued -- it was either removed because never left running
-    # or it was moved out when run 2nd time
-    assert ti.key not in executor.queued_tasks
-    assert not executor.attempts
-
-    # we expect one more "execute_async" if TI was marked successful
-    # this would move it out of running set and free the queued TI to be executed again
-    if second_exec is True:
-        expected_calls += 1
-
-    assert executor.execute_async.call_count == expected_calls
-
-
-@pytest.mark.db_test
-def test_validate_airflow_tasks_run_command(dag_maker):
-    dagrun = setup_dagrun(dag_maker)
-    tis = dagrun.task_instances
-    print(f"command: {tis[0].command_as_list()}")
-    dag_id, task_id = BaseExecutor.validate_airflow_tasks_run_command(tis[0].command_as_list())
-    print(f"dag_id: {dag_id}, task_id: {task_id}")
-    assert dag_id == dagrun.dag_id
-    assert task_id == tis[0].task_id
-
-
-@pytest.mark.db_test
-@mock.patch(
-    "airflow.models.taskinstance.TaskInstance.generate_command",
-    return_value=["airflow", "tasks", "run", "--test_dag", "--test_task"],
-)
-def test_validate_airflow_tasks_run_command_with_complete_forloop(generate_command_mock, dag_maker):
-    dagrun = setup_dagrun(dag_maker)
-    tis = dagrun.task_instances
-    dag_id, task_id = BaseExecutor.validate_airflow_tasks_run_command(tis[0].command_as_list())
-    assert dag_id is None
-    assert task_id is None
-
-
-@pytest.mark.db_test
-@mock.patch(
-    "airflow.models.taskinstance.TaskInstance.generate_command", return_value=["airflow", "task", "run"]
-)
-def test_invalid_airflow_tasks_run_command(generate_command_mock, dag_maker):
-    dagrun = setup_dagrun(dag_maker)
-    tis = dagrun.task_instances
-    with pytest.raises(ValueError):
-        BaseExecutor.validate_airflow_tasks_run_command(tis[0].command_as_list())
-
-
-@pytest.mark.db_test
-@mock.patch(
-    "airflow.models.taskinstance.TaskInstance.generate_command", return_value=["airflow", "tasks", "run"]
-)
-def test_empty_airflow_tasks_run_command(generate_command_mock, dag_maker):
-    dagrun = setup_dagrun(dag_maker)
-    tis = dagrun.task_instances
-    dag_id, task_id = BaseExecutor.validate_airflow_tasks_run_command(tis[0].command_as_list())
-    assert dag_id is None, task_id is None
+    # Verify _process_workloads was called again
+    executor._process_workloads.assert_called_once()
 
 
 def test_debug_dump(caplog):

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -203,7 +203,7 @@ class AwsLambdaExecutor(BaseExecutor):
         ti = workload.ti
         self.queued_tasks[ti.key] = workload
 
-    def _process_workloads(self, workloads: list[workloads.All]) -> None:
+    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         from airflow.executors.workloads import ExecuteTask
 
         for w in workloads:

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -131,7 +131,7 @@ class AwsEcsExecutor(BaseExecutor):
         ti = workload.ti
         self.queued_tasks[ti.key] = workload
 
-    def _process_workloads(self, workloads: list[workloads.All]) -> None:
+    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         from airflow.executors.workloads import ExecuteTask
 
         # Airflow V3 version

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
@@ -607,6 +607,7 @@ class TestAwsBatchExecutor:
         }
         executor.batch.describe_jobs.return_value = {"jobs": [after_batch_job]}
 
+    @pytest.mark.skip(reason="Adopting task instances hasn't been ported over to Airflow 3 yet")
     def test_try_adopt_task_instances(self, mock_executor):
         """Test that executor can adopt orphaned task instances from a SchedulerJob shutdown event."""
         mock_executor.batch.describe_jobs.return_value = {

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1249,6 +1249,7 @@ class TestAwsEcsExecutor:
             "test failure" in caplog.messages[0]
         )
 
+    @pytest.mark.skip(reason="Adopting task instances hasn't been ported over to Airflow 3 yet")
     def test_try_adopt_task_instances(self, mock_executor):
         """Test that executor can adopt orphaned task instances from a SchedulerJob shutdown event."""
         mock_executor.ecs.describe_tasks.return_value = {

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 import traceback
 import warnings
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -63,15 +63,19 @@ if TYPE_CHECKING:
     from celery.result import AsyncResult
 
     from airflow.executors import workloads
-    from airflow.executors.base_executor import CommandType, EventBufferValueType
+    from airflow.executors.base_executor import EventBufferValueType
     from airflow.models.taskinstance import TaskInstanceKey
     from airflow.typing_compat import TypeAlias
 
     # We can't use `if AIRFLOW_V_3_0_PLUS` conditions in type checks, so unfortunately we just have to define
     # the type as the union of both kinds
+    CommandType = Sequence[str]
+
     TaskInstanceInCelery: TypeAlias = tuple[
         TaskInstanceKey, Union[workloads.All, CommandType], Optional[str], Task
     ]
+
+    TaskTuple = tuple[TaskInstanceKey, CommandType, Optional[str], Optional[Any]]
 
 OPERATION_TIMEOUT = conf.getfloat("celery", "operation_timeout")
 
@@ -181,7 +185,7 @@ if not AIRFLOW_V_3_0_PLUS:
     @app.task
     def execute_command(command_to_exec: CommandType) -> None:
         """Execute command."""
-        dag_id, task_id = BaseExecutor.validate_airflow_tasks_run_command(command_to_exec)
+        dag_id, task_id = BaseExecutor.validate_airflow_tasks_run_command(command_to_exec)  # type: ignore[attr-defined]
         celery_task_id = app.current_task.request.id
         log.info("[%s] Executing command in Celery: %s", celery_task_id, command_to_exec)
         with _airflow_parsing_context_manager(dag_id=dag_id, task_id=task_id):

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from deprecated import deprecated
 
@@ -38,13 +38,11 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 if TYPE_CHECKING:
     from airflow.callbacks.base_callback_sink import BaseCallbackSink
     from airflow.callbacks.callback_requests import CallbackRequest
-    from airflow.executors.base_executor import (
-        CommandType,
-        EventBufferValueType,
-        QueuedTaskInstanceType,
-    )
+    from airflow.executors.base_executor import EventBufferValueType
     from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
+
+    CommandType = Sequence[str]
 
 
 class CeleryKubernetesExecutor(BaseExecutor):
@@ -93,7 +91,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         """Not implemented for hybrid executors."""
 
     @property
-    def queued_tasks(self) -> dict[TaskInstanceKey, QueuedTaskInstanceType]:
+    def queued_tasks(self) -> dict[TaskInstanceKey, Any]:
         """Return queued tasks from celery and kubernetes executor."""
         queued_tasks = self.celery_executor.queued_tasks.copy()
         queued_tasks.update(self.kubernetes_executor.queued_tasks)  # type: ignore[arg-type]
@@ -155,7 +153,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         """Queues command via celery or kubernetes executor."""
         executor = self._router(task_instance)
         self.log.debug("Using executor: %s for %s", executor.__class__.__name__, task_instance.key)
-        executor.queue_command(task_instance, command, priority, queue)
+        executor.queue_command(task_instance, command, priority, queue)  # type: ignore[union-attr]
 
     def queue_task_instance(
         self,
@@ -182,7 +180,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         if not hasattr(task_instance, "pickle_id"):
             del kwargs["pickle_id"]
 
-        executor.queue_task_instance(
+        executor.queue_task_instance(  # type: ignore[union-attr]
             task_instance=task_instance,
             mark_success=mark_success,
             ignore_all_deps=ignore_all_deps,

--- a/providers/celery/tests/unit/celery/executors/test_celery_kubernetes_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_kubernetes_executor.py
@@ -88,6 +88,7 @@ class TestCeleryKubernetesExecutor:
         celery_executor_mock.start.assert_called()
         k8s_executor_mock.start.assert_called()
 
+    @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 3 doesn't have queue_command anymore")
     @pytest.mark.parametrize("test_queue", ["any-other-queue", KUBERNETES_QUEUE])
     @mock.patch.object(CeleryExecutor, "queue_command")
     @mock.patch.object(KubernetesExecutor, "queue_command")

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -76,13 +76,13 @@ from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     import argparse
+    from collections.abc import Sequence
 
     from kubernetes import client
     from kubernetes.client import models as k8s
     from sqlalchemy.orm import Session
 
     from airflow.executors import workloads
-    from airflow.executors.base_executor import CommandType
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
@@ -254,7 +254,7 @@ class KubernetesExecutor(BaseExecutor):
     def execute_async(
         self,
         key: TaskInstanceKey,
-        command: CommandType,
+        command: Any,
         queue: str | None = None,
         executor_config: Any | None = None,
     ) -> None:
@@ -292,7 +292,7 @@ class KubernetesExecutor(BaseExecutor):
         ti = workload.ti
         self.queued_tasks[ti.key] = workload
 
-    def _process_workloads(self, workloads: list[workloads.All]) -> None:
+    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         from airflow.executors.workloads import ExecuteTask
 
         # Airflow V3 version

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -20,9 +20,13 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 ADOPTED = "adopted"
 if TYPE_CHECKING:
-    from airflow.executors.base_executor import CommandType
+    from collections.abc import Sequence
+
     from airflow.models.taskinstance import TaskInstanceKey
     from airflow.utils.state import TaskInstanceState
+
+    # TODO: Remove after Airflow 2 support is removed
+    CommandType = Sequence[str]
 
     # TaskInstance key, command, configuration, pod_template_file
     KubernetesJobType = tuple[TaskInstanceKey, CommandType, Any, Optional[str]]

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -41,7 +41,7 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     annotations_to_key,
     create_unique_id,
 )
-from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, workload_to_command_args
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.singleton import Singleton
 from airflow.utils.state import TaskInstanceState
@@ -387,20 +387,12 @@ class AirflowKubernetesScheduler(LoggingMixin):
         key, command, kube_executor_config, pod_template_file = next_job
 
         dag_id, task_id, run_id, try_number, map_index = key
-        ser_input = ""
         if len(command) == 1:
             from airflow.executors.workloads import ExecuteTask
 
             if isinstance(command[0], ExecuteTask):
                 workload = command[0]
-                ser_input = workload.model_dump_json()
-                command = [
-                    "python",
-                    "-m",
-                    "airflow.sdk.execution_time.execute_workload",
-                    "--json-string",
-                    ser_input,
-                ]
+                command = workload_to_command_args(workload)
             else:
                 raise ValueError(
                     f"KubernetesExecutor doesn't know how to handle workload of type: {type(command[0])}"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from deprecated import deprecated
 
@@ -30,13 +30,11 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import Kube
 if TYPE_CHECKING:
     from airflow.callbacks.base_callback_sink import BaseCallbackSink
     from airflow.callbacks.callback_requests import CallbackRequest
-    from airflow.executors.base_executor import (
-        CommandType,
-        EventBufferValueType,
-        QueuedTaskInstanceType,
-    )
+    from airflow.executors.base_executor import EventBufferValueType
     from airflow.executors.local_executor import LocalExecutor
     from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
+
+    CommandType = Sequence[str]
 
 
 class LocalKubernetesExecutor(BaseExecutor):
@@ -81,7 +79,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         """Not implemented for hybrid executors."""
 
     @property
-    def queued_tasks(self) -> dict[TaskInstanceKey, QueuedTaskInstanceType]:
+    def queued_tasks(self) -> dict[TaskInstanceKey, Any]:
         """Return queued tasks from local and kubernetes executor."""
         queued_tasks = self.local_executor.queued_tasks.copy()
         # TODO: fix this, there is misalignment between the types of queued_tasks so it is likely wrong
@@ -145,7 +143,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         """Queues command via local or kubernetes executor."""
         executor = self._router(task_instance)
         self.log.debug("Using executor: %s for %s", executor.__class__.__name__, task_instance.key)
-        executor.queue_command(task_instance, command, priority, queue)
+        executor.queue_command(task_instance, command, priority, queue)  # type: ignore[union-attr]
 
     def queue_task_instance(
         self,
@@ -171,7 +169,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         if not hasattr(task_instance, "pickle_id"):
             del kwargs["pickle_id"]
 
-        executor.queue_task_instance(
+        executor.queue_task_instance(  # type: ignore[union-attr]
             task_instance=task_instance,
             mark_success=mark_success,
             ignore_all_deps=ignore_all_deps,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/template_rendering.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/template_rendering.py
@@ -25,7 +25,7 @@ from kubernetes.client.api_client import ApiClient
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
-from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, generate_pod_command_args
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
@@ -43,6 +43,10 @@ def render_k8s_pod_yaml(task_instance: TaskInstance) -> dict | None:
         # If no such pod_template_file override was passed, we can simply render
         # The pod spec using the default template.
         pod_template_file = kube_config.pod_template_file
+
+    # Generate command args using shared utility function
+    command_args = generate_pod_command_args(task_instance)
+
     pod = PodGenerator.construct_pod(
         dag_id=task_instance.dag_id,
         run_id=task_instance.run_id,
@@ -52,7 +56,7 @@ def render_k8s_pod_yaml(task_instance: TaskInstance) -> dict | None:
         pod_id=create_unique_id(task_instance.dag_id, task_instance.task_id),
         try_number=task_instance.try_number,
         kube_image=kube_config.kube_image,
-        args=task_instance.command_as_list(),
+        args=command_args,
         pod_override_object=PodGenerator.from_obj(task_instance.executor_config),
         scheduler_job_id="0",
         namespace=kube_config.executor_namespace,

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -47,9 +47,10 @@ if TYPE_CHECKING:
 
     from sqlalchemy.engine.base import Engine
 
-    from airflow.executors.base_executor import CommandType
     from airflow.models.taskinstancekey import TaskInstanceKey
 
+    # TODO: Airflow 2 type hints; remove when Airflow 2 support is removed
+    CommandType = Sequence[str]
     # Task tuple to send to be executed
     TaskTuple = tuple[TaskInstanceKey, CommandType, Optional[str], Optional[Any]]
 
@@ -108,7 +109,7 @@ class EdgeExecutor(BaseExecutor):
         Store queued_tasks in own var to be able to access this in execute_async function.
         """
         self.edge_queued_tasks = deepcopy(self.queued_tasks)
-        super()._process_tasks(task_tuples)
+        super()._process_tasks(task_tuples)  # type: ignore[misc]
 
     @provide_session
     def execute_async(
@@ -122,10 +123,11 @@ class EdgeExecutor(BaseExecutor):
         """Execute asynchronously. Airflow 2.10 entry point to execute a task."""
         # Use of a temponary trick to get task instance, will be changed with Airflow 3.0.0
         # code works together with _process_tasks overwrite to get task instance.
-        task_instance = self.edge_queued_tasks[key][3]  # TaskInstance in fourth element
+        # TaskInstance in fourth element
+        task_instance = self.edge_queued_tasks[key][3]  # type: ignore[index]
         del self.edge_queued_tasks[key]
 
-        self.validate_airflow_tasks_run_command(command)
+        self.validate_airflow_tasks_run_command(command)  # type: ignore[attr-defined]
         session.add(
             EdgeJobModel(
                 dag_id=key.dag_id,

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -57,12 +57,14 @@ class TestEdgeExecutor:
 
         return (executor, key)
 
+    @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")
     def test__process_tasks_bad_command(self):
         executor, key = self.get_test_executor()
         task_tuple = (key, ["hello", "world"], None, None)
         with pytest.raises(ValueError):
             executor._process_tasks([task_tuple])
 
+    @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")
     @pytest.mark.parametrize(
         "pool_slots, expected_concurrency",
         [
@@ -291,6 +293,7 @@ class TestEdgeExecutor:
                 else:
                     assert worker.state == EdgeWorkerState.IDLE
 
+    @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="API only available in Airflow <3.0")
     def test_execute_async(self):
         executor, key = self.get_test_executor()
 


### PR DESCRIPTION
We rely on workloads in Airflow 3 as opposed to passing `airflow task run` command in Executor

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
