### PR TITLE
Bump google-cloud-spanner>=3.50

### DIFF
--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -109,9 +109,7 @@ dependencies = [
     "google-cloud-pubsub>=2.21.3",
     "google-cloud-redis>=2.12.0",
     "google-cloud-secret-manager>=2.16.0",
-    # Google Cloud spanner 3.49.0 is excluded due to a bug in the library (missing grpc_interceptor)
-    # See https://github.com/googleapis/python-spanner/issues/1193
-    "google-cloud-spanner>=3.11.1,!=3.49.0",
+    "google-cloud-spanner>=3.50.0",
     "google-cloud-speech>=2.18.0",
     "google-cloud-storage>=2.7.0",
     "google-cloud-storage-transfer>=1.4.1",


### PR DESCRIPTION
google-cloud-spanner 3.11 is from 2021 updating to help pip resolver work more efficiently.