### PR TITLE
Restrict typing-extensions 4.14.0 to fix CI temporarily

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -131,6 +131,8 @@ dependencies = [
     "tabulate>=0.9.0",
     "tenacity>=8.0.0,!=8.2.0",
     "termcolor>=3.0.0",
+    # temporarily exclude 4.14.0 due to its broken compat with cadwyn
+    "typing-extensions!=4.14.0",
     # Universal Pathlib 0.2.4 adds extra validation for Paths and our integration with local file paths
     # Does not work with it Tracked in https://github.com/fsspec/universal_pathlib/issues/276
     "universal-pathlib>=0.2.2,!=0.2.4",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Release of typing-extensions: 4.14.0: https://pypi.org/project/typing-extensions/#history breaks our CI mainly due to cadywn dependency. Error stack:
```
_______ ERROR collecting airflow-core/tests/unit/always/test_secrets.py ________
ImportError while importing test module '/opt/airflow/airflow-core/tests/unit/always/test_secrets.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
airflow-core/tests/unit/always/test_secrets.py:29: in <module>
    from tests_common.test_utils.db import clear_db_variables
devel-common/src/tests_common/test_utils/db.py:24: in <module>
    from airflow.models import (
airflow-core/src/airflow/models/__init__.py:81: in __getattr__
    val = import_string(f"{path}.{name}")
airflow-core/src/airflow/utils/module_loading.py:60: in import_string
    module = import_module(module_path)
/usr/local/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
airflow-core/src/airflow/models/dag.py:66: in <module>
    from airflow.assets.evaluation import AssetEvaluator
airflow-core/src/airflow/assets/evaluation.py:34: in <module>
    from airflow.sdk.definitions.asset.decorators import MultiAssetDefinition
task-sdk/src/airflow/sdk/definitions/asset/decorators.py:25: in <module>
    from airflow.providers.standard.operators.python import PythonOperator
providers/standard/src/airflow/providers/standard/operators/python.py:51: in <module>
    from airflow.models.baseoperator import BaseOperator
airflow-core/src/airflow/models/baseoperator.py:40: in <module>
    from airflow.models.taskinstance import TaskInstance, clear_task_instances
airflow-core/src/airflow/models/taskinstance.py:84: in <module>
    from airflow.models.taskmap import TaskMap
airflow-core/src/airflow/models/taskmap.py:31: in <module>
    from airflow.utils.db import exists_query
airflow-core/src/airflow/utils/db.py:59: in <module>
    from airflow.utils.db_manager import RunDBManager
airflow-core/src/airflow/utils/db_manager.py:26: in <module>
    from airflow.api_fastapi.app import create_auth_manager
airflow-core/src/airflow/api_fastapi/app.py:35: in <module>
    from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
airflow-core/src/airflow/api_fastapi/execution_api/app.py:27: in <module>
    from cadwyn import (
/usr/local/lib/python3.9/site-packages/cadwyn/__init__.py:3: in <module>
    from .applications import Cadwyn
/usr/local/lib/python3.9/site-packages/cadwyn/applications.py:30: in <module>
    from cadwyn.changelogs import CadwynChangelogResource, _generate_changelog
/usr/local/lib/python3.9/site-packages/cadwyn/changelogs.py:23: in <module>
    from cadwyn.route_generation import _get_routes
/usr/local/lib/python3.9/site-packages/cadwyn/route_generation.py:34: in <module>
    from cadwyn.schema_generation import (
/usr/local/lib/python3.9/site-packages/cadwyn/schema_generation.py:86: in <module>
    from typing_extensions import _BaseGenericAlias  # pyright: ignore[reportAttributeAccessIssue]
E   ImportError: cannot import name '_BaseGenericAlias' from 'typing_extensions' (/usr/local/lib/python3.9/site-packages/typing_extensions.py)
```


Example: https://github.com/apache/airflow/actions/runs/15395863318/job/43316849557?pr=51308

Temporarily restricting it.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
