### PR TITLE
Link pool state bar to filter taskinstances for the pool by state.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -16,9 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex } from "@chakra-ui/react";
+import { Flex, Link } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { Link as RouterLink } from "react-router-dom";
 
+import type { PoolResponse } from "openapi/requests/types.gen";
 import { Tooltip } from "src/components/ui";
 import { type Slots, slotConfigs } from "src/utils/slots";
 
@@ -27,7 +29,7 @@ export const PoolBar = ({
   poolsWithSlotType,
   totalSlots,
 }: {
-  readonly pool: Slots;
+  readonly pool: PoolResponse | Slots;
   readonly poolsWithSlotType?: Slots;
   readonly totalSlots: number;
 }) => {
@@ -46,8 +48,7 @@ export const PoolBar = ({
         const slotType = key.replace("_slots", "");
         const poolCount = poolsWithSlotType ? poolsWithSlotType[key] : 0;
         const tooltipContent = `${translate(`pools.${slotType}`)}: ${slotValue} (${poolCount} ${translate("pools.pools", { count: poolCount })})`;
-
-        return (
+        const poolContent = (
           <Tooltip content={tooltipContent} key={key}>
             <Flex
               alignItems="center"
@@ -65,6 +66,14 @@ export const PoolBar = ({
               {slotValue}
             </Flex>
           </Tooltip>
+        );
+
+        return color !== "success" && "name" in pool ? (
+          <Link asChild key={key}>
+            <RouterLink to={`/task_instances?state=${color}&pool=${pool.name}`}>{poolContent}</RouterLink>
+          </Link>
+        ) : (
+          poolContent
         );
       })}
     </>

--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -25,6 +25,7 @@ export enum SearchParamsKeys {
   NAME_PATTERN = "name_pattern",
   OFFSET = "offset",
   PAUSED = "paused",
+  POOL = "pool",
   RUN_TYPE = "run_type",
   SORT = "sort",
   SOURCE = "log_source",

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -44,6 +44,7 @@ type TaskInstanceRow = { row: { original: TaskInstanceResponse } };
 const {
   END_DATE: END_DATE_PARAM,
   NAME_PATTERN: NAME_PATTERN_PARAM,
+  POOL: POOL_PARAM,
   START_DATE: START_DATE_PARAM,
   STATE: STATE_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
@@ -178,7 +179,9 @@ export const TaskInstances = () => {
   const filteredState = searchParams.getAll(STATE_PARAM);
   const startDate = searchParams.get(START_DATE_PARAM);
   const endDate = searchParams.get(END_DATE_PARAM);
+  const pool = searchParams.getAll(POOL_PARAM);
   const hasFilteredState = filteredState.length > 0;
+  const hasFilteredPool = pool.length > 0;
 
   const [taskDisplayNamePattern, setTaskDisplayNamePattern] = useState(
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
@@ -194,6 +197,7 @@ export const TaskInstances = () => {
       limit: pagination.pageSize,
       offset: pagination.pageIndex * pagination.pageSize,
       orderBy,
+      pool: hasFilteredPool ? pool : undefined,
       startDateGte: startDate ?? undefined,
       state: hasFilteredState ? filteredState : undefined,
       taskDisplayNamePattern: groupId ?? taskDisplayNamePattern ?? undefined,


### PR DESCRIPTION
Each state per pool except success will link to task_instances list page passing the pool and state as filter through the query param and then passing the filters to the API. The pool summary in dashboard is an aggregate and won't have any links.

closes #51013 