### PR TITLE
Add lower bound to Sendgrid after #50221

### DIFF
--- a/providers/sendgrid/pyproject.toml
+++ b/providers/sendgrid/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     # workaround conflicts with fab for Python 3.12 https://github.com/apache/airflow/pull/50221#issuecomment-2926765112
     # can be set to sendgrid>=6.12.3 when we upgrade to fab 5
     "sendgrid>=6.12.3; python_version < '3.12'",
-    "sendgrid<6.12.3; python_version >= '3.12'"
+    "sendgrid>=6.0.0,<6.12.3; python_version >= '3.12'",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
After merge of #50221 canary tests failed with lowest dependencies on sendgrid.

See https://github.com/apache/airflow/actions/runs/15375675499

Adding a lower bound to sendgrid lib, if this does not help we maybe need to force werkzeug also being a minimum version. Let's see if this turns green