### PR TITLE
Update dag version when bundle name changes

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -426,7 +426,7 @@ class SerializedDagModel(Base):
             log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
             return False
 
-        if dag_version and (not dag_version.task_instances and dag_version.bundle_name != bundle_name):
+        if dag_version and (not dag_version.task_instances or dag_version.bundle_name != bundle_name):
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -426,7 +426,7 @@ class SerializedDagModel(Base):
             log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
             return False
 
-        if dag_version and (not dag_version.task_instances or dag_version.bundle_name != bundle_name):
+        if dag_version and not dag_version.task_instances:
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -416,12 +416,17 @@ class SerializedDagModel(Base):
         serialized_dag_hash = session.scalars(
             select(cls.dag_hash).where(cls.dag_id == dag.dag_id).order_by(cls.created_at.desc())
         ).first()
+        dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
 
-        if serialized_dag_hash is not None and serialized_dag_hash == new_serialized_dag.dag_hash:
+        if (
+            serialized_dag_hash == new_serialized_dag.dag_hash
+            and dag_version
+            and dag_version.bundle_name == bundle_name
+        ):
             log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
             return False
-        dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
-        if dag_version and not dag_version.task_instances:
+
+        if dag_version and (not dag_version.task_instances and dag_version.bundle_name != bundle_name):
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -112,7 +112,7 @@ class TestGetDAGSource:
         assert response.headers["Content-Type"].startswith("application/json")
 
     @pytest.mark.parametrize("accept", ["application/json", "text/plain"])
-    def test_should_respond_200_version(self, test_client, accept, session, test_dag, testing_dag_bundle):
+    def test_should_respond_200_version(self, test_client, accept, session, test_dag):
         dag_content = self._get_dag_file_code(test_dag.fileloc)
         test_dag.create_dagrun(
             run_id="test1",
@@ -123,7 +123,7 @@ class TestGetDAGSource:
         )
         # force reserialization
         test_dag.doc_md = "new doc"
-        SerializedDagModel.write_dag(test_dag, bundle_name="testing")
+        SerializedDagModel.write_dag(test_dag, bundle_name="dags-folder")
         dagcode = (
             session.query(DagCode)
             .filter(DagCode.fileloc == test_dag.fileloc)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3393,7 +3393,6 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
         orm_dag = dag_maker.dag_model
         assert orm_dag is not None
-        SerializedDagModel.write_dag(dag, bundle_name="testing", session=session)
         self.job_runner._create_dag_runs([orm_dag], session)
 
         drs = DagRun.find(dag_id=dag.dag_id, session=session)
@@ -3410,7 +3409,7 @@ class TestSchedulerJob:
 
         # Now let's say the DAG got updated (new task got added)
         BashOperator(task_id="bash_task_1", dag=dag, bash_command="echo hi")
-        SerializedDagModel.write_dag(dag=dag, bundle_name="testing", session=session)
+        SerializedDagModel.write_dag(dag=dag, bundle_name="dag_maker", session=session)
         session.commit()
         dag_version_2 = DagVersion.get_latest_version(dr.dag_id, session=session)
         assert dag_version_2 != dag_version_1
@@ -5630,7 +5629,7 @@ class TestSchedulerJob:
         assert len(tis) == 1
 
         BashOperator(task_id="dummy2", dag=dag, bash_command="echo test")
-        SerializedDagModel.write_dag(dag=dag, bundle_name="testing", session=session)
+        SerializedDagModel.write_dag(dag=dag, bundle_name="dag_maker", session=session)
         session.commit()
         self.job_runner._schedule_dag_run(dr, session)
         session.expunge_all()

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -336,7 +336,7 @@ class TestSerializedDagModel:
         last_updated = sdm1.last_updated
         # new task
         PythonOperator(task_id="task2", python_callable=lambda: None, dag=dag)
-        SDM.write_dag(dag, bundle_name="testing")
+        SDM.write_dag(dag, bundle_name="dag_maker")
         sdm2 = SDM.get(dag.dag_id, session=session)
 
         assert sdm2.dag_hash != dag_hash  # first recorded serdag
@@ -353,7 +353,7 @@ class TestSerializedDagModel:
         assert session.query(DagVersion).count() == 1
         # new task
         PythonOperator(task_id="task2", python_callable=lambda: None, dag=dag)
-        SDM.write_dag(dag, bundle_name="testing")
+        SDM.write_dag(dag, bundle_name="dag_maker")
 
         assert session.query(DagVersion).count() == 2
         assert session.query(SDM).count() == 2


### PR DESCRIPTION
If there's a bundle name change without the dag structure changing, we should update the dag version to reflect the change.

This issue was fixed in #49886 but the fix randomly assigned versions to the new bundle.

