### PR TITLE
Relax Kubernetes client version support to <33.0.0

### DIFF
--- a/providers/cncf/kubernetes/pyproject.toml
+++ b/providers/cncf/kubernetes/pyproject.toml
@@ -69,13 +69,13 @@ dependencies = [
     # limiting minimum airflow version supported in cncf.kubernetes provider, due to the
     # potential breaking changes in Airflow Core as well (kubernetes is added as extra, so Airflow
     # core is not hard-limited via install-requirements, only by extra).
-    "kubernetes>=29.0.0,<=31.0.0",
+    "kubernetes>=29.0.0,<33.0.0",
     # The Kubernetes_asyncio package is used for providing Asynchronous (AsyncIO) client library for
     # standard Kubernetes API. The version is limited by minimum 18.20.1 because of introducing the ability to
     # load kubernetes config file from dictionary in that release and is limited to the next MAJOR version
     # (started from current 24.2.2 version) to prevent introducing some problems that could be due to some
     #  major changes in the package.
-    "kubernetes_asyncio>=29.0.0,<=31.0.0",
+    "kubernetes_asyncio>=29.0.0,<33.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
We support K8s versions 1.30, 1.31, 1.32, 1.33
Relaxing the client version to match:
https://github.com/kubernetes-client/python?tab=readme-ov-file#compatibility-matrix-of-supported-client-versions


[client 31.y.z](https://pypi.org/project/kubernetes/31.0.0/): Kubernetes 1.30 or below (+-), Kubernetes 1.31 (✓), Kubernetes 1.32 or above (+-)
[client 32.y.z](https://pypi.org/project/kubernetes/32.0.1/): Kubernetes 1.31 or below (+-), Kubernetes 1.32 (✓), Kubernetes 1.33 or above (+-)
[client 33.y.z](https://pypi.org/project/kubernetes/33.0.1/): Kubernetes 1.32 or below (+-), Kubernetes 1.33 (✓), Kubernetes 1.34 or above (+-)

client 33.0 is not yet released
