### PR TITLE
Fix last dag run not showing on dag listing

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dags.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/airflow-core/src/airflow/api_fastapi/common/db/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dags.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import func, null, select
+
+from airflow.api_fastapi.common.db.common import (
+    apply_filters_to_select,
+)
+from airflow.api_fastapi.common.parameters import BaseParam, RangeFilter, SortParam
+from airflow.models import DagModel
+from airflow.models.dagrun import DagRun
+
+if TYPE_CHECKING:
+    from sqlalchemy.sql import Select
+
+
+def generate_dag_with_latest_run_query(max_run_filters: list[BaseParam], order_by: SortParam) -> Select:
+    query = select(DagModel)
+
+    max_run_id_query = (  # ordering by id will not always be "latest run", but it's a simplifying assumption
+        select(DagRun.dag_id, func.max(DagRun.id).label("max_dag_run_id"))
+        .where(DagRun.start_date.is_not(null()))
+        .group_by(DagRun.dag_id)
+        .subquery(name="mrq")
+    )
+
+    has_max_run_filter = False
+
+    for max_run_filter in max_run_filters:
+        if isinstance(max_run_filter, RangeFilter):
+            if max_run_filter.is_active():
+                has_max_run_filter = True
+                break
+        if max_run_filter.value:
+            has_max_run_filter = True
+            break
+
+    if has_max_run_filter or order_by.value in (
+        "last_run_state",
+        "last_run_start_date",
+        "-last_run_state",
+        "-last_run_start_date",
+    ):
+        query = query.join(
+            max_run_id_query,
+            DagModel.dag_id == max_run_id_query.c.dag_id,
+            isouter=True,
+        ).join(DagRun, DagRun.id == max_run_id_query.c.max_dag_run_id, isouter=True)
+
+    if has_max_run_filter:
+        query = apply_filters_to_select(
+            statement=query,
+            filters=max_run_filters,
+        )
+
+    return query

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -94,13 +94,13 @@ paths:
                 title: Response Hook Meta Data
       security:
       - OAuth2PasswordBearer: []
-  /ui/dags/recent_dag_runs:
+  /ui/dags:
     get:
       tags:
       - DAG
-      summary: Recent Dag Runs
-      description: Get recent DAG runs.
-      operationId: recent_dag_runs
+      summary: Get Dags
+      description: Get DAGs with recent DagRun.
+      operationId: get_dags_ui
       security:
       - OAuth2PasswordBearer: []
       parameters:
@@ -211,6 +211,13 @@ paths:
           - $ref: '#/components/schemas/DagRunState'
           - type: 'null'
           title: Last Dag Run State
+      - name: order_by
+        in: query
+        required: false
+        schema:
+          type: string
+          default: dag_id
+          title: Order By
       responses:
         '200':
           description: Successful Response

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -22,15 +22,15 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Query, Response, status
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
-from sqlalchemy import func, null, select, update
+from sqlalchemy import select, update
 
 from airflow.api.common import delete_dag as delete_dag_module
 from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
-    apply_filters_to_select,
     paginated_select,
 )
+from airflow.api_fastapi.common.db.dags import generate_dag_with_latest_run_query
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,
@@ -115,44 +115,15 @@ def get_dags(
     session: SessionDep,
 ) -> DAGCollectionResponse:
     """Get all DAGs."""
