### PR TITLE
Refactor bulk TI deletion endpoint to handle map_index

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/common.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/common.py
@@ -28,6 +28,7 @@ from typing import Annotated, Any, Generic, Literal, TypeVar, Union
 from pydantic import Discriminator, Field, Tag
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
+from airflow.api_fastapi.core_api.datamodels.task_instances import BulkTaskInstanceBody
 
 # Common Bulk Data Models
 T = TypeVar("T")
@@ -83,7 +84,10 @@ class BulkDeleteAction(BulkBaseAction[T]):
     """Bulk Delete entity serializer for request bodies."""
 
     action: Literal[BulkAction.DELETE] = Field(description="The action to be performed on the entities.")
-    entities: list[str] = Field(..., description="A list of entity id/key to be deleted.")
+    entities: list[Union[str, BulkTaskInstanceBody]] = Field(
+        ...,
+        description="A list of entity id/key or entity objects to be deleted.",
+    )
     action_on_non_existence: BulkActionNotOnExistence = BulkActionNotOnExistence.FAIL
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -8528,10 +8528,12 @@ components:
           description: The action to be performed on the entities.
         entities:
           items:
-            type: string
+            anyOf:
+            - type: string
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
-          description: A list of entity id/key to be deleted.
+          description: A list of entity id/key or entity objects to be deleted.
         action_on_non_existence:
           $ref: '#/components/schemas/BulkActionNotOnExistence'
           default: fail
@@ -8550,10 +8552,12 @@ components:
           description: The action to be performed on the entities.
         entities:
           items:
-            type: string
+            anyOf:
+            - type: string
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
-          description: A list of entity id/key to be deleted.
+          description: A list of entity id/key or entity objects to be deleted.
         action_on_non_existence:
           $ref: '#/components/schemas/BulkActionNotOnExistence'
           default: fail
@@ -8572,10 +8576,12 @@ components:
           description: The action to be performed on the entities.
         entities:
           items:
-            type: string
+            anyOf:
+            - type: string
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
-          description: A list of entity id/key to be deleted.
+          description: A list of entity id/key or entity objects to be deleted.
         action_on_non_existence:
           $ref: '#/components/schemas/BulkActionNotOnExistence'
           default: fail
@@ -8594,10 +8600,12 @@ components:
           description: The action to be performed on the entities.
         entities:
           items:
-            type: string
+            anyOf:
+            - type: string
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
-          description: A list of entity id/key to be deleted.
+          description: A list of entity id/key or entity objects to be deleted.
         action_on_non_existence:
           $ref: '#/components/schemas/BulkActionNotOnExistence'
           default: fail

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -261,21 +261,69 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         self, action: BulkDeleteAction[BulkTaskInstanceBody], results: BulkActionResponse
     ) -> None:
         """Bulk delete task instances."""
-        to_delete_task_keys = set((task_id, -1) for task_id in action.entities)
-        _, matched_task_keys, not_found_task_keys = self.categorize_task_instances(to_delete_task_keys)
-        not_found_task_ids = [task_id for task_id, _ in not_found_task_keys]
+        delete_all_map_indexes: set[str] = set()
+        delete_specific_task_keys: set[tuple[str, int]] = set()
+
+        for entity in action.entities:
+            if isinstance(entity, str):
+                # String task ID - remove all task instances for this task
+                delete_all_map_indexes.add(entity)
+            else:
+                # BulkTaskInstanceBody object
+                if entity.map_index is None:
+                    delete_all_map_indexes.add(entity.task_id)
+                else:
+                    delete_specific_task_keys.add((entity.task_id, entity.map_index))
 
         try:
-            if action.action_on_non_existence == BulkActionNotOnExistence.FAIL and not_found_task_keys:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"The task instances with these task_ids: {not_found_task_ids} were not found",
+            # Handle deletion of specific (task_id, map_index) pairs
+            if delete_specific_task_keys:
+                _, matched_task_keys, not_found_task_keys = self.categorize_task_instances(
+                    delete_specific_task_keys
                 )
