### PR TITLE
[v3-0-test] Exclude `sqlalchemy-spanner` 1.12.0 (#51379)

### DIFF
--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -124,7 +124,7 @@ PIP package                                 Version required
 ``python-slugify``                          ``>=7.0.0``
 ``PyOpenSSL``                               ``>=23.0.0``
 ``sqlalchemy-bigquery``                     ``>=1.2.1``
-``sqlalchemy-spanner``                      ``>=1.6.2``
+``sqlalchemy-spanner``                      ``>=1.6.2,!=1.12.0``
 ``tenacity``                                ``>=8.1.0``
 ``immutabledict``                           ``>=4.2.0``
 ``types-protobuf``                          ``!=5.29.1.20250402``

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -175,7 +175,7 @@ PIP package                                 Version required
 ``python-slugify``                          ``>=7.0.0``
 ``PyOpenSSL``                               ``>=23.0.0``
 ``sqlalchemy-bigquery``                     ``>=1.2.1``
-``sqlalchemy-spanner``                      ``>=1.6.2``
+``sqlalchemy-spanner``                      ``>=1.6.2,!=1.12.0``
 ``tenacity``                                ``>=8.1.0``
 ``immutabledict``                           ``>=4.2.0``
 ``types-protobuf``                          ``!=5.29.1.20250402``

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -142,7 +142,7 @@ dependencies = [
     "python-slugify>=7.0.0",
     "PyOpenSSL>=23.0.0",
     "sqlalchemy-bigquery>=1.2.1",
-    "sqlalchemy-spanner>=1.6.2",
+    "sqlalchemy-spanner>=1.6.2,!=1.12.0",
     "tenacity>=8.1.0",
     "immutabledict>=4.2.0",
     # types-protobuf 5.29.1.20250402 is a partial stub package, leading to mypy complaining


### PR DESCRIPTION
(cherry picked from commit 15e0fc92333f97f61ee23dd7c5af7b56d2664202)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
