### PR TITLE
[Discord Provider] Add support to embeds in Discord Webhook and Notifier

### DIFF
--- a/providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py
+++ b/providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py
@@ -47,6 +47,9 @@ class DiscordWebhookHook(HttpHook):
     :param avatar_url: Override the default avatar of the webhook
     :param tts: Is a text-to-speech message
     :param proxy: Proxy to use to make the Discord webhook call
+    :param embeds: List of embed objects to send with the message. Each embed can contain
+                   an author object with name (required), url, and icon_url fields.
+                   URLs must use HTTPS.
     """
 
     conn_name_attr = "http_conn_id"
@@ -143,15 +146,13 @@ class DiscordWebhookHook(HttpHook):
         for embed in embeds:
             if not isinstance(embed, dict):
                 raise AirflowException("Each embed must be a dictionary.")
-            if "title" in embed and not isinstance(embed["title"], str):
-                raise AirflowException("Embed title must be a string.")
-            if "description" in embed and not isinstance(embed["description"], str):
-                raise AirflowException("Embed description must be a string.")
-            if "url" in embed and not isinstance(embed["url"], str):
-                raise AirflowException("Embed URL must be a string.")
+            if "url" in embed:
+                if not isinstance(embed["url"], str) or not embed["url"].startswith("https://"):
+                    raise AirflowException("Embed URL must be a string starting with 'https://'.")
             if "color" in embed and not isinstance(embed["color"], int):
                 raise AirflowException("Embed color must be an integer.")
-            # Add more validations as needed
+            if "author" in embed and not isinstance(embed["author"], dict):
+                raise AirflowException("Embed author must be a dictionary.")
 
     def _build_discord_payload(self) -> str:
         """

--- a/providers/discord/src/airflow/providers/discord/notifications/discord.py
+++ b/providers/discord/src/airflow/providers/discord/notifications/discord.py
@@ -86,7 +86,7 @@ class DiscordNotifier(BaseNotifier):
         self.success_link = None
         self.reactions = None
         self.proxy = None
-        self.embeds = None
+        self.embeds: list[dict[str, Any]] | None = None
         self.description = description
 
     @cached_property
@@ -95,7 +95,7 @@ class DiscordNotifier(BaseNotifier):
         hook = DiscordWebhookHook(
             http_conn_id=self.discord_conn_id,
             webhook_endpoint=None,
-            message=self.text,
+            message=self.text or "",
             username=self.username,
             avatar_url=self.avatar_url,
             tts=self.tts,
@@ -136,17 +136,21 @@ class DiscordNotifier(BaseNotifier):
         }
 
         if self.success_link:
-            embed["fields"].append({
-                "name": "Link",
-                "value": f"[View DAG]({self.success_link})",
-                "inline": False,
-            })
+            embed["fields"].append(
+                {
+                    "name": "Link",
+                    "value": f"[View DAG]({self.success_link})",
+                    "inline": False,
+                }
+            )
         if self.failure_link:
-            embed["fields"].append({
-                "name": "Link",
-                "value": f"[View Logs]({self.failure_link})",
-                "inline": False,
-            })
+            embed["fields"].append(
+                {
+                    "name": "Link",
+                    "value": f"[View Logs]({self.failure_link})",
+                    "inline": False,
+                }
+            )
 
         return [embed]
 
@@ -188,7 +192,10 @@ class DiscordNotifier(BaseNotifier):
                         messages.append(current_message)
                         current_message = line
                 else:
-                    current_message += "\n" + line
+                    if current_message:
+                        current_message += "\n" + line
+                    else:
+                        current_message = line
 
             if current_message:
                 if in_code_block:

--- a/providers/discord/src/airflow/providers/discord/notifications/discord.py
+++ b/providers/discord/src/airflow/providers/discord/notifications/discord.py
@@ -18,9 +18,12 @@
 from __future__ import annotations
 
 from functools import cached_property
+from typing import Any
+from urllib.parse import urlencode
 
-from airflow.providers.common.compat.notifier import BaseNotifier
+from airflow.providers.common.compat.notifier import BaseNotifier  # type: ignore
 from airflow.providers.discord.hooks.discord_webhook import DiscordWebhookHook
