### PR TITLE
CLI: add --batch-size option to "airflow db clean"

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -483,6 +483,15 @@ ARG_DB_RETRY_DELAY = Arg(
     type=positive_int(allow_zero=False),
     help="Wait time between retries in seconds",
 )
+ARG_DB_BATCH_SIZE = Arg(
+    ("--batch-size",),
+    default=5000,
+    type=positive_int(allow_zero=False),
+    help=(
+        "Maximum number of rows to delete or archive in a single transaction."
+        "Lower values reduce long-running locks but increase the number of batches."
+    ),
+)
 
 # pool
 ARG_POOL_NAME = Arg(("pool",), metavar="NAME", help="Pool name")
@@ -1452,6 +1461,7 @@ DB_COMMANDS = (
             ARG_VERBOSE,
             ARG_YES,
             ARG_DB_SKIP_ARCHIVE,
+            ARG_DB_BATCH_SIZE,
         ),
     ),
     ActionCommand(

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -485,10 +485,10 @@ ARG_DB_RETRY_DELAY = Arg(
 )
 ARG_DB_BATCH_SIZE = Arg(
     ("--batch-size",),
-    default=5000,
+    default=None,
     type=positive_int(allow_zero=False),
     help=(
-        "Maximum number of rows to delete or archive in a single transaction."
+        "Maximum number of rows to delete or archive in a single transaction.\n"
         "Lower values reduce long-running locks but increase the number of batches."
     ),
 )

--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -283,6 +283,7 @@ def cleanup_tables(args):
         verbose=args.verbose,
         confirm=not args.yes,
         skip_archive=args.skip_archive,
+        batch_size=args.batch_size,
     )
 
 

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -376,6 +376,7 @@ class TestCLIDBClean:
             verbose=False,
             confirm=False,
             skip_archive=False,
+            batch_size=None,
         )
 
     @pytest.mark.parametrize("timezone", ["UTC", "Europe/Berlin", "America/Los_Angeles"])
@@ -396,6 +397,7 @@ class TestCLIDBClean:
             verbose=False,
             confirm=False,
             skip_archive=False,
+            batch_size=None,
         )
 
     @pytest.mark.parametrize("confirm_arg, expected", [(["-y"], False), ([], True)])
@@ -422,6 +424,7 @@ class TestCLIDBClean:
             verbose=False,
             confirm=expected,
             skip_archive=False,
+            batch_size=None,
         )
 
     @pytest.mark.parametrize("extra_arg, expected", [(["--skip-archive"], True), ([], False)])
@@ -448,6 +451,7 @@ class TestCLIDBClean:
             verbose=False,
             confirm=True,
             skip_archive=expected,
+            batch_size=None,
         )
 
     @pytest.mark.parametrize("dry_run_arg, expected", [(["--dry-run"], True), ([], False)])
@@ -474,6 +478,7 @@ class TestCLIDBClean:
             verbose=False,
             confirm=True,
             skip_archive=False,
+            batch_size=None,
         )
 
     @pytest.mark.parametrize(
@@ -502,6 +507,7 @@ class TestCLIDBClean:
             verbose=False,
             confirm=True,
             skip_archive=False,
+            batch_size=None,
         )
 
     @pytest.mark.parametrize("extra_args, expected", [(["--verbose"], True), ([], False)])
@@ -528,6 +534,34 @@ class TestCLIDBClean:
             verbose=expected,
             confirm=True,
             skip_archive=False,
+            batch_size=None,
+        )
+
+    @pytest.mark.parametrize("extra_args, expected", [(["--batch-size", "1234"], 1234), ([], None)])
+    @patch("airflow.cli.commands.db_command.run_cleanup")
+    def test_batch_size(self, run_cleanup_mock, extra_args, expected):
+        """
+        batch_size should be forwarded to run_cleanup with correct type.
+        """
+        args = self.parser.parse_args(
+            [
+                "db",
+                "clean",
+                "--clean-before-timestamp",
+                "2021-01-01",
+                *extra_args,
+            ]
+        )
+        db_command.cleanup_tables(args)
+
+        run_cleanup_mock.assert_called_once_with(
+            table_names=None,
+            dry_run=False,
+            clean_before_timestamp=pendulum.parse("2021-01-01 00:00:00Z"),
+            verbose=False,
+            confirm=True,
+            skip_archive=False,
+            batch_size=expected,
         )
 
     @patch("airflow.cli.commands.db_command.export_archived_records")

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -123,6 +123,20 @@ class TestDBCleanup:
         )
         assert cleanup_table_mock.call_args.kwargs["skip_archive"] is should_skip
 
