### PR TITLE
Update weaviate connection config

### DIFF
--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -128,10 +128,13 @@ class WeaviateHook(BaseHook):
         extras = conn.extra_dejson
         http_secure = extras.pop("http_secure", False)
         grpc_secure = extras.pop("grpc_secure", False)
-        print("[HOOK] Connecting to Weaviate with:")
-        print(f"        http_host={conn.host}")
-        print(f"        http_port={extras.get('http_port', conn.port or (443 if http_secure else 80))}")
-        print(f"        http_secure={http_secure}")
+        http_port = extras.get("http_port", conn.port or (443 if http_secure else 80))
+        self.log.debug(
+            "Connecting to Weaviate with: http_host=%s, http_port=%s, http_secure=%s",
+            conn.host,
+            http_port,
+            http_secure,
+        )
         return weaviate.connect_to_custom(
             http_host=conn.host,
             http_port=extras.get("http_port", conn.port or (443 if http_secure else 80)),

--- a/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/hooks/weaviate.py
@@ -128,9 +128,13 @@ class WeaviateHook(BaseHook):
         extras = conn.extra_dejson
         http_secure = extras.pop("http_secure", False)
         grpc_secure = extras.pop("grpc_secure", False)
+        print("[HOOK] Connecting to Weaviate with:")
+        print(f"        http_host={conn.host}")
+        print(f"        http_port={extras.get('http_port', conn.port or (443 if http_secure else 80))}")
+        print(f"        http_secure={http_secure}")
         return weaviate.connect_to_custom(
             http_host=conn.host,
-            http_port=conn.port or 443 if http_secure else 80,
+            http_port=extras.get("http_port", conn.port or (443 if http_secure else 80)),
             http_secure=http_secure,
             grpc_host=extras.pop("grpc_host", conn.host),
             grpc_port=extras.pop("grpc_port", 443 if grpc_secure else 80),

--- a/providers/weaviate/tests/unit/weaviate/hooks/test_weaviate.py
+++ b/providers/weaviate/tests/unit/weaviate/hooks/test_weaviate.py
@@ -16,13 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import json
 from unittest import mock
 from unittest.mock import MagicMock, Mock
 
 import pandas as pd
 import pytest
 import requests
-import json
 
 weaviate = pytest.importorskip("weaviate")
 from weaviate import ObjectAlreadyExistsException  # noqa: E402
@@ -249,7 +249,7 @@ class TestWeaviateHook:
             auth_credentials=mock_auth_client_password(username="login", password="password", scope=None),
             headers={},
         )
-    
+
     @mock.patch("airflow.providers.weaviate.hooks.weaviate.weaviate.connect_to_custom")
     def test_get_conn_localhost_with_explicit_port(self, mock_connect, mock_auth_client_password):
         conn = Connection(
@@ -257,12 +257,9 @@ class TestWeaviateHook:
             host="localhost",
             port=8080,
             conn_type="weaviate",
-            extra=json.dumps({
-                "http_secure": False,
-                "grpc_host": "localhost",
-                "grpc_port": 50051,
-                "grpc_secure": False
-            }),
+            extra=json.dumps(
+                {"http_secure": False, "grpc_host": "localhost", "grpc_port": 50051, "grpc_secure": False}
+            ),
         )
         with mock.patch.object(WeaviateHook, "get_connection", return_value=conn):
             hook = WeaviateHook(conn_id="weaviate_local")
@@ -278,6 +275,7 @@ class TestWeaviateHook:
             headers={},
             auth_credentials=mock_auth_client_password(username="", password="", scope=None),
         )
+
     @mock.patch("airflow.providers.weaviate.hooks.weaviate.weaviate.connect_to_custom")
     def test_get_conn_weaviate_cloud(self, mock_connect_to_custom, mock_auth_api_key):
         cloud_host = "myinstance.c0.us-east1.gcp.weaviate.cloud"
@@ -286,13 +284,15 @@ class TestWeaviateHook:
             host=cloud_host,
             port=443,
             conn_type="weaviate",
-            extra=json.dumps({
-                "http_secure": True,
-                "grpc_secure": True,
-                "grpc_host": f"grpc-{cloud_host}",
-                "grpc_port": 443,
-                "token": "fake-api-key"
-            }),
+            extra=json.dumps(
+                {
+                    "http_secure": True,
+                    "grpc_secure": True,
+                    "grpc_host": f"grpc-{cloud_host}",
+                    "grpc_port": 443,
+                    "token": "fake-api-key",
+                }
+            ),
         )
 
         with mock.patch.object(WeaviateHook, "get_connection", return_value=conn):
@@ -310,7 +310,6 @@ class TestWeaviateHook:
             headers={},
             auth_credentials=mock_auth_api_key(api_key="fake-api-key"),
         )
-
 
     @mock.patch("airflow.providers.weaviate.hooks.weaviate.generate_uuid5")
     def test_create_object(self, mock_gen_uuid, weaviate_hook):


### PR DESCRIPTION
## Summary

- Fix port handling logic in WeaviateHook to respect connection port settings input from the Weaviate Connection form in Airflow
- Add comprehensive unit tests for localhost and cloud connection scenarios
- No related issue reported by customer

## Test plan Updates
- [x] Added unit test for localhost connection with explicit port (8080)
- [x] Added unit test for Weaviate Cloud connection with secure port (443)
- [x] Verified port logic works correctly for different connection types
- [x] All existing tests continue to pass

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
