### PR TITLE
Reduce log noise from K8s Pod Operator for XCom

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -630,7 +630,7 @@ class KubernetesPodOperator(BaseOperator):
             self.log.info("xcom result file is empty.")
             return None
 
-        self.log.info("xcom result: \n%s", result)
+        self.log.debug("xcom result: \n%s", result)
         return json.loads(result)
 
     def execute(self, context: Context):


### PR DESCRIPTION
Had an excessive day checking for problems today and realized that K8sPodOperator produces a bit too much log noise in my view. I think it is okay to inform if no XCom is found but printing the XCom to logs is actually not needed as it is published as XCom anyway.

Therefore I propose to remove this... actually propose to keep it for debugging purposes but propose to keep logs clean in usual operations.

I am not sure if there is any legacy reason behind this. let me know if this is an important "feature". Then I can add (oh not yet another) config flag.