+    @patch("airflow.utils.db_cleanup._cleanup_table")
+    def test_run_cleanup_batch_size_propagation(self, cleanup_table_mock):
+        """Ensure batch_size is forwarded from run_cleanup to _cleanup_table."""
+        run_cleanup(
+            clean_before_timestamp=None,
+            table_names=["log"],
+            dry_run=None,
+            verbose=None,
+            confirm=False,
+            batch_size=1234,
+        )
+        cleanup_table_mock.assert_called_once()
+        assert cleanup_table_mock.call_args.kwargs["batch_size"] == 1234
+
     @pytest.mark.parametrize(
         "table_names",
         [


### PR DESCRIPTION
Closes: #47600

Support new argument **`--batch-size`** for `airflow db clean`.

example output
```console
root@b634cda2186b:/opt/airflow# airflow db clean --help
Usage: airflow db clean [-h] [--batch-size BATCH_SIZE] --clean-before-timestamp CLEAN_BEFORE_TIMESTAMP [--dry-run] [--skip-archive] [-t TABLES] [-v] [-y]

Purge old records in metastore tables

Optional Arguments:
  -h, --help            show this help message and exit
  --batch-size BATCH_SIZE
                        Maximum number of rows to delete or archive in a single transaction.
                        Lower values reduce long-running locks but increase the number of batches.
  --clean-before-timestamp CLEAN_BEFORE_TIMESTAMP
                        The date or timestamp before which data should be purged.
                        ...
```

## Unit tests
* `test_run_cleanup_batch_size_propagation`
* `test_batch_size`

## ▶️ Manual / end‑to‑end check

I verified the flag with three back‑ends - PostgreSQL, MySQL, and SQLite. Using 100,000 mock rows in both the `log` and `import_error` tables.

#### PostgreSQL

```sql
-- insert mock data into `log`
INSERT INTO log (dttm, dag_id, task_id, event, owner, extra)
SELECT
    now() - interval '500 days' - (gs.id || ' seconds')::interval,
    'batch_test_dag',
    'dummy_task',
    'unit-test',
    'tester',
    NULL
FROM generate_series(1, 100000) AS gs(id);

-- insert mock data into `import_error`
INSERT INTO import_error (timestamp, filename, stacktrace)
SELECT
    now() - interval '500 days' - (gs.id || ' seconds')::interval,
    concat('dummy_file_', gs.id, '.py'),
    'Traceback (most recent call last): …'
FROM generate_series(1, 100000) AS gs(id);
```

#### MySQL

```mysql
SET SESSION cte_max_recursion_depth = 100000;

-- log
INSERT INTO log (dttm, dag_id, task_id, `event`, owner, extra)
WITH RECURSIVE seq(id) AS (
    SELECT 1
    UNION ALL
    SELECT id + 1 FROM seq WHERE id < 100000
)
SELECT
    TIMESTAMPADD(SECOND, -id, TIMESTAMPADD(DAY, -500, NOW())),
    'batch_test_dag',
    'dummy_task',
    'unit-test',
    'tester',
    NULL
FROM seq;

-- import_error
INSERT INTO import_error (`timestamp`, filename, stacktrace)
WITH RECURSIVE seq(id) AS (
    SELECT 1
    UNION ALL
    SELECT id + 1 FROM seq WHERE id < 100000
)
SELECT
    TIMESTAMPADD(SECOND, -id, TIMESTAMPADD(DAY, -500, NOW())),
    CONCAT('dummy_file_', id, '.py'),
    'Traceback (most recent call last): …'
FROM seq;
```

#### SQLite

```sql
-- log
WITH RECURSIVE seq(id) AS (
    SELECT 1
    UNION ALL
    SELECT id + 1 FROM seq WHERE id < 100000
)
INSERT INTO log (dttm, dag_id, task_id, "event", owner, extra)
SELECT
    datetime('now', '-500 days', printf('-%d seconds', id)),
    'batch_test_dag',
    'dummy_task',
    'unit-test',
    'tester',
    NULL
FROM seq;

-- import_error
WITH RECURSIVE seq(id) AS (
    SELECT 1
    UNION ALL
    SELECT id + 1 FROM seq WHERE id < 100000
)
INSERT INTO import_error ("timestamp", filename, stacktrace)
SELECT
    datetime('now', '-500 days', printf('-%d seconds', id)),
    'dummy_file_' || id || '.py',
    'Traceback (most recent call last): …'
FROM seq;
```

Both commands below completed successfully on all three back‑ends, with rows fully purged and archives created/dropped as expected:

```console
# test new flag
airflow db clean --clean-before-timestamp '2025-06-06 00:00:00+01:00' -t log,import_error --batch-size 25000

# regenerate data and test default behaviour (single large batch)
airflow db clean --clean-before-timestamp '2025-06-06 00:00:00+01:00' -t log,import_error
```

## Docs

I verified that the documentation (cli-and-env-variables-ref.rst) now includes the new argument.

<img width="1244" alt="截圖 2025-06-07 下午5 31 55" src="https://github.com/user-attachments/assets/646a7852-525d-4d3e-afc9-ac3361dbc446" />

---

Please let me know if there's anything that needs to be improved, many thanks 😄
