### PR TITLE
feat(postgres): Add PostgresCDCEventTrigger with AssetWatcher integration

### DIFF
--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -35,6 +35,7 @@
 
     Connection types <connections/postgres>
     Operators <operators>
+    Triggers <triggers>
 
 .. toctree::
     :hidden:

--- a/providers/postgres/docs/triggers.rst
+++ b/providers/postgres/docs/triggers.rst
@@ -1,0 +1,115 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+Postgres CDC Event Trigger
+==========================
+
+.. _howto/trigger:PostgresCDCEventTrigger:
+
+The ``PostgresCDCEventTrigger`` is an event-based trigger that monitors a PostgreSQL table
+for new changes based on a Change Data Capture (CDC) column, such as ``updated_at`` or ``last_modified``.
+
+It is especially useful for **Airflow 3.0+** in combination with the ``AssetWatcher`` system,
+enabling event-driven DAGs based on PostgreSQL updates.
+
+How It Works
+------------
+
+1. Periodically queries the PostgreSQL table for the maximum value of the specified CDC column.
+2. Compares this value with the last known value stored in an Airflow Variable via ``Variable.get()``.
+3. If a newer value is found, emits a ``TriggerEvent`` that can resume a DAG run or trigger downstream logic.
+4. Each instance uses a configurable ``state_key`` to manage independent trigger state.
+5. The actual persistence of the new state must be done in a DAG task via ``Variable.set(...)``.
+
+.. note::
+    This trigger requires **Airflow >= 3.0** due to dependencies on:
+    - ``AssetWatcher``
+    - ``airflow.sdk.Variable``
+    - Event-driven scheduling infrastructure
+
+Usage Example with AssetWatcher
+-------------------------------
+
+Here's a basic example using the trigger inside an AssetWatcher with a manual persistence callback:
+
+.. code-block:: python
+
+    from airflow.models import DAG
+    from airflow.decorators import task
+    from airflow.sdk import Asset, AssetWatcher, Variable
+    from airflow.providers.postgres.triggers.postgres_cdc import PostgresCDCEventTrigger
+    from datetime import datetime
+
+    with DAG(dag_id="example_postgres_cdc", start_date=datetime(2024, 1, 1), schedule=None):
+
+        @task
+        def persist_latest_value(cdc_event):
+            # Persist the latest value (important!)
+            Variable.set("my_table_state", cdc_event["max_iso"])
+
+        watcher = AssetWatcher(
+            asset=Asset("my_postgres_table"),
+            event_trigger=PostgresCDCEventTrigger(
+                conn_id="postgres_default",
+                table="my_table",
+                cdc_column="updated_at",
+                polling_interval=60,
+                state_key="my_table_state",
+            ),
+            callbacks=[persist_latest_value],
+        )
+
+Alternatively, you can refer to a complete working example in:
+
+.. exampleinclude:: ../tests/system/postgres/example_postgres_cdc_asset_watcher.py
+    :language: python
+    :start-after: [START howto_operator_postgres_cdc_watcher]
+    :end-before: [END howto_operator_postgres_cdc_watcher]
+
+Parameters
+----------
+
+``conn_id``
+    Airflow connection ID for the PostgreSQL database
+
+``table``
+    Name of the table to monitor
+
+``cdc_column``
+    Column used to track changes (e.g., ``updated_at``)
+
+``polling_interval``
+    Polling frequency in seconds (default: 10.0)
+
+``state_key``
+    Key used to retrieve the last known CDC value via ``Variable.get()``
+
+Important Notes
+---------------
+
+1. **State Persistence Required**: This trigger **does not automatically persist** the new CDC value. You **must** persist it manually using a callback like ``Variable.set(...)``.
+2. **Idempotency Warning**: If the value is not persisted, the trigger may repeatedly emit the same event.
+3. **Multiple Watchers**: Avoid sharing the same ``state_key`` across multiple watchers unless explicitly coordinating their state.
+4. **Error Handling**: The trigger includes internal error logging and handles polling exceptions gracefully.
+5. **Timezone Support**: Supports both timezone-aware and naive datetime values by converting naive timestamps to UTC.
+
+Reference
+---------
+
+* `PostgreSQL Documentation <https://www.postgresql.org/docs/current/index.html>`__
+* `Airflow Event-driven Scheduling <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`__
+* :class:`airflow.providers.postgres.triggers.postgres_cdc.PostgresCDCEventTrigger`

