### PR TITLE
feat: Add TagsJobFacet to DAGRun OpenLineage events

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import traceback
 from contextlib import ExitStack
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import yaml
 from openlineage.client import OpenLineageClient, set_producer
@@ -32,7 +32,7 @@ from openlineage.client.facet_v2 import (
     job_type_job,
     nominal_time_run,
     ownership_job,
-    source_code_location_job,
+    tags_job,
 )
 from openlineage.client.uuid import generate_static_uuid
 
@@ -63,11 +63,8 @@ _PRODUCER = f"https://github.com/apache/airflow/tree/providers-openlineage/{OPEN
 
 set_producer(_PRODUCER)
 
-# https://openlineage.io/docs/spec/facets/job-facets/job-type
-# They must be set after the `set_producer(_PRODUCER)`
-# otherwise the `JobTypeJobFacet._producer` will be set with the default value
-_JOB_TYPE_DAG = job_type_job.JobTypeJobFacet(jobType="DAG", integration="AIRFLOW", processingType="BATCH")
-_JOB_TYPE_TASK = job_type_job.JobTypeJobFacet(jobType="TASK", integration="AIRFLOW", processingType="BATCH")
+_JOB_TYPE_DAG: Literal["DAG"] = "DAG"
+_JOB_TYPE_TASK: Literal["TASK"] = "TASK"
 
 
 class OpenLineageAdapter(LoggingMixin):
@@ -187,10 +184,10 @@ class OpenLineageAdapter(LoggingMixin):
         job_name: str,
         job_description: str,
         event_time: str,
-        code_location: str | None,
         nominal_start_time: str | None,
         nominal_end_time: str | None,
         owners: list[str] | None,
+        tags: list[str] | None,
         task: OperatorLineage | None,
         run_facets: dict[str, RunFacet] | None = None,
     ) -> RunEvent:
@@ -201,17 +198,16 @@ class OpenLineageAdapter(LoggingMixin):
         :param job_name: globally unique identifier of task in dag
         :param job_description: user provided description of job
         :param event_time:
-        :param code_location: file path or URL of DAG file
         :param nominal_start_time: scheduled time of dag run
         :param nominal_end_time: following schedule of dag run
         :param owners: list of owners
+        :param tags: list of tags
         :param task: metadata container with information extracted from operator
         :param run_facets: custom run facets
         """
         run_facets = run_facets or {}
         if task:
             run_facets = {**task.run_facets, **run_facets}
-        run_facets = {**run_facets, **get_processing_engine_facet()}  # type: ignore
         event = RunEvent(
             eventType=RunState.START,
             eventTime=event_time,
@@ -225,8 +221,8 @@ class OpenLineageAdapter(LoggingMixin):
                 job_name=job_name,
                 job_type=_JOB_TYPE_TASK,
                 job_description=job_description,
-                code_location=code_location,
-                owners=owners,
+                job_owners=owners,
+                job_tags=tags,
                 job_facets=task.job_facets if task else None,
             ),
             inputs=task.inputs if task else [],
@@ -242,6 +238,7 @@ class OpenLineageAdapter(LoggingMixin):
         end_time: str,
         task: OperatorLineage,
         owners: list[str] | None,
+        tags: list[str] | None,
         run_facets: dict[str, RunFacet] | None = None,
     ) -> RunEvent:
         """
@@ -250,6 +247,7 @@ class OpenLineageAdapter(LoggingMixin):
         :param run_id: globally unique identifier of task in dag run
         :param job_name: globally unique identifier of task between dags
         :param end_time: time of task completion
+        :param tags: list of tags
         :param task: metadata container with information extracted from operator
         :param owners: list of owners
         :param run_facets: additional run facets
@@ -257,7 +255,6 @@ class OpenLineageAdapter(LoggingMixin):
         run_facets = run_facets or {}
         if task:
             run_facets = {**task.run_facets, **run_facets}
-        run_facets = {**run_facets, **get_processing_engine_facet()}  # type: ignore
         event = RunEvent(
             eventType=RunState.COMPLETE,
             eventTime=end_time,
@@ -265,7 +262,13 @@ class OpenLineageAdapter(LoggingMixin):
                 run_id=run_id,
                 run_facets=run_facets,
             ),
