### PR TITLE
Adding 'invocation_id' to run-results as expected by OL

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/test_data/run_results.json
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/test_data/run_results.json
@@ -1,7 +1,8 @@
 {
   "metadata": {
     "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
-    "dbt_version": "1.6.1"
+    "dbt_version": "1.6.1",
+    "invocation_id": "188471607"
   },
   "results": [
     {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Openlineage released 1.34.0:
```
> openlineage-integration-common==1.34.0
> openlineage-python==1.34.0
> openlineage_sql==1.34.0
```

This causes a breaking change in OpenLineage 1.34.0 where the DBT processor expects an invocation_id field in the run metadata, but the test data didn't include this field.

Added the invocation_id field to the metadata section of the test run_results.json file and assigned it equal to run_id:
```
{
  "metadata": {
    "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
    "dbt_version": "1.6.1",
    "invocation_id": "188471607"
  }
}
```


Fixes CI:
```
______ TestGenerateOpenLineageEventsFromDbtCloudRun.test_generate_events _______
[gw2] linux -- Python 3.9.23 /usr/local/bin/python3
providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py:187: in test_generate_events
    generate_openlineage_events_from_dbt_cloud_run(mock_operator, task_instance=mock_task_instance)
providers/common/compat/src/airflow/providers/common/compat/openlineage/check.py:100: in wrapper
    return func(*args, **kwargs)
providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py:192: in generate_openlineage_events_from_dbt_cloud_run
    events = processor.parse().events()
/usr/local/lib/python3.9/site-packages/openlineage/common/provider/dbt/processor.py:201: in parse
    events += self.parse_execution(context, nodes)
/usr/local/lib/python3.9/site-packages/openlineage/common/provider/dbt/processor.py:299: in parse_execution
    self.get_run(run_id),
/usr/local/lib/python3.9/site-packages/openlineage/common/provider/dbt/processor.py:685: in get_run
    "dbt_run": self.dbt_run_run_facet(),
/usr/local/lib/python3.9/site-packages/openlineage/common/provider/dbt/processor.py:704: in dbt_run_run_facet
    return DbtRunRunFacet(invocation_id=self.run_metadata["invocation_id"])  # type: ignore[index]
E   KeyError: 'invocation_id'
```

Example failure: https://github.com/apache/airflow/actions/runs/15748852234





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
