### PR TITLE
Add Cloud Run job link

### DIFF
--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -1140,7 +1140,7 @@ extra-links:
   - airflow.providers.google.cloud.links.bigquery.BigQueryTableLink
   - airflow.providers.google.cloud.links.bigquery.BigQueryJobDetailLink
   - airflow.providers.google.cloud.links.bigquery_dts.BigQueryDataTransferConfigLink
-  - airflow.providers.google.cloud.links.cloud_run.CloudRunJobDetailLink
+  - airflow.providers.google.cloud.links.cloud_run.CloudRunJobExecutionLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceDetailsLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceTemplateDetailsLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceGroupManagerDetailsLink

--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -1140,6 +1140,7 @@ extra-links:
   - airflow.providers.google.cloud.links.bigquery.BigQueryTableLink
   - airflow.providers.google.cloud.links.bigquery.BigQueryJobDetailLink
   - airflow.providers.google.cloud.links.bigquery_dts.BigQueryDataTransferConfigLink
+  - airflow.providers.google.cloud.links.cloud_run.CloudRunJobDetailLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceDetailsLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceTemplateDetailsLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceGroupManagerDetailsLink

--- a/providers/google/src/airflow/providers/google/cloud/links/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/links/cloud_run.py
@@ -34,18 +34,18 @@ else:
     from airflow.models.xcom import XCom  # type: ignore[no-redef]
 
 CLOUD_RUN_BASE_LINK = "/run"
-CLOUD_RUN_JOB_DETAIL_LINK = (
-    CLOUD_RUN_BASE_LINK + "/jobs/details/{region}/{job_name}"
-    "?inv=1&project={project_id}"
+CLOUD_RUN_JOB_EXECUTION_LINK = (
+    CLOUD_RUN_BASE_LINK + "/jobs/execution/{region}/{execution_name}"
+    "?project={project_id}"
 )
 
 
-class CloudRunJobDetailLink(BaseGoogleLink):
-    """Helper class for constructing Cloud Run Job Detail Link."""
+class CloudRunJobExecutionLink(BaseGoogleLink):
+    """Helper class for constructing Cloud Run Job Execution Link."""
 
-    name = "Cloud Run Job Detail"
-    key = "cloud_run_job_detail"
-    format_str = CLOUD_RUN_JOB_DETAIL_LINK
+    name = "Cloud Run Job Execution"
+    key = "cloud_run_job_execution"
+    format_str = CLOUD_RUN_JOB_EXECUTION_LINK
 
     @staticmethod
     def persist(
@@ -53,28 +53,16 @@ class CloudRunJobDetailLink(BaseGoogleLink):
         task_instance: BaseOperator,
         project_id: str,
         region: str,
-        job_name: str,
+        execution_name: str,
     ):
         task_instance.xcom_push(
             context,
-            key=CloudRunJobDetailLink.key,
+            key=CloudRunJobExecutionLink.key,
             value={
                 "project_id": project_id,
                 "region": region,
-                "job_name": job_name,
+                "execution_name": execution_name,
             },
-        )
-        # Push the complete URL for the link
-        from airflow.providers.google.cloud.links.base import BASE_LINK
-        full_url = BASE_LINK + CloudRunJobDetailLink.format_str.format(
-            project_id=project_id,
-            region=region,
-            job_name=job_name,
-        )
-        task_instance.xcom_push(
-            context,
-            key=f"_link_{CloudRunJobDetailLink.__name__}",
-            value=full_url,
         )
 
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
@@ -27,7 +27,7 @@ from google.cloud.run_v2 import Job, Service
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_run import CloudRunHook, CloudRunServiceHook
-from airflow.providers.google.cloud.links.cloud_run import CloudRunJobDetailLink, CloudRunJobLoggingLink
+from airflow.providers.google.cloud.links.cloud_run import CloudRunJobExecutionLink, CloudRunJobLoggingLink
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
 from airflow.providers.google.cloud.triggers.cloud_run import CloudRunJobFinishedTrigger, RunJobStatus
 
@@ -266,7 +266,7 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
     :param deferrable: Run the operator in deferrable mode.
     """
 
-    operator_extra_links = (CloudRunJobDetailLink(), CloudRunJobLoggingLink())
+    operator_extra_links = (CloudRunJobExecutionLink(), CloudRunJobLoggingLink())
     template_fields = (
         "project_id",
         "region",
@@ -307,16 +307,7 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
         hook: CloudRunHook = CloudRunHook(
             gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
         )
-        
-        # Persist Cloud Run Job Detail Link for UI immediately
-        CloudRunJobDetailLink.persist(
-            context=context,
-            task_instance=self,
-            project_id=self.project_id,
-            region=self.region,
-            job_name=self.job_name,
-        )
-        
+
         self.operation = hook.execute_job(
             region=self.region, project_id=self.project_id, job_name=self.job_name, overrides=self.overrides
         )
@@ -329,6 +320,15 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
                 context=context,
                 task_instance=self,
                 log_uri=self.operation.metadata.log_uri,
+            )
+
+        if self.operation.metadata.name:
+            CloudRunJobExecutionLink.persist(
+                context=context,
+                task_instance=self,
+                project_id=self.project_id,
+                region=self.region,
+                execution_name=self.operation.metadata.name.split("/")[-1],
             )
 
         if not self.deferrable:


### PR DESCRIPTION
This PR introduces a new helper class for constructing Cloud Run Job Execution Links and integrates it into the existing Cloud Run operators in the Google Cloud provider for Airflow. The most important changes
  include the addition of the CloudRunJobExecutionLink class, its integration into the CloudRunExecuteJobOperator, and the necessary imports and configurations.

  New feature addition:
  - Added CLOUD_RUN_JOB_EXECUTION_LINK constant to construct URLs for Cloud Run Job Execution Links in airflow/providers/google/cloud/links/cloud_run.py
  - Created CloudRunJobExecutionLink class to handle the construction and persistence of Cloud Run Job Execution Links in airflow/providers/google/cloud/links/cloud_run.py

  Integration into existing operators:
  - Imported CloudRunJobExecutionLink in airflow/providers/google/cloud/operators/cloud_run.py to make it available for use in Cloud Run operators
  - Updated operator_extra_links in CloudRunExecuteJobOperator to include CloudRunJobExecutionLink in airflow/providers/google/cloud/operators/cloud_run.py
  - Added logic to persist Cloud Run Job Execution Links in the execute method of CloudRunExecuteJobOperator in airflow/providers/google/cloud/operators/cloud_run.py


  Configuration update:
  - Added CloudRunJobExecutionLink to the extra-links section in airflow/providers/google/provider.yaml to ensure it is recognized as an extra link

  Screenshot:
  The new "Cloud Run Job Execution" link appears in the Extra Links section of the task details page, alongside the existing "Cloud Run Job Logging" link.

<img width="500" alt="スクリーンショット 2025-06-10 18 17 20" src="https://github.com/user-attachments/assets/3ac4374f-9be8-4930-909b-976e0931ed52" />
