### PR TITLE
i18n: Closing zh-TW translation gaps

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -51,6 +51,7 @@ import zhTWAssets from "./locales/zh-TW/assets.json";
 import zhTWBrowse from "./locales/zh-TW/browse.json";
 import zhTWCommon from "./locales/zh-TW/common.json";
 import zhTWComponents from "./locales/zh-TW/components.json";
+import zhTWDag from "./locales/zh-TW/dag.json";
 import zhTWDags from "./locales/zh-TW/dags.json";
 import zhTWDashboard from "./locales/zh-TW/dashboard.json";
 
@@ -115,6 +116,7 @@ const resources = {
     browse: zhTWBrowse,
     common: zhTWCommon,
     components: zhTWComponents,
+    dag: zhTWDag,
     dags: zhTWDags,
     dashboard: zhTWDashboard,
   },

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/admin.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/admin.json
@@ -44,7 +44,7 @@
     "test": "測試連線",
     "testDisabled": "測試連線功能已停用。請聯繫管理員以啟用。",
     "typeMeta": {
-      "error": "取得連線類型元資料失敗",
+      "error": "取得連線類型中繼資料失敗",
       "standardFields": {
         "description": "描述",
         "host": "主機",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/admin.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/admin.json
@@ -49,7 +49,8 @@
       "secondConfirmMessage": "此動作無法復原。",
       "thirdConfirmMessage": "您確定要繼續嗎？"
     },
-    "selected": "已選取"
+    "selected": "已選取",
+    "tooltip": "刪除所選連線"
   },
   "formActions":{
     "reset": "重置",
@@ -103,10 +104,12 @@
       "deleteVariable_other": "刪除 {{count}} 個變數",
       "firstConfirmMessage_one": "您即將刪除以下變數：",
       "firstConfirmMessage_other": "您即將刪除以下變數：",
-      "title": "刪除變數"
+      "title": "刪除變數",
+      "tooltip": "刪除所選變數"
     },
     "edit": "編輯變數",
     "export": "匯出",
+    "exportTooltip": "匯出所選變數",
     "form": {
       "invalidJson": "無效的 JSON",
       "keyMaxLength": "鍵最多只能包含 250 個字元",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/admin.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/admin.json
@@ -19,6 +19,8 @@
       "host": "主機",
       "port": "埠"
     },
+    "connection_one": "連線",
+    "connection_other": "連線",
     "delete":{
       "deleteConnection_one": "刪除 1 個連線",
       "deleteConnection_other": "刪除 {{count}} 個連線",
@@ -40,7 +42,18 @@
     "noRowMessage": "找不到連線",
     "searchPlaceholder": "搜尋連線",
     "test": "測試連線",
-    "testDisabled": "測試連線功能已停用。請聯繫管理員以啟用。"
+    "testDisabled": "測試連線功能已停用。請聯繫管理員以啟用。",
+    "typeMeta": {
+      "error": "取得連線類型元資料失敗",
+      "standardFields": {
+        "description": "描述",
+        "host": "主機",
+        "login": "登入",
+        "password": "密碼",
+        "port": "埠",
+        "url_schema": "Schema"
+      }
+    }
   },
   "deleteActions":{
     "button": "刪除",
@@ -81,6 +94,8 @@
       "slots": "配額"
     },
     "noPoolsFound": "找不到資源池",
+    "pool_one": "資源池",
+    "pool_other": "資源池",
     "searchPlaceholder": "搜尋資源池",
     "sort": {
       "asc": "名稱 (A-Z)",
@@ -139,6 +154,8 @@
       "uploadPlaceholder": "上傳包含變數的 JSON 檔案 (例如：{\"key\": \"value\", ...})"
     },
     "noRowsMessage": "找不到變數",
