### PR TITLE
Ignore generated log files while testing go-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,6 @@ airflow-build-dockerfile*
 *.zip
 
 _api/
+
+#while running go tests inside the go-sdk, it can generate log files for dags, ignore all logs
+go-sdk/**/*.log


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While testing go-sdk, it can generate log files, we should add those to .gitignore

Before:

```
(airflow) ➜  airflow git:(main) ✗ git status --untracked-files=all
On branch main
Your branch is up to date with 'origin/main'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        airflow-core/src/airflow/serialization/serializers/pydantic.py
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:08:57.552577+00:00/task_id=extract/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:08:57.552577+00:00/task_id=transform/attempt=2.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:10:31.125408+00:00/task_id=extract/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:10:31.125408+00:00/task_id=load/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:10:31.125408+00:00/task_id=transform/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:12:12.980840+00:00/task_id=extract/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T10:12:12.980840+00:00/task_id=transform/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T11:31:38.291012+00:00/task_id=extract/attempt=1.log
        go-sdk/dag_id=tutorial_dag/run_id=manual__2025-05-29T11:31:38.291012+00:00/task_id=transform/attempt=1.log
        go-sdk/go-sdk.yml
        go-sdk/worker/dag_id=tutorial_dag/run_id=manual__2025-05-07T15:48:39.420678+00:00/task_id=extract/attempt=5.log

```

After:

```
(airflow) ➜  airflow git:(main) ✗ git status --untracked-files=all
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .gitignore

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        airflow-core/src/airflow/serialization/serializers/pydantic.py
        go-sdk/go-sdk.yml

```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
