### PR TITLE
[v3-0-test] Reset table offset when DagFiltering changes (#51694)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -40,6 +40,7 @@ import { pluralize } from "src/utils";
 
 const {
   LAST_DAG_RUN_STATE: LAST_DAG_RUN_STATE_PARAM,
+  OFFSET: OFFSET_PARAM,
   PAUSED: PAUSED_PARAM,
   TAGS: TAGS_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
@@ -86,6 +87,7 @@ export const DagsFilters = () => {
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      searchParams.delete(OFFSET_PARAM);
       setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
@@ -102,6 +104,7 @@ export const DagsFilters = () => {
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      searchParams.delete(OFFSET_PARAM);
       setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
@@ -117,6 +120,7 @@ export const DagsFilters = () => {
       tags.forEach(({ value }) => {
         searchParams.append(TAGS_PARAM, value);
       });
+      searchParams.delete(OFFSET_PARAM);
       setSearchParams(searchParams);
     },
     [searchParams, setSearchParams],


### PR DESCRIPTION
(cherry picked from commit 5de7cda70478ff43c3b7fb995092900750fb7996)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
