### PR TITLE
Add timezone support for date calculation in TimeSensor

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time.py
@@ -93,7 +93,7 @@ class TimeSensor(BaseSensorOperator):
 
         # Get date considering dag.timezone
         aware_time = timezone.coerce_datetime(
-            datetime.datetime.combine(pendulum.now(tz=self.dag.timezone), target_time, self.dag.timezone)
+            datetime.datetime.combine(pendulum.now(tz=str(self.dag.timezone)), target_time, self.dag.timezone)
         )
 
         # Now that the dag's timezone has made the datetime timezone aware, we need to convert to UTC

--- a/providers/standard/src/airflow/providers/standard/sensors/time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time.py
@@ -22,6 +22,8 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import pendulum
+
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger
@@ -88,8 +90,10 @@ class TimeSensor(BaseSensorOperator):
 
         # Create a "date-aware" timestamp that will be used as the "target_datetime". This is a requirement
         # of the DateTimeTrigger
+
+        # Get date considering dag.timezone
         aware_time = timezone.coerce_datetime(
-            datetime.datetime.combine(datetime.datetime.today(), target_time, self.dag.timezone)
+            datetime.datetime.combine(pendulum.now(tz=self.dag.timezone), target_time, self.dag.timezone)
         )
 
         # Now that the dag's timezone has made the datetime timezone aware, we need to convert to UTC

--- a/providers/standard/src/airflow/providers/standard/sensors/time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time.py
@@ -22,8 +22,6 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import pendulum
-
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger
@@ -93,7 +91,9 @@ class TimeSensor(BaseSensorOperator):
 
         # Get date considering dag.timezone
         aware_time = timezone.coerce_datetime(
-            datetime.datetime.combine(pendulum.now(tz=str(self.dag.timezone)), target_time, self.dag.timezone)
+            datetime.datetime.combine(
+                datetime.datetime.now(self.dag.timezone), target_time, self.dag.timezone
+            )
         )
 
         # Now that the dag's timezone has made the datetime timezone aware, we need to convert to UTC

--- a/providers/standard/tests/unit/standard/sensors/test_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time.py
@@ -61,14 +61,14 @@ class TestTimeSensor:
     @pytest.mark.parametrize(
         "current_datetime, server_timezone",
         [
-            ("2025-01-26 23:00:00", "UTC"),
-            ("2025-01-27 07:00:00", DEFAULT_TIMEZONE),
+            ("2025-01-26 22:00:00", "UTC"),
+            ("2025-01-27 07:00:00", "Asia/Seoul"),  # UTC+09:00
         ],
     )
     def test_target_date_aware_dag_timezone(self, current_datetime, server_timezone):
         travel_time = pendulum.parse(current_datetime, tz=timezone.parse_timezone(server_timezone))
