### PR TITLE
Avoid redundant warning & error logs for the same SDK API client operation

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -103,7 +103,6 @@ def get_json_error(response: httpx.Response):
     """Raise a ServerResponseError if we can extract error info from the error."""
     err = ServerResponseError.from_response(response)
     if err:
-        log.warning("Server error", detail=err.detail)
         raise err
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #49543 

When an SDK client API operation fails -- either getting a variable, connection, xcom etc, we doubly log. One time as a warning and the next as an error. This leads to confusion while debugging and it is irrelevant to do it twice.

DAG used:

```
import json

from airflow import DAG
from airflow.operators.empty import EmptyOperator
from airflow.models import Variable
from airflow.sdk.exceptions import AirflowRuntimeError

try:
    variable_value = Variable.get("some-variable", deserialize_json=True)
except (json.decoder.JSONDecodeError, KeyError, AirflowRuntimeError):
    variable_value = {"task_id": "default_task_name"}


with DAG(dag_id="example_dag_variable_access") as dag:
    task_from_var = EmptyOperator(task_id=variable_value.get("task_id"))
    task_from_var

```

Before:
```
[2025-05-26T13:35:01.326+0000] {manager.py:528} INFO - Not time to refresh bundle dags-folder
[2025-05-26T13:35:04.442+0000] {_client.py:1026} INFO - HTTP Request: GET http://in-process.invalid./variables/some-variable "HTTP/1.1 404 Not Found"
2025-05-26 13:35:04 [warning  ] Server error                   [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'some-variable' not found"}}
2025-05-26 13:35:04 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'some-variable' not found"}} key=some-variable status_code=40
```

After:
```
[2025-05-26T13:38:33.702+0000] {_client.py:1026} INFO - HTTP Request: GET http://in-process.invalid./variables/some-variable "HTTP/1.1 404 Not Found"
2025-05-26 13:38:33 [error    ] Variable not found             [airflow.sdk.api.client] detail={'detail': {'reason': 'not_found', 'message': "Variable with key 'some-variable' not found"}} key=some-variable status_code=404
[2025-05-26T13:38:33.704+0000] {dag.py:1635} INFO - Sync 1 DAG
```



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
