### PR TITLE
Close sockets before SIGKILL to prevent sending partial serdags

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -951,7 +951,9 @@ class TestWatchedSubprocessKill:
                     }
                 )
             expected_logs.append({"chan": "stderr", "event": "Signal 15 received", "logger": "task"})
+        expected_logs.extend(({"chan": None, "event": "Process exited", "logger": "supervisor"},))
         if exit_after == signal.SIGKILL:
+            expected_logs.pop()
             if signal_to_send in {signal.SIGINT, signal.SIGTERM}:
                 expected_logs.append(
                     {
@@ -960,8 +962,18 @@ class TestWatchedSubprocessKill:
                         "logger": "supervisor",
                     }
                 )
+            expected_logs.extend(
+                (
+                    {"chan": None, "event": "Force-closed stuck sockets", "logger": "supervisor"},
+                    {
+                        "chan": None,
+                        "event": "Process terminated by signal. For more information, see "
+                        "https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#TaskRunner-killed",
+                        "logger": "task",
+                    },
+                )
+            )
 
-        expected_logs.extend(({"chan": None, "event": "Process exited", "logger": "supervisor"},))
         assert logs == expected_logs
 
     def test_service_subprocess(self, watched_subprocess, mock_process, mocker):

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -804,7 +804,7 @@ class TestWatchedSubprocess:
         mocker.patch.object(
             ActivitySubprocess,
             "_cleanup_open_sockets",
-            side_effect=lambda: setattr(proc, "_num_open_sockets", 0),
+            side_effect=lambda **kwargs: setattr(proc, "_num_open_sockets", 0),
         )
 
         time_machine.shift(2)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


### Problem

When a huge dag is supplied to the dag processor, and there's a timeout defined on the dag processing, there can be a scenario when we run into a situation where the timeout kicks in exactly when the dag is parsed successfully and before the serdag response is sent to the dag processing manager. 

The problem here is that when we timeout in dag processing, we send a sigkill, but there could be a case when the socket is filled with the serdag waiting to be sent to the dag processing manager, in such scenarios, when we are "killing" the subprocess, the socket ends up sending an incomplete or partially filled socket data to the dag processor manager, which reports an invalid json.

