### PR TITLE
Fix remote logging CloudWatch handler initialization and stream name assignment

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -99,7 +99,7 @@ class CloudWatchRemoteLogIO(LoggingMixin):  # noqa: D101
             aws_conn_id=conf.get("logging", "remote_log_conn_id"), region_name=self.region_name
         )
 
-    @cached_property
+    @property
     def handler(self) -> watchtower.CloudWatchLogHandler:
         _json_serialize = conf.getimport("aws", "cloudwatch_task_handler_json_serializer", fallback=None)
         return watchtower.CloudWatchLogHandler(
@@ -127,8 +127,8 @@ class CloudWatchRemoteLogIO(LoggingMixin):  # noqa: D101
                 return event
             # Only init the handler stream_name once. We cannot do it above when we init the handler because
             # we don't yet know the log path at that point.
-            if not _handler.log_stream_name:
-                _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
+            # we should always use the path(log-stream-name) coming from the logger.
+            _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
             name = event.get("logger_name") or event.get("logger", "")
             level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
             msg = copy.copy(event)

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -139,6 +139,9 @@ class TestCloudRemoteLogIO:
             # We need to close in order to flush the logs etc.
             self.subject.close()
 
+            # close call should only flush the logs and not set shutting_down to True
+            assert self.subject.handler.shutting_down is False
+
             # Inside the Cloudwatch logger we swap colons for underscores since colons are not allowed in
             # stream names.
             stream_name = self.task_log_path.replace(":", "_")


### PR DESCRIPTION
closes: #50802

Currently, logging to CloudWatch only occurs at startup—specifically, when the executor first launches and triggers a DAG. Logging functions correctly for this initial run, but fails on subsequent runs. This issue arises because the handler is implemented as a cached_property, and we call self.handler.close() during the final log upload. In the close() method, the shutdown parameter is set to True https://github.com/kislyuk/watchtower/blob/main/watchtower/__init__.py#L463, which blocks further logging and prevents logs from being uploaded to CloudWatch.

Additionally, we should ensure that the stream name is explicitly assigned if it's available in the logger. Otherwise, we risk reusing a previously configured stream name, which can result in logs being written to the incorrect stream.



```
2025-05-20 11:07:58.746 | 2025-05-20 15:07:58.746784 [warning  ] /home/airflow/.local/lib/python3.12/site-packages/watchtower/__init__.py:464: WatchtowerWarning: Received message after logging system shutdown
2025-05-20 11:07:58.746 |   warnings.warn("Received message after logging system shutdown", WatchtowerWarning)
2025-05-20 11:07:58.746 |  [py.warnings]
2025-05-20 11:07:58.747 | 2025-05-20 15:07:58.747339 [debug    ] send_request_headers.started request=<Request [b'PUT']> [httpcore.http11]
2025-05-20 11:07:58.747 | 2025-05-20 15:07:58.747506 [debug    ] send_request_headers.complete  [httpcore.http11]
```


Before:

<img width="1522" alt="Screenshot 2025-05-23 at 23 10 47" src="https://github.com/user-attachments/assets/e1365e3f-e6ea-48d1-b4bd-dd3e03c25fbb" />



After:
<img width="1701" alt="Screenshot 2025-05-23 at 23 07 12" src="https://github.com/user-attachments/assets/7d542774-13fd-489b-b91b-af82e4e50a6e" />

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
