### PR TITLE
feat(ui): add i18n linting warning rules

### DIFF
--- a/airflow-core/src/airflow/ui/eslint.config.js
+++ b/airflow-core/src/airflow/ui/eslint.config.js
@@ -21,6 +21,7 @@
  * @import { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
  */
 import { coreRules } from "./rules/core.js";
+import { i18nextRules } from "./rules/i18next.js";
 import { perfectionistRules } from "./rules/perfectionist.js";
 import { prettierRules } from "./rules/prettier.js";
 import { reactRules } from "./rules/react.js";
@@ -44,4 +45,5 @@ export default /** @type {const} @satisfies {ReadonlyArray<FlatConfig.Config>} *
   reactRules,
   stylisticRules,
   unicornRules,
+  i18nextRules,
 ]);

--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -74,6 +74,7 @@
     "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^9.25.1",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-i18next": "^6.1.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-perfectionist": "^4.12.3",
     "eslint-plugin-prettier": "^5.2.6",

--- a/airflow-core/src/airflow/ui/pnpm-lock.yaml
+++ b/airflow-core/src/airflow/ui/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.2
         version: 10.1.2(eslint@9.26.0(jiti@1.21.7))
+      eslint-plugin-i18next:
+        specifier: ^6.1.1
+        version: 6.1.1
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.26.0(jiti@1.21.7))
@@ -2316,6 +2319,10 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
+  eslint-plugin-i18next@6.1.1:
+    resolution: {integrity: sha512-/Vy6BfX44njxpRnbJm7bbph0KaNJF2eillqN5W+u03hHuxmh9BjtjdPSrI9HPtyoEbG4j5nBn9gXm/dg99mz3Q==}
+    engines: {node: '>=0.10.0'}
+
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -3784,6 +3791,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  requireindex@1.1.0:
+    resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
+    engines: {node: '>=0.10.5'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -7322,6 +7333,11 @@ snapshots:
     dependencies:
       eslint: 9.26.0(jiti@1.21.7)
 
+  eslint-plugin-i18next@6.1.1:
+    dependencies:
+      lodash: 4.17.21
+      requireindex: 1.1.0
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.26.0(jiti@1.21.7)):
     dependencies:
       aria-query: 5.3.2
@@ -9182,6 +9198,8 @@ snapshots:
       unified: 11.0.5
 
   require-directory@2.1.1: {}
+
+  requireindex@1.1.0: {}
 
   requires-port@1.0.0: {}
 

--- a/airflow-core/src/airflow/ui/rules/i18next.js
+++ b/airflow-core/src/airflow/ui/rules/i18next.js
@@ -34,8 +34,8 @@ const allExtensions = "*.{j,t}s{x,}";
  */
 export const i18nextRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
   files: [
-    // Check files in the UI directory
-    `**/src/${allExtensions}`,
+    // Check files in the ui/src directory
+    `src/**/${allExtensions}`,
   ],
   plugins: {
     i18next: i18nextPlugin,

--- a/airflow-core/src/airflow/ui/rules/i18next.js
+++ b/airflow-core/src/airflow/ui/rules/i18next.js
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @import { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
+ */
+import i18nextPlugin from "eslint-plugin-i18next";
+
+import { WARN } from "./levels.js";
+
+const allExtensions = "*.{j,t}s{x,}";
+
+/**
+ * ESLint rules for i18next to enforce internationalization best practices.
+ * This is a customized configuration.
+ *
+ * @see [eslint-plugin-i18next](https://github.com/edvardchen/eslint-plugin-i18next)
+ */
+export const i18nextRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
+  files: [
+    // Check files in the UI directory
+    `**/src/${allExtensions}`,
+  ],
+  plugins: {
+    i18next: i18nextPlugin,
+  },
+  rules: {
+    /**
+     * Enforce no literal strings in JSX/TSX markup.
+     * This rule helps ensure all user-facing strings are properly internationalized.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * <div>Hello, world!</div>
+     *
+     * // ✅ Correct
+     * <div>{translate('greeting')}</div>
+     * ```
+     * @see [i18next/no-literal-string](https://github.com/edvardchen/eslint-plugin-i18next#no-literal-string)
+     */
+    "i18next/no-literal-string": [
+      WARN,
+      {
+        markupOnly: true,
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Related Issue

#50861
cc: @bbovenzi

## Why

By adding `eslint-plugin-i18next`, we can automatically flag any plaintext literals within TSX components.

## How 

- **New ESLint Rule**: A new configuration file (`rules/i18next.js`) has been created to manage i18n linting.
- **Configured as a `WARN`**: The `i18next/no-literal-string` rule is set to a warning level to avoid disrupting the development workflow.

## Screenshot
![Image](https://github.com/user-attachments/assets/18d3bac2-eff1-4838-8244-b34852214982)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
