### PR TITLE
Enable extra_options even when extra not defined for HttpHook.run

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -159,7 +159,7 @@ class HttpHook(BaseHook):
         connection = self.get_connection(self.http_conn_id)
         self._set_base_url(connection)
         session = self._configure_session_from_auth(session, connection)
-        if connection.extra:
+        if connection.extra or extra_options:
             session = self._configure_session_from_extra(session, connection, extra_options)
         session = self._configure_session_from_mount_adapters(session)
         if self.default_headers:
@@ -298,10 +298,10 @@ class HttpHook(BaseHook):
 
         settings = session.merge_environment_settings(
             prepped_request.url,
-            proxies=extra_options.get("proxies", {}),
-            stream=extra_options.get("stream", False),
-            verify=extra_options.get("verify"),
-            cert=extra_options.get("cert"),
+            proxies=session.proxies,
+            stream=session.stream,
+            verify=session.verify,
+            cert=session.cert,
         )
 
         # Send the request.

--- a/providers/http/tests/unit/http/operators/test_http.py
+++ b/providers/http/tests/unit/http/operators/test_http.py
@@ -142,6 +142,7 @@ class TestHttpOperator:
         a dictionary that override previous' call parameters.
         """
         is_second_call: bool = False
+        extra_options_verify = extra_options["verify"]
 
         def pagination_function(response: Response) -> dict | None:
             """Paginated function which returns None at the second call."""
@@ -175,7 +176,7 @@ class TestHttpOperator:
         first_call = first_endpoint.request_history[0]
         assert first_call.headers.items() >= headers.items()
         assert first_call.body == RequestEncodingMixin._encode_params(data)
-        assert first_call.verify is extra_options["verify"]
+        assert first_call.verify == extra_options_verify
 
         # Ensure the second - paginated - call is made with parameters merged from the pagination function
         second_call = second_endpoint.request_history[0]

--- a/providers/http/tests/unit/http/sensors/test_http.py
+++ b/providers/http/tests/unit/http/sensors/test_http.py
@@ -265,6 +265,10 @@ class FakeSession:
         self.response = requests.Response()
         self.response.status_code = 200
         self.response._content = "apache/airflow".encode("ascii", "ignore")
+        self.proxies = None
+        self.stream = None
+        self.verify = False
+        self.cert = None
 
     def send(self, *args, **kwargs):
         return self.response


### PR DESCRIPTION
closes: [#51685](https://github.com/apache/airflow/issues/51685)