--- a/providers/postgres/provider.yaml
+++ b/providers/postgres/provider.yaml
@@ -106,3 +106,8 @@ asset-uris:
 dataset-uris:
   - schemes: [postgres, postgresql]
     handler: airflow.providers.postgres.assets.postgres.sanitize_uri
+
+triggers:
+  - integration-name: PostgreSQL
+    python-modules:
+      - airflow.providers.postgres.triggers.postgres_cdc

--- a/providers/postgres/src/airflow/providers/postgres/get_provider_info.py
+++ b/providers/postgres/src/airflow/providers/postgres/get_provider_info.py
@@ -65,4 +65,10 @@ def get_provider_info():
                 "handler": "airflow.providers.postgres.assets.postgres.sanitize_uri",
             }
         ],
+        "triggers": [
+            {
+                "integration-name": "PostgreSQL",
+                "python-modules": ["airflow.providers.postgres.triggers.postgres_cdc"],
+            }
+        ],
     }

--- a/providers/postgres/src/airflow/providers/postgres/triggers/__init__.py
+++ b/providers/postgres/src/airflow/providers/postgres/triggers/__init__.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.providers.postgres.triggers.postgres_cdc import PostgresCDCEventTrigger
+
+__all__ = ["PostgresCDCEventTrigger"]

