### PR TITLE
UI: Ensure "select all" checkbox don't appear in column filter

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/FilterMenuButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/FilterMenuButton.tsx
@@ -40,28 +40,31 @@ const FilterMenuButton = <TData,>({ table }: Props<TData>) => {
         </IconButton>
       </Menu.Trigger>
       <Menu.Content>
-        {table.getAllLeafColumns().map((column) => {
-          const text = flexRender(column.columnDef.header, {
-            column,
-            header: { column } as Header<TData, unknown>,
-            table,
-          });
+        {table
+          .getAllLeafColumns()
+          .filter((column) => column.getCanHide())
+          .map((column) => {
+            const text = flexRender(column.columnDef.header, {
+              column,
+              header: { column } as Header<TData, unknown>,
+              table,
+            });
 
-          return text?.toString ? (
-            <Menu.Item asChild key={column.id} value={column.id}>
-              <Checkbox
-                checked={column.getIsVisible()}
-                // At least one item needs to be visible
-                disabled={table.getVisibleFlatColumns().length < 2 && column.getIsVisible()}
-                onChange={() => {
-                  column.toggleVisibility();
-                }}
-              >
-                {text}
-              </Checkbox>
-            </Menu.Item>
-          ) : undefined;
-        })}
+            return text?.toString ? (
+              <Menu.Item asChild key={column.id} value={column.id}>
+                <Checkbox
+                  checked={column.getIsVisible()}
+                  // At least one item needs to be visible
+                  disabled={table.getVisibleFlatColumns().length < 2 && column.getIsVisible()}
+                  onChange={() => {
+                    column.toggleVisibility();
+                  }}
+                >
+                  {text}
+                </Checkbox>
+              </Menu.Item>
+            ) : undefined;
+          })}
       </Menu.Content>
     </Menu.Root>
   );

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -68,6 +68,7 @@ const getColumns = ({
         onCheckedChange={(event) => onRowSelect(row.original.connection_id, Boolean(event.checked))}
       />
     ),
+    enableHiding: false,
     enableSorting: false,
     header: () => (
       <Checkbox

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -58,6 +58,7 @@ const getColumns = ({
         onCheckedChange={(event) => onRowSelect(row.original.key, Boolean(event.checked))}
       />
     ),
+    enableHiding: false,
     enableSorting: false,
     header: () => (
       <Checkbox


### PR DESCRIPTION
### Why

Currently, in tables that support bulk actions(`variables`, `connections`), the "select all" checkbox in the table header is also treated as a value in the column's filter. This is not the intended behavior and can be confusing for users trying to filter the data.

### Before
![before](https://github.com/user-attachments/assets/5515cf26-2a2a-4132-a6e5-0fc5fe7574ab)

### After
![after](https://github.com/user-attachments/assets/6e866d8a-f8a1-49e6-be3e-177283b6951a)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
