### PR TITLE
[v2-11-test] Bugfix/fix latest pypi version check (#51039)

### DIFF
--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -128,6 +128,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: 96a71c258542d77b78e7d5a0badf4a3fe1874acff7b31e1b95323f27303b9aa224cb17e37721269ac114495e00544f2948d9e8739556492f588f8819670f96f7
+Package config hash: 004dd496a1cbe6c9b13a49cbe3cb8b6a72359aa6225785ef186f24236466c11ed8e797274bbdc440067a5cb5bb024cce0c8a7833b8ce436db096cefded100e56
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/src/airflow_breeze/utils/version_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/version_utils.py
@@ -31,7 +31,9 @@ def get_latest_helm_chart_version():
 def get_latest_airflow_version():
     import requests
 
-    response = requests.get("https://pypi.org/pypi/apache-airflow/json")
+    response = requests.get(
+        "https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"}
+    )
     response.raise_for_status()
     latest_released_version = response.json()["info"]["version"]
     return latest_released_version

--- a/dev/validate_version_added_fields_in_config.py
+++ b/dev/validate_version_added_fields_in_config.py
@@ -46,7 +46,7 @@ CONFIG_TEMPLATE_FORMAT_UPDATE = "2.6.0"
 
 
 def fetch_pypi_versions() -> list[str]:
-    r = requests.get("https://pypi.org/pypi/apache-airflow/json")
+    r = requests.get("https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"})
     r.raise_for_status()
     all_version = r.json()["releases"].keys()
     released_versions = [d for d in all_version if not (("rc" in d) or ("b" in d))]

--- a/docker_tests/test_examples_of_prod_image_building.py
+++ b/docker_tests/test_examples_of_prod_image_building.py
@@ -42,7 +42,9 @@ QUARANTINED_DOCKER_EXAMPLES: dict[str, str] = {
 
 @lru_cache(maxsize=None)
 def get_latest_airflow_image():
-    response = requests.get("https://pypi.org/pypi/apache-airflow/json")
+    response = requests.get(
+        "https://pypi.org/pypi/apache-airflow/json", headers={"User-Agent": "Python requests"}
+    )
     response.raise_for_status()
     latest_released_version = response.json()["info"]["version"]
     return f"apache/airflow:{latest_released_version}"

--- a/scripts/ci/pre_commit/update_installers_and_pre_commit.py
+++ b/scripts/ci/pre_commit/update_installers_and_pre_commit.py
@@ -53,7 +53,9 @@ FILES_TO_UPDATE: list[tuple[Path, bool]] = [
 
 
 def get_latest_pypi_version(package_name: str) -> str:
-    response = requests.get(f"https://pypi.org/pypi/{package_name}/json")
+    response = requests.get(
+        f"https://pypi.org/pypi/{package_name}/json", headers={"User-Agent": "Python requests"}
+    )
     response.raise_for_status()  # Ensure we got a successful response
     data = response.json()
     latest_version = data["info"]["version"]  # The version info is under the 'info' key


### PR DESCRIPTION
Fix version check from Pypi, requires user agent else raises HTTP 406

    Fix version check from Pypi, requires user agent else raises HTTP 406, also other cases in codebase (cherry picked from commit https://github.com/apache/airflow/commit/eb7c346dd0dcd510fd99f2382aec81d41dc4d0c3)

Note: Cherry-picker failed, manually back-porting