### PR TITLE
Displaying non native XComs in a human readable way on UI

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -41,7 +41,6 @@ from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import TaskNotFound
 from airflow.models import DAG, DagRun as DR
 from airflow.models.xcom import XComModel
-from airflow.settings import conf
 
 xcom_router = AirflowRouter(
     tags=["XCom"], prefix="/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries"
@@ -69,41 +68,38 @@ def get_xcom_entry(
     stringify: Annotated[bool, Query()] = False,
 ) -> XComResponseNative | XComResponseString:
     """Get an XCom entry."""
-    if deserialize:
-        if not conf.getboolean("api", "enable_xcom_deserialize_support", fallback=False):
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST, "XCom deserialization is disabled in configuration."
-            )
-        query = select(XComModel, XComModel.value)
-    else:
-        query = select(XComModel)
-
-    query = query.where(
-        XComModel.dag_id == dag_id,
-        XComModel.task_id == task_id,
-        XComModel.key == xcom_key,
-        XComModel.map_index == map_index,
+    xcom_query = XComModel.get_many(
+        run_id=dag_run_id,
+        key=xcom_key,
+        task_ids=task_id,
+        dag_ids=dag_id,
+        map_indexes=map_index,
+        session=session,
+        limit=1,
     )
-    query = query.join(DR, and_(XComModel.dag_id == DR.dag_id, XComModel.run_id == DR.run_id))
-    query = query.where(DR.run_id == dag_run_id)
-    query = query.options(joinedload(XComModel.dag_run).joinedload(DR.dag_model))
 
-    if deserialize:
-        item = session.execute(query).one_or_none()
-    else:
-        item = session.scalars(query).one_or_none()
+    # We use `BaseXCom.get_many` to fetch XComs directly from the database, bypassing the XCom Backend.
+    # This avoids deserialization via the backend (e.g., from a remote storage like S3) and instead
+    # retrieves the raw serialized value from the database.
+    result = xcom_query.limit(1).first()
 
-    if item is None:
+    if result is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"XCom entry with key: `{xcom_key}` not found")
 
+    item = copy.copy(result)
     if deserialize:
-        from airflow.sdk.execution_time.xcom import XCom
+        # We use `airflow.serialization.serde` for deserialization here because custom XCom backends (with their own
+        # serializers/deserializers) are only used on the worker side during task execution.
 
-        xcom, value = item
-        xcom_stub = copy.copy(xcom)
-        xcom_stub.value = value
-        xcom_stub.value = XCom.deserialize_value(xcom_stub)
-        item = xcom_stub
+        # However, the XCom value is *always* stored in the metadata database as a valid JSON object.
+        # Therefore, for purposes such as UI display or returning API responses, deserializing with
+        # `airflow.serialization.serde` is safe and recommended.
+        from airflow.serialization.serde import deserialize as serde_deserialize
+
+        # full=False ensures that the `item` is deserialized without loading the classes, and it returns a stringified version
+        item.value = serde_deserialize(XComModel.deserialize_value(item), full=False)
+    else:
+        item.value = XComModel.deserialize_value(item)
 
     if stringify:
         return XComResponseString.model_validate(item)

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
@@ -35,12 +35,16 @@ export const XComEntry = ({ dagId, mapIndex, runId, taskId, xcomKey }: XComEntry
   const { data, isLoading } = useXcomServiceGetXcomEntry<XComResponseNative>({
     dagId,
     dagRunId: runId,
+    deserialize: true,
     mapIndex,
     stringify: false,
     taskId,
     xcomKey,
   });
-  const valueFormatted = JSON.stringify(data?.value, undefined, 4);
+  // When deserialize=true, the API returns a stringified representation
+  // so we don't need to JSON.stringify it again
+  const valueFormatted =
+    typeof data?.value === "string" ? data.value : JSON.stringify(data?.value, undefined, 4);
 
   return isLoading ? (
     <Skeleton

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -72,8 +72,6 @@ def _create_xcom(key, value, backend, session=None) -> None:
         session=session,
     )
 
-    print("hi")
-
 
 @provide_session
 def _create_dag_run(dag_maker, session=None):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -179,7 +179,7 @@ class TestGetXComEntry(TestXComEndpoint):
     @conf_vars({("core", "xcom_backend"): "unit.api_fastapi.core_api.routes.public.test_xcom.CustomXCom"})
     def test_custom_xcom_deserialize(self, params: str, expected_value: int | str, test_client):
         # Even with a CustomXCom defined, we should not be using it during deserialization because API / UI doesn't integrate their
-        # deserialization with chstom backends
+        # deserialization with custom backends
         XCom = resolve_xcom_backend()
         self._create_xcom(TEST_XCOM_KEY, TEST_XCOM_VALUE, backend=XCom)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -72,6 +72,8 @@ def _create_xcom(key, value, backend, session=None) -> None:
         session=session,
     )
 
