### PR TITLE
fix: Persist EventsTimetable's description during serialization

### DIFF
--- a/airflow-core/src/airflow/timetables/events.py
+++ b/airflow-core/src/airflow/timetables/events.py
@@ -62,7 +62,8 @@ class EventsTimetable(Timetable):
         if description is None:
             if self.event_dates:
                 self.description = (
-                    f"{len(self.event_dates)} events between {self.event_dates[0]} and {self.event_dates[-1]}"
+                    f"{len(self.event_dates)} events between "
+                    f"{self.event_dates[0].isoformat(sep='T')} and {self.event_dates[-1].isoformat(sep='T')}"
                 )
             else:
                 self.description = "No events"
@@ -123,12 +124,17 @@ class EventsTimetable(Timetable):
         return {
             "event_dates": [x.isoformat(sep="T") for x in self.event_dates],
             "restrict_to_events": self.restrict_to_events,
+            "description": self.description,
+            "_summary": self._summary,
         }
 
     @classmethod
     def deserialize(cls, data) -> Timetable:
-        return cls(
-            [pendulum.DateTime.fromisoformat(x) for x in data["event_dates"]],
-            data["restrict_to_events"],
+        time_table = cls(
+            event_dates=[pendulum.DateTime.fromisoformat(x) for x in data["event_dates"]],
+            restrict_to_events=data["restrict_to_events"],
             presorted=True,
+            description=data["description"],
         )
+        time_table._summary = data["_summary"]
+        return time_table

--- a/airflow-core/tests/unit/timetables/test_events_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_events_timetable.py
@@ -190,4 +190,33 @@ def test_serialize(unrestricted_timetable: Timetable):
             "2021-10-09T00:00:00+00:00",
         ],
         "restrict_to_events": False,
+        "_summary": "6 events",
+        "description": "6 events between 2021-09-06T00:00:00+00:00 and 2021-10-09T00:00:00+00:00",
     }
+
+
+def test_timetable_after_serialization_is_the_same():
+    description = "Example description"
+    timetable = EventsTimetable(
+        event_dates=EVENT_DATES, restrict_to_events=True, description=description, presorted=True
+    )
+    assert timetable.summary == description
+    assert timetable.description == description
+    assert timetable.event_dates == EVENT_DATES
+
+    deserialized: EventsTimetable = timetable.deserialize(timetable.serialize())
+    assert deserialized.summary == description
+    assert deserialized.description == description
+    assert deserialized.event_dates == EVENT_DATES
+
+
+def test_timetable_without_description_after_serialization_is_the_same():
+    timetable = EventsTimetable(event_dates=EVENT_DATES, presorted=True)
+    summary = f"{timetable.summary}"
+    description = f"{timetable.description}"
+    assert timetable.event_dates == EVENT_DATES
+
+    deserialized: EventsTimetable = timetable.deserialize(timetable.serialize())
+    assert deserialized.summary == summary
+    assert deserialized.description == description
+    assert deserialized.event_dates == EVENT_DATES


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When using EventsTimetable, the schedule in Airflow UI is not shown correctly/. My guess is that the EventsTimetable description (and therefore summary) not being serialized is to blame. 

In Airflow 3 we are relying on [timetable.summary](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/dag.py#L736) when displaying schedule in the UI. Currently, even if user provide a description  Airflow UI will always display "X events" as timetable_summary, instead of description provided by the user.
![image](https://github.com/user-attachments/assets/4565f16d-08d5-446e-80cd-2fe3078f9d77)


In [Airflow 2 ](https://github.com/apache/airflow/blob/2.11.0/airflow/models/dag.py#L679) we kept the timetable summary as DAG attribute and serialize it separately, so it always showed up in UI correctly.
![image](https://github.com/user-attachments/assets/ef2d90f3-fb6a-447a-a56b-2b0d17fc4f60)

This is also causing discrepancies in OpenLineage events, for DagRun events emitted from scheduler (for Airflow 2 and 3), we are receiving "X events", and for task events emitted from worker, the user description.

Example DAG to test it:
```
import pendulum
from datetime import datetime

from airflow import DAG
from airflow.timetables.events import EventsTimetable
from airflow.providers.standard.operators.bash import BashOperator


DAG_ID = "timetable_dag"

with DAG(
    dag_id=DAG_ID,
    start_date=datetime(2021, 1, 1),
    schedule=EventsTimetable(
        description="Example description",
        event_dates=[pendulum.datetime(2095, 3, 1, tz="America/Chicago")]
    ),
    catchup=False,
) as dag:
    nothing_task = BashOperator(task_id="do_nothing_task", bash_command="sleep 1;")
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