--- a/providers/postgres/src/airflow/providers/postgres/triggers/postgres_cdc.py
+++ b/providers/postgres/src/airflow/providers/postgres/triggers/postgres_cdc.py
@@ -1,0 +1,198 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+# Version guard for Event-driven triggers and Variable (requires Airflow >= 3.0)
+try:
+    from airflow.sdk import Variable
+    from airflow.triggers.base import BaseEventTrigger, TriggerEvent
+except ImportError:
+    raise AirflowOptionalProviderFeatureException(
+        "PostgresCDCEventTrigger requires Airflow >= 3.0 due to Event-driven scheduling support."
+    )
+
+
+class PostgresCDCEventTrigger(BaseEventTrigger):
+    """
+    A trigger that waits for changes in a PostgreSQL table using polling over a timestamp/version column.
+
+    The behavior of this trigger is as follows:
+
+    - Check if the state Variable exists. If not, log a warning and skip event emission to prevent recursive DAG executions.
+    - Poll the target table using `SELECT MAX(cdc_column)`.
+    - Compare the result with the stored "last read" value (persisted as an Airflow Variable).
+    - If a new value is found (greater than last read), emit a TriggerEvent containing metadata.
+    - If no new value is found, sleep for `polling_interval` seconds and continue polling.
+
+    **Important**: The state Variable must be created before using this trigger (via UI, CLI, or code).
+    Your DAG must also update this Variable after processing changes to prevent reprocessing the same data.
+    If the Variable is not found, the trigger will log a warning and skip event emission to avoid recursive DAG executions.
+
+    Example usage:
+        .. code-block:: python
+
+            from airflow.sdk import Variable
+            from airflow.providers.postgres.triggers.postgres_cdc import PostgresCDCEventTrigger
+
+            # Create the state Variable (do this once, via UI, CLI, or code)
+            Variable.set("users_cdc_last_value", "2024-01-01T00:00:00+00:00")
+
+            # Use the trigger
+            trigger = PostgresCDCEventTrigger(
+                conn_id="my_postgres", table="users", cdc_column="updated_at", polling_interval=30.0
+            )
+
+
+            # In your DAG task that processes the changes:
+            @task
+            def process_changes():
+                # Get the last processed timestamp
+                last_value = Variable.get("users_cdc_last_value")
+
+                # Process new data since last_value
+                # ... your processing logic here ...
+
+                # IMPORTANT: Update the Variable with the new timestamp
+                # to prevent reprocessing the same data
+                Variable.set("users_cdc_last_value", "2024-01-15T10:30:00+00:00")
+
+    :param conn_id: Airflow connection ID for PostgreSQL.
+    :param table: Name of the table to monitor.
+    :param cdc_column: Column representing the change timestamp or version.
+    :param polling_interval: Time (seconds) between polling attempts (default: 10.0).
+    :param state_key: Key used for persisting CDC state. If None, defaults to `{table}_cdc_last_value`.
+    """
+
+    def __init__(
+        self,
+        conn_id: str,
+        table: str,
+        cdc_column: str,
+        polling_interval: float = 10.0,
+        state_key: str | None = None,
+    ):
+        super().__init__()
+        self.conn_id = conn_id
+        self.table = table
+        self.cdc_column = cdc_column
+        self.polling_interval = polling_interval
+        self._state_key = state_key or f"{self.table}_cdc_last_value"
+
+    @property
+    def state_key(self) -> str:
+        return self._state_key
+
+    async def get_state(self) -> str | None:
+        """Get the last processed state value from Airflow Variables."""
+        try:
+            if hasattr(Variable, "aget"):
+                return await Variable.aget(self.state_key, default=None)
+            return Variable.get(self.state_key, default=None)
+        except Exception as e:
+            self.log.error("Error getting state Variable '%s': %s", self.state_key, e)
+            return None
+
+    def serialize(self) -> tuple[str, dict]:
+        return (
+            "airflow.providers.postgres.triggers.postgres_cdc.PostgresCDCEventTrigger",
+            {
+                "conn_id": self.conn_id,
+                "table": self.table,
+                "cdc_column": self.cdc_column,
+                "polling_interval": self.polling_interval,
+                "state_key": self.state_key,
+            },
+        )
+
+    async def run(self) -> AsyncGenerator[TriggerEvent, None]:
+        hook = PostgresHook(postgres_conn_id=self.conn_id)
+
+        # Check if state Variable exists to prevent recursive DAG executions
+        last_value = await self.get_state()
+        if last_value is None:
+            self.log.warning(
+                "State Variable '%s' not found. Please create this Variable (via UI, CLI, or code) "
+                "and ensure your DAG updates it after processing changes to prevent reprocessing the same data. "
+                "Example: Variable.set('%s', '2024-01-01T00:00:00+00:00'). Skipping event emission.",
+                self.state_key,
+                self.state_key,
+            )
+            # Wait for the polling interval and continue polling
+            self.log.info("Sleeping for %s seconds", self.polling_interval)
+            await asyncio.sleep(self.polling_interval)
+            return
+
+        while True:
+            try:
+                with hook.get_conn() as pg_conn:
+                    with pg_conn.cursor() as cursor:
+                        cursor.execute(f"SELECT MAX({self.cdc_column}) FROM {self.table}")
+                        result = cursor.fetchone()
+                        max_value: datetime | None = result[0]
+
+                        if not max_value:
+                            self.log.info("No data found in %s for column %s.", self.table, self.cdc_column)
+                            return
+
+                        if max_value.tzinfo is None:
+                            max_value = max_value.replace(tzinfo=timezone.utc)
+
+                        max_iso = max_value.isoformat()
+
+                        # Re-fetch state in case it was updated during polling
+                        last_value = await self.get_state()
+                        if last_value:
+                            last_dt = datetime.fromisoformat(last_value)
+                            if last_dt.tzinfo is None:
+                                last_dt = last_dt.replace(tzinfo=timezone.utc)
+                        else:
+                            # This should not happen since we checked above, but handle gracefully
+                            self.log.warning(
+                                "State Variable '%s' was removed during polling. Skipping event emission.",
+                                self.state_key,
+                            )
+                            await asyncio.sleep(self.polling_interval)
+                            return
+
+                        if max_value > last_dt:
+                            self.log.info("New change detected: %s (iso: %s)", max_value, max_iso)
+                            self.log.info(
+                                "IMPORTANT: After processing changes in your DAG, remember to update "
+                                "Variable '%s' with the new timestamp to prevent reprocessing the same data.",
+                                self.state_key,
+                            )
+                            yield TriggerEvent(
+                                {"message": f"New change detected at {max_value}", "max_iso": max_iso}
+                            )
+                            await asyncio.sleep(self.polling_interval)
+                            return
+                        else:
+                            self.log.info("No new change. max: %s, last: %s", max_value, last_dt)
+
+            except Exception as e:
+                self.log.error("Error during CDC polling: %s", e)
+
+            self.log.info("Sleeping for %s seconds", self.polling_interval)
+            await asyncio.sleep(self.polling_interval)

