### PR TITLE
[KubernetesPodOperator] Add xcom sidecar terminated detection

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -822,6 +822,10 @@ class PodManager(LoggingMixin):
             if self.container_is_running(pod, PodDefaults.SIDECAR_CONTAINER_NAME):
                 self.log.info("The xcom sidecar container has started.")
                 break
+            if self.container_is_terminated(pod, PodDefaults.SIDECAR_CONTAINER_NAME):
+                raise AirflowException(
+                    "Xcom sidecar container is already terminated! Not possible to read xcom output of task."
+                )
             if (time.time() - last_log_time) >= log_interval:
                 self.log.warning(
                     "Still waiting for the xcom sidecar container to start. Elapsed time: %d seconds.",


### PR DESCRIPTION
# Overview

During working with the KubernetesPodOperator we found the issue that sometimes the POD was already in terminated state and then it is also not required to wait for a xcom sidecar container. Idea is to check if sidecar is terminated and then end that task.


# Details of change:

* usage of container_is_terminated for xcom sidecar container during waiting for startup.