### PR TITLE
feat: merge TimeDeltaSensorAsync to TimeDeltaSensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ celerybeat-schedule
 # virtualenv
 .venv*
 venv*
+airflow_venv/
 ENV/
 
 # Spyder project settings

--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,6 @@ celerybeat-schedule
 # virtualenv
 .venv*
 venv*
-airflow_venv/
 ENV/
 
 # Spyder project settings

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_defer.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_defer.py
@@ -21,9 +21,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow import DAG
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Variable
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.sensors.time_delta import TimeDeltaSensorAsync
+import pytest
 
 from system.openlineage.operator import OpenLineageTestOperator
 
@@ -45,21 +47,22 @@ with DAG(
     schedule=None,
     catchup=False,
 ) as dag:
-    # Timedelta is compared to the DAGRun start timestamp, which can occur long before a worker picks up the
-    # task. We need to ensure the sensor gets deferred at least once, so setting 180s.
-    wait = TimeDeltaSensorAsync(task_id="wait", delta=timedelta(seconds=180))
+    with pytest.warns(AirflowProviderDeprecationWarning):
+        # Timedelta is compared to the DAGRun start timestamp, which can occur long before a worker picks up the
+        # task. We need to ensure the sensor gets deferred at least once, so setting 180s.
+        wait = TimeDeltaSensorAsync(task_id="wait", delta=timedelta(seconds=180))
 
-    check_start_events_amount = PythonOperator(
-        task_id="check_start_events_amount", python_callable=check_start_amount_func
-    )
+        check_start_events_amount = PythonOperator(
+            task_id="check_start_events_amount", python_callable=check_start_amount_func
+        )
 
-    check_events = OpenLineageTestOperator(
-        task_id="check_events",
-        file_path=str(Path(__file__).parent / "example_openlineage_defer.json"),
-        allow_duplicate_events=True,
-    )
+        check_events = OpenLineageTestOperator(
+            task_id="check_events",
+            file_path=str(Path(__file__).parent / "example_openlineage_defer.json"),
+            allow_duplicate_events=True,
+        )
 
-    wait >> check_start_events_amount >> check_events
+        wait >> check_start_events_amount >> check_events
 
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402

--- a/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
@@ -152,7 +152,7 @@ class TimeDeltaSensor(BaseSensorOperator):
         return None
 
 
-# TODO: Remember to remove
+# TODO: Remove in the next major release
 @deprecated(
     "Use `TimeDeltaSensor` with `deferrable=True` instead", category=AirflowProviderDeprecationWarning
 )

--- a/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timedelta
 from time import sleep
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -25,7 +26,7 @@ from deprecated.classic import deprecated
 from packaging.version import Version
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowSkipException
+from airflow.exceptions import AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.sensors.base import BaseSensorOperator
@@ -61,10 +62,13 @@ class TimeDeltaSensor(BaseSensorOperator):
 
     """
 
-    def __init__(self, *, delta: timedelta, deferrable: bool = False, **kwargs):
+    def __init__(
+        self, *, delta: timedelta, deferrable: bool = False, end_from_trigger: bool = False, **kwargs
+    ):
         super().__init__(**kwargs)
         self.delta = delta
         self.deferrable = deferrable
+        self.end_from_trigger = end_from_trigger
 
     def _derive_base_time(self, context: Context) -> datetime:
         """
@@ -138,64 +142,29 @@ class TimeDeltaSensor(BaseSensorOperator):
             timeout=timeout,
         )
 
-
-# TODO: Remember to remove
-@deprecated(
-    "use `TimeDeltaSensor` with flag `deferrable=True` instead", category="AirflowProvidersDeprecationWarning"
-)
-class TimeDeltaSensorAsync(TimeDeltaSensor):
-    """
-    A deferrable drop-in replacement for TimeDeltaSensor.
-
-    Will defers itself to avoid taking up a worker slot while it is waiting.
-
-    :param delta: time length to wait after the data interval before succeeding.
-    :param end_from_trigger: End the task directly from the triggerer without going into the worker.
-
-    .. seealso::
-        For more information on how to use this sensor, take a look at the guide:
-        :ref:`howto/operator:TimeDeltaSensorAsync`
-
-    """
-
-    def __init__(self, *, end_from_trigger: bool = False, delta, **kwargs) -> None:
-        super().__init__(delta=delta, **kwargs)
-        self.end_from_trigger = end_from_trigger
-
-    def execute(self, context: Context) -> bool | NoReturn:
-        base_time = self._derive_base_time(context=context)
-        target_dttm: datetime = base_time + self.delta
-
-        if timezone.utcnow() > target_dttm:
-            # If the target datetime is in the past, return immediately
-            return True
-        try:
-            if AIRFLOW_V_3_0_PLUS:
-                trigger = DateTimeTrigger(moment=target_dttm, end_from_trigger=self.end_from_trigger)
-            else:
-                trigger = DateTimeTrigger(moment=target_dttm)
-        except (TypeError, ValueError) as e:
-            if self.soft_fail:
-                raise AirflowSkipException("Skipping due to soft_fail is set to True.") from e
-            raise
-
-        # todo: remove backcompat when min airflow version greater than 2.11
-        timeout: int | float | timedelta
-        if AIRFLOW_V_3_0_PLUS:
-            timeout = self.timeout
-        else:
-            # <=2.11 requires timedelta
-            timeout = timedelta(seconds=self.timeout)
-
-        self.defer(
-            trigger=trigger,
-            method_name="execute_complete",
-            timeout=timeout,
-        )
-
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """Handle the event when the trigger fires and return immediately."""
         return None
