### PR TITLE
Optionally retry db connection errors related to temporary DNS failures

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -685,7 +685,7 @@ database:
         If enabled, the dns lookup to the db hostname will be checked with retries.
         Accepts ``True`` or ``False``.
       version_added: 3.1.0
-      type: string
+      type: boolean
       example: ~
       default: "False"
     max_db_discovery_retries:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -679,6 +679,39 @@ database:
       type: integer
       example: ~
       default: "10000"
+    check_db_discovery:
+      description: |
+        Whether to check the db discovery before creating a new session.
+        If enabled, the dns lookup to the db hostname will be checked with retries.
+        Accepts ``True`` or ``False``.
+      version_added: 3.1.0
+      type: string
+      example: ~
+      default: "False"
+    max_db_discov_retries:
+      description: |
+        Number of times the db discovery check should be retried in case of errors.
+      version_added: 3.1.0
+      type: integer
+      example: ~
+      default: "3"
+    db_discov_initial_wait_time:
+      description: |
+        The number of seconds for the initial sleep between db discovery check retries.
+      version_added: 3.1.0
+      type: float
+      example: ~
+      default: "0.5"
+    db_discov_max_wait_time:
+      description: |
+        The sleep between db discovery check retries increases exponentially.
+        Set the maximum number of seconds that the sleep can be.
+        Once this number is reached, the interval won't grow any more.
+        The value should preferably be short.
+      version_added: 3.1.0
+      type: float
+      example: ~
+      default: "5"
 logging:
   description: ~
   options:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -688,21 +688,21 @@ database:
       type: string
       example: ~
       default: "False"
-    max_db_discov_retries:
+    max_db_discovery_retries:
       description: |
         Number of times the db discovery check should be retried in case of errors.
       version_added: 3.1.0
       type: integer
       example: ~
       default: "3"
-    db_discov_initial_wait_time:
+    db_discovery_initial_wait_time:
       description: |
         The number of seconds for the initial sleep between db discovery check retries.
       version_added: 3.1.0
       type: float
       example: ~
       default: "0.5"
-    db_discov_max_wait_time:
+    db_discovery_max_wait_time:
       description: |
         The sleep between db discovery check retries increases exponentially.
         Set the maximum number of seconds that the sleep can be.

