### PR TITLE
Allow translation of term "Dags" in UI in Nav

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -16,6 +16,7 @@
   },
   "nav": {
     "home": "Home",
+    "dags": "Dags",
     "assets": "Assets",
     "browse": "Browse",
     "admin": "Admin",

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -61,7 +61,7 @@ export const Nav = () => {
         <NavButton
           disabled={!authLinks?.authorized_menu_items.includes("Dags")}
           icon={<DagIcon height="1.75rem" width="1.75rem" />}
-          title="Dags"
+          title={translate("nav.dags")}
           to="dags"
         />
         <NavButton


### PR DESCRIPTION
After translation I noticed that the term "Dags" was not translate-able in UI Navbar. This PR closes the gap. No tralsation of existing languages added, also in German I assume we would keep it as "Dags". But depending on language translation can now be made.