### PR TITLE
fix: run_unit_tests.sh

### DIFF
--- a/scripts/ci/testing/run_unit_tests.sh
+++ b/scripts/ci/testing/run_unit_tests.sh
@@ -20,6 +20,7 @@ export COLOR_RED=$'\e[31m'
 export COLOR_BLUE=$'\e[34m'
 export COLOR_YELLOW=$'\e[33m'
 export COLOR_RESET=$'\e[0m'
+export COLOR_GREEN=$'\e[32m'
 
 if [[ ! "$#" -eq 2 ]]; then
     echo "${COLOR_RED}You must provide 2 arguments: Group, Scope!.${COLOR_RESET}"
@@ -117,7 +118,7 @@ function providers_tests() {
         echo
         exit "${RESULT}"
     fi
-    echo "${COLOR_GREEB}Providers tests completed successfully${COLOR_RESET}"
+    echo "${COLOR_GREEN}Providers tests completed successfully${COLOR_RESET}"
 }
 
 


### PR DESCRIPTION
### Summary of changes

- Adds the missing `COLOR_GREEN` environment variable to `scripts/ci/testing/run_unit_tests.sh` for consistent color output.
- Fixes a typo in the providers tests success message, replacing the undefined `${COLOR_GREEB}` with `${COLOR_GREEN}`.
- This prevents an "unbound variable" error when running the script with `bash -u` and ensures successful test completion messages are displayed in green.

### Additional context

No functional changes to test logic; this is a minor fix to improve script robustness and output clarity.
