### PR TITLE
Using `x.y` version for Go in go.mod in Go sdk

### DIFF
--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/airflow/go-sdk
 
-go 1.24.1
+go 1.24
 
 require (
 	github.com/ivanpirog/coloredcobra v1.0.1


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As per some reports, using `x.yy.zz` causes issues with older libraries of golang. Updating it to check if it will work.

Failures:

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/go', 'install', 'mvdan.cc/gofumpt@v0.8.0')
return code: 1
stdout: (none)
stderr:
    go: downloading mvdan.cc/gofumpt v0.8.0
    go: mvdan.cc/gofumpt@v0.8.0 (in mvdan.cc/gofumpt@v0.8.0): go.mod:3: invalid go version '1.23.0': must match format 1.23
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
### version information

pre-commit version: 4.2.0
git --version: git version 2.48.1
sys.version:
    3.9.22 (main, Apr  8 2025, 21:48:25) 
    [GCC 11.4.0]
sys.executable: /home/runner/.local/share/uv/tools/pre-commit/bin/python
os.name: posix
sys.platform: linux


### error information
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/go', 'install', 'mvdan.cc/gofumpt@v0.8.0')
return code: 1
stdout: (none)
stderr:
    go: downloading mvdan.cc/gofumpt v0.8.0
    go: mvdan.cc/gofumpt@v0.8.0 (in mvdan.cc/gofumpt@v0.8.0): go.mod:3: invalid go version '1.23.0': must match format 1.23

Traceback (most recent call last):
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/error_handler.py", line 73, in error_handler
    yield
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/main.py", line 413, in main
    return install_hooks(args.config, store)
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/commands/install_uninstall.py", line 145, in install_hooks
    install_hook_envs(all_hooks(load_config(config_file), store), store)
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/repository.py", line 229, in install_hook_envs
    _hook_install(hook)
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/repository.py", line 85, in _hook_install
    lang.install_environment(
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/languages/golang.py", line 157, in install_environment
    lang_base.setup_cmd(prefix, ('go', 'install', dependency), env=env)
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/lang_base.py", line 86, in setup_cmd
    cmd_output_b(*cmd, cwd=prefix.prefix_dir, **kwargs)
  File "/home/runner/.local/share/uv/tools/pre-commit/lib/python3.9/site-packages/pre_commit/util.py", line 111, in cmd_output_b
    raise CalledProcessError(returncode, cmd, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/usr/bin/go', 'install', 'mvdan.cc/gofumpt@v0.8.0')
return code: 1
stdout: (none)
stderr:
    go: downloading mvdan.cc/gofumpt v0.8.0
    go: mvdan.cc/gofumpt@v0.8.0 (in mvdan.cc/gofumpt@v0.8.0): go.mod:3: invalid go version '1.23.0': must match format 1.23
```

Example: https://github.com/apache/airflow/actions/runs/15213921628/job/42794726642


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
