### PR TITLE
Translate Navbar leftover details

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ConfirmationModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfirmationModal.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Button, type DialogBodyProps, Heading } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 
 import { Dialog } from "src/components/ui";
 
@@ -28,32 +29,36 @@ type Props = {
   readonly open: boolean;
 };
 
-export const ConfirmationModal = ({ children, header, onConfirm, onOpenChange, open }: Props) => (
-  <Dialog.Root onOpenChange={onOpenChange} open={open}>
-    <Dialog.Content backdrop>
-      <Dialog.Header>
-        <Heading>{header}</Heading>
-      </Dialog.Header>
+export const ConfirmationModal = ({ children, header, onConfirm, onOpenChange, open }: Props) => {
+  const { t: translate } = useTranslation("common");
 
-      <Dialog.CloseTrigger />
+  return (
+    <Dialog.Root onOpenChange={onOpenChange} open={open}>
+      <Dialog.Content backdrop>
+        <Dialog.Header>
+          <Heading>{header}</Heading>
+        </Dialog.Header>
 
-      <Dialog.Body>{children}</Dialog.Body>
-      <Dialog.Footer>
-        <Dialog.ActionTrigger asChild>
-          <Button onClick={() => onOpenChange({ open })} variant="outline">
-            Cancel
+        <Dialog.CloseTrigger />
+
+        <Dialog.Body>{children}</Dialog.Body>
+        <Dialog.Footer>
+          <Dialog.ActionTrigger asChild>
+            <Button onClick={() => onOpenChange({ open })} variant="outline">
+              {translate("modal.cancel")}
+            </Button>
+          </Dialog.ActionTrigger>
+          <Button
+            colorPalette="blue"
+            onClick={() => {
+              onConfirm();
+              onOpenChange({ open });
+            }}
+          >
+            {translate("modal.confirm")}
           </Button>
-        </Dialog.ActionTrigger>
-        <Button
-          colorPalette="blue"
-          onClick={() => {
-            onConfirm();
-            onOpenChange({ open });
-          }}
-        >
-          Confirm
-        </Button>
-      </Dialog.Footer>
-    </Dialog.Content>
-  </Dialog.Root>
-);
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
@@ -2,6 +2,7 @@
   "defaultToGraphView": "Graph-Ansicht als Standard",
   "defaultToGridView": "Gitter-Ansicht als Standard",
   "logout": "Abmelden",
+  "logoutConfirmation": "Sie sind dabei sich von dem System abzumelden.",
   "switchToDarkMode": "Zum Dunkelmodus wechseln",
   "switchToLightMode": "Zum Hellmodus wechseln",
   "timezone": "Zeitzone",
@@ -19,6 +20,7 @@
     "assets": "Datensets (Assets)",
     "browse": "Browsen",
     "admin": "Verwaltung",
+    "security": "Sicherheit",
     "docs": "Doku",
     "plugins": "Plug-ins"
   },
@@ -33,6 +35,13 @@
     "Plugins": "Plug-ins",
     "Connections": "Verbindungen",
     "Config": "Konfiguration"
+  },
+  "security": {
+    "users": "Benutzer",
+    "roles": "Rollen",
+    "actions": "Aktionen",
+    "resources": "Ressourcen",
+    "permissions": "Berechtigungen"
   },
   "timeRange": {
     "duration": "Laufzeit",
@@ -76,5 +85,15 @@
     "deferred": "Delegiert",
     "pools_one": "Pool",
     "pools_other": "Pools"
+  },
+  "modal": {
+    "cancel": "Abbrechen",
+    "confirm": "Bestätigen"
+  },
+  "timezoneModal": {
+    "title": "Auswahl der Zeitzone",
+    "placeholder": "Wählen Sie eine Zeitzone",
+    "current-timezone": "Aktuelle Zeit in",
+    "utc": "UTC (Koordinierte Weltzeit)"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -2,6 +2,7 @@
   "defaultToGraphView": "Default to graph view",
   "defaultToGridView": "Default to grid view",
   "logout": "Logout",
+  "logoutConfirmation": "You are about to logout from the application.",
   "switchToDarkMode": "Switch to Dark Mode",
   "switchToLightMode": "Switch to Light Mode",
   "timezone": "timezone",
@@ -19,6 +20,7 @@
     "assets": "Assets",
     "browse": "Browse",
     "admin": "Admin",
+    "security": "Security",
     "docs": "Docs",
     "plugins": "Plugins"
   },
