### PR TITLE
Allow Asset decorator to work with any TaskFlow operator

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -230,7 +230,7 @@ The other way around also applies:
         """Process inlet example_asset..."""
 
 In addition, ``@asset`` can be used with ``@task`` to customize the task that generates the asset,
-utilizing the modern TaskFlow approach described in :doc:/tutorial/taskflow.
+utilizing the modern TaskFlow approach described in :doc:`/tutorial/taskflow`.
 
 This combination allows you to set initial arguments for the task and to use various operators, such as the ``BashOperator``:
 

--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -229,6 +229,15 @@ The other way around also applies:
     def process_example_asset(example_asset):
         """Process inlet example_asset..."""
 
+In addition, ``@asset`` can be used with ``@task`` to set initial arguments for the task or to use an operator other than ``PythonOperator``:
+
+.. code-block:: python
+
+    @asset(schedule=None)
+    @task.bash(retries=3)
+    def example_asset():
+        """Write to example_asset, from a Bash task with 3 retries..."""
+        return "echo 'run'"
 
 Output to multiple assets in one task
 -------------------------------------

--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -229,7 +229,10 @@ The other way around also applies:
     def process_example_asset(example_asset):
         """Process inlet example_asset..."""
 
-In addition, ``@asset`` can be used with ``@task`` to set initial arguments for the task or to use an operator other than ``PythonOperator``:
+In addition, ``@asset`` can be used with ``@task`` to customize the task that generates the asset,
+utilizing the modern TaskFlow approach described in :doc:/tutorial/taskflow.
+
+This combination allows you to set initial arguments for the task and to use various operators, such as the ``BashOperator``:
 
 .. code-block:: python
 

--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Iterator, Mapping
 
     from airflow.sdk import DAG, AssetAlias, ObjectStoragePath
-    from airflow.sdk.bases.decorator import XComArg, _TaskDecorator
+    from airflow.sdk.bases.decorator import _TaskDecorator
     from airflow.sdk.definitions.asset import AssetUniqueKey
     from airflow.sdk.definitions.dag import DagStateChangeCallback, ScheduleArg
     from airflow.sdk.definitions.param import ParamsDict
@@ -97,16 +97,16 @@ class _AssetMainOperator(PythonOperator):
         return dict(self._iter_kwargs(context))
 
 
-def _instanciate_task(definition: AssetDefinition | MultiAssetDefinition) -> _AssetMainOperator | XComArg:
+def _instantiate_task(definition: AssetDefinition | MultiAssetDefinition) -> None:
     decorated_operator = cast("_TaskDecorator", definition._function)
     if getattr(decorated_operator, "_airflow_is_task_decorator", False):
         if "outlets" in decorated_operator.kwargs:
             raise TypeError("@task decorator with 'outlets' argument is not supported in @asset")
 
         decorated_operator.kwargs["outlets"] = [v for _, v in definition.iter_assets()]
-        return decorated_operator()
+        decorated_operator()
 
-    return _AssetMainOperator.from_definition(definition)
+    _AssetMainOperator.from_definition(definition)
 
 
 @attrs.define(kw_only=True)
@@ -122,7 +122,7 @@ class AssetDefinition(Asset):
 
     def __attrs_post_init__(self) -> None:
         with self._source.create_dag(default_dag_id=self.name):
-            _instanciate_task(self)
+            _instantiate_task(self)
 
 
 @attrs.define(kw_only=True)
@@ -142,7 +142,7 @@ class MultiAssetDefinition(BaseAsset):
 
     def __attrs_post_init__(self) -> None:
         with self._source.create_dag(default_dag_id=self._function.__name__):
-            _instanciate_task(self)
+            _instantiate_task(self)
 
     def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
         for o in self._source.outlets:

--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -105,8 +105,8 @@ def _instantiate_task(definition: AssetDefinition | MultiAssetDefinition) -> Non
 
         decorated_operator.kwargs["outlets"] = [v for _, v in definition.iter_assets()]
         decorated_operator()
-
-    _AssetMainOperator.from_definition(definition)
+    else:
+        _AssetMainOperator.from_definition(definition)
 
 
 @attrs.define(kw_only=True)

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -171,6 +171,16 @@ class TestAssetDecorator:
         assert asset_definition._source.dag_id == "dag"
         assert asset_definition._function == _example_task_func
 
