### PR TITLE
Handle SIGSEGV signals during DAG file imports

### DIFF
--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -22,6 +22,7 @@ import importlib
 import importlib.machinery
 import importlib.util
 import os
+import signal
 import sys
 import textwrap
 import traceback
@@ -357,6 +358,14 @@ class DagBag(LoggingMixin):
 
     def _load_modules_from_file(self, filepath, safe_mode):
         from airflow.sdk.definitions._internal.contextmanager import DagContext
+
+        def handler(signum, frame):
+            """Handle SIGSEGV signal and let the user know that the import failed."""
+            msg = f"Received SIGSEGV signal while processing {filepath}."
+            self.log.error(msg)
+            self.import_errors[filepath] = msg
+
+        signal.signal(signal.SIGSEGV, handler)
 
         if not might_contain_dag(filepath, safe_mode):
             # Don't want to spam user with skip messages

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -365,7 +365,10 @@ class DagBag(LoggingMixin):
             self.log.error(msg)
             self.import_errors[filepath] = msg
 
-        signal.signal(signal.SIGSEGV, handler)
+        try:
+            signal.signal(signal.SIGSEGV, handler)
+        except ValueError:
+            self.log.warning("SIGSEGV signal handler registration failed. Not in the main thread")
 
         if not might_contain_dag(filepath, safe_mode):
             # Don't want to spam user with skip messages

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -988,3 +988,27 @@ with airflow.DAG(
         dagbag = DagBag(dag_folder=os.fspath(tmp_path), include_examples=False)
         assert "Received SIGSEGV signal while processing" in caplog.text
         assert dag_file.as_posix() in dagbag.import_errors
+
+    def test_failed_signal_registration_does_not_crash_the_process(self, tmp_path, caplog):
+        """Test that a ValueError raised by a signal setting on child process does not crash the main process.
+        This was raised in test_dag_report.py module in api_fastapi/core_api/routes/public tests
+        """
+        dag_file = tmp_path / "test_dag.py"
+        dag_file.write_text(
+            textwrap.dedent(
+                """\
+                from airflow import DAG
+                from airflow.decorators import task
+
+                with DAG('testbug'):
+                    @task
+                    def mytask():
+                        print(1)
+                    mytask()
+                """
+            )
+        )
+        with mock.patch("airflow.models.dagbag.signal.signal") as mock_signal:
+            mock_signal.side_effect = ValueError("Invalid signal setting")
+            DagBag(dag_folder=os.fspath(tmp_path), include_examples=False)
+            assert "SIGSEGV signal handler registration failed. Not in the main thread" in caplog.text


### PR DESCRIPTION
Add signal handler to catch segmentation faults that occur while loading DAG modules and record them as import errors

Closes: https://github.com/apache/airflow/issues/50303

![Screenshot 2025-05-28 at 18 14 57](https://github.com/user-attachments/assets/92f6fb25-d78e-43bc-b84d-dee8172d106a)
