### PR TITLE
Create `KeycloakAuthManager` and enable authentication

### DIFF
--- a/providers/keycloak/provider.yaml
+++ b/providers/keycloak/provider.yaml
@@ -26,3 +26,44 @@ source-date-epoch: 1741121853
 # note that those versions are maintained by release manager - do not update them manually
 versions:
   - 1.0.0
+
+auth-managers:
+  - airflow.providers.keycloak.auth_manager.keycloak_auth_manager.KeycloakAuthManager
+
+config:
+  keycloak_auth_manager:
+    description: This section contains settings for Keycloak auth manager integration.
+    options:
+      client_id:
+        description: |
+          Client ID configured in Keycloak to integrate with Airflow.
+          This client must follow the standard OpenID Connect authentication flow.
+        type: string
+        version_added: 1.0.0
+        example: ~
+        default: ~
+      client_secret:
+        description: |
+          Secret associated to the client configured in Keycloak to integrate with Airflow.
+        type: string
+        version_added: 1.0.0
+        example: ~
+        default: ~
+      realm:
+        description: |
+          Realm configured in Keycloak associated to Airflow.
+          This realm define all users, roles and groups used in Airflow.
+        type: string
+        version_added: 1.0.0
+        example: ~
+        default: ~
+      server_url:
+        description: |
+          Keycloak server URL.
+          This server URL is used by the Airflow API server to communicate with Keycloak.
+          If the Airflow API server and Keycloak are running in Docker,
+          set "http://host.docker.internal:<PORT>" (default value).
+        type: string
+        version_added: 1.0.0
+        example: ~
+        default: "http://host.docker.internal:48080"

