### PR TITLE
Add config setting to control exposing stacktraces

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -27,6 +27,7 @@ from fastapi import HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
 from airflow.configuration import conf
+from airflow.utils.strings import get_random_string
 
 T = TypeVar("T", bound=Exception)
 
@@ -67,7 +68,7 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
     def exception_handler(self, request: Request, exc: IntegrityError, exc_id: str | None = None):
         """Handle IntegrityError exception."""
         if self._is_dialect_matched(exc):
-            exception_id = hex(id(exc)) if exc_id is None else exc_id
+            exception_id = get_random_string() if exc_id is None else exc_id
             stacktrace = ""
             for tb in traceback.format_tb(exc.__traceback__):
                 stacktrace += tb

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -65,10 +65,10 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
         super().__init__(IntegrityError)
         self.dialect: _DatabaseDialect.value | None = None
 
-    def exception_handler(self, request: Request, exc: IntegrityError, exc_id: str | None = None):
+    def exception_handler(self, request: Request, exc: IntegrityError):
         """Handle IntegrityError exception."""
         if self._is_dialect_matched(exc):
-            exception_id = get_random_string() if exc_id is None else exc_id
+            exception_id = get_random_string()
             stacktrace = ""
             for tb in traceback.format_tb(exc.__traceback__):
                 stacktrace += tb

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -65,7 +65,7 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
         """Handle IntegrityError exception."""
         if self._is_dialect_matched(exc):
             if conf.get("api", "expose_stacktrace") == "True":
-                stacktrace = "\n"
+                stacktrace = ""
                 for tb in traceback.format_tb(exc.__traceback__):
                     stacktrace += tb
             else:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1321,6 +1321,12 @@ api:
       type: string
       example: ~
       default: "False"
+    expose_stacktrace:
+      description: Expose stacktrace in the web server
+      version_added: ~
+      type: string
+      example: ~
+      default: "False"
     base_url:
       description: |
         The base url of the API server. Airflow cannot guess what domain or CNAME you are using.

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -51,6 +51,11 @@ PYTEST_MARKS_DB_DIALECT = [
         "reason": f"Test for {_DatabaseDialect.POSTGRES.value} only",
     },
 ]
+EXC_ID = "0x123e3aade"
+MESSAGE = (
+    "Serious error when handling your request. Check logs for more details - "
+    f"you will find it in api server when you look for ID {EXC_ID}"
+)
 
 
 def generate_test_cases_parametrize(
@@ -110,7 +115,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred) VALUES (?, ?, ?, ?)",
                             "orig_error": "UNIQUE constraint failed: slot_pool.pool",
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -119,7 +124,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred) VALUES (%s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_pool' for key 'slot_pool.slot_pool_pool_uq'\")",
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -128,7 +133,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s) RETURNING slot_pool.id",
                             "orig_error": 'duplicate key value violates unique constraint "slot_pool_pool_uq"\nDETAIL:  Key (pool)=(test_pool) already exists.\n',
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                 ],
@@ -139,7 +144,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": 'INSERT INTO variable ("key", val, description, is_encrypted) VALUES (?, ?, ?, ?)',
                             "orig_error": "UNIQUE constraint failed: variable.key",
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -148,7 +153,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO variable (`key`, val, description, is_encrypted) VALUES (%s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_key' for key 'variable.variable_key_uq'\")",
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -157,7 +162,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO variable (key, val, description, is_encrypted) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s) RETURNING variable.id",
                             "orig_error": 'duplicate key value violates unique constraint "variable_key_uq"\nDETAIL:  Key (key)=(test_key) already exists.\n',
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                 ],
@@ -179,7 +184,11 @@ class TestUniqueConstraintErrorHandler:
             session.commit()
 
         with pytest.raises(HTTPException) as exeinfo_response_error:
-            self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+            self.unique_constraint_error_handler.exception_handler(
+                None,  # type: ignore
+                exeinfo_integrity_error.value,
+                EXC_ID,
+            )
 
         assert exeinfo_response_error.value.status_code == expected_exception.status_code
         assert exeinfo_response_error.value.detail == expected_exception.detail
