### PR TITLE
typo fix: Remove stray 'ń' from SBOM_INDEX_TEMPLATE

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/sbom_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/sbom_commands.py
@@ -108,7 +108,7 @@ def sbom():
 SBOM_INDEX_TEMPLATE = """
 {% set project_name = " " + provider_id + " " if provider_id else " " -%}
 <html>
-<head><title>CycloneDX SBOMs for Apache Airflow{{project_name}}{{ version }}</title></head>ń
+<head><title>CycloneDX SBOMs for Apache Airflow{{project_name}}{{ version }}</title></head>
 <body>
     <h1>CycloneDX SBOMs for Apache Airflow{{project_name}}{{ version }}</h1>
     <ul>


### PR DESCRIPTION
Related: #51791

Delete an unintended Unicode character (ń) that was accidentally appended to the <title> line, so the generated HTML is valid.