--- a/providers/postgres/tests/system/postgres/example_postgres_cdc_asset_watcher.py
+++ b/providers/postgres/tests/system/postgres/example_postgres_cdc_asset_watcher.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import psycopg2
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+from airflow.hooks.base_hook import BaseHook
+
+# Version guard for Airflow 3.0+ due to AssetWatcher and EventTrigger support
+try:
+    from airflow.decorators import task
+    from airflow.models import DAG
+    from airflow.providers.postgres.triggers.postgres_cdc import PostgresCDCEventTrigger
+    from airflow.sdk import Asset, AssetWatcher, Variable
+except ImportError:
+    raise AirflowOptionalProviderFeatureException(
+        "This DAG requires Airflow >= 3.0 due to AssetWatcher and Event-driven trigger support."
+    )
+
+"""
+Example DAG that demonstrates how to use the PostgresCDCEventTrigger.
+
+This DAG sets up an AssetWatcher linked to a PostgreSQL CDC trigger, which monitors changes
+in a specific table based on a timestamp column (`cdc_column`). When a change is detected, it executes a task
+that processes new rows and updates the Airflow Variable used to track CDC state (`state_key`).
+
+**Important**: The state Variable must be explicitly initialized before using the trigger to prevent
+recursive DAG executions. This example shows how to do this properly.
+
+The state variable is configurable via `state_key`.
+"""
+
+STATE_KEY = "my_table_cdc_last_value"
+
+# [START howto_operator_postgres_cdc_watcher]
+# Note: For high load tables, consider the frequency of CDC events.
+# Polling-based CDC may result in many events and load on Airflow.
+cdc_trigger = PostgresCDCEventTrigger(
+    conn_id="postgres_default",
+    table="my_table",
+    cdc_column="updated_at",
+    polling_interval=20,
+    state_key=STATE_KEY,
+)
+
+cdc_asset = Asset(
+    "postgres_cdc_asset", watchers=[AssetWatcher(name="postgres_cdc_watcher", trigger=cdc_trigger)]
+)
+
+with DAG(
+    dag_id="example_postgres_cdc_watcher",
+    schedule=[cdc_asset],
+    catchup=False,
+    max_active_runs=1,
+) as dag:
+
+    @task
+    def initialize_cdc_state():
+        """
+        Initialize the CDC state Variable if it doesn't exist.
+        This prevents recursive DAG executions by ensuring the Variable is set before the trigger runs.
+        """
+        try:
+            current_value = Variable.get(STATE_KEY, default=None)
+            if current_value is None:
+                # Initialize with a timestamp before any expected data
+                initial_timestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+                Variable.set(STATE_KEY, initial_timestamp.isoformat())
+                print(f"Initialized {STATE_KEY} with: {initial_timestamp.isoformat()}")
+            else:
+                print(f"CDC state Variable {STATE_KEY} already exists with value: {current_value}")
+        except Exception as e:
+            print(f"Error initializing CDC state: {e}")
+            raise
+
+    @task
+    def extract_and_update_last_value():
+        """
+        Extracts new rows from the monitored table that have `updated_at` greater than the
+        last recorded value in Airflow Variable, then updates the Variable with the new maximum.
+        """
+        conn = BaseHook.get_connection("postgres_default")
+
+        with psycopg2.connect(
+            host=conn.host, port=conn.port, dbname=conn.schema, user=conn.login, password=conn.password
+        ) as pg_conn:
+            with pg_conn.cursor() as cursor:
+                last_value = Variable.get(STATE_KEY, default=None)
+                if last_value:
+                    last_dt = datetime.fromisoformat(last_value)
+                else:
+                    # This should not happen if initialize_cdc_state ran properly
+                    raise ValueError(
+                        f"CDC state Variable {STATE_KEY} not found. Please run initialize_cdc_state task first."
+                    )
+
+                query = "SELECT updated_at, id, data FROM my_table WHERE updated_at > %s"
+                cursor.execute(query, (last_dt,))
+                results = cursor.fetchall()
+
+                if results:
+                    print(f"Found {len(results)} new updates.")
+                    updated_ats = [row[0] for row in results]
+                    max_updated_at = max(updated_ats)
+                    Variable.set(STATE_KEY, max_updated_at.isoformat())
+                    print(f"Updated {STATE_KEY} to: {max_updated_at.isoformat()}")
+                    print(f"Rows: {results}")
+                else:
+                    print("No new updates found.")
+
+    # Initialize state before processing
+    initialize_cdc_state() >> extract_and_update_last_value()
+# [END howto_operator_postgres_cdc_watcher]
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+test_run = get_test_run(dag)

