### PR TITLE
Bugfix: Create async version of get_ti_count, get_dr_count, get_dagrun_state, get_task_states to avoid Triggerer Lock

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -711,15 +711,15 @@ class CustomTriggerDagRun(BaseTrigger):
         )
 
     async def run(self, **args) -> AsyncIterator[TriggerEvent]:
-        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+        from airflow.sdk.execution_time.triggerer_task_functions import get_dagrun_state, get_dr_count
 
-        dag_run_states_count = await sync_to_async(RuntimeTaskInstance.get_dr_count)(
+        dag_run_states_count = await get_dr_count(
             dag_id=self.trigger_dag_id,
             run_ids=self.run_ids,
             states=self.states,
             logical_dates=self.logical_dates,
         )
-        dag_run_state = await sync_to_async(RuntimeTaskInstance.get_dagrun_state)(
+        dag_run_state = await get_dagrun_state(
             dag_id=self.trigger_dag_id,
             run_id=self.run_ids[0],
         )
@@ -796,9 +796,13 @@ class CustomTriggerWorkflowStateTrigger(BaseTrigger):
         )
 
     async def run(self, **args) -> AsyncIterator[TriggerEvent]:
-        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+        from airflow.sdk.execution_time.triggerer_task_functions import (
+            get_dr_count,
+            get_task_states,
+            get_ti_count,
+        )
 
-        ti_count = await sync_to_async(RuntimeTaskInstance.get_ti_count)(
+        ti_count = await get_ti_count(
             dag_id=self.external_dag_id,
             task_ids=self.external_task_ids,
             task_group_id=None,
@@ -806,13 +810,13 @@ class CustomTriggerWorkflowStateTrigger(BaseTrigger):
             logical_dates=self.execution_dates,
             states=self.allowed_states,
         )
-        dr_count = await sync_to_async(RuntimeTaskInstance.get_dr_count)(
+        dr_count = await get_dr_count(
             dag_id=self.external_dag_id,
             run_ids=self.run_ids,
             logical_dates=self.execution_dates,
             states=["running"],
         )
-        task_states = await sync_to_async(RuntimeTaskInstance.get_task_states)(
+        task_states = await get_task_states(
             dag_id=self.external_dag_id,
             task_ids=self.external_task_ids,
             run_ids=self.run_ids,

--- a/providers/standard/tests/unit/standard/triggers/test_external_task.py
+++ b/providers/standard/tests/unit/standard/triggers/test_external_task.py
@@ -48,7 +48,7 @@ class TestWorkflowTrigger:
     LOGICAL_DATE = timezone.datetime(2022, 1, 1)
 
     @pytest.mark.flaky(reruns=5)
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_ti_count")
     @pytest.mark.asyncio
     async def test_task_workflow_trigger_success(self, mock_get_count):
         """check the db count get called correctly."""
@@ -84,7 +84,7 @@ class TestWorkflowTrigger:
             await gen.__anext__()
 
     @pytest.mark.flaky(reruns=5)
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_ti_count")
     @pytest.mark.asyncio
     async def test_task_workflow_trigger_failed(self, mock_get_count):
         mock_get_count.side_effect = mocked_get_count
@@ -120,7 +120,7 @@ class TestWorkflowTrigger:
             await gen.__anext__()
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_ti_count")
     async def test_task_workflow_trigger_fail_count_eq_0(self, mock_get_count):
         mock_get_count.side_effect = [0, 1]  # First 0 for failed_states, then 1 for allowed_states
 
@@ -162,7 +162,7 @@ class TestWorkflowTrigger:
             await gen.__anext__()
 
     @pytest.mark.flaky(reruns=5)
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_ti_count")
     @pytest.mark.asyncio
     async def test_task_workflow_trigger_skipped(self, mock_get_count):
         mock_get_count.side_effect = mocked_get_count
@@ -193,7 +193,7 @@ class TestWorkflowTrigger:
             states=["success", "fail"],
         )
 
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_ti_count")
     @mock.patch("asyncio.sleep")
     @pytest.mark.asyncio
     async def test_task_workflow_trigger_sleep_success(self, mock_sleep, mock_get_count):
@@ -306,9 +306,9 @@ class TestWorkflowTrigger:
             "no task_ids or task_group_id",
         ],
     )
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_ti_count")
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_dr_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_ti_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_task_states")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_dr_count")
     @pytest.mark.asyncio
     async def test_get_count_af_3(
         self,
@@ -658,7 +658,7 @@ class TestDagStateTrigger:
     @pytest.mark.db_test
     @pytest.mark.asyncio
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Airflow 2 had a different implementation")
-    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_dr_count")
+    @mock.patch("airflow.sdk.execution_time.triggerer_task_functions.get_dr_count")
     async def test_dag_state_trigger_af_3(self, mock_get_dag_run_count, session):
         """
         Assert that the DagStateTrigger only goes off on or after a DagRun

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -431,20 +431,19 @@ class RuntimeTaskInstance(TaskInstance):
         """Return the number of task instances matching the given criteria."""
         log = structlog.get_logger(logger_name="task")
 
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetTICount(
-                    dag_id=dag_id,
-                    map_index=map_index,
-                    task_ids=task_ids,
-                    task_group_id=task_group_id,
-                    logical_dates=logical_dates,
-                    run_ids=run_ids,
-                    states=states,
-                ),
-            )
-            response = SUPERVISOR_COMMS.get_message()
+        SUPERVISOR_COMMS.send_request(
+            log=log,
+            msg=GetTICount(
+                dag_id=dag_id,
+                map_index=map_index,
+                task_ids=task_ids,
+                task_group_id=task_group_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+                states=states,
+            ),
+        )
+        response = SUPERVISOR_COMMS.get_message()
 
         if TYPE_CHECKING:
             assert isinstance(response, TICount)
@@ -463,19 +462,18 @@ class RuntimeTaskInstance(TaskInstance):
         """Return the task states matching the given criteria."""
         log = structlog.get_logger(logger_name="task")
 
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetTaskStates(
-                    dag_id=dag_id,
-                    map_index=map_index,
-                    task_ids=task_ids,
-                    task_group_id=task_group_id,
-                    logical_dates=logical_dates,
-                    run_ids=run_ids,
-                ),
-            )
-            response = SUPERVISOR_COMMS.get_message()
+        SUPERVISOR_COMMS.send_request(
+            log=log,
+            msg=GetTaskStates(
+                dag_id=dag_id,
+                map_index=map_index,
+                task_ids=task_ids,
+                task_group_id=task_group_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+            ),
+        )
+        response = SUPERVISOR_COMMS.get_message()
 
         if TYPE_CHECKING:
             assert isinstance(response, TaskStatesResult)
@@ -492,17 +490,16 @@ class RuntimeTaskInstance(TaskInstance):
         """Return the number of DAG runs matching the given criteria."""
         log = structlog.get_logger(logger_name="task")
 
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetDRCount(
-                    dag_id=dag_id,
-                    logical_dates=logical_dates,
-                    run_ids=run_ids,
-                    states=states,
-                ),
-            )
-            response = SUPERVISOR_COMMS.get_message()
+        SUPERVISOR_COMMS.send_request(
+            log=log,
+            msg=GetDRCount(
+                dag_id=dag_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+                states=states,
+            ),
+        )
+        response = SUPERVISOR_COMMS.get_message()
 
         if TYPE_CHECKING:
             assert isinstance(response, DRCount)
@@ -513,9 +510,9 @@ class RuntimeTaskInstance(TaskInstance):
     def get_dagrun_state(dag_id: str, run_id: str) -> str:
         """Return the state of the DAG run with the given Run ID."""
         log = structlog.get_logger(logger_name="task")
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetDagRunState(dag_id=dag_id, run_id=run_id))
-            response = SUPERVISOR_COMMS.get_message()
+
+        SUPERVISOR_COMMS.send_request(log=log, msg=GetDagRunState(dag_id=dag_id, run_id=run_id))
+        response = SUPERVISOR_COMMS.get_message()
 
         if TYPE_CHECKING:
             assert isinstance(response, DagRunStateResult)

--- a/task-sdk/src/airflow/sdk/execution_time/triggerer_task_functions.py
+++ b/task-sdk/src/airflow/sdk/execution_time/triggerer_task_functions.py
@@ -1,0 +1,138 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+
+async def get_ti_count(
+    dag_id: str,
+    map_index: int | None = None,
+    task_ids: list[str] | None = None,
+    task_group_id: str | None = None,
+    logical_dates: list[datetime] | None = None,
+    run_ids: list[str] | None = None,
+    states: list[str] | None = None,
+) -> int:
+    """Return the number of task instances matching the given criteria."""
+    from airflow.sdk.execution_time.comms import GetTICount, TICount
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    log = structlog.get_logger(logger_name="task")
+
+    async with SUPERVISOR_COMMS.lock:
+        SUPERVISOR_COMMS.send_request(
+            log=log,
+            msg=GetTICount(
+                dag_id=dag_id,
+                map_index=map_index,
+                task_ids=task_ids,
+                task_group_id=task_group_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+                states=states,
+            ),
+        )
+        response = SUPERVISOR_COMMS.get_message()
+
+    if TYPE_CHECKING:
+        assert isinstance(response, TICount)
+
+    return response.count
+
+
+async def get_dr_count(
+    dag_id: str,
+    logical_dates: list[datetime] | None = None,
+    run_ids: list[str] | None = None,
+    states: list[str] | None = None,
+) -> int:
+    """Return the number of DAG runs matching the given criteria."""
+    from airflow.sdk.execution_time.comms import DRCount, GetDRCount
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    log = structlog.get_logger(logger_name="task")
+
+    async with SUPERVISOR_COMMS.lock:
+        SUPERVISOR_COMMS.send_request(
+            log=log,
+            msg=GetDRCount(
+                dag_id=dag_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+                states=states,
+            ),
+        )
+        response = SUPERVISOR_COMMS.get_message()
+
+    if TYPE_CHECKING:
+        assert isinstance(response, DRCount)
+
+    return response.count
+
+
+async def get_dagrun_state(dag_id: str, run_id: str) -> str:
+    """Return the state of the DAG run with the given Run ID."""
+    from airflow.sdk.execution_time.comms import DagRunStateResult, GetDagRunState
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    log = structlog.get_logger(logger_name="task")
+    async with SUPERVISOR_COMMS.lock:
+        SUPERVISOR_COMMS.send_request(log=log, msg=GetDagRunState(dag_id=dag_id, run_id=run_id))
+        response = SUPERVISOR_COMMS.get_message()
+
+    if TYPE_CHECKING:
+        assert isinstance(response, DagRunStateResult)
+
+    return response.state
+
+
+async def get_task_states(
+    dag_id: str,
+    map_index: int | None = None,
+    task_ids: list[str] | None = None,
+    task_group_id: str | None = None,
+    logical_dates: list[datetime] | None = None,
+    run_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Return the task states matching the given criteria."""
+    from airflow.sdk.execution_time.comms import GetTaskStates, TaskStatesResult
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    log = structlog.get_logger(logger_name="task")
+
+    async with SUPERVISOR_COMMS.lock:
+        SUPERVISOR_COMMS.send_request(
+            log=log,
+            msg=GetTaskStates(
+                dag_id=dag_id,
+                map_index=map_index,
+                task_ids=task_ids,
+                task_group_id=task_group_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+            ),
+        )
+        response = SUPERVISOR_COMMS.get_message()
+
+    if TYPE_CHECKING:
+        assert isinstance(response, TaskStatesResult)
+
+    return response.task_states

--- a/task-sdk/tests/task_sdk/execution_time/test_triggerer_task_functions.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_triggerer_task_functions.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.sdk.execution_time.comms import (
+    DagRunStateResult,
+    DRCount,
+    GetDagRunState,
+    GetDRCount,
+    GetTaskStates,
+    GetTICount,
+    TaskStatesResult,
+    TICount,
+)
+from airflow.sdk.execution_time.triggerer_task_functions import (
+    get_dagrun_state,
+    get_dr_count,
+    get_task_states,
+    get_ti_count,
+)
+from airflow.utils import timezone
+
+
+@pytest.mark.asyncio
+async def test_get_ti_count(mock_supervisor_comms):
+    """Test that async get_ti_count sends the correct request and returns the count."""
+
+    mock_supervisor_comms.get_message.return_value = TICount(count=2)
+
+    count = await get_ti_count(
+        dag_id="test_dag",
+        task_ids=["task1", "task2"],
+        task_group_id="group1",
+        logical_dates=[timezone.datetime(2024, 1, 1)],
+        run_ids=["run1"],
+        states=["success", "failed"],
+    )
+
+    mock_supervisor_comms.send_request.assert_called_once_with(
+        log=mock.ANY,
+        msg=GetTICount(
+            dag_id="test_dag",
+            task_ids=["task1", "task2"],
+            task_group_id="group1",
+            logical_dates=[timezone.datetime(2024, 1, 1)],
+            run_ids=["run1"],
+            states=["success", "failed"],
+        ),
+    )
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dr_count(mock_supervisor_comms):
+    """Test that async get_dr_count sends the correct request and returns the count."""
+    mock_supervisor_comms.get_message.return_value = DRCount(count=2)
+
+    count = await get_dr_count(
+        dag_id="test_dag",
+        logical_dates=[timezone.datetime(2024, 1, 1)],
+        run_ids=["run1"],
+        states=["success", "failed"],
+    )
+
+    mock_supervisor_comms.send_request.assert_called_once_with(
+        log=mock.ANY,
+        msg=GetDRCount(
+            dag_id="test_dag",
+            logical_dates=[timezone.datetime(2024, 1, 1)],
+            run_ids=["run1"],
+            states=["success", "failed"],
+        ),
+    )
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dagrun_state(mock_supervisor_comms):
+    """Test that async get_dagrun_state sends the correct request and returns the state."""
+
+    mock_supervisor_comms.get_message.return_value = DagRunStateResult(state="running")
+
+    state = await get_dagrun_state(
+        dag_id="test_dag",
+        run_id="run1",
+    )
+
+    mock_supervisor_comms.send_request.assert_called_once_with(
+        log=mock.ANY,
+        msg=GetDagRunState(
+            dag_id="test_dag",
+            run_id="run1",
+        ),
+    )
+    assert state == "running"
+
+
+@pytest.mark.asyncio
+async def test_get_task_states(mock_supervisor_comms):
+    """Test that async get_task_states sends the correct request and returns the states."""
+    mock_supervisor_comms.get_message.return_value = TaskStatesResult(
+        task_states={"run1": {"task1": "running"}}
+    )
+
+    states = await get_task_states(
+        dag_id="test_dag",
+        task_ids=["task1"],
+        run_ids=["run1"],
+    )
+
+    mock_supervisor_comms.send_request.assert_called_once_with(
+        log=mock.ANY,
+        msg=GetTaskStates(
+            dag_id="test_dag",
+            task_ids=["task1"],
+            run_ids=["run1"],
+        ),
+    )
+    assert states == {"run1": {"task1": "running"}}


### PR DESCRIPTION

Workflow trigger operations are getting locked, when using sync_to_async, to avoid that we can use async version of get_ti_count, get_dr_count, get_dagrun_state ,get_task_states.

As explained in https://github.com/apache/airflow/issues/50185#issuecomment-2908470186, the issue likely causing interference with `sync_to_async` when used alongside aiologic.Lock. This is causing locks to remain unreleased, leading to blocked requests and preventing subsequent triggers from loading.

Another approach, as described in https://github.com/apache/airflow/issues/50185#issuecomment-2891834967, involves fully rewriting the client and task operation methods in the triggerer to be asynchronous. While this approach is good, it introduces additional complexity, such as the need to maintain separate async versions of the client methods.

I’ve already implemented an async client and some task operation methods, but I didn’t observe any significant benefits in making methods like get_ti_count, get_dr_count, get_dagrun_state, and get_task_states asynchronous. Given that, I opted for a minimal-change approach rather than building a fully async client version.

After change tested with around 400+ triggers, nothing blocked everything seems working.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
