### PR TITLE
Adjusted _dump_table_to_file to read rows in batches to prevent memor…

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -160,7 +160,11 @@ def _dump_table_to_file(*, target_table: str, file_path: str, export_format: str
             csv_writer = csv.writer(f)
             cursor = session.execute(text(f"SELECT * FROM {target_table}"))
             csv_writer.writerow(cursor.keys())
-            csv_writer.writerows(cursor.fetchall())
+            BATCH_SIZE = 500
+            rows = cursor.fetchmany(BATCH_SIZE)
+            while rows:
+                csv_writer.writerows(rows)
+                rows = cursor.fetchmany(BATCH_SIZE)
     else:
         raise AirflowException(f"Export format {export_format} is not supported.")
 

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -538,15 +538,25 @@ class TestDBCleanup:
     @patch("airflow.utils.db_cleanup.csv")
     def test_dump_table_to_file_function_for_csv(self, mock_csv):
         mockopen = mock_open()
+        mock_cursor = MagicMock()
+        mock_session = MagicMock()
+        mock_session.execute.return_value = mock_cursor
+        mock_cursor.keys.return_value = ["test-col-1", "test-col-2"]
+        mock_cursor.fetchmany.side_effect = [
+            [("testval-1.1", "testval-1.2"), ("testval-2.1", "testval-2.2")],
+            [],
+        ]
         with patch("airflow.utils.db_cleanup.open", mockopen, create=True):
             _dump_table_to_file(
-                target_table="mytable", file_path="dags/myfile.csv", export_format="csv", session=MagicMock()
+                target_table="mytable", file_path="dags/myfile.csv", export_format="csv", session=mock_session
             )
             mockopen.assert_called_once_with("dags/myfile.csv", "w")
             writer = mock_csv.writer
             writer.assert_called_once()
-            writer.return_value.writerow.assert_called_once()
-            writer.return_value.writerows.assert_called_once()
+            writer.return_value.writerow.assert_called_once_with(["test-col-1", "test-col-2"])
+            writer.return_value.writerows.assert_called_once_with(
+                [("testval-1.1", "testval-1.2"), ("testval-2.1", "testval-2.2")]
+            )
 
     def test_dump_table_to_file_raises_if_format_not_supported(self):
         with pytest.raises(AirflowException) as exc_info:


### PR DESCRIPTION
---

closes: #51156

I have adjusted the `_dump_table_to_file` function, to fetch rows in batches of 500 and thus not run into problems if the db to be exported is larger than your ram. 

The test case now also mocks rows returned by `.fetchmany() `, according to the return of `.fetchmany()` (https://peps.python.org/pep-0249/#fetchmany)