### PR TITLE
fix airflow core directory run_generate_migration.sh

### DIFF
--- a/contributing-docs/14_metadata_database_updates.rst
+++ b/contributing-docs/14_metadata_database_updates.rst
@@ -30,7 +30,7 @@ database schema that you have made. To generate a new migration file, run the fo
 
     # starting at the root of the project
     $ breeze --backend postgres
-    $ cd airflow
+    $ cd airflow-core/src/airflow
     $ alembic revision -m "add new field to db" --autogenerate
 
        Generating

--- a/scripts/in_container/run_generate_migration.sh
+++ b/scripts/in_container/run_generate_migration.sh
@@ -19,7 +19,7 @@
 . "$(dirname "${BASH_SOURCE[0]}")/_in_container_script_init.sh"
 
 cd "${AIRFLOW_SOURCES}" || exit 1
-cd "airflow" || exit 1
+cd "airflow-core/src/airflow" || exit 1
 airflow db reset -y
 airflow db downgrade -n 2.10.3 -y
 airflow db migrate -r heads


### PR DESCRIPTION
I noticed a failure when running `breeze generate-migration-file` due to the wrong airflow core path.

```
/opt/airflow/scripts/in_container/run_generate_migration.sh: line 22: cd: airflow: No such file or directory
Error 1 returned

```