--- a/airflow-core/src/airflow/utils/db_discovery.py
+++ b/airflow-core/src/airflow/utils/db_discovery.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+import socket
+import time
+
+from sqlalchemy.engine.url import make_url
+
+from airflow.configuration import conf
+
+logger = logging.getLogger(__name__)
+
+
+class DbDiscoveryStatus:
+    """Enum with the return value for `check_db_discovery_if_needed()`."""
+
+    # The hostname resolves.
+    OK = "ok"
+    # There has been some temporary DNS lookup blip and the connection will probably recover.
+    # Causes: a dns timeout or a temporary network issue.
+    TEMPORARY_ERROR = "dns_temporary_failure"
+    # Unknown hostname or service, this is permanent and the connection can't be recovered.
+    # Causes: a cmd or config typo, a hostname that doesn't exist.
+    UNKNOWN_HOSTNAME = "unknown_hostname"
+    # Unknown hostname or service, this is permanent and the connection can't be recovered.
+    # Causes: Failed DNS server or config typo.
+    PERMANENT_ERROR = "dns_permanent_failure"
+    # Some other error.
+    UNKNOWN_ERROR = "unknown_error"
+
+
+# db status - how long ago it was retrieved
+db_health_status: tuple[str, float] = (DbDiscoveryStatus.OK, 0.0)
+
+# TODO: For now, this is used for testing
+#  but it can also be used to add stats.
+db_retry_count: int = 0
+
+
+def get_sleep_time(retry_attempt: int, initial_wait: float, max_wait: float) -> float:
+    return min(initial_wait * (2**retry_attempt), max_wait)
+
+
+def _retry_exponential_backoff(retry_attempt: int, initial_wait: float, max_wait: float) -> None:
+    sleep_time = get_sleep_time(retry_attempt, initial_wait, max_wait)
+    unit_str = "second" if sleep_time == float(1) else "seconds"
+    logger.info("Sleeping for %.2f %s.", sleep_time, unit_str)
+    time.sleep(sleep_time)
+
+
+def _check_dns_resolution_with_retries(
+    host: str,
+    retries: int,
+    initial_retry_wait: float,
+    max_retry_wait: float,
+) -> tuple[str, BaseException | None]:
+    global db_retry_count
+    # Initialize to 0 in case it has another value from previous attempts.
+    db_retry_count = 0
+
+    for attempt in range(1, retries + 1):
+        try:
+            socket.getaddrinfo(host, None)
+        except socket.gaierror as err:
+            # This error is temporary, all others are permanent.
+            if err.errno == socket.EAI_AGAIN:
+                db_retry_count += 1
+                logger.warning("Temporary DNS failure for host '%s' (attempt %d/%d)", host, attempt, retries)
+                if db_retry_count >= retries:
+                    return DbDiscoveryStatus.TEMPORARY_ERROR, err
+                # Sleep.
+                _retry_exponential_backoff(
+                    retry_attempt=attempt, initial_wait=initial_retry_wait, max_wait=max_retry_wait
+                )
+                continue
+            if err.errno == socket.EAI_NONAME:
+                return DbDiscoveryStatus.UNKNOWN_HOSTNAME, err
+            if err.errno == socket.EAI_FAIL:
+                return DbDiscoveryStatus.PERMANENT_ERROR, err
+            return DbDiscoveryStatus.UNKNOWN_ERROR, err
+
+    return DbDiscoveryStatus.OK, None
+
+
+def check_db_discovery_with_retries(retry_num: int, initial_retry_wait: float, max_retry_wait: float):
+    global db_health_status
+
+    # DNS check.
+    url = make_url(conf.get("database", "sql_alchemy_conn"))
+    host = url.host
+    dns_status, dns_exc = _check_dns_resolution_with_retries(
+        host, retry_num, initial_retry_wait, max_retry_wait
+    )
+
+    if dns_status != DbDiscoveryStatus.OK and dns_exc:
+        logger.error("Database hostname '%s' failed DNS resolution: %s", host, dns_status)
+        db_health_status = (dns_status, time.time())
+        raise dns_exc
+
+    db_health_status = (dns_status, time.time())

--- a/airflow-core/src/airflow/utils/session.py
+++ b/airflow-core/src/airflow/utils/session.py
@@ -42,16 +42,16 @@ def create_session(scoped: bool = True) -> Generator[SASession, None, None]:
         raise RuntimeError("Session must be set before!")
 
     check_db_discovery = conf.getboolean("database", "check_db_discovery")
-    db_discov_retries = conf.getint("database", "max_db_discov_retries")
-    db_discov_initial_wait = conf.getfloat("database", "db_discov_initial_wait_time")
-    db_discov_max_wait = conf.getfloat("database", "db_discov_max_wait_time")
+    db_discovery_retries = conf.getint("database", "max_db_discovery_retries")
+    db_discovery_initial_wait = conf.getfloat("database", "db_discovery_initial_wait_time")
+    db_discovery_max_wait = conf.getfloat("database", "db_discovery_max_wait_time")
     # If there is an exception, it will be raised
     # in order to prevent the session from unnecessarily being created.
     if check_db_discovery:
         check_db_discovery_with_retries(
-            retry_num=db_discov_retries,
-            initial_retry_wait=db_discov_initial_wait,
-            max_retry_wait=db_discov_max_wait,
+            retry_num=db_discovery_retries,
+            initial_retry_wait=db_discovery_initial_wait,
+            max_retry_wait=db_discovery_max_wait,
         )
 
     session = Session()