@@ -196,7 +205,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT max(log_template.id) AS max_1 \nFROM log_template), ?, ?, ?, ?, ?, ?, ?)",
                             "orig_error": "UNIQUE constraint failed: dag_run.dag_id, dag_run.run_id",
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -205,7 +214,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, (SELECT max(log_template.id) AS max_1 \nFROM log_template), %s, %s, %s, %s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_dag_id-test_run_id' for key 'dag_run.dag_run_dag_id_run_id_key'\")",
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -214,7 +223,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (%(dag_id)s, %(queued_at)s, %(logical_date)s, %(start_date)s, %(end_date)s, %(state)s, %(run_id)s, %(creating_job_id)s, %(run_type)s, %(triggered_by)s, %(conf)s, %(data_interval_start)s, %(data_interval_end)s, %(run_after)s, %(last_scheduling_decision)s, (SELECT max(log_template.id) AS max_1 \nFROM log_template), %(updated_at)s, %(clear_number)s, %(backfill_id)s, %(bundle_version)s, %(scheduled_by_job_id)s, %(context_carrier)s, %(created_dag_version_id)s) RETURNING dag_run.id",
                             "orig_error": 'duplicate key value violates unique constraint "dag_run_dag_id_run_id_key"\nDETAIL:  Key (dag_id, run_id)=(test_dag_id, test_run_id) already exists.\n',
-                            "stacktrace": "Database Integrity Error - Check logs for more details.",
+                            "message": MESSAGE,
                         },
                     ),
                 ],
@@ -242,7 +251,11 @@ class TestUniqueConstraintErrorHandler:
             session.commit()
 
         with pytest.raises(HTTPException) as exeinfo_response_error:
-            self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+            self.unique_constraint_error_handler.exception_handler(
+                None,  # type: ignore
+                exeinfo_integrity_error.value,
+                EXC_ID,
+            )
 
         assert exeinfo_response_error.value.status_code == expected_exception.status_code
         assert exeinfo_response_error.value.detail == expected_exception.detail

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from fastapi import HTTPException, status
 from sqlalchemy.exc import IntegrityError
@@ -169,10 +171,15 @@ class TestUniqueConstraintErrorHandler:
             ],
         ),
     )
+    @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
     @conf_vars({("api", "expose_stacktrace"): "False"})
     @provide_session
     def test_handle_single_column_unique_constraint_error(
-        self, session, table, expected_exception, monkeypatch
+        self,
+        mock_get_random_string,
+        session,
+        table,
+        expected_exception,
     ) -> None:
         # Take Pool and Variable tables as test cases
         if table == "Pool":
@@ -185,10 +192,6 @@ class TestUniqueConstraintErrorHandler:
         with pytest.raises(IntegrityError) as exeinfo_integrity_error:
             session.commit()
 
-        monkeypatch.setattr(
-            "airflow.api_fastapi.common.exceptions.get_random_string",
-            lambda length=None, choices=None: MOCKED_ID,
-        )
         with pytest.raises(HTTPException) as exeinfo_response_error:
             self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
 
@@ -232,10 +235,15 @@ class TestUniqueConstraintErrorHandler:
             ],
         ),
     )
+    @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
     @conf_vars({("api", "expose_stacktrace"): "False"})
     @provide_session
     def test_handle_multiple_columns_unique_constraint_error(
-        self, session, table, expected_exception, monkeypatch
+        self,
+        mock_get_random_string,
+        session,
+        table,
+        expected_exception,
     ) -> None:
         if table == "DagRun":
             session.add(
@@ -252,10 +260,6 @@ class TestUniqueConstraintErrorHandler:
         with pytest.raises(IntegrityError) as exeinfo_integrity_error:
             session.commit()
 
-        monkeypatch.setattr(
-            "airflow.api_fastapi.common.exceptions.get_random_string",
-            lambda length=None, choices=None: MOCKED_ID,
-        )
         with pytest.raises(HTTPException) as exeinfo_response_error:
             self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
 

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -26,6 +26,7 @@ from airflow.models import DagRun, Pool, Variable
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_connections, clear_db_dags, clear_db_pools, clear_db_runs
 
 pytestmark = pytest.mark.db_test
@@ -109,6 +110,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred) VALUES (?, ?, ?, ?)",
                             "orig_error": "UNIQUE constraint failed: slot_pool.pool",
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                     HTTPException(
@@ -117,6 +119,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred) VALUES (%s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_pool' for key 'slot_pool.slot_pool_pool_uq'\")",
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                     HTTPException(
@@ -125,6 +128,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s) RETURNING slot_pool.id",
                             "orig_error": 'duplicate key value violates unique constraint "slot_pool_pool_uq"\nDETAIL:  Key (pool)=(test_pool) already exists.\n',
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                 ],
@@ -135,6 +139,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": 'INSERT INTO variable ("key", val, description, is_encrypted) VALUES (?, ?, ?, ?)',
                             "orig_error": "UNIQUE constraint failed: variable.key",
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                     HTTPException(
@@ -143,6 +148,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO variable (`key`, val, description, is_encrypted) VALUES (%s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_key' for key 'variable.variable_key_uq'\")",
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                     HTTPException(
@@ -151,12 +157,14 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO variable (key, val, description, is_encrypted) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s) RETURNING variable.id",
                             "orig_error": 'duplicate key value violates unique constraint "variable_key_uq"\nDETAIL:  Key (key)=(test_key) already exists.\n',
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                 ],
             ],
         ),
     )
