### PR TITLE
Bump pyexasol>=0.26.0

### DIFF
--- a/providers/exasol/pyproject.toml
+++ b/providers/exasol/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
-    "pyexasol>=0.5.1",
+    "pyexasol>=0.26.0",
     # In pandas 2.2 minimal version of the sqlalchemy is 2.0
     # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies
     # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723


### PR DESCRIPTION
pyexasol 0.5.1 is from 2018. Updating to help pip resolver work faster