The error looks like this:
```
[2025-06-04T15:21:17.133+0000] {dag.py:2251} INFO - Setting next_dagrun for ample_simplest_dag to None, run_after=None
[2025-06-04T15:21:17.226+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-04T15:21:17.230+0000] {dag.py:2251} INFO - Setting next_dagrun for xample_simplest_dag to None, run_after=None
[2025-06-04T15:21:17.320+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-04T15:21:17.323+0000] {dag.py:2251} INFO - Setting next_dagrun for example_time_delta_sensor_async to None, run_after=None
[2025-06-04T15:21:18.016+0000] {manager.py:1015} ERROR - Processor for DagFileInfo(rel_path=PosixPath('a.py'), bundle_name='dags-folder', bundle_path=PosixPath('/files/dags'), bundle_version=None) with PID 1107 started 3 ago killing it.
2025-06-04 15:21:18 [error    ] Unable to decode message       [supervisor] line=bytearray(b'{"fileloc":"/files/dags/a.py","serialized_dags":[{"data":{"__version":2,"dag":{"dag_id":"my_dag_name","start_date":1609459200.0,"timezone":"UTC","relative_fileloc":"a.py","fileloc":"/files/dags/a.py","disable_bundle_versioning":false,"edge_info":{},"timetable":{"__type":"airflow.timetables.trigger.CronTriggerTimetable","__var":{"expression":"0 0 * * *","timezone":"UTC","interval":0.0,"run_immediately":false}},"task_group":{"_group_id":null,"group_display_name":"","prefix_group_id":true,"tooltip":"","ui_color":"CornflowerBlue","ui_fgcolor":"#000","children":{"task0":["operator","task0"],"task1":["operator","task1"],"task2":["operator","task12"],"task13":["operator","task13"],"task14":
...
...
...
["operator","task7342"],"task7343":')
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py:578 in handle_requests        │
│                                                                                                  │
│    575 │   │   │   line = yield                                                                  │
│    576 │   │   │                                                                                 │
│    577 │   │   │   try:                                                                          │
│ ❱  578 │   │   │   │   msg = self.decoder.validate_json(line)                                    │
│    579 │   │   │   except Exception:                                                             │
│    580 │   │   │   │   log.exception("Unable to decode message", line=line)                      │
│    581 │   │   │   │   continue                                                                  │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │ line = bytearray(b'{"fileloc":"/files/dags/a.py","serialized_dags":[{"data":{"__version":2,… │ │
│ │        0 * *                                                                                 │ │
│ │        *","timezone":"UTC","interval":0.0,"run_immediately":false}},"task_group":{"_group_i… │ │
│ │  log = <BoundLoggerLazyProxy(logger=None, wrapper_class=None, processors=None,               │ │
│ │        context_class=None, initial_values={'logger_name': 'supervisor'},                     │ │
│ │        logger_factory_args=())>                                                              │ │
│ │ self = <DagFileProcessorProcess id=UUID('01973b88-403c-76fe-a71c-47d67673bf59') pid=1107>    │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /usr/local/lib/python3.9/site-packages/pydantic/type_adapter.py:468 in validate_json             │
│                                                                                                  │
│   465 │   │   │   │   code='validate-by-alias-and-name-false',                                   │
│   466 │   │   │   )                                                                              │
│   467 │   │                                                                                      │
│ ❱ 468 │   │   return self.validator.validate_json(                                               │
│   469 │   │   │   data,                                                                          │
│   470 │   │   │   strict=strict,                                                                 │
│   471 │   │   │   context=context,                                                               │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │                   by_alias = None                                                            │ │
│ │                    by_name = None                                                            │ │
│ │                    context = None                                                            │ │
│ │                       data = bytearray(b'{"fileloc":"/files/dags/a.py","serialized_dags":[{… │ │
│ │                              0 * *                                                           │ │
│ │                              *","timezone":"UTC","interval":0.0,"run_immediately":false}},"… │ │
│ │ experimental_allow_partial = False                                                           │ │
│ │                       self = TypeAdapter(Annotated[Union[airflow.dag_processing.processor.D… │ │
│ │                              airflow.sdk.execution_time.comms.GetConnection,                 │ │
│ │                              airflow.sdk.execution_time.comms.GetVariable,                   │ │
│ │                              airflow.sdk.execution_time.comms.PutVariable,                   │ │
│ │                              airflow.sdk.execution_time.comms.DeleteVariable],               │ │
│ │                              FieldInfo(annotation=NoneType, required=True,                   │ │
│ │                              discriminator='type')])                                         │ │
│ │                     strict = None                                                            │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValidationError: 1 validation error for
tagged-union[DagFileParsingResult,GetConnection,GetVariable,PutVariable,DeleteVariable]
  Invalid JSON: EOF while parsing a value at line 1 column 255360 [type=json_invalid,
input_value=bytearray(b'{"fileloc":"/...task7342"],"task7343":'), input_type=bytearray]
    For further information visit https://errors.pydantic.dev/2.11/v/json_invalid
2025-06-04 15:21:18 [info     ] Process exited                 [supervisor] exit_code=<Negsignal.SIGKILL: -9> pid=1107 signal_sent=SIGKILL
[2025-06-04T15:21:20.655+0000] {manager.py:528} INFO - Not time to refresh bundle dags-folder
[2025-06-04T15:21:20.658+0000] {manager.py:528} INFO - Not time to refresh bundle example_dags
```

Observe the timeout in between:
```
ERROR - Processor for DagFileInfo(rel_path=PosixPath('a.py'), bundle_name='dags-folder', bundle_path=PosixPath('/files/dags'), bundle_version=None) with PID 1107 started 3 ago killing it.
```


### Approach

The issue here is that the socket from the manager to the subprocess is open and is not drained.

