### PR TITLE
Bugfix/fix latest pypi version check

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/version_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/version_utils.py
@@ -31,7 +31,9 @@ def get_latest_helm_chart_version():
 def get_latest_airflow_version():
     import requests
 
-    response = requests.get("https://pypi.org/pypi/apache-airflow/json")
+    response = requests.get(
+        "https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"}
+    )
     response.raise_for_status()
     latest_released_version = response.json()["info"]["version"]
     return latest_released_version

--- a/dev/validate_version_added_fields_in_config.py
+++ b/dev/validate_version_added_fields_in_config.py
@@ -46,7 +46,7 @@ CONFIG_TEMPLATE_FORMAT_UPDATE = "2.6.0"
 
 
 def fetch_pypi_versions() -> list[str]:
-    r = requests.get("https://pypi.org/pypi/apache-airflow/json")
+    r = requests.get("https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"})
     r.raise_for_status()
     all_version = r.json()["releases"].keys()
     released_versions = [d for d in all_version if not (("rc" in d) or ("b" in d))]

--- a/docker-tests/tests/docker_tests/test_examples_of_prod_image_building.py
+++ b/docker-tests/tests/docker_tests/test_examples_of_prod_image_building.py
@@ -42,7 +42,9 @@ QUARANTINED_DOCKER_EXAMPLES: dict[str, str] = {
 
 @cache
 def get_latest_airflow_image():
-    response = requests.get("https://pypi.org/pypi/apache-airflow/json")
+    response = requests.get(
+        "https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"}
+    )
     response.raise_for_status()
     latest_released_version = response.json()["info"]["version"]
     return f"apache/airflow:{latest_released_version}"

--- a/scripts/ci/airflow_version_check.py
+++ b/scripts/ci/airflow_version_check.py
@@ -45,9 +45,10 @@ def check_airflow_version(airflow_version: Version) -> tuple[str, bool]:
     returns: tuple containing the version and a boolean indicating if it's latest.
     """
     latest = False
-    url = "https://pypi.org/pypi/apache-airflow/json"
     try:
-        response = requests.get(url)
+        response = requests.get(
+            "https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"}
+        )
         response.raise_for_status()
         data = response.json()
         latest_version = Version(data["info"]["version"])

--- a/scripts/ci/pre_commit/update_installers_and_pre_commit.py
+++ b/scripts/ci/pre_commit/update_installers_and_pre_commit.py
@@ -55,7 +55,9 @@ FILES_TO_UPDATE: list[tuple[Path, bool]] = [
 
 
 def get_latest_pypi_version(package_name: str) -> str:
-    response = requests.get(f"https://pypi.org/pypi/{package_name}/json")
+    response = requests.get(
+        f"https://pypi.org/pypi/{package_name}/json", headers={"User-Agent": "Python requests"}
+    )
     response.raise_for_status()  # Ensure we got a successful response
     data = response.json()
     latest_version = data["info"]["version"]  # The version info is under the 'info' key


### PR DESCRIPTION
As of failed canary in https://github.com/apache/airflow/actions/runs/15233855670 and https://github.com/apache/airflow/actions/runs/15235553931 it seems Pypi.org is blocking requests w/o proper user agent.

This PR adds a user agent to all Python script calls. With this you get HTTP 200, else if this is missing HTTP 406.