### PR TITLE
Add is_rtl flag to supportedLanguages for RTL support (#51187)

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -39,12 +39,13 @@ import zhTWDashboard from "./locales/zh-TW/dashboard.json";
 // import Backend from 'i18next-http-backend';
 
 export const supportedLanguages = [
-  { code: "de", name: "Deutsch" },
-  { code: "en", name: "English" },
-  { code: "ko", name: "한국어" },
-  { code: "nl", name: "Nederlands" },
-  { code: "pl", name: "Polski" },
-  { code: "zh-TW", name: "繁體中文" },
+  { code: "de", name: "Deutsch", is_rtl: "No" },
+  { code: "en", name: "English", is_rtl: "No" },
+  { code: "he", name: "עברית", is_rtl: "Yes" },
+  { code: "ko", name: "한국어", is_rtl: "No" },
+  { code: "nl", name: "Nederlands", is_rtl: "No" },
+  { code: "pl", name: "Polski", is_rtl: "No" },
+  { code: "zh-TW", name: "繁體中文", is_rtl: "No" },
 ] as const;
 
 export const defaultLanguage = "en";


### PR DESCRIPTION
Implements AIRFLOW-51187 by adding is_rtl flag to supportedLanguages in config.ts to support RTL languages like Hebrew. Language switcher not available in UI (depends on #51038), but flag is implemented. Most frontend tests passed; some unrelated failures due to test setup issues.
Fixes #51187.