-        user_timezone = timezone.parse_timezone(DEFAULT_TIMEZONE)
-        expected_target_datetime = pendulum.datetime(2025, 1, 26, 23, 0, 0, tz="UTC")
+        user_timezone = timezone.parse_timezone("Asia/Seoul")
+        expected_target_datetime = pendulum.datetime(2025, 1, 26, 22, 0, 0, tz="UTC")
 
         with time_machine.travel(travel_time, tick=False):
             with DAG(
@@ -80,11 +80,11 @@ class TestTimeSensor:
                 op = TimeSensor(task_id="test", target_time=aware_datetime.time())
 
                 # In the old logic, if server's timezone is UTC op.target_datetime could be incorrectly.
-                # For example, it might be set to `2025-01-25 23:00:00 UTC`, not `2025-01-26 23:00:00 UTC`.
+                # For example, it might be set to `2025-01-25 22:00:00 UTC`, not `2025-01-26 22:00:00 UTC`.
                 # This issue stems from using datetime.today() in an environment where the server timezone differs from the user's timezone
                 # The local date '2025-01-26' is combined with the target time `07:00:00`,
                 # resulting in `2025-01-26 07:00:00` in local time.
-                # When this is converted to UTC by convert_to_utc, it becomes `2025-01-25 23:00:00 UTC`.
+                # When this is converted to UTC by convert_to_utc, it becomes `2025-01-25 22:00:00 UTC`.
                 assert op.target_datetime == expected_target_datetime
 
     def test_target_time_naive_dag_timezone(self):

--- a/providers/standard/tests/unit/standard/sensors/test_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time.py
@@ -71,7 +71,11 @@ class TestTimeSensor:
         expected_target_datetime = pendulum.datetime(2025, 1, 26, 23, 0, 0, tz="UTC")
 
         with time_machine.travel(travel_time, tick=False):
-            with DAG("test_target_date_aware", schedule=None, start_date=datetime(2025, 1, 27, 7, tzinfo=user_timezone)):
+            with DAG(
+                "test_target_date_aware",
+                schedule=None,
+                start_date=datetime(2025, 1, 27, 7, tzinfo=user_timezone),
+            ):
                 aware_datetime = pendulum.datetime(2025, 1, 27, 7).replace(tzinfo=user_timezone)
                 op = TimeSensor(task_id="test", target_time=aware_datetime.time())
 

--- a/providers/standard/tests/unit/standard/sensors/test_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time.py
@@ -58,6 +58,31 @@ class TestTimeSensor:
             op = TimeSensor(task_id="test", target_time=aware_time)
             assert op.target_datetime.tzinfo == timezone.utc
 
+    @pytest.mark.parametrize(
+        "current_datetime, server_timezone",
+        [
+            ("2025-01-26 23:00:00", "UTC"),
+            ("2025-01-27 07:00:00", DEFAULT_TIMEZONE),
+        ],
+    )
+    def test_target_date_aware_dag_timezone(self, current_datetime, server_timezone):
+        travel_time = pendulum.parse(current_datetime, tz=timezone.parse_timezone(server_timezone))
+        user_timezone = timezone.parse_timezone(DEFAULT_TIMEZONE)
+        expected_target_datetime = pendulum.datetime(2025, 1, 26, 23, 0, 0, tz="UTC")
+
+        with time_machine.travel(travel_time, tick=False):
+            with DAG("test_target_date_aware", schedule=None, start_date=datetime(2025, 1, 27, 7, tzinfo=user_timezone)):
+                aware_datetime = pendulum.datetime(2025, 1, 27, 7).replace(tzinfo=user_timezone)
+                op = TimeSensor(task_id="test", target_time=aware_datetime.time())
+
+                # In the old logic, if server's timezone is UTC op.target_datetime could be incorrectly.
+                # For example, it might be set to `2025-01-25 23:00:00 UTC`, not `2025-01-26 23:00:00 UTC`.
+                # This issue stems from using datetime.today() in an environment where the server timezone differs from the user's timezone
+                # The local date '2025-01-26' is combined with the target time `07:00:00`,
+                # resulting in `2025-01-26 07:00:00` in local time.
+                # When this is converted to UTC by convert_to_utc, it becomes `2025-01-25 23:00:00 UTC`.
+                assert op.target_datetime == expected_target_datetime
+
     def test_target_time_naive_dag_timezone(self):
         # Again, this behavior should be the same for both deferrable and non-deferrable
         with DAG(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

This PR closes https://github.com/apache/airflow/issues/38337

In the previous logic (using `datetime.datetime.today()`), if server's timezone is UTC, `target_datetime` for TimeSensor could be incorrectly.

For example, when the user intended to use `Asia/Singapore` timezone and server timezone is `UTC`, taget time `2025-01-27 07:00:00+08:00` might be incorrectly converted to `2025-01-25 23:00:00 UTC` instead of `2025-01-26 23:00:00 UTC`.
(This assumes the current time is `2025-01-26 23:00:00 UTC`, which is `2025-01-27 07:00:00` in Asia/Singapore.)


This happens because the local date `2025-01-26` is combined with the target time `07:00:00`, resulting in `2025-01-26 07:00:00` in local time. And then this datetime is converted to UTC using `convert_to_utc`, it becomes `2025-01-25 23:00:00 UTC`.

To fix this, `pendulum.now(tz=str(self.dag.timezone))` is used instead of `datetime.datetime.today()`.


All unit tests for TimeSensor passed
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/e6c57e22-88fb-49ed-b4c2-409080f21ebc" />


