### PR TITLE
Also display languages in current language not in target language name

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
@@ -7,9 +7,10 @@
   "timezone": "Zeitzone",
   "user": "Benutzer",
   "language": {
-    "chinese": "Traditionelles Chinesisch",
-    "english": "Englisch",
-    "german": "Deutsch",
+    "zh_TW": "Traditionelles Chinesisch",
+    "en": "Englisch",
+    "de": "Deutsch",
+    "ko": "Koreanisch",
     "select": "Sprache wählen"
   },
   "nav": {
@@ -17,7 +18,7 @@
     "assets": "Datensets (Assets)",
     "browse": "Browsen",
     "admin": "Verwaltung",
-    "docs": "Dokumentation",
+    "docs": "Doku",
     "plugins": "Plug-ins"
   },
   "browse": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -7,8 +7,10 @@
   "timezone": "timezone",
   "user": "User",
   "language": {
-    "chinese": "Traditional Chinese",
-    "english": "English",
+    "zh_TW": "Traditional Chinese",
+    "en": "English",
+    "de": "German",
+    "ko": "Korean",
     "select": "Select Language"
   },
   "nav": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
@@ -7,10 +7,10 @@
   "timezone": "시간대",
   "user": "사용자",
   "language": {
-    "chinese": "중국어 번체",
-    "english": "영어",
-    "korean": "한국어",
-    "german": "독일어",
+    "zh_TW": "중국어 번체",
+    "en": "영어",
+    "de": "독일어",
+    "ko": "한국어",
     "select": "언어 선택"
   },
   "nav": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh_TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh_TW/common.json
@@ -7,8 +7,10 @@
   "timezone": "時區",
   "user": "使用者",
   "language": {
-    "chinese": "繁體中文",
-    "english": "英文",
+    "zh_TW": "繁體中文",
+    "en": "英文",
+    "de": "德文",
+    "ko": "韓國人",
     "select": "選擇語言"
   },
   "nav": {

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -68,6 +68,15 @@ export const UserSettingsButton = () => {
               {supportedLanguages.map((lang) => (
                 <Menu.RadioItem key={lang.code} value={lang.code}>
                   {lang.name}
+                  {translate(`language.${lang.code}`) !== lang.name &&
+                  translate(`language.${lang.code}`) !== `language.${lang.code}` ? (
+                    <>
+                      {" ("}
+                      {translate(`language.${lang.code}`)})
+                    </>
+                  ) : (
+                    ""
+                  )}
                   <Menu.ItemIndicator />
                 </Menu.RadioItem>
               ))}


### PR DESCRIPTION
I updated one term in German translation as it was two pixels too long and changed to the abbreviated common term in German (Dokumentation -> Doku) - FYI @TJaniF 

While doing this I noticd that the common.json -> language.<language> terms actually were un-used. But using the lang codes as key I am proposing to extend the language selection menu in order to display the language selection not only in target language name but also in current displayed language:

![image](https://github.com/user-attachments/assets/476d66b3-a50b-4164-909f-da2f0bd7e221)
