### PR TITLE
Fix Pinecone Cohere Integration System Test

### DIFF
--- a/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
@@ -44,7 +44,7 @@ with DAG(
 
         hook = PineconeHook()
         pod_spec = hook.get_pod_spec_obj()
-        hook.create_index(index_name=index_name, dimension=768, spec=pod_spec)
+        hook.create_index(index_name=index_name, dimension=1024, spec=pod_spec)
 
     embed_task = CohereEmbeddingOperator(
         task_id="embed_task",
@@ -54,7 +54,7 @@ with DAG(
     @task
     def transform_output(embedding_output) -> list[dict]:
         # Convert each embedding to a map with an ID and the embedding vector
-        return [dict(id=str(i), values=embedding) for i, embedding in enumerate(embedding_output)]
+        return [dict(id=str(i), values=embedding) for i, embedding in enumerate(embedding_output.float_)]
 
     transformed_output = transform_output(embed_task.output)
 


### PR DESCRIPTION
Pinecone Cohere integration system test started failing after Cohere update to 5.13.4 v2 API in [PR](https://github.com/apache/airflow/pull/45267), this PR fixes this issue.

Testing:
**Before**
![image](https://github.com/user-attachments/assets/e9656a82-1e69-4a9b-8a6e-ce53431ddb2d)

**Fix**
![image](https://github.com/user-attachments/assets/d85f015d-b91c-4cca-8e3b-77357ccf5c7a)
