### PR TITLE
Improve Dag run and Task Instance notes

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownArea.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownArea.tsx
@@ -32,7 +32,7 @@ const EditableMarkdownArea = ({
   readonly placeholder?: string | null;
   readonly setMdContent: (value: string) => void;
 }) => (
-  <Box mt={4} px={4} width="100%">
+  <Box width="100%">
     <Editable.Root
       onBlur={onBlur}
       onChange={(event: ChangeEvent<HTMLInputElement>) => setMdContent(event.target.value)}

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownNotes.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownNotes.tsx
@@ -1,0 +1,53 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import EditableMarkdownArea from "./EditableMarkdownArea";
+import { Accordion } from "./ui/Accordion";
+
+const EditableMarkdownNotes = ({
+  header,
+  mdContent,
+  onConfirm,
+  setMdContent,
+}: {
+  readonly header: string;
+  readonly mdContent?: string | null;
+  readonly onConfirm: () => void;
+  readonly setMdContent: (value: string) => void;
+}) => (
+  <Accordion.Root collapsible defaultValue={["notes"]} ms={4} pe={4}>
+    <Accordion.Item key="notes" value="notes">
+      <Accordion.ItemTrigger cursor="button">{header}</Accordion.ItemTrigger>
+      <Accordion.ItemContent
+        maxHeight={200}
+        onMouseEnter={(event) => {
+          event.currentTarget.style.maxHeight = "500px";
+        }}
+        onMouseLeave={(event) => {
+          event.currentTarget.style.maxHeight = "200px";
+        }}
+        overflowY="auto"
+        p={1}
+      >
+        <EditableMarkdownArea mdContent={mdContent} onBlur={onConfirm} setMdContent={setMdContent} />
+      </Accordion.ItemContent>
+    </Accordion.Item>
+  </Accordion.Root>
+);
+
+export default EditableMarkdownNotes;

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -24,8 +24,8 @@ import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
-import EditableMarkdownArea from "src/components/EditableMarkdownArea";
 import EditableMarkdownButton from "src/components/EditableMarkdownButton";
+import EditableMarkdownNotes from "src/components/EditableMarkdownNotes";
 import { HeaderCard } from "src/components/HeaderCard";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
 import { MarkRunAsButton } from "src/components/MarkAs";
@@ -125,7 +125,12 @@ export const Header = ({
         title={<Time datetime={dagRun.run_after} />}
       />
       {Boolean(dagRun.note) && (
-        <EditableMarkdownArea mdContent={note} onBlur={onConfirm} setMdContent={setNote} />
+        <EditableMarkdownNotes
+          header={translate("note.label")}
+          mdContent={note}
+          onConfirm={onConfirm}
+          setMdContent={setNote}
+        />
       )}
     </Box>
   );

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -25,8 +25,8 @@ import { MdOutlineTask } from "react-icons/md";
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
-import EditableMarkdownArea from "src/components/EditableMarkdownArea";
 import EditableMarkdownButton from "src/components/EditableMarkdownButton";
+import EditableMarkdownNotes from "src/components/EditableMarkdownNotes";
 import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
@@ -127,7 +127,12 @@ export const Header = ({
         title={`${taskInstance.task_display_name}${taskInstance.map_index > -1 ? ` [${taskInstance.rendered_map_index ?? taskInstance.map_index}]` : ""}`}
       />
       {Boolean(taskInstance.note) && (
-        <EditableMarkdownArea mdContent={note} onBlur={onConfirm} setMdContent={setNote} />
+        <EditableMarkdownNotes
+          header={translate("note.label")}
+          mdContent={taskInstance.note}
+          onConfirm={onConfirm}
+          setMdContent={setNote}
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
Follow-up of #51764

As @pierrejeambrun and @bbovenzi had some feedback, this adds an accordion and limits the maximum space used, add an option to hide notes.

Better like this?


https://github.com/user-attachments/assets/873b1a47-68a2-4489-b9f8-daaa40fa9cf7