--- a/providers/keycloak/pyproject.toml
+++ b/providers/keycloak/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = "~=3.9"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=3.0.0",
+    "python-keycloak>=5.0.0",
 ]
 
 [dependency-groups]

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/__init__.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -1,0 +1,167 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
+
+from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware
+
+from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
+from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager, T
+from airflow.configuration import conf
+from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
+
+if TYPE_CHECKING:
+    from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
+    from airflow.api_fastapi.auth.managers.models.resource_details import (
+        AccessView,
+        AssetAliasDetails,
+        AssetDetails,
+        BackfillDetails,
+        ConfigurationDetails,
+        ConnectionDetails,
+        DagAccessEntity,
+        DagDetails,
+        PoolDetails,
+        VariableDetails,
+    )
+    from airflow.api_fastapi.common.types import MenuItem
+
+
+class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
+    """
+    Keycloak auth manager.
+
+    Leverages Keycloak to perform authentication and authorization in Airflow.
+    """
+
+    @cached_property
+    def api_server_endpoint(self) -> str:
+        return conf.get("api", "base_url", fallback="/")
+
+    def deserialize_user(self, token: dict[str, Any]) -> KeycloakAuthManagerUser:
+        return KeycloakAuthManagerUser(
+            user_id=token.pop("user_id"),
+            name=token.pop("name"),
+            access_token=token.pop("access_token"),
+            refresh_token=token.pop("refresh_token"),
+        )
+
+    def serialize_user(self, user: KeycloakAuthManagerUser) -> dict[str, Any]:
+        return {
+            "user_id": user.get_id(),
+            "name": user.get_name(),
+            "access_token": user.access_token,
+            "refresh_token": user.refresh_token,
+        }
+
+    def get_url_login(self, **kwargs) -> str:
+        return urljoin(self.api_server_endpoint, f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/login")
+
+    def is_authorized_configuration(
+        self,
+        *,
+        method: ResourceMethod,
+        user: KeycloakAuthManagerUser,
+        details: ConfigurationDetails | None = None,
+    ) -> bool:
+        return True
+
+    def is_authorized_connection(
+        self,
+        *,
+        method: ResourceMethod,
+        user: KeycloakAuthManagerUser,
+        details: ConnectionDetails | None = None,
+    ) -> bool:
+        return True
+
+    def is_authorized_dag(
+        self,
+        *,
+        method: ResourceMethod,
+        user: T,
+        access_entity: DagAccessEntity | None = None,
+        details: DagDetails | None = None,
+    ) -> bool:
+        return True
+
+    def is_authorized_backfill(
+        self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: BackfillDetails | None = None
+    ) -> bool:
+        return True
+
+    def is_authorized_asset(
+        self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: AssetDetails | None = None
+    ) -> bool:
+        return True
+
+    def is_authorized_asset_alias(
+        self,
+        *,
+        method: ResourceMethod,
+        user: KeycloakAuthManagerUser,
+        details: AssetAliasDetails | None = None,
+    ) -> bool:
+        return True
+
+    def is_authorized_variable(
+        self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: VariableDetails | None = None
+    ) -> bool:
+        return True
+
+    def is_authorized_pool(
+        self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: PoolDetails | None = None
+    ) -> bool:
+        return True
+
+    def is_authorized_view(self, *, access_view: AccessView, user: KeycloakAuthManagerUser) -> bool:
+        return True
+
+    def is_authorized_custom_view(
+        self, *, method: ResourceMethod | str, resource_name: str, user: KeycloakAuthManagerUser
+    ) -> bool:
+        return True
+
+    def filter_authorized_menu_items(
+        self, menu_items: list[MenuItem], *, user: KeycloakAuthManagerUser
+    ) -> list[MenuItem]:
+        return menu_items
+
+    def get_fastapi_app(self) -> FastAPI | None:
+        from airflow.providers.keycloak.auth_manager.routes.login import login_router
+
+        app = FastAPI(
+            title="Keycloak auth manager sub application",
+            description=(
+                "This is the Keycloak auth manager fastapi sub application. This API is only available if the "
+                "auth manager used in the Airflow environment is Keycloak auth manager. "
+                "This sub application provides login routes."
+            ),
+        )
+        # authlib requires ``SessionMiddleware``
+        app.add_middleware(
+            SessionMiddleware,
+            secret_key=conf.get("api_auth", "jwt_secret"),
+            https_only=False,
+        )
+        app.include_router(login_router)
+
+        return app

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/__init__.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request  # noqa: TC002
+from keycloak import KeycloakOpenID
+from starlette.responses import HTMLResponse, RedirectResponse
+
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.configuration import conf
+from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
+
+log = logging.getLogger(__name__)
+login_router = AirflowRouter(tags=["KeycloakAuthManagerLogin"])
+
+
+@login_router.get("/login")
+def login(request: Request) -> RedirectResponse:
+    """Initiate the authentication."""
+    client = _get_keycloak_client()
+    redirect_uri = request.url_for("login_callback")
+    auth_url = client.auth_url(redirect_uri=str(redirect_uri), scope="openid")
+    return RedirectResponse(auth_url)
+
+
+@login_router.get("/login_callback")
+def login_callback(request: Request):
+    """Authenticate the user."""
+    code = request.query_params.get("code")
+    if not code:
+        return HTMLResponse("Missing code", status_code=400)
+
+    client = _get_keycloak_client()
+    redirect_uri = request.url_for("login_callback")
+
+    tokens = client.token(
+        grant_type="authorization_code",
+        code=code,
+        redirect_uri=str(redirect_uri),
+    )
+    userinfo = client.userinfo(tokens["access_token"])
+    user = KeycloakAuthManagerUser(
+        user_id=userinfo["sub"],
+        name=userinfo["preferred_username"],
+        access_token=tokens["access_token"],
+        refresh_token=tokens["refresh_token"],
+    )
+    token = get_auth_manager().generate_jwt(user)
+
+    response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"), status_code=303)
+    secure = bool(conf.get("api", "ssl_cert", fallback=""))
+    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
+    return response
+
+
+def _get_keycloak_client() -> KeycloakOpenID:
+    client_id = conf.get("keycloak_auth_manager", "client_id")
+    client_secret = conf.get("keycloak_auth_manager", "client_secret")
+    realm = conf.get("keycloak_auth_manager", "realm")
+    server_url = conf.get("keycloak_auth_manager", "server_url")
+
+    return KeycloakOpenID(
+        server_url=server_url,
+        client_id=client_id,
+        client_secret_key=client_secret,
+        realm_name=realm,
+    )

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/user.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/user.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
+
+
+class KeycloakAuthManagerUser(BaseUser):
+    """User model for users managed by Keycloak auth manager."""
+
+    def __init__(self, *, user_id: str, name: str, access_token: str, refresh_token: str) -> None:
+        self.user_id = user_id
+        self.name = name
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+
+    def get_id(self) -> str:
+        return self.user_id
+
+    def get_name(self) -> str:
+        return self.name

--- a/providers/keycloak/src/airflow/providers/keycloak/get_provider_info.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/get_provider_info.py
@@ -26,4 +26,42 @@ def get_provider_info():
         "package-name": "apache-airflow-providers-keycloak",
         "name": "Keycloak",
         "description": "``Keycloak Provider``\n",
+        "auth-managers": [
+            "airflow.providers.keycloak.auth_manager.keycloak_auth_manager.KeycloakAuthManager"
+        ],
+        "config": {
+            "keycloak_auth_manager": {
+                "description": "This section contains settings for Keycloak auth manager integration.",
+                "options": {
+                    "client_id": {
+                        "description": "Client ID configured in Keycloak to integrate with Airflow.\nThis client must follow the standard OpenID Connect authentication flow.\n",
+                        "type": "string",
+                        "version_added": "1.0.0",
+                        "example": None,
+                        "default": None,
+                    },
+                    "client_secret": {
+                        "description": "Secret associated to the client configured in Keycloak to integrate with Airflow.\n",
+                        "type": "string",
+                        "version_added": "1.0.0",
+                        "example": None,
+                        "default": None,
+                    },
+                    "realm": {
+                        "description": "Realm configured in Keycloak associated to Airflow.\nThis realm define all users, roles and groups used in Airflow.\n",
+                        "type": "string",
+                        "version_added": "1.0.0",
+                        "example": None,
+                        "default": None,
+                    },
+                    "server_url": {
+                        "description": 'Keycloak server URL.\nThis server URL is used by the Airflow API server to communicate with Keycloak.\nIf the Airflow API server and Keycloak are running in Docker,\nset "http://host.docker.internal:<PORT>" (default value).\n',
+                        "type": "string",
+                        "version_added": "1.0.0",
+                        "example": None,
+                        "default": "http://host.docker.internal:48080",
+                    },
+                },
+            }
+        },
     }

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/__init__.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/__init__.py
@@ -14,10 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-# To remove later, we need at least one test, otherwise CI fails
-from __future__ import annotations
-
-
-def test_empty():
-    assert True

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/__init__.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import ANY, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX, create_app
+
+from tests_common.test_utils.config import conf_vars
+
+
+@pytest.fixture
+def client():
+    with conf_vars(
+        {
+            (
+                "core",
+                "auth_manager",
+            ): "airflow.providers.keycloak.auth_manager.keycloak_auth_manager.KeycloakAuthManager",
+            ("keycloak_auth_manager", "client_id"): "test",
+            ("keycloak_auth_manager", "client_secret"): "test",
+            ("keycloak_auth_manager", "realm"): "test",
+            ("keycloak_auth_manager", "base_url"): "http://host.docker.internal:48080",
+        }
+    ):
+        yield TestClient(create_app())
+
+
+class TestLoginRouter:
+    @patch("airflow.providers.keycloak.auth_manager.routes.login._get_keycloak_client")
+    def test_login(self, mock_get_keycloak_client, client):
+        redirect_url = "redirect_url"
+        mock_keycloak_client = Mock()
+        mock_keycloak_client.auth_url.return_value = redirect_url
+        mock_get_keycloak_client.return_value = mock_keycloak_client
+        response = client.get(AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login", follow_redirects=False)
+        assert response.status_code == 307
+        assert "location" in response.headers
+        assert response.headers["location"] == redirect_url
+
+    @patch("airflow.providers.keycloak.auth_manager.routes.login.get_auth_manager")
+    @patch("airflow.providers.keycloak.auth_manager.routes.login._get_keycloak_client")
+    def test_login_callback(self, mock_get_keycloak_client, mock_get_auth_manager, client):
+        code = "code"
+        token = "token"
+        mock_keycloak_client = Mock()
+        mock_keycloak_client.token.return_value = {
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+        }
+        mock_keycloak_client.userinfo.return_value = {
+            "sub": "sub",
+            "preferred_username": "preferred_username",
+        }
+        mock_get_keycloak_client.return_value = mock_keycloak_client
+        mock_auth_manager = Mock()
+        mock_get_auth_manager.return_value = mock_auth_manager
+        mock_auth_manager.generate_jwt.return_value = token
+        response = client.get(
+            AUTH_MANAGER_FASTAPI_APP_PREFIX + f"/login_callback?code={code}", follow_redirects=False
+        )
+        mock_keycloak_client.token.assert_called_once_with(
+            grant_type="authorization_code",
+            code=code,
+            redirect_uri=ANY,
+        )
+        mock_keycloak_client.userinfo.assert_called_once_with("access_token")
+        mock_auth_manager.generate_jwt.assert_called_once()
+        user = mock_auth_manager.generate_jwt.call_args[0][0]
+        assert user.get_id() == "sub"
+        assert user.get_name() == "preferred_username"
+        assert user.access_token == "access_token"
+        assert user.refresh_token == "refresh_token"
+        assert response.status_code == 303
+        assert "location" in response.headers
+        assert "_token" in response.cookies
+        assert response.cookies["_token"] == token
+
+    def test_login_callback_without_code(self, client):
+        response = client.get(AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login_callback")
+        assert response.status_code == 400

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
+from airflow.providers.keycloak.auth_manager.keycloak_auth_manager import KeycloakAuthManager
+from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
+
+
+@pytest.fixture
+def auth_manager():
+    return KeycloakAuthManager()
+
+
+class TestKeycloakAuthManager:
+    def test_deserialize_user(self, auth_manager):
+        result = auth_manager.deserialize_user(
+            {
+                "user_id": "user_id",
+                "name": "name",
+                "access_token": "access_token",
+                "refresh_token": "refresh_token",
+            }
+        )
+        assert result.user_id == "user_id"
+        assert result.name == "name"
+        assert result.access_token == "access_token"
+        assert result.refresh_token == "refresh_token"
+
+    def test_serialize_user(self, auth_manager):
+        result = auth_manager.serialize_user(
+            KeycloakAuthManagerUser(
+                user_id="user_id", name="name", access_token="access_token", refresh_token="refresh_token"
+            )
+        )
+        assert result == {
+            "user_id": "user_id",
+            "name": "name",
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+        }
+
+    def test_get_url_login(self, auth_manager):
+        result = auth_manager.get_url_login()
+        assert result == f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/login"

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_user.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_user.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
+
+
+@pytest.fixture
+def user():
+    return KeycloakAuthManagerUser(
+        user_id="user_id", name="name", access_token="access_token", refresh_token="refresh_token"
+    )
+
+
+class TestKeycloakAuthManagerUser:
+    def test_get_id(self, user):
+        assert user.get_id() == "user_id"
+
+    def test_get_name(self, user):
+        assert user.get_name() == "name"
+
+    def test_get_access_token(self, user):
+        assert user.access_token == "access_token"
+
+    def test_get_refresh_token(self, user):
+        assert user.refresh_token == "refresh_token"


### PR DESCRIPTION
Create the new auth manager `KeycloakAuthManager` and implement all authentication related methods. You can test it using breeze with: `breeze start-airflow --forward-credentials --integration keycloak`. The Keycloak console is accessible at http://localhost:48080/

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
