### PR TITLE
Fix codeowner for NL translation in UI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 # Translations
 airflow-core/src/airflow/ui/src/i18n/locales/de/ @jscheffl
 airflow-core/src/airflow/ui/src/i18n/locales/zh_TW/ @Lee-W
-airflow-core/src/airflow/ui/src/i18n/locales/nl/ @BasPH @DjVinnii
+airflow-core/src/airflow/ui/src/i18n/locales/nl/ @BasPH # not codeowner but engaged: @DjVinnii
 
 # Security/Permissions
 /airflow-core/src/airflow/security/permissions.py @vincbeck


### PR DESCRIPTION
After merge of #50995 - CODEOWNERS were invalid. Unfortunately only committers can be added, else it is invalid.