### PR TITLE
fix: make query_ids in SnowflakeSqlApiOperator in deferrable mode consistent

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -137,6 +137,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             When executing the statement, Snowflake replaces placeholders (? and :name) in
             the statement with these specified values.
         """
+        self.query_ids = []
         conn_config = self._get_conn_params
 
         req_id = uuid.uuid4()

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import time
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import timedelta
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, SupportsAbs, cast
 
 from airflow.configuration import conf
@@ -390,6 +391,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
         self.bindings = bindings
         self.execute_async = False
         self.deferrable = deferrable
+        self.query_ids: list[str] = []
         if any([warehouse, database, role, schema, authenticator, session_parameters]):  # pragma: no cover
             hook_params = kwargs.pop("hook_params", {})  # pragma: no cover
             kwargs["hook_params"] = {
@@ -403,6 +405,16 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
             }
         super().__init__(conn_id=snowflake_conn_id, **kwargs)  # pragma: no cover
 
+    @cached_property
+    def _hook(self):
+        return SnowflakeSqlApiHook(
+            snowflake_conn_id=self.snowflake_conn_id,
+            token_life_time=self.token_life_time,
+            token_renewal_delta=self.token_renewal_delta,
+            deferrable=self.deferrable,
+            **self.hook_params,
+        )
+
     def execute(self, context: Context) -> None:
         """
         Make a POST API request to snowflake by using SnowflakeSQL and execute the query to get the ids.
@@ -410,13 +422,6 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
         By deferring the SnowflakeSqlApiTrigger class passed along with query ids.
         """
         self.log.info("Executing: %s", self.sql)
-        self._hook = SnowflakeSqlApiHook(
-            snowflake_conn_id=self.snowflake_conn_id,
-            token_life_time=self.token_life_time,
-            token_renewal_delta=self.token_renewal_delta,
-            deferrable=self.deferrable,
-            **self.hook_params,
-        )
         self.query_ids = self._hook.execute_query(
             self.sql,  # type: ignore[arg-type]
             statement_count=self.statement_count,
@@ -504,9 +509,11 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
                 msg = f"{event['status']}: {event['message']}"
                 raise AirflowException(msg)
             if "status" in event and event["status"] == "success":
-                hook = SnowflakeSqlApiHook(snowflake_conn_id=self.snowflake_conn_id)
-                query_ids = cast("list[str]", event["statement_query_ids"])
-                hook.check_query_output(query_ids)
+                self.query_ids = cast("list[str]", event["statement_query_ids"])
+                self._hook.check_query_output(self.query_ids)
                 self.log.info("%s completed successfully.", self.task_id)
+                # Re-assign query_ids to hook after coming back from deferral to be consistent for listeners.
+                if not self._hook.query_ids:
+                    self._hook.query_ids = self.query_ids
         else:
             self.log.info("%s completed successfully.", self.task_id)

--- a/providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py
@@ -74,7 +74,6 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
             self.token_renewal_delta,
         )
         try:
-            statement_query_ids: list[str] = []
             for query_id in self.query_ids:
                 while True:
                     statement_status = await self.get_query_status(query_id)
@@ -84,12 +83,10 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
                 if statement_status["status"] == "error":
                     yield TriggerEvent(statement_status)
                     return
-                if statement_status["status"] == "success":
-                    statement_query_ids.extend(statement_status["statement_handles"])
             yield TriggerEvent(
                 {
                     "status": "success",
-                    "statement_query_ids": statement_query_ids,
+                    "statement_query_ids": self.query_ids,
                 }
             )
         except Exception as e:

--- a/providers/snowflake/tests/unit/snowflake/triggers/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/triggers/test_snowflake.py
@@ -30,12 +30,13 @@ POLL_INTERVAL = 1.0
 LIFETIME = timedelta(minutes=59)
 RENEWAL_DELTA = timedelta(minutes=54)
 MODULE = "airflow.providers.snowflake"
+QUERY_IDS = ["uuid"]
 
 
 class TestSnowflakeSqlApiTrigger:
     TRIGGER = SnowflakeSqlApiTrigger(
         poll_interval=POLL_INTERVAL,
-        query_ids=["uuid"],
+        query_ids=QUERY_IDS,
         snowflake_conn_id="test_conn",
         token_life_time=LIFETIME,
         token_renewal_delta=RENEWAL_DELTA,
@@ -82,8 +83,8 @@ class TestSnowflakeSqlApiTrigger:
         Test SnowflakeSqlApiTrigger run method with success status and mock the get_sql_api_query_status
          result and  get_query_status to False.
         """
-        mock_get_query_status.return_value = {"status": "success", "statement_handles": ["uuid", "uuid1"]}
         statement_query_ids = ["uuid", "uuid1"]
+        mock_get_query_status.return_value = {"status": "success", "statement_handles": statement_query_ids}
         mock_get_sql_api_query_status_async.return_value = {
             "message": "Statement executed successfully.",
             "status": "success",
@@ -92,7 +93,7 @@ class TestSnowflakeSqlApiTrigger:
 
         generator = self.TRIGGER.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "success", "statement_query_ids": statement_query_ids}) == actual
+        assert TriggerEvent({"status": "success", "statement_query_ids": QUERY_IDS}) == actual
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_sql_api_query_status_async")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Few fixes included in this PR:
1. `SnowflakeSqlApiHook.execute_query` will now consistently reset query_ids each time it's called, exactly like `SnowflakeHook.run` does. Currently the behavior depended on number of queries executed, which could cause getting query_ids from previous execution as an attribute - sometimes it was overwritten, sometimes not.
2. `SnowflakeSqlApiTrigger` will now return the query_ids of query actually executed, instead of child query_ids of multi-statement queries, which is consistent with non-deferrable behavior that we have right now. This change makes the behavior consistent regardless of execution mode.
3. I've added re-assignment of query_ids after coming back from deferral in `SnowflakeSqlApiOperator`, so that the listeners can use that information and have consistent behavior regardless of execution mode.
4. I've added an explicit caching of `SnowflakeSqlApiHook` in `SnowflakeSqlApiOperator`, right now the property of super class `SQLExecuteQueryOperator` was overwritten during execution, which could lead to inconsistencies, depending on when you ask for `SnowflakeSqlApiOperator._hook`.
5. Added missing `self.query_ids` definition in init of `SnowflakeSqlApiOperator`

Added tests for all changes.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
