### PR TITLE
Add sqlalchemy-spanner limitation for broken 1.12.0 release

### DIFF
--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -346,7 +346,15 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
     providers are used by our users to install Airflow in reproducible way.
     :return:
     """
-    run_command(
+
+    # In case we have some problems with installing highest resolution of a dependency of one of our
+    # providers in PyPI - we can exclude the buggy version here. For example this happened with
+    # sqlalchemy-spanner==1.4.0 which did not have `whl` file in PyPI and was not installable
+    # Current exclusions:
+    # * sqlalchemy-spanner: https://github.com/googleapis/python-spanner-sqlalchemy/issues/682
+    additional_constraints_for_highest_resolution = ["sqlalchemy-spanner!=1.12.0"]
+
+    result = run_command(
         cmd=[
             "uv",
             "pip",
@@ -356,6 +364,7 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
             "apache-airflow-core[all]",
             "apache-airflow-task-sdk",
             "./airflow-ctl",
+            *additional_constraints_for_highest_resolution,
             "--reinstall",  # We need to pull the provider distributions from PyPI or dist, not the local ones
             "--resolution",
             "highest",
@@ -363,8 +372,16 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
             "file://" + str(AIRFLOW_DIST_PATH),
         ],
         github_actions=config_params.github_actions,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        console.print(
+            "[red]Failed to install airflow with PyPI providers with highest resolution.[/]\n"
+            "[yellow]Please check the output above for details. One of they ways how to resolve it, in "
+            "case it is caused by a specific broken dependency version, is to exclude it above in the "
+            f"`additional_constraints_for_highest_resolution` list in [/] {__file__}"
+        )
+        sys.exit(result.returncode)
     console.print("[success]Installed airflow with PyPI providers with eager upgrade.")
     distributions_to_exclude_from_constraints = get_locally_build_distribution_specs()
     with config_params.current_constraints_file.open("w") as constraints_file:


### PR DESCRIPTION
When constraints are calculated, we should termporarily exclude the sqlalchemy-spanner from the install command until they fix the problem where 1.12.0 was relesed without .whl files.

Tracked in https://github.com/googleapis/python-spanner-sqlalchemy/issues/682

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