--- a/airflow-core/src/airflow/utils/session.py
+++ b/airflow-core/src/airflow/utils/session.py
@@ -41,17 +41,13 @@ def create_session(scoped: bool = True) -> Generator[SASession, None, None]:
     if Session is None:
         raise RuntimeError("Session must be set before!")
 
-    check_db_discovery = conf.getboolean("database", "check_db_discovery")
-    db_discovery_retries = conf.getint("database", "max_db_discovery_retries")
-    db_discovery_initial_wait = conf.getfloat("database", "db_discovery_initial_wait_time")
-    db_discovery_max_wait = conf.getfloat("database", "db_discovery_max_wait_time")
     # If there is an exception, it will be raised
     # in order to prevent the session from unnecessarily being created.
-    if check_db_discovery:
+    if conf.getboolean("database", "check_db_discovery"):
         check_db_discovery_with_retries(
-            retry_num=db_discovery_retries,
-            initial_retry_wait=db_discovery_initial_wait,
-            max_retry_wait=db_discovery_max_wait,
+            retry_num=conf.getint("database", "max_db_discovery_retries"),
+            initial_retry_wait=conf.getfloat("database", "db_discovery_initial_wait_time"),
+            max_retry_wait=conf.getfloat("database", "db_discovery_max_wait_time"),
         )
 
     session = Session()

