### PR TITLE
feat(api): decouple non-route methods

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/config.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import textwrap
 
 from fastapi import Depends, HTTPException, status
-from fastapi.responses import Response
 
 from airflow.api_fastapi.common.headers import HeaderAcceptJsonOrText
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -31,6 +30,10 @@ from airflow.api_fastapi.core_api.datamodels.config import (
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_access_configuration
+from airflow.api_fastapi.core_api.services.public.config import (
+    _check_expose_config,
+    _response_based_on_accept,
+)
 from airflow.configuration import conf
 
 text_example_response_for_get_config_value = {
@@ -66,31 +69,6 @@ text_example_response_for_get_config = {
         },
     }
 }
-
-
-def _check_expose_config() -> bool:
-    display_sensitive: bool | None = None
-    if conf.get("api", "expose_config").lower() == "non-sensitive-only":
-        expose_config = True
-        display_sensitive = False
-    else:
-        expose_config = conf.getboolean("api", "expose_config")
-        display_sensitive = True
-
-    if not expose_config:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Your Airflow administrator chose not to expose the configuration, most likely for security reasons.",
-        )
-    return display_sensitive
-
-
-def _response_based_on_accept(accept: Mimetype, config: Config):
-    if accept == Mimetype.TEXT:
-        return Response(content=config.text_format, media_type=Mimetype.TEXT)
-    return config
-
-
 config_router = AirflowRouter(tags=["Config"], prefix="/config")
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/providers.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/providers.py
@@ -17,30 +17,17 @@
 
 from __future__ import annotations
 
-import re
-
 from fastapi import Depends
 
 from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
 from airflow.api_fastapi.common.parameters import QueryLimit, QueryOffset
 from airflow.api_fastapi.common.router import AirflowRouter
-from airflow.api_fastapi.core_api.datamodels.providers import ProviderCollectionResponse, ProviderResponse
+from airflow.api_fastapi.core_api.datamodels.providers import ProviderCollectionResponse
 from airflow.api_fastapi.core_api.security import requires_access_view
-from airflow.providers_manager import ProviderInfo, ProvidersManager
+from airflow.api_fastapi.core_api.services.public.providers import _provider_mapper
+from airflow.providers_manager import ProvidersManager
 
 providers_router = AirflowRouter(tags=["Provider"], prefix="/providers")
-
-
-def _remove_rst_syntax(value: str) -> str:
-    return re.sub("[`_<>]", "", value.strip(" \n."))
-
-
-def _provider_mapper(provider: ProviderInfo) -> ProviderResponse:
-    return ProviderResponse(
-        package_name=provider.data["package-name"],
-        description=_remove_rst_syntax(provider.data["description"]),
-        version=provider.version,
-    )
 
 
 @providers_router.get(

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/config.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from fastapi.responses import Response
+
+from airflow.api_fastapi.common.types import Mimetype
+from airflow.api_fastapi.core_api.datamodels.config import Config
+from airflow.configuration import conf
+
+
+def _check_expose_config() -> bool:
+    display_sensitive: bool | None = None
+    if conf.get("api", "expose_config").lower() == "non-sensitive-only":
+        expose_config = True
+        display_sensitive = False
+    else:
+        expose_config = conf.getboolean("api", "expose_config")
+        display_sensitive = True
+
+    if not expose_config:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your Airflow administrator chose not to expose the configuration, most likely for security reasons.",
+        )
+    return display_sensitive
+
+
+def _response_based_on_accept(accept: Mimetype, config: Config):
+    if accept == Mimetype.TEXT:
+        return Response(content=config.text_format, media_type=Mimetype.TEXT)
+    return config

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/providers.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/providers.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import re
+
+from airflow.api_fastapi.core_api.datamodels.providers import ProviderResponse
+from airflow.providers_manager import ProviderInfo
+
+
+def _remove_rst_syntax(value: str) -> str:
+    return re.sub("[`_<>]", "", value.strip(" \n."))
+
+
+def _provider_mapper(provider: ProviderInfo) -> ProviderResponse:
+    return ProviderResponse(
+        package_name=provider.data["package-name"],
+        description=_remove_rst_syntax(provider.data["description"]),
+        version=provider.version,
+    )


### PR DESCRIPTION
follow up from discussions: #50175
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
