### PR TITLE
Fix OpenLineage macro _get_logical_date

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
@@ -127,7 +127,7 @@ def _get_logical_date(task_instance):
         context = task_instance.get_template_context()
         if hasattr(task_instance, "dag_run"):
             dag_run = task_instance.dag_run
-        elif hasattr(context, "dag_run"):
+        elif context.get("dag_run"):
             dag_run = context["dag_run"]
         if hasattr(dag_run, "logical_date") and dag_run.logical_date:
             date = dag_run.logical_date

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
@@ -127,7 +127,7 @@ def _get_logical_date(task_instance):
         context = task_instance.get_template_context()
         if hasattr(task_instance, "dag_run"):
             dag_run = task_instance.dag_run
-        elif context.get("dag_run"):
+        else:
             dag_run = context["dag_run"]
         if hasattr(dag_run, "logical_date") and dag_run.logical_date:
             date = dag_run.logical_date


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

With the current implementation I was getting the error:

```python
[2025-05-29,` 10:55:56] ERROR - Task failed with exception: source="task"
UnboundLocalError: cannot access local variable 'dag_run' where it is not associated with a value
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 838 in run

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1130 in _execute_task

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 408 in wrapper

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/bases/decorator.py", line 251 in execute

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 408 in wrapper

File "/usr/local/lib/python3.12/site-packages/airflow/providers/standard/operators/python.py", line 212 in execute

File "/usr/local/lib/python3.12/site-packages/airflow/providers/standard/operators/python.py", line 235 in execute_callable

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/callback_runner.py", line 81 in run

File "/tmp/airflow/dag_bundles/astro/main/dags/2025-05-27T19:59:28.0625152Z/dags/ml_ops/model_train.py", line 320 in train_and_evaluate_models

File "/usr/local/lib/python3.12/site-packages/astro_observe_sdk/metrics.py", line 32 in log_metric

File "/usr/local/lib/python3.12/site-packages/astro_observe_sdk/utils.py", line 39 in get_lineage_run_id

File "/usr/local/lib/python3.12/site-packages/airflow/providers/openlineage/plugins/macros.py", line 68 in lineage_run_id
``` 

Updated the openlineage macro _get_logical_date to set the dag_run if it is retrieved from context instead of task_instance. context is a typeddict, so `hasattr(context, 'dag_run')` will always return None. The correct way of accessing the dag_run key of the context variable is with `context.get('dag_run')`. I updated the control flow to be if-else because the context variable should always have the dag_run key. Please correct me if this is an incorrect assessment. 

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
