### PR TITLE
[Providers/HTTP] Add Debug logging for improved troubleshooting in the HTTP Provider Hook

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -246,6 +246,24 @@ class HttpHook(BaseHook):
         """
         extra_options = extra_options or {}
 
+        self.log.debug(
+            "Making HTTP request:\n"
+            "Method: %s\n"
+            "Endpoint: %s\n"
+            "Base URL: %s\n"
+            "Headers: %s\n"
+            "Data: %s\n"
+            "Extra Options: %s\n"
+            "Request Kwargs: %s",
+            self.method,
+            endpoint,
+            self.base_url,
+            headers,
+            data,
+            extra_options,
+            request_kwargs,
+        )
+
         session = self.get_conn(headers, extra_options)
 
         url = self.url_from_endpoint(endpoint)
@@ -294,6 +312,24 @@ class HttpHook(BaseHook):
             i.e. ``{'check_response': False}`` to avoid checking raising exceptions on non 2XX
             or 3XX status codes
         """
+        self.log.debug(
+            "Executing prepared request:\n"
+            "URL: %s\n"
+            "Method: %s\n"
+            "Headers: %s\n"
+            "Body Length: %d bytes\n"
+            "Extra Options: %s\n"
+            "Timeout: %s\n"
+            "Allow Redirects: %s",
+            prepped_request.url,
+            prepped_request.method,
+            prepped_request.headers,
+            len(prepped_request.body) if prepped_request.body else 0,
+            extra_options,
+            extra_options.get("timeout"),
+            extra_options.get("allow_redirects", True),
+        )
+
         extra_options = extra_options or {}
 
         settings = session.merge_environment_settings(
@@ -313,6 +349,18 @@ class HttpHook(BaseHook):
 
         try:
             response = session.send(prepped_request, **send_kwargs)
+
+            self.log.debug(
+                "Response received:\n"
+                "Status Code: %d\n"
+                "Headers: %s\n"
+                "Content Length: %d bytes\n"
+                "Elapsed Time: %s",
+                response.status_code,
+                response.headers,
+                len(response.content),
+                response.elapsed,
+            )
 
             if extra_options.get("check_response", True):
                 self.check_response(response)
@@ -344,6 +392,13 @@ class HttpHook(BaseHook):
             hook.run_with_advanced_retry(endpoint="v1/test", _retry_args=retry_args)
 
         """
+        self.log.debug(
+            "Initializing retry mechanism:\nRetry Arguments: %s\nArgs: %s\nKwargs: %s",
+            _retry_args,
+            args,
+            kwargs,
+        )
+
         self._retry_obj = tenacity.Retrying(**_retry_args)
 
         # TODO: remove ignore type when https://github.com/jd/tenacity/issues/428 is resolved


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Added some debug logging to the HTTP Prover hook (`providers/http/src/airflow/providers/http/hooks/http.py`) since this hook runs on every HTTP call. As a user, the only info missing from the existing logs was more detailed data about the HTTP request itself. It made sense to add logs here because then users can pinpoint exactly where a request failed and troubleshoot more effectively.

**Here is a screenshot highlighting what the debug logging looks like:**

![Screenshot 2025-06-03 at 5 25 58 AM](https://github.com/user-attachments/assets/18d07b9b-eb62-4169-9462-16067cddded5)