--- a/airflow-core/tests/unit/core/test_db_discovery.py
+++ b/airflow-core/tests/unit/core/test_db_discovery.py
@@ -1,0 +1,164 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import shutil
+import socket
+import time
+
+import pytest
+from sqlalchemy import text
+
+from airflow import settings
+from airflow.utils import db_discovery
+from airflow.utils.db_discovery import DbDiscoveryStatus
+
+log = logging.getLogger(__name__)
+
+
+def dispose_connection_pool():
+    """Dispose any cached sockets so that the next query will force a new connect."""
+    settings.engine.dispose()
+    # Wait for SqlAlchemy.
+    time.sleep(0.5)
+
+
+def make_db_test_call():
+    """
+    Create a session and execute a query.
+
+    It will establish a new connection if there isn't one available.
+    New connections use DNS lookup.
+    """
+    from airflow.utils.session import create_session
+
+    with create_session() as session:
+        session.execute(text("SELECT 1"))
+
+
+def assert_query_raises_exc(expected_error_msg: str, expected_status: str, expected_retry_num: int):
+    with pytest.raises(socket.gaierror, match=expected_error_msg):
+        make_db_test_call()
+
+    assert len(db_discovery.db_health_status) == 2
+
+    assert db_discovery.db_health_status[0] == expected_status
+    assert db_discovery.db_retry_count == expected_retry_num
+
+
+@pytest.mark.backend("postgres")
+class TestDbDiscoveryIntegration:
+    @pytest.fixture
+    def patch_getaddrinfo_for_eai_fail(self, monkeypatch):
+        import socket
+
+        def always_fail(*args, **kwargs):
+            # The error message isn't important, as long as the error code is EAI_FAIL.
+            raise socket.gaierror(socket.EAI_FAIL, "permanent failure")
+
+        monkeypatch.setattr(socket, "getaddrinfo", always_fail)
+
+    def test_dns_resolution_blip(self):
+        os.environ["AIRFLOW__DATABASE__CHECK_DB_DISCOVERY"] = "True"
+
+        resolv_file = "/etc/resolv.conf"
+        resolv_backup = "/tmp/resolv.conf.bak"
+
+        # Back up the original file so that it can later be restored.
+        shutil.copy(resolv_file, resolv_backup)
+
+        try:
+            # Replace the IP with a bad resolver.
+            with open(resolv_file, "w", encoding="utf-8") as fh:
+                fh.write("nameserver 10.255.255.1\noptions timeout:1 attempts:1 ndots:0\n")
+
+            # New connection + DNS lookup.
+            dispose_connection_pool()
+            assert_query_raises_exc(
+                expected_error_msg="Temporary failure in name resolution",
+                expected_status=DbDiscoveryStatus.TEMPORARY_ERROR,
+                expected_retry_num=3,
+            )
+
+        finally:
+            # Reset the values for the next tests.
+            db_discovery.db_health_status = (DbDiscoveryStatus.OK, 0.0)
+            db_discovery.db_retry_count = 0
+
+            # Restore the original file.
+            with contextlib.suppress(Exception):
+                shutil.copy(resolv_backup, resolv_file)
+
+    def test_permanent_dns_failure(self, patch_getaddrinfo_for_eai_fail):
+        os.environ["AIRFLOW__DATABASE__CHECK_DB_DISCOVERY"] = "True"
+
+        try:
+            # New connection + DNS lookup.
+            dispose_connection_pool()
+            assert_query_raises_exc(
+                expected_error_msg="permanent failure",
+                expected_status=DbDiscoveryStatus.PERMANENT_ERROR,
+                expected_retry_num=0,
+            )
+
+        finally:
+            # Reset the values for the next tests.
+            db_discovery.db_health_status = (DbDiscoveryStatus.OK, 0.0)
+            db_discovery.db_retry_count = 0
+
+    def test_invalid_hostname_in_config(self):
+        os.environ["AIRFLOW__DATABASE__CHECK_DB_DISCOVERY"] = "True"
+        os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = (
+            "postgresql+psycopg2://postgres:airflow@invalid/airflow"
+        )
+
+        try:
+            # New connection + DNS lookup.
+            dispose_connection_pool()
+            assert_query_raises_exc(
+                expected_error_msg="Name or service not known",
+                expected_status=DbDiscoveryStatus.UNKNOWN_HOSTNAME,
+                expected_retry_num=0,
+            )
+        finally:
+            os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow"
+            )
+
+            # Reset the values for the next tests.
+            db_discovery.db_health_status = (DbDiscoveryStatus.OK, 0.0)
+            db_discovery.db_retry_count = 0
+
+    @pytest.mark.parametrize(
+        "check_enabled",
+        [
+            pytest.param(True, id="check-enabled"),
+            pytest.param(False, id="check-disabled"),
+        ],
+    )
+    def test_no_errors(self, check_enabled: bool):
+        os.environ["AIRFLOW__DATABASE__CHECK_DB_DISCOVERY"] = str(check_enabled)
+
+        dispose_connection_pool()
+        make_db_test_call()
+
+        # No status checks and no retries.
+        assert db_discovery.db_health_status[0] == DbDiscoveryStatus.OK
+        assert db_discovery.db_retry_count == 0

