### PR TITLE
Reset table offset when DagFiltering changes

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -89,6 +89,7 @@ export const DagsFilters = () => {
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      searchParams.delete("offset");
       setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
@@ -105,6 +106,7 @@ export const DagsFilters = () => {
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      searchParams.delete("offset");
       setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
@@ -124,6 +126,7 @@ export const DagsFilters = () => {
       if (tags.length < 2) {
         searchParams.delete(TAGS_MATCH_MODE_PARAM);
       }
+      searchParams.delete("offset");
       setSearchParams(searchParams);
     },
     [searchParams, setSearchParams],


### PR DESCRIPTION
Remove the `offset` from the search param when we modify DagFilters.

Otherwise this would wrongly display "no result found" on the front-end but just because we are requesting an offset that does not exist. 

How to reproduce:
- Browse the dag list, going for instance to page 2 or 3. 
- Modify one of the filters of the `DagsFilters` component, see that 'no results' will appear (suposing there  isn't 2 or 3 pages of result for that filtered query), but actually there are some results.


### Before
(clicking on "failed" when on page 3 will not reset the offset to 0, API will resturn no result for page 3 + failed state ending up in no result displayed in the UI).
![Screenshot 2025-06-13 at 16 37 26](https://github.com/user-attachments/assets/cbfdd410-2d57-4a3b-b715-411696d7b178)


### After
(clicking on "failed" when on page 3 will reset the offset to 0 and display the proper result)
![Screenshot 2025-06-13 at 16 36 11](https://github.com/user-attachments/assets/89031874-ac5e-47b5-a7a2-7ab37fbc010f)
