### PR TITLE
Extend command column in the edge_job table to accomodate more chars

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -73,14 +73,18 @@ class EdgeExecutor(BaseExecutor):
         inspector = inspect(engine)
         edge_job_columns = None
         with contextlib.suppress(NoSuchTableError):
-            edge_job_columns = [column["name"] for column in inspector.get_columns("edge_job")]
+            edge_job_schema = inspector.get_columns("edge_job")
+            edge_job_columns = [column["name"] for column in edge_job_schema]
+            for column in edge_job_schema:
+                if column["name"] == "command":
+                    edge_job_command_len = column["type"].length
 
         # version 0.6.0rc1 added new column concurrency_slots
         if edge_job_columns and "concurrency_slots" not in edge_job_columns:
             EdgeJobModel.metadata.drop_all(engine, tables=[EdgeJobModel.__table__])
 
-        # Increase command column size in edge_job table to support larger commands
-        if edge_job_columns and "command" in edge_job_columns:
+        # version 1.1.0 the command column was changed to VARCHAR(2048)
+        if edge_job_command_len and edge_job_command_len != 2048:
             with Session(engine) as session:
                 query = "ALTER TABLE edge_job ALTER COLUMN command TYPE VARCHAR(2048);"
                 session.execute(text(query))

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -79,6 +79,13 @@ class EdgeExecutor(BaseExecutor):
         if edge_job_columns and "concurrency_slots" not in edge_job_columns:
             EdgeJobModel.metadata.drop_all(engine, tables=[EdgeJobModel.__table__])
 
+        # Increase command column size in edge_job table to support larger commands
+        if edge_job_columns and "command" in edge_job_columns:
+            with Session(engine) as session:
+                query = "ALTER TABLE edge_job ALTER COLUMN command TYPE VARCHAR(2048);"
+                session.execute(text(query))
+                session.commit()
+
         edge_worker_columns = None
         with contextlib.suppress(NoSuchTableError):
             edge_worker_columns = [column["name"] for column in inspector.get_columns("edge_worker")]

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -84,7 +84,7 @@ class EdgeExecutor(BaseExecutor):
             EdgeJobModel.metadata.drop_all(engine, tables=[EdgeJobModel.__table__])
 
         # version 1.1.0 the command column was changed to VARCHAR(2048)
-        if edge_job_command_len and edge_job_command_len != 2048:
+        elif edge_job_command_len and edge_job_command_len != 2048:
             with Session(engine) as session:
                 query = "ALTER TABLE edge_job ALTER COLUMN command TYPE VARCHAR(2048);"
                 session.execute(text(query))

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_job.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_job.py
@@ -49,7 +49,7 @@ class EdgeJobModel(Base, LoggingMixin):
     state = Column(String(20))
     queue = Column(String(256))
     concurrency_slots = Column(Integer)
-    command = Column(String(1000))
+    command = Column(String(2048))
     queued_dttm = Column(UtcDateTime)
     edge_worker = Column(String(64))
     last_update = Column(UtcDateTime)


### PR DESCRIPTION
The `command` column in the `edge_job` table is hitting the character limit of `1000` during retires of decent sized BashOperator commands. This is causing the EdgeExecutor to crash and exit leaving the scheduler in a bad state. This PR bumps up the char limit to `2048`

Here's the snippet of the error from the scheduler logs

```
[SQL: INSERT INTO edge_job (dag_id, task_id, run_id, map_index, try_number, state, queue, concurrency_slots, command, queued_dttm, edge_worker, last_update) VALUES (%(dag_id)s, %(task_id)s, %(run_id)s, %(map_index)s, %(try_number)s, %(state)s, %(queue)s, %(concurrency_slots)s, %(command)s, %(queued_dttm)s, %(edge_worker)s, %(last_update)s)]

(Background on this error at: https://sqlalche.me/e/14/9h9h)
[2025-06-14T02:26:26.528+0000] {edge_executor.py:343} INFO - Shutting down EdgeExecutor
[2025-06-14T02:26:26.528+0000] {scheduler_job_runner.py:1031} INFO - Exited execute loop
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1890, in _execute_context
    self.dialect.do_executemany(
  File "/home/airflow/.local/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 982, in do_executemany
    context._psycopg2_fetched_rows = xtras.execute_values(
                                     ^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/psycopg2/extras.py", line 1299, in execute_values
    cur.execute(b''.join(parts))
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(1000)
