### PR TITLE
Use Connection Hook Names for Dropdown instead of connection IDs

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -49,6 +49,7 @@ const ConnectionForm = ({
   const [errors, setErrors] = useState<{ conf?: string }>({});
   const {
     formattedData: connectionTypeMeta,
+    hookNames: hookNameMap,
     isPending: isMetaPending,
     keysList: connectionTypes,
   } = useConnectionTypeMeta();
@@ -116,7 +117,7 @@ const ConnectionForm = ({
   };
 
   const connTypesOptions = connectionTypes.map((conn) => ({
-    label: conn,
+    label: hookNameMap[conn],
     value: conn,
   }));
 

--- a/airflow-core/src/airflow/ui/src/queries/useConnectionTypeMeta.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useConnectionTypeMeta.ts
@@ -58,6 +58,7 @@ export const useConnectionTypeMeta = () => {
   }
 
   const formattedData: Record<string, ConnectionMetaEntry> = {};
+  const hookNames: Record<string, string> = {};
   const keysList: Array<string> = [];
 
   const defaultStandardFields: StandardFieldSpec | undefined = {
@@ -91,6 +92,7 @@ export const useConnectionTypeMeta = () => {
   data?.forEach((item) => {
     const key = item.connection_type;
 
+    hookNames[key] = item.hook_name;
     keysList.push(key);
 
     const populatedStandardFields: StandardFieldSpec = mergeWithDefaults(
@@ -111,5 +113,5 @@ export const useConnectionTypeMeta = () => {
 
   keysList.sort((first, second) => first.localeCompare(second));
 
-  return { formattedData, isPending, keysList };
+  return { formattedData, hookNames, isPending, keysList };
 };

--- a/airflow-core/src/airflow/ui/src/queries/useConnectionTypeMeta.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useConnectionTypeMeta.ts
@@ -111,7 +111,7 @@ export const useConnectionTypeMeta = () => {
     };
   });
 
-  keysList.sort((first, second) => first.localeCompare(second));
+  keysList.sort((first, second) => (hookNames[first] ?? first).localeCompare(hookNames[second] ?? second));
 
   return { formattedData, hookNames, isPending, keysList };
 };


### PR DESCRIPTION
As of discussion in https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1749504803544369 I realized that we are populating the Hook IDs in the connection form dropdowns and not the hook names (which are better suited for display).

Before:
![image](https://github.com/user-attachments/assets/58012853-ba84-405e-9af3-2d85112b6e1b)

After:
![image](https://github.com/user-attachments/assets/1e6bbe27-06a2-4bca-bf82-cd0d40df6a9c)
(Note: Fixed sorting post-screenshot)