+                not_found_task_ids = [f"{task_id}[{map_index}]" for task_id, map_index in not_found_task_keys]
 
-            for task_id, _ in matched_task_keys:
-                existing_task_instance = self.session.scalar(select(TI).where(TI.task_id == task_id).limit(1))
-                if existing_task_instance:
-                    self.session.delete(existing_task_instance)
+                if action.action_on_non_existence == BulkActionNotOnExistence.FAIL and not_found_task_keys:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"The task instances with these task_ids: {not_found_task_ids} were not found",
+                    )
+
+                for task_id, map_index in matched_task_keys:
+                    result = self.session.execute(
+                        select(TI).where(
+                            TI.task_id == task_id,
+                            TI.dag_id == self.dag_id,
+                            TI.run_id == self.dag_run_id,
+                            TI.map_index == map_index,
+                        )
+                    ).one_or_none()
+
+                    if result:
+                        existing_task_instance = result[0]
+                        self.session.delete(existing_task_instance)
+                        results.success.append(f"{task_id}[{map_index}]")
+
+            # Handle deletion of all map indexes for certain task_ids
+            for task_id in delete_all_map_indexes:
+                all_task_instances = self.session.scalars(
+                    select(TI).where(
+                        TI.task_id == task_id,
+                        TI.dag_id == self.dag_id,
+                        TI.run_id == self.dag_run_id,
+                    )
+                ).all()
+
+                if not all_task_instances and action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"No task instances found for task_id: {task_id}",
+                    )
+
+                for ti in all_task_instances:
+                    self.session.delete(ti)
+
+                if all_task_instances:
                     results.success.append(task_id)
 
         except HTTPException as e:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -290,17 +290,21 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
                     )
 
                 for task_id, map_index in matched_task_keys:
-                    result = self.session.execute(
-                        select(TI).where(
-                            TI.task_id == task_id,
-                            TI.dag_id == self.dag_id,
-                            TI.run_id == self.dag_run_id,
-                            TI.map_index == map_index,
+                    result = (
+                        self.session.execute(
+                            select(TI).where(
+                                TI.task_id == task_id,
+                                TI.dag_id == self.dag_id,
+                                TI.run_id == self.dag_run_id,
+                                TI.map_index == map_index,
+                            )
                         )
-                    ).one_or_none()
+                        .scalars()
+                        .one_or_none()
+                    )
 
                     if result:
-                        existing_task_instance = result[0]
+                        existing_task_instance = result
                         self.session.delete(existing_task_instance)
                         results.success.append(f"{task_id}[{map_index}]")
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -780,11 +780,18 @@ export const $BulkDeleteAction_BulkTaskInstanceBody_ = {
         },
         entities: {
             items: {
-                type: 'string'
+                anyOf: [
+                    {
+                        type: 'string'
+                    },
+                    {
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                    }
+                ]
             },
             type: 'array',
             title: 'Entities',
-            description: 'A list of entity id/key to be deleted.'
+            description: 'A list of entity id/key or entity objects to be deleted.'
         },
         action_on_non_existence: {
             '$ref': '#/components/schemas/BulkActionNotOnExistence',
@@ -807,11 +814,18 @@ export const $BulkDeleteAction_ConnectionBody_ = {
         },
         entities: {
             items: {
-                type: 'string'
+                anyOf: [
+                    {
+                        type: 'string'
+                    },
+                    {
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                    }
+                ]
             },
             type: 'array',
             title: 'Entities',
-            description: 'A list of entity id/key to be deleted.'
+            description: 'A list of entity id/key or entity objects to be deleted.'
         },
         action_on_non_existence: {
             '$ref': '#/components/schemas/BulkActionNotOnExistence',
@@ -834,11 +848,18 @@ export const $BulkDeleteAction_PoolBody_ = {
         },
         entities: {
             items: {
-                type: 'string'
+                anyOf: [
+                    {
+                        type: 'string'
+                    },
+                    {
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                    }
+                ]
             },
             type: 'array',
             title: 'Entities',
-            description: 'A list of entity id/key to be deleted.'
+            description: 'A list of entity id/key or entity objects to be deleted.'
         },
         action_on_non_existence: {
             '$ref': '#/components/schemas/BulkActionNotOnExistence',
@@ -861,11 +882,18 @@ export const $BulkDeleteAction_VariableBody_ = {
         },
         entities: {
             items: {
-                type: 'string'
+                anyOf: [
+                    {
+                        type: 'string'
+                    },
+                    {
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                    }
+                ]
             },
             type: 'array',
             title: 'Entities',
-            description: 'A list of entity id/key to be deleted.'
+            description: 'A list of entity id/key or entity objects to be deleted.'
         },
         action_on_non_existence: {
             '$ref': '#/components/schemas/BulkActionNotOnExistence',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -244,9 +244,9 @@ export type BulkDeleteAction_BulkTaskInstanceBody_ = {
      */
     action: "delete";
     /**
-     * A list of entity id/key to be deleted.
+     * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -256,9 +256,9 @@ export type BulkDeleteAction_ConnectionBody_ = {
      */
     action: "delete";
     /**
-     * A list of entity id/key to be deleted.
+     * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -268,9 +268,9 @@ export type BulkDeleteAction_PoolBody_ = {
      */
     action: "delete";
     /**
-     * A list of entity id/key to be deleted.
+     * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -280,9 +280,9 @@ export type BulkDeleteAction_VariableBody_ = {
      */
     action: "delete";
     /**
-     * A list of entity id/key to be deleted.
+     * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -4516,6 +4516,29 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         {
                             "action": "delete",
                             "entities": [
+                                {
+                                    "task_id": TASK_ID,
+                                    "map_index": -1,
+                                },
+                            ],
+                        }
+                    ]
+                },
+                {
+                    "delete": {
+                        "success": [f"{TASK_ID}[-1]"],
+                        "errors": [],
+                    }
+                },
+                id="delete-with-entity-success",
+            ),
+            pytest.param(
+                [{"task_id": TASK_ID, "state": State.SUCCESS}],
+                {
+                    "actions": [
+                        {
+                            "action": "delete",
+                            "entities": [
                                 "non_existent_task",
                             ],
                             "action_on_non_existence": "skip",
@@ -4537,6 +4560,30 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         {
                             "action": "delete",
                             "entities": [
+                                {
+                                    "task_id": "non_existent_task",
+                                    "map_index": -1,
+                                },
+                            ],
+                            "action_on_non_existence": "skip",
+                        }
+                    ]
+                },
+                {
+                    "delete": {
+                        "success": [],
+                        "errors": [],
+                    }
+                },
+                id="delete-with-entity-skip",
+            ),
+            pytest.param(
+                [{"task_id": TASK_ID, "state": State.SUCCESS}],
+                {
+                    "actions": [
+                        {
+                            "action": "delete",
+                            "entities": [
                                 "non_existent_task",
                             ],
                         }
@@ -4547,13 +4594,86 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [],
                         "errors": [
                             {
-                                "error": "The task instances with these task_ids: ['non_existent_task'] were not found",
+                                "error": "No task instances found for task_id: non_existent_task",
                                 "status_code": 404,
                             }
                         ],
                     }
                 },
                 id="delete-failure",
+            ),
+            pytest.param(
+                [{"task_id": TASK_ID, "state": State.SUCCESS}],
+                {
+                    "actions": [
+                        {
+                            "action": "delete",
+                            "entities": [
+                                {
+                                    "task_id": "non_existent_task",
+                                    "map_index": -1,
+                                },
+                            ],
+                        }
+                    ]
+                },
+                {
+                    "delete": {
+                        "success": [],
+                        "errors": [
+                            {
+                                "error": "The task instances with these task_ids: ['non_existent_task[-1]'] were not found",
+                                "status_code": 404,
+                            }
+                        ],
+                    }
+                },
+                id="delete-with-entity-failure",
+            ),
+            pytest.param(
+                [
+                    {"task_id": TASK_ID, "state": State.SUCCESS, "map_index": 0},
+                    {"task_id": TASK_ID, "state": State.SUCCESS, "map_index": 1},
+                    {"task_id": TASK_ID, "state": State.SUCCESS, "map_index": 2},
+                ],
+                {
+                    "actions": [
+                        {
+                            "action": "delete",
+                            "entities": [
+                                {"task_id": TASK_ID, "map_index": None},
+                            ],
+                        }
+                    ]
+                },
+                {
+                    "delete": {
+                        "success": [TASK_ID],
+                        "errors": [],
+                    }
+                },
+                id="delete-all-map-indexes",
+            ),
+            pytest.param(
+                [
+                    {"task_id": TASK_ID, "state": State.SUCCESS},
+                    {"task_id": "another_task", "state": State.SUCCESS},
+                ],
+                {
+                    "actions": [
+                        {
+                            "action": "delete",
+                            "entities": [TASK_ID, {"task_id": "another_task", "map_index": -1}],
+                        }
+                    ]
+                },
+                {
+                    "delete": {
+                        "success": ["another_task[-1]", TASK_ID],
+                        "errors": [],
+                    }
+                },
+                id="mixed-string-and-object",
             ),
             pytest.param(
                 [{"task_id": TASK_ID, "state": State.RUNNING}],
@@ -4788,7 +4908,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [TASK_ID],
                         "errors": [
                             {
-                                "error": "The task instances with these task_ids: ['non_existent_task'] were not found",
+                                "error": "No task instances found for task_id: non_existent_task",
                                 "status_code": 404,
                             }
                         ],

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -98,58 +98,6 @@ class BulkActionResponse(BaseModel):
     ] = []
 
 
-class BulkDeleteActionBulkTaskInstanceBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str], Field(description="A list of entity id/key to be deleted.", title="Entities")
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionConnectionBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str], Field(description="A list of entity id/key to be deleted.", title="Entities")
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionPoolBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str], Field(description="A list of entity id/key to be deleted.", title="Entities")
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionVariableBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str], Field(description="A list of entity id/key to be deleted.", title="Entities")
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
 class BulkResponse(BaseModel):
     """
     Serializer for responses to bulk entity operations.
@@ -1732,38 +1680,6 @@ class BackfillCollectionResponse(BaseModel):
     total_entries: Annotated[int, Field(title="Total Entries")]
 
 
-class BulkBodyConnectionBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[
-            BulkCreateActionConnectionBody | BulkUpdateActionConnectionBody | BulkDeleteActionConnectionBody
-        ],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyPoolBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[BulkCreateActionPoolBody | BulkUpdateActionPoolBody | BulkDeleteActionPoolBody],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyVariableBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
-        Field(title="Actions"),
-    ]
-
-
 class BulkCreateActionBulkTaskInstanceBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1775,6 +1691,62 @@ class BulkCreateActionBulkTaskInstanceBody(BaseModel):
         list[BulkTaskInstanceBody], Field(description="A list of entities to be created.", title="Entities")
     ]
     action_on_existence: BulkActionOnExistence | None = "fail"
+
+
+class BulkDeleteActionBulkTaskInstanceBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionConnectionBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionPoolBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionVariableBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class DAGCollectionResponse(BaseModel):
@@ -1887,5 +1859,37 @@ class BulkBodyBulkTaskInstanceBody(BaseModel):
             | BulkUpdateActionBulkTaskInstanceBody
             | BulkDeleteActionBulkTaskInstanceBody
         ],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyConnectionBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[
+            BulkCreateActionConnectionBody | BulkUpdateActionConnectionBody | BulkDeleteActionConnectionBody
+        ],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyPoolBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[BulkCreateActionPoolBody | BulkUpdateActionPoolBody | BulkDeleteActionPoolBody],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyVariableBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
         Field(title="Actions"),
     ]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


## Related Issue 

#51564 
cc @pierrejeambrun 

## Why 

Current implementation only support task_id for bulk deletion. We need to update service to accept map_index.


## How

- add `BulkDeleteWithEntityAction` to let BulkTaskInstanceService's deletion accept object

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