+    print("hi")
+
 
 @provide_session
 def _create_dag_run(dag_maker, session=None):
@@ -161,7 +163,7 @@ class TestGetXComEntry(TestXComEndpoint):
         [
             pytest.param(
                 {"deserialize": True},
-                f"{TEST_XCOM_VALUE_AS_JSON}",
+                TEST_XCOM_VALUE,
                 id="deserialize=true",
             ),
             pytest.param(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -157,63 +157,38 @@ class TestGetXComEntry(TestXComEndpoint):
         assert response.json()["detail"] == f"XCom entry with key: `{TEST_XCOM_KEY_2}` not found"
 
     @pytest.mark.parametrize(
-        "support_deserialize, params, expected_status_or_value",
+        "params, expected_value",
         [
             pytest.param(
-                True,
                 {"deserialize": True},
-                f"real deserialized {TEST_XCOM_VALUE_AS_JSON}",
-                id="enabled deserialize-true",
+                f"{TEST_XCOM_VALUE_AS_JSON}",
+                id="deserialize=true",
             ),
             pytest.param(
-                False,
-                {"deserialize": True},
-                400,
-                id="disabled deserialize-true",
-            ),
-            pytest.param(
-                True,
                 {"deserialize": False},
                 f"{TEST_XCOM_VALUE_AS_JSON}",
-                id="enabled deserialize-false",
+                id="deserialize=false",
             ),
             pytest.param(
-                False,
-                {"deserialize": False},
-                f"{TEST_XCOM_VALUE_AS_JSON}",
-                id="disabled deserialize-false",
-            ),
-            pytest.param(
-                True,
                 {},
                 f"{TEST_XCOM_VALUE_AS_JSON}",
-                id="enabled default",
-            ),
-            pytest.param(
-                False,
-                {},
-                f"{TEST_XCOM_VALUE_AS_JSON}",
-                id="disabled default",
+                id="default",
             ),
         ],
     )
     @conf_vars({("core", "xcom_backend"): "unit.api_fastapi.core_api.routes.public.test_xcom.CustomXCom"})
-    def test_custom_xcom_deserialize(
-        self, support_deserialize: bool, params: str, expected_status_or_value: int | str, test_client
-    ):
+    def test_custom_xcom_deserialize(self, params: str, expected_value: int | str, test_client):
+        # Even with a CustomXCom defined, we should not be using it during deserialization because API / UI doesn't integrate their
+        # deserialization with chstom backends
         XCom = resolve_xcom_backend()
         self._create_xcom(TEST_XCOM_KEY, TEST_XCOM_VALUE, backend=XCom)
 
         url = f"/dags/{TEST_DAG_ID}/dagRuns/{run_id}/taskInstances/{TEST_TASK_ID}/xcomEntries/{TEST_XCOM_KEY}"
         with mock.patch("airflow.sdk.execution_time.xcom.XCom", XCom):
-            with conf_vars({("api", "enable_xcom_deserialize_support"): str(support_deserialize)}):
-                response = test_client.get(url, params=params)
+            response = test_client.get(url, params=params)
 
-        if isinstance(expected_status_or_value, int):
-            assert response.status_code == expected_status_or_value
-        else:
-            assert response.status_code == 200
-            assert response.json()["value"] == expected_status_or_value
+        assert response.status_code == 200
+        assert response.json()["value"] == expected_value
 
 
 class TestGetXComEntries(TestXComEndpoint):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/49456




## Problem

The problem was that we used custom XCom serialisation (if defined) or regular XcomModel serialisation to serialise the xcoms before sending it across to the API server to persist to the DB.


Flow:

1. XCom is pushed via task return value or `ti.xcom_push` and then uses the object that is serialised using `CustomXComBackend` or the XCom class via the `XComEncoder`  (e.g set, Asset, datetime) into Python JSON-serializable object.

    https://github.com/apache/airflow/blob/3208bbb9e08d19d02db6928fe01f99b538781641/task-sdk/src/airflow/sdk/execution_time/task_runner.py#L526

    https://github.com/apache/airflow/blob/3208bbb9e08d19d02db6928fe01f99b538781641/task-sdk/src/airflow/sdk/bases/xcom.py#L64-L71

    https://github.com/apache/airflow/blob/3208bbb9e08d19d02db6928fe01f99b538781641/task-sdk/src/airflow/sdk/bases/xcom.py#L280-L283

2. FastAPI deserializes it (JsonValue) when API call is sent to API server → Converts it into a Python dict.

    https://github.com/apache/airflow/blob/3208bbb9e08d19d02db6928fe01f99b538781641/task-sdk/src/airflow/sdk/api/client.py#L414

    https://github.com/apache/airflow/blob/3208bbb9e08d19d02db6928fe01f99b538781641/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py#L204-L223


3. SQLAlchemy stores it (Column(JSON)) → Serializes it back into JSON in the database.

    https://github.com/apache/airflow/blob/3208bbb9e08d19d02db6928fe01f99b538781641/airflow-core/src/airflow/models/xcom.py#L79


But when de-serializing to show in the UI or API, we don't de-serialize using our Serialization module which happened in (1) above.


## Approach

We are certain at all times that the value stored in the DB is going to be a valid JSON object, irrespective of where it got serialised from. 

In airflow 3, the custom xcom backend is also only handled on the worker side and the reference for it is stored in the Xcom table in the metadata DB. So, we should not use the custom xcom backend ser / deser on the API server side at all.

A safe way to deserialize would be to pass in the `full=False` to the serde deserialize so that the deser can happen without loading the custom classes that COULD be present. This will return a stringified version of the object deserialized.

Since we use the "full=False", we will be returning a stringified version of the value when deserialize is set to true. A good way of handling this would be to have the UI not `JSON.stringify` it if it already is a string to avoid quotes display on the UI.

## Testing

DAG used:
```
from airflow.sdk import ObjectStoragePath
from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator

def push_class(**kwargs):
    value = ObjectStoragePath("file:///tmp/foo")
    return value

with DAG(
    'xcom_push_class',
    schedule=None,
    catchup=False,
) as dag:

    push_xcom_task = PythonOperator(
        task_id='push_class',
        python_callable=push_class,
    )

    push_xcom_task

```


Request sent by the UI to the execution API:
```
curl 'http://localhost:28080/api/v2/dags/xcom_push_class/dagRuns/manual__2025-06-10T07:23:01.644733+00:00/taskInstances/push_class/xcomEntries/return_value?map_index=-1&deserialize=true&stringify=false' \
  -H 'Accept: application/json' \
  -H 'Accept-Language: en-GB,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Referer: http://localhost:28080/dags/xcom_push_class/runs/manual__2025-06-10T07:23:01.644733+00:00/tasks/push_class/xcom' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"'
```


Before:

![image](https://github.com/user-attachments/assets/193eebb7-67db-4704-b6da-96e6d8e05f8e)


After:

![image](https://github.com/user-attachments/assets/11dcc5ff-139d-4f54-a9c3-cb8a772f7550)




TODO:

- [x] Update PR desc
- [x] Add testing details
- [x] Fix tests
- [x] Update UI code and tests to send "deserialize" flag as true

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