-            job=self._build_job(job_name, job_type=_JOB_TYPE_TASK, job_facets=task.job_facets, owners=owners),
+            job=self._build_job(
+                job_name,
+                job_type=_JOB_TYPE_TASK,
+                job_facets=task.job_facets,
+                job_owners=owners,
+                job_tags=tags,
+            ),
             inputs=task.inputs,
             outputs=task.outputs,
             producer=_PRODUCER,
@@ -279,6 +282,7 @@ class OpenLineageAdapter(LoggingMixin):
         end_time: str,
         task: OperatorLineage,
         owners: list[str] | None,
+        tags: list[str] | None,
         error: str | BaseException | None = None,
         run_facets: dict[str, RunFacet] | None = None,
     ) -> RunEvent:
@@ -290,6 +294,7 @@ class OpenLineageAdapter(LoggingMixin):
         :param end_time: time of task completion
         :param task: metadata container with information extracted from operator
         :param run_facets: custom run facets
+        :param tags: list of tags
         :param owners: list of owners
         :param error: error
         :param run_facets: additional run facets
@@ -297,7 +302,6 @@ class OpenLineageAdapter(LoggingMixin):
         run_facets = run_facets or {}
         if task:
             run_facets = {**task.run_facets, **run_facets}
-        run_facets = {**run_facets, **get_processing_engine_facet()}  # type: ignore
 
         if error:
             stack_trace = None
@@ -316,7 +320,13 @@ class OpenLineageAdapter(LoggingMixin):
                 run_id=run_id,
                 run_facets=run_facets,
             ),
-            job=self._build_job(job_name, job_type=_JOB_TYPE_TASK, job_facets=task.job_facets, owners=owners),
+            job=self._build_job(
+                job_name,
+                job_type=_JOB_TYPE_TASK,
+                job_facets=task.job_facets,
+                job_owners=owners,
+                job_tags=tags,
+            ),
             inputs=task.inputs,
             outputs=task.outputs,
             producer=_PRODUCER,
@@ -328,9 +338,10 @@ class OpenLineageAdapter(LoggingMixin):
         dag_id: str,
         logical_date: datetime,
         start_date: datetime,
-        nominal_start_time: str,
-        nominal_end_time: str,
+        nominal_start_time: str | None,
+        nominal_end_time: str | None,
         owners: list[str] | None,
+        tags: list[str],
         run_facets: dict[str, RunFacet],
         clear_number: int,
         description: str | None = None,
@@ -344,8 +355,9 @@ class OpenLineageAdapter(LoggingMixin):
                     job_name=dag_id,
                     job_type=_JOB_TYPE_DAG,
                     job_description=description,
-                    owners=owners,
+                    job_owners=owners,
                     job_facets=job_facets,
+                    job_tags=tags,
                 ),
                 run=self._build_run(
                     run_id=self.build_dag_run_id(
@@ -353,7 +365,7 @@ class OpenLineageAdapter(LoggingMixin):
                     ),
                     nominal_start_time=nominal_start_time,
                     nominal_end_time=nominal_end_time,
-                    run_facets={**run_facets, **get_airflow_debug_facet(), **get_processing_engine_facet()},
+                    run_facets={**run_facets, **get_airflow_debug_facet()},
                 ),
                 inputs=[],
                 outputs=[],
@@ -372,6 +384,7 @@ class OpenLineageAdapter(LoggingMixin):
         run_id: str,
         end_date: datetime,
         logical_date: datetime,
+        tags: list[str] | None,
         clear_number: int,
         dag_run_state: DagRunState,
         task_ids: list[str],