-    "searchPlaceholder": "搜尋鍵"
+    "searchPlaceholder": "搜尋鍵",
+    "variable_one": "變數",
+    "variable_other": "變數"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/assets.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/assets.json
@@ -1,5 +1,26 @@
 {
   "consumingDags": "消費者 Dags",
+  "createEvent": {
+    "button": "建立事件",
+    "manual": {
+      "description": "直接建立資源事件",
+      "extra": "資源事件額外資訊",
+      "label": "手動"
+    },
+    "materialize": {
+      "description": "觸發資源上游的 Dag",
+      "descriptionWithDag": "觸發此資源上游的 Dag: {{dagName}}",
+      "label": "實體化",
+      "unpauseDag": "觸發時取消暫停 {{dagName}}"
+    },
+    "success": {
+      "manualDescription": "已成功手動建立資源事件。",
+      "manualTitle": "已建立資源事件",
+      "materializeDescription": "已成功觸發上游 Dag {{dagId}}。",
+      "materializeTitle": "正在實體化資源"
+    },
+    "title": "為 {{name}} 建立資源事件"
+  },
   "group": "群組",
   "lastAssetEvent": "最後資源事件",
   "name": "名稱",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/browse.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/browse.json
@@ -17,6 +17,7 @@
       "dag": "Dag",
       "key": "鍵",
       "value": "值"
-    }
+    },
+    "title": "XCom"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -197,7 +197,7 @@
     "priorityWeight": "優先權權重",
     "queue": "排隊",
     "queuedWhen": "開始排隊時間",
-    "scheduledWhen": "排程時間",
+    "scheduledWhen": "開始排程時間",
     "triggerer": {
       "assigned": "指派的觸發器",
       "class": "觸發器類別",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -17,19 +17,44 @@
     "auditLog": "審計日誌",
     "xcoms": "XComs"
   },
+  "createdAssetEvent_one": "已建立資源事件",
+  "createdAssetEvent_other": "已建立資源事件",
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "catchup": "自動回填",
+    "concurrency": "併發數",
+    "dagRunTimeout": "Dag 執行超時",
+    "defaultArgs": "預設參數",
+    "description": "描述",
+    "documentation": "Dag 文件",
+    "fileLocation": "檔案位置",
+    "hasTaskConcurrencyLimits": "有任務併發限制",
+    "lastExpired": "最後過期時間",
+    "lastParsed": "最後解析時間",
+    "latestDagVersion": "最新 Dag 版本",
     "latestRun": "上次 Dag 執行",
+    "maxActiveRuns": "最大活躍執行數",
+    "maxActiveTasks": "最大活躍任務數",
+    "maxConsecutiveFailedDagRuns": "最大連續失敗執行數",
     "nextRun": "下次 Dag 執行",
+    "owner": "擁有者",
+    "params": "參數",
     "schedule": "排程",
     "tags": "標籤"
   },
   "dagId": "Dag ID",
   "dagRun": {
+    "conf": "設定",
     "dagVersions": "Dag 版本",
+    "dataIntervalEnd": "資料區間結束",
+    "dataIntervalStart": "資料區間開始",
+    "lastSchedulingDecision": "最後排程決策",
+    "queuedAt": "開始排隊時間",
     "runAfter": "最早可執行時間",
-    "runType": "執行類型"
+    "runType": "執行類型",
+    "sourceAssetEvent": "來源資源事件",
+    "triggeredBy": "觸發者"
   },
   "dagRun_one": "Dag 執行",
   "dagRun_other": "Dag 執行",
@@ -44,6 +69,13 @@
   },
   "duration": "時間範圍",
   "endDate": "結束日期",
+  "error": {
+    "back": "返回",
+    "defaultMessage": "發生未預期的錯誤",
+    "home": "首頁",
+    "notFound": "找不到頁面",
+    "title": "錯誤"
+  },
   "expression": {
     "all": "全部",
     "and": "且",
@@ -74,8 +106,11 @@
   },
   "noItemsFound": "找不到 {{modelName}}",
   "note": {
-    "label": "備註",
-    "placeholder": "新增備註..."
+    "add": "新增筆記",
+    "dagRun": "Dag 執行筆記",
+    "label": "筆記",
+    "placeholder": "新增筆記...",
+    "taskInstance": "任務實例筆記"
   },
   "pools": {
     "deferred": "已延後",
@@ -102,6 +137,8 @@
     "users": "使用者"
   },
   "selectLanguage": "選擇語言",
