### PR TITLE
Dont render empty run config

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -123,13 +123,10 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
   },
   {
     accessorKey: "conf",
-    cell: ({ row: { original } }) => {
-      if (original.conf) {
-        return <RenderedJsonField content={original.conf} jsonProps={{ collapsed: true }} />;
-      }
-
-      return undefined;
-    },
+    cell: ({ row: { original } }) =>
+      original.conf && Object.keys(original.conf).length > 0 ? (
+        <RenderedJsonField content={original.conf} jsonProps={{ collapsed: true }} />
+      ) : undefined,
     header: translate("dags:runs.columns.conf"),
   },
   {


### PR DESCRIPTION
We should return undefined when the dag run config is just `{}`. Then it if much easier to find the dag runs with a config we actually care about.

Before:
<img width="822" alt="Screenshot 2025-06-09 at 12 10 22 PM" src="https://github.com/user-attachments/assets/3bf940e1-bdc9-488c-ac19-4441aafa1fde" />

After:
<img width="943" alt="Screenshot 2025-06-09 at 12 10 11 PM" src="https://github.com/user-attachments/assets/bf01f91b-8a1d-466f-b602-48767d3a15c5" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
