### PR TITLE
Move Dag, run and TI into common.json

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
@@ -50,7 +50,7 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
         <Accordion.Item key="tasks" value="tasks">
           <Accordion.ItemTrigger>
             <Text fontWeight="bold">
-              {translate("dags:runAndTaskActions.clear.dialog.affectedTasks.title", {
+              {translate("dags:runAndTaskActions.affectedTasks.title", {
                 count: affectedTasks.total_entries,
               })}
             </Text>
@@ -62,7 +62,7 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
                 data={affectedTasks.task_instances}
                 displayMode="table"
                 modelName={translate("common:taskInstance_other")}
-                noRowsMessage={translate("dags:runAndTaskActions.clear.dialog.affectedTasks.noItemsFound")}
+                noRowsMessage={translate("dags:runAndTaskActions.affectedTasks.noItemsFound")}
                 total={affectedTasks.total_entries}
               />
             </Box>
@@ -71,7 +71,7 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
       ) : undefined}
       <Accordion.Item key="note" value="note">
         <Accordion.ItemTrigger>
-          <Text fontWeight="bold">{translate("dags:runAndTaskActions.clear.dialog.note.title")}</Text>
+          <Text fontWeight="bold">{translate("note.label")}</Text>
         </Accordion.ItemTrigger>
         <Accordion.ItemContent>
           <Editable.Root
@@ -90,16 +90,14 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
               {Boolean(note) ? (
                 <ReactMarkdown>{note}</ReactMarkdown>
               ) : (
-                <Text color="fg.subtle">
-                  {translate("dags:runAndTaskActions.clear.dialog.note.placeholder")}
-                </Text>
+                <Text color="fg.subtle">{translate("note.addPlaceholder")}</Text>
               )}
             </Editable.Preview>
             <Editable.Textarea
               data-testid="notes-input"
               height="200px"
               overflowY="auto"
-              placeholder={translate("dags:runAndTaskActions.clear.dialog.note.placeholder")}
+              placeholder={translate("note.addPlaceholder")}
               resize="none"
             />
           </Editable.Root>

--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
@@ -90,14 +90,14 @@ const ActionAccordion = ({ affectedTasks, note, setNote }: Props) => {
               {Boolean(note) ? (
                 <ReactMarkdown>{note}</ReactMarkdown>
               ) : (
-                <Text color="fg.subtle">{translate("note.addPlaceholder")}</Text>
+                <Text color="fg.subtle">{translate("note.placeholder")}</Text>
               )}
             </Editable.Preview>
             <Editable.Textarea
               data-testid="notes-input"
               height="200px"
               overflowY="auto"
-              placeholder={translate("note.addPlaceholder")}
+              placeholder={translate("note.placeholder")}
               resize="none"
             />
           </Editable.Root>

--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
@@ -25,7 +25,7 @@ import { StateBadge } from "src/components/StateBadge";
 export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceResponse>> => [
   {
     accessorKey: "task_id",
-    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.taskId"),
+    header: translate("taskId"),
     size: 200,
   },
   {
@@ -35,14 +35,14 @@ export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceR
         original: { state },
       },
     }) => <StateBadge state={state}>{translate(`common:states.${state}`)}</StateBadge>,
-    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.state"),
+    header: translate("state"),
   },
   {
     accessorKey: "map_index",
-    header: translate("common:mapIndex"),
+    header: translate("mapIndex"),
   },
   {
     accessorKey: "run_id",
-    header: translate("dags:runAndTaskActions.clear.dialog.affectedTasks.columns.runId"),
+    header: translate("runId"),
   },
 ];

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -54,10 +54,10 @@ const ClearRunButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Pr
     >
       <Box>
         <ActionButton
-          actionName={translate("dags:runAndTaskActions.clear.button", { type: "Run" })}
+          actionName={translate("dags:runAndTaskActions.clear.title", { type: "Run" })}
           icon={<CgRedo />}
           onClick={onOpen}
-          text={translate("dags:runAndTaskActions.clear.button", { type: "Run" })}
+          text={translate("dags:runAndTaskActions.clear.title", { type: "Run" })}
           withText={withText}
         />
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -54,10 +54,10 @@ const ClearRunButton = ({ dagRun, isHotkeyEnabled = false, withText = true }: Pr
     >
       <Box>
         <ActionButton
-          actionName={translate("dags:runAndTaskActions.clear.title", { type: "Run" })}
+          actionName={translate("dags:runAndTaskActions.clear.button", { type: "Run" })}
           icon={<CgRedo />}
           onClick={onOpen}
-          text={translate("dags:runAndTaskActions.clear.title", { type: "Run" })}
+          text={translate("dags:runAndTaskActions.clear.button", { type: "Run" })}
           withText={withText}
         />
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -68,8 +68,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
         <Dialog.Header>
           <VStack align="start" gap={4}>
             <Heading size="xl">
-              <strong>{translate("dags:runAndTaskActions.clear.dialog.title", { type: "Run" })}: </strong>{" "}
-              {dagRunId}
+              <strong>{translate("dags:runAndTaskActions.clear.title", { type: "Run" })}: </strong> {dagRunId}
             </Heading>
           </VStack>
         </Dialog.Header>
@@ -83,16 +82,16 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
               onChange={setSelectedOptions}
               options={[
                 {
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.existingTasks"),
+                  label: translate("dags:runAndTaskActions.options.existingTasks"),
                   value: "existingTasks",
                 },
                 {
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.onlyFailed"),
+                  label: translate("dags:runAndTaskActions.options.onlyFailed"),
                   value: "onlyFailed",
                 },
                 {
                   disabled: true,
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.queueNew"),
+                  label: translate("dags:runAndTaskActions.options.queueNew"),
                   value: "new_tasks",
                 },
               ]}
@@ -119,7 +118,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
                 }
               }}
             >
-              <CgRedo /> {translate("dags:runAndTaskActions.clear.dialog.confirm")}
+              <CgRedo /> {translate("modal.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -54,10 +54,10 @@ const ClearTaskInstanceButton = ({ isHotkeyEnabled = false, taskInstance, withTe
     >
       <Box>
         <ActionButton
-          actionName={translate("runAndTaskActions.clear.title", { type: "Task Instance" })}
+          actionName={translate("runAndTaskActions.clear.button", { type: "Task Instance" })}
           icon={<CgRedo />}
           onClick={onOpen}
-          text={translate("runAndTaskActions.clear.title", { type: "Task Instance" })}
+          text={translate("runAndTaskActions.clear.button", { type: "Task Instance" })}
           withText={withText}
         />
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -54,10 +54,10 @@ const ClearTaskInstanceButton = ({ isHotkeyEnabled = false, taskInstance, withTe
     >
       <Box>
         <ActionButton
-          actionName={translate("runAndTaskActions.clear.button", { type: "Task Instance" })}
+          actionName={translate("runAndTaskActions.clear.title", { type: "Task Instance" })}
           icon={<CgRedo />}
           onClick={onOpen}
-          text={translate("runAndTaskActions.clear.button", { type: "Task Instance" })}
+          text={translate("runAndTaskActions.clear.title", { type: "Task Instance" })}
           withText={withText}
         />
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -112,24 +112,24 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
               options={[
                 {
                   disabled: taskInstance.logical_date === null,
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.past"),
+                  label: translate("dags:runAndTaskActions.options.past"),
                   value: "past",
                 },
                 {
                   disabled: taskInstance.logical_date === null,
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.future"),
+                  label: translate("dags:runAndTaskActions.options.future"),
                   value: "future",
                 },
                 {
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.upstream"),
+                  label: translate("dags:runAndTaskActions.options.upstream"),
                   value: "upstream",
                 },
                 {
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.downstream"),
+                  label: translate("dags:runAndTaskActions.options.downstream"),
                   value: "downstream",
                 },
                 {
-                  label: translate("dags:runAndTaskActions.clear.dialog.options.onlyFailed"),
+                  label: translate("dags:runAndTaskActions.options.onlyFailed"),
                   value: "onlyFailed",
                 },
               ]}
@@ -166,7 +166,7 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
                 }
               }}
             >
-              <CgRedo /> {translate("dags:runAndTaskActions.clear.dialog.confirm")}
+              <CgRedo /> {translate("modal.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -193,7 +193,7 @@ export const DurationChart = ({
               ticks: {
                 maxTicksLimit: 3,
               },
-              title: { align: "end", display: true, text: translate("durationChart.runAfter") },
+              title: { align: "end", display: true, text: translate("dagRun.runAfter") },
             },
             y: {
               title: { align: "end", display: true, text: translate("duration") },

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -65,7 +65,7 @@ export const DurationChart = ({
   readonly entries: Array<RunResponse> | undefined;
   readonly kind: "Dag Run" | "Task Instance";
 }) => {
-  const { t: translate } = useTranslation("components");
+  const { t: translate } = useTranslation(["components", "common"]);
   const navigate = useNavigate();
 
   if (!entries) {
@@ -196,7 +196,7 @@ export const DurationChart = ({
               title: { align: "end", display: true, text: translate("durationChart.runAfter") },
             },
             y: {
-              title: { align: "end", display: true, text: translate("durationChart.duration") },
+              title: { align: "end", display: true, text: translate("duration") },
             },
           },
         }}

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
@@ -47,7 +47,7 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
         <Dialog.Header>
           <VStack align="start" gap={4}>
             <Heading size="xl">
-              {translate("dags:runAndTaskActions.markAs.dialog.title", { state, type: "Run" })}: {dagRunId}{" "}
+              {translate("dags:runAndTaskActions.markAs.title", { state, type: "Run" })}: {dagRunId}{" "}
               <StateBadge state={state} />
             </Heading>
           </VStack>
@@ -69,7 +69,7 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
                 });
               }}
             >
-              {translate("dags:runAndTaskActions.markAs.dialog.confirm")}
+              {translate("modal.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -90,7 +90,7 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
           <VStack align="start" gap={4}>
             <Heading size="xl">
               <strong>
-                {translate("dags:runAndTaskActions.markAs.dialog.title", { state, type: "Task Instance" })}:
+                {translate("dags:runAndTaskActions.markAs.title", { state, type: "Task Instance" })}:
               </strong>{" "}
               {taskInstance.task_display_name} <Time datetime={taskInstance.start_date} />{" "}
               <StateBadge state={state} />
@@ -108,20 +108,20 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
               options={[
                 {
                   disabled: taskInstance.logical_date === null,
-                  label: translate("dags:runAndTaskActions.markAs.dialog.options.past"),
+                  label: translate("dags:runAndTaskActions.options.past"),
                   value: "past",
                 },
                 {
                   disabled: taskInstance.logical_date === null,
-                  label: translate("dags:runAndTaskActions.markAs.dialog.options.future"),
+                  label: translate("dags:runAndTaskActions.options.future"),
                   value: "future",
                 },
                 {
-                  label: translate("dags:runAndTaskActions.markAs.dialog.options.upstream"),
+                  label: translate("dags:runAndTaskActions.options.upstream"),
                   value: "upstream",
                 },
                 {
-                  label: translate("dags:runAndTaskActions.markAs.dialog.options.downstream"),
+                  label: translate("dags:runAndTaskActions.options.downstream"),
                   value: "downstream",
                 },
               ]}
@@ -149,7 +149,7 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
                 });
               }}
             >
