### PR TITLE
Add user impersonation (run_as_user) support for task execution

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -719,8 +719,8 @@ def impersonate_user(username: str, log: Logger):
         pw_record = pwd.getpwnam(username)
         uid, gid = pw_record.pw_uid, pw_record.pw_gid
 
-        os.setgid(uid)
-        os.setuid(gid)
+        os.setuid(uid)
+        os.setgid(gid)
 
         log.info("Running task as impersonated user", impersonated_user=username)
     except KeyError:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/50423

## Why?

Airflow 2 had support for user impersonation: https://airflow.apache.org/docs/apache-airflow/stable/security/workload.html. Quoting from docs:

> Airflow has the ability to impersonate a unix user while running task instances based on the task’s run_as_user parameter, which takes a user’s name.

The intention here is to de-elevate the user running the task to reduce priviliges from the process / worker launching the process which runs as root. We can configure the task to impersonate as an user with lesser priviliges and control the behaviour of the tasks running for a more secure task run.


Quoting one of the use case from one of the airflow users too:

> I suspect there might be something wrong with user impersonation (run_as_user) in 3.0.0+ with docker (tested on 3.0.1rc1). My setup uses an overlay filesystem so I can fake-interact with a shared network drive. When I connect to the docker cli, I can do sudo -u data_user -i and create/delete files without problem. However, the celery worker encounters a permission error when running a task that writes to the network drive as that very same data_user. Does anyone have any idea what might be the reason? Anything I can try to pinpoint the issue? In 2.10.5 my setup worked fine. The difference in configurations comes down to changes to the "official" docker-compose from 2.x to 3.x (on top of which my own additions, which didn't change, are included).

https://apache-airflow.slack.com/archives/CCQB40SQJ/p1746728794387939

## Implementation

Airflow 2 essentially did: `sudo -u user "your_bash_command_here"`.

For airflow 3, we should do something simular, basically run the task runner running the workload as the provided `run_as_user`.

- Introduced a helper method to attempt impersonation,
	•	Uses `pwd.getpwnam()` to resolve the UID and GID of the user.
	•	Applies os.setgid() followed by os.setuid() to apply privileges.
	•	Handles KeyError, PermissionError.
The order of setgid() → setuid() is intentional. Once a user is dropped to non-root via setuid, regaining privileges is impossible.
	
-  In the task runner startup, we check if the run_as_user is set, if not check if the config for default_impersonation is set: https://airflow.apache.org/docs/apache-airflow/stable/security/workload.html#default-impersonation.
- If neither is set, continues with the current user. (root usually, for CE atleast)


## Testing

Intention is to run airflow as "root" and switch to a lesser privileged user: "airflowuser". We will try and use a user that cannot list some files like `/root/airflow/airflow.cfg` intentionally.

### Setup for testing

1. Run airflow with celery executor
2. Create a "airflowuser": `sudo useradd -m -s /bin/bash airflowuser`
3. Switch to "airflowuser" and ensure that the privilieges are lesser, for eg:
```
root@1b92a329d570:/opt/airflow# sudo -u airflowuser -i
airflowuser@1b92a329d570:~$ namei -l /root/airflow/airflow.cfg
f: /root/airflow/airflow.cfg
drwxr-xr-x root root /
drwx------ root root root
                     airflow - Permission denied
```
4. Run celery worker with root now:
```
root@1b92a329d570:/opt/airflow# airflow celery worker
2025-05-29 07:41:56.804540 [info     ] starting stale bundle cleanup process [airflow.providers.celery.cli.celery_command]
[2025-05-29 07:41:56 +0000] [418] [INFO] Starting gunicorn 23.0.0
[2025-05-29 07:41:56 +0000] [418] [INFO] Listening at: http://[::]:8793 (418)
[2025-05-29 07:41:56 +0000] [418] [INFO] Using worker: sync
[2025-05-29 07:41:56 +0000] [420] [INFO] Booting worker with pid: 420
[2025-05-29 07:41:56 +0000] [421] [INFO] Booting worker with pid: 421
2025-05-29 07:41:58.159935 [warning  ] You're running the worker with superuser privileges: this is
absolutely not recommended!

Please specify a different user using the --uid option.

User information: uid=0 euid=0 gid=0 egid=0
 [py.warnings] category=SecurityWarning filename=/usr/local/lib/python3.9/site-packages/celery/platforms.py lineno=84
```

DAG:
```
from airflow import DAG
from datetime import datetime

from airflow.providers.standard.operators.bash import BashOperator

with DAG(
    dag_id="check_cfg_file_access",
    schedule=None,
    catchup=False,
) as dag:

    check_access = BashOperator(
        task_id="ls_root_cfg",
        bash_command="ls -l /root/airflow/airflow.cfg",
    )
```

Running this without run_as_user, can access that file:

![image](https://github.com/user-attachments/assets/405ccc50-9b49-46e7-830c-7f74f13f7c52)


### Test 1: Check if a task can run with `run_as_user` provided at task level.

DAG Used:
```
from airflow import DAG
from datetime import datetime

from airflow.providers.standard.operators.bash import BashOperator

with DAG(
    dag_id="check_cfg_file_access",
    schedule=None,
    catchup=False,
) as dag:

    check_access = BashOperator(
        task_id="ls_root_cfg",
        bash_command="ls -l /root/airflow/airflow.cfg",
    )
```

extract is running with "airflowuser" and airflowuser is present.


Errors out, logs:
![image](https://github.com/user-attachments/assets/21ddf75d-3b01-4135-9815-e5030b02ef4b)

```
[2025-05-29, 13:18:01] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-05-29, 1[3](http://localhost:28080/dags/check_cfg_file_access/runs/manual__2025-05-29T07:48:00.771934+00:00/tasks/ls_root_cfg?try_number=1#3):18:01] INFO - Filling up the DagBag from /files/dags/bashoperator-trying-ls.py: source="airflow.models.dagbag.DagBag"
[2025-05-29, 13:18:01] INFO - Running task as impersonated user: impersonated_user="airflowuser": source="task"
[2025-05-29, 13:18:01] INFO - Tmp dir root location: /tmp: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:18:01] INFO - Running command: ['/usr/bin/bash', '-c', 'ls -l /root/airflow/airflow.cfg']: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:18:01] INFO - Output:: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:18:01] INFO - ls: cannot access '/root/airflow/airflow.cfg': Permission denied: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:18:01] INFO - Command exited with return code 2: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:18:01] ERROR - Task failed with exception: source="task"
AirflowException: Bash command failed. The command returned a non-zero exit code 2.
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 90[4](http://localhost:28080/dags/check_cfg_file_access/runs/manual__2025-05-29T07:48:00.771934+00:00/tasks/ls_root_cfg?try_number=1#4) in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1196 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/bash.py", line 233 in execute
```

### Test 2: Do not provide `run_as_user` but override with the conf instead: "airflowuser" itself

Set env in worker:
```
export AIRFLOW__CORE__DEFAULT_IMPERSONATION="airflowuser"
```


DAG Used:
```
from airflow import DAG
from datetime import datetime

from airflow.providers.standard.operators.bash import BashOperator

with DAG(
    dag_id="check_cfg_file_access",
    schedule=None,
    catchup=False,
) as dag:

    check_access = BashOperator(
        task_id="ls_root_cfg",
        bash_command="ls -l /root/airflow/airflow.cfg",
    )
```

Same error as before:

![image](https://github.com/user-attachments/assets/8940a44c-0d1e-4d25-82f5-f47c17e73688)


Logs:

```
[2025-05-29, 13:21:13] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-05-29, 1[3](http://localhost:28080/dags/check_cfg_file_access/runs/manual__2025-05-29T07:51:12.790374+00:00/tasks/ls_root_cfg?try_number=1#3):21:13] INFO - Filling up the DagBag from /files/dags/bashoperator-trying-ls.py: source="airflow.models.dagbag.DagBag"
[2025-05-29, 13:21:13] INFO - Running task as impersonated user: impersonated_user="airflowuser": source="task"
[2025-05-29, 13:21:13] INFO - Tmp dir root location: /tmp: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:21:13] INFO - Running command: ['/usr/bin/bash', '-c', 'ls -l /root/airflow/airflow.cfg']: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:21:13] INFO - Output:: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:21:13] INFO - ls: cannot access '/root/airflow/airflow.cfg': Permission denied: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:21:13] INFO - Command exited with return code 2: source="airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook"
[2025-05-29, 13:21:13] ERROR - Task failed with exception: source="task"
AirflowException: Bash command failed. The command returned a non-zero exit code 2.
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 90[4](http://localhost:28080/dags/check_cfg_file_access/runs/manual__2025-05-29T07:51:12.790374+00:00/tasks/ls_root_cfg?try_number=1#4) in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1196 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/bash.py", line 233 in execute
```

### Test 3: Provide `run_as_user` and in conf, to check which one is picked up

In worker, create new user: `randomuser` and set env to "airflowuser"
```
sudo useradd -m -s /bin/bash randomuser
export AIRFLOW__CORE__DEFAULT_IMPERSONATION="airflowuser"
```

DAG used:

```
from airflow import DAG
from datetime import datetime

from airflow.providers.standard.operators.bash import BashOperator

with DAG(
    dag_id="check_cfg_file_access",
    schedule=None,
    catchup=False,
) as dag:

    check_access = BashOperator(
        task_id="ls_root_cfg",
        bash_command="ls -l /root/airflow/airflow.cfg",
        run_as_user="randomuser"
    )

```


Random user picked up:
![image](https://github.com/user-attachments/assets/489ecd9f-7cb8-4bc4-80ef-a94f028774a4)


### TODO:
- [ ] Add tests in task sdk
- [ ] Update docs if any
- [ ] Figure out what happens in v2 for PermissionError or UserNotFound case and replicate here

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
