### PR TITLE
Update doc to highlight the statically coded hybrid executors are no longer supported in Airflow 3.0.0+

### DIFF
--- a/airflow-core/docs/core-concepts/executor/index.rst
+++ b/airflow-core/docs/core-concepts/executor/index.rst
@@ -112,6 +112,8 @@ Airflow tasks are executed ad hoc inside containers/pods. Each task is isolated 
 
     New Airflow users may assume they need to run a separate executor process using one of the Local or Remote Executors. This is not correct. The executor logic runs *inside* the scheduler process, and will run the tasks locally or not depending on the executor selected.
 
+.. _using-multiple-executors-concurrently:
+
 Using Multiple Executors Concurrently
 -------------------------------------
 
@@ -208,11 +210,13 @@ Logging works the same as the single executor use case.
 Statically-coded Hybrid Executors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are currently two "statically coded" executors, these executors are hybrids of two different executors: the :doc:`LocalKubernetesExecutor <apache-airflow-providers-cncf-kubernetes:local_kubernetes_executor>` and the :doc:`CeleryKubernetesExecutor <apache-airflow-providers-celery:celery_kubernetes_executor>`. Their implementation is not native or intrinsic to core Airflow. These hybrid executors instead make use of the ``queue`` field on Task Instances to indicate and persist which sub-executor to run on. This is a misuse of the ``queue`` field and makes it impossible to use it for its intended purpose when using these hybrid executors.
+There were two "statically coded" executors, but they are no longer supported starting from Airflow 3.0.0.
+
+These executors are hybrids of two different executors: the :doc:`LocalKubernetesExecutor <apache-airflow-providers-cncf-kubernetes:local_kubernetes_executor>` and the :doc:`CeleryKubernetesExecutor <apache-airflow-providers-celery:celery_kubernetes_executor>`. Their implementation is not native or intrinsic to core Airflow. These hybrid executors instead make use of the ``queue`` field on Task Instances to indicate and persist which sub-executor to run on. This is a misuse of the ``queue`` field and makes it impossible to use it for its intended purpose when using these hybrid executors.
 
 Executors such as these also require hand crafting new "concrete" classes to create each permutation of possible combinations of executors. This is untenable as more executors are created and leads to more maintenance overhead. Bespoke coding effort should not be required to use any combination of executors.
 
-Therefore using these types of executors is no longer recommended.
+Therefore using these types of executors is no longer supported starting from Airflow 3.0.0. It's recommended to use the :ref:`Using Multiple Executors Concurrently <using-multiple-executors-concurrently>` feature instead.
 
 
 Writing Your Own Executor

--- a/providers/celery/docs/celery_kubernetes_executor.rst
+++ b/providers/celery/docs/celery_kubernetes_executor.rst
@@ -25,6 +25,11 @@ CeleryKubernetes Executor
     ``apache-airflow-providers-cncf-kubernetes>=7.4.0`` or by installing Airflow
     with the ``celery`` and ``cncf.kubernetes`` extras: ``pip install 'apache-airflow[celery,cncf.kubernetes]'``.
 
+.. note::
+
+    ``CeleryKubernetesExecutor`` is no longer supported starting from Airflow 3.0.0. You can use the
+    :ref:`Using Multiple Executors Concurrently <using-multiple-executors-concurrently>` feature instead,
+    which provides equivalent functionality in a more flexible manner.
 
 The :class:`~airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` allows users
 to run simultaneously a ``CeleryExecutor`` and a ``KubernetesExecutor``.

--- a/providers/cncf/kubernetes/docs/local_kubernetes_executor.rst
+++ b/providers/cncf/kubernetes/docs/local_kubernetes_executor.rst
@@ -28,6 +28,12 @@ LocalKubernetes Executor
     or by installing Airflow with the ``cncf.kubernetes`` extras:
     ``pip install 'apache-airflow[cncf.kubernetes]'``.
 
+.. note::
+
+    ``LocalKubernetesExecutor`` is no longer supported starting from Airflow 3.0.0. You can use the
+    :ref:`Using Multiple Executors Concurrently <using-multiple-executors-concurrently>` feature instead,
+    which provides equivalent functionality in a more flexible manner.
+
 The :class:`~airflow.providers.cncf.kubernetes.executors.local_kubernetes_executor.LocalKubernetesExecutor` allows users
 to simultaneously run a ``LocalExecutor`` and a ``KubernetesExecutor``.
 An executor is chosen to run a task based on the task's queue.


### PR DESCRIPTION
As discussed at Slack thread https://apache-airflow.slack.com/archives/C07813CNKA8/p1749747275499659

**Background:** 
`CeleryKubernetesExecutor` and `LocalKubernetesExecutor` are no longer working in Airflow 3.0.*, which is by purpose.
But this is not being made clear enough in the documentation, causing confusion.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
