### PR TITLE
Bump structlog min to 25.4.0 and handle tests accordingly

### DIFF
--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     'pendulum>=3.0.0,<4.0;python_version>="3.12"',
     "python-dateutil>=2.7.0",
     "psutil>=6.1.0",
-    "structlog>=25.2.0",
+    "structlog>=25.4.0",
     "retryhttp>=1.2.0,!=1.3.0",
 ]
 

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -136,6 +136,8 @@ def test_xcom_convert_to_kwargs_fails_task(run_ti: RunTI, mock_supervisor_comms,
                         "exc_value": "expand_kwargs() expects a list[dict], not list[None]",
                         "frames": mock.ANY,
                         "is_cause": False,
+                        "is_group": False,
+                        "exceptions": [],
                         "syntax_error": None,
                     }
                 ],
@@ -180,6 +182,8 @@ def test_xcom_map_error_fails_task(mock_supervisor_comms, run_ti, captured_logs)
                         "exc_value": "nope",
                         "frames": mock.ANY,
                         "is_cause": False,
+                        "is_group": False,
+                        "exceptions": [],
                         "syntax_error": None,
                     }
                 ],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Structlog released 25.4.0 changing some log trace structure leading to our CI failing:

```
FAILED task-sdk/tests/task_sdk/definitions/test_xcom_arg.py::test_xcom_map_error_fails_task - AssertionError: assert [{'event': 'Task failed with exception', 'exception': [{'exc_notes': [], 'exc_type': 'RuntimeError', 'exc_value': 'nope', 'exceptions': [], ...}], 'level': 'error', 'timestamp': '2025-06-02T13:52:49.877193Z'}] == [{'event': 'Task failed with exception', 'level': 'error', 'timestamp': <ANY>, 'exception': [{'exc_notes': [], 'exc_type': 'RuntimeError', 'exc_value': 'nope', 'frames': <ANY>, 'is_cause': False, 'syntax_error': None}]}]
  One item replaced:
  Omitting 3 identical items, use -vv to show
  Differing items:
  {'exception': [{'exc_notes': [], 'exc_type': 'RuntimeError', 'exc_value': 'nope', 'exceptions': [], ...}]} != {'exception': [{'exc_notes': [], 'exc_type': 'RuntimeError', 'exc_value': 'nope', 'frames': <ANY>, ...}]}
  
  Full diff:
    {
        'event': 'Task failed with exception',
        'exception': [
            {
                'exc_notes': [],
                'exc_type': 'RuntimeError',
                'exc_value': 'nope',
  +             'exceptions': [],
  -             'frames': <ANY>,
  ?                       ^^^^^^
  +             'frames': [
  ?                       ^
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
  +                     'lineno': 856,
  +                     'name': 'run',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
  +                     'lineno': 776,
  +                     'name': '_prepare',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py',
  +                     'lineno': 277,
  +                     'name': 'render_templates',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/definitions/mappedoperator.py',
  +                     'lineno': 826,
  +                     'name': 'render_template_fields',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/bases/decorator.py',
  +                     'lineno': 576,
  +                     'name': '_expand_mapped_kwargs',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/definitions/mappedoperator.py',
  +                     'lineno': 697,
  +                     'name': '_expand_mapped_kwargs',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py',
  +                     'lineno': 264,
  +                     'name': 'resolve',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/src/airflow/sdk/definitions/xcom_arg.py',
  +                     'lineno': 389,
  +                     'name': '__getitem__',
  +                 },
  +                 {
  +                     'filename': '/opt/airflow/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py',
  +                     'lineno': 160,
  +                     'name': 'does_not_work_with_c',
  +                 },
  +             ],
                'is_cause': False,
  +             'is_group': False,
                'syntax_error': None,
            },
        ],
        'level': 'error',
  -     'timestamp': <ANY>,
  +     'timestamp': '2025-06-02T13:52:49.877193Z',
```


Updating the min version to 25.4.0 and handling test failures accordingly.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
