### PR TITLE
Exclude libcst 1.8.0 (no wheels <3.12)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -241,7 +241,8 @@ repos:
         language: python
         entry: ./scripts/ci/pre_commit/check_deferrable_default.py
         pass_filenames: false
-        additional_dependencies: ['libcst>=1.1.0']
+        # libcst doesn't have source wheels for PY3.12, excluding it
+        additional_dependencies: ['libcst>=1.1.0,!=1.8.0']
         files: ^(providers/.*/)?airflow/.*/(sensors|operators)/.*\.py$
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.19.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -241,7 +241,7 @@ repos:
         language: python
         entry: ./scripts/ci/pre_commit/check_deferrable_default.py
         pass_filenames: false
-        # libcst doesn't have source wheels for PY3.12, excluding it
+        # libcst doesn't have source wheels for all PY except PY3.12, excluding it
         additional_dependencies: ['libcst>=1.1.0,!=1.8.0']
         files: ^(providers/.*/)?airflow/.*/(sensors|operators)/.*\.py$
   - repo: https://github.com/asottile/blacken-docs


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

libcst released 1.8.0 few hours ago which has missing wheels for all PY except 3.12, this is leading to bulk failure of our tests.


Example error:

```
Resolved 848 packages in 206ms
  error: Distribution `libcst==1.8.0 @ registry+[https://pypi.org/simple`](https://pypi.org/simple%60) can't be installed because it doesn't have a source distribution or wheel for the current platform
  
  hint: You're using CPython 3.9 (`cp39`), but `libcst` (v1.8.0) only has wheels with the following Python implementation tags: `cp310`, `cp311`, `cp312`
```

Ex: https://github.com/apache/airflow/actions/runs/15276855155/job/42968833523

Attempting to fix it because it seems that precommit only uses it.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
