### PR TITLE
Fix MaxComputeSQLOperator Argument 

### DIFF
--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/maxcompute.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/maxcompute.py
@@ -45,7 +45,7 @@ def fallback_to_default_project_endpoint(func: Callable[..., RT]) -> Callable[..
     def inner_wrapper(self, **kwargs) -> RT:
         required_args = ("project", "endpoint")
         for arg_name in required_args:
-            kwargs[arg_name] = kwargs.get(arg_name, getattr(self, arg_name))
+            kwargs[arg_name] = getattr(self, arg_name) if kwargs.get(arg_name) is None else kwargs[arg_name]
             if not kwargs[arg_name]:
                 raise MaxComputeConfigurationException(
                     f'"{arg_name}" must be passed either as '

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/maxcompute.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/maxcompute.py
@@ -45,6 +45,8 @@ def fallback_to_default_project_endpoint(func: Callable[..., RT]) -> Callable[..
     def inner_wrapper(self, **kwargs) -> RT:
         required_args = ("project", "endpoint")
         for arg_name in required_args:
+            # Use the value from kwargs if it is provided and value is not None, otherwise use the
+            # value from the connection extra property.
             kwargs[arg_name] = getattr(self, arg_name) if kwargs.get(arg_name) is None else kwargs[arg_name]
             if not kwargs[arg_name]:
                 raise MaxComputeConfigurationException(

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/maxcompute.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/maxcompute.py
@@ -56,8 +56,8 @@ class MaxComputeSQLOperator(BaseOperator):
     :param default_schema: The default schema to use.
     :param quota_name: The quota name to use.
         Defaults to project default quota if not specified.
-    :param alibabacloud_conn_id: The connection ID to use. Defaults to
-        `alibabacloud_default` if not specified.
+    :param maxcompute_conn_id: The connection ID to use. Defaults to
+        `maxcompute_default` if not specified.
     :param cancel_on_kill: Flag which indicates whether to stop running instance
         or not when task is killed. Default is True.
     """
@@ -72,7 +72,7 @@ class MaxComputeSQLOperator(BaseOperator):
         "aliases",
         "default_schema",
         "quota_name",
-        "alibabacloud_conn_id",
+        "maxcompute_conn_id",
     )
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"sql": "sql"}
@@ -90,7 +90,7 @@ class MaxComputeSQLOperator(BaseOperator):
         aliases: dict[str, str] | None = None,
         default_schema: str | None = None,
         quota_name: str | None = None,
-        alibabacloud_conn_id: str = "alibabacloud_default",
+        maxcompute_conn_id: str = "maxcompute_default",
         cancel_on_kill: bool = True,
         **kwargs,
     ) -> None:
@@ -104,13 +104,13 @@ class MaxComputeSQLOperator(BaseOperator):
         self.aliases = aliases
         self.default_schema = default_schema
         self.quota_name = quota_name
-        self.alibabacloud_conn_id = alibabacloud_conn_id
+        self.maxcompute_conn_id = maxcompute_conn_id
         self.cancel_on_kill = cancel_on_kill
         self.hook: MaxComputeHook | None = None
         self.instance: Instance | None = None
 
     def execute(self, context: Context) -> str:
-        self.hook = MaxComputeHook(alibabacloud_conn_id=self.alibabacloud_conn_id)
+        self.hook = MaxComputeHook(maxcompute_conn_id=self.maxcompute_conn_id)
 
         self.instance = self.hook.run_sql(
             sql=self.sql,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

The MaxComputeSQLOperator has errors due to incorrect argument usage. This PR fixes the conn_id argument naming and the fallback logic

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
