### PR TITLE
fix alembic revision check in db utils

### DIFF
--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -1044,8 +1044,7 @@ def _revision_greater(config, this_rev, base_rev):
     # This ensures that the revisions are above `min_revision`
     script = _get_script_object(config)
     try:
-        list(script.revision_map.iterate_revisions(upper=this_rev, lower=base_rev))
-        return True
+        bool(list(script.revision_map.iterate_revisions(upper=this_rev, lower=base_rev)))
     except Exception:
         return False
 

--- a/contributing-docs/14_metadata_database_updates.rst
+++ b/contributing-docs/14_metadata_database_updates.rst
@@ -30,7 +30,7 @@ database schema that you have made. To generate a new migration file, run the fo
 
     # starting at the root of the project
     $ breeze --backend postgres
-    $ cd airflow
+    $ cd airflow-core/src/airflow
     $ alembic revision -m "add new field to db" --autogenerate
 
        Generating

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -93,7 +93,7 @@ def initial_db_init():
 
     db.resetdb()
     if AIRFLOW_V_3_0_PLUS:
-        db.downgrade(to_revision="5f2621c13b39")
+        db.downgrade(to_revision="044f740568ec")
         db.upgradedb(to_revision="head")
     else:
         from flask import Flask

--- a/scripts/in_container/run_generate_migration.sh
+++ b/scripts/in_container/run_generate_migration.sh
@@ -19,7 +19,7 @@
 . "$(dirname "${BASH_SOURCE[0]}")/_in_container_script_init.sh"
 
 cd "${AIRFLOW_SOURCES}" || exit 1
-cd "airflow" || exit 1
+cd "airflow-core/src/airflow" || exit 1
 airflow db reset -y
 airflow db downgrade -n 2.10.3 -y
 airflow db migrate -r heads

--- a/scripts/in_container/run_generate_migration.sh
+++ b/scripts/in_container/run_generate_migration.sh
@@ -21,6 +21,6 @@
 cd "${AIRFLOW_SOURCES}" || exit 1
 cd "airflow-core/src/airflow" || exit 1
 airflow db reset -y
-airflow db downgrade -n 2.10.3 -y
+airflow db downgrade -n 3.0.0 -y
 airflow db migrate -r heads
 alembic revision --autogenerate -m "${@}"


### PR DESCRIPTION
`airflow db downgrade -n 3.0.0` currently raises following error:

```
airflow.exceptions.AirflowException: Downgrade to revision less than 3.0.0 requires that `ab_user` table is present. Please add FabDBManager to [core] external_db_managers and run fab migrations before proceeding
```

This is because, `list(script.revision_map.iterate_revisions(upper=this_rev, lower=base_rev))` returns an empty list instead of raising an error

![image](https://github.com/user-attachments/assets/fe9a619a-b125-4c0c-9aa0-428a1d4b10a5)


Instead of directly returning True, we can just evaluate bool.

Also, modifying run_generate_migration.sh to downgrade to 3.0.0 and generate the revision

