### PR TITLE
Add link to latest run info in DAG page header

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Link } from "@chakra-ui/react";
 import { FiBookOpen } from "react-icons/fi";
-import { useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
 
 import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
@@ -54,13 +55,17 @@ export const Header = ({
       label: "Latest Run",
       value:
         Boolean(latestRun) && latestRun !== undefined ? (
-          <DagRunInfo
-            endDate={latestRun.end_date}
-            logicalDate={latestRun.logical_date}
-            runAfter={latestRun.run_after}
-            startDate={latestRun.start_date}
-            state={latestRun.state}
-          />
+          <Link asChild color="fg.info">
+            <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}>
+              <DagRunInfo
+                endDate={latestRun.end_date}
+                logicalDate={latestRun.logical_date}
+                runAfter={latestRun.run_after}
+                startDate={latestRun.start_date}
+                state={latestRun.state}
+              />
+            </RouterLink>
+          </Link>
         ) : undefined,
     },
     {


### PR DESCRIPTION
Follow-up of #45312 and #46939.

Hello, airflow!

This pull request introduces a link to the latest DAG run info, to align with the previous one.

Thanks for the kind reviews in advance.
