### PR TITLE
Link to latest dagrun in Dag header.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Link } from "@chakra-ui/react";
 import { FiBookOpen } from "react-icons/fi";
-import { useParams } from "react-router-dom";
+import { useParams, Link as RouterLink } from "react-router-dom";
 
 import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
@@ -54,13 +55,17 @@ export const Header = ({
       label: "Latest Run",
       value:
         Boolean(latestRun) && latestRun !== undefined ? (
-          <DagRunInfo
-            endDate={latestRun.end_date}
-            logicalDate={latestRun.logical_date}
-            runAfter={latestRun.run_after}
-            startDate={latestRun.start_date}
-            state={latestRun.state}
-          />
+          <Link asChild color="fg.info">
+            <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}>
+              <DagRunInfo
+                endDate={latestRun.end_date}
+                logicalDate={latestRun.logical_date}
+                runAfter={latestRun.run_after}
+                startDate={latestRun.start_date}
+                state={latestRun.state}
+              />
+            </RouterLink>
+          </Link>
         ) : undefined,
     },
     {


### PR DESCRIPTION
For dags with graph view as default when the latest dagrun fails then getting to the dagrun is a two step to switch to runs tab and then select the recent run. Since the latest run is already linked in dags list page for card and list view the dag detail header can also link to the latest dag run for easier access.