### PR TITLE
Delete import error when a dag bundle becomes inactive

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -141,7 +141,7 @@ class DagBundlesManager(LoggingMixin):
             from airflow.models.errors import ParseImportError
 
             session.execute(delete(ParseImportError).where(ParseImportError.bundle_name == name))
-            self.log.info("Deleted import errors for bundle %s which no longer exists", name)
+            self.log.info("Deleted import errors for bundle %s which is no longer configured", name)
 
         if inactive_bundle_names and active_bundle_names:
             new_bundle_name = sorted(active_bundle_names)[0]

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sqlalchemy import delete
+
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.models.dag_version import DagVersion
@@ -136,6 +138,10 @@ class DagBundlesManager(LoggingMixin):
             bundle.active = False
             inactive_bundle_names.append(name)
             self.log.warning("DAG bundle %s is no longer found in config and has been disabled", name)
+            from airflow.models.errors import ParseImportError
+
+            session.execute(delete(ParseImportError).where(ParseImportError.bundle_name == name))
+            self.log.info("Deleted import errors for bundle %s which no longer exists", name)
 
         if inactive_bundle_names and active_bundle_names:
             new_bundle_name = sorted(active_bundle_names)[0]


### PR DESCRIPTION
Currently, when a bundle is marked as inactive, its associated import errors continue to appear. To resolve this, we delete the import errors at the moment the bundle is deactivated.