### PR TITLE
fix: Use task owner for TASK level Ownership facet

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -205,7 +205,8 @@ class OpenLineageListener:
                 code_location=None,
                 nominal_start_time=data_interval_start,
                 nominal_end_time=data_interval_end,
-                owners=dag.owner.split(", "),
+                # If task owner is default ("airflow"), use DAG owner instead that may have more details
+                owners=[x.strip() for x in (task if task.owner != "airflow" else dag).owner.split(",")],
                 task=task_metadata,
                 run_facets={
                     **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
@@ -316,6 +317,8 @@ class OpenLineageListener:
                 job_name=get_job_name(task),
                 end_time=end_date.isoformat(),
                 task=task_metadata,
+                # If task owner is default ("airflow"), use DAG owner instead that may have more details
+                owners=[x.strip() for x in (task if task.owner != "airflow" else dag).owner.split(",")],
                 run_facets={
                     **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_user_provided_run_facets(task_instance, TaskInstanceState.SUCCESS),
@@ -436,6 +439,8 @@ class OpenLineageListener:
                 end_time=end_date.isoformat(),
                 task=task_metadata,
                 error=error,
+                # If task owner is default ("airflow"), use DAG owner instead that may have more details
+                owners=[x.strip() for x in (task if task.owner != "airflow" else dag).owner.split(",")],
                 run_facets={
                     **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_user_provided_run_facets(task_instance, TaskInstanceState.FAILED),
@@ -641,6 +646,7 @@ class OpenLineageListener:
                 end_date=dag_run.end_date,
                 logical_date=date,
                 clear_number=dag_run.clear_number,
+                owners=[x.strip() for x in dag_run.dag.owner.split(",")] if dag_run.dag else None,
                 task_ids=task_ids,
                 dag_run_state=dag_run.get_state(),
                 run_facets={**get_airflow_dag_run_facet(dag_run)},
@@ -677,6 +683,7 @@ class OpenLineageListener:
                 end_date=dag_run.end_date,
                 logical_date=date,
                 clear_number=dag_run.clear_number,
+                owners=[x.strip() for x in dag_run.dag.owner.split(",")] if dag_run.dag else None,
                 dag_run_state=dag_run.get_state(),
                 task_ids=task_ids,
                 msg=msg,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -314,10 +314,7 @@ def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
     run_id = str(uuid.uuid4())
     event_time = datetime.datetime.now().isoformat()
     adapter.complete_task(
-        run_id=run_id,
-        end_time=event_time,
-        job_name="job",
-        task=OperatorLineage(),
+        run_id=run_id, end_time=event_time, job_name="job", task=OperatorLineage(), owners=[]
     )
 
     assert (
@@ -367,6 +364,7 @@ def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_s
         run_id=run_id,
         end_time=event_time,
         job_name="job",
+        owners=["owner1", "owner2"],
         task=OperatorLineage(
             inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
             outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
@@ -423,6 +421,12 @@ def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_s
                     namespace="default",
                     name="job",
                     facets={
+                        "ownership": ownership_job.OwnershipJobFacet(
+                            owners=[
+                                ownership_job.Owner(name="owner1", type=None),
+                                ownership_job.Owner(name="owner2", type=None),
+                            ]
+                        ),
                         "sql": sql_job.SQLJobFacet(query="SELECT 1;"),
                         "jobType": job_type_job.JobTypeJobFacet(
                             processingType="BATCH", integration="AIRFLOW", jobType="TASK"
@@ -457,6 +461,7 @@ def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
         end_time=event_time,
         job_name="job",
         task=OperatorLineage(),
+        owners=[],
     )
 
     assert (
@@ -506,6 +511,7 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
         run_id=run_id,
         end_time=event_time,
         job_name="job",
+        owners=["owner1", "owner2"],
         task=OperatorLineage(
             inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
             outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
@@ -565,6 +571,12 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
                 namespace="default",
                 name="job",
                 facets={
+                    "ownership": ownership_job.OwnershipJobFacet(
+                        owners=[
+                            ownership_job.Owner(name="owner1", type=None),
+                            ownership_job.Owner(name="owner2", type=None),
+                        ]
+                    ),
                     "sql": sql_job.SQLJobFacet(query="SELECT 1;"),
                     "jobType": job_type_job.JobTypeJobFacet(
                         processingType="BATCH", integration="AIRFLOW", jobType="TASK"
@@ -663,7 +675,7 @@ def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, generate_stat
         clear_number=0,
         nominal_start_time=event_time.isoformat(),
         nominal_end_time=event_time.isoformat(),
-        owners=["airflow"],
+        owners=["owner1", "owner2"],
         description=dag.description,
         run_facets={
             "parent": parent_run.ParentRunFacet(
@@ -725,7 +737,8 @@ def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, generate_stat
                     "documentation": documentation_job.DocumentationJobFacet(description="dag desc"),
                     "ownership": ownership_job.OwnershipJobFacet(
                         owners=[
-                            ownership_job.Owner(name="airflow", type=None),
+                            ownership_job.Owner(name="owner1", type=None),
+                            ownership_job.Owner(name="owner2", type=None),
                         ]
                     ),
                     **job_facets,
@@ -796,6 +809,7 @@ def test_emit_dag_complete_event(
         clear_number=0,
         dag_run_state=DagRunState.SUCCESS,
         task_ids=["task_0", "task_1", "task_2.test"],
+        owners=["owner1", "owner2"],
         run_facets={
             "parent": parent_run.ParentRunFacet(
                 run=parent_run.Run(runId=random_uuid),
@@ -843,9 +857,15 @@ def test_emit_dag_complete_event(
                 namespace=namespace(),
                 name=dag_id,
                 facets={
+                    "ownership": ownership_job.OwnershipJobFacet(
+                        owners=[
+                            ownership_job.Owner(name="owner1", type=None),
+                            ownership_job.Owner(name="owner2", type=None),
+                        ]
+                    ),
                     "jobType": job_type_job.JobTypeJobFacet(
                         processingType="BATCH", integration="AIRFLOW", jobType="DAG"
-                    )
+                    ),
                 },
             ),
             producer=_PRODUCER,
@@ -910,6 +930,7 @@ def test_emit_dag_failed_event(
         dag_run_state=DagRunState.FAILED,
         task_ids=["task_0", "task_1", "task_2.test"],
         msg="error msg",
+        owners=["owner1", "owner2"],
         run_facets={
             "parent": parent_run.ParentRunFacet(
                 run=parent_run.Run(runId=random_uuid),
@@ -960,9 +981,15 @@ def test_emit_dag_failed_event(
                 namespace=namespace(),
                 name=dag_id,
                 facets={
+                    "ownership": ownership_job.OwnershipJobFacet(
+                        owners=[
+                            ownership_job.Owner(name="owner1", type=None),
+                            ownership_job.Owner(name="owner2", type=None),
+                        ]
+                    ),
                     "jobType": job_type_job.JobTypeJobFacet(
                         processingType="BATCH", integration="AIRFLOW", jobType="DAG"
-                    )
+                    ),
                 },
             ),
             producer=_PRODUCER,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -22,7 +22,7 @@ from concurrent.futures import Future
 from contextlib import suppress
 from typing import TYPE_CHECKING, Callable
 from unittest import mock
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -35,7 +35,6 @@ from airflow.models import DAG, DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.providers.openlineage.extractors.base import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
-from airflow.providers.openlineage.plugins.facets import AirflowDebugRunFacet
 from airflow.providers.openlineage.plugins.listener import OpenLineageListener
 from airflow.providers.openlineage.utils.selective_enable import disable_lineage, enable_lineage
 from airflow.utils import timezone, types
@@ -250,6 +249,7 @@ class TestOpenLineageListenerAirflow2:
         task_instance.task.dag.dag_id = "dag_id"
         task_instance.task.dag.description = "Test DAG Description"
         task_instance.task.dag.owner = "Test Owner"
+        task_instance.task.owner = "task_owner"
         task_instance.task.inlets = []
         task_instance.task.outlets = []
         task_instance.dag_id = "dag_id"
@@ -268,6 +268,7 @@ class TestOpenLineageListenerAirflow2:
         return listener, task_instance
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
@@ -285,6 +286,7 @@ class TestOpenLineageListenerAirflow2:
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'start_task' method of the OpenLineageAdapter is invoked with the correct arguments.
@@ -301,6 +303,7 @@ class TestOpenLineageListenerAirflow2:
         mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
         mock_disabled.return_value = False
 
         listener.on_task_instance_running(None, task_instance, None)
@@ -312,18 +315,54 @@ class TestOpenLineageListenerAirflow2:
             code_location=None,
             nominal_start_time=None,
             nominal_end_time=None,
-            owners=["Test Owner"],
+            owners=["task_owner"],
             task=listener.extractor_manager.extract_metadata(),
             run_facets={
                 "parent": 4,
                 "mapped_facet": 1,
                 "custom_user_facet": 2,
                 "airflow_run_facet": 3,
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
         )
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_adapter_start_task_is_called_with_dag_owners_when_task_owner_is_default(
+        self,
+        mock_get_job_name,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        mock_debug_mode,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        mock_get_job_name.return_value = "job_name"
+        mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
+        mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
+        mock_disabled.return_value = False
+
+        task_instance.task.owner = "airflow"  # Simulate default owner on task to force fallback to DAG owner
+        listener.on_task_instance_running(None, task_instance, None)
+        assert listener.adapter.start_task.call_args.kwargs["owners"] == ["Test Owner"]
+
+    @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
@@ -341,6 +380,7 @@ class TestOpenLineageListenerAirflow2:
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'fail_task' method of the OpenLineageAdapter is invoked with the correct arguments.
@@ -357,30 +397,68 @@ class TestOpenLineageListenerAirflow2:
         mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
         mock_disabled.return_value = False
 
         err = ValueError("test")
-        on_task_failed_listener_kwargs = {"error": err}
-        expected_err_kwargs = {"error": err}
-
         listener.on_task_instance_failed(
-            previous_state=None, task_instance=task_instance, **on_task_failed_listener_kwargs, session=None
+            previous_state=None, task_instance=task_instance, error=err, session=None
         )
         listener.adapter.fail_task.assert_called_once_with(
             end_time="2023-01-03T13:01:01+00:00",
             job_name="job_name",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
+            owners=["task_owner"],
             task=listener.extractor_manager.extract_metadata(),
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,
                 "airflow": {"task": "..."},
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
-            **expected_err_kwargs,
+            error=err,
         )
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_adapter_fail_task_is_called_with_dag_owners_when_task_owner_is_default(
+        self,
+        mock_get_job_name,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        mock_debug_mode,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        mock_get_job_name.return_value = "job_name"
+        mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
+        mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
+        mock_disabled.return_value = False
+
+        task_instance.task.owner = "airflow"  # Simulate default owner on task to force fallback to DAG owner
+        err = ValueError("test")
+        listener.on_task_instance_failed(
+            previous_state=None, task_instance=task_instance, error=err, session=None
+        )
+        assert listener.adapter.fail_task.call_args.kwargs["owners"] == ["Test Owner"]
+
+    @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
@@ -398,6 +476,7 @@ class TestOpenLineageListenerAirflow2:
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'complete_task' method of the OpenLineageAdapter is called with the correct arguments.
@@ -414,6 +493,7 @@ class TestOpenLineageListenerAirflow2:
         mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
         mock_disabled.return_value = False
 
         listener.on_task_instance_success(None, task_instance, None)
@@ -426,13 +506,49 @@ class TestOpenLineageListenerAirflow2:
             job_name="job_name",
             run_id=f"2020-01-01T01:01:01+00:00.dag_id.task_id.{EXPECTED_TRY_NUMBER_1}.-1",
             task=listener.extractor_manager.extract_metadata(),
+            owners=["task_owner"],
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,
                 "airflow": {"task": "..."},
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
         )
+
+    @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_adapter_complete_task_is_called_with_dag_owners_when_task_owner_is_default(
+        self,
+        mock_get_job_name,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        mock_debug_mode,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        mock_get_job_name.return_value = "job_name"
+        mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
+        mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
+        mock_disabled.return_value = False
+
+        task_instance.task.owner = "airflow"  # Simulate default owner on task to force fallback to DAG owner
+        listener.on_task_instance_success(None, task_instance, None)
+        assert listener.adapter.complete_task.call_args.kwargs["owners"] == ["Test Owner"]
 
     @mock.patch(
         "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
@@ -870,7 +986,8 @@ class TestOpenLineageListenerAirflow3:
                 dag_id="dag_id",
                 description="Test DAG Description",
             )
-            task = EmptyOperator(task_id="task_id", dag=dag, owner="Test Owner")
+            task = EmptyOperator(task_id="task_id", dag=dag, owner="task_owner")
+            task2 = EmptyOperator(task_id="task_id2", dag=dag, owner="another_owner")  # noqa: F841
 
             sdk_task_instance = SdkTaskInstance(
                 id=uuid7(),
@@ -929,6 +1046,7 @@ class TestOpenLineageListenerAirflow3:
         return listener, task_instance
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
@@ -946,6 +1064,7 @@ class TestOpenLineageListenerAirflow3:
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'start_task' method of the OpenLineageAdapter is invoked with the correct arguments.
@@ -962,6 +1081,7 @@ class TestOpenLineageListenerAirflow3:
         mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
         mock_disabled.return_value = False
 
         listener.on_task_instance_running(None, task_instance)
@@ -973,18 +1093,55 @@ class TestOpenLineageListenerAirflow3:
             code_location=None,
             nominal_start_time=None,
             nominal_end_time=None,
-            owners=["Test Owner"],
+            owners=["task_owner"],
             task=listener.extractor_manager.extract_metadata(),
             run_facets={
                 "mapped_facet": 1,
                 "custom_user_facet": 2,
                 "airflow_run_facet": 3,
                 "parent": 4,
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
         )
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_adapter_start_task_is_called_with_dag_owners_when_task_owner_is_default(
+        self,
+        mock_get_job_name,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        mock_debug_mode,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        mock_get_job_name.return_value = "job_name"
+        mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
+        mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
+        mock_disabled.return_value = False
+
+        task_instance.task.owner = "airflow"  # Simulate default owner on task to force fallback to DAG owner
+        listener.on_task_instance_running(None, task_instance)
+        call_owners = listener.adapter.start_task.call_args.kwargs["owners"]
+        assert sorted(call_owners) == ["airflow", "another_owner"]
+
+    @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
@@ -1002,6 +1159,7 @@ class TestOpenLineageListenerAirflow3:
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'fail_task' method of the OpenLineageAdapter is invoked with the correct arguments.
@@ -1018,30 +1176,66 @@ class TestOpenLineageListenerAirflow3:
         mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
         mock_disabled.return_value = False
 
         err = ValueError("test")
-        on_task_failed_listener_kwargs = {"error": err}
-        expected_err_kwargs = {"error": err}
-
-        listener.on_task_instance_failed(
-            previous_state=None, task_instance=task_instance, **on_task_failed_listener_kwargs
-        )
+        listener.on_task_instance_failed(previous_state=None, task_instance=task_instance, error=err)
         listener.adapter.fail_task.assert_called_once_with(
             end_time="2023-01-03T13:01:01+00:00",
             job_name="job_name",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=listener.extractor_manager.extract_metadata(),
+            owners=["task_owner"],
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,
                 "airflow": {"task": "..."},
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
-            **expected_err_kwargs,
+            error=err,
         )
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_adapter_fail_task_is_called_with_dag_owners_when_task_owner_is_default(
+        self,
+        mock_get_job_name,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        mock_debug_mode,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        mock_get_job_name.return_value = "job_name"
+        mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
+        mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
+        mock_disabled.return_value = False
+
+        task_instance.task.owner = "airflow"  # Simulate default owner on task to force fallback to DAG owner
+        err = ValueError("test")
+        listener.on_task_instance_failed(previous_state=None, task_instance=task_instance, error=err)
+
+        call_owners = listener.adapter.fail_task.call_args.kwargs["owners"]
+        assert sorted(call_owners) == ["airflow", "another_owner"]
+
+    @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
     @mock.patch(
@@ -1053,6 +1247,7 @@ class TestOpenLineageListenerAirflow3:
         mock_utcnow,
         mock_get_job_name,
         mock_get_task_parent_run_facet,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'fail_task' method of the OpenLineageAdapter is invoked with the correct arguments.
@@ -1064,6 +1259,7 @@ class TestOpenLineageListenerAirflow3:
         listener, task_instance = self._create_listener_and_task_instance(runtime_ti=False)
         mock_get_job_name.return_value = "job_name"
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
 
         err = ValueError("test")
         on_task_failed_listener_kwargs = {"error": err}
@@ -1082,12 +1278,13 @@ class TestOpenLineageListenerAirflow3:
             task=OperatorLineage(),
             run_facets={
                 "parent": 4,
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
             **expected_err_kwargs,
         )
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
@@ -1105,6 +1302,7 @@ class TestOpenLineageListenerAirflow3:
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'complete_task' method of the OpenLineageAdapter is called with the correct arguments.
@@ -1121,6 +1319,7 @@ class TestOpenLineageListenerAirflow3:
         mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
         mock_disabled.return_value = False
 
         listener.on_task_instance_success(None, task_instance)
@@ -1131,15 +1330,54 @@ class TestOpenLineageListenerAirflow3:
             job_name="job_name",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=listener.extractor_manager.extract_metadata(),
+            owners=["task_owner"],
             run_facets={
                 "parent": 4,
                 "custom_user_facet": 2,
                 "airflow": {"task": "..."},
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
         )
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_adapter_complete_task_is_called_with_dag_owners_when_task_owner_is_default(
+        self,
+        mock_get_job_name,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        mock_debug_mode,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        mock_get_job_name.return_value = "job_name"
+        mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
+        mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
+        mock_disabled.return_value = False
+
+        task_instance.task.owner = "airflow"  # Simulate default owner on task to force fallback to DAG owner
+        listener.on_task_instance_success(None, task_instance)
+
+        call_owners = listener.adapter.complete_task.call_args.kwargs["owners"]
+        assert sorted(call_owners) == ["airflow", "another_owner"]
+
+    @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
     @mock.patch(
@@ -1151,6 +1389,7 @@ class TestOpenLineageListenerAirflow3:
         mock_utcnow,
         mock_get_job_name,
         mock_get_task_parent_run_facet,
+        mock_debug_facet,
         mock_debug_mode,
     ):
         """Tests that the 'complete_task' method of the OpenLineageAdapter is called with the correct arguments.
@@ -1161,6 +1400,7 @@ class TestOpenLineageListenerAirflow3:
         listener, task_instance = self._create_listener_and_task_instance(runtime_ti=False)
         mock_get_job_name.return_value = "job_name"
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
+        mock_debug_facet.return_value = {"debug": "packages"}
 
         listener.on_task_instance_success(None, task_instance)
         calls = listener.adapter.complete_task.call_args_list
@@ -1175,7 +1415,7 @@ class TestOpenLineageListenerAirflow3:
             task=OperatorLineage(),
             run_facets={
                 "parent": 4,
-                "debug": AirflowDebugRunFacet(packages=ANY),
+                "debug": "packages",
             },
         )
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Currently DAG owner is used to create TASK level Ownership facet. This PR changes that behavior, now TASK owner is used and it fallbacks to DAG owner only if task owner is default value ("airflow"). Also Ownership facet is added to COMPLETE and FAIL TASK events. Also Ownership facet is added to COMPLETE and FAIL DAG events (with DAG owners only of course).


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
