### PR TITLE
Add Dag Pages to German

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -23,6 +23,7 @@ import { initReactI18next } from "react-i18next";
 import deCommon from "./locales/de/common.json";
 import deComponents from "./locales/de/components.json";
 import deConnections from "./locales/de/connections.json";
+import deDag from "./locales/de/dag.json";
 import deDags from "./locales/de/dags.json";
 import deDashboard from "./locales/de/dashboard.json";
 import enCommon from "./locales/en/common.json";
@@ -65,6 +66,7 @@ const resources = {
     common: deCommon,
     components: deComponents,
     connections: deConnections,
+    dag: deDag,
     dags: deDags,
     dashboard: deDashboard,
   },

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/README.md
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/README.md
@@ -63,10 +63,10 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
   Übersetzung von -->"Asset" ohne einen sperrigen Begriff wie
   "Datenssatz-Ereignis" zu erzeugen.
 - `Backfill` --> `Auffüllen`: Der technisch geprägte Term im Programm passt zu
-  dr direkten Übersetzung, auch im Deutschen werden Lücken wieder "aufgefüllt".
+  der direkten Übersetzung, auch im Deutschen werden Lücken wieder "aufgefüllt".
 - `Bundle` --> `Bündel`: Die direkte Übersetzung passt zu dem Ziel der
   Englischen Begriffsdefinition.
-- `Catchup` --> `Nacholung`: Direkte Übersetzung.
+- `Catchup` --> `Nachholen`: Direkte Übersetzung.
 - `Connections` --> `Verbindungen`: Ist zwar ein feststehender Begriff in
   Airflow und ein technisches Konstrukt das im Code zu finden ist, jedoch
   direkt übersetzbar und erschließt sich damit neuen Benutzern direkt.
@@ -86,8 +86,8 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
   gibt und der Begriff "Mapping" eigentlich übersetzbar ist - aber in dem
   genutzen Kontext irreführend wäre, wurde hier auf die Task-Planung verwiesen
   in der ein Task aufgeplant wird.
-- `Operator` --> `Operator`: Da es sich hier um den vor allem Mathematisch-
-  Technischen Begriff der Implemtentierung geht, passt dieser Begriff am
+- `Operator` --> `Operator`: Da es sich hier um den vor allem mathematisch-
+  technischen Begriff der Implementierung handelt, passt dieser Begriff am
   ehesten. Alternativen wie "Betreiber-Implementierung" sind sehr sperrig.
   Wir nutzen weiter den Begriff weil er im Programmcode sich auch so
   wiederfindet.
@@ -107,13 +107,15 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
   genutzt und passt zu der technischen Nutzung in Airflow. Alternativ wäre
   "Aufgabe" eine mögliche Übersetzung gewesen. Da aber der Begriff Task auch in
   Logs und Code zu finden ist, lag der Begriff etwas näher als "Aufgabe".
-- `Trigger`(to) --> `Anstoßen`: Genutzt für die Aktionen ein Lauf eines Dag zu
+- `Trigger`(to) --> `Auslösen`: Genutzt für die Aktionen ein Lauf eines Dag zu
   starten. Von allen Optionen der am ehesten passende Begriff auch wenn es eine
-  direkte Nutzung des Begriffs "Triggern" im Deutschen gibt. In der Nutzung im
-  UI ist der Begriff "Anstoßen" inhaltlich passender.
-- `Trigger Rule` --> `Auslöse-Regel`: Im Ablauf eines Dag geht es für den
-  Begriff um den Punkt und die Regel zu dem ein abhängiger Task gestartet
-  werden kann.
+  direkte Nutzung des Begriffs "Triggern" im Deutschen gibt. Der Begriff
+  "Anstoßen" ist auch passend aber in dem Zusammenhan mit Trigger Rule zur
+  Konsistenz ist "Auslösen" passender.
+- `Trigger Rule` --> `Auslöse-Regel`: Im Ablauf eines Dags bestimmt die
+  Auslöse-Regel (in Kombination mit der Position) jedes Tasks unter welchen
+  Bedingungen und zu welchem Zeitpunkt im Dag Lauf dieser Task gestartet werden
+  kann.
 - `Try Number` --> `Versuch Nummer`: Direkt Übersetzung ist passend.
 
 (Andere klassische Begriffsübersetzungen nicht im Einzelnen aufgeführt)

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/README.md
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/README.md
@@ -62,6 +62,11 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
 - `Asset Event` --> `Ereignis zu Datenset (Asset)`: Logische Konsequenz der
   Übersetzung von -->"Asset" ohne einen sperrigen Begriff wie
   "Datenssatz-Ereignis" zu erzeugen.
