### PR TITLE
Structure endpoint attach downstream asset to task level

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -26,7 +26,7 @@ from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.structure import StructureDataResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_access_dag
-from airflow.api_fastapi.core_api.services.ui.structure import get_upstream_assets
+from airflow.api_fastapi.core_api.services.ui.structure import bind_output_assets_to_task, get_upstream_assets
 from airflow.models.dag_version import DagVersion
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.dag_edges import dag_edges
@@ -138,5 +138,7 @@ def structure_data(
             data["edges"] = upstream_asset_edges
 
         data["edges"] += start_edges + edges + end_edges
+
+    bind_output_assets_to_task(data["edges"], serialized_dag)
 
     return StructureDataResponse(**data)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -26,7 +26,10 @@ from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.structure import StructureDataResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_access_dag
-from airflow.api_fastapi.core_api.services.ui.structure import bind_output_assets_to_task, get_upstream_assets
+from airflow.api_fastapi.core_api.services.ui.structure import (
+    bind_output_assets_to_tasks,
+    get_upstream_assets,
+)
 from airflow.models.dag_version import DagVersion
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.dag_edges import dag_edges
@@ -139,6 +142,6 @@ def structure_data(
 
         data["edges"] += start_edges + edges + end_edges
 
-    bind_output_assets_to_task(data["edges"], serialized_dag)
+    bind_output_assets_to_tasks(data["edges"], serialized_dag)
 
     return StructureDataResponse(**data)

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/structure.py
@@ -116,18 +116,18 @@ def get_upstream_assets(
     return nodes, edges
 
 
-def bind_output_assets_to_task(edges: list[dict], serialized_dag: SerializedDagModel) -> None:
-    """Try to bind the downstream assets to the relevant task that produces them."""
+def bind_output_assets_to_tasks(edges: list[dict], serialized_dag: SerializedDagModel) -> None:
+    """
+    Try to bind the downstream assets to the relevant task that produces them.
+
+    This function will mutate the `edges` in place.
+    """
     outlet_asset_references = serialized_dag.dag_model.task_outlet_asset_references
 
-    downstream_asset_related_edges = [
-        edge
-        for edge in edges
-        if edge["target_id"].startswith("asset:") or edge["target_id"].startswith("asset-alias:")
-    ]
+    downstream_asset_related_edges = [edge for edge in edges if edge["target_id"].startswith("asset:")]
 
     for edge in downstream_asset_related_edges:
-        asset_id = int(edge["target_id"].strip("asset:").strip("asset-alias:"))
+        asset_id = int(edge["target_id"].strip("asset:"))
         try:
             # Try to attach the outlet asset to the relevant task
             outlet_asset_reference = next(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -369,7 +369,7 @@ class TestStructureDataEndpoint:
                 {
                     "is_setup_teardown": None,
                     "label": None,
-                    "source_id": "task_2",
+                    "source_id": "task_1",
                     "target_id": f"asset:{asset3_id}",
                     "is_source_asset": None,
                 },


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/49316

Add an additional look up to bind the assets to the relevant task based on the `dag_model.task_outlet_asset_references`


### Before:
![Screenshot 2025-06-04 at 16 26 13](https://github.com/user-attachments/assets/872fdb3d-2d59-4211-a36c-0a8e0f7d37d4)


### After
![Screenshot 2025-06-04 at 16 10 54](https://github.com/user-attachments/assets/6d6437f5-7965-4b7f-a5f5-ed81da183077)
![Screenshot 2025-06-04 at 16 12 24](https://github.com/user-attachments/assets/08032fa7-8344-4b75-8188-9ba179acc627)