-    query = select(DagModel)
-
-    max_run_id_query = (  # ordering by id will not always be "latest run", but it's a simplifying assumption
-        select(DagRun.dag_id, func.max(DagRun.id).label("max_dag_run_id"))
-        .where(DagRun.start_date.is_not(null()))
-        .group_by(DagRun.dag_id)
-        .subquery(name="mrq")
+    query = generate_dag_with_latest_run_query(
+        max_run_filters=[
+            dag_run_start_date_range,
+            dag_run_end_date_range,
+            dag_run_state,
+            last_dag_run_state,
+        ],
+        order_by=order_by,
     )
-
-    has_max_run_filter = (
-        dag_run_state.value
-        or last_dag_run_state.value
-        or dag_run_start_date_range.is_active()
-        or dag_run_end_date_range.is_active()
-    )
-
-    if has_max_run_filter or order_by.value in (
-        "last_run_state",
-        "last_run_start_date",
-        "-last_run_state",
-        "-last_run_start_date",
-    ):
-        query = query.join(
-            max_run_id_query,
-            DagModel.dag_id == max_run_id_query.c.dag_id,
-            isouter=True,
-        ).join(DagRun, DagRun.id == max_run_id_query.c.max_dag_run_id, isouter=True)
-
-    if has_max_run_filter:
-        query = apply_filters_to_select(
-            statement=query,
-            filters=[
-                dag_run_start_date_range,
-                dag_run_end_date_range,
-                dag_run_state,
-                last_dag_run_state,
-            ],
-        )
 
     dags_select, total_entries = paginated_select(
         statement=query,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -75,7 +75,7 @@ def get_dags(
     owners: QueryOwnersFilter,
     dag_ids: Annotated[
         FilterParam[list[str] | None],
-        Depends(filter_param_factory(DagRun.dag_id, list[str] | None, FilterOptionEnum.IN, "dag_ids")),
+        Depends(filter_param_factory(DagModel.dag_id, list[str] | None, FilterOptionEnum.IN, "dag_ids")),
     ],
     dag_id_pattern: QueryDagIdPatternSearch,
     dag_display_name_pattern: QueryDagDisplayNamePatternSearch,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -157,7 +157,6 @@ def get_dags(
         )
         .where(recent_runs_subquery.c.rank <= dag_runs_limit)
         .group_by(
-            # DagModel.dag_id,
             recent_runs_subquery.c.run_after,
             DagRun.run_after,
             DagRun.id,
@@ -180,7 +179,6 @@ def get_dags(
     }
 
     for row in recent_dag_runs:
-        print(row)
         _, dag_run = row
         dag_id = dag_run.dag_id
         dag_run_response = DAGRunResponse.model_validate(dag_run)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -27,6 +27,7 @@ from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
 )
+from airflow.api_fastapi.common.db.dags import generate_dag_with_latest_run_query
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,
@@ -39,6 +40,7 @@ from airflow.api_fastapi.common.parameters import (
     QueryOwnersFilter,
     QueryPausedFilter,
     QueryTagsFilter,
+    SortParam,
     filter_param_factory,
 )
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -58,14 +60,15 @@ dags_router = AirflowRouter(prefix="/dags", tags=["DAG"])
 
 
 @dags_router.get(
-    "/recent_dag_runs",
+    "",
     response_model_exclude_none=True,
     dependencies=[
         Depends(requires_access_dag(method="GET")),
         Depends(requires_access_dag("GET", DagAccessEntity.RUN)),
     ],
+    operation_id="get_dags_ui",
 )
-def recent_dag_runs(
+def get_dags(
     limit: QueryLimit,
     offset: QueryOffset,
     tags: QueryTagsFilter,
@@ -79,50 +82,31 @@ def recent_dag_runs(
     exclude_stale: QueryExcludeStaleFilter,
     paused: QueryPausedFilter,
     last_dag_run_state: QueryLastDagRunStateFilter,
+    order_by: Annotated[
+        SortParam,
+        Depends(
+            SortParam(
+                ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date"],
+                DagModel,
+                {"last_run_state": DagRun.state, "last_run_start_date": DagRun.start_date},
+            ).dynamic_depends()
+        ),
+    ],
     readable_dags_filter: ReadableDagsFilterDep,
     session: SessionDep,
     dag_runs_limit: int = 10,
 ) -> DAGWithLatestDagRunsCollectionResponse:
-    """Get recent DAG runs."""
-    recent_runs_subquery = (
-        select(
-            DagRun.dag_id,
-            DagRun.run_after,
-            func.rank()
-            .over(
-                partition_by=DagRun.dag_id,
-                order_by=DagRun.run_after.desc(),
-            )
-            .label("rank"),
-        )
-        .order_by(DagRun.run_after.desc())
-        .subquery()
+    """Get DAGs with recent DagRun."""
+    # Fetch DAGs with their latest DagRun and apply filters
+    query = generate_dag_with_latest_run_query(
+        max_run_filters=[
+            last_dag_run_state,
+        ],
+        order_by=order_by,
     )
-    dags_with_recent_dag_runs_select = (
-        select(
-            DagRun,
-            DagModel,
-            recent_runs_subquery.c.run_after,
-        )
-        .join(DagModel, DagModel.dag_id == recent_runs_subquery.c.dag_id)
-        .join(
-            DagRun,
-            and_(
-                DagRun.dag_id == DagModel.dag_id,
-                DagRun.run_after == recent_runs_subquery.c.run_after,
-            ),
-        )
-        .where(recent_runs_subquery.c.rank <= dag_runs_limit)
-        .group_by(
-            DagModel.dag_id,
-            recent_runs_subquery.c.run_after,
-            DagRun.run_after,
-            DagRun.id,
-        )
-        .order_by(recent_runs_subquery.c.run_after.desc())
-    )
-    dags_with_recent_dag_runs_select_filter, _ = paginated_select(
-        statement=dags_with_recent_dag_runs_select,
+
+    dags_select, total_entries = paginated_select(
+        statement=query,
         filters=[
             exclude_stale,
             paused,
@@ -134,32 +118,75 @@ def recent_dag_runs(
             last_dag_run_state,
             readable_dags_filter,
         ],
-        order_by=None,
+        order_by=order_by,
         offset=offset,
         limit=limit,
+        session=session,
     )
-    dags_with_recent_dag_runs = session.execute(dags_with_recent_dag_runs_select_filter)
-    # aggregate rows by dag_id
-    dag_runs_by_dag_id: dict[str, DAGWithLatestDagRunsResponse] = {}
 
-    for row in dags_with_recent_dag_runs:
-        dag_run, dag, *_ = row
-        dag_id = dag.dag_id
-        dag_run_response = DAGRunResponse.model_validate(dag_run)
-        if dag_id not in dag_runs_by_dag_id:
-            dag_response = DAGResponse.model_validate(dag)
-            dag_model: DagModel = session.get(DagModel, dag.dag_id)
-            dag_runs_by_dag_id[dag_id] = DAGWithLatestDagRunsResponse.model_validate(
-                {
-                    **dag_response.model_dump(),
-                    "asset_expression": dag_model.asset_expression,
-                    "latest_dag_runs": [dag_run_response],
-                }
+    dags = [dag for dag in session.scalars(dags_select)]
+
+    # Populate the last 'dag_runs_limit' DagRuns for each DAG
+    recent_runs_subquery = (
+        select(
+            DagRun.dag_id,
+            DagRun.run_after,
+            func.rank()
+            .over(
+                partition_by=DagRun.dag_id,
+                order_by=DagRun.run_after.desc(),
             )
-        else:
-            dag_runs_by_dag_id[dag_id].latest_dag_runs.append(dag_run_response)
+            .label("rank"),
+        )
+        .where(DagRun.dag_id.in_([dag.dag_id for dag in dags]))
+        .order_by(DagRun.run_after.desc())
+        .subquery()
+    )
+
+    recent_dag_runs_select = (
+        select(
+            recent_runs_subquery.c.run_after,
+            DagRun,
+        )
+        .join(
+            DagRun,
+            and_(
+                DagRun.dag_id == recent_runs_subquery.c.dag_id,
+                DagRun.run_after == recent_runs_subquery.c.run_after,
+            ),
+        )
+        .where(recent_runs_subquery.c.rank <= dag_runs_limit)
+        .group_by(
+            # DagModel.dag_id,
+            recent_runs_subquery.c.run_after,
+            DagRun.run_after,
+            DagRun.id,
+        )
+        .order_by(recent_runs_subquery.c.run_after.desc())
+    )
+
+    recent_dag_runs = session.execute(recent_dag_runs_select)
+
+    # aggregate rows by dag_id
+    dag_runs_by_dag_id: dict[str, DAGWithLatestDagRunsResponse] = {
+        dag.dag_id: DAGWithLatestDagRunsResponse.model_validate(
+            {
+                **DAGResponse.model_validate(dag).model_dump(),
+                "asset_expression": dag.asset_expression,
+                "latest_dag_runs": [],
+            }
+        )
+        for dag in dags
+    }
+
+    for row in recent_dag_runs:
+        print(row)
+        _, dag_run = row
+        dag_id = dag_run.dag_id
+        dag_run_response = DAGRunResponse.model_validate(dag_run)
+        dag_runs_by_dag_id[dag_id].latest_dag_runs.append(dag_run_response)
 
     return DAGWithLatestDagRunsCollectionResponse(
-        total_entries=len(dag_runs_by_dag_id),
+        total_entries=total_entries,
         dags=list(dag_runs_by_dag_id.values()),
     )

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -689,13 +689,13 @@ export const UseDagServiceGetDagTagsKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [useDagServiceGetDagTagsKey, ...(queryKey ?? [{ limit, offset, orderBy, tagNamePattern }])];
-export type DagServiceRecentDagRunsDefaultResponse = Awaited<ReturnType<typeof DagService.recentDagRuns>>;
-export type DagServiceRecentDagRunsQueryResult<
-  TData = DagServiceRecentDagRunsDefaultResponse,
+export type DagServiceGetDagsUiDefaultResponse = Awaited<ReturnType<typeof DagService.getDagsUi>>;
+export type DagServiceGetDagsUiQueryResult<
+  TData = DagServiceGetDagsUiDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagServiceRecentDagRunsKey = "DagServiceRecentDagRuns";
-export const UseDagServiceRecentDagRunsKeyFn = (
+export const useDagServiceGetDagsUiKey = "DagServiceGetDagsUi";
+export const UseDagServiceGetDagsUiKeyFn = (
   {
     dagDisplayNamePattern,
     dagIdPattern,
@@ -705,6 +705,7 @@ export const UseDagServiceRecentDagRunsKeyFn = (
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -718,6 +719,7 @@ export const UseDagServiceRecentDagRunsKeyFn = (
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -725,7 +727,7 @@ export const UseDagServiceRecentDagRunsKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [
-  useDagServiceRecentDagRunsKey,
+  useDagServiceGetDagsUiKey,
   ...(queryKey ?? [
     {
       dagDisplayNamePattern,
@@ -736,6 +738,7 @@ export const UseDagServiceRecentDagRunsKeyFn = (
       lastDagRunState,
       limit,
       offset,
+      orderBy,
       owners,
       paused,
       tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -924,8 +924,8 @@ export const ensureUseDagServiceGetDagTagsData = (
     queryFn: () => DagService.getDagTags({ limit, offset, orderBy, tagNamePattern }),
   });
 /**
- * Recent Dag Runs
- * Get recent DAG runs.
+ * Get Dags
+ * Get DAGs with recent DagRun.
  * @param data The data for the request.
  * @param data.dagRunsLimit
  * @param data.limit
@@ -939,10 +939,11 @@ export const ensureUseDagServiceGetDagTagsData = (
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
-export const ensureUseDagServiceRecentDagRunsData = (
+export const ensureUseDagServiceGetDagsUiData = (
   queryClient: QueryClient,
   {
     dagDisplayNamePattern,
@@ -953,6 +954,7 @@ export const ensureUseDagServiceRecentDagRunsData = (
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -966,6 +968,7 @@ export const ensureUseDagServiceRecentDagRunsData = (
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -973,7 +976,7 @@ export const ensureUseDagServiceRecentDagRunsData = (
   } = {},
 ) =>
   queryClient.ensureQueryData({
-    queryKey: Common.UseDagServiceRecentDagRunsKeyFn({
+    queryKey: Common.UseDagServiceGetDagsUiKeyFn({
       dagDisplayNamePattern,
       dagIdPattern,
       dagIds,
@@ -982,13 +985,14 @@ export const ensureUseDagServiceRecentDagRunsData = (
       lastDagRunState,
       limit,
       offset,
+      orderBy,
       owners,
       paused,
       tags,
       tagsMatchMode,
     }),
     queryFn: () =>
-      DagService.recentDagRuns({
+      DagService.getDagsUi({
         dagDisplayNamePattern,
         dagIdPattern,
         dagIds,
@@ -997,6 +1001,7 @@ export const ensureUseDagServiceRecentDagRunsData = (
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -924,8 +924,8 @@ export const prefetchUseDagServiceGetDagTags = (
     queryFn: () => DagService.getDagTags({ limit, offset, orderBy, tagNamePattern }),
   });
 /**
- * Recent Dag Runs
- * Get recent DAG runs.
+ * Get Dags
+ * Get DAGs with recent DagRun.
  * @param data The data for the request.
  * @param data.dagRunsLimit
  * @param data.limit
@@ -939,10 +939,11 @@ export const prefetchUseDagServiceGetDagTags = (
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
-export const prefetchUseDagServiceRecentDagRuns = (
+export const prefetchUseDagServiceGetDagsUi = (
   queryClient: QueryClient,
   {
     dagDisplayNamePattern,
@@ -953,6 +954,7 @@ export const prefetchUseDagServiceRecentDagRuns = (
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -966,6 +968,7 @@ export const prefetchUseDagServiceRecentDagRuns = (
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -973,7 +976,7 @@ export const prefetchUseDagServiceRecentDagRuns = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagServiceRecentDagRunsKeyFn({
+    queryKey: Common.UseDagServiceGetDagsUiKeyFn({
       dagDisplayNamePattern,
       dagIdPattern,
       dagIds,
@@ -982,13 +985,14 @@ export const prefetchUseDagServiceRecentDagRuns = (
       lastDagRunState,
       limit,
       offset,
+      orderBy,
       owners,
       paused,
       tags,
       tagsMatchMode,
     }),
     queryFn: () =>
-      DagService.recentDagRuns({
+      DagService.getDagsUi({
         dagDisplayNamePattern,
         dagIdPattern,
         dagIds,
@@ -997,6 +1001,7 @@ export const prefetchUseDagServiceRecentDagRuns = (
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -1147,8 +1147,8 @@ export const useDagServiceGetDagTags = <
     ...options,
   });
 /**
- * Recent Dag Runs
- * Get recent DAG runs.
+ * Get Dags
+ * Get DAGs with recent DagRun.
  * @param data The data for the request.
  * @param data.dagRunsLimit
  * @param data.limit
@@ -1162,11 +1162,12 @@ export const useDagServiceGetDagTags = <
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServiceRecentDagRuns = <
-  TData = Common.DagServiceRecentDagRunsDefaultResponse,
+export const useDagServiceGetDagsUi = <
+  TData = Common.DagServiceGetDagsUiDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -1179,6 +1180,7 @@ export const useDagServiceRecentDagRuns = <
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -1192,6 +1194,7 @@ export const useDagServiceRecentDagRuns = <
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -1201,7 +1204,7 @@ export const useDagServiceRecentDagRuns = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagServiceRecentDagRunsKeyFn(
+    queryKey: Common.UseDagServiceGetDagsUiKeyFn(
       {
         dagDisplayNamePattern,
         dagIdPattern,
@@ -1211,6 +1214,7 @@ export const useDagServiceRecentDagRuns = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,
@@ -1219,7 +1223,7 @@ export const useDagServiceRecentDagRuns = <
       queryKey,
     ),
     queryFn: () =>
-      DagService.recentDagRuns({
+      DagService.getDagsUi({
         dagDisplayNamePattern,
         dagIdPattern,
         dagIds,
@@ -1228,6 +1232,7 @@ export const useDagServiceRecentDagRuns = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1123,8 +1123,8 @@ export const useDagServiceGetDagTagsSuspense = <
     ...options,
   });
 /**
- * Recent Dag Runs
- * Get recent DAG runs.
+ * Get Dags
+ * Get DAGs with recent DagRun.
  * @param data The data for the request.
  * @param data.dagRunsLimit
  * @param data.limit
@@ -1138,11 +1138,12 @@ export const useDagServiceGetDagTagsSuspense = <
  * @param data.excludeStale
  * @param data.paused
  * @param data.lastDagRunState
+ * @param data.orderBy
  * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServiceRecentDagRunsSuspense = <
-  TData = Common.DagServiceRecentDagRunsDefaultResponse,
+export const useDagServiceGetDagsUiSuspense = <
+  TData = Common.DagServiceGetDagsUiDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -1155,6 +1156,7 @@ export const useDagServiceRecentDagRunsSuspense = <
     lastDagRunState,
     limit,
     offset,
+    orderBy,
     owners,
     paused,
     tags,
@@ -1168,6 +1170,7 @@ export const useDagServiceRecentDagRunsSuspense = <
     lastDagRunState?: DagRunState;
     limit?: number;
     offset?: number;
+    orderBy?: string;
     owners?: string[];
     paused?: boolean;
     tags?: string[];
@@ -1177,7 +1180,7 @@ export const useDagServiceRecentDagRunsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagServiceRecentDagRunsKeyFn(
+    queryKey: Common.UseDagServiceGetDagsUiKeyFn(
       {
         dagDisplayNamePattern,
         dagIdPattern,
@@ -1187,6 +1190,7 @@ export const useDagServiceRecentDagRunsSuspense = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,
@@ -1195,7 +1199,7 @@ export const useDagServiceRecentDagRunsSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      DagService.recentDagRuns({
+      DagService.getDagsUi({
         dagDisplayNamePattern,
         dagIdPattern,
         dagIds,
@@ -1204,6 +1208,7 @@ export const useDagServiceRecentDagRunsSuspense = <
         lastDagRunState,
         limit,
         offset,
+        orderBy,
         owners,
         paused,
         tags,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -106,8 +106,8 @@ import type {
   GetDagDetailsResponse,
   GetDagTagsData,
   GetDagTagsResponse,
-  RecentDagRunsData,
-  RecentDagRunsResponse,
+  GetDagsUiData,
+  GetDagsUiResponse,
   GetEventLogData,
   GetEventLogResponse,
   GetEventLogsData,
@@ -1744,8 +1744,8 @@ export class DagService {
   }
 
   /**
-   * Recent Dag Runs
-   * Get recent DAG runs.
+   * Get Dags
+   * Get DAGs with recent DagRun.
    * @param data The data for the request.
    * @param data.dagRunsLimit
    * @param data.limit
@@ -1759,13 +1759,14 @@ export class DagService {
    * @param data.excludeStale
    * @param data.paused
    * @param data.lastDagRunState
+   * @param data.orderBy
    * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static recentDagRuns(data: RecentDagRunsData = {}): CancelablePromise<RecentDagRunsResponse> {
+  public static getDagsUi(data: GetDagsUiData = {}): CancelablePromise<GetDagsUiResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/ui/dags/recent_dag_runs",
+      url: "/ui/dags",
       query: {
         dag_runs_limit: data.dagRunsLimit,
         limit: data.limit,
@@ -1779,6 +1780,7 @@ export class DagService {
         exclude_stale: data.excludeStale,
         paused: data.paused,
         last_dag_run_state: data.lastDagRunState,
+        order_by: data.orderBy,
       },
       errors: {
         422: "Validation Error",

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2285,7 +2285,7 @@ export type GetDagTagsData = {
 
 export type GetDagTagsResponse = DAGTagCollectionResponse;
 
-export type RecentDagRunsData = {
+export type GetDagsUiData = {
   /**
    * SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
    */
@@ -2300,13 +2300,14 @@ export type RecentDagRunsData = {
   lastDagRunState?: DagRunState | null;
   limit?: number;
   offset?: number;
+  orderBy?: string;
   owners?: Array<string>;
   paused?: boolean | null;
   tags?: Array<string>;
   tagsMatchMode?: "any" | "all" | null;
 };
 
-export type RecentDagRunsResponse = DAGWithLatestDagRunsCollectionResponse;
+export type GetDagsUiResponse = DAGWithLatestDagRunsCollectionResponse;
 
 export type GetEventLogData = {
   eventLogId: number;
@@ -4266,9 +4267,9 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/ui/dags/recent_dag_runs": {
+  "/ui/dags": {
     get: {
-      req: RecentDagRunsData;
+      req: GetDagsUiData;
       res: {
         /**
          * Successful Response

--- a/airflow-core/src/airflow/ui/src/mocks/handlers/dags.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/dags.ts
@@ -21,7 +21,7 @@
 import { http, HttpResponse, type HttpHandler } from "msw";
 
 export const handlers: Array<HttpHandler> = [
-  http.get("/ui/dags/recent_dag_runs", ({ request }) => {
+  http.get("/ui/dags", ({ request }) => {
     const url = new URL(request.url);
     const lastDagRunState = url.searchParams.get("last_dag_run_state");
     const successDag = {

--- a/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
@@ -27,7 +27,7 @@ import {
   useAssetServiceMaterializeAsset,
   UseDagRunServiceGetDagRunsKeyFn,
   useDagServiceGetDagDetails,
-  useDagServiceRecentDagRunsKey,
+  useDagServiceGetDagsUiKey,
   useDependenciesServiceGetDependencies,
   UseGridServiceGridDataKeyFn,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
@@ -100,7 +100,7 @@ export const CreateAssetEventModal = ({ asset, onClose, open }: Props) => {
 
       queryKeys = [
         ...queryKeys,
-        [useDagServiceRecentDagRunsKey],
+        [useDagServiceGetDagsUiKey],
         UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
         UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
         UseGridServiceGridDataKeyFn({ dagId }, [{ dagId }]),

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -24,7 +24,7 @@ import { MdDetails, MdOutlineEventNote } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { useParams } from "react-router-dom";
 
-import { useDagServiceGetDagDetails, useDagServiceRecentDagRuns } from "openapi/queries";
+import { useDagServiceGetDagDetails, useDagServiceGetDagsUi } from "openapi/queries";
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { TaskIcon } from "src/assets/TaskIcon";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
@@ -62,7 +62,7 @@ export const Dag = () => {
     data: runsData,
     error: runsError,
     isLoading: isLoadingRuns,
-  } = useDagServiceRecentDagRuns({ dagIds: [dagId], dagRunsLimit: 1 }, undefined, {
+  } = useDagServiceGetDagsUi({ dagIds: [dagId], dagRunsLimit: 1 }, undefined, {
     enabled: Boolean(dagId),
     refetchInterval: (query) => {
       setHasPendingRuns(

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -210,12 +210,13 @@ export const DagsList = () => {
     paused = false;
   }
 
-  const { data, error, isLoading } = useDags(dagRunsLimit, {
+  const { data, error, isLoading } = useDags({
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? `${dagDisplayNamePattern}` : undefined,
+    dagRunsLimit,
+    excludeStale: true,
     lastDagRunState,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
-    onlyActive: true,
     orderBy,
     paused,
     tags: selectedTags,
@@ -248,7 +249,7 @@ export const DagsList = () => {
         <HStack justifyContent="space-between">
           <HStack>
             <Heading py={3} size="md">
-              {`${data.total_entries} ${data.total_entries === 1 ? translate("common:dag_one") : translate("common:dag_other")}`}
+              {`${data?.total_entries ?? 0} ${(data?.total_entries ?? 0) === 1 ? translate("common:dag_one") : translate("common:dag_other")}`}
             </Heading>
             <DAGImportErrors iconOnly />
           </HStack>
@@ -262,15 +263,15 @@ export const DagsList = () => {
         <DataTable
           cardDef={cardDef}
           columns={columns}
-          data={data.dags}
+          data={data?.dags ?? []}
           displayMode={display}
           errorMessage={<ErrorAlert error={error} />}
           initialState={tableURLState}
           isLoading={isLoading}
-          modelName={translate("common:dag_one")}
+          modelName="Dag"
           onStateChange={setTableURLState}
           skeletonCount={display === "card" ? 5 : undefined}
-          total={data.total_entries}
+          total={data?.total_entries ?? 0}
         />
       </Box>
     </DagsLayout>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -213,7 +213,6 @@ export const DagsList = () => {
   const { data, error, isLoading } = useDags({
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? `${dagDisplayNamePattern}` : undefined,
     dagRunsLimit,
-    excludeStale: true,
     lastDagRunState,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -38,11 +38,14 @@ export const RecentRuns = ({
 }) => {
   const { t: translate } = useTranslation(["dags", "common"]);
 
-  if (!latestRuns.length) {
+  // Because of the styling (`row-reverse`), we need to reverse the runs so that the most recent run is on the right.
+  const reversedRuns = [...latestRuns].reverse();
+
+  if (!reversedRuns.length) {
     return undefined;
   }
 
-  const runsWithDuration = latestRuns.map((run) => ({
+  const runsWithDuration = reversedRuns.map((run) => ({
     ...run,
     duration: dayjs.duration(dayjs(run.end_date).diff(run.start_date)).asSeconds(),
   }));

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useDagServiceGetDags, useDagServiceRecentDagRuns } from "openapi/queries";
+import { useDagServiceGetDagsUi } from "openapi/queries";
 import type { DagRunState, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -24,36 +24,49 @@ export type DagWithLatest = {
   last_run_start_date: string;
 } & DAGWithLatestDagRunsResponse;
 
-export const useDags = (
-  dagRunsLimit: number,
-  searchParams: {
-    dagDisplayNamePattern?: string;
-    dagIdPattern?: string;
-    lastDagRunState?: DagRunState;
-    limit?: number;
-    offset?: number;
-    onlyActive?: boolean;
-    orderBy?: string;
-    owners?: Array<string>;
-    paused?: boolean;
-    tags?: Array<string>;
-    tagsMatchMode?: "all" | "any";
-  } = {},
-) => {
-  const { data, error, isFetching, isLoading } = useDagServiceGetDags(searchParams);
-
+export const useDags = ({
+  dagDisplayNamePattern,
+  dagIdPattern,
+  dagRunsLimit,
+  excludeStale = true,
+  lastDagRunState,
+  limit,
+  offset,
+  orderBy,
+  owners,
+  paused,
+  tags,
+  tagsMatchMode,
+}: {
+  dagDisplayNamePattern?: string;
+  dagIdPattern?: string;
+  dagRunsLimit: number;
+  excludeStale?: boolean;
+  lastDagRunState?: DagRunState;
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  owners?: Array<string>;
+  paused?: boolean;
+  tags?: Array<string>;
+  tagsMatchMode?: "all" | "any";
+}) => {
   const refetchInterval = useAutoRefresh({});
 
-  const { orderBy, ...runsParams } = searchParams;
-  const {
-    data: runsData,
-    error: runsError,
-    isFetching: isRunsFetching,
-    isLoading: isRunsLoading,
-  } = useDagServiceRecentDagRuns(
+  const { data, error, isFetching, isLoading } = useDagServiceGetDagsUi(
     {
-      ...runsParams,
+      dagDisplayNamePattern,
+      dagIdPattern,
       dagRunsLimit,
+      excludeStale,
+      lastDagRunState,
+      limit,
+      offset,
+      orderBy,
+      owners,
+      paused,
+      tags,
+      tagsMatchMode,
     },
     undefined,
     {
@@ -66,24 +79,10 @@ export const useDags = (
     },
   );
 
-  const dags = (data?.dags ?? []).map((dag) => {
-    const dagWithRuns = runsData?.dags.find((runsDag) => runsDag.dag_id === dag.dag_id);
-
-    return {
-      // eslint-disable-next-line unicorn/no-null
-      asset_expression: null,
-      latest_dag_runs: [],
-      ...dagWithRuns,
-      ...dag,
-      // We need last_run_start_date to exist on the object in order for react-table sort to work correctly
-      last_run_start_date: "",
-    };
-  });
-
   return {
-    data: { dags, total_entries: data?.total_entries ?? 0 },
-    error: error ?? runsError,
-    isFetching: isFetching || isRunsFetching,
-    isLoading: isLoading || isRunsLoading,
+    data,
+    error,
+    isFetching,
+    isLoading,
   };
 };

--- a/airflow-core/src/airflow/ui/src/queries/useDeleteDag.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDeleteDag.ts
@@ -19,7 +19,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useDagServiceDeleteDag } from "openapi/queries";
-import { useDagServiceGetDagKey, useDagServiceGetDagsKey } from "openapi/queries";
+import { useDagServiceGetDagKey } from "openapi/queries";
 import { toaster } from "src/components/ui";
 
 const onError = () => {
@@ -40,7 +40,7 @@ export const useDeleteDag = ({
   const queryClient = useQueryClient();
 
   const onSuccess = async () => {
-    const queryKeys = [[useDagServiceGetDagsKey], [useDagServiceGetDagKey, { dagId }]];
+    const queryKeys = [[useDagServiceGetDagKey, { dagId }]];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 

--- a/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
@@ -24,7 +24,7 @@ import {
   useDagServiceGetDagDetailsKey,
   UseDagRunServiceGetDagRunsKeyFn,
   UseDagServiceGetDagDetailsKeyFn,
-  useDagServiceRecentDagRunsKey,
+  useDagServiceGetDagsUi,
   UseGridServiceGridDataKeyFn,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
@@ -50,7 +50,7 @@ export const useRefreshOnNewDagRuns = (dagId: string, hasPendingRuns: boolean | 
       previousDagRunIdRef.current = latestDagRunId;
 
       const queryKeys = [
-        [useDagServiceRecentDagRunsKey],
+        [useDagServiceGetDagsUi],
         [useDagServiceGetDagDetailsKey],
         UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }]),
         UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),

--- a/airflow-core/src/airflow/ui/src/queries/useTogglePause.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTogglePause.ts
@@ -22,7 +22,6 @@ import {
   UseDagRunServiceGetDagRunsKeyFn,
   UseDagServiceGetDagDetailsKeyFn,
   UseDagServiceGetDagKeyFn,
-  useDagServiceGetDagsKey,
   useDagServicePatchDag,
   useDagServiceGetDagsUiKey,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
@@ -33,7 +32,6 @@ export const useTogglePause = ({ dagId }: { dagId: string }) => {
 
   const onSuccess = async () => {
     const queryKeys = [
-      [useDagServiceGetDagsKey],
       [useDagServiceGetDagsUiKey],
       UseDagServiceGetDagKeyFn({ dagId }, [{ dagId }]),
       UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }]),

--- a/airflow-core/src/airflow/ui/src/queries/useTogglePause.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTogglePause.ts
@@ -24,7 +24,7 @@ import {
   UseDagServiceGetDagKeyFn,
   useDagServiceGetDagsKey,
   useDagServicePatchDag,
-  useDagServiceRecentDagRunsKey,
+  useDagServiceGetDagsUiKey,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
 
@@ -34,7 +34,7 @@ export const useTogglePause = ({ dagId }: { dagId: string }) => {
   const onSuccess = async () => {
     const queryKeys = [
       [useDagServiceGetDagsKey],
-      [useDagServiceRecentDagRunsKey],
+      [useDagServiceGetDagsUiKey],
       UseDagServiceGetDagKeyFn({ dagId }, [{ dagId }]),
       UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }]),
       UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -23,7 +23,7 @@ import {
   UseDagRunServiceGetDagRunsKeyFn,
   useDagRunServiceTriggerDagRun,
   useDagServiceGetDagsKey,
-  useDagServiceRecentDagRunsKey,
+  useDagServiceGetDagsUiKey,
   UseGridServiceGridDataKeyFn,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
 } from "openapi/queries";
@@ -37,7 +37,7 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const onSuccess = async () => {
     const queryKeys = [
       [useDagServiceGetDagsKey],
-      [useDagServiceRecentDagRunsKey],
+      [useDagServiceGetDagsUiKey],
       UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
       UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
       UseGridServiceGridDataKeyFn({ dagId }, [{ dagId }]),

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -22,7 +22,6 @@ import { useState } from "react";
 import {
   UseDagRunServiceGetDagRunsKeyFn,
   useDagRunServiceTriggerDagRun,
-  useDagServiceGetDagsKey,
   useDagServiceGetDagsUiKey,
   UseGridServiceGridDataKeyFn,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
@@ -36,7 +35,6 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
 
   const onSuccess = async () => {
     const queryKeys = [
-      [useDagServiceGetDagsKey],
       [useDagServiceGetDagsUiKey],
       UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
       UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -38,7 +38,7 @@ from unit.api_fastapi.core_api.routes.public.test_dags import (
 pytestmark = pytest.mark.db_test
 
 
-class TestRecentDagRuns(TestPublicDagEndpoint):
+class TestGetDagRuns(TestPublicDagEndpoint):
     @pytest.fixture(autouse=True)
     @provide_session
     def setup_dag_runs(self, session=None) -> None:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -69,15 +69,15 @@ class TestRecentDagRuns(TestPublicDagEndpoint):
             ({"limit": 1}, [DAG1_ID], 2),
             ({"offset": 1}, [DAG1_ID, DAG2_ID], 11),
             ({"tags": ["example"]}, [DAG1_ID], 6),
-            ({"only_active": False}, [DAG1_ID, DAG2_ID, DAG3_ID], 15),
-            ({"paused": True, "only_active": False}, [DAG3_ID], 4),
+            ({"exclude_stale": False}, [DAG1_ID, DAG2_ID, DAG3_ID], 15),
+            ({"paused": True, "exclude_stale": False}, [DAG3_ID], 4),
             ({"paused": False}, [DAG1_ID, DAG2_ID], 11),
             ({"owners": ["airflow"]}, [DAG1_ID, DAG2_ID], 11),
-            ({"owners": ["test_owner"], "only_active": False}, [DAG3_ID], 4),
+            ({"owners": ["test_owner"], "exclude_stale": False}, [DAG3_ID], 4),
             ({"dag_ids": [DAG1_ID]}, [DAG1_ID], 6),
             ({"dag_ids": [DAG1_ID, DAG2_ID]}, [DAG1_ID, DAG2_ID], 11),
-            ({"last_dag_run_state": "success", "only_active": False}, [DAG1_ID, DAG2_ID, DAG3_ID], 6),
-            ({"last_dag_run_state": "failed", "only_active": False}, [DAG1_ID, DAG2_ID, DAG3_ID], 9),
+            ({"last_dag_run_state": "success", "exclude_stale": False}, [DAG1_ID, DAG2_ID, DAG3_ID], 6),
+            ({"last_dag_run_state": "failed", "exclude_stale": False}, [DAG1_ID, DAG2_ID, DAG3_ID], 9),
             # Search
             ({"dag_id_pattern": "1"}, [DAG1_ID], 6),
             ({"dag_display_name_pattern": "test_dag2"}, [DAG2_ID], 5),
@@ -85,7 +85,7 @@ class TestRecentDagRuns(TestPublicDagEndpoint):
     )
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_should_return_200(self, test_client, query_params, expected_ids, expected_total_dag_runs):
-        response = test_client.get("/dags/recent_dag_runs", params=query_params)
+        response = test_client.get("/dags", params=query_params)
         assert response.status_code == 200
         body = response.json()
         required_dag_run_key = [
@@ -108,9 +108,9 @@ class TestRecentDagRuns(TestPublicDagEndpoint):
                 previous_run_after = dag_run["run_after"]
 
     def test_should_response_401(self, unauthenticated_test_client):
-        response = unauthenticated_test_client.get("/dags/recent_dag_runs", params={})
+        response = unauthenticated_test_client.get("/dags", params={})
         assert response.status_code == 401
 
     def test_should_response_403(self, unauthorized_test_client):
-        response = unauthorized_test_client.get("/dags/recent_dag_runs", params={})
+        response = unauthorized_test_client.get("/dags", params={})
         assert response.status_code == 403


### PR DESCRIPTION
Closes: #49135

- Rework backend ui endpoint for getting dags with recent dag runs. Add ordering options, renaming, refactoring for it to work properly. (Basically do the same as the public one, but just at the end, fetch the recent dag runs per dag fetched and add them to the response.
- Rework the UI `getDags` hook to only query the UI endpoint and stop mix matching data coming from UI and PUBLIC endpoint
