### PR TITLE
Airflow db export archived buffer

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -160,7 +160,11 @@ def _dump_table_to_file(*, target_table: str, file_path: str, export_format: str
             csv_writer = csv.writer(f)
             cursor = session.execute(text(f"SELECT * FROM {target_table}"))
             csv_writer.writerow(cursor.keys())
-            csv_writer.writerows(cursor.fetchall())
+            BATCH_SIZE = 500
+            rows = cursor.fetchmany(BATCH_SIZE)
+            while len(rows) > 0:
+                csv_writer.writerows(rows)
+                rows = cursor.fetchmany(BATCH_SIZE)
     else:
         raise AirflowException(f"Export format {export_format} is not supported.")
 

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -538,15 +538,23 @@ class TestDBCleanup:
     @patch("airflow.utils.db_cleanup.csv")
     def test_dump_table_to_file_function_for_csv(self, mock_csv):
         mockopen = mock_open()
+        mock_cursor = MagicMock()
+        mock_session = MagicMock()
+        mock_session.execute.return_value = mock_cursor
+        mock_cursor.keys.return_value = ["test-col-1", "test-col-2"]
+        mock_cursor.fetchmany.side_effect = [
+            [("testval-1.1", "testval-1.2"), ("testval-2.1", "testval-2.2")],
+            [],
+        ]
         with patch("airflow.utils.db_cleanup.open", mockopen, create=True):
             _dump_table_to_file(
-                target_table="mytable", file_path="dags/myfile.csv", export_format="csv", session=MagicMock()
+                target_table="mytable", file_path="dags/myfile.csv", export_format="csv", session=mock_session
             )
             mockopen.assert_called_once_with("dags/myfile.csv", "w")
             writer = mock_csv.writer
             writer.assert_called_once()
-            writer.return_value.writerow.assert_called_once()
-            writer.return_value.writerows.assert_called_once()
+            writer.return_value.writerow.assert_called_once_with(["id", "name"])
+            writer.return_value.writerows.assert_called_once_with([("1", "Alice"), ("2", "Bob")])
 
     def test_dump_table_to_file_raises_if_format_not_supported(self):
         with pytest.raises(AirflowException) as exc_info:

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_cloud_formation.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_cloud_formation.py
@@ -103,6 +103,23 @@ class TestCloudFormationCreateStackOperator:
 
         validate_template_fields(op)
 
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = CloudFormationCreateStackOperator(
+            task_id="cf_create_stack_pass_conn",
+            stack_name="fake-stack",
+            cloudformation_parameters={},
+            aws_conn_id=OVERWRITTEN_CONN,
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_default_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = CloudFormationCreateStackOperator(
+            task_id="cf_create_stack_pass_default_conn", stack_name="fake-stack", cloudformation_parameters={}
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN
+
 
 class TestCloudFormationDeleteStackOperator:
     def test_init(self):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_comprehend.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_comprehend.py
@@ -80,6 +80,29 @@ class TestComprehendBaseOperator:
         assert comprehend_base_op.client == mocked_client
         comprehend_base_operator_mock_hook.assert_called_once()
 
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = ComprehendBaseOperator(
+            task_id="comprehend_base_operator",
+            input_data_config=INPUT_DATA_CONFIG,
+            output_data_config=OUTPUT_DATA_CONFIG,
+            language_code=LANGUAGE_CODE,
+            data_access_role_arn=ROLE_ARN,
+            aws_conn_id=OVERWRITTEN_CONN,
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_default_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = ComprehendBaseOperator(
+            task_id="comprehend_base_operator",
+            input_data_config=INPUT_DATA_CONFIG,
+            output_data_config=OUTPUT_DATA_CONFIG,
+            language_code=LANGUAGE_CODE,
+            data_access_role_arn=ROLE_ARN,
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN
+
 
 class TestComprehendStartPiiEntitiesDetectionJobOperator:
     JOB_ID = "random-job-id-1234567"

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_dms.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_dms.py
@@ -149,6 +149,27 @@ class TestDmsCreateTaskOperator:
 
         validate_template_fields(op)
 
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = DmsCreateTaskOperator(
+            task_id="dms_create_task_operator",
+            **self.TASK_DATA,
+            aws_conn_id=OVERWRITTEN_CONN,
+            verify=True,
+            botocore_config={"read_timeout": 42},
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_default_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = DmsCreateTaskOperator(
+            task_id="dms_create_task_operator",
+            **self.TASK_DATA,
+            verify=True,
+            botocore_config={"read_timeout": 42},
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN
+
 
 class TestDmsDeleteTaskOperator:
     TASK_DATA = {

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue.py
@@ -408,6 +408,25 @@ class TestGlueJobOperator:
         )
         validate_template_fields(operator)
 
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = GlueJobOperator(
+            task_id=TASK_ID,
+            aws_conn_id=OVERWRITTEN_CONN,
+            iam_role_name="role_arn",
+            replace_script_file=True,
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_default_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = GlueJobOperator(
+            task_id=TASK_ID,
+            iam_role_name="role_arn",
+            replace_script_file=True,
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN
+
 
 class TestGlueDataQualityOperator:
     RULE_SET_NAME = "TestRuleSet"
@@ -542,6 +561,23 @@ class TestGlueDataQualityOperator:
         )
         validate_template_fields(operator)
 
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = GlueDataQualityOperator(
+            task_id="create_data_quality_ruleset",
+            name=self.RULE_SET_NAME,
+            ruleset=self.RULE_SET,
+            aws_conn_id=OVERWRITTEN_CONN,
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_ndefault_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = GlueDataQualityOperator(
+            task_id="create_data_quality_ruleset", name=self.RULE_SET_NAME, ruleset=self.RULE_SET
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN
+
 
 class TestGlueDataQualityRuleSetEvaluationRunOperator:
     RUN_ID = "1234567890"
@@ -647,6 +683,29 @@ class TestGlueDataQualityRuleSetEvaluationRunOperator:
 
     def test_template_fields(self):
         validate_template_fields(self.operator)
+
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = GlueDataQualityRuleSetEvaluationRunOperator(
+            task_id="stat_evaluation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            rule_set_names=self.RULE_SET_NAMES,
+            show_results=False,
+            aws_conn_id=OVERWRITTEN_CONN,
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_default_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = GlueDataQualityRuleSetEvaluationRunOperator(
+            task_id="stat_evaluation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            rule_set_names=self.RULE_SET_NAMES,
+            show_results=False,
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN
 
 
 class TestGlueDataQualityRuleRecommendationRunOperator:
@@ -756,3 +815,28 @@ class TestGlueDataQualityRuleRecommendationRunOperator:
 
     def test_template_fields(self):
         validate_template_fields(self.operator)
+
+    def test_overwritten_conn_passed_to_hook(self):
+        OVERWRITTEN_CONN = "new-conn-id"
+        op = GlueDataQualityRuleRecommendationRunOperator(
+            task_id="start_recommendation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            number_of_workers=10,
+            timeout=1000,
+            recommendation_run_kwargs={"CreatedRulesetName": "test-ruleset"},
+            aws_conn_id=OVERWRITTEN_CONN,
+        )
+        assert op.hook.aws_conn_id == OVERWRITTEN_CONN
+
+    def test_default_conn_passed_to_hook(self):
+        DEFAULT_CONN = "aws_default"
+        op = GlueDataQualityRuleRecommendationRunOperator(
+            task_id="start_recommendation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            number_of_workers=10,
+            timeout=1000,
+            recommendation_run_kwargs={"CreatedRulesetName": "test-ruleset"},
+        )
+        assert op.hook.aws_conn_id == DEFAULT_CONN

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_rds.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_rds.py
@@ -181,9 +181,9 @@ class TestBaseRdsOperator:
         )
         assert op.hook.aws_conn_id == OVERWRITTEN_CONN
 
-    def test_no_conn_passed_to_hook(self):
+    def test_default_conn_passed_to_hook(self):
         DEFAULT_CONN = "aws_default"
-        op = RdsBaseOperator(task_id="test_no_conn_passed_to_hook_task", dag=self.dag)
+        op = RdsBaseOperator(task_id="test_default_conn_passed_to_hook_task", dag=self.dag)
         assert op.hook.aws_conn_id == DEFAULT_CONN
 
 


### PR DESCRIPTION

---

closes: #

I have adjusted the `_dump_table_to_file` function, to fetch rows in batches of 500 and thus not run into problems if the db to be exported is larger than your ram. 

The test case now also mocks rows returned by `.fetchmany() `, according to the return type of `.fetchmany()` (https://peps.python.org/pep-0249/#fetchmany) 