### PR TITLE
Sort languages and beautify codeowner and tranlation owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,12 +35,14 @@
 # UI
 /airflow-core/src/airflow/ui/ @bbovenzi @pierrejeambrun @ryanahamilton @jscheffl @shubhamraj-git
 
-# Translations (i18n)
-airflow-core/src/airflow/ui/src/i18n/locales/de/ @jscheffl # not codeowner but engaged: @TJaniF @m1racoli
-airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/ @Lee-W
-airflow-core/src/airflow/ui/src/i18n/locales/nl/ @BasPH # not codeowner but engaged: @DjVinnii
-airflow-core/src/airflow/ui/src/i18n/locales/pl/ @potiuk @mobuchowski # not codeowner but engaged: @kacpermuda
+# Translation Owners (i18n)
+# Note: Non committer engaged translators are listed in comments prevent making file syntax invalid
+# See: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/ui/src/i18n/README.md#43-engaged-translator
+airflow-core/src/airflow/ui/src/i18n/locales/de/ @jscheffl # + @TJaniF @m1racoli
 airflow-core/src/airflow/ui/src/i18n/locales/he/ @eladkal @shahar1 @romsharon98
+airflow-core/src/airflow/ui/src/i18n/locales/nl/ @BasPH # + @DjVinnii
+airflow-core/src/airflow/ui/src/i18n/locales/pl/ @potiuk @mobuchowski # + @kacpermuda
+airflow-core/src/airflow/ui/src/i18n/locales/zh-TW/ @Lee-W
 
 # Security/Permissions
 /airflow-core/src/airflow/security/permissions.py @vincbeck


### PR DESCRIPTION
Just realized after https://lists.apache.org/thread/q49n1ow3nv188fllbqgytr7tkmw6vmtm that (1) the list is not sorted and (2) a general comment and reference to policy is good. Also just having names of engaged translators, no repeating the roles.

FYI @shahar1 