### PR TITLE
[v2-11-test] Stop streaming task logs if end of log mark is missing

### DIFF
--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -105,9 +105,9 @@ class TaskLogReader:
                         if empty_iterations >= self.STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS:
                             # we have not received any logs for a while, so we stop the stream
                             yield "\n(Log stream stopped - End of log marker not found; logs may be incomplete.)\n"
-                            return
+                            break
                 else:
-                    return
+                    break
 
     @cached_property
     def log_handler(self):

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -95,17 +95,19 @@ class TaskLogReader:
                     not metadata["end_of_log"]
                     and ti.state not in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED)
                 ):
-                    if not logs[0]:
+                    if logs[0]:
+                        empty_iterations = 0
+                    else:
                         # we did not receive any logs in this loop
                         # sleeping to conserve resources / limit requests on external services
                         time.sleep(self.STREAM_LOOP_SLEEP_SECONDS)
                         empty_iterations += 1
                         if empty_iterations >= self.STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS:
                             # we have not received any logs for a while, so we stop the stream
-                            yield "\n(Log stream stopped - End of log marker not found, so logs may be incomplete)\n"
-                            break
+                            yield "\n(Log stream stopped - End of log marker not found; logs may be incomplete.)\n"
+                            return
                 else:
-                    break
+                    return
 
     @cached_property
     def log_handler(self):

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -242,7 +242,7 @@ class TestLogView:
         log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
         assert list(log_stream) == [
             "\nhello\n",
-            "\n(Log stream stopped - End of log marker not found, so logs may be incomplete)\n",
+            "\n(Log stream stopped - End of log marker not found; logs may be incomplete.)\n",
         ]
         assert mock_read.call_count == 6
 

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -225,6 +225,27 @@ class TestLogView:
             any_order=False,
         )
 
+    @mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read")
+    def test_read_log_stream_no_end_of_log_marker(self, mock_read):
+        mock_read.side_effect = [
+            ([[("", "hello")]], [{"end_of_log": False}]),
+            ([[]], [{"end_of_log": False}]),
+            ([[]], [{"end_of_log": False}]),
+            ([[]], [{"end_of_log": False}]),
+            ([[]], [{"end_of_log": False}]),
+            ([[]], [{"end_of_log": False}]),
+        ]
+
+        self.ti.state = TaskInstanceState.SUCCESS
+        task_log_reader = TaskLogReader()
+        task_log_reader.STREAM_LOOP_SLEEP_SECONDS = 0.001  # to speed up the test
+        log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
+        assert list(log_stream) == [
+            "\nhello\n",
+            "\n(Log stream stopped - End of log marker not found, so logs may be incomplete)\n",
+        ]
+        assert mock_read.call_count == 6
+
     def test_supports_external_link(self):
         task_log_reader = TaskLogReader()
 


### PR DESCRIPTION
Sometimes, somehow, the end of log mark can be missing, and when that
happens the streaming log reader enters an infinite loop. Instead, if
the task is in a non-running state and we stop receiving log lines but
never get the end of log mark, we assume we won't and stop trying. We do
tell emit that we are stopping though.

Backport of #50715.