### PR TITLE
Move MESSAGE_QUEUE_PROVIDERS array to where it belongs - to msq_queue

### DIFF
--- a/providers/common/messaging/src/airflow/providers/common/messaging/providers/__init__.py
+++ b/providers/common/messaging/src/airflow/providers/common/messaging/providers/__init__.py
@@ -16,22 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import importlib
-
-from airflow.providers_manager import ProvidersManager
 from airflow.utils.deprecation_tools import add_deprecated_classes
-
-providers_manager = ProvidersManager()
-providers_manager.initialize_providers_queues()
-
-
-def create_class_by_name(name: str):
-    module_name, class_name = name.rsplit(".", 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
-
-
-MESSAGE_QUEUE_PROVIDERS = [create_class_by_name(name)() for name in providers_manager.queue_class_names]
 
 __deprecated_classes = {
     "sqs": {

--- a/providers/common/messaging/src/airflow/providers/common/messaging/triggers/msg_queue.py
+++ b/providers/common/messaging/src/airflow/providers/common/messaging/triggers/msg_queue.py
@@ -17,12 +17,25 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
 from collections.abc import AsyncIterator
 from functools import cached_property
 from typing import Any
 
-from airflow.providers.common.messaging.providers import MESSAGE_QUEUE_PROVIDERS
+from airflow.providers_manager import ProvidersManager
 from airflow.triggers.base import BaseEventTrigger, TriggerEvent
+
+providers_manager = ProvidersManager()
+providers_manager.initialize_providers_queues()
+
+
+def create_class_by_name(name: str):
+    module_name, class_name = name.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
+
+
+MESSAGE_QUEUE_PROVIDERS = [create_class_by_name(name)() for name in providers_manager.queue_class_names]
 
 
 class MessageQueueTrigger(BaseEventTrigger):

--- a/providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py
+++ b/providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py
@@ -22,7 +22,8 @@ from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTr
 
 
 @mock.patch(
-    "airflow.providers.common.messaging.providers.MESSAGE_QUEUE_PROVIDERS", new_callable=mock.PropertyMock
+    "airflow.providers.common.messaging.triggers.msg_queue.MESSAGE_QUEUE_PROVIDERS",
+    new_callable=mock.PropertyMock,
 )
 def test_provider_integrations(_):
     trigger = MessageQueueTrigger(queue="any queue")


### PR DESCRIPTION
The MESSAGE_QUEUE_PROVIDERS array was defined in the `__init__.py` of the provider and it was pretty wrong because it was evaluated when the provider was imported - so it was impossible to import the base provider without initializing the arraym which caused circular import.

Fixes: #51770

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
