### PR TITLE
Relax databricks test a bit to support compatibility with older version of it

### DIFF
--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
@@ -37,6 +37,8 @@ COPY_FILE_LOCATION = "s3://my-bucket/jsonData"
 
 
 def test_copy_with_files():
+    import re
+
     op = DatabricksCopyIntoOperator(
         file_location=COPY_FILE_LOCATION,
         file_format="JSON",
@@ -45,15 +47,15 @@ def test_copy_with_files():
         format_options={"dateFormat": "yyyy-MM-dd"},
         task_id=TASK_ID,
     )
-    assert (
-        op._create_sql_query()
-        == f"""COPY INTO test
-FROM '{COPY_FILE_LOCATION}'
-FILEFORMAT = JSON
-FILES = ARRAY('file1','file2','file3')
-FORMAT_OPTIONS ('dateFormat' = 'yyyy-MM-dd')
-""".strip()
+    sql = op._create_sql_query()
+    expected_pattern = (
+        rf"COPY INTO test\s+FROM '{COPY_FILE_LOCATION}'\s+"
+        r"FILEFORMAT = JSON\s+"
+        r"(FILES = (ARRAY\(|\())'file1','file2','file3'\)?\s+"
+        r"FORMAT_OPTIONS \('dateFormat' = 'yyyy-MM-dd'\)"
     )
+
+    assert re.fullmatch(expected_pattern, sql.strip(), flags=re.MULTILINE)
 
 
 def test_copy_with_expression():

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
@@ -50,7 +50,7 @@ def test_copy_with_files():
         == f"""COPY INTO test
 FROM '{COPY_FILE_LOCATION}'
 FILEFORMAT = JSON
-FILES = ('file1','file2','file3')
+FILES = ARRAY('file1','file2','file3')
 FORMAT_OPTIONS ('dateFormat' = 'yyyy-MM-dd')
 """.strip()
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Databricks-sql-connector released a new version: https://pypi.org/project/databricks-sql-connector/4.0.4/ which breaks our compat tests. This is because the new version converts files to ARRAY type.

```
=========================== short test summary info ============================
FAILED providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py::test_copy_with_files - assert equals failed
  "COPY INTO test\nFROM 's3://my-  "COPY INTO test\nFROM 's3://my- 
  bucket/jsonData'\nFILEFORMAT =   bucket/jsonData'\nFILEFORMAT =  
  JSON\nFILES = ARRAY('file1','fi  JSON\nFILES = ('file1','file2', 
  le2','file3')\nFORMAT_OPTIONS (  'file3')\nFORMAT_OPTIONS ('date 
  'dateFormat' = 'yyyy-MM-dd')"    Format' = 'yyyy-MM-dd')"
= 1 failed, 7474 passed, 161 skipped, 1 xfailed, 1 warning in 1065.64s (0:17:45) =
```

Example: https://github.com/apache/airflow/actions/runs/15680409547/job/44170737488?pr=51782

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
