### PR TITLE
Minor fix in python client docs

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -599,7 +599,7 @@ You can also set it by env variable: `export AIRFLOW__CORE__LOAD_EXAMPLES=True`
 
 * optionally expose configuration (NOTE! that this is dangerous setting). The script will happily run with
   the default setting, but if you want to see the configuration, you need to expose it.
-  In the `[webserver]` section of your `airflow.cfg` set:
+  In the `[api]` section of your `airflow.cfg` set:
 
 ```ini
 [api]


### PR DESCRIPTION
`expose_config` is an option in `[api]` and not `[webserver]`
