### PR TITLE
Bring back "standard" example dags to the airflow-core package

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
@@ -35,7 +34,6 @@ if TYPE_CHECKING:
     from airflow.dag_processing.bundles.base import BaseDagBundle
 
 _example_dag_bundle_name = "example_dags"
-_example_standard_dag_bundle_name = "example_standard_dags"
 
 
 def _bundle_item_exc(msg):
@@ -82,25 +80,6 @@ def _add_example_dag_bundle(config_list):
     )
 
 
-def _add_example_standard_dag_bundle(config_list):
-    # TODO(potiuk): make it more generic - for now we only add standard example_dags if they are locally available
-    try:
-        from system import standard
-    except ImportError:
-        return
-
-    example_dag_folder = next(iter(standard.__path__))
-    config_list.append(
-        {
-            "name": _example_standard_dag_bundle_name,
-            "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
-            "kwargs": {
-                "path": example_dag_folder,
-            },
-        }
-    )
-
-
 class DagBundlesManager(LoggingMixin):
     """Manager for DAG bundles."""
 
@@ -133,11 +112,6 @@ class DagBundlesManager(LoggingMixin):
         _validate_bundle_config(config_list)
         if conf.getboolean("core", "LOAD_EXAMPLES"):
             _add_example_dag_bundle(config_list)
-            if (
-                os.environ.get("BREEZE", "").lower() == "true"
-                or os.environ.get("_IN_UNIT_TESTS", "").lower() == "true"
-            ):
-                _add_example_standard_dag_bundle(config_list)
 
         for cfg in config_list:
             name = cfg["name"]

--- a/airflow-core/src/airflow/example_dags/standard
+++ b/airflow-core/src/airflow/example_dags/standard
@@ -1,0 +1,1 @@
+../../../../providers/standard/tests/system/standard/

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -598,14 +598,6 @@ class DagBag(LoggingMixin):
             example_dag_folder = next(iter(example_dags.__path__))
 
             files_to_parse.extend(list_py_file_paths(example_dag_folder, safe_mode=safe_mode))
-            try:
-                from system import standard
-
-                example_dag_folder_standard = next(iter(standard.__path__))
-                files_to_parse.extend(list_py_file_paths(example_dag_folder_standard, safe_mode=safe_mode))
-            except ImportError:
-                # Nothing happens - this should only work during tests
-                pass
 
         for filepath in files_to_parse:
             try:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_report.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_report.py
@@ -23,7 +23,6 @@ import pytest
 
 from airflow.utils.file import list_py_file_paths
 
-from tests_common.pytest_plugin import AIRFLOW_ROOT_PATH
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, parse_and_sync_to_db
 
@@ -34,18 +33,12 @@ TEST_DAG_FOLDER_WITH_SUBDIR = f"{TEST_DAG_FOLDER}/subdir2"
 TEST_DAG_FOLDER_INVALID = "/invalid/path"
 TEST_DAG_FOLDER_INVALID_2 = "/root/airflow/tests/dags/"
 
-STANDARD_PROVIDER_SYSTEM_TESTS_PATH = (
-    AIRFLOW_ROOT_PATH / "providers" / "standard" / "tests" / "system" / "standard"
-)
-
 
 def get_corresponding_dag_file_count(dir: str, include_examples: bool = True) -> int:
     from airflow import example_dags
 
-    return (
-        len(list_py_file_paths(directory=dir))
-        + (len(list_py_file_paths(next(iter(example_dags.__path__)))) if include_examples else 0)
-        + (len(list_py_file_paths(STANDARD_PROVIDER_SYSTEM_TESTS_PATH.as_posix())) if include_examples else 0)
+    return len(list_py_file_paths(directory=dir)) + (
+        len(list_py_file_paths(next(iter(example_dags.__path__)))) if include_examples else 0
     )
 
 

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -52,7 +52,7 @@ from unit.models import TEST_DAGS_FOLDER
 
 pytestmark = pytest.mark.db_test
 
-example_dags_folder = AIRFLOW_ROOT_PATH / "providers" / "standard" / "tests" / "system" / "standard"
+example_dags_folder = AIRFLOW_ROOT_PATH / "airflow-core" / "src" / "airflow" / "example_dags" / "standard"
 
 PY311 = sys.version_info >= (3, 11)
 


### PR DESCRIPTION
As we are working on a longer-term solution for example-dags, the short-term one is to bring the standard example_dags back to the airflow-core via symbolic link to the standard package folder.

This makes the dags to be copied to the airflow-core from the latest main version (but those dags don't change) while not requiring to duplicate the dags and keep them in standard provider where the documentation for them is kept.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
