### PR TITLE
Fix asset events table title

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -44,7 +44,7 @@ type AssetEventProps = {
   readonly setOrderBy?: (order: string) => void;
   readonly setTableUrlState?: (state: TableState) => void;
   readonly tableUrlState?: TableState;
-  readonly title?: string;
+  readonly titleKey?: string;
 };
 
 export const AssetEvents = ({
@@ -54,10 +54,10 @@ export const AssetEvents = ({
   setOrderBy,
   setTableUrlState,
   tableUrlState,
-  title,
+  titleKey,
   ...rest
 }: AssetEventProps & BoxProps) => {
-  const { t: translate } = useTranslation(["dashboard", "common"]);
+  const { t: translate } = useTranslation(["dashboard", "common", "dag"]);
   const assetSortOptions = createListCollection({
     items: [
       { label: translate("sortBy.newestFirst"), value: "-timestamp" },
@@ -74,7 +74,7 @@ export const AssetEvents = ({
             {data?.total_entries ?? " "}
           </StateBadge>
           <Heading marginEnd="auto" size="md">
-            {title ?? translate("common:assetEvent", { count: data?.total_entries ?? 0 })}
+            {translate(titleKey ?? "common:assetEvent", { count: data?.total_entries ?? 0 })}
           </Heading>
         </HStack>
         {setOrderBy === undefined ? undefined : (

--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -74,7 +74,7 @@ export const AssetEvents = ({
             {data?.total_entries ?? " "}
           </StateBadge>
           <Heading marginEnd="auto" size="md">
-            {translate("common:assetEvent", { count: data?.total_entries ?? 0 })}
+            {title ?? translate("common:assetEvent", { count: data?.total_entries ?? 0 })}
           </Heading>
         </HStack>
         {setOrderBy === undefined ? undefined : (

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -17,6 +17,7 @@
     "auditLog": "Audit Log",
     "xcoms": "XComs"
   },
+  "createdAssetEvent": "Created Asset Event",
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
@@ -127,6 +128,7 @@
     "users": "Users"
   },
   "selectLanguage": "Select Language",
+  "sourceAssetEvent": "Source Asset Event",
   "startDate": "Start Date",
   "state": "State",
   "states": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -17,7 +17,8 @@
     "auditLog": "Audit Log",
     "xcoms": "XComs"
   },
-  "createdAssetEvent": "Created Asset Event",
+  "createdAssetEvent_one": "Created Asset Event",
+  "createdAssetEvent_other": "Created Asset Events",
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
@@ -128,7 +129,8 @@
     "users": "Users"
   },
   "selectLanguage": "Select Language",
-  "sourceAssetEvent": "Source Asset Event",
+  "sourceAssetEvent_one": "Source Asset Event",
+  "sourceAssetEvent_other": "Source Asset Events",
   "startDate": "Start Date",
   "state": "State",
   "states": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
@@ -24,7 +24,8 @@
       "failedTask_other": "Failed Tasks"
     },
     "charts": {
-      "assetEvent": "Created Asset Event"
+      "assetEvent_one": "Created Asset Event",
+      "assetEvent_other": "Created Asset Events"
     },
     "failedLogs": {
       "title": "Recent Failed Task Logs",

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -142,7 +142,7 @@ export const Overview = () => {
             isLoading={isLoadingAssetEvents}
             ml={0}
             setOrderBy={setAssetSortBy}
-            title={translate("overview.charts.assetEvent")}
+            titleKey="dag:overview.charts.assetEvent"
           />
         ) : undefined}
       </HStack>

--- a/airflow-core/src/airflow/ui/src/pages/Run/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/AssetEvents.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRun, useDagRunServiceGetUpstreamAssetEvents } from "openapi/queries";
@@ -24,7 +23,6 @@ import { AssetEvents as AssetEventsTable } from "src/components/Assets/AssetEven
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 export const AssetEvents = () => {
-  const { t: translate } = useTranslation(["common"]);
   const { dagId = "", runId = "" } = useParams();
 
   const refetchInterval = useAutoRefresh({ dagId });
@@ -43,5 +41,5 @@ export const AssetEvents = () => {
     refetchInterval: () => (isStatePending(dagRun?.state) ? refetchInterval : false),
   });
 
-  return <AssetEventsTable data={data} isLoading={isLoading} title={translate("sourceAssetEvent")} />;
+  return <AssetEventsTable data={data} isLoading={isLoading} titleKey="common:sourceAssetEvent" />;
 };

--- a/airflow-core/src/airflow/ui/src/pages/Run/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/AssetEvents.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRun, useDagRunServiceGetUpstreamAssetEvents } from "openapi/queries";
@@ -23,6 +24,7 @@ import { AssetEvents as AssetEventsTable } from "src/components/Assets/AssetEven
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 export const AssetEvents = () => {
+  const { t: translate } = useTranslation(["common"]);
   const { dagId = "", runId = "" } = useParams();
 
   const refetchInterval = useAutoRefresh({ dagId });
@@ -41,5 +43,5 @@ export const AssetEvents = () => {
     refetchInterval: () => (isStatePending(dagRun?.state) ? refetchInterval : false),
   });
 
-  return <AssetEventsTable data={data} isLoading={isLoading} title="Source Asset Event" />;
+  return <AssetEventsTable data={data} isLoading={isLoading} title={translate("sourceAssetEvent")} />;
 };

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/AssetEvents.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { useAssetServiceGetAssetEvents, useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
@@ -23,6 +24,7 @@ import { AssetEvents as AssetEventsTable } from "src/components/Assets/AssetEven
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 export const AssetEvents = () => {
+  const { t: translate } = useTranslation(["common"]);
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
 
   const { data: taskInstance } = useTaskInstanceServiceGetMappedTaskInstance({
@@ -47,5 +49,7 @@ export const AssetEvents = () => {
     },
   );
 
-  return <AssetEventsTable data={assetEventsData} isLoading={isLoading} title="Created Asset Event" />;
+  return (
+    <AssetEventsTable data={assetEventsData} isLoading={isLoading} title={translate("createdAssetEvent")} />
+  );
 };

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/AssetEvents.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { useAssetServiceGetAssetEvents, useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
@@ -24,7 +23,6 @@ import { AssetEvents as AssetEventsTable } from "src/components/Assets/AssetEven
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 export const AssetEvents = () => {
-  const { t: translate } = useTranslation(["common"]);
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
 
   const { data: taskInstance } = useTaskInstanceServiceGetMappedTaskInstance({
@@ -50,6 +48,6 @@ export const AssetEvents = () => {
   );
 
   return (
-    <AssetEventsTable data={assetEventsData} isLoading={isLoading} title={translate("createdAssetEvent")} />
+    <AssetEventsTable data={assetEventsData} isLoading={isLoading} titleKey="common:createdAssetEvent" />
   );
 };


### PR DESCRIPTION
Display the `title` as the asset events header.

If no title is displayed, default to the `AssetEvent` key.

### Before
![Screenshot 2025-06-12 at 16 42 29](https://github.com/user-attachments/assets/ce82509b-9e69-4c8c-8ac1-57e91b1b4b3c)
![Screenshot 2025-06-12 at 16 42 41](https://github.com/user-attachments/assets/81409dc2-4979-47c5-99f4-5db8d03f2fb0)
![Screenshot 2025-06-12 at 16 42 50](https://github.com/user-attachments/assets/4dd19ec0-f200-4292-bc7a-9a47d7cc82f3)


### After
![Screenshot 2025-06-12 at 16 40 31](https://github.com/user-attachments/assets/58374457-b351-4713-ae33-df92f3906701)

![Screenshot 2025-06-12 at 16 39 20](https://github.com/user-attachments/assets/7e62ea85-251d-4776-9048-326ede05ce89)
![Screenshot 2025-06-12 at 16 39 30](https://github.com/user-attachments/assets/86ac83bf-d13a-493d-88b2-7a80ffc53acd)
