### PR TITLE
Fix bad width w/no options in multi-select DAG parameter

### DIFF
--- a/airflow/www/static/js/trigger.js
+++ b/airflow/www/static/js/trigger.js
@@ -170,6 +170,7 @@ function initForm() {
           $(elementId).select2({
             placeholder: "Select Values",
             allowClear: true,
+            width: "100%",
           });
           elements[i].addEventListener("blur", updateJSONconf);
         } else if (elements[i].type === "checkbox") {


### PR DESCRIPTION
Address inproper input element width when no options were present in a multi-select field for a DAG parameter in the DAG trigger page and:

* the parameter is in a section: the element would become too narrow making the dropdown options unreadable.
* the parameter is not in a section: the element would overflow it's parent if re-sized smaller

closes: #50322 