### PR TITLE
airflowctl: convert to `BulkResponse` in variables.import

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -37,6 +37,7 @@ from airflowctl.api.datamodels.generated import (
     BulkBodyConnectionBody,
     BulkBodyPoolBody,
     BulkBodyVariableBody,
+    BulkResponse,
     Config,
     ConnectionBody,
     ConnectionCollectionResponse,
@@ -672,11 +673,11 @@ class VariablesOperations(BaseOperations):
         except ServerResponseError as e:
             raise e
 
-    def bulk(self, variables: BulkBodyVariableBody) -> BulkActionResponse | ServerResponseError:
+    def bulk(self, variables: BulkBodyVariableBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple variables."""
         try:
             self.response = self.client.patch("variables", json=variables.model_dump())
-            return BulkActionResponse.model_validate_json(self.response.content)
+            return BulkResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:
             raise e
 

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -44,6 +44,7 @@ from airflowctl.api.datamodels.generated import (
     BulkCreateActionConnectionBody,
     BulkCreateActionPoolBody,
     BulkCreateActionVariableBody,
+    BulkResponse,
     Config,
     ConfigOption,
     ConfigSection,
@@ -1054,9 +1055,10 @@ class TestVariablesOperations:
             )
         ]
     )
-    variable_bulk_response = BulkActionResponse(
-        success=[key],
-        errors=[],
+    variable_bulk_response = BulkResponse(
+        create=BulkActionResponse(success=[key], errors=[]),
+        update=None,
+        delete=None,
     )
 
     def test_get(self):

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 import json
 import os
 
+import pytest
+
 from airflowctl.api.client import ClientKind
 from airflowctl.api.datamodels.generated import (
     BulkActionResponse,
+    BulkResponse,
     VariableCollectionResponse,
     VariableResponse,
 )
@@ -46,12 +49,24 @@ class TestCliVariableCommands:
         ],
         total_entries=1,
     )
-    bulk_action_response = BulkActionResponse(success=[key], errors=[])
+    bulk_response_success = BulkResponse(
+        create=BulkActionResponse(success=[key], errors=[]), update=None, delete=None
+    )
+    bulk_response_error = BulkResponse(
+        create=BulkActionResponse(
+            success=[],
+            errors=[
+                {"error": f"The variables with these keys: {{'{key}'}} already exist.", "status_code": 409}
+            ],
+        ),
+        update=None,
+        delete=None,
+    )
 
-    def test_import(self, api_client_maker, tmp_path, monkeypatch):
+    def test_import_success(self, api_client_maker, tmp_path, monkeypatch):
         api_client = api_client_maker(
             path="/api/v2/variables",
-            response_json=self.bulk_action_response.model_dump(),
+            response_json=self.bulk_response_success.model_dump(),
             expected_http_status_code=200,
             kind=ClientKind.CLI,
         )
@@ -67,7 +82,28 @@ class TestCliVariableCommands:
             self.parser.parse_args(["variables", "import", expected_json_path.as_posix()]),
             api_client=api_client,
         )
-        assert response == ([self.key], [])
+        assert response == [self.key]
+
+    def test_import_error(self, api_client_maker, tmp_path, monkeypatch):
+        api_client = api_client_maker(
+            path="/api/v2/variables",
+            response_json=self.bulk_response_error.model_dump(),
+            expected_http_status_code=200,
+            kind=ClientKind.CLI,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        expected_json_path = tmp_path / self.export_file_name
+        variable_file = {
+            self.key: self.value,
+        }
+
+        expected_json_path.write_text(json.dumps(variable_file))
+        with pytest.raises(SystemExit):
+            variable_command.import_(
+                self.parser.parse_args(["variables", "import", expected_json_path.as_posix()]),
+                api_client=api_client,
+            )
 
     def test_export(self, api_client_maker, tmp_path, monkeypatch):
         api_client = api_client_maker(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #51310

Change BulkActionResponse to BulkResponse in operations (only variable command. seperate pools command)
cc. @bugraoz93 

- If need to solve pools command in this PR, I'll edit together. Ping me!
- I thought splitting into two separate issues—one for `variables` and one for `pools`—would be the better approach.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
