### PR TITLE
Delete unneeded `and` operator

### DIFF
--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -85,7 +85,7 @@ subjects:
     name: {{ include "createUserJob.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
   {{- end }}
-  {{- if and .Values.cleanup.enabled }}
+  {{- if .Values.cleanup.enabled }}
   - kind: ServiceAccount
     name: {{ include "cleanup.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
This PR removes the use of the `and` operator in the Airflow Helm chart.

The operator is not a required and removing it simplifies the chart for users who do not use it. 

