### PR TITLE
Update Import Error display on the UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
@@ -40,7 +40,7 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({ impor
   const [page, setPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredErrors, setFilteredErrors] = useState(importErrors);
-  const { t: translate } = useTranslation("dashboard");
+  const { t: translate } = useTranslation(["dashboard", "components"]);
 
   const startRange = (page - 1) * PAGE_LIMIT;
   const endRange = startRange + PAGE_LIMIT;

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
@@ -85,7 +85,8 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({ impor
               <Accordion.Item key={importError.import_error_id} value={importError.filename}>
                 <Accordion.ItemTrigger cursor="pointer">
                   <Text display="flex" fontWeight="bold">
-                    {translate("Bundle name:")}
+                    {translate("components:versionDetails.bundleName")}
+                    {": "}
                     {importError.bundle_name}
                   </Text>
                   <PiFilePy />

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
@@ -84,6 +84,10 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({ impor
             {visibleItems.map((importError) => (
               <Accordion.Item key={importError.import_error_id} value={importError.filename}>
                 <Accordion.ItemTrigger cursor="pointer">
+                  <Text display="flex" fontWeight="bold">
+                    {translate("Bundle name:")}
+                    {importError.bundle_name}
+                  </Text>
                   <PiFilePy />
                   {importError.filename}
                 </Accordion.ItemTrigger>


### PR DESCRIPTION
Now that the import error file location is relative, I have updated the UI part to display the bundle name along side the relative filename

![Screenshot 2025-06-12 at 23 43 16](https://github.com/user-attachments/assets/091bf714-5c76-40a8-b5ab-01bc93b5b167)

