### PR TITLE
Bump minimal Kubernetes version to 1.30 in the Helm chart

### DIFF
--- a/airflow-core/tests/unit/charts/helm_template_generator.py
+++ b/airflow-core/tests/unit/charts/helm_template_generator.py
@@ -34,7 +34,7 @@ api_client = ApiClient()
 
 CHART_DIR = Path(__file__).resolve().parents[4] / "chart"
 
-DEFAULT_KUBERNETES_VERSION = "1.29.1"
+DEFAULT_KUBERNETES_VERSION = "1.30.13"
 BASE_URL_SPEC = (
     f"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
     f"v{DEFAULT_KUBERNETES_VERSION}-standalone-strict"

--- a/chart/README.md
+++ b/chart/README.md
@@ -30,7 +30,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Requirements
 
-- Kubernetes 1.29+ cluster
+- Kubernetes 1.30+ cluster
 - Helm 3.0+
 - PV provisioner support in the underlying infrastructure (optionally)
 

--- a/chart/docs/index.rst
+++ b/chart/docs/index.rst
@@ -59,7 +59,7 @@ deployment on a `Kubernetes <http://kubernetes.io>`__ cluster using the
 Requirements
 ------------
 
--  Kubernetes 1.29+ cluster
+-  Kubernetes 1.30+ cluster
 -  Helm 3.10+
 -  PV provisioner support in the underlying infrastructure (optionally)
 

--- a/chart/docs/quick-start.rst
+++ b/chart/docs/quick-start.rst
@@ -23,11 +23,11 @@ This article will show you how to install Airflow using Helm Chart on `Kind <htt
 Install kind, and create a cluster
 ----------------------------------
 
-We recommend testing with Kubernetes 1.20+, example:
+We recommend testing with Kubernetes 1.30+, example:
 
 .. code-block:: bash
 
-   kind create cluster --image kindest/node:v1.21.1
+   kind create cluster --image kindest/node:v1.30.13
 
 Confirm it's up:
 

--- a/helm-tests/tests/chart_utils/helm_template_generator.py
+++ b/helm-tests/tests/chart_utils/helm_template_generator.py
@@ -36,7 +36,7 @@ api_client = ApiClient()
 
 CHART_DIR = Path(__file__).resolve().parents[3] / "chart"
 
-DEFAULT_KUBERNETES_VERSION = "1.29.1"
+DEFAULT_KUBERNETES_VERSION = "1.30.13"
 BASE_URL_SPEC = (
     f"https://api.github.com/repos/yannh/kubernetes-json-schema/contents/"
     f"v{DEFAULT_KUBERNETES_VERSION}-standalone-strict"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

This PR updates the minimum Kubernetes version to 1.30 in the Helm chart to align with the versions supported by Airflow, which were updated earlier: https://github.com/apache/airflow/pull/49945/files

The Helm chart has nothing to remove according to https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/#deprecations-and-removals.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
