### PR TITLE
[2.x] Fix delete button visibility in search filters

### DIFF
--- a/airflow/www/templates/airflow/variable_list.html
+++ b/airflow/www/templates/airflow/variable_list.html
@@ -51,7 +51,7 @@
   {% endif %}
   {{ super() }}
   <style>
-    td { white-space: nowrap; text-overflow: ellipsis; overflow: hidden; max-width:1px;}
+    td { white-space: nowrap; text-overflow: ellipsis; overflow: hidden;}
     th { resize: horizontal; overflow: auto;}
   </style>
 {% endblock %}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

## Description

This PR fixes a UI bug in the Variable List page where the "Delete" (remove filter) button for search filters was not fully visible. The issue was caused by legacy table cell (`td`) settings in the template, which became problematic after upgrading the Flask-AppBuilder package. The button was partially hidden, with only its right border visible, making it difficult for users to remove filters.

**What was changed:**
- Adjusted the table cell settings in `variable_list.html` to ensure the remove filter button is always fully visible and accessible in the Variable List filter UI.

## Related Issues

closes: #50296

## Related PRs

- [Airflow: Add 'Show record' option for variables](https://github.com/apache/airflow/pull/21342)
- [Flask-AppBuilder: fix: filter list UI spacing between elements](https://github.com/dpgaspar/Flask-AppBuilder/pull/2128)
- [[2.x] Fix pools list page's delete button visibility in search filters](https://github.com/apache/airflow/pull/51161)

## How to reproduce

1. Go to Admin → Variables in the Airflow UI.
2. Click "Add Filter" and select a filter.
3. Observe that the delete (remove filter) button is not fully visible (only the right border shows).

## What you think should happen instead

The delete search filter button should be fully visible and easily clickable.

## Additional context

- This issue appeared after upgrading Flask-AppBuilder, which changed some default table rendering behaviors.
- The fix is backward-compatible and only affects the Variable List page.

## Screenshots

**Before:**
<img width="1006" alt="Screenshot 2025-05-27 at 12 12 37 PM" src="https://github.com/user-attachments/assets/0c78e78c-8acc-4524-b02f-bebf6fe2b7de" />


**After:**
<img width="1001" alt="Screenshot 2025-05-27 at 12 11 42 PM" src="https://github.com/user-attachments/assets/019d8850-8bee-408c-b114-ddcd09e0f043" />

---

**Please review and let me know if further adjustments are needed.**

---