### PR TITLE
Fix protobuf resolution knot for pip 25.1

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -102,6 +102,16 @@ dependencies = [
     "methodtools>=0.4.7",
     "opentelemetry-api>=1.27.0",
     "opentelemetry-exporter-otlp>=1.27.0",
+    # opentelemetry-proto is a transitive dependency of
+    # opentelemetry-exporter-otlp and other OpenTelemetry packages.
+    # opentelemetry-proto adds a very restrictive dependency on
+    # protobuf, causing conflicts with other packages, so to help
+    # the pip resolver we add it as a direct dependency with an upper
+    # bound, which signals to the pip resolver it is a problematic
+    # dependency and should be resolved as early as possible.
+    # This may be removed when future versions of pip are able
+    # to handle this dependency resolution automatically.
+    "opentelemetry-proto<9999",
     "packaging>=23.2",
     "pathspec>=0.9.0",
     'pendulum>=2.1.2,<4.0;python_version<"3.12"',


### PR DESCRIPTION
Related to https://github.com/apache/airflow/pull/51702.

There is a resolution "knot" involving `protobuf` when pip 25.1 attempts to resolve dependencies during CI. Many Google dependencies require `protobuf`, but `grpcio-status` and `opentelemetry-proto` often have conflicting version requirements, for example:

* `grpcio-status` 1.73.0 requires `protobuf<7.0.0,>=6.30.0`
* `opentelemetry-proto` 1.27.0 requires `protobuf<5.0,>=3.19`

Because so many packages depend on `protobuf`, pip's heuristics struggle to correctly identify which packages to backtrack on, leading to resolution too deep errors.

This change introduces a workaround by adding `opentelemetry-proto` with an upper bound to the dependency list. This signals to pip that the package should be resolved early, while the use of a very high upper bound ensures that it doesn't meaningfully restrict user environments. I considered using a requirement like `opentelemetry-proto<2!0`, but decided against it, as it felt too magical and might break tools that are not fully PEP 440 compliant.