--- a/providers/postgres/tests/unit/postgres/triggers/__init__.py
+++ b/providers/postgres/tests/unit/postgres/triggers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/postgres/tests/unit/postgres/triggers/test_postgres_cdc.py
+++ b/providers/postgres/tests/unit/postgres/triggers/test_postgres_cdc.py
@@ -1,0 +1,212 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from airflow.models import Connection
+from airflow.triggers.base import TriggerEvent
+from airflow.utils import db
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if not AIRFLOW_V_3_0_PLUS:
+    pytest.skip(
+        "Event-driven scheduling is only compatible with Airflow versions >= 3.0.0", allow_module_level=True
+    )
+
+from airflow.providers.postgres.triggers.postgres_cdc import PostgresCDCEventTrigger
+
+pytestmark = pytest.mark.db_test
+
+
+class TestPostgresCDCEventTrigger:
+    """
+    Unit tests for PostgresCDCEventTrigger.
+
+    These tests validate:
+    - Correct serialization of trigger parameters.
+    - Trigger behavior when new changes are detected.
+    - Correct handling when no new changes are present.
+    - Proper exception handling on connection failures.
+    - Guard behavior when state Variable is not initialized.
+    - Proper handling when state Variable is removed during polling.
+    """
+
+    def setup_method(self):
+        db.merge_conn(
+            Connection(
+                conn_id="postgres_default",
+                conn_type="postgres",
+                host="localhost",
+                schema="test_db",
+                login="user",
+                password="pass",
+                port=5432,
+            )
+        )
+
+    def test_trigger_serialization(self):
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+            polling_interval=30,
+            state_key="custom_cdc_state",
+        )
+
+        classpath, kwargs = trigger.serialize()
+
+        assert classpath == "airflow.providers.postgres.triggers.postgres_cdc.PostgresCDCEventTrigger"
+        assert kwargs == {
+            "conn_id": "postgres_default",
+            "table": "my_table",
+            "cdc_column": "updated_at",
+            "polling_interval": 30,
+            "state_key": "custom_cdc_state",
+        }
+
+    def test_default_state_key(self):
+        """Test that default state key is generated correctly."""
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+        )
+        assert trigger.state_key == "my_table_cdc_last_value"
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_without_state_variable(self):
+        """Test that trigger logs warning and skips event emission when state Variable doesn't exist."""
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+            polling_interval=0.1,
+            state_key="custom_cdc_state",
+        )
+
+        with patch("airflow.sdk.Variable.get", return_value=None):
+            # The trigger should return early without yielding any events
+            with pytest.raises(StopAsyncIteration):
+                await trigger.run().__anext__()
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_with_change(self):
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+            polling_interval=0.1,
+            state_key="custom_cdc_state",
+        )
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc),)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.__enter__.return_value = mock_conn
+
+        with (
+            patch("airflow.providers.postgres.hooks.postgres.PostgresHook.get_conn", return_value=mock_conn),
+            patch("airflow.sdk.Variable.get", return_value="2024-01-01T00:00:00"),
+            patch("airflow.sdk.Variable.set"),
+        ):
+            async for result in trigger.run():
+                assert isinstance(result, TriggerEvent)
+                assert "message" in result.payload
+                assert "max_iso" in result.payload
+                break
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_no_change(self):
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+            polling_interval=0.1,
+            state_key="custom_cdc_state",
+        )
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.__enter__.return_value = mock_conn
+
+        with (
+            patch("airflow.providers.postgres.hooks.postgres.PostgresHook.get_conn", return_value=mock_conn),
+            patch("airflow.sdk.Variable.get", return_value="2024-01-02T00:00:00"),
+        ):
+            task = asyncio.create_task(trigger.run().__anext__())
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(task, timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_state_variable_removed_during_polling(self):
+        """Test that trigger handles state Variable being removed during polling."""
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+            polling_interval=0.1,
+            state_key="custom_cdc_state",
+        )
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc),)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.__enter__.return_value = mock_conn
+
+        # First call returns a value, second call returns None (Variable removed)
+        with (
+            patch("airflow.providers.postgres.hooks.postgres.PostgresHook.get_conn", return_value=mock_conn),
+            patch("airflow.sdk.Variable.get", side_effect=["2024-01-01T00:00:00", None]),
+        ):
+            # The trigger should return early without yielding any events
+            with pytest.raises(StopAsyncIteration):
+                await trigger.run().__anext__()
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_exception(self, mocker):
+        trigger = PostgresCDCEventTrigger(
+            conn_id="postgres_default",
+            table="my_table",
+            cdc_column="updated_at",
+            polling_interval=0.1,
+            state_key="custom_cdc_state",
+        )
+
+        mocker.patch(
+            "airflow.providers.postgres.hooks.postgres.PostgresHook.get_conn",
+            side_effect=Exception("Connection failed"),
+        )
+
+        # Mock Variable.get to return a value so the guard doesn't trigger
+        mocker.patch("airflow.sdk.Variable.get", return_value="2024-01-01T00:00:00")
+
+        task = asyncio.create_task(trigger.run().__anext__())
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(task, timeout=1)


### PR DESCRIPTION
Description
- Adds PostgresCDCEventTrigger to Postgres provider.
- Supports polling-based CDC using timestamp or version column.
- Integrates with AssetWatcher for triggering Airflow assets.
- Includes unit tests and example DAG.
- Adds state_key parameter for configurable state persistence.
- Updates provider.yaml and generated provider info.

All pre-commit checks and tests passed successfully.

Closes: none
Related: none

---
Notes
This feature enables simple polling-based CDC for PostgreSQL within Airflow, complementing the Asset-based workflow model introduced in Airflow 3.x.

This feature requires Airflow 3.0+ as it depends on `AssetWatcher` and `BaseEventTrigger`.
