### PR TITLE
Fix Edge State Model Link

### DIFF
--- a/providers/edge3/docs/architecture.rst
+++ b/providers/edge3/docs/architecture.rst
@@ -141,7 +141,7 @@ The following states are used to track the worker:
       TERMINATING->OFFLINE[label="on clean shutdown if running tasks = 0"];
    }
 
-See also https://github.com/apache/airflow/blob/main/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py#L45
+See also :py:class:`airflow.providers.edge3.models.edge_worker.EdgeWorkerState`
 for a documentation of details of all states of the Edge Worker.
 
 Feature Backlog Edge Provider


### PR DESCRIPTION
As per private chat... the previous link was pointing to an outdated line-numer in code. Therefore we better link to APIdoc of the class we wanted to reference.