### PR TITLE
feat: added `request_body` support in the `PowerBIDatasetRefreshOperator` (enables support for enhanced dataset refreshes)

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -189,12 +189,15 @@ class PowerBIHook(KiotaRequestAdapterHook):
 
         return refresh_details
 
-    async def trigger_dataset_refresh(self, *, dataset_id: str, group_id: str) -> str:
+    async def trigger_dataset_refresh(
+        self, *, dataset_id: str, group_id: str, request_body: dict[str, Any] | None = None
+    ) -> str:
         """
         Triggers a refresh for the specified dataset from the given group id.
 
         :param dataset_id: The dataset id.
         :param group_id: The workspace id.
+        :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest.
 
         :return: Request id of the dataset refresh request.
         """
@@ -207,6 +210,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
                     "group_id": group_id,
                     "dataset_id": dataset_id,
                 },
+                data=request_body,
             )
 
             request_id = response.get("requestid")

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -197,7 +197,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
 
         :param dataset_id: The dataset id.
         :param group_id: The workspace id.
-        :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest.
+        :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group#request-body.
 
         :return: Request id of the dataset refresh request.
         """

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -72,6 +72,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
     :param timeout: Time in seconds to wait for a dataset to reach a terminal status for asynchronous waits. Used only if ``wait_for_termination`` is True.
     :param check_interval: Number of seconds to wait before rechecking the
         refresh status.
+    :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest.
     """
 
     template_fields: Sequence[str] = (
@@ -92,6 +93,8 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         proxies: dict | None = None,
         api_version: APIVersion | str | None = None,
         check_interval: int = 60,
+        request_body: dict[str, Any]
+        | None = None,  # TODO: Maybe change to pydantic model / dataclass / typeddict in future?
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -102,6 +105,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         self.conn_id = conn_id
         self.timeout = timeout
         self.check_interval = check_interval
+        self.request_body = request_body
 
     @property
     def proxies(self) -> dict | None:
@@ -124,6 +128,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
                     api_version=self.api_version,
                     check_interval=self.check_interval,
                     wait_for_termination=self.wait_for_termination,
+                    request_body=self.request_body,
                 ),
                 method_name=self.get_refresh_status.__name__,
             )

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -72,7 +72,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
     :param timeout: Time in seconds to wait for a dataset to reach a terminal status for asynchronous waits. Used only if ``wait_for_termination`` is True.
     :param check_interval: Number of seconds to wait before rechecking the
         refresh status.
-    :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest.
+    :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group#request-body.
     """
 
     template_fields: Sequence[str] = (

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -93,8 +93,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         proxies: dict | None = None,
         api_version: APIVersion | str | None = None,
         check_interval: int = 60,
-        request_body: dict[str, Any]
-        | None = None,  # TODO: Maybe change to pydantic model / dataclass / typeddict in future?
+        request_body: dict[str, Any] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -53,7 +53,7 @@ class PowerBITrigger(BaseTrigger):
     :param group_id: The workspace Id where dataset is located.
     :param check_interval: Time in seconds to wait between each poll.
     :param wait_for_termination: Wait for the dataset refresh to complete or fail.
-    :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest.
+    :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group#request-body.
     """
 
     def __init__(

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -67,8 +67,7 @@ class PowerBITrigger(BaseTrigger):
         api_version: APIVersion | str | None = None,
         check_interval: int = 60,
         wait_for_termination: bool = True,
-        request_body: dict[str, Any]
-        | None = None,  # TODO: Maybe change to pydantic model / dataclass / typeddict in future?
+        request_body: dict[str, Any] | None = None,
     ):
         super().__init__()
         self.hook = PowerBIHook(conn_id=conn_id, proxies=proxies, api_version=api_version, timeout=timeout)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import tenacity
 
@@ -51,9 +51,9 @@ class PowerBITrigger(BaseTrigger):
     :param dataset_id: The dataset Id to refresh.
     :param dataset_refresh_id: The dataset refresh Id to poll for the status, if not provided a new refresh will be triggered.
     :param group_id: The workspace Id where dataset is located.
-    :param end_time: Time in seconds when trigger should stop polling.
     :param check_interval: Time in seconds to wait between each poll.
     :param wait_for_termination: Wait for the dataset refresh to complete or fail.