+    def test_with_task_decorator_and_outlets(self, func_fixer):
+        @task(retries=3, outlets=Asset(name="a"))
+        @func_fixer
+        def _example_task_func():
+            return "This is example_task"
+
+        with pytest.raises(TypeError) as err:
+            asset(schedule=None)(_example_task_func)
+        assert err.value.args[0] == "@task decorator with 'outlets' argument is not supported in @asset"
+
     @pytest.mark.parametrize(
         "provided_uri, expected_uri",
         [

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -22,6 +22,7 @@ import pytest
 
 from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.definitions.asset.decorators import _AssetMainOperator, asset
+from airflow.sdk.definitions.decorators import task
 from airflow.sdk.execution_time.comms import AssetResult, GetAssetByName
 
 
@@ -159,6 +160,17 @@ class TestAssetDecorator:
             == "positional-only argument 'self' without a default is not supported in @asset"
         )
 
+    def test_with_task_decorator(self, func_fixer):
+        @task(retries=3)
+        @func_fixer
+        def _example_task_func():
+            return "This is example_task"
+
+        asset_definition = asset(name="asset", dag_id="dag", schedule=None)(_example_task_func)
+        assert asset_definition.name == "asset"
+        assert asset_definition._source.dag_id == "dag"
+        assert asset_definition._function == _example_task_func
+
     @pytest.mark.parametrize(
         "provided_uri, expected_uri",
         [
@@ -222,6 +234,36 @@ class TestAssetDefinition:
         )
         from_definition.assert_called_once_with(asset_definition)
 
+    @mock.patch("airflow.sdk.bases.decorator._TaskDecorator.__call__")
+    @mock.patch("airflow.sdk.definitions.dag.DAG")
+    def test_with_task_decorator(self, DAG, __call__, func_fixer):
+        @task(retries=3)
+        @func_fixer
+        def _example_task_func():
+            return "This is example_task"
+
+        asset_definition = asset(schedule=None, uri="s3://bucket/object", group="MLModel", extra={"k": "v"})(
+            _example_task_func
+        )
+
+        DAG.assert_called_once_with(
+            dag_id="example_asset_func",
+            dag_display_name="example_asset_func",
+            description=None,
+            schedule=None,
+            catchup=False,
+            is_paused_upon_creation=None,
+            on_failure_callback=None,
+            on_success_callback=None,
+            params=None,
+            access_control=None,
+            owner_links={},
+            tags=set(),
+            auto_register=True,
+        )
+        __call__.assert_called_once_with()
+        assert asset_definition._function.kwargs["outlets"] == [asset_definition]
+
 
 class TestMultiAssetDefinition:
     @mock.patch("airflow.sdk.definitions.asset.decorators._AssetMainOperator.from_definition")
@@ -248,6 +290,37 @@ class TestMultiAssetDefinition:
             auto_register=True,
         )
         from_definition.assert_called_once_with(definition)
+
+    @mock.patch("airflow.sdk.bases.decorator._TaskDecorator.__call__")
+    @mock.patch("airflow.sdk.definitions.dag.DAG")
+    def test_with_task_decorator(self, DAG, __call__, func_fixer):
+        @task(retries=3)
+        @func_fixer
+        def _example_task_func():
+            return "This is example_task"
+
+        definition = asset.multi(
+            schedule=None,
+            outlets=[Asset(name="a"), Asset(name="b")],
+        )(_example_task_func)
+
+        DAG.assert_called_once_with(
+            dag_id="example_asset_func",
+            dag_display_name="example_asset_func",
+            description=None,
+            schedule=None,
+            catchup=False,
+            is_paused_upon_creation=None,
+            on_failure_callback=None,
+            on_success_callback=None,
+            params=None,
+            access_control=None,
+            owner_links={},
+            tags=set(),
+            auto_register=True,
+        )
+        __call__.assert_called_once_with()
+        assert definition._function.kwargs["outlets"] == [Asset(name="a"), Asset(name="b")]
 
 
 class Test_AssetMainOperator:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #51228 


<!-- Please keep an empty line above the dashes. -->
---
Extends the Airflow 3 `@asset` decorator to support any `TaskFlow` operator.
To match the [Asset-Centric Syntax](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-75+New+Asset-Centric+Syntax) specification, the asset is implicitly set as an outlet of the that task it decorates.

This is my first contribution here, I tried to keep the changes to a minimum but please let me know if there are any issues, and I will do my best to address them.

Thanks.

---
Examples usage (from #51228 ):
```python
from airflow.sdk import asset, task


# Asset generated by a PythonOperator task with extra arguments
# The task `outlets` argument is implicitly set to `[secret_data]`
@asset(schedule="@daily")
@task(doc="Generate a secret number", retries=3)
def secret_data():
    return 42


# Asset generated by a BashOperator task (supports extra arguments as well)
# The task `outlets` argument is implicitly set to `[write_data]`
@asset(schedule=secret_data)
@task.bash()
def write_data(ti):
    random_number = ti.xcom_pull(
        dag_id="secret_data",
        task_ids="secret_data",
        key="return_value",
        include_prior_dates=True,
    )
    return f"echo {random_number}"
```
![image](https://github.com/user-attachments/assets/401f6c3c-6abb-4dd3-baca-aa3e86f8df12)
