### PR TITLE
Add some missing translations

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -59,7 +59,7 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
                   <Table.ColumnHeader colSpan={colSpan} key={id} whiteSpace="nowrap">
                     {isPlaceholder ? undefined : (
                       <Button
-                        aria-label="sort"
+                        aria-label={translate("sort")}
                         disabled={!canSort}
                         onClick={column.getToggleSortingHandler()}
                         variant="plain"

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
@@ -109,7 +109,7 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
                       label={translate("triggerDag.selectLabel")}
                       value={RunMode.SINGLE}
                     />
-                    <Tooltip content="Backfill requires a schedule" disabled={hasSchedule}>
+                    <Tooltip content={translate("backfill.tooltip")} disabled={hasSchedule}>
                       <RadioCardItem
                         description={translate("backfill.selectDescription")}
                         disabled={!hasSchedule}

--- a/airflow-core/src/airflow/ui/src/components/ui/CloseButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/CloseButton.tsx
@@ -19,12 +19,17 @@
 import type { ButtonProps as ChakraCloseButtonProps } from "@chakra-ui/react";
 import { IconButton as ChakraIconButton } from "@chakra-ui/react";
 import { forwardRef } from "react";
+import { useTranslation } from "react-i18next";
 import { LuX } from "react-icons/lu";
 
 export type CloseButtonProps = {} & ChakraCloseButtonProps;
 
-export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>((props, ref) => (
-  <ChakraIconButton aria-label="Close" ref={ref} variant="ghost" {...props}>
-    {props.children ?? <LuX />}
-  </ChakraIconButton>
-));
+export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>((props, ref) => {
+  const { t: translate } = useTranslation(["components"]);
+
+  return (
+    <ChakraIconButton aria-label={translate("close")} ref={ref} variant="ghost" {...props}>
+      {props.children ?? <LuX />}
+    </ChakraIconButton>
+  );
+});

--- a/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/de/common.json
@@ -195,7 +195,7 @@
   "tryNumber": "Versuch Nummer",
   "user": "Benutzer",
   "wrap": {
-    "tooltip": "Buchstabe w drücken um den Zeilenumbruch umzuschalten",
+    "tooltip": "Buchstabe {{hotkey}} drücken um den Zeilenumbruch umzuschalten",
     "unwrap": "Kein Zeilenumbruch",
     "wrap": "Zeilenumbruch"
   }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/admin.json
@@ -49,7 +49,8 @@
       "secondConfirmMessage": "This action is permanent and cannot be undone.",
       "thirdConfirmMessage": " Are you sure you want to proceed?"
     },
-    "selected": "Selected"
+    "selected": "Selected",
+    "tooltip": "Delete selected connections"
   },
   "formActions":{
     "reset": "Reset",
@@ -103,10 +104,12 @@
       "deleteVariable_other": "Delete {{count}} Variables",
       "firstConfirmMessage_one": "You are about to delete the following variable:",
       "firstConfirmMessage_other": "You are about to delete the following variables:",
-      "title": "Delete Variable"
+      "title": "Delete Variable",
+      "tooltip": "Delete selected variables"
     },
     "edit":  "Edit Variable",
     "export": "Export",
