### PR TITLE
Added mark_success_url to Task Instance during task runner startup pa…

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -143,6 +143,8 @@ class RuntimeTaskInstance(TaskInstance):
 
     log_url: str | None = None
 
+    mark_success_url: str | None = None
+
     def __rich_repr__(self):
         yield "id", self.id
         yield "task_id", self.task_id
@@ -735,6 +737,7 @@ def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
         with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
             ti = parse(msg, log)
             ti.log_url = get_log_url_from_ti(ti)
+            ti.mark_success_url = ti.log_url
         log.debug("DAG file parsed", file=msg.dag_rel_path)
     else:
         raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2201,6 +2201,7 @@ class TestTaskRunnerCallsListeners:
         runtime_ti, context, log = startup()
         assert runtime_ti is not None
         assert runtime_ti.log_url == get_log_url_from_ti(runtime_ti)
+        assert runtime_ti.mark_success_url == runtime_ti.log_url
         assert isinstance(listener.component, TaskRunnerMarker)
         del listener.component
 


### PR DESCRIPTION
### Fixes #50330 

The `mark_success_url` variable is required in the `email.html` template. Since the configuration has been removed it is raising exception when `mark_success_url` is being used to send email notifications.

This PR adds `mark_success_url` to the task instance context `(context.ti)` during execution.


This PR introduces the following changes:

- Adds `mark_success_url` to `RuntimeTaskInstance`
- Adds `mark_success_url` property to `ti` 