@@ -382,15 +395,19 @@ class OpenLineageAdapter(LoggingMixin):
             event = RunEvent(
                 eventType=RunState.COMPLETE,
                 eventTime=end_date.isoformat(),
-                job=self._build_job(job_name=dag_id, job_type=_JOB_TYPE_DAG, owners=owners),
-                run=Run(
-                    runId=self.build_dag_run_id(
+                job=self._build_job(
+                    job_name=dag_id,
+                    job_type=_JOB_TYPE_DAG,
+                    job_owners=owners,
+                    job_tags=tags,
+                ),
+                run=self._build_run(
+                    run_id=self.build_dag_run_id(
                         dag_id=dag_id, logical_date=logical_date, clear_number=clear_number
                     ),
-                    facets={
+                    run_facets={
                         **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
                         **get_airflow_debug_facet(),
-                        **get_processing_engine_facet(),
                         **run_facets,
                     },
                 ),
@@ -411,6 +428,7 @@ class OpenLineageAdapter(LoggingMixin):
         run_id: str,
         end_date: datetime,
         logical_date: datetime,
+        tags: list[str] | None,
         clear_number: int,
         dag_run_state: DagRunState,
         task_ids: list[str],
@@ -422,20 +440,22 @@ class OpenLineageAdapter(LoggingMixin):
             event = RunEvent(
                 eventType=RunState.FAIL,
                 eventTime=end_date.isoformat(),
-                job=self._build_job(job_name=dag_id, job_type=_JOB_TYPE_DAG, owners=owners),
-                run=Run(
-                    runId=self.build_dag_run_id(
-                        dag_id=dag_id,
-                        logical_date=logical_date,
-                        clear_number=clear_number,
+                job=self._build_job(
+                    job_name=dag_id,
+                    job_type=_JOB_TYPE_DAG,
+                    job_owners=owners,
+                    job_tags=tags,
+                ),
+                run=self._build_run(
+                    run_id=self.build_dag_run_id(
+                        dag_id=dag_id, logical_date=logical_date, clear_number=clear_number
                     ),
-                    facets={
+                    run_facets={
                         "errorMessage": error_message_run.ErrorMessageRunFacet(
                             message=msg, programmingLanguage="python"
                         ),
                         **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
                         **get_airflow_debug_facet(),
-                        **get_processing_engine_facet(),
                         **run_facets,
                     },
                 ),
@@ -457,10 +477,16 @@ class OpenLineageAdapter(LoggingMixin):
         nominal_end_time: str | None = None,
         run_facets: dict[str, RunFacet] | None = None,
     ) -> Run:
-        facets: dict[str, RunFacet] = {}
+        facets: dict[str, RunFacet] = get_processing_engine_facet()  # type: ignore[assignment]
         if nominal_start_time:
             facets.update(
-                {"nominalTime": nominal_time_run.NominalTimeRunFacet(nominal_start_time, nominal_end_time)}
+                {
+                    "nominalTime": nominal_time_run.NominalTimeRunFacet(
+                        nominalStartTime=nominal_start_time,
+                        nominalEndTime=nominal_end_time,
+                        producer=_PRODUCER,
+                    )
+                }
             )
         if run_facets:
             facets.update(run_facets)
@@ -470,37 +496,51 @@ class OpenLineageAdapter(LoggingMixin):
     @staticmethod
     def _build_job(
         job_name: str,
-        job_type: job_type_job.JobTypeJobFacet,
+        job_type: Literal["DAG", "TASK"],
         job_description: str | None = None,
-        code_location: str | None = None,
-        owners: list[str] | None = None,
+        job_owners: list[str] | None = None,
+        job_tags: list[str] | None = None,
         job_facets: dict[str, JobFacet] | None = None,
     ):
-        facets: dict[str, JobFacet] = {}
-
+        facets: dict[str, JobFacet] = {
+            "jobType": job_type_job.JobTypeJobFacet(
+                jobType=job_type, integration="AIRFLOW", processingType="BATCH", producer=_PRODUCER
+            )
+        }
         if job_description:
             facets.update(
-                {"documentation": documentation_job.DocumentationJobFacet(description=job_description)}
-            )
-        if code_location:
-            facets.update(
                 {
-                    "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
-                        "", url=code_location
+                    "documentation": documentation_job.DocumentationJobFacet(
+                        description=job_description, producer=_PRODUCER
                     )
                 }
             )
-        if owners:
+        if job_owners:
             facets.update(
                 {
                     "ownership": ownership_job.OwnershipJobFacet(
-                        owners=[ownership_job.Owner(name=owner) for owner in sorted(owners)]
+                        owners=[ownership_job.Owner(name=owner) for owner in sorted(job_owners)],
+                        producer=_PRODUCER,
+                    )
+                }
+            )
+        if job_tags:
+            facets.update(
+                {
+                    "tags": tags_job.TagsJobFacet(
+                        tags=[
+                            tags_job.TagsJobFacetFields(
+                                key=tag,
+                                value=tag,
+                                source="AIRFLOW",
+                            )
+                            for tag in sorted(job_tags)
+                        ],
+                        producer=_PRODUCER,
                     )
                 }
             )
         if job_facets:
-            facets = {**facets, **job_facets}
+            facets.update(job_facets)
 
-        facets.update({"jobType": job_type})
-
-        return Job(conf.namespace(), job_name, facets)
+        return Job(namespace=conf.namespace(), name=job_name, facets=facets)

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -151,7 +151,6 @@ class OpenLineageListener:
             )
             return
 
-        # Needs to be calculated outside of inner method so that it gets cached for usage in fork processes
         data_interval_start = dagrun.data_interval_start
         if isinstance(data_interval_start, datetime):
             data_interval_start = data_interval_start.isoformat()
@@ -163,6 +162,7 @@ class OpenLineageListener:
         if hasattr(dagrun, "clear_number"):
             clear_number = dagrun.clear_number
 
+        # Needs to be calculated outside of inner method so that it gets cached for usage in fork processes
         debug_facet = get_airflow_debug_facet()
 
         @print_warning(self.log)
@@ -202,11 +202,11 @@ class OpenLineageListener:
                 job_name=get_job_name(task),
                 job_description=dag.description,
                 event_time=start_date.isoformat(),
-                code_location=None,
                 nominal_start_time=data_interval_start,
                 nominal_end_time=data_interval_end,
                 # If task owner is default ("airflow"), use DAG owner instead that may have more details
                 owners=[x.strip() for x in (task if task.owner != "airflow" else dag).owner.split(",")],
+                tags=dag.tags,
                 task=task_metadata,
                 run_facets={
                     **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
@@ -319,6 +319,7 @@ class OpenLineageListener:
                 task=task_metadata,
                 # If task owner is default ("airflow"), use DAG owner instead that may have more details
                 owners=[x.strip() for x in (task if task.owner != "airflow" else dag).owner.split(",")],
+                tags=dag.tags,
                 run_facets={
                     **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_user_provided_run_facets(task_instance, TaskInstanceState.SUCCESS),
@@ -439,6 +440,7 @@ class OpenLineageListener:
                 end_time=end_date.isoformat(),
                 task=task_metadata,
                 error=error,
+                tags=dag.tags,
                 # If task owner is default ("airflow"), use DAG owner instead that may have more details
                 owners=[x.strip() for x in (task if task.owner != "airflow" else dag).owner.split(",")],
                 run_facets={
@@ -610,6 +612,7 @@ class OpenLineageListener:
                 clear_number=dag_run.clear_number,
                 owners=[x.strip() for x in dag_run.dag.owner.split(",")] if dag_run.dag else None,
                 description=dag_run.dag.description if dag_run.dag else None,
+                tags=dag_run.dag.tags if dag_run.dag else [],
                 # AirflowJobFacet should be created outside ProcessPoolExecutor that pickles objects,
                 # as it causes lack of some TaskGroup attributes and crashes event emission.
                 job_facets=get_airflow_job_facet(dag_run=dag_run),
@@ -647,6 +650,7 @@ class OpenLineageListener:
                 logical_date=date,
                 clear_number=dag_run.clear_number,
                 owners=[x.strip() for x in dag_run.dag.owner.split(",")] if dag_run.dag else None,
+                tags=dag_run.dag.tags if dag_run.dag else [],
                 task_ids=task_ids,
                 dag_run_state=dag_run.get_state(),
                 run_facets={**get_airflow_dag_run_facet(dag_run)},
@@ -684,6 +688,7 @@ class OpenLineageListener:
                 logical_date=date,
                 clear_number=dag_run.clear_number,
                 owners=[x.strip() for x in dag_run.dag.owner.split(",")] if dag_run.dag else None,
+                tags=dag_run.dag.tags if dag_run.dag else [],
                 dag_run_state=dag_run.get_state(),
                 task_ids=task_ids,
                 msg=msg,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -249,6 +249,7 @@ class TestOpenLineageListenerAirflow2:
         task_instance.task.dag.dag_id = "dag_id"
         task_instance.task.dag.description = "Test DAG Description"
         task_instance.task.dag.owner = "Test Owner"
+        task_instance.task.dag.tags = ["tag1", "tag2"]
         task_instance.task.owner = "task_owner"
         task_instance.task.inlets = []
         task_instance.task.outlets = []
@@ -312,10 +313,10 @@ class TestOpenLineageListenerAirflow2:
             job_name="job_name",
             job_description="Test DAG Description",
             event_time="2023-01-01T13:01:01+00:00",
-            code_location=None,
             nominal_start_time=None,
             nominal_end_time=None,
             owners=["task_owner"],
+            tags=["tag1", "tag2"],
             task=listener.extractor_manager.extract_metadata(),
             run_facets={
                 "parent": 4,
@@ -409,6 +410,7 @@ class TestOpenLineageListenerAirflow2:
             job_name="job_name",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             owners=["task_owner"],
+            tags=["tag1", "tag2"],
             task=listener.extractor_manager.extract_metadata(),
             run_facets={
                 "parent": 4,
@@ -507,6 +509,7 @@ class TestOpenLineageListenerAirflow2:
             run_id=f"2020-01-01T01:01:01+00:00.dag_id.task_id.{EXPECTED_TRY_NUMBER_1}.-1",
             task=listener.extractor_manager.extract_metadata(),
             owners=["task_owner"],
+            tags=["tag1", "tag2"],
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,
@@ -985,6 +988,7 @@ class TestOpenLineageListenerAirflow3:
             dag = DAG(
                 dag_id="dag_id",
                 description="Test DAG Description",
+                tags=["tag1", "tag2"],
             )
             task = EmptyOperator(task_id="task_id", dag=dag, owner="task_owner")
             task2 = EmptyOperator(task_id="task_id2", dag=dag, owner="another_owner")  # noqa: F841
@@ -1090,10 +1094,10 @@ class TestOpenLineageListenerAirflow3:
             job_name="job_name",
             job_description="Test DAG Description",
             event_time="2023-01-01T13:01:01+00:00",
-            code_location=None,
             nominal_start_time=None,
             nominal_end_time=None,
             owners=["task_owner"],
+            tags={"tag1", "tag2"},
             task=listener.extractor_manager.extract_metadata(),
             run_facets={
                 "mapped_facet": 1,
@@ -1187,6 +1191,7 @@ class TestOpenLineageListenerAirflow3:
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=listener.extractor_manager.extract_metadata(),
             owners=["task_owner"],
+            tags={"tag1", "tag2"},
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,
@@ -1331,6 +1336,7 @@ class TestOpenLineageListenerAirflow3:
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=listener.extractor_manager.extract_metadata(),
             owners=["task_owner"],
+            tags={"tag1", "tag2"},
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Adding TagsJobFacet to DAGRun events, with DAG tags. Currently DAG tags have only been included in AirflowRunFacet, but they are not serialized in a consistent manner, this should provide a reliable way to retrieve them. I'm also passing the producer explicitly when creating facet, to avoid any room for mistakes.

Apart from that, in this PR I've added all the facets included in DAG START event also to COMPLETE and FAIL event. From now, if the source info is present, all these facets will be available in all DAG level events, for consistency:
- OwnershipJobFacet
- DocumentationJobFacet
- NominalTimeRunFacet

Also removed the code_location arg from adapter method, it has not been used, None has been hardcoded there since beginning. I plan to refactor the facet creation process, as it looks a bit chaotic now. This will be done in a separate PR.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