--- a/airflow-core/tests/unit/utils/test_db_discovery_status.py
+++ b/airflow-core/tests/unit/utils/test_db_discovery_status.py
@@ -27,22 +27,6 @@ from airflow.utils.db_discovery import DbDiscoveryStatus
 
 class TestDbDiscoveryStatus:
     @pytest.mark.parametrize(
-        "retry, expected_sleep_time",
-        [
-            pytest.param(0, 0.5, id="attempt-1"),
-            pytest.param(1, 1, id="attempt-2"),
-            pytest.param(2, 2, id="attempt-3"),
-            pytest.param(3, 4, id="attempt-4"),
-            pytest.param(4, 8, id="attempt-5"),
-            pytest.param(5, 15, id="attempt-6"),
-            pytest.param(6, 15, id="attempt-7"),
-        ],
-    )
-    def test_get_sleep_time(self, retry: int, expected_sleep_time: float):
-        sleep = db_discovery.get_sleep_time(retry, 0.5, 15)
-        assert sleep == expected_sleep_time
-
-    @pytest.mark.parametrize(
         "error_code, expected_status",
         [
             (socket.EAI_FAIL, DbDiscoveryStatus.PERMANENT_ERROR),

--- a/airflow-core/tests/unit/utils/test_db_discovery_status.py
+++ b/airflow-core/tests/unit/utils/test_db_discovery_status.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from airflow.utils import db_discovery
+from airflow.utils.db_discovery import DbDiscoveryStatus
+
+
+class TestDbDiscoveryStatus:
+    @pytest.mark.parametrize(
+        "retry, expected_sleep_time",
+        [
+            pytest.param(0, 0.5, id="attempt-1"),
+            pytest.param(1, 1, id="attempt-2"),
+            pytest.param(2, 2, id="attempt-3"),
+            pytest.param(3, 4, id="attempt-4"),
+            pytest.param(4, 8, id="attempt-5"),
+            pytest.param(5, 15, id="attempt-6"),
+            pytest.param(6, 15, id="attempt-7"),
+        ],
+    )
+    def test_get_sleep_time(self, retry: int, expected_sleep_time: float):
+        sleep = db_discovery.get_sleep_time(retry, 0.5, 15)
+        assert sleep == expected_sleep_time
+
+    @pytest.mark.parametrize(
+        "error_code, expected_status",
+        [
+            (socket.EAI_FAIL, DbDiscoveryStatus.PERMANENT_ERROR),
+            (socket.EAI_AGAIN, DbDiscoveryStatus.TEMPORARY_ERROR),
+            (socket.EAI_NONAME, DbDiscoveryStatus.UNKNOWN_HOSTNAME),
+            (socket.EAI_SYSTEM, DbDiscoveryStatus.UNKNOWN_ERROR),
+        ],
+    )
+    def test_check_dns_resolution_with_retries(self, monkeypatch, error_code, expected_status):
+        def raise_exc(*args, **kwargs):
+            # The error message isn't important because the validation is based on the error code.
+            raise socket.gaierror(error_code, "patched failure")
+
+        monkeypatch.setattr(socket, "getaddrinfo", raise_exc)
+
+        status, err = db_discovery._check_dns_resolution_with_retries("some_host", 3, 0.5, 5)
+
+        assert status == expected_status
+        assert isinstance(err, socket.gaierror)
+        assert err.errno == error_code
+
+        # If the failure is temporary, then there must be retries.
+        if error_code == socket.EAI_AGAIN:
+            assert db_discovery.db_retry_count > 1
+        else:
+            assert db_discovery.db_retry_count == 0


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We are using Airflow with Kubernetes and we are occasionally experiencing failures due to DNS resolution blips. These failures are temporary and usually take mere seconds to go away.

The failure is occurring while a new db connection is required and Airflow performs a DNS lookup on the db hostname.

This can be resolved by retrying to establish the DB connection but there are better approaches.

This patch is adding a config flag that enables a db discovery check right before creating a new session object. If the option is turned on, we run a `socket.getaddrinfo(...)` on the db hostname to see if it can be looked up. If the failure is a temporary DNS error, then the check is retried a few times, so that it can give it enough time to resolve.

This approach is chosen for the following reasons
* `socket.getaddrinfo(...)` is less expensive and much faster than retrying to create a new session
* not all kinds of DNS errors are temporary and must be retried.
  * e.g. a wrong value on the database config option `sql_alchemy_conn` is also a DNS error but it shouldn't be retried 
  * in case of an exception, the error that we get from `socket.getaddrinfo(...)` carries an error code which can be used for  distinguishing between the different DNS errors
  * `create_session()` will give us an exception with the same error message but no other info
  * the error code is more reliable than the error message which might be prone to changes during a new version update of the component that is generating it

I've added a unit test and an integration test. The integration test hasn't been added under the `integration` package because it doesn't need any integration other than a db backend. The code is db agnostic but for the test I used specifically a postgres backend because it's easier to just hardcode a postgres address.

The check is turned off by default.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
