### PR TITLE
Bugfix Breeze BetterChoice with newer click versions

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/custom_param_types.py
+++ b/dev/breeze/src/airflow_breeze/utils/custom_param_types.py
@@ -50,7 +50,7 @@ class BetterChoice(click.Choice):
         super().__init__(*args)
         self.all_choices: Sequence[str] = self.choices
 
-    def get_metavar(self, param) -> str:
+    def get_metavar(self, param, ctx=None) -> str:
         choices_str = " | ".join(self.all_choices)
         # Use curly braces to indicate a required argument.
         if param.required and param.param_type_name == "argument":
@@ -167,7 +167,7 @@ class CacheableChoice(click.Choice):
                 write_to_cache_file(param_name, new_value, check_allowed_values=False)
         return super().convert(new_value, param, ctx)
 
-    def get_metavar(self, param) -> str:
+    def get_metavar(self, param, ctx=None) -> str:
         param_name = param.envvar if param.envvar else param.name.upper()
         current_value = (
             read_from_cache_file(param_name) if not generating_command_images() else param.default.value


### PR DESCRIPTION
While committing to #51050 I realized that breeze was broken as a result of newer click integration - wondering why this was un-detected. I catched it with `pre-commit run -a check-breeze-top-dependencies-limited`

Exception I saw:
```
(airflow) jscheffl@hp860g9:~/Workspace/airflow$ pre-commit run -a check-breeze-top-dependencies-limited
Check top-level breeze deps..............................................Failed
- hook id: check-breeze-top-dependencies-limited
- exit code: 1

Traceback (most recent call last):
  File "/home/jscheffl/Workspace/airflow/dev/breeze/src/airflow_breeze/breeze.py", line 54, in <module>
    main()
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1362, in main
    with self.make_context(prog_name, args, **extra) as ctx:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1186, in make_context
    self.parse_args(ctx, args)
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1786, in parse_args
    rest = super().parse_args(ctx, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1197, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 2416, in handle_parse_result
    value = self.process_value(ctx, value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 2355, in process_value
    value = self.callback(ctx, self, value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/decorators.py", line 539, in show_help
    echo(ctx.get_help(), color=ctx.color)
         ^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 730, in get_help
    return self.command.get_help(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1064, in get_help
    self.format_help(ctx, formatter)
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1104, in format_help
    self.format_options(ctx, formatter)
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1751, in format_options
    super().format_options(ctx, formatter)
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 1135, in format_options
    rv = param.get_help_record(ctx)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 2796, in get_help_record
    rv = [_write_opts(self.opts)]
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 2792, in _write_opts
    rv += f" {self.make_metavar(ctx=ctx)}"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jscheffl/.cache/pre-commit/repoymx7_s7n/py_env-python3/lib/python3.12/site-packages/click/core.py", line 2212, in make_metavar
    metavar = self.type.get_metavar(param=self, ctx=ctx)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CacheableChoice.get_metavar() got an unexpected keyword argument 'ctx'
Breeze should only use limited dependencies when imported (see errors above).

Please make sure you only use local imports for new dependencies in breeze.

The only top-level dependencies should be `rich` and `click'
```