### PR TITLE
Remove unnecessary logs while retrieving connections / variables

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -138,7 +138,7 @@ def _get_connection(conn_id: str) -> Connection:
                 type(secrets_backend).__name__,
             )
 
-    if len(backends):
+    if backends:
         log.debug(
             "Connection not found in any of the configured Secrets Backends. Trying to retrieve from API server",
             conn_id=conn_id,
@@ -193,7 +193,7 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
                 type(secrets_backend).__name__,
             )
 
-    if len(backends):
+    if backends:
         log.debug(
             "Variable not found in any of the configured Secrets Backends. Trying to retrieve from API server",
             key=key,

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -125,7 +125,8 @@ def _get_connection(conn_id: str) -> Connection:
     # enabled only if SecretCache.init() has been called first
 
     # iterate over configured backends if not in cache (or expired)
-    for secrets_backend in ensure_secrets_backend_loaded():
+    backends = ensure_secrets_backend_loaded()
+    for secrets_backend in backends:
         try:
             conn = secrets_backend.get_connection(conn_id=conn_id)
             if conn:
@@ -137,10 +138,11 @@ def _get_connection(conn_id: str) -> Connection:
                 type(secrets_backend).__name__,
             )
 
-    log.debug(
-        "Connection not found in any of the configured Secrets Backends. Trying to retrieve from API server",
-        conn_id=conn_id,
-    )
+    if len(backends):
+        log.debug(
+            "Connection not found in any of the configured Secrets Backends. Trying to retrieve from API server",
+            conn_id=conn_id,
+        )
 
     # TODO: This should probably be moved to a separate module like `airflow.sdk.execution_time.comms`
     #   or `airflow.sdk.execution_time.connection`
@@ -172,8 +174,9 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
     from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
 
     var_val = None
+    backends = ensure_secrets_backend_loaded()
     # iterate over backends if not in cache (or expired)
-    for secrets_backend in ensure_secrets_backend_loaded():
+    for secrets_backend in backends:
         try:
             var_val = secrets_backend.get_variable(key=key)  # type: ignore[assignment]
             if var_val is not None:
@@ -190,10 +193,11 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
                 type(secrets_backend).__name__,
             )
 
-    log.debug(
-        "Variable not found in any of the configured Secrets Backends. Trying to retrieve from API server",
-        key=key,
-    )
+    if len(backends):
+        log.debug(
+            "Variable not found in any of the configured Secrets Backends. Trying to retrieve from API server",
+            key=key,
+        )
 
     # TODO: This should probably be moved to a separate module like `airflow.sdk.execution_time.comms`
     #   or `airflow.sdk.execution_time.variable`


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When connection / secrets backend isnt setup, we should not log that those entities aren't found there.
It leads to wrong information and confusion.

DAG used:
```
from __future__ import annotations

from airflow.models.baseoperator import BaseOperator
from airflow import DAG
from airflow.sdk.definitions.connection import Connection


class CustomOperator(BaseOperator):
    def execute(self, context):
        gc = Connection.get("athena_default")
        print("The conn is", gc)
        # print("Conn uri is", gc.get_uri())


with DAG("example_get_connection_from_defn", schedule=None, catchup=False) as dag:
    CustomOperator(task_id="print_conn")
```

No backend configured, logs show:
```
[2025-06-16, 17:55:11] INFO - 2025-06-16 12:25:11 [debug    ] DAG file parsed                [task] file=example-metadatadb-backend.py: chan="stdout": source="task"
[2025-06-16, 17:55:11] INFO - 2025-06-16 12:25:11 [debug    ] Connection not found in any of the configured Secrets Backends. Trying to retrieve from API server [task] conn_id=athena_default: chan="stdout": source="task"
[2025-06-16, 17:55:[11](http://localhost:28080/dags/example_get_connection_from_defn/runs/manual__2025-06-16T12:25:06.782393+00:00/tasks/print_conn?try_number=1#11)] INFO - The conn is Connection(conn_id='athena_default', conn_type='athena', description=None, host=None, schema=None, login=None, password=None, port=None, extra=None): chan="stdout": source="task"
```

After fix:

```
DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-06-16, 18:06:[3](http://localhost:28080/dags/example_get_connection_from_defn/runs/manual__2025-06-16T12:36:33.447212+00:00/tasks/print_conn?try_number=1#3)3] INFO - Filling up the DagBag from /files/dags/example-metadatadb-backend.py: source="airflow.models.dagbag.DagBag"
[2025-06-16, 18:06:33] INFO - The conn is Connection(conn_id='athena_default', conn_type='athena', description=None, host=None, schema=None, login=None, password=None, port=None, extra=None): chan="stdout": source="task"
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