+    "exportTooltip": "Export selected variables",
     "form": {
       "invalidJson": "Invalid JSON",
       "keyMaxLength": "Key can contain a maximum of 250 characters",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/common.json
@@ -227,7 +227,7 @@
   "tryNumber": "Try Number",
   "user": "User",
   "wrap": {
-    "tooltip": "Press w to toggle wrap",
+    "tooltip": "Press {{hotkey}} to toggle wrap",
     "unwrap": "Unwrap",
     "wrap": "Wrap"
   }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
@@ -25,6 +25,7 @@
   "clipboard": {
     "copy": "Copy"
   },
+  "close": "Close",
   "configForm": {
     "advancedOptions": "Advanced Options",
     "configJson": "Configuration JSON",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/components.json
@@ -14,6 +14,7 @@
     "selectDescription": "Run this Dag for a range of dates",
     "selectLabel": "Backfill",
     "title": "Run Backfill",
+    "tooltip": "Backfill requires a schedule",
     "unpause": "Unpause {{dag_display_name}} on trigger"
   },
   "banner": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/en/dag.json
@@ -85,5 +85,13 @@
   "taskGroups": {
     "collapseAll": "Collapse all task groups",
     "expandAll": "Expand all task groups"
+  },
+  "taskLogs": {
+    "allLogLevels": "All Log Levels",
+    "allSources": "All Sources",
+    "fullscreen": {
+      "button": "Full screen",
+      "tooltip": "Press {{hotkey}} for fullscreen"
+    }
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/pl/common.json
@@ -188,7 +188,7 @@
   "tryNumber": "Numer próby",
   "user": "Użytkownik",
   "wrap": {
-    "tooltip": "Wybierz w aby przełączyć zawijanie",
+    "tooltip": "Wybierz {{hotkey}} aby przełączyć zawijanie",
     "unwrap": "Wyłącz zawijanie",
     "wrap": "Włącz zawijanie"
   }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -171,7 +171,7 @@
   "tryNumber": "嘗試次數",
   "user": "使用者",
   "wrap": {
-    "tooltip": "按 w 切換換行",
+    "tooltip": "按 {{hotkey}} 切換換行",
     "unwrap": "不換行",
     "wrap": "換行"
   }

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -123,7 +123,7 @@ const getColumns = ({
 ];
 
 export const Connections = () => {
-  const { t: translate } = useTranslation("admin");
+  const { t: translate } = useTranslation(["admin", "common"]);
   const { setTableURLState, tableURLState } = useTableURLState();
   const [searchParams, setSearchParams] = useSearchParams();
   const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType = SearchParamsKeys;
@@ -208,7 +208,7 @@ export const Connections = () => {
             {selectedRows.size} {translate("deleteActions.selected")}
           </ActionBar.SelectionTrigger>
           <ActionBar.Separator />
-          <Tooltip content="Delete selected connections">
+          <Tooltip content={translate("deleteActions.tooltip")}>
             <DeleteConnectionsButton
               clearSelections={clearSelections}
               deleteKeys={[...selectedRows.keys()]}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionsButton.tsx
@@ -43,7 +43,7 @@ const DeleteConnectionsButton = ({ clearSelections, deleteKeys: connectionIds }:
 
   return (
     <>
-      <Button aria-label="Delete selected connections" onClick={onOpen} size="sm" variant="outline">
+      <Button aria-label={translate("deleteActions.button")} onClick={onOpen} size="sm" variant="outline">
         <FiTrash2 /> {translate("deleteActions.button")}
       </Button>
 

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
@@ -60,7 +60,7 @@ export const Tasks = () => {
         displayMode="card"
         isFetching={isFetching}
         isLoading={isLoading}
-        modelName="Task"
+        modelName={translate("task_one")}
         total={data ? data.total_entries : 0}
       />
     </Box>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -25,6 +25,7 @@ import {
   type SelectValueChangeDetails,
 } from "@chakra-ui/react";
 import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { MdOutlineOpenInFull } from "react-icons/md";
 import { useSearchParams } from "react-router-dom";
 
@@ -56,6 +57,7 @@ export const TaskLogHeader = ({
   tryNumber,
   wrap,
 }: Props) => {
+  const { t: translate } = useTranslation(["common", "dag"]);
   const [searchParams, setSearchParams] = useSearchParams();
   const sources = searchParams.getAll(SearchParamsKeys.SOURCE);
   const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
@@ -72,7 +74,7 @@ export const TaskLogHeader = ({
     value: string;
   }>({
     items: [
-      { label: "All Sources", value: "all" },
+      { label: translate("dag:taskLogs.allSources"), value: "all" },
       ...(sourceOptions ?? []).map((source) => ({ label: source, value: source })),
     ],
   });
@@ -141,7 +143,7 @@ export const TaskLogHeader = ({
                     ))}
                   </HStack>
                 ) : (
-                  "All Log Levels"
+                  translate("dag:taskLogs.allLogLevels")
                 )
               }
             </Select.ValueText>
@@ -167,7 +169,7 @@ export const TaskLogHeader = ({
             value={sources}
           >
             <Select.Trigger clearable>
-              <Select.ValueText placeholder="All Sources" />
+              <Select.ValueText placeholder={translate("dag:taskLogs.allSources")} />
             </Select.Trigger>
             <Select.Content>
               {sourceOptionList.items.map((option) => (
@@ -179,19 +181,28 @@ export const TaskLogHeader = ({
           </Select.Root>
         ) : undefined}
         <HStack>
-          <Tooltip closeDelay={100} content="Press w to toggle wrap" openDelay={100}>
+          <Tooltip closeDelay={100} content={translate("wrap.tooltip", { hotkey: "w" })} openDelay={100}>
             <Button
-              aria-label={wrap ? "Unwrap" : "Wrap"}
+              aria-label={wrap ? translate("wrap.unwrap") : translate("wrap.wrap")}
               bg="bg.panel"
               onClick={toggleWrap}
               variant="outline"
             >
-              {wrap ? "Unwrap" : "Wrap"}
+              {wrap ? translate("wrap.unwrap") : translate("wrap.wrap")}
             </Button>
           </Tooltip>
           {!isFullscreen && (
-            <Tooltip closeDelay={100} content="Press f for fullscreen" openDelay={100}>
-              <IconButton aria-label="Full screen" bg="bg.panel" onClick={toggleFullscreen} variant="outline">
+            <Tooltip
+              closeDelay={100}
+              content={translate("dag:taskLogs.fullscreen.tooltip", { hotkey: "f" })}
+              openDelay={100}
+            >
+              <IconButton
+                aria-label={translate("dag:taskLogs.fullscreen.button")}
+                bg="bg.panel"
+                onClick={toggleFullscreen}
+                variant="outline"
+              >
                 <MdOutlineOpenInFull />
               </IconButton>
             </Tooltip>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -223,10 +223,10 @@ export const Variables = () => {
             {selectedRows.size} {translate("deleteActions.selected")}
           </ActionBar.SelectionTrigger>
           <ActionBar.Separator />
-          <Tooltip content="Delete selected variables">
+          <Tooltip content={translate("variables.delete.tooltip")}>
             <DeleteVariablesButton clearSelections={clearSelections} deleteKeys={[...selectedRows.keys()]} />
           </Tooltip>
-          <Tooltip content="Export selected variables">
+          <Tooltip content={translate("variables.exportTooltip")}>
             <Button onClick={() => downloadJson(selectedVariables, "variables")} size="sm" variant="outline">
               <FiShare />
               {translate("variables.export")}


### PR DESCRIPTION
There were a few strings not explicitly defined inside of a jsx component that I forgot to translate. I wonder how we can improve our linting to catch these in the future.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
