### PR TITLE
Fix: allow users with specific DAG permissions to access DAGs when no pecific DAG is requested

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -564,8 +564,9 @@ class FabAuthManager(BaseAuthManager[User]):
             # Check whether the user has permissions to access a specific DAG
             resource_dag_name = permissions.resource_name(details.id, RESOURCE_DAG)
             return self._is_authorized(method=method, resource_type=resource_dag_name, user=user)
-
-        return False
+        else:
+            authorized_dags = self.get_authorized_dag_ids(user=user, method=method)
+            return len(authorized_dags) > 0
 
     def _is_authorized_dag_run(
         self,
@@ -590,8 +591,9 @@ class FabAuthManager(BaseAuthManager[User]):
             # Check whether the user has permissions to access a specific DAG Run permission on a DAG Level
             resource_dag_name = permissions.resource_name(details.id, RESOURCE_DAG_RUN)
             return self._is_authorized(method=method, resource_type=resource_dag_name, user=user)
-
-        return False
+        else:
+            authorized_dags = self.get_authorized_dag_ids(user=user, method=method)
+            return len(authorized_dags) > 0
 
     @staticmethod
     def _get_fab_action(method: ResourceMethod) -> str:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -564,9 +564,8 @@ class FabAuthManager(BaseAuthManager[User]):
             # Check whether the user has permissions to access a specific DAG
             resource_dag_name = permissions.resource_name(details.id, RESOURCE_DAG)
             return self._is_authorized(method=method, resource_type=resource_dag_name, user=user)
-        else:
-            authorized_dags = self.get_authorized_dag_ids(user=user, method=method)
-            return len(authorized_dags) > 0
+        authorized_dags = self.get_authorized_dag_ids(user=user, method=method)
+        return len(authorized_dags) > 0
 
     def _is_authorized_dag_run(
         self,
@@ -591,9 +590,8 @@ class FabAuthManager(BaseAuthManager[User]):
             # Check whether the user has permissions to access a specific DAG Run permission on a DAG Level
             resource_dag_name = permissions.resource_name(details.id, RESOURCE_DAG_RUN)
             return self._is_authorized(method=method, resource_type=resource_dag_name, user=user)
-        else:
-            authorized_dags = self.get_authorized_dag_ids(user=user, method=method)
-            return len(authorized_dags) > 0
+        authorized_dags = self.get_authorized_dag_ids(user=user, method=method)
+        return len(authorized_dags) > 0
 
     @staticmethod
     def _get_fab_action(method: ResourceMethod) -> str:

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -279,6 +279,62 @@ class TestFabAuthManager:
                 [(ACTION_CAN_READ, "resource_test")],
                 False,
             ),
+             # With specific DAG permissions but no specific DAG requested
+            (
+                "GET",
+                None,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id")],
+                True,
+            ),
+            # With multiple specific DAG permissions, no specific DAG requested
+            (
+                "GET",
+                None,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id"), (ACTION_CAN_READ, "DAG:test_dag_id2")],
+                True,
+            ),
+            # With specific DAG permissions but wrong method
+            (
+                "POST",
+                None,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id")],
+                False,
+            ),
+            # With correct method permissions for specific DAG
+            (
+                "POST",
+                None,
+                None,
+                [(ACTION_CAN_CREATE, "DAG:test_dag_id")],
+                True,
+            ),
+            # With EDIT permission on specific DAG, no specific DAG requested
+            (
+                "PUT",
+                None,
+                None,
+                [(ACTION_CAN_EDIT, "DAG:test_dag_id")],
+                True,
+            ),
+            # With DELETE permission on specific DAG, no specific DAG requested
+            (
+                "DELETE",
+                None,
+                None,
+                [(ACTION_CAN_DELETE, "DAG:test_dag_id")],
+                True,
+            ),
+            # Mixed permissions - some DAG, some non-DAG
+            (
+                "GET",
+                None,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id"), (ACTION_CAN_READ, "resource_test")],
+                True,
+            ),
             # Scenario 2 #
             # With global permissions on DAGs
             (
@@ -346,6 +402,46 @@ class TestFabAuthManager:
                 DagAccessEntity.TASK_LOGS,
                 DagDetails(id="test_dag_id"),
                 [(ACTION_CAN_READ, RESOURCE_TASK_INSTANCE)],
+                False,
+            ),
+            # DAG sub-entity with specific DAG permissions but no specific DAG requested
+            (
+                "GET",
+                DagAccessEntity.RUN,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id"), (ACTION_CAN_READ, RESOURCE_DAG_RUN)],
+                True,
+            ),
+            # DAG sub-entity access with no DAG permissions, no specific DAG requested
+            (
+                "GET",
+                DagAccessEntity.RUN,
+                None,
+                [(ACTION_CAN_READ, RESOURCE_DAG_RUN)],
+                False,
+            ),
+            # DAG sub-entity with specific DAG permissions but missing sub-entity permission
+            (
+                "GET",
+                DagAccessEntity.TASK_INSTANCE,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id")],
+                False,
+            ),
+            # Multiple DAG access entities with proper permissions
+            (
+                "DELETE",
+                DagAccessEntity.TASK,
+                None,
+                [(ACTION_CAN_EDIT, "DAG:test_dag_id"), (ACTION_CAN_DELETE, RESOURCE_TASK_INSTANCE)],
+                True,
+            ),
+            # User with specific DAG permissions but wrong method for sub-entity
+            (
+                "POST",
+                DagAccessEntity.RUN,
+                None,
+                [(ACTION_CAN_READ, "DAG:test_dag_id"), (ACTION_CAN_READ, RESOURCE_DAG_RUN)],
                 False,
             ),
         ],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #51325
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

closes: https://github.com/apache/airflow/issues/51325

fix: authorize users with specific DAG permissions for general DAG operations

Allow users with specific DAG permissions (e.g., "DAG:my_dag") to access 
DAG-related endpoints when no specific DAG is requested, instead of denying 
access. Users are authorized if they have access to at least one DAG.

- Updated _is_authorized_dag() and _is_authorized_dag_run() 
- Added comprehensive test coverage
- Maintains backward compatibility
---

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
