### PR TITLE
Mocked time.sleep to avoid actual sleep time

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_elasticache_replication_group.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_elasticache_replication_group.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 
@@ -46,7 +46,7 @@ class TestElastiCacheReplicationGroupHook:
     def setup_method(self):
         self.hook = ElastiCacheReplicationGroupHook()
         # noinspection PyPropertyAccess
-        self.hook.conn = Mock()
+        self.hook.conn = mock.Mock()
 
         # We need this for every test
         self.hook.conn.create_replication_group.return_value = {
@@ -94,7 +94,8 @@ class TestElastiCacheReplicationGroupHook:
         response = self.hook.is_replication_group_available(replication_group_id=self.REPLICATION_GROUP_ID)
         assert response in (True, False)
 
-    def test_wait_for_availability(self):
+    @mock.patch("time.sleep", return_value=None)
+    def test_wait_for_availability(self, time_mock):
         self._create_replication_group()
 
         # Test non availability
@@ -160,7 +161,8 @@ class TestElastiCacheReplicationGroupHook:
             self._raise_replication_group_not_found_exp(),
         ]
 
-    def test_wait_for_deletion(self):
+    @mock.patch("time.sleep", return_value=None)
+    def test_wait_for_deletion(self, time_mock):
         self._create_replication_group()
 
         self.hook.conn.describe_replication_groups.side_effect = self._mock_describe_side_effect()


### PR DESCRIPTION

---

I noticed that some tests in `test_elasticache_replication_group.py` do execute time.sleep in the tested methods and not mock it or use a time of 0. I thus adjusted the tests to mock time.sleep. 
I also checked the tests of all other methods in the aws provider package that use time.sleep() and none other of them actually executes it with a time >0. 

Feel free to close the PR if deemed unnecessary. 