I tried fixing by closing away the sockets before we perform a sigkill so that inflight data is drained before we perform a kill (SIGKILL) on the subprocess.

Before SIGKILL is sent, we first close all sockets using `_cleanup_open_sockets()`:
- This ensures any in-flight data in the sockets is discarded before the process is killed
- The selector is kept alive (since close_selector=False by default) for other processes
- Only then is SIGKILL sent to the process

So there's no chance for the process to send incomplete JSON data through the sockets because they're already closed when SIGKILL arrives. This prevents the race condition that we saw.

### Testing

DAG:
```
import datetime

from airflow.sdk import DAG
from airflow.providers.standard.operators.empty import EmptyOperator

with DAG(
    dag_id="my_dag_name",
    start_date=datetime.datetime(2021, 1, 1),
    schedule="@daily",
):
    for i in range(20000):
        EmptyOperator(task_id=f"task{i}")

```

This dag takes rougly between 5-7 seconds to parse on my laptop, so setting a timeout of 5 to observe that sweet spot. Start dag processor with:
`AIRFLOW__DAG_PROCESSOR__DAG_FILE_PROCESSOR_TIMEOUT=5 airflow dag-processor`


Earlier:
```
[2025-06-04T15:21:17.133+0000] {dag.py:2251} INFO - Setting next_dagrun for ample_simplest_dag to None, run_after=None
[2025-06-04T15:21:17.226+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-04T15:21:17.230+0000] {dag.py:2251} INFO - Setting next_dagrun for xample_simplest_dag to None, run_after=None
[2025-06-04T15:21:17.320+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-04T15:21:17.323+0000] {dag.py:2251} INFO - Setting next_dagrun for example_time_delta_sensor_async to None, run_after=None
[2025-06-04T15:21:18.016+0000] {manager.py:1015} ERROR - Processor for DagFileInfo(rel_path=PosixPath('a.py'), bundle_name='dags-folder', bundle_path=PosixPath('/files/dags'), bundle_version=None) with PID 1107 started 3 ago killing it.
2025-06-04 15:21:18 [error    ] Unable to decode message       [supervisor] line=bytearray(b'{"fileloc":"/files/dags/a.py","serialized_dags":[{"data":{"__version":2,"dag":{"dag_id":"my_dag_name","start_date":1609459200.0,"timezone":"UTC","relative_fileloc":"a.py","fileloc":"/files/dags/a.py","disable_bundle_versioning":false,"edge_info":{},"timetable":{"__type":"airflow.timetables.trigger.CronTriggerTimetable","__var":{"expression":"0 0 * * *","timezone":"UTC","interval":0.0,"run_immediately":false}},"task_group":{"_group_id":null,"group_display_name":"","prefix_group_id":true,"tooltip":"","ui_color":"CornflowerBlue","ui_fgcolor":"#000","children":{"task0":["operator","task0"],"task1":["operator","task1"],"task2":["operator","task12"],"task13":["operator","task13"],"task14":
...
...
...
["operator","task7342"],"task7343":')
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py:578 in handle_requests        │
│                                                                                                  │
│    575 │   │   │   line = yield                                                                  │
│    576 │   │   │                                                                                 │
│    577 │   │   │   try:                                                                          │
│ ❱  578 │   │   │   │   msg = self.decoder.validate_json(line)                                    │
│    579 │   │   │   except Exception:                                                             │
│    580 │   │   │   │   log.exception("Unable to decode message", line=line)                      │
│    581 │   │   │   │   continue                                                                  │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │ line = bytearray(b'{"fileloc":"/files/dags/a.py","serialized_dags":[{"data":{"__version":2,… │ │
│ │        0 * *                                                                                 │ │
│ │        *","timezone":"UTC","interval":0.0,"run_immediately":false}},"task_group":{"_group_i… │ │
│ │  log = <BoundLoggerLazyProxy(logger=None, wrapper_class=None, processors=None,               │ │
│ │        context_class=None, initial_values={'logger_name': 'supervisor'},                     │ │
│ │        logger_factory_args=())>                                                              │ │
│ │ self = <DagFileProcessorProcess id=UUID('01973b88-403c-76fe-a71c-47d67673bf59') pid=1107>    │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /usr/local/lib/python3.9/site-packages/pydantic/type_adapter.py:468 in validate_json             │
│                                                                                                  │
│   465 │   │   │   │   code='validate-by-alias-and-name-false',                                   │
│   466 │   │   │   )                                                                              │
│   467 │   │                                                                                      │
│ ❱ 468 │   │   return self.validator.validate_json(                                               │
│   469 │   │   │   data,                                                                          │
│   470 │   │   │   strict=strict,                                                                 │
│   471 │   │   │   context=context,                                                               │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │                   by_alias = None                                                            │ │
│ │                    by_name = None                                                            │ │
│ │                    context = None                                                            │ │
│ │                       data = bytearray(b'{"fileloc":"/files/dags/a.py","serialized_dags":[{… │ │
│ │                              0 * *                                                           │ │
│ │                              *","timezone":"UTC","interval":0.0,"run_immediately":false}},"… │ │
│ │ experimental_allow_partial = False                                                           │ │
│ │                       self = TypeAdapter(Annotated[Union[airflow.dag_processing.processor.D… │ │
│ │                              airflow.sdk.execution_time.comms.GetConnection,                 │ │
│ │                              airflow.sdk.execution_time.comms.GetVariable,                   │ │
│ │                              airflow.sdk.execution_time.comms.PutVariable,                   │ │
│ │                              airflow.sdk.execution_time.comms.DeleteVariable],               │ │
│ │                              FieldInfo(annotation=NoneType, required=True,                   │ │
│ │                              discriminator='type')])                                         │ │
│ │                     strict = None                                                            │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValidationError: 1 validation error for
tagged-union[DagFileParsingResult,GetConnection,GetVariable,PutVariable,DeleteVariable]
  Invalid JSON: EOF while parsing a value at line 1 column 255360 [type=json_invalid,
input_value=bytearray(b'{"fileloc":"/...task7342"],"task7343":'), input_type=bytearray]
    For further information visit https://errors.pydantic.dev/2.11/v/json_invalid
2025-06-04 15:21:18 [info     ] Process exited                 [supervisor] exit_code=<Negsignal.SIGKILL: -9> pid=1107 signal_sent=SIGKILL
[2025-06-04T15:21:20.655+0000] {manager.py:528} INFO - Not time to refresh bundle dags-folder
[2025-06-04T15:21:20.658+0000] {manager.py:528} INFO - Not time to refresh bundle example_dags
```

