### PR TITLE
Add codegen files to prettier ignore

### DIFF
--- a/airflow-core/src/airflow/ui/.prettierignore
+++ b/airflow-core/src/airflow/ui/.prettierignore
@@ -6,3 +6,4 @@ dist/
 coverage/*
 .pnpm-store
 src/i18n/locales/*
+openapi-gen/


### PR DESCRIPTION
After https://github.com/apache/airflow/pull/51755, we should make sure the `pnpm format` command doesn't try to edit codegen files either.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
