### PR TITLE
Exclude sqlalchemy-spanner 1.12.0 from core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ version = "3.1.0"
 dependencies = [
     "apache-airflow-task-sdk<1.2.0,>=1.0.0",
     "apache-airflow-core==3.1.0",
+    "sqlalchemy-spanner!=1.12.0",
 ]
 
 packages = []


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/51379/files was done but that seems to have fixed it for google but seems that the core is pulling in with this dependency leading to conflicts!

Error:
```
  Using Python 3.9.22 environment at: /usr/local
    × Failed to build `sqlalchemy-spanner==1.12.0`
    ├─▶ The build backend returned an error
    ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
        status: 1)
  
        [stderr]
        Traceback (most recent call last):
          File "<string>", line 14, in <module>
          File
        "/root/.cache/uv/builds-v0/.tmpGXqNjn/lib/python3.9/site-packages/setuptools/build_meta.py",
        line 331, in get_requires_for_build_wheel
            return self._get_build_requires(config_settings, requirements=[])
          File
        "/root/.cache/uv/builds-v0/.tmpGXqNjn/lib/python3.9/site-packages/setuptools/build_meta.py",
        line 301, in _get_build_requires
            self.run_setup()
          File
        "/root/.cache/uv/builds-v0/.tmpGXqNjn/lib/python3.9/site-packages/setuptools/build_meta.py",
        line 512, in run_setup
            super().run_setup(setup_script=setup_script)
          File
        "/root/.cache/uv/builds-v0/.tmpGXqNjn/lib/python3.9/site-packages/setuptools/build_meta.py",
        line 317, in run_setup
            exec(code, locals())
          File "<string>", line 42, in <module>
        FileNotFoundError: [Errno 2] No such file or directory:
        '/root/.cache/uv/sdists-v9/pypi/sqlalchemy-spanner/1.12.0/ov5x7gb8PILJehef0Gf3j/src/version.py'
  
        hint: This usually indicates a problem with the package or the build
        environment.
    help: `sqlalchemy-spanner` (v1.12.0) was included
          because `apache-airflow[all]` (v3.1.0) depends on
          `apache-airflow-providers-google>=10.24.0` (v15.1.0) which depends on
          `sqlalchemy-spanner>=1.6.2`
```

Example: https://github.com/apache/airflow/actions/runs/15433020002/job/43434553777


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
