### PR TITLE
Add worker_umask to celery provider.yaml

### DIFF
--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -327,6 +327,18 @@ config:
         type: string
         example: ~
         default: "{{}}"
+      worker_umask:
+        description: |
+          The default umask to use for celery worker when run in daemon mode
+
+          This controls the file-creation mode mask which determines the initial value of file permission bits
+          for newly created files.
+
+          This value is treated as an octal-integer.
+        version_added: ~
+        type: string
+        default: ~
+        example: ~
   celery_broker_transport_options:
     description: |
       This section is for specifying options which can be passed to the

--- a/providers/celery/src/airflow/providers/celery/get_provider_info.py
+++ b/providers/celery/src/airflow/providers/celery/get_provider_info.py
@@ -231,6 +231,13 @@ def get_provider_info():
                         "example": None,
                         "default": "{{}}",
                     },
+                    "worker_umask": {
+                        "description": "The default umask to use for celery worker when run in daemon mode\n\nThis controls the file-creation mode mask which determines the initial value of file permission bits\nfor newly created files.\n\nThis value is treated as an octal-integer.\n",
+                        "version_added": None,
+                        "type": "string",
+                        "default": None,
+                        "example": None,
+                    },
                 },
             },
             "celery_broker_transport_options": {


### PR DESCRIPTION
worker_umask is used in `providers/celery/src/airflow/providers/celery/cli/celery_command.py` and documented in the docs. However, it is missing entry in the provider.yaml. Adding it to the yaml
