### PR TITLE
Document EdgeExecutor migration from `internal_api_secret_key` to `jwt_secret`

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -51,9 +51,6 @@ Minimum Airflow configuration settings for the Edge Worker to make it running is
 - Section ``[core]``
 
   - ``executor``: Executor must be set or added to be ``airflow.providers.edge3.executors.EdgeExecutor``
-  - ``internal_api_secret_key``: An encryption key must be set on api-server and Edge Worker component as
-    shared secret to authenticate traffic. It should be a random string like the fernet key
-    (but preferably not the same).
 
 - Section ``[edge]``
 

--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -44,6 +44,10 @@ Here are a few imperative requirements for your workers:
 
 Minimum Airflow configuration settings for the Edge Worker to make it running is:
 
+- Section ``[api_auth]``
+
+  - ``jwt_secret``: A matching secret to that on the api-server (starting from version 3.0.0).
+
 - Section ``[core]``
 
   - ``executor``: Executor must be set or added to be ``airflow.providers.edge3.executors.EdgeExecutor``

--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -51,6 +51,9 @@ Minimum Airflow configuration settings for the Edge Worker to make it running is
 - Section ``[core]``
 
   - ``executor``: Executor must be set or added to be ``airflow.providers.edge3.executors.EdgeExecutor``
+  - ``internal_api_secret_key``: An encryption key must be set on api-server and Edge Worker component as
+    shared secret to authenticate traffic. It should be a random string like the fernet key
+    (for versions earlier than 3.0.0).
 
 - Section ``[edge]``
 

--- a/providers/edge3/docs/install_on_windows.rst
+++ b/providers/edge3/docs/install_on_windows.rst
@@ -39,8 +39,8 @@ To setup a instance of Edge Worker on Windows, you need to follow the steps belo
    (At least the DAG files which should be executed on the edge alongside the dependencies.)
 7. Collect needed parameters from your running Airflow backend, at least the following:
 
+  - ``api_auth`` / ``jwt_token``: The shared secret key between the api-server and the Edge Worker
   - ``edge`` / ``api_url``: The HTTP(s) endpoint where the Edge Worker connects to
-  - ``core`` / ``internal_api_secret_key``: The shared secret key between the api-server and the Edge Worker
   - Any proxy details if applicable for your environment.
 
 8. Create a worker start script to prevent repeated typing. Create a new file ``start_worker.bat`` in
@@ -49,11 +49,11 @@ To setup a instance of Edge Worker on Windows, you need to follow the steps belo
 .. code-block:: bash
 
     @echo off
+    set AIRFLOW__API_AUTH__JWT_SECRET=<matching the api-server...>
     set AIRFLOW__CORE__DAGS_FOLDER=dags
     set AIRFLOW__LOGGING__BASE_LOG_FOLDER=edge_logs
     set AIRFLOW__EDGE__API_URL=https://your-hostname-and-port/edge_worker/v1/rpcapi
     set AIRFLOW__CORE__EXECUTOR=airflow.providers.edge3.executors.edge_executor.EdgeExecutor
-    set AIRFLOW__CORE__INTERNAL_API_SECRET_KEY=<use this as configured centrally in api-server...>
     set AIRFLOW__CORE__LOAD_EXAMPLES=False
     set AIRFLOW_ENABLE_AIP_44=true
     @REM Add if needed: set http_proxy=http://my-company-proxy.com:3128


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

This PR updated the documentation to use the new `[api_auth] jwt_secret` required configuration for `EdgeExecutor` instead of the old `internal_api_secret_key`.

Without it, the following error is emitted:

```txt
 ____________       _____________
 ____    |__( )_________  __/__  /________      __
____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
 _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
   ____   __           _      __         __
  / __/__/ /__ ____   | | /| / /__  ____/ /_____ ____
 / _// _  / _ `/ -_)  | |/ |/ / _ \/ __/  '_/ -_) __/
/___/\_,_/\_, /\__/   |__/|__/\___/_/ /_/\_\\__/_/
         /___/
Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/__main__.py", line 55, in main
    args.func(args)
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/cli.py", line 112, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/edge_command.py", line 522, in worker
    run_command_with_daemon_option(
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/cli/commands/daemon_utils.py", line 86, in run_command_with_daemon_option
    callback()
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/edge_command.py", line 525, in <lambda>
    callback=lambda: _launch_worker(args),
                     ^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/edge_command.py", line 513, in _launch_worker
    edge_worker.start()
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/edge_command.py", line 337, in start
    self.last_hb = worker_register(
                   ^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/api_client.py", line 119, in worker_register
    result = _make_generic_request(
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 338, in wrapped_f
    return copy(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 477, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 378, in iter
    result = action(retry_state)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
                                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 480, in __call__
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/api_client.py", line 91, in _make_generic_request
    generator = jwt_generator()
                ^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/api_client.py", line 85, in jwt_generator
    return JWTGenerator(
           ^^^^^^^^^^^^^
  File "<attrs generated methods airflow.api_fastapi.auth.tokens.JWTGenerator>", line 34, in __init__
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/api_fastapi/auth/tokens.py", line 417, in __attrs_post_init__
    raise ValueError("Exactly one of private_key and secret_key must be specified")
ValueError: Exactly one of private_key and secret_key must be specified
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
