### PR TITLE
Fix redirects for back-references that caused bad generated links

### DIFF
--- a/airflow-core/docs/redirects.txt
+++ b/airflow-core/docs/redirects.txt
@@ -26,12 +26,12 @@ administration-and-deployment/security/kerberos.rst security/kerberos.rst
 ## It's okay to include ``/stable/``, because there's no relationship between a version of
 ## Airflow and the version of any provider package.
 
-administration-and-deployment/security/access-control.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
-administration-and-deployment/security/access-control/index.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
+administration-and-deployment/security/access-control.rst ../../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
+administration-and-deployment/security/access-control/index.rst ../../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
 administration-and-deployment/security/api.rst security/api.rst
 administration-and-deployment/security/audit_logs.rst security/audit_logs.rst
 administration-and-deployment/security/flower.rst security/flower.rst
-administration-and-deployment/security/webserver.rst ../apache-airflow-providers-fab/stable/auth-manager/security.rst
+administration-and-deployment/security/webserver.rst ../../apache-airflow-providers-fab/stable/auth-manager/security.rst
 administration-and-deployment/security/workload.rst security/workload.rst
 administration-and-deployment/security/secrets/secrets-backends/index.rst security/secrets/secrets-backends/index.rst
 administration-and-deployment/security/secrets/secrets-backends/local-filesystem-secrets-backend.rst security/secrets/secrets-backends/local-filesystem-secrets-backend.rst
@@ -158,12 +158,12 @@ authoring-and-scheduling/datasets.rst authoring-and-scheduling/asset-scheduling.
 ## It's okay to include ``/stable/``, because there's no relationship between a version of
 ## Airflow and the version of any provider package.
 ### Kubernetes Executors
-core-concepts/executor/kubernetes.rst ../apache-airflow-providers-cncf-kubernetes/stable/kubernetes_executor.html
-core-concepts/executor/local_kubernetes.rst ../apache-airflow-providers-cncf-kubernetes/stable/local_kubernetes_executor.html
+core-concepts/executor/kubernetes.rst ../../apache-airflow-providers-cncf-kubernetes/stable/kubernetes_executor.html
+core-concepts/executor/local_kubernetes.rst ../../apache-airflow-providers-cncf-kubernetes/stable/local_kubernetes_executor.html
 
 ### Celery Executors
-core-concepts/executor/celery_kubernetes.rst ../apache-airflow-providers-celery/stable/celery_kubernetes_executor.html
-core-concepts/executor/celery.rst ../apache-airflow-providers-celery/stable/celery_executor.html
+core-concepts/executor/celery_kubernetes.rst ../../apache-airflow-providers-celery/stable/celery_kubernetes_executor.html
+core-concepts/executor/celery.rst ../../apache-airflow-providers-celery/stable/celery_executor.html
 
 # Python API
 python-api-ref.rst public-airflow-interface.rst
@@ -176,10 +176,10 @@ howto/use-test-config.rst index.rst
 
 # Operators/Sensors moved to standard providers
 
-howto/operator/bash.rst ../apache-airflow-providers-standard/stable/operators/bash.rst
-howto/operator/datetime.rst ../apache-airflow-providers-standard/stable/operators/datetime.rst
-howto/operator/external_task_sensor.rst ../apache-airflow-providers-standard/stable/sensors/external_task_sensor.rst
-howto/operator/file.rst ../apache-airflow-providers-standard/stable/sensors/file.rst
-howto/operator/python.rst ../apache-airflow-providers-standard/stable/operators/python.rst
-howto/operator/time.rst ../apache-airflow-providers-standard/stable/sensors/datetime.rst
-howto/operator/weekday.rst ../apache-airflow-providers-standard/stable/operators/datetime.rst#branchdayofweekoperator
+howto/operator/bash.rst ../../apache-airflow-providers-standard/stable/operators/bash.rst
+howto/operator/datetime.rst ../../apache-airflow-providers-standard/stable/operators/datetime.rst
+howto/operator/external_task_sensor.rst ../../apache-airflow-providers-standard/stable/sensors/external_task_sensor.rst
+howto/operator/file.rst ../../apache-airflow-providers-standard/stable/sensors/file.rst
+howto/operator/python.rst ../../apache-airflow-providers-standard/stable/operators/python.rst
+howto/operator/time.rst ../../apache-airflow-providers-standard/stable/sensors/datetime.rst
+howto/operator/weekday.rst ../../apache-airflow-providers-standard/stable/operators/datetime.rst#branchdayofweekoperator


### PR DESCRIPTION
Those generated links had not enough `../` and created links as the `apache-airflow` subdirectory.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
