### PR TITLE
Chart: Always deploy jwt secret

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -98,7 +98,7 @@ If release name contains chart name it will be used as a full name.
         name: {{ template "webserver_secret_key_secret" . }}
         key: webserver-secret-key
   {{- end }}
-  {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__API_AUTH__JWT_SECRET }}
+  {{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.enableBuiltInSecretEnvVars.AIRFLOW__API_AUTH__JWT_SECRET }}
   - name: AIRFLOW__API_AUTH__JWT_SECRET
     valueFrom:
       secretKeyRef:

--- a/chart/templates/secrets/jwt-secret.yaml
+++ b/chart/templates/secrets/jwt-secret.yaml
@@ -20,6 +20,7 @@
 ############################################
 ## Airflow JWT Secret
 ############################################
+{{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
 {{- if not .Values.jwtSecretName }}
 {{ $generated_secret_key := (randAlphaNum 32 | b64enc) }}
 apiVersion: v1
@@ -35,11 +36,8 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
 type: Opaque
 data:
   jwt-secret: {{ (default $generated_secret_key .Values.jwtSecret) | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -38,7 +38,6 @@ OBJECTS_STD_NAMING = {
     ("Secret", "test-basic-airflow-metadata"),
     ("Secret", "test-basic-broker-url"),
     ("Secret", "test-basic-fernet-key"),
-    ("Secret", "test-basic-airflow-jwt-secret"),
     ("Secret", "test-basic-airflow-webserver-secret-key"),
     ("Secret", "test-basic-redis-password"),
     ("Secret", "test-basic-postgresql"),
@@ -72,6 +71,7 @@ DEFAULT_OBJECTS_STD_NAMING = OBJECTS_STD_NAMING.union(
         ("Deployment", "test-basic-airflow-dag-processor"),
         ("ServiceAccount", "test-basic-airflow-api-server"),
         ("ServiceAccount", "test-basic-airflow-dag-processor"),
+        ("Secret", "test-basic-airflow-jwt-secret"),
     }
 )
 
@@ -137,7 +137,6 @@ class TestBaseChartTest:
             ("Secret", "test-basic-metadata"),
             ("Secret", "test-basic-broker-url"),
             ("Secret", "test-basic-fernet-key"),
-            ("Secret", "test-basic-jwt-secret"),
             ("Secret", "test-basic-webserver-secret-key"),
             ("Secret", "test-basic-postgresql"),
             ("Secret", "test-basic-redis-password"),
@@ -172,6 +171,7 @@ class TestBaseChartTest:
                     ("ServiceAccount", "test-basic-api-server"),
                     ("ServiceAccount", "test-basic-dag-processor"),
                     ("Service", "test-basic-triggerer"),
+                    ("Secret", "test-basic-jwt-secret"),
                 )
             )
         else:
@@ -238,7 +238,6 @@ class TestBaseChartTest:
             ("Secret", "test-basic-metadata"),
             ("Secret", "test-basic-broker-url"),
             ("Secret", "test-basic-fernet-key"),
-            ("Secret", "test-basic-jwt-secret"),
             ("Secret", "test-basic-webserver-secret-key"),
             ("Secret", "test-basic-postgresql"),
             ("Secret", "test-basic-redis-password"),
@@ -272,6 +271,7 @@ class TestBaseChartTest:
                     ("Deployment", "test-basic-api-server"),
                     ("Service", "test-basic-api-server"),
                     ("ServiceAccount", "test-basic-api-server"),
+                    ("Secret", "test-basic-jwt-secret"),
                 }
             )
         else:

--- a/helm-tests/tests/helm_tests/security/test_rbac.py
+++ b/helm-tests/tests/helm_tests/security/test_rbac.py
@@ -46,7 +46,6 @@ DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES = [
     ("StatefulSet", "test-rbac-worker"),
     ("Secret", "test-rbac-broker-url"),
     ("Secret", "test-rbac-fernet-key"),
-    ("Secret", "test-rbac-jwt-secret"),
     ("Secret", "test-rbac-redis-password"),
     ("Secret", "test-rbac-webserver-secret-key"),
     ("Job", "test-rbac-create-user"),
@@ -122,6 +121,7 @@ class TestRBAC:
                     ("Service", "test-rbac-api-server"),
                     ("Deployment", "test-rbac-api-server"),
                     ("Deployment", "test-rbac-dag-processor"),
+                    ("Secret", "test-rbac-jwt-secret"),
                 )
             )
             if sa:


### PR DESCRIPTION
While using a pre-install hook is nice since the secret doesn't change, the downside is on upgrade the jwt secret will never be added. As this is a new secret for 3.0, that is more problematic than having a changing secret. Plus, it's best practice to set this explicitly anyway.

Follow up of #49923.