### PR TITLE
nit: snowflake api was missing from OL supported classes

### DIFF
--- a/devel-common/src/sphinx_exts/providers_extensions.py
+++ b/devel-common/src/sphinx_exts/providers_extensions.py
@@ -318,7 +318,7 @@ def _render_openlineage_supported_classes_content():
                 db_type = (  # Extract db type from hook name
                     class_name.replace("RedshiftSQL", "Redshift")  # for RedshiftSQLHook
                     .replace("DatabricksSql", "Databricks")  # for DatabricksSqlHook
-                    .replace("SnowflakeSqlApi", "Snowflake")  # for SnowflakeSqlApiHook
+                    .replace("SnowflakeSqlApi", "SnowflakeApi")  # for SnowflakeSqlApiHook
                     .replace("Hook", "")  # for others like MySqlHook, TrinoHook etc.
                 )
                 db_hooks.append((db_type, class_path))
@@ -348,7 +348,7 @@ def _render_openlineage_supported_classes_content():
         # Below filters out providers with empty 'operators' and 'hooks'
         if details["hooks"] or details["operators"]
     }
-    db_hooks = sorted({db_type: hook for db_type, hook in db_hooks}.items(), key=lambda x: x[0])
+    db_hooks = sorted({hook: db_type for db_type, hook in db_hooks}.items(), key=lambda x: x[1])
 
     return _render_template(
         "openlineage.rst.jinja2",

--- a/devel-common/src/sphinx_exts/templates/openlineage.rst.jinja2
+++ b/devel-common/src/sphinx_exts/templates/openlineage.rst.jinja2
@@ -67,18 +67,20 @@ apache-airflow-providers-google
 
 These operators are using SQL parsing and may query DB for lineage extraction.
 To extract unique data from each database type, a dedicated Hook implementing OpenLineage methods is required.
+Not all subclasses of :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`
+are automatically supported, only those also using a supported Hook.
 
 .. note::
-  Not all subclasses of :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator` are automatically
-  supported, only those also using a supported Hook (e.g., one of supported operators is
-  :class:`~airflow.providers.databricks.operators.databricks_sql.DatabricksSqlOperator`).
   Due to the automatic generation of this documentation, some supported operators inheriting from
   :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator` may not appear in the ``Providers``
-  section below - to prevent false positives. Please check your operator's code to confirm OpenLineage support.
+  section below - to prevent false positives. Examples of such Operators are:
+  :class:`~airflow.providers.databricks.operators.databricks_sql.DatabricksSqlOperator` and
+  :class:`~airflow.providers.snowflake.operators.snowflake.SnowflakeSqlApiOperator`.
+  Please check your operator's code to confirm OpenLineage support.
 
 Currently, the following databases (hooks) are supported:
 
-{% for db_type, hook in db_hooks %}
+{% for hook, db_type in db_hooks %}
 - {{ db_type }} (via :class:`~{{ hook }}`)
 {% endfor %}
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
SnowflakeSqlApiHook was missing from OL docs, due to wrong deduplication logic. Some small additional nit to docs.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
