### PR TITLE
Rds Operator pass custom conn_id to superclass

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
@@ -54,13 +54,9 @@ class RdsBaseOperator(AwsBaseOperator[RdsHook]):
     def __init__(
         self,
         *args,
-        aws_conn_id: str | None = "aws_default",
-        region_name: str | None = None,
         **kwargs,
     ):
-        self.aws_conn_id = aws_conn_id
-        self.region_name = region_name
-        super().__init__(*args, aws_conn_id=aws_conn_id, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._await_interval = 60  # seconds
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
@@ -54,7 +54,7 @@ class RdsBaseOperator(AwsBaseOperator[RdsHook]):
     def __init__(
         self,
         *args,
-        aws_conn_id: str | None = None,
+        aws_conn_id: str | None = "aws_default",
         region_name: str | None = None,
         **kwargs,
     ):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
@@ -54,13 +54,13 @@ class RdsBaseOperator(AwsBaseOperator[RdsHook]):
     def __init__(
         self,
         *args,
-        aws_conn_id: str | None = "aws_conn_id",
+        aws_conn_id: str | None = None,
         region_name: str | None = None,
         **kwargs,
     ):
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, aws_conn_id=aws_conn_id, **kwargs)
 
         self._await_interval = 60  # seconds
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_rds.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_rds.py
@@ -173,16 +173,19 @@ class TestBaseRdsOperator:
     def test_hook_attribute(self):
         assert hasattr(self.op, "hook")
         assert self.op.hook.__class__.__name__ == "RdsHook"
-    
+
     def test_overwritten_conn_passed_to_hook(self):
         OVERWRITTEN_CONN = "new-conn-id"
-        op = RdsBaseOperator(task_id="test_overwritten_conn_passed_to_hook_task", aws_conn_id=OVERWRITTEN_CONN, dag=self.dag)
+        op = RdsBaseOperator(
+            task_id="test_overwritten_conn_passed_to_hook_task", aws_conn_id=OVERWRITTEN_CONN, dag=self.dag
+        )
         assert op.hook.aws_conn_id == OVERWRITTEN_CONN
 
     def test_no_conn_passed_to_hook(self):
         DEFAULT_CONN = "aws_default"
         op = RdsBaseOperator(task_id="test_no_conn_passed_to_hook_task", dag=self.dag)
         assert op.hook.aws_conn_id == DEFAULT_CONN
+
 
 class TestRdsCreateDbSnapshotOperator:
     @classmethod

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_rds.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_rds.py
@@ -173,7 +173,16 @@ class TestBaseRdsOperator:
     def test_hook_attribute(self):
         assert hasattr(self.op, "hook")
         assert self.op.hook.__class__.__name__ == "RdsHook"
+    
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = RdsBaseOperator(task_id="test_overwritten_conn_passed_to_hook_task", aws_conn_id=OVERWRITTEN_CONN, dag=self.dag)
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
 
+    def test_no_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = RdsBaseOperator(task_id="test_no_conn_passed_to_hook_task", dag=self.dag)
+        assert op.hook.aws_conn_id == DEFAULT_CONN
 
 class TestRdsCreateDbSnapshotOperator:
     @classmethod


### PR DESCRIPTION

---

Fixes #50766

I have adjusted the `RdsBaseOperator` class to explicitly pass the `aws_conn_id` to its superclass, such that if a custom conn_id is provided the super class does not fall back to the default and the base classes receive the correct conn_id.

Moreover I have adjusted the name of the default value of the aws_conn_id in RdsBaseOperator from `aws_conn_id ` to `aws_default ` , to be consistent with the  RdsBaseOperator and all other operators.
