### PR TITLE
Fixing example from adding 2 oneof_ attributes

### DIFF
--- a/providers/google/tests/system/google/cloud/dataform/example_dataform.py
+++ b/providers/google/tests/system/google/cloud/dataform/example_dataform.py
@@ -120,7 +120,6 @@ with DAG(
         region=REGION,
         repository_id=REPOSITORY_ID,
         compilation_result={
-            "git_commitish": "main",
             "workspace": (
                 f"projects/{PROJECT_ID}/locations/{REGION}/repositories/{REPOSITORY_ID}/"
                 f"workspaces/{WORKSPACE_ID}"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
The **CompilationResult** class in the Dataform documentation indicates that the attributes "git_commitish", "workspace", and "release_config" are all **oneof_** fields of the same group. This means that all are permitted, but only one is permitted at a time. If two or more are passed, then only the last one in the sequence will be used. 

The current example was passing both "git_commitish" and "workspace". While this won't throw an error, "git_commitish" will be ignored. So, passing both is misleading to someone trying to understand this operator from this example, like I was.

I just fixed the current example. There's only one example per operator and there's not any comments, so I kept it consistent with the style.

**Dataform Source:** https://cloud.google.com/python/docs/reference/dataform/latest/google.cloud.dataform_v1beta1.types.CompilationResult

**Oneofs (mutually-exclusive fields) Source:** https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields

Cheers!
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
