### PR TITLE
Fix regex match for auto classification of test/example changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -739,8 +739,8 @@ def _is_test_or_example_dag_only_changes(commit_hash: str) -> bool:
 
         for file_path in changed_files:
             if not (
-                re.match(r"airflow/providers/[^/]+/tests/", file_path)
-                or re.match(r"airflow/providers/[^/]+/src/airflow/providers/[^/]+/example_dags/", file_path)
+                re.match(r"providers/[^/]+/tests/", file_path)
+                or re.match(r"providers/[^/]+/src/airflow/providers/[^/]+/example_dags/", file_path)
             ):
                 return False
         return True


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The `_is_test_or_example_dag_only_changes` function in `provider_documentation.py` was incorrectly checking for test files with an `airflow/` prefix in the path. This caused test files in paths like `providers/amazon/tests/system/amazon/aws/tests/test_aws_auth_manager.py` to be incorrectly classified as non-test changes because our CWD is root of airflow.


- Verified that test files in paths like `providers/amazon/tests/system/amazon/aws/tests/test_aws_auth_manager.py` are now correctly identified as test changes

```
_is_test_or_example_dag_only_changes("cbdc98409e7a6e2bf89c119aa07aee56c7c7ba76")
Out[3]: True

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