+    :param request_body: Additional arguments to pass to the request body, as described in https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest.
     """
 
     def __init__(
@@ -67,6 +67,8 @@ class PowerBITrigger(BaseTrigger):
         api_version: APIVersion | str | None = None,
         check_interval: int = 60,
         wait_for_termination: bool = True,
+        request_body: dict[str, Any]
+        | None = None,  # TODO: Maybe change to pydantic model / dataclass / typeddict in future?
     ):
         super().__init__()
         self.hook = PowerBIHook(conn_id=conn_id, proxies=proxies, api_version=api_version, timeout=timeout)
@@ -76,6 +78,7 @@ class PowerBITrigger(BaseTrigger):
         self.group_id = group_id
         self.check_interval = check_interval
         self.wait_for_termination = wait_for_termination
+        self.request_body = request_body
 
     def serialize(self):
         """Serialize the trigger instance."""
@@ -91,6 +94,7 @@ class PowerBITrigger(BaseTrigger):
                 "timeout": self.timeout,
                 "check_interval": self.check_interval,
                 "wait_for_termination": self.wait_for_termination,
+                "request_body": self.request_body,
             },
         )
 
@@ -113,6 +117,7 @@ class PowerBITrigger(BaseTrigger):
             dataset_refresh_id = await self.hook.trigger_dataset_refresh(
                 dataset_id=self.dataset_id,
                 group_id=self.group_id,
+                request_body=self.request_body,
             )
 
             if dataset_refresh_id:

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
@@ -66,6 +66,12 @@ with DAG(
         group_id=GROUP_ID,
         check_interval=30,
         timeout=120,
+        request_body={
+            "type": "full",
+            "retryCount": 3,
+            "commitMode": "transactional",
+            "notifyOption": "MailOnFailure",
+        }
     )
     # [END howto_operator_powerbi_refresh_async]
 

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
@@ -71,7 +71,7 @@ with DAG(
             "retryCount": 3,
             "commitMode": "transactional",
             "notifyOption": "MailOnFailure",
-        }
+        },
     )
     # [END howto_operator_powerbi_refresh_async]
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_powerbi.py
@@ -39,6 +39,13 @@ DEFAULT_CONNECTION_CLIENT_SECRET = "powerbi_conn_id"
 TASK_ID = "run_powerbi_operator"
 GROUP_ID = "group_id"
 DATASET_ID = "dataset_id"
+REQUEST_BODY = {
+    "type": "full",
+    "commitMode": "transactional",
+    "objects": [{"table": "Customer", "partition": "Robert"}],
+    "applyRefreshPolicy": "false",
+    "timeout": "05:00:00",
+}
 CONFIG = {
     "task_id": TASK_ID,
     "conn_id": DEFAULT_CONNECTION_CLIENT_SECRET,
@@ -46,6 +53,7 @@ CONFIG = {
     "dataset_id": DATASET_ID,
     "check_interval": 1,
     "timeout": 3,
+    "request_body": REQUEST_BODY,
 }
 NEW_REFRESH_REQUEST_ID = "5e2d9921-e91b-491f-b7e1-e7d8db49194c"
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
@@ -47,14 +47,9 @@ CHECK_INTERVAL = 1
 REQUEST_BODY = {
     "type": "full",
     "commitMode": "transactional",
-    "objects": [
-        {
-            "table": "Customer",
-            "partition": "Robert"
-        }
-    ],
+    "objects": [{"table": "Customer", "partition": "Robert"}],
     "applyRefreshPolicy": "false",
-    "timeout": "05:00:00"
+    "timeout": "05:00:00",
 }
 API_VERSION = "v1.0"
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
@@ -44,6 +44,18 @@ WORKSPACE_IDS = "workspace_ids"
 TIMEOUT = 5
 MODULE = "airflow.providers.microsoft.azure"
 CHECK_INTERVAL = 1
+REQUEST_BODY = {
+    "type": "full",
+    "commitMode": "transactional",
+    "objects": [
+        {
+            "table": "Customer",
+            "partition": "Robert"
+        }
+    ],
+    "applyRefreshPolicy": "false",
+    "timeout": "05:00:00"
+}
 API_VERSION = "v1.0"
 
 
@@ -102,6 +114,7 @@ class TestPowerBITrigger:
             check_interval=CHECK_INTERVAL,
             wait_for_termination=True,
             timeout=TIMEOUT,
+            request_body=REQUEST_BODY,
         )
 
         classpath, kwargs = powerbi_trigger.serialize()
@@ -116,6 +129,7 @@ class TestPowerBITrigger:
             "api_version": API_VERSION,
             "check_interval": CHECK_INTERVAL,
             "wait_for_termination": True,
+            "request_body": REQUEST_BODY,
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/50529

<h3>TL;DR;</h3>

Original implementation was done in https://github.com/apache/airflow/pull/40356

- Enables support for providing data with the `PowerBIDatasetRefreshOperator`, in the form of a `request_body` that should map 1:1 with the [DatasetRefreshRequest](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset#datasetrefreshrequest) spec.
- Enables users to refresh PowerBI Datasets on a more granular level, such as specific tables or partitions within a dataset, and provide more arguments such as `retryCount`, `timeout` (on the PBI side), `maxParallelism`, or `notifyOption`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

---

<h3>Manual testing:</h3>

For manual testing I used the breeze set-up which is described in the [contribution quick-start guide](https://github.com/apache/airflow/blob/main/contributing-docs/03_contributors_quick_start.rst#setting-up-breeze). Besides that I registered an [Azure Application](https://learn.microsoft.com/en-us/power-bi/developer/embedded/register-app) and used [option 1 in the Airflow Microsoft Azure connection guide](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/azure.html) to configure a `power_bi_default` connection within the local Airflow instance. For PowerBI I made use of the 60 days trial, which allows you to have a pro-license for 60 days and makes it possible to test this functionality.

<details>
<summary><b>For manual testing I used the following sample DAG, and tweaked around with the original parameters group_id, dataset_id, and the newly added parameter request_body:</b></summary>

```python
from airflow import DAG
from datetime import timedelta

from airflow.providers.microsoft.azure.operators.powerbi import PowerBIDatasetRefreshOperator
from airflow.providers.standard.operators.bash import BashOperator

default_args = {
    "retries": 0,
    "retry_delay": timedelta(minutes=1),
}

DATASET_ID = ""
GROUP_ID = ""
REQUEST_BODY = None

with DAG(
    dag_id="trigger_powerbi_dataset_refresh",
    default_args=default_args,
    schedule="*/1 0 * * *",
    catchup=False,
    tags=["power_bi"],
) as dag:
    sample_task = BashOperator(
        task_id="sample_task",
        bash_command="echo 'This is a sample task to demonstrate Power BI dataset refresh trigger.'",
    )

    refresh_powerbi_dataset = PowerBIDatasetRefreshOperator(
        conn_id="powerbi_default",
        task_id="refresh_powerbi_dataset",
        dataset_id=DATASET_ID,
        group_id=GROUP_ID,
        check_interval=30,
        timeout=120,
        request_body=REQUEST_BODY, # newly added argument
    )

    sample_task >> refresh_powerbi_dataset
```
</details>

<details>
<summary>✅ Test case 1 - invalid dataset_id and group_id should cause 404</summary>


input:
```python
DATASET_ID = "foo"
GROUP_ID = "bar"
REQUEST_BODY = None
```

logs:
```
[2025-06-05, 20:30:26] ERROR - Trigger failed:
Traceback (most recent call last):
  File "/opt/airflow/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py", line 205, in trigger_dataset_refresh
    response = await self.run(
  File "/opt/airflow/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py", line 402, in run
    response = await self.send_request(
  File "/opt/airflow/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py", line 426, in send_request
    return await self.get_conn().send_no_response_content_async(
  File "/usr/local/lib/python3.9/site-packages/kiota_http/httpx_request_adapter.py", line 387, in send_no_response_content_async
    return await response_handler.handle_response_async(response, error_map)
  File "/opt/airflow/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py", line 93, in handle_response_async
    raise AirflowNotFoundException(message)
airflow.exceptions.AirflowNotFoundException: {'error': {'code': 'ItemNotFound', 'message': 'Dataset foo is not found! please verify datasetId is correct and user have sufficient permissions.'}}
```

<img width="778" alt="image" src="https://github.com/user-attachments/assets/9d051409-8fbf-4bdd-a9cb-f53818067f16" />


</details>

<details>
<summary>✅ Test case 2 - correct dataset_id and group_id (empty request_body) should refresh dataset as a whole (so all objects within the dataset)</summary>


input:
```python
DATASET_ID = "XXXXX" # masked but supposed to be a correct id
GROUP_ID = "XXXXX" # masked but supposed to be a correct id
REQUEST_BODY = None
```

logs:
```
[2025-06-05, 21:41:10] INFO - Pausing task as DEFERRED. : dag_id="trigger_powerbi_dataset_refresh": task_id="refresh_powerbi_dataset": run_id="manual__2025-06-05T19:41:05.248590+00:00": source="task"
[2025-06-05, 21:41:12] INFO - trigger trigger_powerbi_dataset_refresh/manual__2025-06-05T19:41:05.248590+00:00/refresh_powerbi_dataset/-1/1 (ID 7) starting
[2025-06-05, 21:41:12] INFO - Executing url 'myorg/groups/{group_id}/datasets/{dataset_id}/refreshes' as 'GET': source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 21:41:12] INFO - ClientSecretCredential.get_token succeeded: source="azure.identity._internal.get_token_mixin"
[2025-06-05, 21:41:12] INFO - Executing url 'myorg/groups/{group_id}/datasets/{dataset_id}/refreshes' as 'GET': source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 21:41:12] INFO - ClientSecretCredential.get_token succeeded: source="azure.identity._internal.get_token_mixin"
[2025-06-05, 21:41:12] INFO - Sleeping for 30. The dataset refresh status is In Progress.: source="airflow.providers.microsoft.azure.triggers.powerbi.PowerBITrigger"
[2025-06-05, 21:41:42] INFO - Executing url 'myorg/groups/{group_id}/datasets/{dataset_id}/refreshes' as 'GET': source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 21:41:42] INFO - ClientSecretCredential.get_token succeeded: source="azure.identity._internal.get_token_mixin"
[2025-06-05, 21:41:42] INFO - Trigger fired event: name="trigger_powerbi_dataset_refresh/manual__2025-06-05T19:41:05.248590+00:00/refresh_powerbi_dataset/-1/1 (ID 7)": result="TriggerEvent<{'status': 'success', 'dataset_refresh_status': 'Completed', 'message': 'The dataset refresh f7ee659e-288e-44fc-ab3f-fd7279346a6f has Completed.', 'dataset_refresh_id': 'f7ee6[59](http://localhost:28080/dags/trigger_powerbi_dataset_refresh/runs/manual__2025-06-05T19:41:05.248590+00:00/tasks/refresh_powerbi_dataset?try_number=1#59)e-288e-44fc-ab3f-fd7279346a6f'}>"
[2025-06-05, 21:41:42] INFO - trigger completed: name="trigger_powerbi_dataset_refresh/manual__2025-06-05T19:41:05.248590+00:00/refresh_powerbi_dataset/-1/1 (ID 7)"
[2025-06-05, 21:41:43] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-06-05, 21:41:43] INFO - Filling up the DagBag from /files/dags/powerbi_refresh_example_dag.py: source="airflow.models.dagbag.DagBag"
```

<img width="527" alt="image" src="https://github.com/user-attachments/assets/57a48eca-a7ae-4929-b112-c7ff386ba7c0" />

![example](https://github.com/user-attachments/assets/75b6f402-e66a-4db2-b7ed-2eadd23d28c1)

<img width="941" alt="image" src="https://github.com/user-attachments/assets/c2671939-4114-4693-9206-927980993bac" />


</details>

<details>
<summary>✅ Test case 3 - correct dataset_id and group_id refreshing a specific table via the new request_body param</summary>

input:
```python
DATASET_ID = "XXXXX" # masked but supposed to be a correct id
GROUP_ID = "XXXXX" # masked but supposed to be a correct id
REQUEST_BODY = {
    "objects": [
        {
            "table": "crime",
        },
        {
            "table": "waste_and_diversion",
        },
    ]
}
```

logs:
```
[2025-06-05, 22:05:17] INFO - Certificate data: False: source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:17] INFO - Authority: None: source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:17] INFO - Disable instance discovery: False: source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:17] INFO - MSAL Proxies: {}: source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:17] INFO - Pausing task as DEFERRED. : dag_id="trigger_powerbi_dataset_refresh": task_id="refresh_powerbi_dataset": run_id="manual__2025-06-05T20:05:12.[46](http://localhost:28080/dags/trigger_powerbi_dataset_refresh/runs/manual__2025-06-05T20:05:12.464732+00:00/tasks/refresh_powerbi_dataset?try_number=1#46)4732+00:00": source="task"
[2025-06-05, 22:05:19] INFO - trigger trigger_powerbi_dataset_refresh/manual__2025-06-05T20:05:12.464732+00:00/refresh_powerbi_dataset/-1/1 (ID 9) starting
[2025-06-05, 22:05:19] INFO - Executing url 'myorg/groups/{group_id}/datasets/{dataset_id}/refreshes' as 'GET': source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:19] INFO - ClientSecretCredential.get_token succeeded: source="azure.identity._internal.get_token_mixin"
[2025-06-05, 22:05:19] INFO - Executing url 'myorg/groups/{group_id}/datasets/{dataset_id}/refreshes' as 'GET': source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:19] INFO - ClientSecretCredential.get_token succeeded: source="azure.identity._internal.get_token_mixin"
[2025-06-05, 22:05:19] INFO - Sleeping for 30. The dataset refresh status is In Progress.: source="airflow.providers.microsoft.azure.triggers.powerbi.PowerBITrigger"
[2025-06-05, 22:05:49] INFO - Executing url 'myorg/groups/{group_id}/datasets/{dataset_id}/refreshes' as 'GET': source="airflow.task.hooks.airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook"
[2025-06-05, 22:05:49] INFO - ClientSecretCredential.get_token succeeded: source="azure.identity._internal.get_token_mixin"
[2025-06-05, 22:05:49] INFO - Trigger fired event: name="trigger_powerbi_dataset_refresh/manual__2025-06-05T20:05:12.46[47](http://localhost:28080/dags/trigger_powerbi_dataset_refresh/runs/manual__2025-06-05T20:05:12.464732+00:00/tasks/refresh_powerbi_dataset?try_number=1#47)32+00:00/refresh_powerbi_dataset/-1/1 (ID 9)": result="TriggerEvent<{'status': 'success', 'dataset_refresh_status': 'Completed', 'message': 'The dataset refresh 8071[48](http://localhost:28080/dags/trigger_powerbi_dataset_refresh/runs/manual__2025-06-05T20:05:12.464732+00:00/tasks/refresh_powerbi_dataset?try_number=1#48)99-a0a3-4eae-a530-99dbb7217051 has Completed.', 'dataset_refresh_id': '80714899-a0a3-4eae-a530-99dbb7217051'}>"
[2025-06-05, 22:05:[49](http://localhost:28080/dags/trigger_powerbi_dataset_refresh/runs/manual__2025-06-05T20:05:12.464732+00:00/tasks/refresh_powerbi_dataset?try_number=1#49)] INFO - trigger completed: name="trigger_powerbi_dataset_refresh/manual__2025-06-05T20:05:12.464732+00:00/refresh_powerbi_dataset/-1/1 (ID 9)"
[2025-06-05, 22:05:51] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-06-05, 22:05:51] INFO - Filling up the DagBag from /files/dags/powerbi_refresh_example_dag.py: source="airflow.models.dagbag.DagBag"
```

<img width="478" alt="image" src="https://github.com/user-attachments/assets/74ba9da1-dafd-4875-a05e-7c3e4cc2777c" />

(Shows specifically via `enhanced API` for this request with a body, targeting specific objects):
![example2](https://github.com/user-attachments/assets/e45348fe-6549-4b1a-bf7c-e15add8293bd)

I really tried looking for a place in the PowerBI service app portal where I can show that specifically `crime` and `waste_and_diversion` are refreshed, but I couldn't find this anywhere.


</details>

<details>
<summary>✅ Test case 4 - correct dataset_id and group_id with a request_body containing tables that do not exist</summary>

input
```python
DATASET_ID = "XXXXX" # masked but supposed to be a correct id
GROUP_ID = "XXXXX" # masked but supposed to be a correct id
REQUEST_BODY = {
    "objects": [
        {
            "table": "xxx",
        },
        {
            "table": "aaa",
        },
    ]
}
```

<img width="685" alt="image" src="https://github.com/user-attachments/assets/bb992300-57d7-4988-b3d3-dace2b6ef3af" />


logs
```
[2025-06-05, 22:15:57] ERROR - Task failed with exception: source="task"
AirflowException: The dataset refresh d119acd0-58ed-4690-ad06-3a361ab6a393 has Failed. Error: {"errorCode":"ModelRefresh_ShortMessage_ProcessingError","errorDescription":"The specified table 'xxx' not found in the target model."}
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 888 in run
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1180 in _execute_task
File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 1608 in resume_execution
File "/opt/airflow/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py", line 177 in execute_complete
```
</details>

I also did a test putting entries in the request body that are not supported by the API reference, it seems like the API just ignores these entries (does not throw a 400 bad request for example). 

Could improve the PR by adding a pydantic / typeddict / dataclass for the request body, to improve the UX. On the other hand it will also increase the coupling (e.g. requires "client side" changes when the upstream API changes it's spec, for example due to added fields), want to keep this decision up to a reviewer with more provider experience.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
