### PR TITLE
remove `test_serde_serialize_recursion_limit` to fix ci

### DIFF
--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import datetime
 import decimal
-import sys
 from importlib import metadata
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
@@ -589,11 +588,6 @@ class TestSerializers:
         bad = {CLASSNAME: 123, VERSION: 1, DATA: {}}
         with pytest.raises(ValueError, match="cannot decode"):
             decode(bad)
-
-    def test_serde_serialize_recursion_limit(self):
-        depth = sys.getrecursionlimit() - 1
-        with pytest.raises(RecursionError, match="maximum recursion depth reached for serialization"):
-            serialize(object(), depth=depth)
 
     def test_serde_deserialize_with_type_hint_stringified(self):
         fake = {"a": 1, "b": 2, "__version__": 1}


### PR DESCRIPTION
Yesterday, a PR I submitted adding a unit test for the serialize-related function was merged. However, I'm not sure why this unit test fails in CI when running the following command: `breeze testing core-tests --use-xdist --skip-db-tests --no-db-cleanup --backend none`

For now, I'm removing this test, as I've noticed it is causing failures in several PRs.

Affected PRs:
https://github.com/apache/airflow/pull/51701
https://github.com/apache/airflow/pull/51735
https://github.com/apache/airflow/pull/51698