@@ -33,6 +35,13 @@
     "Plugins": "Plugins",
     "Connections": "Connections",
     "Config": "Config"
+  },
+  "security": {
+    "users": "Users",
+    "roles": "Roles",
+    "actions": "Actions",
+    "resources": "Resources",
+    "permissions": "Permissions"
   },
   "timeRange": {
     "duration": "Duration",
@@ -76,5 +85,15 @@
     "deferred": "Deferred",
     "pools_one": "pool",
     "pools_other": "pools"
+  },
+  "modal": {
+    "cancel": "Cancel",
+    "confirm": "Confirm"
+  },
+  "timezoneModal": {
+    "title": "Select Timezone",
+    "placeholder": "Select a timezone",
+    "current-timezone": "Current time in",
+    "utc": "UTC (Coordinated Universal Time)"
   }
 }

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/LogoutModal.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/LogoutModal.tsx
@@ -18,6 +18,7 @@
  */
 import { Text } from "@chakra-ui/react";
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { ConfirmationModal } from "src/components/ConfirmationModal";
 import { getRedirectPath } from "src/utils/links.ts";
@@ -28,20 +29,24 @@ type LogoutModalProps = {
   readonly onClose: () => void;
 };
 
-const LogoutModal: React.FC<LogoutModalProps> = ({ isOpen, onClose }) => (
-  <ConfirmationModal
-    header="Logout"
-    onConfirm={() => {
-      const logoutPath = getRedirectPath("api/v2/auth/logout");
+const LogoutModal: React.FC<LogoutModalProps> = ({ isOpen, onClose }) => {
+  const { t: translate } = useTranslation("common");
 
-      localStorage.removeItem(TOKEN_STORAGE_KEY);
-      globalThis.location.replace(logoutPath);
-    }}
-    onOpenChange={onClose}
-    open={isOpen}
-  >
-    <Text>You are about to logout from the application.</Text>
-  </ConfirmationModal>
-);
+  return (
+    <ConfirmationModal
+      header={translate("logout")}
+      onConfirm={() => {
+        const logoutPath = getRedirectPath("api/v2/auth/logout");
+
+        localStorage.removeItem(TOKEN_STORAGE_KEY);
+        globalThis.location.replace(logoutPath);
+      }}
+      onOpenChange={onClose}
+      open={isOpen}
+    >
+      <Text>{translate("logoutConfirmation")}</Text>
+    </ConfirmationModal>
+  );
+};
 
 export default LogoutModal;

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/SecurityButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/SecurityButton.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useTranslation } from "react-i18next";
 import { FiLock } from "react-icons/fi";
 import { Link } from "react-router-dom";
 
