### PR TITLE
[Tests only] Fix `StopIteration` error in AWS System Test `variable_fetcher` when using remote executor

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/utils/__init__.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/__init__.py
@@ -69,12 +69,11 @@ def _get_test_name() -> str:
     """
     # The exact layer of the stack will depend on if this is called directly
     # or from another helper, but the test will always contain the identifier.
-    test_filename: str = next(
-        frame.filename
+    return next(
+        Path(frame.filename).stem
         for frame in inspect.stack()
-        if any(identifier in frame.filename for identifier in TEST_FILE_IDENTIFIERS)
+        if any(identifier in Path(frame.filename).stem for identifier in TEST_FILE_IDENTIFIERS)
     )
-    return Path(test_filename).stem
 
 
 def _validate_env_id(env_id: str) -> str:
@@ -95,19 +94,18 @@ def _validate_env_id(env_id: str) -> str:
 
 
 @functools.cache
-def _fetch_from_ssm(key: str, test_name: str | None = None) -> str:
+def _fetch_from_ssm(key: str, test_name: str) -> str:
     """
     Test values are stored in the SSM Value as a JSON-encoded dict of key/value pairs.
 
     :param key: The key to search for within the returned Parameter Value.
     :return: The value of the provided key from SSM
     """
-    _test_name: str = test_name or _get_test_name()
     hook = SsmHook(aws_conn_id=None)
     value: str = ""
 
     try:
-        value = json.loads(hook.get_parameter_value(_test_name))[key]
+        value = json.loads(hook.get_parameter_value(test_name))[key]
     # Since a default value after the SSM check is allowed, these exceptions should not stop execution.
     except NoCredentialsError as e:
         log.info("No boto credentials found: %s", e)
@@ -136,9 +134,9 @@ class Variable:
     def __init__(
         self,
         name: str,
+        test_name: str,
         to_split: bool = False,
         delimiter: str | None = None,
-        test_name: str | None = None,
         optional: bool = False,
     ):
         self.name = name
@@ -228,7 +226,7 @@ class SystemTestContextBuilder:
 
         @task
         def variable_fetcher(ti=None):
-            ti.xcom_push(ENV_ID_KEY, set_env_id())
+            ti.xcom_push(ENV_ID_KEY, set_env_id(self.test_name))
             for variable in self.variables:
                 ti.xcom_push(variable.name, variable.get_value())
 
@@ -237,8 +235,8 @@ class SystemTestContextBuilder:
 
 def fetch_variable(
     key: str,
+    test_name: str,
     default_value: str | None = None,
-    test_name: str | None = None,
     optional: bool = False,
 ) -> str | None:
     """
@@ -260,7 +258,7 @@ def fetch_variable(
     return value
 
 
-def set_env_id() -> str:
+def set_env_id(test_name) -> str:
     """
     Retrieves or generates an Environment ID, validate that it is suitable,
     export it as an Environment Variable, and return it.
@@ -271,7 +269,7 @@ def set_env_id() -> str:
 
     :return: A valid System Test Environment ID.
     """
-    env_id: str = str(fetch_variable(ENV_ID_ENVIRON_KEY, DEFAULT_ENV_ID))
+    env_id: str = str(fetch_variable(ENV_ID_ENVIRON_KEY, test_name, DEFAULT_ENV_ID))
     env_id = _validate_env_id(env_id)
 
     os.environ[ENV_ID_ENVIRON_KEY] = env_id

--- a/providers/amazon/tests/unit/amazon/aws/system/utils/test_helpers.py
+++ b/providers/amazon/tests/unit/amazon/aws/system/utils/test_helpers.py
@@ -82,9 +82,9 @@ class TestAmazonSystemTestHelpers:
         utils._fetch_from_ssm.cache_clear()
 
         result = (
-            utils.fetch_variable("some_key", default_value)
+            utils.fetch_variable(key="some_key", test_name=TEST_NAME, default_value=default_value)
             if default_value
-            else utils.fetch_variable(ANY_STR)
+            else utils.fetch_variable(key=ANY_STR, test_name=TEST_NAME)
         )
 
         utils._fetch_from_ssm.cache_clear()
@@ -93,7 +93,7 @@ class TestAmazonSystemTestHelpers:
     def test_fetch_variable_no_value_found_raises_exception(self):
         # This would be the (None, None, None) test case from above.
         with pytest.raises(ValueError) as raised_exception:
-            utils.fetch_variable(ANY_STR)
+            utils.fetch_variable(key=ANY_STR, test_name=TEST_NAME)
 
         assert NO_VALUE_MSG.format(key=ANY_STR) in str(raised_exception.value)
 
@@ -136,13 +136,13 @@ class TestAmazonSystemTestHelpers:
 
     def test_set_env_id_generates_if_required(self):
         # No environment variable nor SSM value has been found
-        result = set_env_id()
+        result = set_env_id(TEST_NAME)
 
         assert len(result) == DEFAULT_ENV_ID_LEN + len(DEFAULT_ENV_ID_PREFIX)
         assert result.isalnum()
         assert result.islower()
 
     def test_set_env_id_exports_environment_variable(self):
-        env_id = set_env_id()
+        env_id = set_env_id(TEST_NAME)
 
         assert os.environ[ENV_ID_ENVIRON_KEY] == env_id


### PR DESCRIPTION
In `_get_test_name()` called by `set_env_id()`, the call stack is used to determine the name of the current test. After #50571, `set_env_id()` was being called from a `PythonOperator` (in addition to another call from the `SystemTestContextBuilder`) which changed the call stack to not include the name of the dag. As an example, here's all the files included in the call stack when called from `SystemTestContextBuilder`:
```
[
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/example_mwaa.py', '<frozen importlib._bootstrap>',
    '<frozen importlib._bootstrap_external>', '/opt/airflow/airflow-core/src/airflow/models/dagbag.py',
    '/opt/airflow/airflow-core/src/airflow/models/dagbag.py',
    '/opt/airflow/airflow-core/src/airflow/models/dagbag.py',
    '/opt/airflow/airflow-core/src/airflow/models/dagbag.py',
    '/opt/airflow/airflow-core/src/airflow/models/dagbag.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/execute_workload.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/execute_workload.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/execute_workload.py', '<frozen runpy>',
    '<frozen runpy>'
]
```
and from the `PythonOperator`:
```
[
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/providers/amazon/tests/system/amazon/aws/utils/__init__.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py',
    '/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py',
    '/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/bases/decorator.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/execute_workload.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/execute_workload.py',
    '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/execute_workload.py', '<frozen runpy>',
    '<frozen runpy>'
]
```

So the `StopIteration` error was being caused because it couldn't find the name of the test (in this case `example_mwaa`) in the call stack. This PR fixes this by using the test name already computed earlier in the `SystemTestContextBuilder`, in the `PythonOperator` for `variable_fetcher`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
