### PR TITLE
fix: Helm execution_api_server_url when base_url has a subpath

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -40,9 +40,13 @@ metadata:
 data:
   {{/*- Set a default for core.execution_api_server_url pointing to the api-server service if it's not set -*/}}
   {{- if semverCompare ">=3.0.0" .Values.airflowVersion -}}
+    {{- $basePath := "" -}}
     {{- $config := merge .Values.config ( dict  "core" dict )}}
     {{- if not (hasKey $config.core "execution_api_server_url") -}}
-      {{- $_ := set $config.core "execution_api_server_url" (printf "http://%s-api-server:%d/execution/" (include "airflow.fullname" .) (int .Values.ports.apiServer))  -}}
+      {{-  if (and $config.api $config.api.base_url) -}}
+        {{- with urlParse $config.api.base_url }}{{ $basePath = (trimSuffix "/" .path) }}{{ end }}
+      {{- end -}}
+      {{- $_ := set $config.core "execution_api_server_url" (printf "http://%s-api-server:%d%s/execution/" (include "airflow.fullname" .) (int .Values.ports.apiServer) $basePath)  -}}
     {{- end -}}
   {{- end -}}
   # These are system-specified config overrides.


### PR DESCRIPTION
When the `config.core.base_url` has a subpath, this path should be copied to the `execution_api_server_url` as a path-prefix.

For example, when `base_url=http://example.com/airflow`, then the `execution_api_server_url=http://name-api-server:8080/airflow/execution`

The chart behavior is unchanged if
- the `base_url` is empty
- the `base_url` does _not_ have a subpath
- the `execution_api_server_url` is already set in the config

This can easily be tested using `helm template`, here are the 4 cases I considered

1. No config overrides will produce the current behavior

    ```sh
    $ helm template local ./  -s templates/configmaps/configmap.yaml | grep "execution_api_server_url"
        execution_api_server_url = http://local-api-server:8080/execution/
    ```

2. Adding a `base_url` with a sub-path shows the new behavior of copying the subpath to the execution url

    ```sh
    $ helm template local ./ --set config.api.base_url="http://example.com/airflow"  -s templates/configmaps/configmap.yaml | grep "execution_api_server_url"
        execution_api_server_url = http://local-api-server:8080/airflow/execution/
    ```

3. Adding a `base_url` without a subpath also preserves the existing behavior

    ```sh
    $ helm template local ./ --set config.api.base_url="http://example.com/"  -s templates/configmaps/configmap.yaml | grep "execution_api_server_url"
        execution_api_server_url = http://local-api-server:8080/execution/
    ```

4. Finallly, even adding a subpath to the base url, if the execution url is directly set, this is preserved

    ```sh
    $ helm template local ./ --set config.api.base_url="http://example.com/airflow" --set config.core.execution_api_server_url="http://service:9090/execution/"  -s templates/configmaps/configmap.yaml
     | grep "execution_api_server_url"
        execution_api_server_url = http://service:9090/execution/
    ```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Closes: #51450

<!-- Please keep an empty line above the dashes. -->
---