@@ -26,6 +27,7 @@ import { NavButton } from "./NavButton";
 
 export const SecurityButton = () => {
   const { data: authLinks } = useAuthLinksServiceGetAuthMenus();
+  const { t: translate } = useTranslation("common");
 
   if (authLinks?.extra_menu_items === undefined || authLinks.extra_menu_items.length < 1) {
     return undefined;
@@ -34,13 +36,13 @@ export const SecurityButton = () => {
   return (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger asChild>
-        <NavButton icon={<FiLock size="1.75rem" />} title="Security" />
+        <NavButton icon={<FiLock size="1.75rem" />} title={translate("nav.security")} />
       </Menu.Trigger>
       <Menu.Content>
         {authLinks.extra_menu_items.map(({ text }) => (
           <Menu.Item asChild key={text} value={text}>
             <Link aria-label={text} to={`security/${text.toLowerCase().replace(" ", "-")}`}>
-              {text}
+              {translate(`security.${text.toLowerCase().replace(" ", "-")}`)}
             </Link>
           </Menu.Item>
         ))}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneModal.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneModal.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { Dialog } from "src/components/ui";
 
@@ -27,16 +28,20 @@ type TimezoneModalProps = {
   readonly onClose: () => void;
 };
 
-const TimezoneModal: React.FC<TimezoneModalProps> = ({ isOpen, onClose }) => (
-  <Dialog.Root lazyMount onOpenChange={onClose} open={isOpen} size="xl">
-    <Dialog.Content backdrop>
-      <Dialog.Header>Select Timezone</Dialog.Header>
-      <Dialog.CloseTrigger />
-      <Dialog.Body>
-        <TimezoneSelector />
-      </Dialog.Body>
-    </Dialog.Content>
-  </Dialog.Root>
-);
+const TimezoneModal: React.FC<TimezoneModalProps> = ({ isOpen, onClose }) => {
+  const { t: translate } = useTranslation("common");
+
+  return (
+    <Dialog.Root lazyMount onOpenChange={onClose} open={isOpen} size="xl">
+      <Dialog.Content backdrop>
+        <Dialog.Header>{translate("timezoneModal.title")}</Dialog.Header>
+        <Dialog.CloseTrigger />
+        <Dialog.Body>
+          <TimezoneSelector />
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
 
 export default TimezoneModal;

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
@@ -22,6 +22,7 @@ import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useTimezone } from "src/context/timezone";
 import type { Option as TimezoneOption } from "src/utils/option";
@@ -31,6 +32,7 @@ dayjs.extend(timezone);
 
 const TimezoneSelector: React.FC = () => {
   const { selectedTimezone, setSelectedTimezone } = useTimezone();
+  const { t: translate } = useTranslation("common");
   const timezones = useMemo<Array<string>>(() => {
     const tzList = Intl.supportedValuesOf("timeZone");
     const guessedTz = dayjs.tz.guess();
@@ -42,10 +44,10 @@ const TimezoneSelector: React.FC = () => {
   const options = useMemo<Array<TimezoneOption>>(
     () =>
       timezones.map((tz) => ({
-        label: tz === "UTC" ? "UTC (Coordinated Universal Time)" : tz,
+        label: tz === "UTC" ? translate("timezoneModal.utc") : tz,
         value: tz,
       })),
-    [timezones],
+    [timezones, translate],
   );
 
   const handleTimezoneChange = (selectedOption: SingleValue<TimezoneOption>) => {
@@ -62,13 +64,13 @@ const TimezoneSelector: React.FC = () => {
         <Select<TimezoneOption>
           onChange={handleTimezoneChange}
           options={options}
-          placeholder="Select a timezone"
+          placeholder={translate("timezoneModal.placeholder")}
           value={options.find((option) => option.value === selectedTimezone)}
         />
       </Field.Root>
       <Box borderRadius="md" boxShadow="sm" display="flex" flexDirection="column" gap={2} p={6}>
         <Text fontSize="lg" fontWeight="bold">
-          Current time in {selectedTimezone}:
+          {translate("timezoneModal.current-timezone")} {selectedTimezone}:
         </Text>
         <Text fontSize="2xl">{currentTime}</Text>
       </Box>


### PR DESCRIPTION
I noticed that some details and modals of the navbar are not (yet) translated. as a small increment adding translations here.

(I think we need to cover more stuff incrementally before more translations roll and details are un-translated)

Fab Auth menu:
![image](https://github.com/user-attachments/assets/a7cd9fbe-28b0-4072-8c00-fa979a357a43)

Timezone Modal:
![image](https://github.com/user-attachments/assets/8ca1f223-bef3-4a19-bf2f-8753d7f7cff9)
(Note: Did not find a way to translate (easily) all time zones in dropdown... would be bad to list all of them in s´translation... might need a clever lib in a follow-up PR)

Log out dialog:
![image](https://github.com/user-attachments/assets/e273a912-35ea-4b63-b905-15d401286fa2)
