### PR TITLE
Allow pre-release test with task SDK via breeze

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -631,6 +631,9 @@ def install_airflow_and_providers(
                 f"\n[bright_blue]Installing airflow core distribution: {installation_spec.airflow_core_distribution} with constraints"
             )
             base_install_airflow_cmd.append(installation_spec.airflow_core_distribution)
+            if "rc" in installation_spec.airflow_core_distribution:
+                # If we install Airflow core from a pre-release version, we need to allow pre-releases to have task-sdk installable
+                base_install_airflow_cmd.append("--prerelease=allow")
         install_airflow_cmd = base_install_airflow_cmd.copy()
         if installation_spec.airflow_constraints_location:
             console.print(f"[bright_blue]Use constraints: {installation_spec.airflow_constraints_location}")


### PR DESCRIPTION
During testing of release 3.0.2 via breeze using 3.0.2rc2 I noticed that the install in breeze fails as the dependencies refer also to task-sdk==2.0.2rc2 - but the pip install does not allow installing pre-release versions.

With this CLI extension the breeze installer will allow pre-release dependencies so that I can test via:
`breeze start-airflow --load-example-dags --executor EdgeExecutor --answer y --use-airflow-version 3.0.2rc2 --use-distributions-from-dist`