### PR TITLE
Remove logical_date check when validate inlets and outlets

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -899,7 +899,7 @@ def validate_inlets_and_outlets(
     bind_contextvars(ti_id=ti_id_str)
 
     ti = session.scalar(select(TI).where(TI.id == ti_id_str))
-    if not ti or not ti.logical_date:
+    if not ti:
         log.error("Task Instance not found")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2181,7 +2181,14 @@ class TestGetTaskStates:
 
 
 class TestInvactiveInletsAndOutlets:
-    def test_ti_inactive_inlets_and_outlets(self, client, dag_maker):
+    @pytest.mark.parametrize(
+        "logical_date",
+        [
+            datetime(2025, 6, 6, tzinfo=timezone.utc),
+            None,
+        ],
+    )
+    def test_ti_inactive_inlets_and_outlets(self, logical_date, client, dag_maker):
         """Test the inactive assets in inlets and outlets can be found."""
         with dag_maker("test_inlets_and_outlets"):
             EmptyOperator(
@@ -2193,7 +2200,7 @@ class TestInvactiveInletsAndOutlets:
                 ],
             )
 
-        dr = dag_maker.create_dagrun()
+        dr = dag_maker.create_dagrun(logical_date=logical_date)
 
         task1_ti = dr.get_task_instance("task1")
         response = client.get(f"/execution/task-instances/{task1_ti.id}/validate-inlets-and-outlets")
@@ -2214,7 +2221,14 @@ class TestInvactiveInletsAndOutlets:
         for asset in expected_inactive_assets:
             assert asset in inactive_assets
 
-    def test_ti_inactive_inlets_and_outlets_without_inactive_assets(self, client, dag_maker):
+    @pytest.mark.parametrize(
+        "logical_date",
+        [
+            datetime(2025, 6, 6, tzinfo=timezone.utc),
+            None,
+        ],
+    )
+    def test_ti_inactive_inlets_and_outlets_without_inactive_assets(self, logical_date, client, dag_maker):
         """Test the task without inactive assets in its inlets or outlets returns empty list."""
         with dag_maker("test_inlets_and_outlets_inactive"):
             EmptyOperator(
@@ -2223,7 +2237,7 @@ class TestInvactiveInletsAndOutlets:
                 outlets=[Asset(name="outlet-name", uri="uri")],
             )
 
-        dr = dag_maker.create_dagrun()
+        dr = dag_maker.create_dagrun(logical_date=logical_date)
 
         task1_ti = dr.get_task_instance("inactive_task1")
         response = client.get(f"/execution/task-instances/{task1_ti.id}/validate-inlets-and-outlets")


### PR DESCRIPTION
## Why
`validate_inlets_and_outlets` currently checks whether `ti.logical_date` is None, which causes all asset triggered dags to fail as they have their `logical_date` set as None and it's expected

## What
Remove the `ti.logical_date` check in `validate_inlets_and_outlets`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
