### PR TITLE
Fix widget error for core hooks

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -116,9 +116,9 @@ class HookMetaService:
         """Mock any flask appbuilder widget."""
 
     @staticmethod
-    def _get_hooks_with_mocked_fab() -> tuple[
-        MutableMapping[str, HookInfo | None], dict[str, ConnectionFormWidgetInfo], dict[str, dict]
-    ]:
+    def _get_hooks_with_mocked_fab() -> (
+        tuple[MutableMapping[str, HookInfo | None], dict[str, ConnectionFormWidgetInfo], dict[str, dict]]
+    ):
         """Get hooks with all details w/o FAB needing to be installed."""
         from unittest import mock
 
@@ -185,7 +185,9 @@ class HookMetaService:
                 pass
 
             pm = ProvidersManager()
-            return pm.hooks, pm.connection_form_widgets, pm.field_behaviours
+            pm._cleanup()  # Remove any cached hooks with non mocked FAB
+            pm._init_airflow_core_hooks()  # Initialize core hooks
+            return pm.hooks, pm.connection_form_widgets, pm.field_behaviours  # Will init providers hooks
 
         return (
             {},

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -116,9 +116,9 @@ class HookMetaService:
         """Mock any flask appbuilder widget."""
 
     @staticmethod
-    def _get_hooks_with_mocked_fab() -> (
-        tuple[MutableMapping[str, HookInfo | None], dict[str, ConnectionFormWidgetInfo], dict[str, dict]]
-    ):
+    def _get_hooks_with_mocked_fab() -> tuple[
+        MutableMapping[str, HookInfo | None], dict[str, ConnectionFormWidgetInfo], dict[str, dict]
+    ]:
         """Get hooks with all details w/o FAB needing to be installed."""
         from unittest import mock
 


### PR DESCRIPTION
Fix widget warning error:
![Screenshot 2025-05-28 at 18 40 03](https://github.com/user-attachments/assets/b2e493bf-2443-4b17-aecc-451899042726)

That's caused in core hooks, because those are initialized when instanciating the ProvidersManager and then cached. (ProvidersManager is a singleton therefore we end up with unmocked hooks in the `hook_meta` endpoint).

After the fix, no more error, we have the form available in the front-end for the fs hook:
![Screenshot 2025-05-28 at 18 41 17](https://github.com/user-attachments/assets/fdb70245-dcbb-44b2-a8f0-6858758a6c07)