+from airflow.utils.timezone import utcnow  # type: ignore
 
 ICON_URL: str = (
     "https://raw.githubusercontent.com/apache/airflow/main/airflow-core/src/airflow/ui/public/pin_100.png"
@@ -46,31 +49,156 @@ class DiscordNotifier(BaseNotifier):
     def __init__(
         self,
         discord_conn_id: str = "discord_webhook_default",
-        text: str = "This is a default message",
-        username: str = "Airflow",
-        avatar_url: str = ICON_URL,
+        text: str | None = None,
+        username: str | None = "Airflow",
+        avatar_url: str | None = ICON_URL,
         tts: bool = False,
+        success: bool | None = False,
+        failure: bool | None = False,
+        success_color: int = 0x00FF00,
+        failure_color: int = 0xFF0000,
+        mentions: list[dict[str, Any]] | None = None,
+        mention_everyone: bool = False,
+        mention_roles: list[str] | None = None,
+        mention_channels: list[dict[str, Any]] | None = None,
+        reactions: list[dict[str, Any]] | None = None,
+        application_id: str = "airflow",
+        description: str = "",
     ):
         super().__init__()
         self.discord_conn_id = discord_conn_id
         self.text = text
         self.username = username
         self.avatar_url = avatar_url
-
-        # If you're having problems with tts not being recognized in __init__(),
-        # you can define that after instantiating the class
         self.tts = tts
+        self.success = success or not failure
+        self.success_color = success_color
+        self.failure_color = failure_color
+        self.mentions = mentions
+        self.mention_everyone = mention_everyone
+        self.mention_roles = mention_roles
+        self.mention_channels = mention_channels
+        self.application_id = application_id
+        self.dag_name = None
+        self.task_name = None
+        self.duration = None
+        self.failure_link = None
+        self.success_link = None
+        self.reactions = None
+        self.proxy = None
+        self.embeds = None
+        self.description = description
 
     @cached_property
     def hook(self) -> DiscordWebhookHook:
         """Discord Webhook Hook."""
-        return DiscordWebhookHook(http_conn_id=self.discord_conn_id)
+        hook = DiscordWebhookHook(
+            http_conn_id=self.discord_conn_id,
+            webhook_endpoint=None,
+            message=self.text,
+            username=self.username,
+            avatar_url=self.avatar_url,
+            tts=self.tts,
+            proxy=None,
+        )
+        if not hook.message:
+            self.embeds = self._build_embed()
+        hook.embeds = self.embeds
+        hook.mentions = self.mentions
+        hook.mention_everyone = self.mention_everyone
+        hook.mention_roles = self.mention_roles
+        hook.mention_channels = self.mention_channels
+        hook.reactions = self.reactions
+        hook.application_id = self.application_id
+        return hook
+
+    def _build_embed(self) -> list[dict[str, Any]]:
+        """Build the embed structure for the Discord message."""
+        color = self.success_color if self.success else self.failure_color
+        title = f"DAG run: {self.dag_name}" if self.success else f"DAG failure: {self.dag_name}"
+        description = self.description
+
+        embed = {
+            "title": title,
+            "description": description,
+            "color": color,
+            "fields": [
+                {
+                    "name": "Status",
+                    "value": "✅ Success" if self.success else "❌ Failed",
+                    "inline": True,
+                },
+                {"name": "Duration", "value": self.duration, "inline": True},
+                {"name": "DAG", "value": self.dag_name, "inline": True},
+            ],
+            "footer": {"text": f"Task: {self.task_name}"},
+            "timestamp": utcnow().isoformat(),
+        }
+
+        if self.success_link:
+            embed["fields"].append({
+                "name": "Link",
+                "value": f"[View DAG]({self.success_link})",
+                "inline": False,
+            })
+        if self.failure_link:
+            embed["fields"].append({
+                "name": "Link",
+                "value": f"[View Logs]({self.failure_link})",
+                "inline": False,
+            })
+
+        return [embed]
 
     def notify(self, context):
         """Send a message to a Discord channel."""
+        task_instance = context.get("task_instance")
+        if task_instance:
+            self.dag_name = task_instance.dag_id.replace("_", "\\_")
+            self.task_name = task_instance.task_id
+            self.duration = str(task_instance.duration)
+            self.failure_link = f"https://airflow.data.retize.io/dags/{task_instance.dag_id}/grid?task_id={task_instance.task_id}&tab=logs&dag_run_id={urlencode({'dag_run_id': task_instance.run_id.replace('+', '%2B')})}"
+            self.success_link = f"https://airflow.data.retize.io/dags/{task_instance.dag_id}/grid?task_id={task_instance.task_id}&tab=logs&dag_run_id={urlencode({'dag_run_id': task_instance.run_id.replace('+', '%2B')})}"
+
         self.hook.username = self.username
-        self.hook.message = self.text
         self.hook.avatar_url = self.avatar_url
         self.hook.tts = self.tts
 
-        self.hook.execute()
+        if self.text:
+            lines = self.text.split("\n")
+            messages = []
+            current_message = ""
+            in_code_block = False
+
+            for line in lines:
+                if line.startswith("```"):
+                    if in_code_block:
+                        current_message += "\n```"
+                        messages.append(current_message)
+                        current_message = "```"
+                    else:
+                        current_message += "\n" + line
+                    in_code_block = not in_code_block
+                elif len(current_message) + len(line) + 1 > 2000:
+                    if in_code_block:
+                        current_message += "\n```"
+                        messages.append(current_message)
+                        current_message = "```" + line
+                    else:
+                        messages.append(current_message)
+                        current_message = line
+                else:
+                    current_message += "\n" + line
+
+            if current_message:
+                if in_code_block:
+                    current_message += "\n```"
+                messages.append(current_message)
+
+            self.embeds = []
+            for message in messages:
+                self.hook.message = message
+                self.hook.execute()
+        else:
+            self.hook.embeds = self._build_embed()
+            self.hook.execute()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

I created an issue showing this example a few months ago. I implemented it locally and we've been using since then.

By default, the webhook only supports a message. This is a notification from it:
![image](https://github.com/user-attachments/assets/52954ef4-eb04-4c2c-8ba3-ec0aeea44c70)

And this is a notification with the suggested embed:
![image](https://github.com/user-attachments/assets/152c6512-7029-49ff-84ce-932098f5bb4e)

We get some informations from task_instance.
closes #46838

