### PR TITLE
Fix: SimpleAuth Middleware auth header precedence 

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/middleware.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/middleware.py
@@ -28,7 +28,5 @@ class SimpleAllAdminMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         token = SimpleAuthManagerLogin.create_token_all_admins()
-        request.scope["headers"].insert(
-            0, (b"authorization", f"Bearer {token}".encode())
-        )
+        request.scope["headers"].insert(0, (b"authorization", f"Bearer {token}".encode()))
         return await call_next(request)

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/middleware.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/middleware.py
@@ -28,5 +28,7 @@ class SimpleAllAdminMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         token = SimpleAuthManagerLogin.create_token_all_admins()
-        request.scope["headers"].append((b"authorization", f"Bearer {token}".encode()))
+        request.scope["headers"].insert(
+            0, (b"authorization", f"Bearer {token}".encode())
+        )
         return await call_next(request)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Insert the authorization header at the front in case one already exists when using the simple auth middleware.  FastAPI is only expecting a single auth header so it will take the first one it finds and there could be situations, like DevPod, where auth headers are getting passed through.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
