### PR TITLE
Edge list worker cli command to list active job metrics

### DIFF
--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -402,6 +402,9 @@ class TestEdgeWorker:
             "worker_name",
             "state",
             "queues",
+            "jobs_active",
+            "concurrency",
+            "free_concurrency",
             "maintenance_comment",
         ]:
             assert key in edge_workers[0]


### PR DESCRIPTION
Currently `airflow edge list-workers` only lists the worker name, state and the queues its servicing. This PR aims to provide more info on how many `jobs_active` , `concurrency` and `free_concurrency` on the edge worker host. This information is extremely useful to asses the workload and health of the worker pool