+  "sourceAssetEvent_one": "來源資源事件",
+  "sourceAssetEvent_other": "來源資源事件",
   "startDate": "開始日期",
   "state": "狀態",
   "states": {
@@ -125,7 +162,6 @@
   "table": {
     "completedAt": "完成時間",
     "createdAt": "建立時間",
-    "duration": "持續時間",
     "filterByTag": "依標籤篩選 Dags",
     "filterColumns": "篩選表格欄位",
     "filterReset_one": "重置篩選",
@@ -133,7 +169,6 @@
     "from": "從",
     "maxActiveRuns": "最大活躍執行數",
     "noTagsFound": "找不到標籤",
-    "reprocessBehavior": "重新處理行為",
     "tagMode": {
       "all": "全部",
       "any": "任何"
@@ -142,6 +177,8 @@
     "to": "到"
   },
   "task": {
+    "documentation": "任務文件",
+    "lastInstance": "最後實例",
     "operator": "運算子",
     "triggerRule": "觸發規則"
   },
@@ -150,7 +187,26 @@
   "taskId": "任務 ID",
   "taskInstance": {
     "dagVersion": "Dag 版本",
-    "pool": "資源池"
+    "executor": "執行器",
+    "executorConfig": "執行器設定",
+    "hostname": "主機名稱",
+    "maxTries": "最大嘗試次數",
+    "pid": "PID",
+    "pool": "資源池",
+    "poolSlots": "資源池配額",
+    "priorityWeight": "優先權權重",
+    "queue": "排隊",
+    "queuedWhen": "開始排隊時間",
+    "scheduledWhen": "排程時間",
+    "triggerer": {
+      "assigned": "指派的觸發器",
+      "class": "觸發器類別",
+      "createdAt": "觸發器建立時間",
+      "id": "觸發器 ID",
+      "latestHeartbeat": "最新觸發器心跳時間",
+      "title": "觸發器資訊"
+    },
+    "unixname": "Unix 名稱"
   },
   "taskInstance_one": "任務實例",
   "taskInstance_other": "任務實例",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -23,7 +23,7 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "自動回填",
-    "concurrency": "同時執行數",
+    "concurrency": "並行數",
     "dagRunTimeout": "Dag 執行超時",
     "defaultArgs": "預設參數",
     "description": "描述",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -23,20 +23,20 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "自動回填",
-    "concurrency": "併發數",
+    "concurrency": "併行數",
     "dagRunTimeout": "Dag 執行超時",
     "defaultArgs": "預設參數",
     "description": "描述",
     "documentation": "Dag 文件",
     "fileLocation": "檔案位置",
-    "hasTaskConcurrencyLimits": "有任務併發限制",
+    "hasTaskConcurrencyLimits": "有任務並行數限制",
     "lastExpired": "最後過期時間",
     "lastParsed": "最後解析時間",
     "latestDagVersion": "最新 Dag 版本",
     "latestRun": "上次 Dag 執行",
-    "maxActiveRuns": "最大活躍執行數",
-    "maxActiveTasks": "最大活躍任務數",
-    "maxConsecutiveFailedDagRuns": "最大連續失敗執行數",
+    "maxActiveRuns": "活躍執行數上限",
+    "maxActiveTasks": "活躍任務數上限",
+    "maxConsecutiveFailedDagRuns": "連續失敗執行數上限",
     "nextRun": "下次 Dag 執行",
     "owner": "擁有者",
     "params": "參數",
@@ -48,7 +48,7 @@
     "conf": "設定",
     "dagVersions": "Dag 版本",
     "dataIntervalEnd": "資料區間結束",
-    "dataIntervalStart": "資料區間開始",
+    "dataIntervalStart": "資料區間起始",
     "lastSchedulingDecision": "最後排程決策",
     "queuedAt": "開始排隊時間",
     "runAfter": "最早可執行時間",
@@ -222,6 +222,43 @@
     "placeholder": "搜尋時區",
     "title": "選擇時區",
     "utc": "UTC"
+  },
+    "toaster": {
+    "bulkDelete": {
+      "error": "批次刪除 {{resourceName}} 請求失敗",
+      "success": {
+        "description": "已成功刪除 {{count}} 個 {{resourceName}}。鍵：{{keys}}",
+        "title": "已提交批次刪除 {{resourceName}} 請求"
+      }
+    },
+    "create": {
+      "error": "建立 {{resourceName}} 請求失敗",
+      "success": {
+        "description": "{{resourceName}} 已成功建立。",
+        "title": "已提交建立 {{resourceName}} 請求"
+      }
+    },
+    "delete": {
+      "error": "刪除 {{resourceName}} 請求失敗",
+      "success": {
+        "description": "{{resourceName}} 已成功刪除。",
+        "title": "已提交刪除 {{resourceName}} 請求"
+      }
+    },
+    "import": {
+      "error": "匯入 {{resourceName}} 請求失敗",
+      "success": {
+        "description": "已成功匯入 {{count}} 個 {{resourceName}}。",
+        "title": "已提交匯入 {{resourceName}} 請求"
+      }
+    },
+    "update": {
+      "error": "更新 {{resourceName}} 請求失敗",
+      "success": {
+        "description": "{{resourceName}} 已成功更新。",
+        "title": "已提交更新 {{resourceName}} 請求"
+      }
+    }
   },
   "triggered": "已觸發",
   "tryNumber": "嘗試次數",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/common.json
@@ -23,7 +23,7 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "自動回填",
-    "concurrency": "併行數",
+    "concurrency": "同時執行數",
     "dagRunTimeout": "Dag 執行超時",
     "defaultArgs": "預設參數",
     "description": "描述",

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/components.json
@@ -1,6 +1,116 @@
 {
+  "backfill": {
+    "affected_one": "將會觸發 1 次執行。",
+    "affected_other": "將會觸發 {{count}} 次執行。",
+    "affectedNone": "沒有符合條件的執行。",
+    "backwards": "反向執行",
+    "dateRange": "日期範圍",
+    "dateRangeFrom": "從",
+    "dateRangeTo": "到",
+    "errorStartDateBeforeEndDate": "開始日期必須早於結束日期。",
+    "maxRuns": "最大活躍運行數",
+    "reprocessBehavior": "重新處理行為",
+    "run": "執行回填",
+    "selectDescription": "為指定的日期範圍補上 Dag 執行",
+    "selectLabel": "回填",
+    "title": "執行回填",
+    "tooltip": "回填功能需要 Dag 具有排程",
+    "unpause": "觸發時取消暫停 {{dag_display_name}}"
+  },
+  "banner": {
+    "backfillInProgress": "回填正在進行中",
+    "cancel": "取消回填",
+    "pause": "暫停回填",
+    "unpause": "取消暫停回填"
+  },
+  "clipboard": {
+    "copy": "複製"
+  },
+  "close": "關閉",
+  "configForm": {
+    "advancedOptions": "進階選項",
+    "configJson": "設定 JSON",
+    "invalidJson": "無效的 JSON 格式：{{errorMessage}}"
+  },
+  "dagWarnings": {
+    "error_one": "1 個錯誤",
+    "errorAndWarning": "1 個錯誤與 {{warningText}}",
+    "warning_one": "1 個警告",
+    "warning_other": "{{count}} 個警告"
+  },
+  "durationChart": {
+    "duration": "持續時間 (秒)",
+    "lastDagRun_one": "最近 1 次 Dag 執行",
+    "lastDagRun_other": "最近 {{count}} 次 Dag 執行",
+    "lastTaskInstance_one": "最近 1 次任務實例",
+    "lastTaskInstance_other": "最近 {{count}} 次任務實例",
+    "queuedDuration": "排隊等候時間",
+    "runAfter": "最早可執行時間",
+    "runDuration": "執行持續時間"
+  },
+  "fileUpload": {
+    "files_other": "{{count}} 個檔案"
+  },
+  "flexibleForm": {
+    "placeholder": "請選擇一個值",
+    "placeholderArray": "請逐行輸入，每行輸入一個字串",
+    "placeholderExamples": "開始輸入以查看選項",
+    "placeholderMulti": "可選擇單一或多個值",
+    "validationErrorArrayNotArray": "值必須是陣列格式。",
+    "validationErrorArrayNotNumbers": "陣列中的所有元素都必須是數字。",
+    "validationErrorArrayNotObject": "陣列中的所有元素都必須是物件。",
+    "validationErrorRequired": "此為必填欄位"
+  },
+  "graph": {
+    "directionDown": "由上到下",
+    "directionLeft": "由右到左",
+    "directionRight": "由左到右",
+    "directionUp": "由下到上",
+    "downloadImage": "下載圖表圖片",
+    "downloadImageError": "下載圖表圖片失敗。",
+    "downloadImageErrorTitle": "下載失敗",
+    "otherDagRuns": "+ 其他 Dag 執行",
+    "taskCount_one": "1 個任務",
+    "taskCount_other": "{{count}} 個任務",
+    "taskGroup": "任務群組"
+  },
+  "limitedList": "+ 其他 {{count}} 項",
+  "logs": {
+    "file": "檔案",
+    "in": "在",
+    "line": "行"
+  },
+  "reparseDag": "重新解析 Dag",
+  "sortedAscending": "遞增排序",
+  "sortedDescending": "遞減排序",
+  "sortedUnsorted": "未排序",
+  "taskTries": "任務嘗試次數",
+  "toggleCardView": "顯示卡片視圖",
+  "toggleTableView": "顯示表格視圖",
   "triggerDag": {
     "button": "觸發",
-    "title": "觸發 Dag"
+    "loading": "正在載入 Dag 資訊...",
+    "loadingFailed": "載入 Dag 資訊失敗，請重試。",
+    "runIdHelp": "選填 - 若未提供將會自動產生",
+    "selectDescription": "觸發此 Dag 單次執行",
+    "selectLabel": "單次執行",
+    "title": "觸發 Dag",
+    "unpause": "觸發時取消暫停 {{dagDisplayName}}"
+  },
+  "trimText": {
+    "details": "詳細資訊",
+    "empty": "空的",
+    "noContent": "無可用內容。"
+  },
+  "versionDetails": {
+    "bundleLink": "套件包連結",
+    "bundleName": "套件包名稱",
+    "bundleVersion": "套件包版本",
+    "createdAt": "建立時間",
+    "versionId": "版本 ID"
+  },
+  "versionSelect": {
+    "dagVersion": "Dag 版本",
+    "versionCode": "v{{versionCode}}"
   }
 }

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/components.json
@@ -8,14 +8,24 @@
     "dateRangeFrom": "從",
     "dateRangeTo": "到",
     "errorStartDateBeforeEndDate": "開始日期必須早於結束日期。",
-    "maxRuns": "最大活躍運行數",
+    "maxRuns": "活躍執行數上限",
     "reprocessBehavior": "重新處理行為",
     "run": "執行回填",
     "selectDescription": "為指定的日期範圍補上 Dag 執行",
     "selectLabel": "回填",
     "title": "執行回填",
+    "toaster": {
+      "success": {
+        "description": "已成功觸發回填作業。",
+        "title": "已觸發 Dag 執行"
+      }
+    },
     "tooltip": "回填功能需要 Dag 具有排程",
-    "unpause": "觸發時取消暫停 {{dag_display_name}}"
+    "unpause": "觸發時取消暫停 {{dag_display_name}}",
+    "validation": {
+      "datesRequired": "必須提供資料區間的開始與結束日期。",
+      "startBeforeEnd": "資料區間起始日期必須早於或等於結束日期。"
+    }
   },
   "banner": {
     "backfillInProgress": "回填正在進行中",
@@ -30,7 +40,7 @@
   "configForm": {
     "advancedOptions": "進階選項",
     "configJson": "設定 JSON",
-    "invalidJson": "無效的 JSON 格式：{{errorMessage}}"
+    "invalidJson": "無效的 JSON 格式: {{errorMessage}}"
   },
   "dagWarnings": {
     "error_one": "1 個錯誤",
@@ -95,6 +105,12 @@
     "selectDescription": "觸發此 Dag 單次執行",
     "selectLabel": "單次執行",
     "title": "觸發 Dag",
+    "toaster": {
+      "success": {
+        "description": "已成功觸發 Dag 執行。",
+        "title": "已觸發 Dag 執行"
+      }
+    },
     "unpause": "觸發時取消暫停 {{dagDisplayName}}"
   },
   "trimText": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dag.json
@@ -1,5 +1,5 @@
 {
-  "allRuns": "所有運行",
+  "allRuns": "所有執行",
   "blockingDeps": {
     "dependency": "依賴 (Dependencies)",
     "reason": "原因",
@@ -36,8 +36,8 @@
       "failedTaskInstance_other": "失敗的任務實例"
     },
     "charts": {
-      "assetEvent_one": "已建立資產事件",
-      "assetEvent_other": "已建立資產事件"
+      "assetEvent_one": "已建立資源事件",
+      "assetEvent_other": "已建立資源事件"
     },
     "failedLogs": {
       "title": "最近失敗任務的日誌",
@@ -60,7 +60,7 @@
         "externalConditions": "外部條件",
         "onlyTasks": "僅限任務"
       },
-      "placeholder": " (Dependencies)"
+      "placeholder": "依賴 (Dependencies)"
     },
     "graphDirection": {
       "label": "圖表方向"

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dag.json
@@ -1,0 +1,97 @@
+{
+  "allRuns": "所有運行",
+  "blockingDeps": {
+    "dependency": "依賴(Dependencies)",
+    "reason": "原因",
+    "title": "依賴(Dependencies)阻礙任務排程"
+  },
+  "code": {
+    "bundleUrl": "套件包網址",
+    "noCode": "找不到程式碼",
+    "parsedAt": "解析時間："
+  },
+  "extraLinks": "額外連結",
+  "grid": {
+    "buttons": {
+      "resetToLatest": "重設為最新",
+      "toggleGroup": "切換群組狀態"
+    }
+  },
+  "header": {
+    "buttons": {
+      "dagDocs": "Dag 文件"
+    }
+  },
+  "logs": {
+    "noTryNumber": "沒有嘗試次數",
+    "viewInExternal": "在 {{name}} 中檢視日誌(嘗試 {{attempt}})"
+  },
+  "overview": {
+    "buttons": {
+      "failedRun_one": "失敗的執行",
+      "failedRun_other": "失敗的執行",
+      "failedTask_one": "失敗的任務",
+      "failedTask_other": "失敗的任務",
+      "failedTaskInstance_one": "失敗的任務實例",
+      "failedTaskInstance_other": "失敗的任務實例"
+    },
+    "charts": {
+      "assetEvent_one": "已建立資產事件",
+      "assetEvent_other": "已建立資產事件"
+    },
+    "failedLogs": {
+      "title": "最近失敗任務的日誌",
+      "viewFullLogs": "檢視完整日誌"
+    }
+  },
+  "panel": {
+    "buttons": {
+      "options": "選項",
+      "showGraph": "顯示圖表",
+      "showGrid": "顯示網格"
+    },
+    "dagRuns": {
+      "label": "Dag 執行次數"
+    },
+    "dependencies": {
+      "label": "依賴(Dependencies)",
+      "options": {
+        "allDagDependencies": "所有 Dag 相依性",
+        "externalConditions": "外部條件",
+        "onlyTasks": "僅限任務"
+      },
+      "placeholder": "依賴(Dependencies)"
+    },
+    "graphDirection": {
+      "label": "圖表方向"
+    }
+  },
+  "tabs": {
+    "assetEvents": "資源事件",
+    "auditLog": "審計日誌",
+    "backfills": "回填",
+    "code": "程式碼",
+    "details": "詳細資訊",
+    "logs": "日誌",
+    "mappedTaskInstances_one": "任務實例 [{{count}}]",
+    "mappedTaskInstances_other": "任務實例 [{{count}}]",
+    "overview": "總覽",
+    "renderedTemplates": "渲染後的範本",
+    "runs": "執行紀錄",
+    "taskInstances": "任務實例",
+    "tasks": "任務",
+    "xcom": "XCom"
+  },
+  "taskGroups": {
+    "collapseAll": "收合所有任務群組",
+    "expandAll": "展開所有任務群組"
+  },
+  "taskLogs": {
+    "allLogLevels": "所有日誌等級",
+    "allSources": "所有來源",
+    "fullscreen": {
+      "button": "全螢幕",
+      "tooltip": "按下 {{hotkey}} 進入全螢幕"
+    }
+  }
+}

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dag.json
@@ -1,9 +1,9 @@
 {
   "allRuns": "所有運行",
   "blockingDeps": {
-    "dependency": "依賴(Dependencies)",
+    "dependency": "依賴 (Dependencies)",
     "reason": "原因",
-    "title": "依賴(Dependencies)阻礙任務排程"
+    "title": "依賴 (Dependencies) 阻礙任務排程"
   },
   "code": {
     "bundleUrl": "套件包網址",
@@ -54,16 +54,29 @@
       "label": "Dag 執行次數"
     },
     "dependencies": {
-      "label": "依賴(Dependencies)",
+      "label": "依賴 (Dependencies)",
       "options": {
         "allDagDependencies": "所有 Dag 相依性",
         "externalConditions": "外部條件",
         "onlyTasks": "僅限任務"
       },
-      "placeholder": "依賴(Dependencies)"
+      "placeholder": " (Dependencies)"
     },
     "graphDirection": {
       "label": "圖表方向"
+    }
+  },
+  "paramsFailed": "載入參數失敗",
+  "parse": {
+    "toaster": {
+      "error": {
+        "description": "Dag 解析請求失敗。可能還有待處理的解析請求。",
+        "title": "Dag 重新解析失敗"
+      },
+      "success": {
+        "description": "Dag 即將重新解析。",
+        "title": "已成功提交重新解析請求"
+      }
     }
   },
   "tabs": {

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dags.json
@@ -24,34 +24,35 @@
     "clear": {
       "button": "清除 {{type}}",
       "buttonTooltip": "按下 shift+c 清除",
-      "title": "清除{{type}}"
+      "error": "清除 {{type}} 時發生錯誤",
+      "title": "清除 {{type}}"
     },
     "delete": {
-      "button": "刪除{{type}}",
+      "button": "刪除 {{type}}",
       "dialog": {
         "resourceName": "{{type}} {{id}}",
-        "title": "刪除{{type}}",
-        "warning": "這將會刪除所有與此{{type}}相關的系統資料。"
+        "title": "刪除 {{type}}",
+        "warning": "這將會刪除所有與此 {{type}} 相關的系統資料。"
       },
-      "error": "刪除{{type}}時發生錯誤",
+      "error": "刪除 {{type}} 時發生錯誤",
       "success": {
-        "description": "{{type}}刪除請求成功。",
-        "title": "{{type}}刪除成功"
+        "description": "{{type}} 刪除請求成功。",
+        "title": "{{type}} 刪除成功"
       }
     },
     "markAs": {
-      "button": "標記為{{type}}...",
+      "button": "標記 {{type}} 為...",
       "buttonTooltip": {
         "failed": "按下 shift+f 標記為失敗",
         "success": "按下 shift+s 標記為成功"
       },
-      "title": "標記為{{type}}為{{state}}"
+      "title": "標記為 {{type}} 為 {{state}}"
     },
     "options": {
       "downstream": "下游",
       "existingTasks": "清除現有任務",
       "future": "未來",
-      "onlyFailed": "清除失敗任務",
+      "onlyFailed": "只清除失敗任務",
       "past": "過去",
       "queueNew": "排隊新任務",
       "upstream": "上游"

--- a/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dags.json
+++ b/airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/dags.json
@@ -61,6 +61,7 @@
     "advanced": "進階搜尋",
     "clear": "清除搜尋",
     "dags": "搜尋 Dags",
+    "hotkey": "+K",
     "tasks": "搜尋任務"
   },
   "sort": {


### PR DESCRIPTION
### Related PR
#50861 #51674

This PR completes all the remaining translations for zh-TW, bringing the coverage to 100%.

### Key Translations for Discussion
**assets.json**
- "unpauseDag": "觸發時取消暫停 {{dagName}}”       // "unpauseDag": "Unpause {{dagName}} on trigger”

**common.json:**
- "catchup":”自動回填",

    - `backfill` is best translated as `回填` . If I understand this correctly, `catchup` performs a similar function but is triggered automatically by the scheduler. Using the same word `回填` for both could be confusing.
    - To make the distinction clear for users, I propose the following:
        - **`catchup`**: **`自動回填`**  — *Literally: "Automatic Backfill"*
        - **`backfill`**: **`回填`**       — *Literally: "Backfill"*

- "concurrency": "併發數",
- "dataIntervalEnd": "資料區間結束",
- "lastSchedulingDecision": "最後排程決策",
- "queuedAt": "開始排隊時間"
- "scheduledWhen": "排程時間",
- “sourceAssetEvent”: "來源資源事件”
- "pid": "PID",
- "latestHeartbeat": "最新觸發器心跳時間",
- "reprocessBehavior": "重新處理行為",

**components.json:**
- "selectDescription": "為指定的日期範圍補上 Dag 執行",
- "bundleLink": "套件包連結",

**dag.json:**
- "dependency": "依賴(Dependency)",


### Screenshots

**Before**
![before](https://github.com/user-attachments/assets/5baccc30-112a-4b0f-a336-d78845c9045f)

**After**
![after](https://github.com/user-attachments/assets/bffc6393-37ac-462d-bcbf-2ba869a021c1)


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