-              {translate("dags:runAndTaskActions.markAs.dialog.confirm")}
+              {translate("modal.confirm")}
             </Button>
           </Flex>
         </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -31,7 +31,7 @@ describe("Test SearchBar", () => {
 
     const input = screen.getByTestId("search-dags");
 
-    expect(screen.getByText("list.advancedSearch")).toBeDefined();
+    expect(screen.getByText("search.advanced")).toBeDefined();
     expect(screen.queryByTestId("clear-search")).toBeNull();
 
     fireEvent.change(input, { target: { value: "search" } });

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -74,7 +74,7 @@ export const SearchBar = ({
         <>
           {Boolean(value) ? (
             <CloseButton
-              aria-label={translate("list.clearSearch")}
+              aria-label={translate("search.clear")}
               colorPalette="gray"
               data-testid="clear-search"
               onClick={() => {
@@ -86,10 +86,15 @@ export const SearchBar = ({
           ) : undefined}
           {Boolean(hideAdvanced) ? undefined : (
             <Button fontWeight="normal" height="1.75rem" variant="ghost" width={140} {...buttonProps}>
-              {translate("list.advancedSearch")}
+              {translate("search.advanced")}
             </Button>
           )}
-          {!hotkeyDisabled && <Kbd size="sm">{metaKey}+K</Kbd>}
+          {!hotkeyDisabled && (
+            <Kbd size="sm">
+              {metaKey}
+              {translate("search.hotkey")}
+            </Kbd>
+          )}
         </>
       }
       startElement={<FiSearch />}

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
@@ -86,7 +86,7 @@ export const SearchDags = ({
         loadOptions={searchDagDebounced}
         menuIsOpen
         onChange={onSelect}
-        placeholder={translate("search.placeholder")}
+        placeholder={translate("search.dags")}
         // eslint-disable-next-line unicorn/no-null
         value={null} // null is required https://github.com/JedWatson/react-select/issues/3066
       />

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
@@ -37,7 +37,7 @@ export const SearchDags = ({
 }: {
   readonly setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
-  const { t: translate } = useTranslation("components");
+  const { t: translate } = useTranslation("dags");
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const SEARCH_LIMIT = 10;
@@ -86,7 +86,7 @@ export const SearchDags = ({
         loadOptions={searchDagDebounced}
         menuIsOpen
         onChange={onSelect}
-        placeholder={translate("searchDags.placeholder")}
+        placeholder={translate("search.placeholder")}
         // eslint-disable-next-line unicorn/no-null
         value={null} // null is required https://github.com/JedWatson/react-select/issues/3066
       />

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
@@ -28,7 +28,7 @@ import { getMetaKey } from "src/utils";
 import { SearchDags } from "./SearchDags";
 
 export const SearchDagsButton = () => {
-  const { t: translate } = useTranslation("components");
+  const { t: translate } = useTranslation("dags");
   const [isOpen, setIsOpen] = useState(false);
   const metaKey = getMetaKey();
 
@@ -48,10 +48,10 @@ export const SearchDagsButton = () => {
   return (
     <Box>
       <Button justifyContent="flex-start" onClick={() => setIsOpen(true)} variant="subtle" w={200}>
-        <MdSearch /> {translate("searchDags.button")}{" "}
+        <MdSearch /> {translate("search.dags")}{" "}
         <Kbd size="sm">
           {metaKey}
-          {translate("searchDags.hotkey")}
+          {translate("search.hotkey")}
         </Kbd>
       </Button>
       <Dialog.Root onOpenChange={onOpenChange} open={isOpen} size="sm">

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
@@ -33,16 +33,16 @@ type Props = {
 
 const TriggerDAGButton: React.FC<Props> = ({ dag, withText = true }) => {
   const { onClose, onOpen, open } = useDisclosure();
-  const { t: translate } = useTranslation("dags");
+  const { t: translate } = useTranslation("components");
 
   return (
     <Box>
       <ActionButton
-        actionName={translate("dagActions.trigger.triggerDag")}
+        actionName={translate("triggerDag.title")}
         colorPalette="blue"
         icon={<FiPlay />}
         onClick={onOpen}
-        text={translate("dagActions.trigger.button")}
+        text={translate("triggerDag.button")}
         variant="solid"
         withText={withText}
       />

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -169,7 +169,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
             disabled={Boolean(errors.conf) || Boolean(errors.date) || formError || isPending}
             onClick={() => void handleSubmit(onSubmit)()}
           >
-            <FiPlay /> {translate("components:triggerDag.trigger")}
+            <FiPlay /> {translate("components:triggerDag.button")}
           </Button>
         </HStack>
       </Box>

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -50,7 +50,7 @@ export type DagRunTriggerParams = {
 };
 
 const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: TriggerDAGFormProps) => {
-  const { t: translate } = useTranslation("components");
+  const { t: translate } = useTranslation(["common", "components"]);
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const [formError, setFormError] = useState(false);
   const initialParamsDict = useDagParams(dagId, open);
@@ -112,7 +112,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
             <Field.Root invalid={Boolean(errors.date)} orientation="horizontal">
               <Stack>
                 <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
-                  {translate("triggerDag.logicalDate")}
+                  {translate("logicalDate")}
                 </Field.Label>
               </Stack>
               <Stack css={{ flexBasis: "70%" }}>
@@ -129,12 +129,12 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
             <Field.Root mt={6} orientation="horizontal">
               <Stack>
                 <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
-                  {translate("triggerDag.runId")}
+                  {translate("runId")}
                 </Field.Label>
               </Stack>
               <Stack css={{ flexBasis: "70%" }}>
                 <Input {...field} size="sm" />
-                <Field.HelperText>{translate("triggerDag.runIdHelp")}</Field.HelperText>
+                <Field.HelperText>{translate("components:triggerDag.runIdHelp")}</Field.HelperText>
               </Stack>
             </Field.Root>
           )}
@@ -144,8 +144,8 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
           name="note"
           render={({ field }) => (
             <Field.Root mt={6}>
-              <Field.Label fontSize="md">{translate("triggerDag.notes")}</Field.Label>
-              <EditableMarkdown field={field} placeholder={translate("triggerDag.notesPlaceholder")} />
+              <Field.Label fontSize="md">{translate("note.dagRun")}</Field.Label>
+              <EditableMarkdown field={field} placeholder={translate("note.placeholder")} />
             </Field.Root>
           )}
         />
@@ -169,7 +169,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
             disabled={Boolean(errors.conf) || Boolean(errors.date) || formError || isPending}
             onClick={() => void handleSubmit(onSubmit)()}
           >
-            <FiPlay /> {translate("triggerDag.trigger")}
+            <FiPlay /> {translate("components:triggerDag.trigger")}
           </Button>
         </HStack>
       </Box>

--- a/airflow-core/src/airflow/ui/src/constants/stateOptions.ts
+++ b/airflow-core/src/airflow/ui/src/constants/stateOptions.ts
@@ -25,7 +25,7 @@ export const taskInstanceStateOptions = createListCollection<{
   value: TaskInstanceState | "all" | "none";
 }>({
   items: [
-    { label: "dags:taskInstances.allStates", value: "all" },
+    { label: "dags:filters.allStates", value: "all" },
     { label: "common:states.scheduled", value: "scheduled" },
     { label: "common:states.queued", value: "queued" },
     { label: "common:states.running", value: "running" },
@@ -44,7 +44,7 @@ export const taskInstanceStateOptions = createListCollection<{
 
 export const dagRunStateOptions = createListCollection({
   items: [
-    { label: "dags:runs.allStates", value: "all" },
+    { label: "dags:filters.allStates", value: "all" },
     { label: "common:states.queued", value: "queued" },
     { label: "common:states.running", value: "running" },
     { label: "common:states.failed", value: "failed" },
@@ -54,7 +54,7 @@ export const dagRunStateOptions = createListCollection({
 
 export const dagRunTypeOptions = createListCollection({
   items: [
-    { label: "dags:runs.allRunTypes", value: "all" },
+    { label: "dags:filters.allRunTypes", value: "all" },
     { label: "common:runTypes.backfill", value: "backfill" },
     { label: "common:runTypes.manual", value: "manual" },
     { label: "common:runTypes.scheduled", value: "scheduled" },

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -51,7 +51,6 @@ import zhTWAssets from "./locales/zh-TW/assets.json";
 import zhTWBrowse from "./locales/zh-TW/browse.json";
 import zhTWCommon from "./locales/zh-TW/common.json";
 import zhTWComponents from "./locales/zh-TW/components.json";
-import zhTWConnections from "./locales/zh-TW/connections.json";
 import zhTWDags from "./locales/zh-TW/dags.json";
 import zhTWDashboard from "./locales/zh-TW/dashboard.json";
 
@@ -116,7 +115,6 @@ const resources = {
     browse: zhTWBrowse,
     common: zhTWCommon,
     components: zhTWComponents,
-    connections: zhTWConnections,
     dags: zhTWDags,
     dashboard: zhTWDashboard,
   },

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -50,6 +50,8 @@ import zhTWAdmin from "./locales/zh-TW/admin.json";
 import zhTWAssets from "./locales/zh-TW/assets.json";
 import zhTWBrowse from "./locales/zh-TW/browse.json";
 import zhTWCommon from "./locales/zh-TW/common.json";
+import zhTWComponents from "./locales/zh-TW/components.json";
+import zhTWConnections from "./locales/zh-TW/connections.json";
 import zhTWDags from "./locales/zh-TW/dags.json";
 import zhTWDashboard from "./locales/zh-TW/dashboard.json";
 
@@ -113,6 +115,8 @@ const resources = {
     assets: zhTWAssets,
     browse: zhTWBrowse,
     common: zhTWCommon,
+    components: zhTWComponents,
+    connections: zhTWConnections,
     dags: zhTWDags,
     dashboard: zhTWDashboard,
   },

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
@@ -15,11 +15,9 @@
     "auditLog": "Prüf-Log",
     "xcoms": "Task Kommunikation (XComs)"
   },
-  "bundleVersion": "Bündel Version",
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
-    "bundleVersion": "Bündel Version",
     "catchup": "Nachgeholt",
     "concurrency": "Parallelität",
     "dagRunTimeout": "Dag Lauf Zeitüberschreitung",
@@ -38,8 +36,7 @@
     "owner": "Eigentümer",
     "params": "Parameter",
     "schedule": "Zeitplan",
-    "tags": "Markierungen",
-    "timezone": "Zeitzone"
+    "tags": "Markierungen"
   },
   "dagId": "Dag ID",
   "dagRun": {
@@ -102,7 +99,6 @@
     "placeholder": "Eine Notiz hinzufügen...",
     "taskInstance": "Notizen zu Task Instanzen"
   },
-  "operator": "Operator",
   "pools": {
     "deferred": "Delegiert",
     "open": "Frei",
@@ -166,11 +162,15 @@
     "tagPlaceholder": "Dags nach Markierung filtern",
     "to": "Zu"
   },
+  "task": {
+    "lastInstance": "Letzte Task Instanz",
+    "operator": "Operator",
+    "triggerRule": "Auslöse-Regel"
+  },
   "task_one": "Task",
   "task_other": "Tasks",
   "taskInstance": {
     "dagVersion": "Dag Version",
-    "operator": "Operator-Klasse",
     "pid": "PID",
     "pool": "Pool",
     "queuedAt": "Wartend seit"
@@ -192,7 +192,6 @@
     "utc": "UTC (Koordinierte Weltzeit)"
   },
   "triggered": "Angestoßen",
-  "triggerRule": "Auslöse-Regel",
   "tryNumber": "Versuch Nummer",
   "user": "Benutzer",
   "wrap": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
@@ -15,8 +15,44 @@
     "auditLog": "Prüf-Log",
     "xcoms": "Task Kommunikation (XComs)"
   },
+  "bundleVersion": "Bündel Version",
   "dag_one": "Dag",
   "dag_other": "Dags",
+  "dagDetails": {
+    "bundleVersion": "Bündel Version",
+    "catchup": "Nachgeholt",
+    "concurrency": "Parallelität",
+    "dagRunTimeout": "Dag Lauf Zeitüberschreitung",
+    "defaultArgs": "Standard-Parameter",
+    "description": "Beschreibung",
+    "fileLocation": "Ablagepfad",
+    "hasTaskConcurrencyLimits": "Hat der Task Limitierungen zur Parallelität",
+    "lastExpired": "Letztmaliger Ablauf",
+    "lastParsed": "Letztmalig Eingelesen",
+    "latestDagVersion": "Letzte Dag Version",
+    "latestRun": "Letzter Lauf",
+    "maxActiveRuns": "Maximal aktive Läufe",
+    "maxActiveTasks": "Maximal aktive Tasks",
+    "maxConsecutiveFailedDagRuns": "Maximal fortlaufende fehlerhafte Dag Läufe",
+    "nextRun": "Nächster Lauf",
+    "owner": "Eigentümer",
+    "params": "Parameter",
+    "schedule": "Zeitplan",
+    "tags": "Markierungen",
+    "timezone": "Zeitzone"
+  },
+  "dagId": "Dag ID",
+  "dagRun": {
+    "conf": "Konfiguration",
+    "dagVersions": "Dag Versionen",
+    "dataIntervalEnd": "Datenintervall Ende",
+    "dataIntervalStart": "Datenintervall Start",
+    "lastSchedulingDecision": "Letzte Planungsentscheidung",
+    "queuedAt": "Wartend seit",
+    "runAfter": "Gelaufen ab",
+    "runType": "Typ des Laufs",
+    "triggeredBy": "Angestoßen von"
+  },
   "dagRun_one": "Dag Lauf",
   "dagRun_other": "Dag Läufe",
   "dagWarnings": "Dag Warnungen und Fehler",
@@ -28,10 +64,7 @@
     "githubRepo": "GitHub Ablage",
     "restApiReference": "REST API Referenz"
   },
-  "duration": {
-    "label": "Laufzeit",
-    "seconds": "{{count}}s"
-  },
+  "duration": "Laufzeit",
   "endDate": "Enddatum",
   "expression": {
     "all": "Alle",
@@ -62,6 +95,13 @@
     "security": "Sicherheit"
   },
   "noItemsFound": "Kein Element vom Typ {{modelName}} gefunden",
+  "note": {
+    "add": "Eine Notiz hinzufügen",
+    "dagRun": "Notizen zum Dag Lauf",
+    "label": "Notiz",
+    "placeholder": "Eine Notiz hinzufügen...",
+    "taskInstance": "Notizen zu Task Instanzen"
+  },
   "operator": "Operator",
   "pools": {
     "deferred": "Delegiert",
@@ -79,6 +119,7 @@
     "manual": "Manuell",
     "scheduled": "Geplant"
   },
+  "seconds": "{{count}}s",
   "security": {
     "actions": "Aktionen",
     "permissions": "Berechtigungen",
@@ -110,7 +151,6 @@
   "table": {
     "completedAt": "Abgeschlossen um",
     "createdAt": "Erstellt um",
-    "duration": "Laufzeit",
     "filterByTag": "Dags nach Markierung filtern",
     "filterColumns": "Tabellenspalten filtern",
     "filterReset_one": "Filter zurücksetzen",
@@ -128,6 +168,13 @@
   },
   "task_one": "Task",
   "task_other": "Tasks",
+  "taskInstance": {
+    "dagVersion": "Dag Version",
+    "operator": "Operator-Klasse",
+    "pid": "PID",
+    "pool": "Pool",
+    "queuedAt": "Wartend seit"
+  },
   "taskInstance_one": "Task Instanz",
   "taskInstance_other": "Task Instanzen",
   "timeRange": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
@@ -80,11 +80,6 @@
     "line": "Zeile"
   },
   "reparseDag": "Dag neu parsen",
-  "searchDags": {
-    "button": "Dags suchen",
-    "hotkey": "+K",
-    "placeholder": "Dags suchen"
-  },
   "sortedAscending": "aufsteigend sortier",
   "sortedDescending": "absteigend sortier",
   "sortedUnsorted": "unsortiert",
@@ -94,10 +89,6 @@
   "triggerDag": {
     "loading": "Lade DAG Information...",
     "loadingFailed": "Das Laden der DAG Information fehlgeschlagen. Bitt versuchen Sie es noch einmal.",
-    "logicalDate": "Logisches Datum",
-    "notes": "Notizen zum Dag Lauf",
-    "notesPlaceholder": "Klicken Sie hier um eine Notiz hinzuzufügen",
-    "runId": "ID des Laufes (Run Id)",
     "runIdHelp": "Optional - wird automatisch erzeugt wenn nicht angegeben",
     "selectDescription": "Einen einzelnen Lauf dieses Dag auslösen",
     "selectLabel": "Einzelner Lauf",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/components.json
@@ -87,13 +87,13 @@
   "toggleCardView": "Kachelansicht anzeigen",
   "toggleTableView": "Tabellenansicht anzeigen",
   "triggerDag": {
+    "button": "Auslösen",
     "loading": "Lade DAG Information...",
     "loadingFailed": "Das Laden der DAG Information fehlgeschlagen. Bitt versuchen Sie es noch einmal.",
     "runIdHelp": "Optional - wird automatisch erzeugt wenn nicht angegeben",
     "selectDescription": "Einen einzelnen Lauf dieses Dag auslösen",
     "selectLabel": "Einzelner Lauf",
     "title": "Dag Auslösen",
-    "trigger": "Auslösen",
     "unpause": "Dag {{dagDisplayName}} beim Auslösen des Laufes aktiv schalten"
   },
   "versionDetails": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
@@ -2,32 +2,8 @@
   "allRuns": "Alle Läufe",
   "code": {
     "bundleUrl": "Bündel Url",
-    "bundleVersion": "Bündel Version:",
     "noCode": "Kein Programmcode gefunden",
     "parsedAt": "Eingelesen um:"
-  },
-  "details": {
-    "fields": {
-      "bundleVersion": "Bündel Version",
-      "catchup": "Nachgeholt",
-      "concurrency": "Parallelität",
-      "dagId": "Dag ID",
-      "dagRunTimeout": "Dag Lauf Zeitüberschreitung",
-      "defaultArgs": "Standard-Parameter",
-      "description": "Beschreibung",
-      "endDate": "Enddatum",
-      "fileLocation": "Ablagepfad",
-      "hasTaskConcurrencyLimits": "Hat der Task Limitierungen zur Parallelität",
-      "lastExpired": "Letztmaliger Ablauf",
-      "lastParsed": "Letztmalig Eingelesen",
-      "latestDagVersion": "Latzte Dag Version",
-      "maxActiveRuns": "Maximal aktive Läufe",
-      "maxActiveTasks": "Maximal aktive Tasks",
-      "maxConsecutiveFailedDagRuns": "Maximal fortlaufende fehlerhafte Dag Läufe",
-      "params": "Parameter",
-      "startDate": "Startdatum",
-      "timezone": "Zeitzone"
-    }
   },
   "grid": {
     "buttons": {
@@ -38,17 +14,6 @@
   "header": {
     "buttons": {
       "dagDocs": "Dag Dokumentation"
-    },
-    "modals": {
-      "docTitle": "Dag Dokumentation"
-    },
-    "stats": {
-      "latestDagVersion": "Letzte Dag Version",
-      "latestRun": "Letzter Lauf",
-      "nextRun": "Nächster Lauf",
-      "owner": "Eigentümer",
-      "schedule": "Zeitplan",
-      "tags": "Markierungen"
     }
   },
   "overview": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dag.json
@@ -62,11 +62,6 @@
     "runs": "Läufe",
     "tasks": "Tasks"
   },
-  "task": {
-    "card": {
-      "lastInstance": "Letzte Task Instanz"
-    }
-  },
   "taskGroups": {
     "collapseAll": "Alle Task-Gruppen einklappen",
     "expandAll": "Alle Task-Gruppen aufklappen"

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
@@ -11,55 +11,24 @@
     }
   },
   "filters": {
+    "allRunTypes": "Alle Arten von Läufen",
+    "allStates": "Alle Stati",
     "paused": {
       "active": "Aktiv",
       "all": "Alle",
       "paused": "Pausiert"
     }
   },
-  "list": {
-    "advancedSearch": "Erweiterte Suche",
-    "clearSearch": "Suche zurücksetzen",
-    "columns": {
-      "dagId": "Dag ID",
-      "lastDagRun": "Letzter Dag Lauf",
-      "nextDagRun": "Nächster Dag Lauf",
-      "schedule": "Zeitplan",
-      "tags": "Markierungen"
-    },
-    "ownerLink": "Besitzer Verlinkungen zu {{owner}}",
-    "searchPlaceholder": "Dags suchen"
-  },
+  "ownerLink": "Besitzer Verlinkungen zu {{owner}}",
   "runAndTaskActions": {
+    "affectedTasks": {
+      "noItemsFound": "Keine Tasks gefunden.",
+      "title": "Betroffene Tasks: {{count}}"
+    },
     "clear": {
       "button": "{{type}} zurücksetzen",
       "buttonTooltip": "STRG+C zum Zurücksetzen tippen",
-      "dialog": {
-        "affectedTasks": {
-          "columns": {
-            "runId": "Lauf ID",
-            "state": "Status",
-            "taskId": "Task ID"
-          },
-          "noItemsFound": "Keine Tasks gefunden.",
-          "title": "Betroffene Tasks: {{count}}"
-        },
-        "confirm": "Bestätigen",
-        "note": {
-          "placeholder": "Eine Notiz hinzufügen...",
-          "title": "Notiz"
-        },
-        "options": {
-          "downstream": "Nachfolgende",
-          "existingTasks": "Bestehende Tasks bereinigen",
-          "future": "Zukünftige",
-          "onlyFailed": "Nur fehlgeschlagene Tasks bereinigen",
-          "past": "Vergangene",
-          "queueNew": "Neue Tasks einplanen",
-          "upstream": "Vorangegangene"
-        },
-        "title": "{{type}} bereinigen und neu planen"
-      }
+      "title": "{{type}} bereinigen und neu planen"
     },
     "delete": {
       "button": "{{type}} löschen",
@@ -80,32 +49,24 @@
         "failed": "STRG+F tippen um als fehlgeschlagen zu markieren",
         "success": "STRG+S tippen um als erfolgreich zu markieren"
       },
-      "dialog": {
-        "confirm": "Bestätigen",
-        "options": {
-          "downstream": "Nachfolgende",
-          "future": "Zukünftige",
-          "past": "Vergangene",
-          "upstream": "Vorangegangene"
-        },
-        "title": "{{type}} auf den Status {{state}} setzen"
-      }
+      "title": "{{type}} auf den Status {{state}} setzen"
+    },
+    "options": {
+      "downstream": "Nachfolgende",
+      "existingTasks": "Bestehende Tasks bereinigen",
+      "future": "Zukünftige",
+      "onlyFailed": "Nur fehlgeschlagene Tasks bereinigen",
+      "past": "Vergangene",
+      "queueNew": "Neue Tasks einplanen",
+      "upstream": "Vorangegangene"
     }
   },
-  "runs": {
-    "allRunTypes": "Alle Arten von Läufen",
-    "allStates": "Alle Stati",
-    "columns": {
-      "conf": "Dag Konfiguration",
-      "dagId": "Dag ID",
-      "dagVersions": "Dag Version",
-      "duration": "Laufzeit",
-      "endDate": "Enddatum",
-      "runAfter": "Gelaufen ab",
-      "runType": "Typ des Laufs",
-      "startDate": "Startdatum",
-      "state": "Status"
-    }
+  "search": {
+    "advanced": "Erweiterte Suche",
+    "clear": "Suche zurücksetzen",
+    "dags": "Dags suchen",
+    "hotkey": "+K",
+    "tasks": "Tasks suchen"
   },
   "sort": {
     "displayName": {
@@ -125,22 +86,5 @@
       "desc": "Sortiert nach nächstem Laufdatum (Letzter-Erster)"
     },
     "placeholder": "Sortieren nach"
-  },
-  "taskInstances": {
-    "allStates": "Alle Stati",
-    "columns": {
-      "dagId": "Dag ID",
-      "dagRun": "Dag Lauf",
-      "dagVersion": "Dag Version",
-      "duration": "Laufzeit",
-      "endDate": "Enddatum",
-      "operator": "Operator-Klasse",
-      "pool": "Pool",
-      "startDate": "Startdatum",
-      "state": "Status",
-      "taskId": "Task ID",
-      "tryNumber": "Versuch Nummer"
-    },
-    "searchPlaceholder": "Tasks suchen"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/dags.json
@@ -4,10 +4,6 @@
     "delete": {
       "button": "Dag löschen",
       "warning": "Diese Aktion löscht alle Metadaten zu diesem Dag mit allen Läufen und Task Instanzen."
-    },
-    "trigger": {
-      "button": "Auslösen",
-      "triggerDag": "Dag auslösen"
     }
   },
   "filters": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -42,8 +42,6 @@
     "params": "Params",
     "schedule": "Schedule",
     "tags": "Tags",
-    "timetableDescription": "Timetable Description",
-    "timetableSummary": "Timetable Summary",
     "timezone": "Timezone"
   },
   "dagId": "Dag ID",
@@ -102,10 +100,10 @@
   "noItemsFound": "No {{modelName}} found",
   "note": {
     "add": "Add a note",
-    "addPlaceholder": "Add a note...",
-    "dagRunTitle": "Dag Run Note",
+    "dagRun": "Dag Run Note",
     "label": "Note",
-    "taskInstanceTitle": "Task Instance Note"
+    "placeholder": "Add a note...",
+    "taskInstance": "Task Instance Note"
   },
   "operator": "Operator",
   "pools": {
@@ -170,6 +168,8 @@
     "tagPlaceholder": "Filter by tag",
     "to": "To"
   },
+  "task_one": "Task",
+  "task_other": "Tasks",
   "taskId": "Task ID",
   "taskInstance": {
     "dagVersion": "Dag Version",
@@ -184,8 +184,6 @@
     "priorityWeight": "Priority Weight",
     "queue": "Queue",
     "queuedWhen": "Queued At",
-    "renderedFields": "Rendered Fields",
-    "renderedMapIndex": "Rendered Map Index",
     "scheduledWhen": "Scheduled At",
     "unixname": "Unix Name"
   },

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -17,11 +17,9 @@
     "auditLog": "Audit Log",
     "xcoms": "XComs"
   },
-  "bundleVersion": "Bundle Version",
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
-    "bundleName": "Bundle Name",
     "catchup": "Catchup",
     "concurrency": "Concurrency",
     "dagRunTimeout": "Dag Run Timeout",
@@ -41,8 +39,7 @@
     "owner": "Owner",
     "params": "Params",
     "schedule": "Schedule",
-    "tags": "Tags",
-    "timezone": "Timezone"
+    "tags": "Tags"
   },
   "dagId": "Dag ID",
   "dagRun": {
@@ -105,7 +102,6 @@
     "placeholder": "Add a note...",
     "taskInstance": "Task Instance Note"
   },
-  "operator": "Operator",
   "pools": {
     "deferred": "Deferred",
     "open": "Open",
@@ -168,6 +164,11 @@
     "tagPlaceholder": "Filter by tag",
     "to": "To"
   },
+  "task": {
+    "lastInstance": "Last Instance",
+    "operator": "Operator",
+    "triggerRule": "Trigger Rule"
+  },
   "task_one": "Task",
   "task_other": "Tasks",
   "taskId": "Task ID",
@@ -177,7 +178,6 @@
     "executorConfig": "Executor Config",
     "hostname": "Hostname",
     "maxTries": "Max Tries",
-    "operator": "Operator",
     "pid": "PID",
     "pool": "Pool",
     "poolSlots": "Pool Slots",
@@ -195,7 +195,7 @@
     "lastHour": "Last Hour",
     "pastWeek": "Past Week"
   },
-  "timezone": "timezone",
+  "timezone": "Timezone",
   "timezoneModal": {
     "current-timezone": "Current time in",
     "placeholder": "Select a timezone",
@@ -203,7 +203,6 @@
     "utc": "UTC (Coordinated Universal Time)"
   },
   "triggered": "Triggered",
-  "triggerRule": "Trigger Rule",
   "tryNumber": "Try Number",
   "user": "User",
   "wrap": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -17,9 +17,46 @@
     "auditLog": "Audit Log",
     "xcoms": "XComs"
   },
+  "bundleVersion": "Bundle Version",
   "dag_one": "Dag",
   "dag_other": "Dags",
+  "dagDetails": {
+    "bundleName": "Bundle Name",
+    "catchup": "Catchup",
+    "concurrency": "Concurrency",
+    "dagRunTimeout": "Dag Run Timeout",
+    "defaultArgs": "Default Args",
+    "description": "Description",
+    "documentation": "Dag Documentation",
+    "fileLocation": "File Location",
+    "hasTaskConcurrencyLimits": "Has Task Concurrency Limits",
+    "lastExpired": "Last Expired",
+    "lastParsed": "Last Parsed",
+    "latestDagVersion": "Latest Dag Version",
+    "latestRun": "Latest Run",
+    "maxActiveRuns": "Max Active Runs",
+    "maxActiveTasks": "Max Active Tasks",
+    "maxConsecutiveFailedDagRuns": "Max Consecutive Failed Dag Runs",
+    "nextRun": "Next Run",
+    "owner": "Owner",
+    "params": "Params",
+    "schedule": "Schedule",
+    "tags": "Tags",
+    "timetableDescription": "Timetable Description",
+    "timetableSummary": "Timetable Summary",
+    "timezone": "Timezone"
+  },
   "dagId": "Dag ID",
+  "dagRun": {
+    "conf": "Conf",
+    "dagVersions": "Dag Version(s)",
+    "dataIntervalEnd": "Data Interval End",
+    "dataIntervalStart": "Data Interval Start",
+    "lastSchedulingDecision": "Last Scheduling Decision",
+    "queuedAt": "Queued At",
+    "runType": "Run Type",
+    "triggeredBy": "Triggered By"
+  },
   "dagRun_one": "Dag Run",
   "dagRun_other": "Dag Runs",
   "dagWarnings": "Dag warnings/errors",
@@ -31,10 +68,7 @@
     "githubRepo": "GitHub Repo",
     "restApiReference": "REST API Reference"
   },
-  "duration": {
-    "label": "Duration",
-    "seconds": "{{count}}s"
-  },
+  "duration": "Duration",
   "endDate": "End Date",
   "expression": {
     "all": "All",
@@ -65,6 +99,13 @@
     "security": "Security"
   },
   "noItemsFound": "No {{modelName}} found",
+  "note": {
+    "add": "Add a note",
+    "addPlaceholder": "Add a note...",
+    "dagRunTitle": "Dag Run Note",
+    "label": "Note",
+    "taskInstanceTitle": "Task Instance Note"
+  },
   "operator": "Operator",
   "pools": {
     "deferred": "Deferred",
@@ -75,6 +116,7 @@
     "running": "Running",
     "scheduled": "Scheduled"
   },
+  "runAfter": "Run After",
   "runId": "Run ID",
   "runTypes": {
     "asset_triggered": "Asset Triggered",
@@ -82,6 +124,7 @@
     "manual": "Manual",
     "scheduled": "Scheduled"
   },
+  "seconds": "{{count}}s",
   "security": {
     "actions": "Actions",
     "permissions": "Permissions",
@@ -113,7 +156,6 @@
   "table": {
     "completedAt": "Completed at",
     "createdAt": "Created at",
-    "duration": "Duration",
     "filterByTag": "Filter Dags by tag",
     "filterColumns": "Filter table columns",
     "filterReset_one": "Reset filter",
@@ -121,7 +163,6 @@
     "from": "From",
     "maxActiveRuns": "Max Active Runs",
     "noTagsFound": "No tags found",
-    "reprocessBehavior": "Reprocess Behavior",
     "tagMode": {
       "all": "All",
       "any": "Any"
@@ -129,13 +170,28 @@
     "tagPlaceholder": "Filter by tag",
     "to": "To"
   },
-  "task_one": "Task",
-  "task_other": "Tasks",
   "taskId": "Task ID",
+  "taskInstance": {
+    "dagVersion": "Dag Version",
+    "executor": "Executor",
+    "executorConfig": "Executor Config",
+    "hostname": "Hostname",
+    "maxTries": "Max Tries",
+    "operator": "Operator",
+    "pid": "PID",
+    "pool": "Pool",
+    "poolSlots": "Pool Slots",
+    "priorityWeight": "Priority Weight",
+    "queue": "Queue",
+    "queuedWhen": "Queued At",
+    "renderedFields": "Rendered Fields",
+    "renderedMapIndex": "Rendered Map Index",
+    "scheduledWhen": "Scheduled At",
+    "unixname": "Unix Name"
+  },
   "taskInstance_one": "Task Instance",
   "taskInstance_other": "Task Instances",
   "timeRange": {
-    "duration": "Duration",
     "last12Hours": "Last 12 Hours",
     "last24Hours": "Last 24 Hours",
     "lastHour": "Last Hour",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -54,6 +54,7 @@
     "dataIntervalStart": "Data Interval Start",
     "lastSchedulingDecision": "Last Scheduling Decision",
     "queuedAt": "Queued At",
+    "runAfter": "Run After",
     "runType": "Run Type",
     "triggeredBy": "Triggered By"
   },
@@ -116,7 +117,6 @@
     "running": "Running",
     "scheduled": "Scheduled"
   },
-  "runAfter": "Run After",
   "runId": "Run ID",
   "runTypes": {
     "asset_triggered": "Asset Triggered",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
@@ -80,11 +80,6 @@
     "line": "line"
   },
   "reparseDag": "Reparse Dag",
-  "searchDags": {
-    "button": "Search Dags",
-    "hotkey": "+K",
-    "placeholder": "Search Dags"
-  },
   "sortedAscending": "sorted ascending",
   "sortedDescending": "sorted descending",
   "sortedUnsorted": "unsorted",
@@ -94,10 +89,6 @@
   "triggerDag": {
     "loading": "Loading DAG information...",
     "loadingFailed": "Failed to load DAG information. Please try again.",
-    "logicalDate": "Logical Date",
-    "notes": "Dag Run Notes",
-    "notesPlaceholder": "Click to add note",
-    "runId": "Run ID",
     "runIdHelp": "Optional - will be generated if not provided",
     "selectDescription": "Trigger a single run of this Dag",
     "selectLabel": "Single Run",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
@@ -87,13 +87,13 @@
   "toggleCardView": "Show card view",
   "toggleTableView": "Show table view",
   "triggerDag": {
+    "button": "Trigger",
     "loading": "Loading DAG information...",
     "loadingFailed": "Failed to load DAG information. Please try again.",
     "runIdHelp": "Optional - will be generated if not provided",
     "selectDescription": "Trigger a single run of this Dag",
     "selectLabel": "Single Run",
     "title": "Trigger Dag",
-    "trigger": "Trigger",
     "unpause": "Unpause {{dagDisplayName}} on trigger"
   },
   "versionDetails": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
@@ -2,32 +2,8 @@
   "allRuns": "All Runs",
   "code": {
     "bundleUrl": "Bundle Url",
-    "bundleVersion": "Bundle Version:",
     "noCode": "No Code Found",
     "parsedAt": "Parsed at:"
-  },
-  "details": {
-    "fields": {
-      "bundleVersion": "Bundle Version",
-      "catchup": "Catchup",
-      "concurrency": "Concurrency",
-      "dagId": "Dag ID",
-      "dagRunTimeout": "Dag Run Timeout",
-      "defaultArgs": "Default Args",
-      "description": "Description",
-      "endDate": "End Date",
-      "fileLocation": "File Location",
-      "hasTaskConcurrencyLimits": "Has Task Concurrency Limits",
-      "lastExpired": "Last Expired",
-      "lastParsed": "Last Parsed",
-      "latestDagVersion": "Latest Dag Version",
-      "maxActiveRuns": "Max Active Runs",
-      "maxActiveTasks": "Max Active Tasks",
-      "maxConsecutiveFailedDagRuns": "Max Consecutive Failed Dag Runs",
-      "params": "Params",
-      "startDate": "Start Date",
-      "timezone": "Timezone"
-    }
   },
   "grid": {
     "buttons": {
@@ -38,17 +14,6 @@
   "header": {
     "buttons": {
       "dagDocs": "Dag Docs"
-    },
-    "modals": {
-      "docTitle": "Dag Documentation"
-    },
-    "stats": {
-      "latestDagVersion": "Latest Dag Version",
-      "latestRun": "Latest Run",
-      "nextRun": "Next Run",
-      "owner": "Owner",
-      "schedule": "Schedule",
-      "tags": "Tags"
     }
   },
   "overview": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
@@ -62,11 +62,6 @@
     "runs": "Runs",
     "tasks": "Tasks"
   },
-  "task": {
-    "card": {
-      "lastInstance": "Last Instance"
-    }
-  },
   "taskGroups": {
     "collapseAll": "Collapse all task groups",
     "expandAll": "Expand all task groups"

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
@@ -11,24 +11,22 @@
     }
   },
   "filters": {
+    "allRunTypes": "All Run Types",
+    "allStates": "All States",
     "paused": {
       "active": "Active",
       "all": "All",
       "paused": "Paused"
     }
   },
-  "list": {
-    "advancedSearch": "Advanced Search",
-    "clearSearch": "Clear search",
-    "ownerLink": "Owner link for {{owner}}",
-    "searchPlaceholder": "Search Dags"
-  },
+  "ownerLink": "Owner link for {{owner}}",
   "runAndTaskActions": {
     "affectedTasks": {
       "noItemsFound": "No tasks found.",
       "title": "Affected Tasks: {{count}}"
     },
     "clear": {
+      "button": "Clear {{type}}",
       "buttonTooltip": "Press shift+c to clear",
       "title": "Clear {{type}}"
     },
@@ -63,9 +61,12 @@
       "upstream": "Upstream"
     }
   },
-  "runs": {
-    "allRunTypes": "All Run Types",
-    "allStates": "All States"
+  "search": {
+    "advanced": "Advanced Search",
+    "clear": "Clear search",
+    "dags": "Search Dags",
+    "hotkey": "+K",
+    "tasks": "Search Tasks"
   },
   "sort": {
     "displayName": {
@@ -85,9 +86,5 @@
       "desc": "Sort by Next Dag Run (Latest-Earliest)"
     },
     "placeholder": "Sort by"
-  },
-  "taskInstances": {
-    "allStates": "All States",
-    "searchPlaceholder": "Search Tasks"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
@@ -4,10 +4,6 @@
     "delete": {
       "button": "Delete Dag",
       "warning": "This will remove all metadata related to the Dag, including Runs and Tasks."
-    },
-    "trigger": {
-      "button": "Trigger",
-      "triggerDag": "Trigger Dag"
     }
   },
   "filters": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
@@ -20,46 +20,17 @@
   "list": {
     "advancedSearch": "Advanced Search",
     "clearSearch": "Clear search",
-    "columns": {
-      "dagId": "Dag ID",
-      "lastDagRun": "Last Dag Run",
-      "nextDagRun": "Next Dag Run",
-      "schedule": "Schedule",
-      "tags": "Tags"
-    },
     "ownerLink": "Owner link for {{owner}}",
     "searchPlaceholder": "Search Dags"
   },
   "runAndTaskActions": {
+    "affectedTasks": {
+      "noItemsFound": "No tasks found.",
+      "title": "Affected Tasks: {{count}}"
+    },
     "clear": {
-      "button": "Clear {{type}}",
       "buttonTooltip": "Press shift+c to clear",
-      "dialog": {
-        "affectedTasks": {
-          "columns": {
-            "runId": "Run ID",
-            "state": "State",
-            "taskId": "Task ID"
-          },
-          "noItemsFound": "No tasks found.",
-          "title": "Affected Tasks: {{count}}"
-        },
-        "confirm": "Confirm",
-        "note": {
-          "placeholder": "Add a note...",
-          "title": "Note"
-        },
-        "options": {
-          "downstream": "Downstream",
-          "existingTasks": "Clear existing tasks",
-          "future": "Future",
-          "onlyFailed": "Clear only failed tasks",
-          "past": "Past",
-          "queueNew": "Queue up new tasks",
-          "upstream": "Upstream"
-        },
-        "title": "Clear {{type}}"
-      }
+      "title": "Clear {{type}}"
     },
     "delete": {
       "button": "Delete {{type}}",
@@ -80,16 +51,16 @@
         "failed": "Press shift+f to mark as failed",
         "success": "Press shift+s to mark as success"
       },
-      "dialog": {
-        "confirm": "Confirm",
-        "options": {
-          "downstream": "Downstream",
-          "future": "Future",
-          "past": "Past",
-          "upstream": "Upstream"
-        },
-        "title": "Mark {{type}} as {{state}}"
-      }
+      "title": "Mark {{type}} as {{state}}"
+    },
+    "options": {
+      "downstream": "Downstream",
+      "existingTasks": "Clear existing tasks",
+      "future": "Future",
+      "onlyFailed": "Clear only failed tasks",
+      "past": "Past",
+      "queueNew": "Queue up new tasks",
+      "upstream": "Upstream"
     }
   },
   "runs": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dags.json
@@ -94,18 +94,7 @@
   },
   "runs": {
     "allRunTypes": "All Run Types",
-    "allStates": "All States",
-    "columns": {
-      "conf": "Conf",
-      "dagId": "Dag ID",
-      "dagVersions": "Dag Versions",
-      "duration": "Duration",
-      "endDate": "End Date",
-      "runAfter": "Run After",
-      "runType": "Run Type",
-      "startDate": "Start Date",
-      "state": "State"
-    }
+    "allStates": "All States"
   },
   "sort": {
     "displayName": {
@@ -128,19 +117,6 @@
   },
   "taskInstances": {
     "allStates": "All States",
-    "columns": {
-      "dagId": "Dag ID",
-      "dagRun": "Dag Run",
-      "dagVersion": "Dag Version",
-      "duration": "Duration",
-      "endDate": "End Date",
-      "operator": "Operator",
-      "pool": "Pool",
-      "startDate": "Start Date",
-      "state": "State",
-      "taskId": "Task ID",
-      "tryNumber": "Try Number"
-    },
     "searchPlaceholder": "Search Tasks"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/he/common.json
@@ -22,6 +22,7 @@
     "githubRepo": "GitHub Repo",
     "restApiReference": "REST API תיעוד"
   },
+  "duration": "משך זמן",
   "language": {
     "chinese": "סינית מסורתית",
     "english": "אנגלית",
@@ -67,7 +68,6 @@
   "taskInstance_one": "משימה בודדת",
   "taskInstance_other": "משימה אחרת",
   "timeRange": {
-    "duration": "משך זמן",
     "last12Hours": "12 השעות האחרונות",
     "last24Hours": "24 השעות האחרונות",
     "lastHour": "השעה האחרונה",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/ko/common.json
@@ -22,6 +22,7 @@
     "githubRepo": "GitHub 저장소",
     "restApiReference": "REST API 참조"
   },
+  "duration": "지속 시간",
   "logout": "로그아웃",
   "nav": {
     "admin": "관리자",
@@ -62,7 +63,6 @@
   "taskInstance_one": "작업 인스턴스",
   "taskInstance_other": "작업 인스턴스들",
   "timeRange": {
-    "duration": "지속 시간",
     "last12Hours": "지난 12 시간",
     "last24Hours": "지난 24 시간",
     "lastHour": "지난 1시간",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/nl/common.json
@@ -22,6 +22,7 @@
     "githubRepo": "GitHub Repo",
     "restApiReference": "REST API referentie"
   },
+  "duration": "Duur",
   "logout": "Uitloggen",
   "nav": {
     "admin": "Beheer",
@@ -61,7 +62,6 @@
   "taskInstance_one": "Task Instance",
   "taskInstance_other": "Task Instances",
   "timeRange": {
-    "duration": "Duur",
     "last12Hours": "Laatste 12 uur",
     "last24Hours": "Laatste 24 uur",
     "lastHour": "Laatste uur",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/pl/common.json
@@ -17,6 +17,35 @@
   },
   "dag_one": "Dag",
   "dag_other": "Dagi",
+  "dagDetails": {
+    "catchup": "Nadrabianie zaległości",
+    "concurrency": "Współbieżność",
+    "dagRunTimeout": "Limit czasu wykonania Daga",
+    "defaultArgs": "Domyślne argumenty",
+    "description": "Opis",
+    "documentation": "Dokumentacja Daga",
+    "fileLocation": "Lokalizacja pliku",
+    "hasTaskConcurrencyLimits": "Posiada ograniczenia współbieżności zadań",
+    "lastExpired": "Ostatnio wygasły",
+    "lastParsed": "Ostatnia analiza",
+    "latestDagVersion": "Najnowsza wersja Daga",
+    "latestRun": "Ostatnie wykonanie",
+    "maxActiveRuns": "Maksymalna liczba aktywnych wykonań",
+    "maxActiveTasks": "Maksymalna liczba aktywnych zadań",
+    "maxConsecutiveFailedDagRuns": "Maksymalna liczba kolejnych nieudanych wykonań Daga",
+    "nextRun": "Następne Wykonanie Daga",
+    "owner": "Właściciel",
+    "params": "Parametry",
+    "schedule": "Harmonogram",
+    "tags": "Etykiety"
+  },
+  "dagId": "Identyfikator Daga",
+  "dagRun": {
+    "conf": "Konfiguracja",
+    "dagVersions": "Wersje Daga",
+    "runAfter": "Wykonaj po",
+    "runType": "Typ wykonania"
+  },
   "dagRun_one": "Wykonanie Daga",
   "dagRun_other": "Wykonania Dagów",
   "dagWarnings": "Ostrzeżenia/Błędy Daga",
@@ -28,10 +57,7 @@
     "githubRepo": "Repozytorium GitHub",
     "restApiReference": "Dokuentacja REST API"
   },
-  "duration": {
-    "label": "Czas trwania",
-    "seconds": "{{count}}s"
-  },
+  "duration": "Czas trwania",
   "endDate": "Data zakończenia",
   "expression": {
     "all": "Wszystkie",
@@ -62,7 +88,12 @@
     "security": "Bezpieczeństwo"
   },
   "noItemsFound": "Nie znaleziono modelu {{modelName}}",
-  "operator": "Operator",
+  "note": {
+    "add": "Dodać notatkę",
+    "dagRun": "Notatki wykonania Daga",
+    "label": "Notatka",
+    "placeholder": "Dodaj notatkę..."
+  },
   "pools": {
     "deferred": "Odłożone",
     "open": "Otwarte",
@@ -79,6 +110,7 @@
     "manual": "Ręcznie",
     "scheduled": "Według harmonogramu"
   },
+  "seconds": "{{count}}s",
   "security": {
     "actions": "Akcje",
     "permissions": "Uprawnienia",
@@ -110,7 +142,6 @@
   "table": {
     "completedAt": "Zakończono o",
     "createdAt": "Utworzono o",
-    "duration": "Czas trwania",
     "filterByTag": "Filtruj Dagi według tagu",
     "filterColumns": "Filtruj kolumny tabeli",
     "filterReset_one": "Resetuj filtr",
@@ -126,12 +157,21 @@
     "tagPlaceholder": "Filtruj według etykiety",
     "to": "Do"
   },
+  "task": {
+    "lastInstance": "Ostatnia instancja",
+    "operator": "Operator",
+    "triggerRule": "Reguła wywołania"
+  },
   "task_one": "Zadanie",
   "task_other": "Zadania",
+  "taskId": "Identifikator Zadania",
+  "taskInstance": {
+    "dagVersion": "Wersja Daga",
+    "pool": "Pula"
+  },
   "taskInstance_one": "Instancja Zadania",
   "taskInstance_other": "Instancje Zadań",
   "timeRange": {
-    "duration": "Czas trwania",
     "last12Hours": "Ostatnie 12 godzin",
     "last24Hours": "Ostatnie 24 godziny",
     "lastHour": "Ostatnia godzina",
@@ -145,7 +185,6 @@
     "utc": "UTC (Uniwersalny Czas Koordynowany)"
   },
   "triggered": "Wywołany",
-  "triggerRule": "Reguła wywołania",
   "tryNumber": "Numer próby",
   "user": "Użytkownik",
   "wrap": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/pl/components.json
@@ -80,11 +80,6 @@
     "line": "linia"
   },
   "reparseDag": "Ponowne parsowanie Daga",
-  "searchDags": {
-    "button": "Szukaj Daga",
-    "hotkey": "+K",
-    "placeholder": "Szukaj Daga"
-  },
   "sortedAscending": "posortowane rosnąco",
   "sortedDescending": "posortowane malejąco",
   "sortedUnsorted": "nieposortowane",
@@ -94,10 +89,6 @@
   "triggerDag": {
     "loading": "Ładowanie informacji o Dagach...",
     "loadingFailed": "Nie udało się załadować informacji o Dagach. Spróbuj ponownie.",
-    "logicalDate": "Data logiczna",
-    "notes": "Notatki wykonania Daga",
-    "notesPlaceholder": "Kliknij, aby dodać notatkę",
-    "runId": "Identyfikator wykonania",
     "runIdHelp": "Opcjonalne - zostanie wygenerowane, jeśli nie podano",
     "selectDescription": "Wyzwól pojedyncze wykonanie tego Daga",
     "selectLabel": "Pojedyncze wykonanie",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/pl/dag.json
@@ -2,32 +2,8 @@
   "allRuns": "Wszystkie wykonania",
   "code": {
     "bundleUrl": "Adres URL paczki Dagów",
-    "bundleVersion": "Wersja paczki Dagów:",
     "noCode": "Nie znaleziono kodu",
     "parsedAt": "Przeanalizowano o:"
-  },
-  "details": {
-    "fields": {
-      "bundleVersion": "Wersja paczki Dagów",
-      "catchup": "Nadrabianie zaległości",
-      "concurrency": "Współbieżność",
-      "dagId": "Identyfikator Daga",
-      "dagRunTimeout": "Limit czasu wykonania Daga",
-      "defaultArgs": "Domyślne argumenty",
-      "description": "Opis",
-      "endDate": "Data zakończenia",
-      "fileLocation": "Lokalizacja pliku",
-      "hasTaskConcurrencyLimits": "Posiada ograniczenia współbieżności zadań",
-      "lastExpired": "Ostatnio wygasły",
-      "lastParsed": "Ostatnia analiza",
-      "latestDagVersion": "Najnowsza wersja Daga",
-      "maxActiveRuns": "Maksymalna liczba aktywnych wykonań",
-      "maxActiveTasks": "Maksymalna liczba aktywnych zadań",
-      "maxConsecutiveFailedDagRuns": "Maksymalna liczba kolejnych nieudanych wykonań Daga",
-      "params": "Parametry",
-      "startDate": "Data rozpoczęcia",
-      "timezone": "Strefa czasowa"
-    }
   },
   "grid": {
     "buttons": {
@@ -38,17 +14,6 @@
   "header": {
     "buttons": {
       "dagDocs": "Dokumentacja Daga"
-    },
-    "modals": {
-      "docTitle": "Dokumentacja Daga"
-    },
-    "stats": {
-      "latestDagVersion": "Najnowsza wersja Daga",
-      "latestRun": "Ostatnie wykonanie",
-      "nextRun": "Następne wykonanie",
-      "owner": "Właściciel",
-      "schedule": "Harmonogram",
-      "tags": "Etykiety"
     }
   },
   "overview": {
@@ -96,11 +61,6 @@
     "overview": "Przegląd",
     "runs": "Uruchomienia",
     "tasks": "Zadania"
-  },
-  "task": {
-    "card": {
-      "lastInstance": "Ostatnia instancja"
-    }
   },
   "taskGroups": {
     "collapseAll": "Zwiń wszystkie grupy zadań",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/pl/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/pl/dags.json
@@ -4,62 +4,27 @@
     "delete": {
       "button": "Usuń Daga",
       "warning": "Wszystkie metadane, włączając metadane Dagów, wykonań i zadań zostaną usunięte."
-    },
-    "trigger": {
-      "button": "Uruchom",
-      "triggerDag": "Uruchom Daga"
     }
   },
   "filters": {
+    "allRunTypes": "Wszystkie Typy Wykonań",
+    "allStates": "Wszystkie Stany",
     "paused": {
       "active": "Aktywne",
       "all": "Wszystkie",
       "paused": "Wstrzymane"
     }
   },
-  "list": {
-    "advancedSearch": "Wyszukiwanie zaawansowane",
-    "clearSearch": "Wyczyść wyszukiwanie",
-    "columns": {
-      "dagId": "Identyfikator Daga",
-      "lastDagRun": "Ostatnie Wykonanie Daga",
-      "nextDagRun": "Następne Wykonanie Daga",
-      "schedule": "Harmonogram",
-      "tags": "Etykiety"
-    },
-    "ownerLink": "Link do właściciela {{owner}}",
-    "searchPlaceholder": "Szukaj Dagów"
-  },
+  "ownerLink": "Link do właściciela {{owner}}",
   "runAndTaskActions": {
+    "affectedTasks": {
+      "noItemsFound": "Nie znaleziono zadań.",
+      "title": "Liczba wybranych zadań: {{count}}"
+    },
     "clear": {
       "button": "Wyczyść {{type}}",
       "buttonTooltip": "Użyj shift+c żeby wyczyścić",
-      "dialog": {
-        "affectedTasks": {
-          "columns": {
-            "runId": "Identifikator Wykonania",
-            "state": "Stan",
-            "taskId": "Identifikator Zadania"
-          },
-          "noItemsFound": "Nie znaleziono zadań.",
-          "title": "Liczba wybranych zadań: {{count}}"
-        },
-        "confirm": "Potwierdź",
-        "note": {
-          "placeholder": "Dodaj notatkę..",
-          "title": "Notatka"
-        },
-        "options": {
-          "downstream": "Taski podrzędne",
-          "existingTasks": "Wyczyść istniejące zadania",
-          "future": "Przyszłe zadania",
-          "onlyFailed": "Wyczyść tylko nieudane zadania",
-          "past": "Przeszłe zadania",
-          "queueNew": "Kolejkuj nowe zadania",
-          "upstream": "Taski nadrzędne"
-        },
-        "title": "Wyczyść {{type}}"
-      }
+      "title": "Wyczyść {{type}}"
     },
     "delete": {
       "button": "Usuń {{type}}",
@@ -80,32 +45,24 @@
         "failed": "Użyj shift+f aby oznaczyć jako nieudane",
         "success": "Użyj shift+s aby oznaczyć jako udane"
       },
-      "dialog": {
-        "confirm": "Potwierdź",
-        "options": {
-          "downstream": "Podrzędne",
-          "future": "Przyszłe",
-          "past": "Przeszłe",
-          "upstream": "Nadrzędne"
-        },
-        "title": "Ustaw {{type}} jako {{state}}"
-      }
+      "title": "Ustaw {{type}} jako {{state}}"
+    },
+    "options": {
+      "downstream": "Taski podrzędne",
+      "existingTasks": "Wyczyść istniejące zadania",
+      "future": "Przyszłe zadania",
+      "onlyFailed": "Wyczyść tylko nieudane zadania",
+      "past": "Przeszłe zadania",
+      "queueNew": "Kolejkuj nowe zadania",
+      "upstream": "Taski nadrzędne"
     }
   },
-  "runs": {
-    "allRunTypes": "Wszystkie Typy Wykonań",
-    "allStates": "Wszystkie Stany",
-    "columns": {
-      "conf": "Konfiguracja",
-      "dagId": "Identyfikator Daga",
-      "dagVersions": "Wersje Daga",
-      "duration": "Czas trwania",
-      "endDate": "Data zakończenia",
-      "runAfter": "Wykonaj po",
-      "runType": "Typ wykonania",
-      "startDate": "Data rozpoczęcia",
-      "state": "Stan"
-    }
+  "search": {
+    "advanced": "Wyszukiwanie zaawansowane",
+    "clear": "Wyczyść wyszukiwanie",
+    "dags": "Szukaj Dagów",
+    "hotkey": "+K",
+    "tasks": "Szukaj instancji zadań"
   },
   "sort": {
     "displayName": {
@@ -125,22 +82,5 @@
       "desc": "Sortuj według Następnego Wykonania Daga (Najnowsze-Najwcześniejsze)"
     },
     "placeholder": "Sortuj według"
-  },
-  "taskInstances": {
-    "allStates": "Wszystkie Stany",
-    "columns": {
-      "dagId": "Identyfikator Daga",
-      "dagRun": "Identifikator Wykonania Daga",
-      "dagVersion": "Wersja Daga",
-      "duration": "Czas trwania",
-      "endDate": "Data zakończenia",
-      "operator": "Operator",
-      "pool": "Pula",
-      "startDate": "Data rozpoczęcia",
-      "state": "Stan",
-      "taskId": "Identifikator Zadania",
-      "tryNumber": "Numer próby"
-    },
-    "searchPlaceholder": "Szukaj instancji zadań"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -42,6 +42,8 @@
     "githubRepo": "GitHub 倉庫",
     "restApiReference": "REST API 參考"
   },
+  "duration": "時間範圍",
+  "endDate": "結束日期",
   "expression": {
     "all": "全部",
     "and": "且",
@@ -49,8 +51,6 @@
     "or": "或"
   },
   "logicalDate": "邏輯日期",
-  "duration": "時間範圍",
-  "endDate": "結束日期",
   "logout": "登出",
   "logoutConfirmation": "確定要登出嗎？",
   "mapIndex": "映射索引",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -19,7 +19,18 @@
   },
   "dag_one": "Dag",
   "dag_other": "Dags",
+  "dagDetails": {
+    "latestRun": "上次 Dag 執行",
+    "nextRun": "下次 Dag 執行",
+    "schedule": "排程",
+    "tags": "標籤"
+  },
   "dagId": "Dag ID",
+  "dagRun": {
+    "dagVersions": "Dag 版本",
+    "runAfter": "最早可執行時間",
+    "runType": "執行類型"
+  },
   "dagRun_one": "Dag 執行",
   "dagRun_other": "Dag 執行",
   "dagWarnings": "Dag 警告 / 錯誤",
@@ -31,11 +42,6 @@
     "githubRepo": "GitHub 倉庫",
     "restApiReference": "REST API 參考"
   },
-  "duration": {
-    "label": "持續時間",
-    "seconds": "{{count}} 秒"
-  },
-  "endDate": "結束日期",
   "expression": {
     "all": "全部",
     "and": "且",
@@ -43,6 +49,8 @@
     "or": "或"
   },
   "logicalDate": "邏輯日期",
+  "duration": "時間範圍",
+  "endDate": "結束日期",
   "logout": "登出",
   "logoutConfirmation": "確定要登出嗎？",
   "mapIndex": "映射索引",
@@ -65,7 +73,10 @@
     "security": "安全"
   },
   "noItemsFound": "找不到 {{modelName}}",
-  "operator": "運算子",
+  "note": {
+    "label": "備註",
+    "placeholder": "新增備註..."
+  },
   "pools": {
     "deferred": "已延後",
     "open": "開放",
@@ -82,6 +93,7 @@
     "manual": "手動觸發",
     "scheduled": "已排程"
   },
+  "seconds": "{{count}} 秒",
   "security": {
     "actions": "操作",
     "permissions": "權限",
@@ -129,13 +141,20 @@
     "tagPlaceholder": "依標籤篩選",
     "to": "到"
   },
+  "task": {
+    "operator": "運算子",
+    "triggerRule": "觸發規則"
+  },
   "task_one": "任務",
   "task_other": "任務",
   "taskId": "任務 ID",
+  "taskInstance": {
+    "dagVersion": "Dag 版本",
+    "pool": "資源池"
+  },
   "taskInstance_one": "任務實例",
   "taskInstance_other": "任務實例",
   "timeRange": {
-    "duration": "時間範圍",
     "last12Hours": "最近 12 小時",
     "last24Hours": "最近 24 小時",
     "lastHour": "最近 1 小時",
@@ -149,7 +168,6 @@
     "utc": "UTC"
   },
   "triggered": "已觸發",
-  "triggerRule": "觸發規則",
   "tryNumber": "嘗試次數",
   "user": "使用者",
   "wrap": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/components.json
@@ -1,0 +1,6 @@
+{
+  "triggerDag": {
+    "button": "觸發",
+    "title": "觸發 Dag"
+  }
+}

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dags.json
@@ -4,62 +4,27 @@
     "delete": {
       "button": "刪除 Dag",
       "warning": "這將會刪除所有與此 Dag 相關的系統資料，包括 Dag 執行與任務。"
-    },
-    "trigger": {
-      "button": "觸發",
-      "triggerDag": "觸發 Dag"
     }
   },
   "filters": {
+    "allRunTypes": "全部執行類型",
+    "allStates": "全部狀態",
     "paused": {
       "active": "啟用中",
       "all": "全部",
       "paused": "暫停"
     }
   },
-  "list": {
-    "advancedSearch": "進階搜尋",
-    "clearSearch": "清除搜尋",
-    "columns": {
-      "dagId": "Dag ID",
-      "lastDagRun": "上次 Dag 執行",
-      "nextDagRun": "下次 Dag 執行",
-      "schedule": "排程",
-      "tags": "標籤"
-    },
-    "ownerLink": "擁有者 {{owner}} 的連結",
-    "searchPlaceholder": "搜尋 Dags"
-  },
+  "ownerLink": "擁有者 {{owner}} 的連結",
   "runAndTaskActions": {
+    "affectedTasks": {
+      "noItemsFound": "找不到任務。",
+      "title": "受影響的任務: {{count}}"
+    },
     "clear": {
       "button": "清除 {{type}}",
       "buttonTooltip": "按下 shift+c 清除",
-      "dialog": {
-        "affectedTasks": {
-          "columns": {
-            "runId": "執行 ID",
-            "state": "狀態",
-            "taskId": "任務 ID"
-          },
-          "noItemsFound": "找不到任務。",
-          "title": "受影響的任務: {{count}}"
-        },
-        "confirm": "確認",
-        "note": {
-          "placeholder": "新增備註...",
-          "title": "備註"
-        },
-        "options": {
-          "downstream": "下游",
-          "existingTasks": "清除現有任務",
-          "future": "未來",
-          "onlyFailed": "清除失敗任務",
-          "past": "過去",
-          "queueNew": "排隊新任務",
-          "upstream": "上游"
-        },
-        "title": "清除{{type}}"
-      }
+      "title": "清除{{type}}"
     },
     "delete": {
       "button": "刪除{{type}}",
@@ -80,31 +45,23 @@
         "failed": "按下 shift+f 標記為失敗",
         "success": "按下 shift+s 標記為成功"
       },
-      "dialog": {
-        "confirm": "確認",
-        "options": {
-          "downstream": "下游",
-          "future": "未來",
-          "past": "過去",
-          "upstream": "上游"
-        },
-        "title": "標記為{{type}}為{{state}}"
-      }
+      "title": "標記為{{type}}為{{state}}"
+    },
+    "options": {
+      "downstream": "下游",
+      "existingTasks": "清除現有任務",
+      "future": "未來",
+      "onlyFailed": "清除失敗任務",
+      "past": "過去",
+      "queueNew": "排隊新任務",
+      "upstream": "上游"
     }
   },
-  "runs": {
-    "allRunTypes": "全部執行類型",
-    "allStates": "全部狀態",
-    "columns": {
-      "dagId": "Dag ID",
-      "dagVersions": "Dag 版本",
-      "duration": "持續時間",
-      "endDate": "結束日期",
-      "runAfter": "最早可執行時間",
-      "runType": "執行類型",
-      "startDate": "開始日期",
-      "state": "狀態"
-    }
+  "search": {
+    "advanced": "進階搜尋",
+    "clear": "清除搜尋",
+    "dags": "搜尋 Dags",
+    "tasks": "搜尋任務"
   },
   "sort": {
     "displayName": {
@@ -124,22 +81,5 @@
       "desc": "依下次執行時間排序 (由遠而近)"
     },
     "placeholder": "排序方式"
-  },
-  "taskInstances": {
-    "allStates": "全部狀態",
-    "columns": {
-      "dagId": "Dag ID",
-      "dagRun": "Dag 執行",
-      "dagVersion": "Dag 版本",
-      "duration": "持續時間",
-      "endDate": "結束日期",
-      "operator": "運算子",
-      "pool": "資源池",
-      "startDate": "開始日期",
-      "state": "狀態",
-      "taskId": "任務 ID",
-      "tryNumber": "嘗試次數"
-    },
-    "searchPlaceholder": "搜尋任務"
   }
 }

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
@@ -28,7 +28,7 @@ export const DurationTick = ({ duration, ...rest }: Props) => {
 
   return (
     <Text color="border.emphasized" fontSize="xs" position="absolute" right={1} whiteSpace="nowrap" {...rest}>
-      {translate("duration.seconds", { count: Math.floor(duration) })}
+      {translate("seconds", { count: Math.floor(duration) })}
     </Text>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -105,7 +105,7 @@ export const Code = () => {
             // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
             dagVersion !== undefined && dagVersion.bundle_version !== null ? (
               <Heading as="h4" fontSize="14px" size="md" wordBreak="break-word">
-                {translate("bundleVersion")}
+                {translate("dagDetails.bundleVersion")}
                 {": "}
                 {dagVersion.bundle_url === null ? (
                   dagVersion.bundle_version

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -105,7 +105,8 @@ export const Code = () => {
             // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
             dagVersion !== undefined && dagVersion.bundle_version !== null ? (
               <Heading as="h4" fontSize="14px" size="md" wordBreak="break-word">
-                {translate("code.bundleVersion")}{" "}
+                {translate("bundleVersion")}
+                {": "}
                 {dagVersion.bundle_url === null ? (
                   dagVersion.bundle_version
                 ) : (

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -27,7 +27,7 @@ import Time from "src/components/Time";
 import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
 
 export const Details = () => {
-  const { t: translate } = useTranslation("dag");
+  const { t: translate } = useTranslation(["common", "dag"]);
   const { dagId = "" } = useParams();
 
   const { data: dag } = useDagServiceGetDagDetails({
@@ -42,7 +42,7 @@ export const Details = () => {
         <Table.Root striped>
           <Table.Body>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.dagId")}</Table.Cell>
+              <Table.Cell>{translate("dagId")}</Table.Cell>
               <Table.Cell>
                 <HStack>
                   {dag.dag_id}
@@ -53,86 +53,86 @@ export const Details = () => {
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.description")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.description")}</Table.Cell>
               <Table.Cell>{dag.description}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.timezone")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.timezone")}</Table.Cell>
               <Table.Cell>{dag.timezone}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.fileLocation")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.fileLocation")}</Table.Cell>
               <Table.Cell>
                 <Code>{dag.fileloc}</Code>
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.lastParsed")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.lastParsed")}</Table.Cell>
               <Table.Cell>
                 <Time datetime={dag.last_parsed} />
               </Table.Cell>
             </Table.Row>
             {dag.bundle_version !== null && (
               <Table.Row>
-                <Table.Cell>{translate("details.fields.bundleVersion")}</Table.Cell>
+                <Table.Cell>{translate("dagDetails.bundleName")}</Table.Cell>
                 <Table.Cell>{dag.bundle_version}</Table.Cell>
               </Table.Row>
             )}
             <Table.Row>
-              <Table.Cell>{translate("details.fields.latestDagVersion")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.latestDagVersion")}</Table.Cell>
               <Table.Cell>
                 <DagVersionDetails dagVersion={dag.latest_dag_version} />
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.startDate")}</Table.Cell>
+              <Table.Cell>{translate("startDate")}</Table.Cell>
               <Table.Cell>
                 <Time datetime={dag.start_date} />
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.endDate")}</Table.Cell>
+              <Table.Cell>{translate("endDate")}</Table.Cell>
               <Table.Cell>
                 <Time datetime={dag.end_date} />
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.lastExpired")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.lastExpired")}</Table.Cell>
               <Table.Cell>
                 <Time datetime={dag.last_expired} />
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.concurrency")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.concurrency")}</Table.Cell>
               <Table.Cell>{dag.concurrency}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.hasTaskConcurrencyLimits")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.hasTaskConcurrencyLimits")}</Table.Cell>
               <Table.Cell>{dag.has_task_concurrency_limits.toString()}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.dagRunTimeout")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.dagRunTimeout")}</Table.Cell>
               <Table.Cell>{dag.dag_run_timeout}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.maxActiveRuns")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.maxActiveRuns")}</Table.Cell>
               <Table.Cell>{dag.max_active_runs}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.maxActiveTasks")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.maxActiveTasks")}</Table.Cell>
               <Table.Cell>{dag.max_active_tasks}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.maxConsecutiveFailedDagRuns")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.maxConsecutiveFailedDagRuns")}</Table.Cell>
               <Table.Cell>{dag.max_consecutive_failed_dag_runs}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("details.fields.catchup")}</Table.Cell>
+              <Table.Cell>{translate("dagDetails.catchup")}</Table.Cell>
               <Table.Cell>{dag.catchup.toString()}</Table.Cell>
             </Table.Row>
             {dag.default_args === null ? undefined : (
               <Table.Row>
-                <Table.Cell>{translate("details.fields.defaultArgs")}</Table.Cell>
+                <Table.Cell>{translate("dagDetails.defaultArgs")}</Table.Cell>
                 <Table.Cell>
                   <RenderedJsonField content={dag.default_args} />
                 </Table.Cell>
@@ -140,7 +140,7 @@ export const Details = () => {
             )}
             {dag.params === null ? undefined : (
               <Table.Row>
-                <Table.Cell>{translate("details.fields.params")}</Table.Cell>
+                <Table.Cell>{translate("dagDetails.params")}</Table.Cell>
                 <Table.Cell>
                   <RenderedJsonField content={dag.params} />
                 </Table.Cell>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -57,7 +57,7 @@ export const Details = () => {
               <Table.Cell>{dag.description}</Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("dagDetails.timezone")}</Table.Cell>
+              <Table.Cell>{translate("common:timezone")}</Table.Cell>
               <Table.Cell>{dag.timezone}</Table.Cell>
             </Table.Row>
             <Table.Row>
@@ -72,12 +72,6 @@ export const Details = () => {
                 <Time datetime={dag.last_parsed} />
               </Table.Cell>
             </Table.Row>
-            {dag.bundle_version !== null && (
-              <Table.Row>
-                <Table.Cell>{translate("dagDetails.bundleName")}</Table.Cell>
-                <Table.Cell>{dag.bundle_version}</Table.Cell>
-              </Table.Row>
-            )}
             <Table.Row>
               <Table.Cell>{translate("dagDetails.latestDagVersion")}</Table.Cell>
               <Table.Cell>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -43,18 +43,18 @@ export const Header = ({
   readonly dagWithRuns?: DAGWithLatestDagRunsResponse;
   readonly isRefreshing?: boolean;
 }) => {
-  const { t: translate } = useTranslation("dag");
+  const { t: translate } = useTranslation(["common", "dag"]);
   // We would still like to show the dagId even if the dag object hasn't loaded yet
   const { dagId } = useParams();
   const latestRun = dagWithRuns?.latest_dag_runs ? dagWithRuns.latest_dag_runs[0] : undefined;
 
   const stats = [
     {
-      label: translate("header.stats.schedule"),
+      label: translate("dagDetails.schedule"),
       value: dagWithRuns === undefined ? undefined : <Schedule dag={dagWithRuns} />,
     },
     {
-      label: translate("header.stats.latestRun"),
+      label: translate("dagDetails.latestRun"),
       value:
         Boolean(latestRun) && latestRun !== undefined ? (
           <Link asChild color="fg.info">
@@ -71,7 +71,7 @@ export const Header = ({
         ) : undefined,
     },
     {
-      label: translate("header.stats.nextRun"),
+      label: translate("dagDetails.nextRun"),
       value: Boolean(dagWithRuns?.next_dagrun_run_after) ? (
         <DagRunInfo
           logicalDate={dagWithRuns?.next_dagrun_logical_date}
@@ -80,15 +80,15 @@ export const Header = ({
       ) : undefined,
     },
     {
-      label: translate("header.stats.owner"),
+      label: translate("dagDetails.owner"),
       value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
     },
     {
-      label: translate("header.stats.tags"),
+      label: translate("dagDetails.tags"),
       value: <DagTags tags={dag?.tags ?? []} />,
     },
     {
-      label: translate("header.stats.latestDagVersion"),
+      label: translate("dagDetails.latestDagVersion"),
       value: <DagVersion version={dag?.latest_dag_version} />,
     },
   ];
@@ -100,10 +100,10 @@ export const Header = ({
           <>
             {dag.doc_md === null ? undefined : (
               <DisplayMarkdownButton
-                header={translate("header.modals.docTitle")}
+                header={translate("dagDetails.documentation")}
                 icon={<FiBookOpen />}
                 mdContent={dag.doc_md}
-                text={translate("header.buttons.dagDocs")}
+                text={translate("dag:header.buttons.dagDocs")}
               />
             )}
             <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -36,7 +36,7 @@ type Props = {
 };
 
 export const TaskCard = ({ dagId, task }: Props) => {
-  const { t: translate } = useTranslation(["dag", "common"]);
+  const { t: translate } = useTranslation();
   const refetchInterval = useAutoRefresh({ dagId });
 
   const { data } = useTaskInstanceServiceGetTaskInstances(
@@ -66,19 +66,19 @@ export const TaskCard = ({ dagId, task }: Props) => {
       <SimpleGrid columns={4} gap={4} height={20}>
         <VStack align="flex-start" gap={1}>
           <Heading color="fg.muted" fontSize="xs">
-            {translate("common:operator")}
+            {translate("task.operator")}
           </Heading>
           <Text fontSize="sm">{task.operator_name}</Text>
         </VStack>
         <VStack align="flex-start" gap={1}>
           <Heading color="fg.muted" fontSize="xs">
-            {translate("common:triggerRule")}
+            {translate("task.triggerRule")}
           </Heading>
           <Text fontSize="sm">{task.trigger_rule}</Text>
         </VStack>
         <VStack align="flex-start" gap={1}>
           <Heading color="fg.muted" fontSize="xs">
-            {translate("task.card.lastInstance")}
+            {translate("task.lastInstance")}
           </Heading>
           {data?.task_instances[0] ? (
             <TaskInstanceTooltip taskInstance={data.task_instances[0]}>

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -71,7 +71,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
         </RouterLink>
       </Link>
     ),
-    header: translate("runAfter"),
+    header: translate("dagRun.runAfter"),
   },
   {
     accessorKey: "state",

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -59,7 +59,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
         {
           accessorKey: "dag_display_name",
           enableSorting: false,
-          header: translate("dags:runs.columns.dagId"),
+          header: translate("dagId"),
         },
       ]),
   {
@@ -71,7 +71,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
         </RouterLink>
       </Link>
     ),
-    header: translate("dags:runs.columns.runAfter"),
+    header: translate("runAfter"),
   },
   {
     accessorKey: "state",
@@ -80,7 +80,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
         original: { state },
       },
     }) => <StateBadge state={state}>{state}</StateBadge>,
-    header: () => translate("dags:runs.columns.state"),
+    header: () => translate("state"),
   },
   {
     accessorKey: "run_type",
@@ -91,22 +91,22 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
       </HStack>
     ),
     enableSorting: false,
-    header: translate("dags:runs.columns.runType"),
+    header: translate("dagRun.runType"),
   },
   {
     accessorKey: "start_date",
     cell: ({ row: { original } }) => <Time datetime={original.start_date} />,
-    header: translate("dags:runs.columns.startDate"),
+    header: translate("startDate"),
   },
   {
     accessorKey: "end_date",
     cell: ({ row: { original } }) => <Time datetime={original.end_date} />,
-    header: translate("dags:runs.columns.endDate"),
+    header: translate("endDate"),
   },
   {
     accessorKey: "duration",
     cell: ({ row: { original } }) => renderDuration(original.duration),
-    header: translate("dags:runs.columns.duration"),
+    header: translate("duration"),
   },
   {
     accessorKey: "dag_versions",
@@ -119,7 +119,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
       />
     ),
     enableSorting: false,
-    header: translate("dags:runs.columns.dagVersions"),
+    header: translate("dagRun.dagVersions"),
   },
   {
     accessorKey: "conf",
@@ -127,7 +127,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
       original.conf && Object.keys(original.conf).length > 0 ? (
         <RenderedJsonField content={original.conf} jsonProps={{ collapsed: true }} />
       ) : undefined,
-    header: translate("dags:runs.columns.conf"),
+    header: translate("dagRun.conf"),
   },
   {
     accessorKey: "actions",

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -231,7 +231,7 @@ export const DagRuns = () => {
             <Select.ValueText width="auto">
               {() =>
                 filteredState === null ? (
-                  translate("dags:runs.allStates")
+                  translate("dags:filters.allStates")
                 ) : (
                   <StateBadge state={filteredState as DagRunState}>
                     {translate(`common:states.${filteredState}`)}
@@ -262,7 +262,7 @@ export const DagRuns = () => {
             <Select.ValueText width="auto">
               {() =>
                 filteredType === null ? (
-                  translate("dags:runs.allRunTypes")
+                  translate("dags:filters.allRunTypes")
                 ) : (
                   <Flex alignItems="center" gap={1}>
                     <RunTypeIcon runType={filteredType as DagRunType} />

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -38,7 +38,7 @@ type Props = {
 };
 
 export const DagCard = ({ dag }: Props) => {
-  const { t: translate } = useTranslation(["dags", "common"]);
+  const { t: translate } = useTranslation(["common", "dag"]);
   const [latestRun] = dag.latest_dag_runs;
 
   const refetchInterval = useAutoRefresh({ isPaused: dag.is_paused });
@@ -66,10 +66,10 @@ export const DagCard = ({ dag }: Props) => {
         </HStack>
       </Flex>
       <SimpleGrid columns={4} gap={1} height={20} px={3} py={1}>
-        <Stat label={translate("list.columns.schedule")}>
+        <Stat label={translate("dagDetails.schedule")}>
           <Schedule dag={dag} />
         </Stat>
-        <Stat label={translate("list.columns.lastDagRun")}>
+        <Stat label={translate("dagDetails.latestRun")}>
           {latestRun ? (
             <Link asChild color="fg.info">
               <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}>
@@ -85,7 +85,7 @@ export const DagCard = ({ dag }: Props) => {
             </Link>
           ) : undefined}
         </Stat>
-        <Stat label={translate("list.columns.nextDagRun")}>
+        <Stat label={translate("dagDetails.nextRun")}>
           {Boolean(dag.next_dagrun_run_after) ? (
             <DagRunInfo
               logicalDate={dag.next_dagrun_logical_date}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx
@@ -38,7 +38,7 @@ export const DagOwners = ({
 
     return hasOwnerLink ? (
       <Link
-        aria-label={translate("list.ownerLink", { owner })}
+        aria-label={translate("ownerLink", { owner })}
         asChild
         color="fg.info"
         href={link}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -79,13 +79,13 @@ const createColumns = (
         <RouterLink to={`/dags/${original.dag_id}`}>{original.dag_display_name}</RouterLink>
       </Link>
     ),
-    header: () => translate("list.columns.dagId"),
+    header: () => translate("dagId"),
   },
   {
     accessorKey: "timetable_description",
     cell: ({ row: { original } }) => <Schedule dag={original} />,
     enableSorting: false,
-    header: () => translate("list.columns.schedule"),
+    header: () => translate("dagDetails.schedule"),
   },
   {
     accessorKey: "next_dagrun",
@@ -96,7 +96,7 @@ const createColumns = (
           runAfter={original.next_dagrun_run_after as string}
         />
       ) : undefined,
-    header: () => translate("list.columns.nextDagRun"),
+    header: () => translate("dagDetails.nextRun"),
   },
   {
     accessorKey: "last_run_start_date",
@@ -114,7 +114,7 @@ const createColumns = (
           </RouterLink>
         </Link>
       ) : undefined,
-    header: () => translate("list.columns.lastDagRun"),
+    header: () => translate("dagDetails.latestRun"),
   },
   {
     accessorKey: "tags",
@@ -124,7 +124,7 @@ const createColumns = (
       },
     }) => <DagTags hideIcon tags={tags} />,
     enableSorting: false,
-    header: () => translate("list.columns.tags"),
+    header: () => translate("dagDetails.tags"),
   },
   {
     accessorKey: "trigger",
@@ -160,7 +160,7 @@ const cardDef: CardDef<DAGWithLatestDagRunsResponse> = {
 const DAGS_LIST_DISPLAY = "dags_list_display";
 
 export const DagsList = () => {
-  const { t: translate } = useTranslation(["dags", "common"]);
+  const { t: translate } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [display, setDisplay] = useLocalStorage<"card" | "table">(DAGS_LIST_DISPLAY, "card");
   const dagRunsLimit = display === "card" ? 14 : 1;
@@ -242,13 +242,13 @@ export const DagsList = () => {
           buttonProps={{ disabled: true }}
           defaultValue={dagDisplayNamePattern ?? ""}
           onChange={handleSearchChange}
-          placeHolder={translate("list.searchPlaceholder")}
+          placeHolder={translate("dags:list.searchPlaceholder")}
         />
         <DagsFilters />
         <HStack justifyContent="space-between">
           <HStack>
             <Heading py={3} size="md">
-              {`${data?.total_entries ?? 0} ${(data?.total_entries ?? 0) === 1 ? translate("common:dag_one") : translate("common:dag_other")}`}
+              {`${data?.total_entries ?? 0} ${(data?.total_entries ?? 0) === 1 ? translate("dag_one") : translate("dag_other")}`}
             </Heading>
             <DAGImportErrors iconOnly />
           </HStack>
@@ -267,7 +267,7 @@ export const DagsList = () => {
           errorMessage={<ErrorAlert error={error} />}
           initialState={tableURLState}
           isLoading={isLoading}
-          modelName="Dag"
+          modelName={translate("dag_one")}
           onStateChange={setTableURLState}
           skeletonCount={display === "card" ? 5 : undefined}
           total={data?.total_entries ?? 0}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -242,7 +242,7 @@ export const DagsList = () => {
           buttonProps={{ disabled: true }}
           defaultValue={dagDisplayNamePattern ?? ""}
           onChange={handleSearchChange}
-          placeHolder={translate("dags:list.searchPlaceholder")}
+          placeHolder={translate("dags:search.dags")}
         />
         <DagsFilters />
         <HStack justifyContent="space-between">

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -36,7 +36,7 @@ export const RecentRuns = ({
 }: {
   readonly latestRuns: DAGWithLatestDagRunsResponse["latest_dag_runs"];
 }) => {
-  const { t: translate } = useTranslation(["dags", "common"]);
+  const { t: translate } = useTranslation();
 
   // Because of the styling (`row-reverse`), we need to reverse the runs so that the most recent run is on the right.
   const reversedRuns = [...latestRuns].reverse();
@@ -62,23 +62,23 @@ export const RecentRuns = ({
           content={
             <Box>
               <Text>
-                {translate("list.runs.state")}: {translate(`common:states.${run.state}`)}
+                {translate("state")}: {translate(`common:states.${run.state}`)}
               </Text>
               <Text>
-                {translate("list.runs.runAfter")}: <Time datetime={run.run_after} />
+                {translate("dagRun.runAfter")}: <Time datetime={run.run_after} />
               </Text>
               {run.start_date === null ? undefined : (
                 <Text>
-                  {translate("list.runs.startDate")}: <Time datetime={run.start_date} />
+                  {translate("startDate")}: <Time datetime={run.start_date} />
                 </Text>
               )}
               {run.end_date === null ? undefined : (
                 <Text>
-                  {translate("list.runs.endDate")}: <Time datetime={run.end_date} />
+                  {translate("endDate")}: <Time datetime={run.end_date} />
                 </Text>
               )}
               <Text>
-                {translate("list.runs.duration")}: {getDuration(run.start_date, run.end_date)}
+                {translate("duration")}: {getDuration(run.start_date, run.end_date)}
               </Text>
             </Box>
           }

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -151,7 +151,7 @@ const taskInstanceColumns = ({
   {
     accessorKey: "operator",
     enableSorting: false,
-    header: translate("taskInstance.operator"),
+    header: translate("task.operator"),
   },
   {
     cell: ({ row: { original } }) =>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -68,7 +68,7 @@ const taskInstanceColumns = ({
         {
           accessorKey: "dag_display_name",
           enableSorting: false,
-          header: translate("dags:taskInstances.columns.dagId"),
+          header: translate("dagId"),
         },
       ]),
   ...(Boolean(runId)
@@ -87,7 +87,7 @@ const taskInstanceColumns = ({
             ) : (
               <Time datetime={original.run_after} />
             ),
-          header: translate("dags:taskInstances.columns.dagRun"),
+          header: translate("dagRun_one"),
         },
       ]),
   ...(Boolean(taskId)
@@ -103,12 +103,12 @@ const taskInstanceColumns = ({
             </Link>
           ),
           enableSorting: false,
-          header: translate("dags:taskInstances.columns.taskId"),
+          header: translate("taskId"),
         },
       ]),
   {
     accessorKey: "rendered_map_index",
-    header: translate("common:mapIndex"),
+    header: translate("mapIndex"),
   },
   {
     accessorKey: "state",
@@ -117,7 +117,7 @@ const taskInstanceColumns = ({
         original: { state },
       },
     }) => <StateBadge state={state}>{translate(`common:states.${state}`)}</StateBadge>,
-    header: () => translate("dags:taskInstances.columns.state"),
+    header: () => translate("state"),
   },
   {
     accessorKey: "start_date",
@@ -131,38 +131,38 @@ const taskInstanceColumns = ({
       ) : (
         <Time datetime={original.start_date} />
       ),
-    header: translate("dags:taskInstances.columns.startDate"),
+    header: translate("startDate"),
   },
   {
     accessorKey: "end_date",
     cell: ({ row: { original } }) => <Time datetime={original.end_date} />,
-    header: translate("dags:taskInstances.columns.endDate"),
+    header: translate("endDate"),
   },
   {
     accessorKey: "try_number",
     enableSorting: false,
-    header: translate("dags:taskInstances.columns.tryNumber"),
+    header: translate("tryNumber"),
   },
   {
     accessorKey: "pool",
     enableSorting: false,
-    header: translate("dags:taskInstances.columns.pool"),
+    header: translate("taskInstance.pool"),
   },
   {
     accessorKey: "operator",
     enableSorting: false,
-    header: translate("dags:taskInstances.columns.operator"),
+    header: translate("taskInstance.operator"),
   },
   {
     cell: ({ row: { original } }) =>
       Boolean(original.start_date) ? getDuration(original.start_date, original.end_date) : "",
-    header: translate("dags:taskInstances.columns.duration"),
+    header: translate("duration"),
   },
   {
     accessorKey: "dag_version",
     cell: ({ row: { original } }) => <DagVersion version={original.dag_version} />,
     enableSorting: false,
-    header: translate("dags:taskInstances.columns.dagVersion"),
+    header: translate("taskInstance.dagVersion"),
   },
   {
     accessorKey: "actions",

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
@@ -88,7 +88,7 @@ export const TaskInstancesFilter = ({
         hideAdvanced
         hotkeyDisabled={Boolean(runId)}
         onChange={handleSearchChange}
-        placeHolder={translate("dags:taskInstances.searchPlaceholder")}
+        placeHolder={translate("dags:search.tasks")}
       />
       <Select.Root
         collection={taskInstanceStateOptions}
@@ -113,7 +113,7 @@ export const TaskInstancesFilter = ({
                   ))}
                 </HStack>
               ) : (
-                translate("dags:taskInstances.allStates")
+                translate("dags:filters.allStates")
               )
             }
           </Select.ValueText>


### PR DESCRIPTION
Clean up redundancies in our translation files:
- Have all the translations for each field on a Dag, Dag Run, and TaskInstance in one place
- Move a few shared fields (endDate, duration, dagId, runId, etc) into the top level common.json

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