+- `Backfill` --> `Auffüllen`: Der technisch geprägte Term im Programm passt zu
+  dr direkten Übersetzung, auch im Deutschen werden Lücken wieder "aufgefüllt".
+- `Bundle` --> `Bündel`: Die direkte Übersetzung passt zu dem Ziel der
+  Englischen Begriffsdefinition.
+- `Catchup` --> `Nacholung`: Direkte Übersetzung.
 - `Connections` --> `Verbindungen`: Ist zwar ein feststehender Begriff in
   Airflow und ein technisches Konstrukt das im Code zu finden ist, jedoch
   direkt übersetzbar und erschließt sich damit neuen Benutzern direkt.
@@ -81,6 +86,11 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
   gibt und der Begriff "Mapping" eigentlich übersetzbar ist - aber in dem
   genutzen Kontext irreführend wäre, wurde hier auf die Task-Planung verwiesen
   in der ein Task aufgeplant wird.
+- `Operator` --> `Operator`: Da es sich hier um den vor allem Mathematisch-
+  Technischen Begriff der Implemtentierung geht, passt dieser Begriff am
+  ehesten. Alternativen wie "Betreiber-Implementierung" sind sehr sperrig.
+  Wir nutzen weiter den Begriff weil er im Programmcode sich auch so
+  wiederfindet.
 - `Plugins` --> `Plug-ins`: Nach Duden empfohlen.
 - `Pools` (Unübersetzt): Der Englische Term ist so im Deutschen direkt
   verständlich. Ein präzise Übersetzung als "Ressourcen-Pool" wäre zu sperrig
@@ -101,6 +111,9 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
   starten. Von allen Optionen der am ehesten passende Begriff auch wenn es eine
   direkte Nutzung des Begriffs "Triggern" im Deutschen gibt. In der Nutzung im
   UI ist der Begriff "Anstoßen" inhaltlich passender.
+- `Trigger Rule` --> `Auslöse-Regel`: Im Ablauf eines Dag geht es für den
+  Begriff um den Punkt und die Regel zu dem ein abhängiger Task gestartet
+  werden kann.
 - `Try Number` --> `Versuch Nummer`: Direkt Übersetzung ist passend.
 
 (Andere klassische Begriffsübersetzungen nicht im Einzelnen aufgeführt)

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
@@ -9,6 +9,8 @@
   },
   "assetEvent_one": "Ereignis zu Datensets (Asset)",
   "assetEvent_other": "Ereignisse zu Datensets (Asset)",
