### PR TITLE
AIP- 81 Handle User Login for AUTH Clientkind

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -139,16 +139,18 @@ class Credentials:
         """Load the credentials from keyring and URL from disk file."""
         default_config_dir = user_config_path("airflow", "Apache Software Foundation")
         credential_path = os.path.join(default_config_dir, self.input_cli_config_file)
+        if self.client_kind == ClientKind.AUTH:
+            # Saving the URL set from the Auth Commands if Kind is AUTH
+            credentials = Credentials()
+            return credentials
         if os.path.exists(credential_path):
             try:
                 with open(credential_path) as f:
                     credentials = json.load(f)
                     self.api_url = credentials["api_url"]
                     self.api_token = keyring.get_password("airflowctl", f"api_token-{self.api_environment}")
-            except FileNotFoundError:
-                if self.client_kind == ClientKind.AUTH:
-                    # Saving the URL set from the Auth Commands if Kind is AUTH
-                    self.save()
+            except FileNotFoundError as e:
+                raise e
             return self
         raise AirflowCtlCredentialNotFoundException(f"No credentials found in {default_config_dir}")
 


### PR DESCRIPTION
`airflowctl auth login --username="admin" --password` shows 
```
Password:
command failed due to No credentials found in
/root/.config/airflow
```
To fix this add check for `Cleintkind.AUTH` first then handle user loading 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
