### PR TITLE
i18n - Translate Task Instance and Dag Run tables

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
@@ -18,13 +18,14 @@
  */
 import { Box, Editable, Text, VStack } from "@chakra-ui/react";
 import type { ChangeEvent } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { DAGRunResponse, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
 import ReactMarkdown from "src/components/ReactMarkdown";
 import { Accordion } from "src/components/ui";
 
 import { DataTable } from "../DataTable";
-import { columns } from "./columns";
+import { getColumns } from "./columns";
 
 type Props = {
   readonly affectedTasks?: TaskInstanceCollectionResponse;
@@ -36,6 +37,7 @@ type Props = {
 // TODO: Make a front-end only unconnected table component with client side ordering and pagination
 const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
   const showTaskSection = affectedTasks !== undefined;
+  const { t: translate } = useTranslation();
 
   return (
     <Accordion.Root
@@ -47,15 +49,20 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
       {showTaskSection ? (
         <Accordion.Item key="tasks" value="tasks">
           <Accordion.ItemTrigger>
-            <Text fontWeight="bold">Affected Tasks: {affectedTasks.total_entries}</Text>
+            <Text fontWeight="bold">
+              {translate("dags:runAndTaskActions.clear.dialog.affectedTasks.title", {
+                count: affectedTasks.total_entries,
+              })}
+            </Text>
           </Accordion.ItemTrigger>
           <Accordion.ItemContent>
             <Box maxH="400px" overflowY="scroll">
               <DataTable
-                columns={columns}
+                columns={getColumns(translate)}
                 data={affectedTasks.task_instances}
                 displayMode="table"
-                modelName="Task Instance"
+                modelName={translate("common:taskInstance_other")}
+                noRowsMessage={translate("dags:runAndTaskActions.clear.dialog.affectedTasks.noItemsFound")}
                 total={affectedTasks.total_entries}
               />
             </Box>
@@ -64,7 +71,7 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
       ) : undefined}
       <Accordion.Item key="note" value="note">
         <Accordion.ItemTrigger>
-          <Text fontWeight="bold">Note</Text>
+          <Text fontWeight="bold">{translate("dags:runAndTaskActions.clear.dialog.note.title")}</Text>
         </Accordion.ItemTrigger>
         <Accordion.ItemContent>
           <Editable.Root
@@ -83,14 +90,16 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
               {Boolean(note) ? (
                 <ReactMarkdown>{note}</ReactMarkdown>
               ) : (
-                <Text color="fg.subtle">Add a note...</Text>
+                <Text color="fg.subtle">
+                  {translate("dags:runAndTaskActions.clear.dialog.note.placeholder")}
+                </Text>
               )}
             </Editable.Preview>
             <Editable.Textarea
               data-testid="notes-input"
               height="200px"
               overflowY="auto"
-              placeholder="Add a note..."
+              placeholder={translate("dags:runAndTaskActions.clear.dialog.note.placeholder")}
               resize="none"
             />
           </Editable.Root>

--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
@@ -16,50 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link } from "@chakra-ui/react";
-import type { ColumnDef } from "@tanstack/react-table";
-import { Link as RouterLink } from "react-router-dom";
+import type { TFunction } from "i18next";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import type { MetaColumn } from "src/components/DataTable/types";
 import { StateBadge } from "src/components/StateBadge";
-import { Tooltip } from "src/components/ui";
-import { getTaskInstanceLink } from "src/utils/links";
-import { trimText } from "src/utils/trimTextFn";
 
-export const columns: Array<ColumnDef<TaskInstanceResponse>> = [
+export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceResponse>> => [
   {
-    accessorKey: "task_display_name",
-    cell: ({ row: { original } }) => (
-      <Tooltip content={original.task_display_name}>
-        <Link asChild color="fg.info" fontWeight="bold" maxWidth="200px" overflow="hidden">
-          <RouterLink to={getTaskInstanceLink(original)}>
-            {trimText(original.task_display_name, 25).trimmedText}
-          </RouterLink>
-        </Link>
-      </Tooltip>
-    ),
-    enableSorting: false,
-    header: "Task ID",
+    accessorKey: "task_id",
+    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.taskId"),
+    size: 200,
   },
   {
     accessorKey: "state",
-    cell: ({
-      row: {
-        original: { state },
-      },
-    }) => <StateBadge state={state}>{state}</StateBadge>,
-    enableSorting: false,
-    header: () => "State",
-  },
-  {
-    accessorKey: "rendered_map_index",
-    enableSorting: false,
-    header: "Map Index",
-  },
+    cell: ({ getValue }) => {
+      const state = getValue<TaskInstanceResponse["state"]>();
 
+      return <StateBadge state={state} />;
+    },
+    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.state"),
+    size: 100,
+  },
   {
-    accessorKey: "dag_run_id",
-    enableSorting: false,
-    header: "Run Id",
+    accessorKey: "map_index",
+    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.mapIndex"),
+    size: 100,
+  },
+  {
+    accessorKey: "run_id",
+    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.runId"),
+    size: 200,
   },
 ];

--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
@@ -30,22 +30,19 @@ export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceR
   },
   {
     accessorKey: "state",
-    cell: ({ getValue }) => {
-      const state = getValue<TaskInstanceResponse["state"]>();
-
-      return <StateBadge state={state} />;
-    },
+    cell: ({
+      row: {
+        original: { state },
+      },
+    }) => <StateBadge state={state}>{translate(`common:states.${state}`)}</StateBadge>,
     header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.state"),
-    size: 100,
   },
   {
     accessorKey: "map_index",
     header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.mapIndex"),
-    size: 100,
   },
   {
     accessorKey: "run_id",
     header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.runId"),
-    size: 200,
   },
 ];

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -34,6 +35,7 @@ type Props = {
 
 const ClearRunButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
 
   useHotkeys(
     "shift+c",
@@ -44,13 +46,18 @@ const ClearRunButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Pr
   );
 
   return (
-    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!isHotkeyEnabled} openDelay={100}>
+    <Tooltip
+      closeDelay={100}
+      content={translate("dags:runAndTaskActions.clear.buttonTooltip")}
+      disabled={!isHotkeyEnabled}
+      openDelay={100}
+    >
       <Box>
         <ActionButton
-          actionName="Clear Dag Run"
+          actionName={translate("dags:runAndTaskActions.clear.button", { type: "Run" })}
           icon={<CgRedo />}
           onClick={onOpen}
-          text="Clear Run"
+          text={translate("dags:runAndTaskActions.clear.button", { type: "Run" })}
           withText={withText}
         />
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -18,6 +18,7 @@
  */
 import { Flex, Heading, VStack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -35,10 +36,19 @@ type Props = {
 };
 
 const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
-  const [selectedOptions, setSelectedOptions] = useState<Array<string>>([]);
-
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
+  const { t: translate } = useTranslation();
+
+  const [note, setNote] = useState<string | null>(dagRun.note);
+  const [selectedOptions, setSelectedOptions] = useState<Array<string>>(["existingTasks"]);
+  const onlyFailed = selectedOptions.includes("onlyFailed");
+
+  const { data: affectedTasks = { task_instances: [], total_entries: 0 } } = useClearDagRunDryRun({
+    dagId,
+    dagRunId,
+    requestBody: { only_failed: onlyFailed },
+  });
 
   const { isPending, mutate } = useClearDagRun({
     dagId,
@@ -46,27 +56,11 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     onSuccessConfirm: onClose,
   });
 
-  const onlyFailed = selectedOptions.includes("onlyFailed");
-
-  const [note, setNote] = useState<string | null>(dagRun.note);
-  const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } = usePatchDagRun({ dagId, dagRunId });
-
-  const { data } = useClearDagRunDryRun({
+  const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } = usePatchDagRun({
     dagId,
     dagRunId,
-    options: {
-      enabled: open,
-      refetchOnMount: "always",
-    },
-    requestBody: {
-      only_failed: onlyFailed,
-    },
+    onSuccess: onClose,
   });
-
-  const affectedTasks = data ?? {
-    task_instances: [],
-    total_entries: 0,
-  };
 
   return (
     <Dialog.Root lazyMount onOpenChange={onClose} open={open} size="xl">
@@ -74,7 +68,8 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
         <Dialog.Header>
           <VStack align="start" gap={4}>
             <Heading size="xl">
-              <strong>Clear DagRun: </strong> {dagRunId}
+              <strong>{translate("dags:runAndTaskActions.clear.dialog.title", { type: "Run" })}: </strong>{" "}
+              {dagRunId}
             </Heading>
           </VStack>
         </Dialog.Header>
@@ -87,11 +82,17 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
               defaultValues={["existingTasks"]}
               onChange={setSelectedOptions}
               options={[
-                { label: "Clear existing tasks", value: "existingTasks" },
-                { label: "Clear only failed tasks", value: "onlyFailed" },
+                {
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.existingTasks"),
+                  value: "existingTasks",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.onlyFailed"),
+                  value: "onlyFailed",
+                },
                 {
                   disabled: true,
-                  label: "Queue up new tasks",
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.queueNew"),
                   value: "new_tasks",
                 },
               ]}
@@ -118,7 +119,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
                 }
               }}
             >
-              <CgRedo /> Confirm
+              <CgRedo /> {translate("dags:runAndTaskActions.clear.dialog.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
@@ -34,6 +35,7 @@ type Props = {
 
 const ClearTaskInstanceButton = ({ isHotkeyEnabled = false, taskInstance, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
 
   useHotkeys(
     "shift+c",
@@ -44,13 +46,18 @@ const ClearTaskInstanceButton = ({ isHotkeyEnabled = false, taskInstance, withTe
   );
 
   return (
-    <Tooltip closeDelay={100} content="Press shift+c to clear" disabled={!isHotkeyEnabled} openDelay={100}>
+    <Tooltip
+      closeDelay={100}
+      content={translate("dags:runAndTaskActions.clear.buttonTooltip")}
+      disabled={!isHotkeyEnabled}
+      openDelay={100}
+    >
       <Box>
         <ActionButton
-          actionName="Clear Task Instance"
+          actionName={translate("dags:runAndTaskActions.clear.button", { type: "Task Instance" })}
           icon={<CgRedo />}
           onClick={onOpen}
-          text="Clear Task Instance"
+          text={translate("dags:runAndTaskActions.clear.button", { type: "Task Instance" })}
           withText={withText}
         />
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -18,6 +18,7 @@
  */
 import { Flex, Heading, VStack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
@@ -38,6 +39,7 @@ type Props = {
 const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
   const taskId = taskInstance.task_id;
   const mapIndex = taskInstance.map_index;
+  const { t: translate } = useTranslation();
 
   const dagId = taskInstance.dag_id;
   const dagRunId = taskInstance.dag_run_id;
@@ -92,8 +94,10 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
         <Dialog.Header>
           <VStack align="start" gap={4}>
             <Heading size="xl">
-              <strong>Clear Task Instance:</strong> {taskInstance.task_display_name}{" "}
-              <Time datetime={taskInstance.start_date} />
+              <strong>
+                {translate("dags:runAndTaskActions.clear.dialog.title", { type: "Task Instance" })}:
+              </strong>{" "}
+              {taskInstance.task_display_name} <Time datetime={taskInstance.start_date} />
             </Heading>
           </VStack>
         </Dialog.Header>
@@ -106,11 +110,28 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
               multiple
               onChange={setSelectedOptions}
               options={[
-                { disabled: taskInstance.logical_date === null, label: "Past", value: "past" },
-                { disabled: taskInstance.logical_date === null, label: "Future", value: "future" },
-                { label: "Upstream", value: "upstream" },
-                { label: "Downstream", value: "downstream" },
-                { label: "Only Failed", value: "onlyFailed" },
+                {
+                  disabled: taskInstance.logical_date === null,
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.past"),
+                  value: "past",
+                },
+                {
+                  disabled: taskInstance.logical_date === null,
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.future"),
+                  value: "future",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.upstream"),
+                  value: "upstream",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.downstream"),
+                  value: "downstream",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.clear.dialog.options.onlyFailed"),
+                  value: "onlyFailed",
+                },
               ]}
             />
           </Flex>
@@ -145,7 +166,7 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
                 }
               }}
             >
-              <CgRedo /> Confirm
+              <CgRedo /> {translate("dags:runAndTaskActions.clear.dialog.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/DagActions/DeleteDagButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/DeleteDagButton.tsx
@@ -46,11 +46,11 @@ const DeleteDagButton = ({ dagDisplayName, dagId, withText = true }: DeleteDagBu
   return (
     <>
       <ActionButton
-        actionName={translate("actions.delete")}
+        actionName={translate("dagActions.delete.button")}
         colorPalette="red"
         icon={<FiTrash2 />}
         onClick={onOpen}
-        text={translate("actions.delete")}
+        text={translate("dagActions.delete.button")}
         variant="solid"
         withText={withText}
       />
@@ -61,8 +61,8 @@ const DeleteDagButton = ({ dagDisplayName, dagId, withText = true }: DeleteDagBu
         onDelete={() => deleteDag({ dagId })}
         open={open}
         resourceName={dagDisplayName}
-        title={translate("actions.delete")}
-        warningText={translate("actions.deleteDagWarning")}
+        title={translate("dagActions.delete.button")}
+        warningText={translate("dagActions.delete.warning")}
       />
     </>
   );

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -19,6 +19,7 @@
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useTranslation } from "react-i18next";
 import { MdArrowDropDown } from "react-icons/md";
 
 import type { DAGRunPatchStates, DAGRunResponse } from "openapi/requests/types.gen";
@@ -38,6 +39,7 @@ type Props = {
 const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
   const [state, setState] = useState<DAGRunPatchStates>("success");
+  const { t: translate } = useTranslation();
 
   useHotkeys(
     "shift+f",
@@ -62,19 +64,18 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: P
       <Menu.Root positioning={{ gutter: 0, placement: "bottom" }}>
         <Menu.Trigger asChild>
           <ActionButton
-            actionName="Mark Dag Run as..."
+            actionName={translate("dags:runAndTaskActions.markAs.button", { type: "Run" })}
             flexDirection="row-reverse"
             icon={<MdArrowDropDown />}
-            text="Mark Run as..."
+            text={translate("dags:runAndTaskActions.markAs.button", { type: "Run" })}
             withText={withText}
           />
         </Menu.Trigger>
         <Menu.Content>
           {allowedStates.map((menuState) => {
-            const content =
-              menuState === "success"
-                ? "Press shift+s to mark as success"
-                : "Press shift+f to mark as failed";
+            const content = translate(
+              `dags:runAndTaskActions.markAs.buttonTooltip.${menuState === "success" ? "success" : "failed"}`,
+            );
 
             return (
               <Tooltip
@@ -97,7 +98,7 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: P
                   value={menuState}
                 >
                   <StateBadge my={1} state={menuState}>
-                    {menuState}
+                    {translate(`common:states.${menuState}`)}
                   </StateBadge>
                 </Menu.Item>
               </Tooltip>

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
@@ -18,6 +18,7 @@
  */
 import { Flex, Heading, VStack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { DAGRunPatchStates, DAGRunResponse } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
@@ -35,6 +36,7 @@ type Props = {
 const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
+  const { t: translate } = useTranslation();
 
   const [note, setNote] = useState<string | null>(dagRun.note);
   const { isPending, mutate } = usePatchDagRun({ dagId, dagRunId, onSuccess: onClose });
@@ -45,7 +47,8 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
         <Dialog.Header>
           <VStack align="start" gap={4}>
             <Heading size="xl">
-              <strong>Mark DagRun as {state}:</strong> {dagRunId} <StateBadge state={state} />
+              {translate("dags:runAndTaskActions.markAs.dialog.title", { state, type: "Run" })}: {dagRunId}{" "}
+              <StateBadge state={state} />
             </Heading>
           </VStack>
         </Dialog.Header>
@@ -66,7 +69,7 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
                 });
               }}
             >
-              Confirm
+              {translate("dags:runAndTaskActions.markAs.dialog.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -19,6 +19,7 @@
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useTranslation } from "react-i18next";
 import { MdArrowDropDown } from "react-icons/md";
 
 import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
@@ -37,6 +38,7 @@ type Props = {
 
 const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
 
   const [state, setState] = useState<TaskInstanceState>("success");
 
@@ -63,19 +65,18 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance, withT
       <Menu.Root positioning={{ gutter: 0, placement: "bottom" }}>
         <Menu.Trigger asChild>
           <ActionButton
-            actionName="Mark Task Instance as..."
+            actionName={translate("dags:runAndTaskActions.markAs.button", { type: "Task Instance" })}
             flexDirection="row-reverse"
             icon={<MdArrowDropDown />}
-            text="Mark Task Instance as..."
+            text={translate("dags:runAndTaskActions.markAs.button", { type: "Task Instance" })}
             withText={withText}
           />
         </Menu.Trigger>
         <Menu.Content>
           {allowedStates.map((menuState) => {
-            const content =
-              menuState === "success"
-                ? "Press shift+s to mark as success"
-                : "Press shift+f to mark as failed";
+            const content = translate(
+              `dags:runAndTaskActions.markAs.buttonTooltip.${menuState === "success" ? "success" : "failed"}`,
+            );
 
             return (
               <Tooltip
@@ -98,7 +99,7 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance, withT
                   value={menuState}
                 >
                   <StateBadge my={1} state={menuState}>
-                    {menuState}
+                    {translate(`common:states.${menuState}`)}
                   </StateBadge>
                 </Menu.Item>
               </Tooltip>

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -18,6 +18,7 @@
  */
 import { Flex, Heading, VStack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
@@ -40,6 +41,7 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
   const dagRunId = taskInstance.dag_run_id;
   const taskId = taskInstance.task_id;
   const mapIndex = taskInstance.map_index;
+  const { t: translate } = useTranslation();
 
   const [selectedOptions, setSelectedOptions] = useState<Array<string>>([]);
 
@@ -87,8 +89,11 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
         <Dialog.Header>
           <VStack align="start" gap={4}>
             <Heading size="xl">
-              <strong>Mark Task Instance as {state}:</strong> {taskInstance.task_display_name}{" "}
-              <Time datetime={taskInstance.start_date} /> <StateBadge state={state} />
+              <strong>
+                {translate("dags:runAndTaskActions.markAs.dialog.title", { state, type: "Task Instance" })}:
+              </strong>{" "}
+              {taskInstance.task_display_name} <Time datetime={taskInstance.start_date} />{" "}
+              <StateBadge state={state} />
             </Heading>
           </VStack>
         </Dialog.Header>
@@ -101,10 +106,24 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
               multiple
               onChange={setSelectedOptions}
               options={[
-                { disabled: taskInstance.logical_date === null, label: "Past", value: "past" },
-                { disabled: taskInstance.logical_date === null, label: "Future", value: "future" },
-                { label: "Upstream", value: "upstream" },
-                { label: "Downstream", value: "downstream" },
+                {
+                  disabled: taskInstance.logical_date === null,
+                  label: translate("dags:runAndTaskActions.markAs.dialog.options.past"),
+                  value: "past",
+                },
+                {
+                  disabled: taskInstance.logical_date === null,
+                  label: translate("dags:runAndTaskActions.markAs.dialog.options.future"),
+                  value: "future",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.markAs.dialog.options.upstream"),
+                  value: "upstream",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.markAs.dialog.options.downstream"),
+                  value: "downstream",
+                },
               ]}
             />
           </Flex>
@@ -130,7 +149,7 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
                 });
               }}
             >
-              Confirm
+              {translate("dags:runAndTaskActions.markAs.dialog.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -31,7 +31,7 @@ describe("Test SearchBar", () => {
 
     const input = screen.getByTestId("search-dags");
 
-    expect(screen.getByText("advancedSearch")).toBeDefined();
+    expect(screen.getByText("list.advancedSearch")).toBeDefined();
     expect(screen.queryByTestId("clear-search")).toBeNull();
 
     fireEvent.change(input, { target: { value: "search" } });

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -74,7 +74,7 @@ export const SearchBar = ({
         <>
           {Boolean(value) ? (
             <CloseButton
-              aria-label={translate("clearSearch")}
+              aria-label={translate("list.clearSearch")}
               colorPalette="gray"
               data-testid="clear-search"
               onClick={() => {
@@ -86,7 +86,7 @@ export const SearchBar = ({
           ) : undefined}
           {Boolean(hideAdvanced) ? undefined : (
             <Button fontWeight="normal" height="1.75rem" variant="ghost" width={140} {...buttonProps}>
-              {translate("advancedSearch")}
+              {translate("list.advancedSearch")}
             </Button>
           )}
           {!hotkeyDisabled && <Kbd size="sm">{metaKey}+K</Kbd>}

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
@@ -38,11 +38,11 @@ const TriggerDAGButton: React.FC<Props> = ({ dag, withText = true }) => {
   return (
     <Box>
       <ActionButton
-        actionName={translate("actions.triggerDag")}
+        actionName={translate("dagActions.trigger.triggerDag")}
         colorPalette="blue"
         icon={<FiPlay />}
         onClick={onOpen}
-        text={translate("actions.trigger")}
+        text={translate("dagActions.trigger.button")}
         variant="solid"
         withText={withText}
       />

--- a/airflow-core/src/airflow/ui/src/constants/stateOptions.ts
+++ b/airflow-core/src/airflow/ui/src/constants/stateOptions.ts
@@ -25,39 +25,39 @@ export const taskInstanceStateOptions = createListCollection<{
   value: TaskInstanceState | "all" | "none";
 }>({
   items: [
-    { label: "All States", value: "all" },
-    { label: "Scheduled", value: "scheduled" },
-    { label: "Queued", value: "queued" },
-    { label: "Running", value: "running" },
-    { label: "Success", value: "success" },
-    { label: "Restarting", value: "restarting" },
-    { label: "Failed", value: "failed" },
-    { label: "Up For Retry", value: "up_for_retry" },
-    { label: "Up For Reschedule", value: "up_for_reschedule" },
-    { label: "Upstream failed", value: "upstream_failed" },
-    { label: "Skipped", value: "skipped" },
-    { label: "Deferred", value: "deferred" },
-    { label: "Removed", value: "removed" },
-    { label: "No Status", value: "none" },
+    { label: "dags:taskInstances.allStates", value: "all" },
+    { label: "common:states.scheduled", value: "scheduled" },
+    { label: "common:states.queued", value: "queued" },
+    { label: "common:states.running", value: "running" },
+    { label: "common:states.success", value: "success" },
+    { label: "common:states.restarting", value: "restarting" },
+    { label: "common:states.failed", value: "failed" },
+    { label: "common:states.up_for_retry", value: "up_for_retry" },
+    { label: "common:states.up_for_reschedule", value: "up_for_reschedule" },
+    { label: "common:states.upstream_failed", value: "upstream_failed" },
+    { label: "common:states.skipped", value: "skipped" },
+    { label: "common:states.deferred", value: "deferred" },
+    { label: "common:states.removed", value: "removed" },
+    { label: "common:states.none", value: "none" },
   ],
 });
 
 export const dagRunStateOptions = createListCollection({
   items: [
-    { label: "All States", value: "all" },
-    { label: "Queued", value: "queued" },
-    { label: "Running", value: "running" },
-    { label: "Failed", value: "failed" },
-    { label: "Success", value: "success" },
+    { label: "dags:runs.allStates", value: "all" },
+    { label: "common:states.queued", value: "queued" },
+    { label: "common:states.running", value: "running" },
+    { label: "common:states.failed", value: "failed" },
+    { label: "common:states.success", value: "success" },
   ],
 });
 
 export const dagRunTypeOptions = createListCollection({
   items: [
-    { label: "All Run Types", value: "all" },
-    { label: "Backfill", value: "backfill" },
-    { label: "Manual", value: "manual" },
-    { label: "Scheduled", value: "scheduled" },
-    { label: "Asset Triggered", value: "asset_triggered" },
+    { label: "dags:runs.allRunTypes", value: "all" },
+    { label: "common:runTypes.backfill", value: "backfill" },
+    { label: "common:runTypes.manual", value: "manual" },
+    { label: "common:runTypes.scheduled", value: "scheduled" },
+    { label: "common:runTypes.asset_triggered", value: "asset_triggered" },
   ],
 });

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -53,6 +53,12 @@
     "running": "Running",
     "scheduled": "Scheduled"
   },
+  "runTypes": {
+    "asset_triggered": "Asset Triggered",
+    "backfill": "Backfill",
+    "manual": "Manual",
+    "scheduled": "Scheduled"
+  },
   "security": {
     "actions": "Actions",
     "permissions": "Permissions",
@@ -65,6 +71,7 @@
     "deferred": "Deferred",
     "failed": "Failed",
     "no_status": "No Status",
+    "none": "No Status",
     "queued": "Queued",
     "removed": "Removed",
     "restarting": "Restarting",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
@@ -69,6 +69,7 @@
         "title": "Delete {{type}}",
         "warning": "This will remove all metadata related to the {{type}}."
       },
+      "error": "Error deleting {{type}}",
       "success": {
         "description": "The {{type}} deletion request was successful.",
         "title": "{{type}} Deleted Successfully"

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
@@ -1,11 +1,15 @@
 {
-  "actions": {
-    "delete": "Delete Dag",
-    "deleteDagWarning": "This will remove all metadata related to the DAG, including DAG Runs and Tasks.",
-    "trigger": "Trigger",
-    "triggerDag": "Trigger Dag"
-  },
   "assetSchedule": "{{count}} of {{total}} assets updated",
+  "dagActions": {
+    "delete": {
+      "button": "Delete Dag",
+      "warning": "This will remove all metadata related to the Dag, including Runs and Tasks."
+    },
+    "trigger": {
+      "button": "Trigger",
+      "triggerDag": "Trigger Dag"
+    }
+  },
   "filters": {
     "paused": {
       "active": "Active",
@@ -24,14 +28,83 @@
       "tags": "Tags"
     },
     "ownerLink": "Owner link for {{owner}}",
-    "runs": {
+    "searchPlaceholder": "Search Dags"
+  },
+  "runAndTaskActions": {
+    "clear": {
+      "button": "Clear {{type}}",
+      "buttonTooltip": "Press shift+c to clear",
+      "dialog": {
+        "affectedTasks": {
+          "columns": {
+            "mapIndex": "Map Index",
+            "runId": "Run ID",
+            "state": "State",
+            "taskId": "Task ID"
+          },
+          "noItemsFound": "No tasks found.",
+          "title": "Affected Tasks: {{count}}"
+        },
+        "confirm": "Confirm",
+        "note": {
+          "placeholder": "Add a note...",
+          "title": "Note"
+        },
+        "options": {
+          "downstream": "Downstream",
+          "existingTasks": "Clear existing tasks",
+          "future": "Future",
+          "onlyFailed": "Clear only failed tasks",
+          "past": "Past",
+          "queueNew": "Queue up new tasks",
+          "upstream": "Upstream"
+        },
+        "title": "Clear {{type}}"
+      }
+    },
+    "delete": {
+      "button": "Delete {{type}}",
+      "dialog": {
+        "resourceName": "{{type}} {{id}}",
+        "title": "Delete {{type}}",
+        "warning": "This will remove all metadata related to the {{type}}."
+      },
+      "success": {
+        "description": "The {{type}} deletion request was successful.",
+        "title": "{{type}} Deleted Successfully"
+      }
+    },
+    "markAs": {
+      "button": "Mark {{type}} as...",
+      "buttonTooltip": {
+        "failed": "Press shift+f to mark as failed",
+        "success": "Press shift+s to mark as success"
+      },
+      "dialog": {
+        "confirm": "Confirm",
+        "options": {
+          "downstream": "Downstream",
+          "future": "Future",
+          "past": "Past",
+          "upstream": "Upstream"
+        },
+        "title": "Mark {{type}} as {{state}}"
+      }
+    }
+  },
+  "runs": {
+    "allRunTypes": "All Run Types",
+    "allStates": "All States",
+    "columns": {
+      "dagId": "Dag ID",
+      "dagVersions": "Dag Versions",
       "duration": "Duration",
       "endDate": "End Date",
       "runAfter": "Run After",
+      "runType": "Run Type",
       "startDate": "Start Date",
       "state": "State"
-    },
-    "searchPlaceholder": "Search Dags"
+    }
   },
   "sort": {
     "displayName": {
@@ -51,5 +124,23 @@
       "desc": "Sort by Next Dag Run (Latest-Earliest)"
     },
     "placeholder": "Sort by"
+  },
+  "taskInstances": {
+    "allStates": "All States",
+    "columns": {
+      "dagId": "Dag ID",
+      "dagRun": "Dag Run",
+      "dagVersion": "Dag Version",
+      "duration": "Duration",
+      "endDate": "End Date",
+      "mapIndex": "Map Index",
+      "operator": "Operator",
+      "pool": "Pool",
+      "startDate": "Start Date",
+      "state": "State",
+      "taskId": "Task ID",
+      "tryNumber": "Try Number"
+    },
+    "searchPlaceholder": "Search Tasks"
   }
 }

--- a/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useDisclosure } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { FiTrash2 } from "react-icons/fi";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -31,6 +32,7 @@ type DeleteRunButtonProps = {
 
 const DeleteRunButton = ({ dagRun, withText = true }: DeleteRunButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
 
   const { isPending, mutate: deleteDagRun } = useDeleteDagRun({
     dagId: dagRun.dag_id,
@@ -43,11 +45,11 @@ const DeleteRunButton = ({ dagRun, withText = true }: DeleteRunButtonProps) => {
   return (
     <>
       <ActionButton
-        actionName="Delete DAG Run"
+        actionName={translate("dags:runAndTaskActions.delete.button", { type: "Run" })}
         colorPalette="red"
         icon={<FiTrash2 />}
         onClick={onOpen}
-        text="Delete DAG Run"
+        text={translate("dags:runAndTaskActions.delete.button", { type: "Run" })}
         variant="solid"
         withText={withText}
       />
@@ -62,9 +64,12 @@ const DeleteRunButton = ({ dagRun, withText = true }: DeleteRunButtonProps) => {
           });
         }}
         open={open}
-        resourceName={`DAG Run ${dagRun.dag_run_id}`}
-        title="Delete DAG Run"
-        warningText="This will remove all metadata related to the DAG Run."
+        resourceName={translate("dags:runAndTaskActions.delete.dialog.resourceName", {
+          id: dagRun.dag_run_id,
+          type: "Run",
+        })}
+        title={translate("dags:runAndTaskActions.delete.dialog.title", { type: "Run" })}
+        warningText={translate("dags:runAndTaskActions.delete.dialog.warning", { type: "Run" })}
       />
     </>
   );

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/DeleteTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/DeleteTaskInstanceButton.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useDisclosure } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { FiTrash2 } from "react-icons/fi";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
@@ -31,6 +32,7 @@ type DeleteTaskInstanceButtonProps = {
 
 const DeleteTaskInstanceButton = ({ taskInstance, withText = true }: DeleteTaskInstanceButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
 
   const { isPending, mutate: deleteTaskInstance } = useDeleteTaskInstance({
     dagId: taskInstance.dag_id,
@@ -45,11 +47,11 @@ const DeleteTaskInstanceButton = ({ taskInstance, withText = true }: DeleteTaskI
   return (
     <>
       <ActionButton
-        actionName="Delete Task Instance"
+        actionName={translate("dags:runAndTaskActions.delete.button", { type: "Task Instance" })}
         colorPalette="red"
         icon={<FiTrash2 />}
         onClick={onOpen}
-        text="Delete Task Instance"
+        text={translate("dags:runAndTaskActions.delete.button", { type: "Task Instance" })}
         variant="solid"
         withText={withText}
       />
@@ -66,9 +68,12 @@ const DeleteTaskInstanceButton = ({ taskInstance, withText = true }: DeleteTaskI
           });
         }}
         open={open}
-        resourceName={taskInstance.task_id}
-        title="Delete Task Instance"
-        warningText="This will remove all metadata related to the Task Instance."
+        resourceName={translate("dags:runAndTaskActions.delete.dialog.resourceName", {
+          id: taskInstance.task_id,
+          type: "Task Instance",
+        })}
+        title={translate("dags:runAndTaskActions.delete.dialog.title", { type: "Task Instance" })}
+        warningText={translate("dags:runAndTaskActions.delete.dialog.warning", { type: "Task Instance" })}
       />
     </>
   );

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -18,7 +18,9 @@
  */
 import { Flex, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
+import type { TFunction } from "i18next";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
@@ -49,18 +51,24 @@ const {
   STATE: STATE_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
-const taskInstanceColumns = (
-  dagId?: string,
-  runId?: string,
-  taskId?: string,
-): Array<ColumnDef<TaskInstanceResponse>> => [
+const taskInstanceColumns = ({
+  dagId,
+  runId,
+  taskId,
+  translate,
+}: {
+  dagId?: string;
+  runId?: string;
+  taskId?: string;
+  translate: TFunction;
+}): Array<ColumnDef<TaskInstanceResponse>> => [
   ...(Boolean(dagId)
     ? []
     : [
         {
           accessorKey: "dag_display_name",
           enableSorting: false,
-          header: "Dag ID",
+          header: translate("dags:taskInstances.columns.dagId"),
         },
       ]),
   ...(Boolean(runId)
@@ -79,7 +87,7 @@ const taskInstanceColumns = (
             ) : (
               <Time datetime={original.run_after} />
             ),
-          header: "Dag Run",
+          header: translate("dags:taskInstances.columns.dagRun"),
         },
       ]),
   ...(Boolean(taskId)
@@ -95,12 +103,12 @@ const taskInstanceColumns = (
             </Link>
           ),
           enableSorting: false,
-          header: "Task ID",
+          header: translate("dags:taskInstances.columns.taskId"),
         },
       ]),
   {
     accessorKey: "rendered_map_index",
-    header: "Map Index",
+    header: translate("dags:taskInstances.columns.mapIndex"),
   },
   {
     accessorKey: "state",
@@ -108,8 +116,8 @@ const taskInstanceColumns = (
       row: {
         original: { state },
       },
-    }) => <StateBadge state={state}>{state}</StateBadge>,
-    header: () => "State",
+    }) => <StateBadge state={state}>{translate(`common:states.${state}`)}</StateBadge>,
+    header: () => translate("dags:taskInstances.columns.state"),
   },
   {
     accessorKey: "start_date",
@@ -123,38 +131,38 @@ const taskInstanceColumns = (
       ) : (
         <Time datetime={original.start_date} />
       ),
-    header: "Start Date",
+    header: translate("dags:taskInstances.columns.startDate"),
   },
   {
     accessorKey: "end_date",
     cell: ({ row: { original } }) => <Time datetime={original.end_date} />,
-    header: "End Date",
+    header: translate("dags:taskInstances.columns.endDate"),
   },
   {
     accessorKey: "try_number",
     enableSorting: false,
-    header: "Try Number",
+    header: translate("dags:taskInstances.columns.tryNumber"),
   },
   {
     accessorKey: "pool",
     enableSorting: false,
-    header: "Pool",
+    header: translate("dags:taskInstances.columns.pool"),
   },
   {
     accessorKey: "operator",
     enableSorting: false,
-    header: "Operator",
+    header: translate("dags:taskInstances.columns.operator"),
   },
   {
     cell: ({ row: { original } }) =>
       Boolean(original.start_date) ? getDuration(original.start_date, original.end_date) : "",
-    header: "Duration",
+    header: translate("dags:taskInstances.columns.duration"),
   },
   {
     accessorKey: "dag_version",
     cell: ({ row: { original } }) => <DagVersion version={original.dag_version} />,
     enableSorting: false,
-    header: "Dag Version",
+    header: translate("dags:taskInstances.columns.dagVersion"),
   },
   {
     accessorKey: "actions",
@@ -174,6 +182,7 @@ const taskInstanceColumns = (
 ];
 
 export const TaskInstances = () => {
+  const { t: translate } = useTranslation();
   const { dagId, groupId, runId, taskId } = useParams();
   const [searchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
@@ -223,12 +232,17 @@ export const TaskInstances = () => {
         taskDisplayNamePattern={taskDisplayNamePattern}
       />
       <DataTable
-        columns={taskInstanceColumns(dagId, runId, Boolean(groupId) ? undefined : taskId)}
+        columns={taskInstanceColumns({
+          dagId,
+          runId,
+          taskId: Boolean(groupId) ? undefined : taskId,
+          translate,
+        })}
         data={data?.task_instances ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
         isLoading={isLoading}
-        modelName="Task Instance"
+        modelName={translate("common:taskInstance_other")}
         onStateChange={setTableURLState}
         total={data?.total_entries}
       />

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
@@ -18,6 +18,7 @@
  */
 import { HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
 import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { useSearchParams, useParams } from "react-router-dom";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
@@ -26,8 +27,7 @@ import { SearchBar } from "src/components/SearchBar";
 import { StateBadge } from "src/components/StateBadge";
 import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { taskInstanceStateOptions as stateOptions } from "src/constants/stateOptions";
-import { capitalize } from "src/utils";
+import { taskInstanceStateOptions } from "src/constants/stateOptions";
 
 const { NAME_PATTERN: NAME_PATTERN_PARAM, STATE: STATE_PARAM }: SearchParamsKeysType = SearchParamsKeys;
 
@@ -42,6 +42,7 @@ export const TaskInstancesFilter = ({
   const [searchParams, setSearchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
+  const { t: translate } = useTranslation();
 
   const filteredState = searchParams.getAll(STATE_PARAM);
   const hasFilteredState = filteredState.length > 0;
@@ -87,10 +88,10 @@ export const TaskInstancesFilter = ({
         hideAdvanced
         hotkeyDisabled={Boolean(runId)}
         onChange={handleSearchChange}
-        placeHolder="Search Tasks"
+        placeHolder={translate("dags:taskInstances.searchPlaceholder")}
       />
       <Select.Root
-        collection={stateOptions}
+        collection={taskInstanceStateOptions}
         maxW="450px"
         multiple
         onValueChange={handleStateChange}
@@ -107,23 +108,23 @@ export const TaskInstancesFilter = ({
                 <HStack flexWrap="wrap" fontSize="sm" gap="4px" paddingY="8px">
                   {filteredState.map((state) => (
                     <StateBadge key={state} state={state as TaskInstanceState}>
-                      {state === "none" ? "No Status" : capitalize(state)}
+                      {translate(`common:states.${state}`)}
                     </StateBadge>
                   ))}
                 </HStack>
               ) : (
-                "All States"
+                translate("dags:taskInstances.allStates")
               )
             }
           </Select.ValueText>
         </Select.Trigger>
         <Select.Content>
-          {stateOptions.items.map((option) => (
+          {taskInstanceStateOptions.items.map((option) => (
             <Select.Item item={option} key={option.label}>
               {option.value === "all" ? (
-                option.label
+                translate(option.label)
               ) : (
-                <StateBadge state={option.value as TaskInstanceState}>{option.label}</StateBadge>
+                <StateBadge state={option.value as TaskInstanceState}>{translate(option.label)}</StateBadge>
               )}
             </Select.Item>
           ))}

--- a/airflow-core/src/airflow/ui/src/queries/useDeleteDagRun.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDeleteDagRun.ts
@@ -33,17 +33,17 @@ type DeleteDagRunParams = {
   onSuccessConfirm: () => void;
 };
 
-const onError = (error: Error) => {
-  toaster.create({
-    description: error.message,
-    title: "Error deleting DAG Run",
-    type: "error",
-  });
-};
-
 export const useDeleteDagRun = ({ dagId, dagRunId, onSuccessConfirm }: DeleteDagRunParams) => {
-  const queryClient = useQueryClient();
   const { t: translate } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const onError = (error: Error) => {
+    toaster.create({
+      description: error.message,
+      title: translate("dags:runAndTaskActions.delete.error", { type: "Run" }),
+      type: "error",
+    });
+  };
 
   const onSuccess = async () => {
     const queryKeys = [

--- a/airflow-core/src/airflow/ui/src/queries/useDeleteDagRun.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDeleteDagRun.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 
 import {
   useDagRunServiceDeleteDagRun,
@@ -32,16 +33,17 @@ type DeleteDagRunParams = {
   onSuccessConfirm: () => void;
 };
 
-const onError = () => {
+const onError = (error: Error) => {
   toaster.create({
-    description: "Delete DAG Run request failed.",
-    title: "Failed to delete DAG Run",
+    description: error.message,
+    title: "Error deleting DAG Run",
     type: "error",
   });
 };
 
 export const useDeleteDagRun = ({ dagId, dagRunId, onSuccessConfirm }: DeleteDagRunParams) => {
   const queryClient = useQueryClient();
+  const { t: translate } = useTranslation();
 
   const onSuccess = async () => {
     const queryKeys = [
@@ -53,8 +55,8 @@ export const useDeleteDagRun = ({ dagId, dagRunId, onSuccessConfirm }: DeleteDag
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
     toaster.create({
-      description: "The DAG Run deletion request was successful.",
-      title: "DAG Run Deleted Successfully",
+      description: translate("dags:runAndTaskActions.delete.success.description", { type: "Run" }),
+      title: translate("dags:runAndTaskActions.delete.success.title", { type: "Run" }),
       type: "success",
     });
 

--- a/airflow-core/src/airflow/ui/src/queries/useDeleteTaskInstance.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDeleteTaskInstance.ts
@@ -47,10 +47,10 @@ export const useDeleteTaskInstance = ({
   const queryClient = useQueryClient();
   const { t: translate } = useTranslation();
 
-  const onError = () => {
+  const onError = (error: Error) => {
     toaster.create({
-      description: translate("dags:runAndTaskActions.delete.success.description", { type: "Task Instance" }),
-      title: translate("dags:runAndTaskActions.delete.success.title", { type: "Task Instance" }),
+      description: error.message,
+      title: translate("dags:runAndTaskActions.delete.error", { type: "Task Instance" }),
       type: "error",
     });
   };

--- a/airflow-core/src/airflow/ui/src/queries/useDeleteTaskInstance.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDeleteTaskInstance.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 
 import {
   useTaskInstanceServiceDeleteTaskInstance,
@@ -36,14 +37,6 @@ type DeleteTaskInstanceParams = {
   taskId: string;
 };
 
-const onError = () => {
-  toaster.create({
-    description: "Delete Task Instance request failed.",
-    title: "Failed to delete Task Instance",
-    type: "error",
-  });
-};
-
 export const useDeleteTaskInstance = ({
   dagId,
   dagRunId,
@@ -52,6 +45,15 @@ export const useDeleteTaskInstance = ({
   taskId,
 }: DeleteTaskInstanceParams) => {
   const queryClient = useQueryClient();
+  const { t: translate } = useTranslation();
+
+  const onError = () => {
+    toaster.create({
+      description: translate("dags:runAndTaskActions.delete.success.description", { type: "Task Instance" }),
+      title: translate("dags:runAndTaskActions.delete.success.title", { type: "Task Instance" }),
+      type: "error",
+    });
+  };
 
   const onSuccess = async () => {
     const queryKeys = [
@@ -65,8 +67,8 @@ export const useDeleteTaskInstance = ({
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
     toaster.create({
-      description: "The Task Instance deletion request was successful.",
-      title: "Task Instance Deleted Successfully",
+      description: translate("dags:runAndTaskActions.delete.success.description", { type: "Task Instance" }),
+      title: translate("dags:runAndTaskActions.delete.success.title", { type: "Task Instance" }),
       type: "success",
     });
 


### PR DESCRIPTION
Continued work on https://github.com/apache/airflow/issues/50861

Replace all the plain text that shows up in Dag Runs and Task Instance tables including the modals for each type of action.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