+    @conf_vars({("api", "expose_stacktrace"): "False"})
     @provide_session
     def test_handle_single_column_unique_constraint_error(self, session, table, expected_exception) -> None:
         # Take Pool and Variable tables as test cases
@@ -188,6 +196,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT max(log_template.id) AS max_1 \nFROM log_template), ?, ?, ?, ?, ?, ?, ?)",
                             "orig_error": "UNIQUE constraint failed: dag_run.dag_id, dag_run.run_id",
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                     HTTPException(
@@ -196,6 +205,7 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, (SELECT max(log_template.id) AS max_1 \nFROM log_template), %s, %s, %s, %s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_dag_id-test_run_id' for key 'dag_run.dag_run_dag_id_run_id_key'\")",
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                     HTTPException(
@@ -204,12 +214,14 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (%(dag_id)s, %(queued_at)s, %(logical_date)s, %(start_date)s, %(end_date)s, %(state)s, %(run_id)s, %(creating_job_id)s, %(run_type)s, %(triggered_by)s, %(conf)s, %(data_interval_start)s, %(data_interval_end)s, %(run_after)s, %(last_scheduling_decision)s, (SELECT max(log_template.id) AS max_1 \nFROM log_template), %(updated_at)s, %(clear_number)s, %(backfill_id)s, %(bundle_version)s, %(scheduled_by_job_id)s, %(context_carrier)s, %(created_dag_version_id)s) RETURNING dag_run.id",
                             "orig_error": 'duplicate key value violates unique constraint "dag_run_dag_id_run_id_key"\nDETAIL:  Key (dag_id, run_id)=(test_dag_id, test_run_id) already exists.\n',
+                            "stacktrace": "Database Integrity Error - Check logs for more details.",
                         },
                     ),
                 ],
             ],
         ),
     )
+    @conf_vars({("api", "expose_stacktrace"): "False"})
     @provide_session
     def test_handle_multiple_columns_unique_constraint_error(
         self, session, table, expected_exception

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -306,7 +306,7 @@ class TestPostConnection(TestConnectionEndpoint):
         assert response.status_code == 409
         response_json = response.json()
         assert "detail" in response_json
-        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
+        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error", "message"]
 
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -38,12 +38,7 @@ from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.api_fastapi import _check_dag_run_note, _check_last_log
-from tests_common.test_utils.db import (
-    clear_db_dags,
-    clear_db_logs,
-    clear_db_runs,
-    clear_db_serialized_dags,
-)
+from tests_common.test_utils.db import clear_db_dags, clear_db_logs, clear_db_runs, clear_db_serialized_dags
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_datetime_to_zulu_without_ms
 
 if TYPE_CHECKING:
@@ -1577,7 +1572,7 @@ class TestTriggerDagRun:
         assert response.status_code == 409
         response_json = response.json()
         assert "detail" in response_json
-        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
+        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error", "message"]
 
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_should_respond_200_with_null_logical_date(self, test_client):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -417,7 +417,7 @@ class TestPostPool(TestPoolsEndpoint):
         else:
             response_json = response.json()
             assert "detail" in response_json
-            assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
+            assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error", "message"]
 
         assert session.query(Pool).count() == n_pools + 1
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #51351

(Sorry for accidentally messing up the commit history. I created a new PR for this issue)

## Why
This PR reintroduces expose_stacktrace to control whether tracebacks are displayed in the webserver UI.

## What
* Add config api.expose_stacktrace to align with the settings in AF2.
* Display db tracebacks when expose_stacktrace is enabled.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
