### PR TITLE
Remove check box from linked issues in issue template for providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
+++ b/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
@@ -16,7 +16,7 @@ These are providers that require testing as there were some substantial changes 
    {%- if pr.number in linked_issues %}
      Linked issues:
      {%- for linked_issue in linked_issues[pr.number] %}
-       - [ ] [Linked Issue #{{ linked_issue.number }}]({{ linked_issue.html_url }}): @{{ linked_issue.user.login }}
+       - [Linked Issue #{{ linked_issue.number }}]({{ linked_issue.html_url }}): @{{ linked_issue.user.login }}
      {%- endfor %}
    {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
We don't need checkbox on the linked issues only on the PRs
Tested the change looks good
![Screenshot 2025-06-18 at 22 49 00](https://github.com/user-attachments/assets/298de727-969a-4210-a843-de2f49868352)
