### PR TITLE
Pin patchlevel version while setting up Go in CI

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -784,7 +784,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.24.0
 
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -535,7 +535,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.24.0
 
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Observed
```
Setup go version spec 1.24
Attempting to download 1.24...
matching 1.24...
Acquiring 1.24.3 from https://github.com/actions/go-versions/releases/download/1.24.3-[14](https://github.com/apache/airflow/actions/runs/15281207510/job/42983260314?pr=51122#step:3:15)875263452/go-1.24.3-linux-x64.tar.gz
Extracting Go...
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/958e0d9a-9ea1-49ed-8500-a0f2a5123443 -f /home/runner/work/_temp/0256b5ef-38c5-4b7d-813c-69c0ff85771f
Successfully extracted go to /home/runner/work/_temp/958e0d9a-9ea1-49ed-8500-a0f2a5123443
Adding to the cache ...
Successfully cached go to /opt/hostedtoolcache/go/1.24.3/x64
Added go to the path
Successfully set up Go version 1.24
/opt/hostedtoolcache/go/1.24.3/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.[24](https://github.com/apache/airflow/actions/runs/15281207510/job/42983260314?pr=51122#step:3:25).3/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/airflow/airflow. Supported file pattern: go.sum
go version go1.24.3 linux/amd64
```

in https://github.com/apache/airflow/actions/runs/15281207510/job/42983260314?pr=51122.

If patch level version isnt specificed, it seems to pick any patch level version. To keep it consistent, marking patch level version.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