Handles it more gracefully now:
```
[2025-06-05T09:41:21.379+0000] {manager.py:528} INFO - Not time to refresh bundle dags-folder
[2025-06-05T09:41:25.335+0000] {manager.py:1015} ERROR - Processor for DagFileInfo(rel_path=PosixPath('large-dag.py'), bundle_name='dags-folder', bundle_path=PosixPath('/files/dags'), bundle_version=None) with PID 2193 started 5 ago killing it.
2025-06-05 09:41:25 [warning  ] Force-closed stuck sockets     [supervisor] pid=2193 sockets=['stdout(11)', 'stderr(13)', 'logs(17)', 'requests(15)']
[2025-06-05T09:41:27.355+0000] {manager.py:528} INFO - Not time to refresh bundle dags-folder
[2025-06-05T09:41:27.421+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-05T09:41:27.424+0000] {dag.py:2251} INFO - Setting next_dagrun for test_dag to None, run_after=None
[2025-06-05T09:41:27.468+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-05T09:41:27.471+0000] {dag.py:2251} INFO - Setting next_dagrun for check_cfg_file_access to None, run_after=None
[2025-06-05T09:41:27.489+0000] {dag.py:1635} INFO - Sync 1 DAGs
[2025-06-05T09:41:27.492+0000] {dag.py:2251} INFO - Setting next_dagrun for legacy_etl_pipeline to None, run_after=Non
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
