### PR TITLE
Ensure plurality in backfill count message with more than 1 run.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagActions/inlineMessage.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/inlineMessage.tsx
@@ -28,8 +28,6 @@ export const getInlineMessage = (isPendingDryRun: boolean, totalEntries: number,
     </Text>
   ) : (
     <Text color="fg.success" fontSize="sm">
-      {translate(totalEntries > 1 ? "backfill.affectedMultiple" : "backfill.affectedOne", {
-        count: totalEntries,
-      })}
+      {translate("backfill.affected", { count: totalEntries })}
     </Text>
   );

--- a/airflow-core/src/airflow/ui/src/components/DagActions/inlineMessage.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/inlineMessage.tsx
@@ -22,16 +22,14 @@ import type { TFunction } from "i18next";
 export const getInlineMessage = (isPendingDryRun: boolean, totalEntries: number, translate: TFunction) =>
   isPendingDryRun ? (
     <Skeleton height="20px" width="100px" />
-  ) : totalEntries === 1 ? (
-    <Text color="fg.success" fontSize="sm">
-      {translate("backfill.affectedOne")}
-    </Text>
-  ) : totalEntries > 1 ? (
-    <Text color="fg.success" fontSize="sm">
-      {translate("backfill.affectedMultiple", { count: totalEntries })}
-    </Text>
-  ) : (
+  ) : totalEntries === 0 ? (
     <Text color="fg.error" fontSize="sm" fontWeight="medium">
       {translate("backfill.affectedNone")}
+    </Text>
+  ) : (
+    <Text color="fg.success" fontSize="sm">
+      {translate(totalEntries > 1 ? "backfill.affectedMultiple" : "backfill.affectedOne", {
+        count: totalEntries,
+      })}
     </Text>
   );

--- a/airflow-core/src/airflow/ui/src/components/DagActions/inlineMessage.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/inlineMessage.tsx
@@ -22,11 +22,11 @@ import type { TFunction } from "i18next";
 export const getInlineMessage = (isPendingDryRun: boolean, totalEntries: number, translate: TFunction) =>
   isPendingDryRun ? (
     <Skeleton height="20px" width="100px" />
-  ) : totalEntries > 1 ? (
+  ) : totalEntries === 1 ? (
     <Text color="fg.success" fontSize="sm">
       {translate("backfill.affectedOne")}
     </Text>
-  ) : totalEntries > 0 ? (
+  ) : totalEntries > 1 ? (
     <Text color="fg.success" fontSize="sm">
       {translate("backfill.affectedMultiple", { count: totalEntries })}
     </Text>

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
@@ -1,8 +1,8 @@
 {
   "backfill": {
-    "affectedMultiple": "{{count}} Läufe werden ausgelöst.",
+    "affected_one": "1 Lauf wird ausgelöst.",
+    "affected_other": "{{count}} Läufe werden ausgelöst.",
     "affectedNone": "Keine Läufe entsprechend en Kriterien.",
-    "affectedOne": "1 Lauf wird ausgelöst.",
     "backwards": "Verarbeitung in Rückwärtiger Reihenfolge",
     "dateRange": "Datumsbereich",
     "dateRangeFrom": "Von",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
@@ -1,8 +1,8 @@
 {
   "backfill": {
-    "affectedMultiple": "{{count}} runs will be triggered.",
+    "affected_one": "1 run will be triggered.",
+    "affected_other": "{{count}} runs will be triggered.",
     "affectedNone": "No runs matching selected criteria.",
-    "affectedOne": "1 run will be triggered.",
     "backwards": "Run Backwards",
     "dateRange": "Date Range",
     "dateRangeFrom": "From",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/pl/components.json
@@ -1,8 +1,8 @@
 {
   "backfill": {
-    "affectedMultiple": "Zostanie wywołanych {{count}} wykonań.",
+    "affected_one": "Zostanie wywołane 1 wykonanie.",
+    "affected_other": "Zostanie wywołanych {{count}} wykonań.",
     "affectedNone": "Brak wykonań spełniających wybrane kryteria.",
-    "affectedOne": "Zostanie wywołane 1 wykonanie.",
     "backwards": "Uruchom wstecz",
     "dateRange": "Zakres dat",
     "dateRangeFrom": "Od",


### PR DESCRIPTION
For backfill with more than 1 run "totalEntries > 1" becomes true and "1 run will be triggered" message is shown which is incorrect. This fixes the logic to show the message when there is 1 run and for more than 1 run the plural message will be shown