+
+
+# TODO: Remember to remove
+@deprecated(
+    "Use `TimeDeltaSensor` with `deferrable=True` instead", category="AirflowProvidersDeprecationWarning"
+)
+class TimeDeltaSensorAsync(TimeDeltaSensor):
+    """
+    Deprecated. Use TimeDeltaSensor with deferrable=True instead.
+
+    :sphinx-autoapi-skip:
+    """
+
+    def __init__(self, *, end_from_trigger: bool = False, delta, **kwargs) -> None:
+        warnings.warn(
+            "TimeDeltaSensorAsync is deprecated and will be removed in a future version. Use `TimeDeltaSensor` with `deferrable=True` instead.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(delta=delta, deferrable=True, end_from_trigger=end_from_trigger, **kwargs)
 
 
 class WaitSensor(BaseSensorOperator):

--- a/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
@@ -63,7 +63,12 @@ class TimeDeltaSensor(BaseSensorOperator):
     """
 
     def __init__(
-        self, *, delta: timedelta, deferrable: bool = False, end_from_trigger: bool = False, **kwargs
+        self,
+        *,
+        delta: timedelta,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        end_from_trigger: bool = False,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.delta = delta
@@ -149,7 +154,7 @@ class TimeDeltaSensor(BaseSensorOperator):
 
 # TODO: Remember to remove
 @deprecated(
-    "Use `TimeDeltaSensor` with `deferrable=True` instead", category="AirflowProvidersDeprecationWarning"
+    "Use `TimeDeltaSensor` with `deferrable=True` instead", category=AirflowProviderDeprecationWarning
 )
 class TimeDeltaSensorAsync(TimeDeltaSensor):
     """

--- a/providers/standard/tests/system/standard/example_sensors.py
+++ b/providers/standard/tests/system/standard/example_sensors.py
@@ -26,7 +26,7 @@ from airflow.providers.standard.sensors.bash import BashSensor
 from airflow.providers.standard.sensors.filesystem import FileSensor
 from airflow.providers.standard.sensors.python import PythonSensor
 from airflow.providers.standard.sensors.time import TimeSensor
-from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor, TimeDeltaSensorAsync
+from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
 from airflow.providers.standard.sensors.weekday import DayOfWeekSensor
 from airflow.providers.standard.utils.weekday import WeekDay
 from airflow.sdk import DAG
@@ -57,7 +57,9 @@ with DAG(
     # [END example_time_delta_sensor]
 
     # [START example_time_delta_sensor_async]
-    t0a = TimeDeltaSensorAsync(task_id="wait_some_seconds_async", delta=datetime.timedelta(seconds=2))
+    t0a = TimeDeltaSensor(
+        task_id="wait_some_seconds_async", delta=datetime.timedelta(seconds=2), deferrable=True
+    )
     # [END example_time_delta_sensor_async]
 
     # [START example_time_sensors]

--- a/providers/standard/tests/unit/standard/sensors/test_time_delta.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time_delta.py
@@ -170,7 +170,7 @@ class TestTimeDeltaSensorAsync:
     )
     @mock.patch(DEFER_PATH)
     def test_timedelta_sensor(self, defer_mock, should_defer):
-        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+        with pytest.warns(AirflowProviderDeprecationWarning):
             delta = timedelta(hours=1)
             op = TimeDeltaSensorAsync(task_id="timedelta_sensor_check", delta=delta, dag=self.dag)
             if should_defer:
@@ -213,7 +213,7 @@ class TestTimeDeltaSensorAsync:
     )
     def test_timedelta_sensor_async_run_after_vs_interval(self, run_after, interval_end, dag_maker):
         """Interval end should be used as base time when present else run_after"""
-        with pytest.warns(AirflowProviderDeprecationWarning) as m:
+        with pytest.warns(AirflowProviderDeprecationWarning):
             if not AIRFLOW_V_3_0_PLUS and not interval_end:
                 pytest.skip("not applicable")
 

--- a/providers/standard/tests/unit/standard/sensors/test_time_delta.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time_delta.py
@@ -124,8 +124,7 @@ def test_timedelta_sensor_deferrable_run_after_vs_interval(run_after, interval_e
         context["data_interval_end"] = interval_end
 
     with dag_maker() as dag:
-        # DagRun kwargs differ slightly between 2.x and 3.0+
-        dagrun_kwargs = {"run_id": "test_deferrable"}
+        dagrun_kwargs = {}
         if AIRFLOW_V_3_0_PLUS:
             from airflow.utils.types import DagRunTriggeredByType
 


### PR DESCRIPTION
### Description
Allow TimeDeltaSensor to act as a deferrable by consuming a feature flag.
Added a deprecation warning for TimeDeltaSensorAsync to nudge users to use TimeDeltaSensor with deferrable=True instead.

### Tests
* Added a test to verify that the time delta sensor has deferred once with a DateTimeTrigger when flag is enabled

### Related Issues
Closes #50811 

### Checklist
- [x] Code follows Airflow's style and guidelines
- [x] Tests have been added
- [x] No backward-incompatible changes introduced