+  "backfill_one": "Auffüllung",
+  "backfill_other": "Auffüllungen",
   "browse": {
     "auditLog": "Prüf-Log",
     "xcoms": "Task Kommunikation (XComs)"
@@ -17,14 +19,19 @@
   "dag_other": "Dags",
   "dagRun_one": "Dag Lauf",
   "dagRun_other": "Dag Läufe",
+  "dagWarnings": "Dag Warnungen und Fehler",
   "defaultToGraphView": "Graph-Ansicht als Standard",
   "defaultToGridView": "Gitter-Ansicht als Standard",
+  "direction": "Richtung",
   "docs": {
     "documentation": "Dokumentation",
     "githubRepo": "GitHub Ablage",
     "restApiReference": "REST API Referenz"
   },
-  "duration": "Laufzeit",
+  "duration": {
+    "label": "Laufzeit",
+    "seconds": "{{count}}s"
+  },
   "endDate": "Enddatum",
   "expression": {
     "all": "Alle",
@@ -55,6 +62,7 @@
     "security": "Sicherheit"
   },
   "noItemsFound": "Kein Element vom Typ {{modelName}} gefunden",
+  "operator": "Operator",
   "pools": {
     "deferred": "Delegiert",
     "open": "Frei",
@@ -100,17 +108,26 @@
   "switchToDarkMode": "Zum Dunkelmodus wechseln",
   "switchToLightMode": "Zum Hellmodus wechseln",
   "table": {
+    "completedAt": "Abgeschlossen um",
+    "createdAt": "Erstellt um",
+    "duration": "Laufzeit",
     "filterByTag": "Dags nach Markierung filtern",
     "filterColumns": "Tabellenspalten filtern",
     "filterReset_one": "Filter zurücksetzen",
     "filterReset_other": "Filter zurücksetzen",
+    "from": "Von",
+    "maxActiveRuns": "Maximal aktive Läufe",
     "noTagsFound": "Keine Markierungen gefunden",
+    "reprocessBehavior": "Verhalten beim Wiederverarbeiten",
     "tagMode": {
       "all": "Alle",
       "any": "Einer"
     },
-    "tagPlaceholder": "Dags nach Markierung filtern"
+    "tagPlaceholder": "Dags nach Markierung filtern",
+    "to": "Zu"
   },
+  "task_one": "Task",
+  "task_other": "Tasks",
   "taskInstance_one": "Task Instanz",
   "taskInstance_other": "Task Instanzen",
   "timeRange": {
@@ -128,6 +145,12 @@
     "utc": "UTC (Koordinierte Weltzeit)"
   },
   "triggered": "Angestoßen",
+  "triggerRule": "Auslöse-Regel",
   "tryNumber": "Versuch Nummer",
-  "user": "Benutzer"
+  "user": "Benutzer",
+  "wrap": {
+    "tooltip": "Buchstabe w drücken um den Zeilenumbruch umzuschalten",
+    "unwrap": "Kein Zeilenumbruch",
+    "wrap": "Zeilenumbruch"
+  }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
@@ -99,11 +99,11 @@
     "notesPlaceholder": "Klicken Sie hier um eine Notiz hinzuzufügen",
     "runId": "ID des Laufes (Run Id)",
     "runIdHelp": "Optional - wird automatisch erzeugt wenn nicht angegeben",
-    "selectDescription": "Einen einzelnen Lauf dieses Dag anstoßen",
+    "selectDescription": "Einen einzelnen Lauf dieses Dag auslösen",
     "selectLabel": "Einzelner Lauf",
-    "title": "Dag Anstoßen",
-    "trigger": "Anstoßen",
-    "unpause": "Dag {{dagDisplayName}} beim Anstoßen des Laufes aktiv schalten"
+    "title": "Dag Auslösen",
+    "trigger": "Auslösen",
+    "unpause": "Dag {{dagDisplayName}} beim Auslösen des Laufes aktiv schalten"
   },
   "versionDetails": {
     "bundleLink": "Bündel-Link",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
@@ -44,7 +44,7 @@
     "lasttaskInstance_one": "Letzte Task Instanz",
     "lasttaskInstance_other": "Letzte {{count}} Task Instanzen",
     "queuedDuration": "Zeit in der Warteschlange",
-    "runAfter": "Lauf nach",
+    "runAfter": "Lauf ab",
     "runDuration": "Laufzeit"
   },
   "fileUpload": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
@@ -9,7 +9,7 @@
   "details": {
     "fields": {
       "bundleVersion": "Bündel Version",
-      "catchup": "Nachholung",
+      "catchup": "Nachgeholt",
       "concurrency": "Parallelität",
       "dagId": "Dag ID",
       "dagRunTimeout": "Dag Lauf Zeitüberschreitung",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
@@ -1,0 +1,109 @@
+{
+  "allRuns": "Alle Läufe",
+  "code": {
+    "bundleUrl": "Bündel Url",
+    "bundleVersion": "Bündel Version:",
+    "noCode": "Kein Programmcode gefunden",
+    "parsedAt": "Eingelesen um:"
+  },
+  "details": {
+    "fields": {
+      "bundleVersion": "Bündel Version",
+      "catchup": "Nachholung",
+      "concurrency": "Parallelität",
+      "dagId": "Dag ID",
+      "dagRunTimeout": "Dag Lauf Zeitüberschreitung",
+      "defaultArgs": "Standard-Parameter",
+      "description": "Beschreibung",
+      "endDate": "Enddatum",
+      "fileLocation": "Ablagepfad",
+      "hasTaskConcurrencyLimits": "Hat der Task Limitierungen zur Parallelität",
+      "lastExpired": "Letztmaliger Ablauf",
+      "lastParsed": "Letztmalig Eingelesen",
+      "latestDagVersion": "Latzte Dag Version",
+      "maxActiveRuns": "Maximal aktive Läufe",
+      "maxActiveTasks": "Maximal aktive Tasks",
+      "maxConsecutiveFailedDagRuns": "Maximal fortlaufende fehlerhafte Dag Läufe",
+      "params": "Parameter",
+      "startDate": "Startdatum",
+      "timezone": "Zeitzone"
+    }
+  },
+  "grid": {
+    "buttons": {
+      "resetToLatest": "Auf Letzten zurücksetzen",
+      "toggleGroup": "Gruppen umschalten"
+    }
+  },
+  "header": {
+    "buttons": {
+      "dagDocs": "Dag Dokumentation"
+    },
+    "modals": {
+      "docTitle": "Dag Dokumentation"
+    },
+    "stats": {
+      "latestDagVersion": "Letzte Dag Version",
+      "latestRun": "Letzter Lauf",
+      "nextRun": "Nächster Lauf",
+      "owner": "Eigentümer",
+      "schedule": "Zeitplan",
+      "tags": "Markierungen"
+    }
+  },
+  "overview": {
+    "buttons": {
+      "failedRun_one": "Fehlgeschlagener Lauf",
+      "failedRun_other": "Fehlgeschlagene Läufe",
+      "failedTask_one": "Fehlgeschlagener Task",
+      "failedTask_other": "Fehlgeschlagene Tasks"
+    },
+    "charts": {
+      "assetEvent": "Erstelltes Datenset-Ereignis"
+    },
+    "failedLogs": {
+      "title": "Protokolle kürzlich fehlgeschlagener Tasks",
+      "viewFullLogs": "Vollständige Protokolle ansehen"
+    }
+  },
+  "panel": {
+    "buttons": {
+      "options": "Optionen",
+      "showGraph": "Graph zeigen",
+      "showGrid": "Gitter zeigen"
+    },
+    "dagRuns": {
+      "label": "Anzahl von Dag Läufen"
+    },
+    "dependencies": {
+      "label": "Abhängigkeiten",
+      "options": {
+        "allDagDependencies": "Alle Dag Abhängigkeiten",
+        "externalConditions": "Externe Bedingungen",
+        "onlyTasks": "Nur Tasks"
+      },
+      "placeholder": "Abhängigkeiten"
+    },
+    "graphDirection": {
+      "label": "Richtung des Graph"
+    }
+  },
+  "tabs": {
+    "backfills": "Auffüllungen",
+    "code": "Programmcode",
+    "details": "Details",
+    "events": "Ereignisse",
+    "overview": "Übersicht",
+    "runs": "Läufe",
+    "tasks": "Tasks"
+  },
+  "task": {
+    "card": {
+      "lastInstance": "Letzte Task Instanz"
+    }
+  },
+  "taskGroups": {
+    "collapseAll": "Alle Task-Gruppen einklappen",
+    "expandAll": "Alle Task-Gruppen aufklappen"
+  }
+}

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
@@ -6,8 +6,8 @@
       "warning": "Diese Aktion löscht alle Metadaten zu diesem Dag mit allen Läufen und Task Instanzen."
     },
     "trigger": {
-      "button": "Anstoßen",
-      "triggerDag": "Dag anstoßen"
+      "button": "Auslösen",
+      "triggerDag": "Dag auslösen"
     }
   },
   "filters": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
@@ -24,7 +24,7 @@
       "dagId": "Dag ID",
       "lastDagRun": "Letzter Dag Lauf",
       "nextDagRun": "Nächster Dag Lauf",
-      "schedule": "Planung",
+      "schedule": "Zeitplan",
       "tags": "Markierungen"
     },
     "ownerLink": "Besitzer Verlinkungen zu {{owner}}",
@@ -101,7 +101,7 @@
       "dagVersions": "Dag Version",
       "duration": "Laufzeit",
       "endDate": "Enddatum",
-      "runAfter": "Gelaufen nach",
+      "runAfter": "Gelaufen ab",
       "runType": "Typ des Laufs",
       "startDate": "Startdatum",
       "state": "Status"


### PR DESCRIPTION
After #51493 this updates the German translation gaps for the next increment.

FYI @TJaniF - I hope I double checked all missing "e" letters this time and have less typos.

Also as I was reviewing on the screen I made some minor adjustments where I "felt" like terms might be a bit better like "Geplant" -> "Zeitplan"