### PR TITLE
Assert non-zero exit code for missing export directory in db export-archived

### DIFF
--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -391,13 +391,13 @@ class TestCli:
                 assert "airflow command error" not in stderr
 
     def test_non_existing_directory_raises_when_metavar_is_dir_for_db_export_cleaned(self):
-        """Test that the error message is correct when the directory does not exist."""
+        """Test that the error message is correct when the directory does not exist and exit code is non-zero."""
         with contextlib.redirect_stderr(StringIO()) as stderr:
             parser = cli_parser.get_parser()
-            with pytest.raises(SystemExit):
+            with pytest.raises(SystemExit) as e:
                 parser.parse_args(["db", "export-archived", "--output-path", "/non/existing/directory"])
             error_msg = stderr.getvalue()
-
+        assert e.value.code != 0
         assert error_msg == (
             "\nairflow db export-archived command error: The directory "
             "'/non/existing/directory' does not exist!, see help above.\n"


### PR DESCRIPTION
This PR improves the robustness of the CLI parser test for the `db export-archived` command when the output directory does not exist.

## Summary of changes

- Updates the test `test_non_existing_directory_raises_when_metavar_is_dir_for_db_export_cleaned` to:
  - Capture the `SystemExit` exception raised when a non-existent output directory is provided.
  - Assert that the exit code is non-zero, ensuring the CLI signals an error condition as expected.
  - Continue to verify that the correct error message is output to stderr.
  
  ## Why?

- Ensures that the Airflow CLI not only displays the correct error message but also exits with a non-zero status code, which is important for scripting and automation.