### PR TITLE
Fix serializing task.weight_rule in OpenLineage facet

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -53,7 +53,7 @@ from airflow.providers.openlineage.utils.selective_enable import (
 )
 from airflow.providers.openlineage.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.sensors.base import BaseSensorOperator
-from airflow.serialization.serialized_objects import SerializedBaseOperator
+from airflow.serialization.serialized_objects import SerializedBaseOperator, encode_priority_weight_strategy
 from airflow.utils.module_loading import import_string
 
 if not AIRFLOW_V_3_0_PLUS:
@@ -506,6 +506,7 @@ class TaskInfo(InfoJsonEncodable):
         ),
         "inlets": lambda task: [AssetInfo(i) for i in task.inlets if isinstance(i, Asset)],
         "outlets": lambda task: [AssetInfo(o) for o in task.outlets if isinstance(o, Asset)],
+        "weight_rule": lambda task: encode_priority_weight_strategy(task.weight_rule),
     }
 
 

--- a/providers/openlineage/tests/system/openlineage/example_openlineage.json
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage.json
@@ -52,7 +52,8 @@
                         "operator_class_path": "{{ result.endswith('.PythonOperator') }}",
                         "wait_for_downstream": false,
                         "retry_exponential_backoff": false,
-                        "wait_for_past_depends_before_skipping": false
+                        "wait_for_past_depends_before_skipping": false,
+                        "weight_rule": "downstream"
                     },
                     "taskUuid": "{{ is_uuid(result) }}"
                 },

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -1601,6 +1601,7 @@ def test_task_info_af3():
         "upstream_task_ids": "['task_0']",
         "wait_for_downstream": False,
         "wait_for_past_depends_before_skipping": False,
+        "weight_rule": "downstream",
     }
 
 
@@ -1678,6 +1679,7 @@ def test_task_info_af2():
         "upstream_task_ids": "['task_0']",
         "wait_for_downstream": False,
         "wait_for_past_depends_before_skipping": False,
+        "weight_rule": "downstream",
     }
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

OpenLineage integration 1.11.0 produces events with `task` facet containing:
```
"weight_rule": "<<non-serializable: _DownstreamPriorityWeightStrategy>>"
```

<details>
<summary>event.json</summary>

```json
{
    "run": {
        "facets": {
            "airflow": {
                "_producer": "https://github.com/apache/airflow/tree/providers-openlineage/1.11.0",
                "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
                "task": {
                    "depends_on_past": false,
                    "downstream_task_ids": "['add_period_in_hive']",
                    "executor_config": {},
                    "ignore_first_depends_on_past": true,
                    "inlets": [],
                    "is_setup": false,
                    "is_teardown": false,
                    "mapped": false,
                    "multiple_outputs": false,
                    "operator_class": "PythonOperator",
                    "operator_class_path": "***.operators.python.PythonOperator",
                    "outlets": [],
                    "owner": "***",
                    "priority_weight": 1,
                    "queue": "default",
                    "retries": 2,
                    "retry_exponential_backoff": false,
                    "task_id": "add_params_in_xcom",
                    "trigger_rule": "all_success",
                    "upstream_task_ids": "['Sensors.Sensor__hdp2gp_oebsap_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebsar_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebsfa_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__postgres2gp_1c_sales_report__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebsgl_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebspa_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebsinv_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebsxtr_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebspay_dm__oebs-dm-replication-to-greenplum', 'Sensors.Sensor__hdp2gp_oebsce_dm__oebs-dm-replication-to-greenplum']",
                    "wait_for_downstream": false,
                    "wait_for_past_depends_before_skipping": false,
                    "weight_rule": "<<non-serializable: _DownstreamPriorityWeightStrategy>>"
                }
            }
        }
    }
}
```
</details>

Instead serialize it properly:
```
"weight_rule": "downstream"
```
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
