### PR TITLE
Add extra_credentials and roles to TrinoHook

### DIFF
--- a/providers/trino/docs/connections.rst
+++ b/providers/trino/docs/connections.rst
@@ -55,5 +55,7 @@ Extra (optional, connection parameters)
     * ``session_properties`` - JSON dictionary which allows to set session_properties. Example: ``{'session_properties':{'scale_writers':true,'task_writer_count:1'}}``
     * ``client_tags`` - List of comma separated tags. Example ``{'client_tags':['sales','cluster1']}```
     * ``timezone`` - The time zone for the session can be explicitly set using the IANA time zone name. Example: ``{'timezone':'Asia/Jerusalem'}``.
+    * ``extra_credential`` - List of key-value string pairs which are passed to the Trino connector. For more, refer to the `Trino docs <https://trino.io/docs/current/develop/client-protocol.html>`__.
+    * ``roles`` - Dict mapping catalog names to their corresponding Trino authorization role. For more, refer to the `Trino Python client docs<https://github.com/trinodb/trino-python-client?tab=readme-ov-file#roles>`__.
 
     Note: If ``jwt__file`` and ``jwt__token`` are both given, ``jwt__file`` will take precedent.

--- a/providers/trino/docs/connections.rst
+++ b/providers/trino/docs/connections.rst
@@ -55,7 +55,7 @@ Extra (optional, connection parameters)
     * ``session_properties`` - JSON dictionary which allows to set session_properties. Example: ``{'session_properties':{'scale_writers':true,'task_writer_count:1'}}``
     * ``client_tags`` - List of comma separated tags. Example ``{'client_tags':['sales','cluster1']}```
     * ``timezone`` - The time zone for the session can be explicitly set using the IANA time zone name. Example: ``{'timezone':'Asia/Jerusalem'}``.
-    * ``extra_credential`` - List of key-value string pairs which are passed to the Trino connector. For more, refer to the `Trino docs <https://trino.io/docs/current/develop/client-protocol.html>`__.
-    * ``roles`` - Dict mapping catalog names to their corresponding Trino authorization role. For more, refer to the `Trino Python client docs<https://github.com/trinodb/trino-python-client?tab=readme-ov-file#roles>`__.
+    * ``extra_credential`` - List of key-value string pairs which are passed to the Trino connector. For more information, refer to the Trino client protocol doc page here: https://trino.io/docs/current/develop/client-protocol.html
+    * ``roles`` - Mapping of catalog names to their corresponding Trino authorization role. For more information, refer to the Trino Python client docs here: https://github.com/trinodb/trino-python-client?tab=readme-ov-file#roles
 
     Note: If ``jwt__file`` and ``jwt__token`` are both given, ``jwt__file`` will take precedent.

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -211,6 +211,8 @@ class TrinoHook(DbApiHook):
             session_properties=extra.get("session_properties") or None,
             client_tags=extra.get("client_tags") or None,
             timezone=extra.get("timezone") or None,
+            extra_credential=extra.get("extra_credential") or None,
+            roles=extra.get("roles") or None,
         )
 
         return trino_conn

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -258,6 +258,22 @@ class TestTrinoHookConn:
         TrinoHook().get_conn()
         self.assert_connection_called_with(mock_connect, timezone="Asia/Jerusalem")
 
+    @patch(HOOK_GET_CONNECTION)
+    @patch(TRINO_DBAPI_CONNECT)
+    def test_get_conn_extra_credential(self, mock_connect, mock_get_connection):
+        extras = {"extra_credential": [["a.username", "bar"], ["a.password", "foo"]]}
+        self.set_get_connection_return_value(mock_get_connection, extra=json.dumps(extras))
+        TrinoHook().get_conn()
+        self.assert_connection_called_with(mock_connect, extra_credential=extras["extra_credential"])
+
+    @patch(HOOK_GET_CONNECTION)
+    @patch(TRINO_DBAPI_CONNECT)
+    def test_get_conn_roles(self, mock_connect, mock_get_connection):
+        extras = {"roles": {"catalog1": "trinoRoleA", "catalog2": "trinoRoleB"}}
+        self.set_get_connection_return_value(mock_get_connection, extra=json.dumps(extras))
+        TrinoHook().get_conn()
+        self.assert_connection_called_with(mock_connect, roles=extras["roles"])
+
     @staticmethod
     def set_get_connection_return_value(mock_get_connection, extra=None, password=None):
         mocked_connection = Connection(
@@ -274,6 +290,8 @@ class TestTrinoHookConn:
         session_properties=None,
         client_tags=None,
         timezone=None,
+        extra_credential=None,
+        roles=None,
     ):
         mock_connect.assert_called_once_with(
             catalog="hive",
@@ -290,6 +308,8 @@ class TestTrinoHookConn:
             session_properties=session_properties,
             client_tags=client_tags,
             timezone=timezone,
+            extra_credential=extra_credential,
+            roles=roles,
         )
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Related issue: No existing issue that I could find. I'm happy to create one if that is preferred.

## What?
Adds two optional parameters to the `TrinoHook`'s extra JSON. This PR generally follows these 2 similar past PRs: https://github.com/apache/airflow/pull/27095 and https://github.com/apache/airflow/pull/27213
1. Adds the optional [`extra_credential` parameter](https://github.com/trinodb/trino-python-client?tab=readme-ov-file#extra-credentials) in the `TrinoHook` extra payload.
2. Adds the optional [`roles` parameter](https://github.com/trinodb/trino-python-client?tab=readme-ov-file#roles) in the `TrinoHook` extra payload.

## Why?
* The [Trino python client](https://github.com/trinodb/trino-python-client) used by the `TrinoHook` allows for the use of these fields, and we would like to use the official TrinoHook rather than maintain a custom subclass which exposes these options. 
* I've confirmed that both `extra_credential` and `roles` is available in Airflow's current pinned version of the Trino python client (`0.334.0`).

