### PR TITLE
[v3-0-test] Switch the Supervisor/task process from line-based to length-prefixed (#51699)

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -77,6 +77,8 @@ from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.sqlalchemy import prohibit_commit, with_row_locks
 
 if TYPE_CHECKING:
+    from socket import socket
+
     from sqlalchemy.orm import Session
 
     from airflow.callbacks.callback_requests import CallbackRequest
@@ -388,7 +390,7 @@ class DagFileProcessorManager(LoggingMixin):
         """
         events = self.selector.select(timeout=timeout)
         for key, _ in events:
-            socket_handler = key.data
+            socket_handler, on_close = key.data
 
             # BrokenPipeError should be caught and treated as if the handler returned false, similar
             # to EOF case
@@ -397,8 +399,9 @@ class DagFileProcessorManager(LoggingMixin):
             except (BrokenPipeError, ConnectionResetError):
                 need_more = False
             if not need_more:
-                self.selector.unregister(key.fileobj)
-                key.fileobj.close()  # type: ignore[union-attr]
+                sock: socket = key.fileobj  # type: ignore[assignment]
+                on_close(sock)
+                sock.close()
 
     def _queue_requested_files_for_parsing(self) -> None:
         """Queue any files requested for parsing as requested by users via UI/API."""

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -30,10 +30,11 @@ from collections import deque
 from datetime import datetime, timedelta
 from logging.config import dictConfig
 from pathlib import Path
-from socket import socket
+from socket import socket, socketpair
 from unittest import mock
 from unittest.mock import MagicMock
 
+import msgspec
 import pytest
 import time_machine
 from sqlalchemy import func, select
@@ -54,7 +55,6 @@ from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.sdk.execution_time.supervisor import mkpipe
 from airflow.utils import timezone
 from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session
@@ -138,20 +138,19 @@ class TestDagFileProcessorManager:
         logger_filehandle = MagicMock()
         proc.create_time.return_value = time.time()
         proc.wait.return_value = 0
-        read_end, write_end = mkpipe(remote_read=True)
+        read_end, write_end = socketpair()
         ret = DagFileProcessorProcess(
             process_log=MagicMock(),
             id=uuid7(),
             pid=1234,
             process=proc,
             stdin=write_end,
-            requests_fd=123,
             logger_filehandle=logger_filehandle,
             client=MagicMock(),
         )
         if start_time:
             ret.start_time = start_time
-        ret._num_open_sockets = 0
+        ret._open_sockets.clear()
         return ret, read_end
 
     @pytest.fixture
@@ -552,18 +551,17 @@ class TestDagFileProcessorManager:
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     @pytest.mark.parametrize(
-        ["callbacks", "path", "expected_buffer"],
+        ["callbacks", "path", "expected_body"],
         [
             pytest.param(
                 [],
                 "/opt/airflow/dags/test_dag.py",
-                b"{"
-                b'"file":"/opt/airflow/dags/test_dag.py",'
-                b'"bundle_path":"/opt/airflow/dags",'
-                b'"requests_fd":123,'
-                b'"callback_requests":[],'
-                b'"type":"DagFileParseRequest"'
-                b"}\n",
+                {
+                    "file": "/opt/airflow/dags/test_dag.py",
+                    "bundle_path": "/opt/airflow/dags",
+                    "callback_requests": [],
+                    "type": "DagFileParseRequest",
+                },
             ),
             pytest.param(
                 [
@@ -577,44 +575,39 @@ class TestDagFileProcessorManager:
                     )
                 ],
                 "/opt/airflow/dags/dag_callback_dag.py",
-                b"{"
-                b'"file":"/opt/airflow/dags/dag_callback_dag.py",'
-                b'"bundle_path":"/opt/airflow/dags",'
-                b'"requests_fd":123,"callback_requests":'
-                b"["
-                b"{"
-                b'"filepath":"dag_callback_dag.py",'
-                b'"bundle_name":"testing",'
-                b'"bundle_version":null,'
-                b'"msg":null,'
-                b'"dag_id":"dag_id",'
-                b'"run_id":"run_id",'
-                b'"is_failure_callback":false,'
-                b'"type":"DagCallbackRequest"'
-                b"}"
-                b"],"
-                b'"type":"DagFileParseRequest"'
-                b"}\n",
+                {
+                    "file": "/opt/airflow/dags/dag_callback_dag.py",
+                    "bundle_path": "/opt/airflow/dags",
+                    "callback_requests": [
+                        {
+                            "filepath": "dag_callback_dag.py",
+                            "bundle_name": "testing",
+                            "bundle_version": None,
+                            "msg": None,
+                            "dag_id": "dag_id",
+                            "run_id": "run_id",
+                            "is_failure_callback": False,
+                            "type": "DagCallbackRequest",
+                        }
+                    ],
+                    "type": "DagFileParseRequest",
+                },
             ),
         ],
     )
-    def test_serialize_callback_requests(self, callbacks, path, expected_buffer):
+    def test_serialize_callback_requests(self, callbacks, path, expected_body):
+        from airflow.sdk.execution_time.comms import _ResponseFrame
+
         processor, read_socket = self.mock_processor()
         processor._on_child_started(callbacks, path, bundle_path=Path("/opt/airflow/dags"))
 
         read_socket.settimeout(0.1)
-        val = b""
-        try:
-            while not val.endswith(b"\n"):
-                chunk = read_socket.recv(4096)
-                if not chunk:
-                    break
-                val += chunk
-        except (BlockingIOError, TimeoutError):
-            # no response written, valid for some message types.
-            pass
+        # Read response from the read end of the socket
+        frame_len = int.from_bytes(read_socket.recv(4), "big")
+        bytes = read_socket.recv(frame_len)
+        frame = msgspec.msgpack.Decoder(_ResponseFrame).decode(bytes)
 
-        assert val == expected_buffer
+        assert frame.body == expected_body
 
     @conf_vars({("core", "load_examples"): "False"})
     @pytest.mark.execution_timeout(10)

--- a/airflow-core/tests/unit/hooks/test_base.py
+++ b/airflow-core/tests/unit/hooks/test_base.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import mock
-
 import pytest
 
 from airflow.exceptions import AirflowNotFoundException
@@ -54,18 +52,18 @@ class TestBaseHook:
             extra='{"extra_key": "extra_value"}',
         )
 
-        mock_supervisor_comms.get_message.return_value = conn
+        mock_supervisor_comms.send.return_value = conn
 
         hook = BaseHook(logger_name="")
         hook.get_connection(conn_id="test_conn")
-        mock_supervisor_comms.send_request.assert_called_once_with(
-            msg=GetConnection(conn_id="test_conn"), log=mock.ANY
+        mock_supervisor_comms.send.assert_called_once_with(
+            msg=GetConnection(conn_id="test_conn"),
         )
 
     def test_get_connection_not_found(self, mock_supervisor_comms):
         conn_id = "test_conn"
         hook = BaseHook()
-        mock_supervisor_comms.get_message.return_value = ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND)
+        mock_supervisor_comms.send.return_value = ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND)
 
         with pytest.raises(AirflowNotFoundException, match=rf".*{conn_id}.*"):
             hook.get_connection(conn_id=conn_id)
@@ -85,5 +83,4 @@ class TestBaseHook:
 
             assert retrieved_conn.conn_id == "CONN_A"
 
-            mock_supervisor_comms.send_request.assert_not_called()
-            mock_supervisor_comms.get_message.assert_not_called()
+            mock_supervisor_comms.send.assert_not_called()

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -34,6 +34,7 @@ from airflow.executors import workloads
 from airflow.hooks.base import BaseHook
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import (
+    TriggerCommsDecoder,
     TriggererJobRunner,
     TriggerRunner,
     TriggerRunnerSupervisor,
@@ -172,7 +173,6 @@ def supervisor_builder(mocker, session):
             pid=process.pid,
             stdin=mocker.Mock(),
             process=process,
-            requests_fd=-1,
             capacity=10,
         )
         # Mock the selector
@@ -302,10 +302,9 @@ class TestTriggerRunner:
             id=1, ti=None, classpath="fake.classpath", encrypted_kwargs={}
         )
         trigger_runner = TriggerRunner()
-        trigger_runner.requests_sock = MagicMock()
-        trigger_runner.response_sock = AsyncMock()
-        trigger_runner.response_sock.readline.return_value = (
-            b'{"type": "TriggerStateSync", "to_create": [], "to_cancel": []}\n'
+        trigger_runner.comms_decoder = AsyncMock(spec=TriggerCommsDecoder)
+        trigger_runner.comms_decoder.asend.return_value = messages.TriggerStateSync(
+            to_create=[], to_cancel=[]
         )
 
         trigger_runner.to_create.append(workload)
@@ -316,9 +315,9 @@ class TestTriggerRunner:
         await trigger_runner.sync_state_to_supervisor(ids)
 
         # Check that we sent the right info in the failure message
-        assert trigger_runner.requests_sock.write.call_count == 1
-        blob = trigger_runner.requests_sock.write.mock_calls[0].args[0]
-        msg = messages.TriggerStateChanges.model_validate_json(blob)
+        assert trigger_runner.comms_decoder.asend.call_count == 1
+        msg = trigger_runner.comms_decoder.asend.mock_calls[0].args[0]
+        assert isinstance(msg, messages.TriggerStateChanges)
 
         assert msg.events is None
         assert msg.failures is not None
@@ -552,6 +551,7 @@ def test_failed_trigger(session, dag_maker, supervisor_builder):
                 )
             ],
         ),
+        req_id=1,
         log=MagicMock(),
     )
 
@@ -622,10 +622,6 @@ class DummyTriggerRunnerSupervisor(TriggerRunnerSupervisor):
         super().handle_events()
 
 
-@pytest.mark.xfail(
-    reason="We know that test is flaky and have no time to fix it before 3.0. "
-    "We should fix it later. TODO: AIP-72"
-)
 @pytest.mark.asyncio
 @pytest.mark.execution_timeout(20)
 async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_maker):
@@ -726,13 +722,8 @@ class CustomTriggerDagRun(BaseTrigger):
         yield TriggerEvent({"count": dag_run_states_count, "dag_run_state": dag_run_state})
 
 
-@pytest.mark.xfail(
-    reason="We know that test is flaky and have no time to fix it before 3.0. "
-    "We should fix it later. TODO: AIP-72"
-)
 @pytest.mark.asyncio
-@pytest.mark.flaky(reruns=2, reruns_delay=10)
-@pytest.mark.execution_timeout(30)
+@pytest.mark.execution_timeout(10)
 async def test_trigger_can_fetch_trigger_dag_run_count_and_state_in_deferrable(session, dag_maker):
     """Checks that the trigger will successfully fetch the count of trigger DAG runs."""
     # Create the test DAG and task
@@ -822,13 +813,8 @@ class CustomTriggerWorkflowStateTrigger(BaseTrigger):
         yield TriggerEvent({"ti_count": ti_count, "dr_count": dr_count, "task_states": task_states})
 
 
-@pytest.mark.xfail(
-    reason="We know that test is flaky and have no time to fix it before 3.0. "
-    "We should fix it later. TODO: AIP-72"
-)
 @pytest.mark.asyncio
-@pytest.mark.flaky(reruns=2, reruns_delay=10)
-@pytest.mark.execution_timeout(30)
+@pytest.mark.execution_timeout(10)
 async def test_trigger_can_fetch_dag_run_count_ti_count_in_deferrable(session, dag_maker):
     """Checks that the trigger will successfully fetch the count of DAG runs, Task count and task states."""
     # Create the test DAG and task

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -1885,7 +1885,7 @@ class TestTaskInstance:
     def test_inlet_asset_extra(self, dag_maker, session, mock_supervisor_comms):
         from airflow.sdk.definitions.asset import Asset
 
-        mock_supervisor_comms.get_message.return_value = AssetEventsResult(
+        mock_supervisor_comms.send.return_value = AssetEventsResult(
             asset_events=[
                 AssetEventResponse(
                     id=1,
@@ -1959,7 +1959,7 @@ class TestTaskInstance:
     @pytest.mark.need_serialized_dag
     def test_inlet_unresolved_asset_alias(self, dag_maker, session, mock_supervisor_comms):
         asset_alias_name = "test_inlet_asset_extra_asset_alias"
-        mock_supervisor_comms.get_message.return_value = AssetEventsResult(asset_events=[])
+        mock_supervisor_comms.send.return_value = AssetEventsResult(asset_events=[])
 
         asset_alias_model = AssetAliasModel(name=asset_alias_name)
         session.add(asset_alias_model)

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1948,17 +1948,27 @@ def override_caplog(request):
 
 
 @pytest.fixture
-def mock_supervisor_comms():
+def mock_supervisor_comms(monkeypatch):
     # for back-compat
     from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
     if not AIRFLOW_V_3_0_PLUS:
         yield None
         return
-    with mock.patch(
-        "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
-    ) as supervisor_comms:
-        yield supervisor_comms
+
+    from airflow.sdk.execution_time import comms, task_runner
+
+    # Deal with TaskSDK 1.0/1.1 vs 1.2+. Annoying, and shouldn't need to exist once the separation between
+    # core and TaskSDK is finished
+    if CommsDecoder := getattr(comms, "CommsDecoder", None):
+        comms = mock.create_autospec(CommsDecoder)
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+    else:
+        CommsDecoder = getattr(task_runner, "CommsDecoder")
+        comms = mock.create_autospec(CommsDecoder)
+        comms.send = comms.get_message
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+    yield comms
 
 
 @pytest.fixture
@@ -1983,7 +1993,6 @@ def mocked_parse(spy_agency):
                         id=uuid7(), task_id="hello", dag_id="super_basic_run", run_id="c", try_number=1
                     ),
                     file="",
-                    requests_fd=0,
                 ),
                 "example_dag_id",
                 CustomOperator(task_id="hello"),
@@ -2190,9 +2199,10 @@ def create_runtime_ti(mocked_parse):
             ),
             dag_rel_path="",
             bundle_info=BundleInfo(name="anything", version="any"),
-            requests_fd=0,
             ti_context=ti_context,
             start_date=start_date,  # type: ignore
+            # Back-compat of task-sdk. Only affects us when we manually create these objects in tests.
+            **({"requests_fd": 0} if "requests_fd" in StartupDetails.model_fields else {}),  # type: ignore
         )
 
         ti = mocked_parse(startup_details, dag_id, task)

--- a/providers/amazon/tests/unit/amazon/aws/links/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_athena.py
@@ -30,7 +30,7 @@ class TestAthenaQueryResultsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=AthenaQueryResultsLink.key,
                 value={
                     "region_name": "eu-west-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_batch.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_batch.py
@@ -34,7 +34,7 @@ class TestBatchJobDefinitionLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-1",
@@ -58,7 +58,7 @@ class TestBatchJobDetailsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "cn-north-1",
@@ -80,7 +80,7 @@ class TestBatchJobQueueLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-east-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_comprehend.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_comprehend.py
@@ -34,7 +34,7 @@ class TestComprehendPiiEntitiesDetectionLink(BaseAwsLinksTestCase):
     def test_extra_link(self, mock_supervisor_comms):
         test_job_id = "123-345-678"
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-1",
@@ -61,7 +61,7 @@ class TestComprehendDocumentClassifierLink(BaseAwsLinksTestCase):
             "arn:aws:comprehend:us-east-1:0123456789:document-classifier/test-custom-document-classifier"
         )
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-east-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_datasync.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_datasync.py
@@ -34,7 +34,7 @@ class TestDataSyncTaskLink(BaseAwsLinksTestCase):
     def test_extra_link(self, mock_supervisor_comms):
         task_id = TASK_ID
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-east-1",
@@ -56,7 +56,7 @@ class TestDataSyncTaskExecutionLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-east-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_ec2.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_ec2.py
@@ -32,7 +32,7 @@ class TestEC2InstanceLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-1",
@@ -66,7 +66,7 @@ class TestEC2InstanceDashboardLink(BaseAwsLinksTestCase):
     def test_extra_link(self, mock_supervisor_comms):
         instance_list = ",:".join(self.INSTANCE_IDS)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_emr.py
@@ -45,7 +45,7 @@ class TestEmrClusterLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-west-1",
@@ -82,7 +82,7 @@ class TestEmrLogsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-2",
@@ -127,7 +127,7 @@ class TestEmrServerlessLogsLink(BaseAwsLinksTestCase):
         mocked_client.get_dashboard_for_job_run.return_value = {"url": "https://example.com/?authToken=1234"}
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "conn_id": "aws-test",
@@ -160,7 +160,7 @@ class TestEmrServerlessDashboardLink(BaseAwsLinksTestCase):
         mocked_client.get_dashboard_for_job_run.return_value = {"url": "https://example.com/?authToken=1234"}
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "conn_id": "aws-test",
@@ -254,7 +254,7 @@ class TestEmrServerlessS3LogsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-west-1",
@@ -282,7 +282,7 @@ class TestEmrServerlessCloudWatchLogsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-west-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_glue.py
@@ -30,7 +30,7 @@ class TestGlueJobRunDetailsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "ap-southeast-2",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_logs.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_logs.py
@@ -30,7 +30,7 @@ class TestCloudWatchEventsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-west-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_sagemaker.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_sagemaker.py
@@ -31,7 +31,7 @@ class TestSageMakerTransformDetailsLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="sagemaker_transform_job_details",
                 value={
                     "region_name": "us-east-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_sagemaker_unified_studio.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_sagemaker_unified_studio.py
@@ -30,7 +30,7 @@ class TestSageMakerUnifiedStudioLink(BaseAwsLinksTestCase):
 
     def test_extra_link(self, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "us-east-1",

--- a/providers/amazon/tests/unit/amazon/aws/links/test_step_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_step_function.py
@@ -47,7 +47,7 @@ class TestStateMachineDetailsLink(BaseAwsLinksTestCase):
     )
     def test_extra_link(self, state_machine_arn, expected_url: str, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-1",
@@ -82,7 +82,7 @@ class TestStateMachineExecutionsDetailsLink(BaseAwsLinksTestCase):
     )
     def test_extra_link(self, execution_arn, expected_url: str, mock_supervisor_comms):
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key=self.link_class.key,
                 value={
                     "region_name": "eu-west-1",

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -665,7 +665,7 @@ class TestDbtCloudRunJobOperator:
         ti.xcom_push(key="job_run_url", value=_run_response["data"]["href"])
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="job_run_url",
                 value=EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(
                     account_id=account_id or DEFAULT_ACCOUNT_ID,

--- a/providers/google/tests/unit/google/cloud/links/test_dataplex.py
+++ b/providers/google/tests/unit/google/cloud/links/test_dataplex.py
@@ -123,7 +123,7 @@ class TestDataplexTaskLink:
         link.persist(context={"ti": ti}, task_instance=ti.task)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "lake_id": ti.task.lake_id,
@@ -153,7 +153,7 @@ class TestDataplexTasksLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "project_id": ti.task.project_id,
@@ -183,7 +183,7 @@ class TestDataplexLakeLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "lake_id": ti.task.lake_id,
@@ -212,7 +212,7 @@ class TestDataplexCatalogEntryGroupLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "entry_group_id": ti.task.entry_group_id,
@@ -242,7 +242,7 @@ class TestDataplexCatalogEntryGroupsLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "location": ti.task.location,
@@ -270,7 +270,7 @@ class TestDataplexCatalogEntryTypeLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "entry_type_id": ti.task.entry_type_id,
@@ -300,7 +300,7 @@ class TestDataplexCatalogEntryTypesLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "location": ti.task.location,
@@ -328,7 +328,7 @@ class TestDataplexCatalogAspectTypeLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "aspect_type_id": ti.task.aspect_type_id,
@@ -358,7 +358,7 @@ class TestDataplexCatalogAspectTypesLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "location": ti.task.location,
@@ -387,7 +387,7 @@ class TestDataplexCatalogEntryLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "entry_id": ti.task.entry_id,

--- a/providers/google/tests/unit/google/cloud/links/test_translate.py
+++ b/providers/google/tests/unit/google/cloud/links/test_translate.py
@@ -62,7 +62,7 @@ class TestTranslationLegacyDatasetLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task, dataset_id=DATASET, project_id=GCP_PROJECT_ID)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={"location": ti.task.location, "dataset_id": DATASET, "project_id": GCP_PROJECT_ID},
             )
@@ -85,7 +85,7 @@ class TestTranslationDatasetListLink:
         session.commit()
         link.persist(context={"ti": ti}, task_instance=ti.task, project_id=GCP_PROJECT_ID)
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "project_id": GCP_PROJECT_ID,
@@ -121,7 +121,7 @@ class TestTranslationLegacyModelLink:
             project_id=GCP_PROJECT_ID,
         )
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "location": ti.task.location,
@@ -158,7 +158,7 @@ class TestTranslationLegacyModelTrainLink:
             project_id=GCP_PROJECT_ID,
         )
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
                     "location": ti.task.location,

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -1132,7 +1132,7 @@ def test_create_cluster_operator_extra_links(
     assert operator_extra_link.name == "Dataproc Cluster"
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="key",
             value="",
         )
@@ -1142,7 +1142,7 @@ def test_create_cluster_operator_extra_links(
     ti.xcom_push(key="dataproc_cluster", value=DATAPROC_CLUSTER_EXPECTED)
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="key",
             value={"cluster_id": "cluster_name", "project_id": "test-project", "region": "test-location"},
         )
@@ -2014,7 +2014,7 @@ def test_submit_job_operator_extra_links(
     assert operator_extra_link.name == "Dataproc Job"
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_job",
             value="",
         )
@@ -2025,7 +2025,7 @@ def test_submit_job_operator_extra_links(
     ti.xcom_push(key="dataproc_job", value=DATAPROC_JOB_EXPECTED)
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_job",
             value=DATAPROC_JOB_EXPECTED,
         )
@@ -2230,7 +2230,7 @@ def test_update_cluster_operator_extra_links(
     assert operator_extra_link.name == "Dataproc Cluster"
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_cluster",
             value="",
         )
@@ -2240,7 +2240,7 @@ def test_update_cluster_operator_extra_links(
     ti.xcom_push(key="dataproc_cluster", value=DATAPROC_CLUSTER_EXPECTED)
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_cluster",
             value=DATAPROC_CLUSTER_EXPECTED,
         )
@@ -2456,7 +2456,7 @@ def test_instantiate_workflow_operator_extra_links(
     assert operator_extra_link.name == "Dataproc Workflow"
 
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_workflow",
             value="",
         )
@@ -2465,7 +2465,7 @@ def test_instantiate_workflow_operator_extra_links(
 
     ti.xcom_push(key="dataproc_workflow", value=DATAPROC_WORKFLOW_EXPECTED)
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_workflow",
             value=DATAPROC_WORKFLOW_EXPECTED,
         )
@@ -3138,7 +3138,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
     operator_extra_link = deserialized_dag.tasks[0].operator_extra_links[0]
     assert operator_extra_link.name == "Dataproc Workflow"
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_workflow",
             value="",
         )
@@ -3147,7 +3147,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
 
     ti.xcom_push(key="dataproc_workflow", value=DATAPROC_WORKFLOW_EXPECTED)
     if AIRFLOW_V_3_0_PLUS:
-        mock_supervisor_comms.get_message.return_value = XComResult(
+        mock_supervisor_comms.send.return_value = XComResult(
             key="dataproc_workflow", value=DATAPROC_WORKFLOW_EXPECTED
         )
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_data_factory.py
@@ -253,7 +253,7 @@ class TestAzureDataFactoryRunPipelineOperator:
         ti.xcom_push(key="run_id", value=PIPELINE_RUN_RESPONSE["run_id"])
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="run_id",
                 value=PIPELINE_RUN_RESPONSE["run_id"],
             )

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py
@@ -292,7 +292,7 @@ class TestAzureSynapseRunPipelineOperator:
 
         ti.xcom_push(key="run_id", value=PIPELINE_RUN_RESPONSE["run_id"])
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
-            mock_supervisor_comms.get_message.return_value = XComResult(
+            mock_supervisor_comms.send.return_value = XComResult(
                 key="run_id",
                 value=PIPELINE_RUN_RESPONSE["run_id"],
             )

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -47,7 +47,6 @@ classifiers = [
 
 dependencies = [
     "apache-airflow-core<3.1.0,>=3.0.2",
-    "aiologic>=0.14.0",
     "attrs>=24.2.0, !=25.2.0",
     "fsspec>=2023.10.0",
     "httpx>=0.27.0",

--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -70,9 +70,8 @@ class BaseXCom:
             map_index=map_index,
         )
 
-        SUPERVISOR_COMMS.send_request(
-            log=log,
-            msg=SetXCom(
+        SUPERVISOR_COMMS.send(
+            SetXCom(
                 key=key,
                 value=value,
                 dag_id=dag_id,
@@ -107,9 +106,8 @@ class BaseXCom:
         """
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-        SUPERVISOR_COMMS.send_request(
-            log=log,
-            msg=SetXCom(
+        SUPERVISOR_COMMS.send(
+            SetXCom(
                 key=key,
                 value=value,
                 dag_id=dag_id,
@@ -181,23 +179,16 @@ class BaseXCom:
         """
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-        # Since Triggers can hit this code path via `sync_to_async` (which uses threads internally)
-        # we need to make sure that we "atomically" send a request and get the response to that
-        # back so that two triggers don't end up interleaving requests and create a possible
-        # race condition where the wrong trigger reads the response.
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetXCom(
-                    key=key,
-                    dag_id=dag_id,
-                    task_id=task_id,
-                    run_id=run_id,
-                    map_index=map_index,
-                ),
-            )
+        msg = SUPERVISOR_COMMS.send(
+            GetXCom(
+                key=key,
+                dag_id=dag_id,
+                task_id=task_id,
+                run_id=run_id,
+                map_index=map_index,
+            ),
+        )
 
-            msg = SUPERVISOR_COMMS.get_message()
         if not isinstance(msg, XComResult):
             raise TypeError(f"Expected XComResult, received: {type(msg)} {msg}")
 
@@ -241,23 +232,16 @@ class BaseXCom:
         """
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-        # Since Triggers can hit this code path via `sync_to_async` (which uses threads internally)
-        # we need to make sure that we "atomically" send a request and get the response to that
-        # back so that two triggers don't end up interleaving requests and create a possible
-        # race condition where the wrong trigger reads the response.
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetXCom(
-                    key=key,
-                    dag_id=dag_id,
-                    task_id=task_id,
-                    run_id=run_id,
-                    map_index=map_index,
-                    include_prior_dates=include_prior_dates,
-                ),
-            )
-            msg = SUPERVISOR_COMMS.get_message()
+        msg = SUPERVISOR_COMMS.send(
+            GetXCom(
+                key=key,
+                dag_id=dag_id,
+                task_id=task_id,
+                run_id=run_id,
+                map_index=map_index,
+                include_prior_dates=include_prior_dates,
+            ),
+        )
 
         if not isinstance(msg, XComResult):
             raise TypeError(f"Expected XComResult, received: {type(msg)} {msg}")
@@ -322,9 +306,8 @@ class BaseXCom:
             map_index=map_index,
         )
         cls.purge(xcom_result)  # type: ignore[call-arg]
-        SUPERVISOR_COMMS.send_request(
-            log=log,
-            msg=DeleteXCom(
+        SUPERVISOR_COMMS.send(
+            DeleteXCom(
                 key=key,
                 dag_id=dag_id,
                 task_id=task_id,

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -19,12 +19,17 @@ r"""
 Communication protocol between the Supervisor and the task process
 ==================================================================
 
-* All communication is done over stdout/stdin in the form of "JSON lines" (each
-  message is a single JSON document terminated by `\n` character)
-* Messages from the subprocess are all log messages and are sent directly to the log
+* All communication is done over the subprocesses stdin in the form of a binary length-prefixed msgpack frame
+  (4 byte, big-endian length, followed by the msgpack-encoded _RequestFrame.) Each side uses this same
+  encoding
+* Log Messages from the subprocess are sent over the dedicated logs socket (which is line-based JSON)
 * No messages are sent to task process except in response to a request. (This is because the task process will
   be running user's code, so we can't read from stdin until we enter our code, such as when requesting an XCom
   value etc.)
+* Every request returns a response, even if the frame is otherwise empty.
+* Requests are written by the subprocess to fd0/stdin. This is making use of the fact that stdin is a
+  bi-directional socket, and thus we can write to it and don't need a dedicated extra socket for sending
+  requests.
 
 The reason this communication protocol exists, rather than the task process speaking directly to the Task
 Execution API server is because:
@@ -43,15 +48,20 @@ Execution API server is because:
 
 from __future__ import annotations
 
+import itertools
 from collections.abc import Iterator
 from datetime import datetime
 from functools import cached_property
-from typing import Annotated, Any, Literal, Union
+from pathlib import Path
+from socket import socket
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Generic, Literal, TypeVar, Union
 from uuid import UUID
 
 import attrs
+import msgspec
+import structlog
 from fastapi import Body
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, field_serializer
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, field_serializer
 
 from airflow.sdk.api.datamodels._generated import (
     AssetEventDagRunReference,
@@ -80,6 +90,145 @@ from airflow.sdk.api.datamodels._generated import (
 )
 from airflow.sdk.exceptions import ErrorType
 
+if TYPE_CHECKING:
+    from structlog.typing import FilteringBoundLogger as Logger
+
+SendMsgType = TypeVar("SendMsgType", bound=BaseModel)
+ReceiveMsgType = TypeVar("ReceiveMsgType", bound=BaseModel)
+
+
+def _msgpack_enc_hook(obj: Any) -> Any:
+    import pendulum
+
+    if isinstance(obj, pendulum.DateTime):
+        # convert the pendulm Datetime subclass into a raw datetime so that msgspec can use it's native
+        # encoding
+        return datetime(
+            obj.year, obj.month, obj.day, obj.hour, obj.minute, obj.second, obj.microsecond, tzinfo=obj.tzinfo
+        )
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(exclude_unset=True)
+
+    # Raise a NotImplementedError for other types
+    raise NotImplementedError(f"Objects of type {type(obj)} are not supported")
+
+
+def _new_encoder() -> msgspec.msgpack.Encoder:
+    return msgspec.msgpack.Encoder(enc_hook=_msgpack_enc_hook)
+
+
+class _RequestFrame(msgspec.Struct, array_like=True, frozen=True, omit_defaults=True):
+    id: int
+    """
+    The request id, set by the sender.
+
+    This is used to allow "pipeling" of requests and to be able to tie response to requests, which is
+    particularly useful in the Triggerer where multiple async tasks can send a requests concurrently.
+    """
+    body: dict[str, Any] | None
+
+    req_encoder: ClassVar[msgspec.msgpack.Encoder] = _new_encoder()
+
+    def as_bytes(self) -> bytearray:
+        # https://jcristharif.com/msgspec/perf-tips.html#length-prefix-framing for inspiration
+        buffer = bytearray(256)
+
+        self.req_encoder.encode_into(self, buffer, 4)
+
+        n = len(buffer) - 4
+        if n >= 2**32:
+            raise OverflowError(f"Cannot send messages larger than 4GiB {n=}")
+        buffer[:4] = n.to_bytes(4, byteorder="big")
+
+        return buffer
+
+
+class _ResponseFrame(_RequestFrame, frozen=True):
+    id: int
+    """
+    The id of the request this is a response to
+    """
+    body: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+
+
+@attrs.define()
+class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
+    """Handle communication between the task in this process and the supervisor parent process."""
+
+    log: Logger = attrs.field(repr=False, factory=structlog.get_logger)
+    socket: socket = attrs.field(factory=lambda: socket(fileno=0))
+
+    resp_decoder: msgspec.msgpack.Decoder[_ResponseFrame] = attrs.field(
+        factory=lambda: msgspec.msgpack.Decoder(_ResponseFrame), repr=False
+    )
+
+    id_counter: Iterator[int] = attrs.field(factory=itertools.count)
+
+    # We could be "clever" here and set the default to this based type parameters and a custom
+    # `__class_getitem__`, but that's a lot of code the one subclass we've got currently. So we'll just use a
+    # "sort of wrong default"
+    body_decoder: TypeAdapter[ReceiveMsgType] = attrs.field(factory=lambda: TypeAdapter(ToTask), repr=False)
+
+    err_decoder: TypeAdapter[ErrorResponse] = attrs.field(factory=lambda: TypeAdapter(ToTask), repr=False)
+
+    def send(self, msg: SendMsgType) -> ReceiveMsgType | None:
+        """Send a request to the parent and block until the response is received."""
+        frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
+        bytes = frame.as_bytes()
+
+        self.socket.sendall(bytes)
+
+        return self._get_response()
+
+    def _read_frame(self):
+        """
+        Get a message from the parent.
+
+        This will block until the message has been received.
+        """
+        if self.socket:
+            self.socket.setblocking(True)
+        len_bytes = self.socket.recv(4)
+
+        if len_bytes == b"":
+            raise EOFError("Request socket closed before length")
+
+        len = int.from_bytes(len_bytes, byteorder="big")
+
+        buffer = bytearray(len)
+        nread = self.socket.recv_into(buffer)
+        if nread != len:
+            raise RuntimeError(
+                f"unable to read full response in child. (We read {nread}, but expected {len})"
+            )
+        if nread == 0:
+            raise EOFError(f"Request socket closed before response was complete ({self.id_counter=})")
+
+        return self.resp_decoder.decode(buffer)
+
+    def _from_frame(self, frame) -> ReceiveMsgType | None:
+        from airflow.sdk.exceptions import AirflowRuntimeError
+
+        if frame.error is not None:
+            err = self.err_decoder.validate_python(frame.error)
+            raise AirflowRuntimeError(error=err)
+
+        if frame.body is None:
+            return None
+
+        try:
+            return self.body_decoder.validate_python(frame.body)
+        except Exception:
+            self.log.exception("Unable to decode message")
+            raise
+
+    def _get_response(self) -> ReceiveMsgType | None:
+        frame = self._read_frame()
+        return self._from_frame(frame)
+
 
 class StartupDetails(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -87,13 +236,7 @@ class StartupDetails(BaseModel):
     ti: TaskInstance
     dag_rel_path: str
     bundle_info: BundleInfo
-    requests_fd: int
     start_date: datetime
-    """
-    The channel for the task to send requests over.
-
-    Responses will come back on stdin
-    """
     ti_context: TIRunContext
     type: Literal["StartupDetails"] = "StartupDetails"
 

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -150,13 +150,7 @@ def _get_connection(conn_id: str) -> Connection:
     from airflow.sdk.execution_time.comms import ErrorResponse, GetConnection
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    # Since Triggers can hit this code path via `sync_to_async` (which uses threads internally)
-    # we need to make sure that we "atomically" send a request and get the response to that
-    # back so that two triggers don't end up interleaving requests and create a possible
-    # race condition where the wrong trigger reads the response.
-    with SUPERVISOR_COMMS.lock:
-        SUPERVISOR_COMMS.send_request(log=log, msg=GetConnection(conn_id=conn_id))
-        msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send(GetConnection(conn_id=conn_id))
 
     if isinstance(msg, ErrorResponse):
         raise AirflowRuntimeError(msg)
@@ -203,13 +197,7 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
     from airflow.sdk.execution_time.comms import ErrorResponse, GetVariable
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    # Since Triggers can hit this code path via `sync_to_async` (which uses threads internally)
-    # we need to make sure that we "atomically" send a request and get the response to that
-    # back so that two triggers don't end up interleaving requests and create a possible
-    # race condition where the wrong trigger reads the response.
-    with SUPERVISOR_COMMS.lock:
-        SUPERVISOR_COMMS.send_request(log=log, msg=GetVariable(key=key))
-        msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send(GetVariable(key=key))
 
     if isinstance(msg, ErrorResponse):
         raise AirflowRuntimeError(msg)
@@ -259,11 +247,7 @@ def _set_variable(key: str, value: Any, description: str | None = None, serializ
     except Exception as e:
         log.exception(e)
 
-    # It is best to have lock everywhere or nowhere on the SUPERVISOR_COMMS, lock was
-    # primarily added for triggers but it doesn't make sense to have it in some places
-    # and not in the rest. A lot of this will be simplified by https://github.com/apache/airflow/issues/46426
-    with SUPERVISOR_COMMS.lock:
-        SUPERVISOR_COMMS.send_request(log=log, msg=PutVariable(key=key, value=value, description=description))
+    SUPERVISOR_COMMS.send(PutVariable(key=key, value=value, description=description))
 
 
 def _delete_variable(key: str) -> None:
@@ -275,12 +259,7 @@ def _delete_variable(key: str) -> None:
     from airflow.sdk.execution_time.comms import DeleteVariable
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    # It is best to have lock everywhere or nowhere on the SUPERVISOR_COMMS, lock was
-    # primarily added for triggers but it doesn't make sense to have it in some places
-    # and not in the rest. A lot of this will be simplified by https://github.com/apache/airflow/issues/46426
-    with SUPERVISOR_COMMS.lock:
-        SUPERVISOR_COMMS.send_request(log=log, msg=DeleteVariable(key=key))
-        msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send(DeleteVariable(key=key))
     if TYPE_CHECKING:
         assert isinstance(msg, OKResponse)
 
@@ -383,23 +362,29 @@ class _AssetRefResolutionMixin:
     @staticmethod
     def _get_asset_from_db(name: str | None = None, uri: str | None = None) -> Asset:
         from airflow.sdk.definitions.asset import Asset
-        from airflow.sdk.execution_time.comms import ErrorResponse, GetAssetByName, GetAssetByUri
+        from airflow.sdk.execution_time.comms import (
+            ErrorResponse,
+            GetAssetByName,
+            GetAssetByUri,
+            ToSupervisor,
+        )
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
+        msg: ToSupervisor
         if name:
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetByName(name=name))
+            msg = GetAssetByName(name=name)
         elif uri:
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetByUri(uri=uri))
+            msg = GetAssetByUri(uri=uri)
         else:
             raise ValueError("Either name or uri must be provided")
 
-        msg = SUPERVISOR_COMMS.get_message()
-        if isinstance(msg, ErrorResponse):
-            raise AirflowRuntimeError(msg)
+        resp = SUPERVISOR_COMMS.send(msg)
+        if isinstance(resp, ErrorResponse):
+            raise AirflowRuntimeError(resp)
 
         if TYPE_CHECKING:
-            assert isinstance(msg, AssetResult)
-        return Asset(**msg.model_dump(exclude={"type"}))
+            assert isinstance(resp, AssetResult)
+        return Asset(**resp.model_dump(exclude={"type"}))
 
 
 @attrs.define
@@ -565,9 +550,11 @@ class InletEventsAccessors(Mapping[Union[int, Asset, AssetAlias, AssetRef], Any]
             ErrorResponse,
             GetAssetEventByAsset,
             GetAssetEventByAssetAlias,
+            ToSupervisor,
         )
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
+        msg: ToSupervisor
         if isinstance(key, int):  # Support index access; it's easier for trivial cases.
             obj = self._inlets[key]
             if not isinstance(obj, (Asset, AssetAlias, AssetRef)):
@@ -577,31 +564,33 @@ class InletEventsAccessors(Mapping[Union[int, Asset, AssetAlias, AssetRef], Any]
 
         if isinstance(obj, Asset):
             asset = self._assets[AssetUniqueKey.from_asset(obj)]
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetEventByAsset(name=asset.name, uri=asset.uri))
+            msg = GetAssetEventByAsset(name=asset.name, uri=asset.uri)
         elif isinstance(obj, AssetNameRef):
             try:
                 asset = next(a for k, a in self._assets.items() if k.name == obj.name)
             except StopIteration:
                 raise KeyError(obj) from None
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetEventByAsset(name=asset.name, uri=None))
+            msg = GetAssetEventByAsset(name=asset.name, uri=None)
         elif isinstance(obj, AssetUriRef):
             try:
                 asset = next(a for k, a in self._assets.items() if k.uri == obj.uri)
             except StopIteration:
                 raise KeyError(obj) from None
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetEventByAsset(name=None, uri=asset.uri))
+            msg = GetAssetEventByAsset(name=None, uri=asset.uri)
         elif isinstance(obj, AssetAlias):
             asset_alias = self._asset_aliases[AssetAliasUniqueKey.from_asset_alias(obj)]
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetEventByAssetAlias(alias_name=asset_alias.name))
+            msg = GetAssetEventByAssetAlias(alias_name=asset_alias.name)
+        else:
+            raise TypeError(f"`key` is of unknown type ({type(key).__name__})")
 
-        msg = SUPERVISOR_COMMS.get_message()
-        if isinstance(msg, ErrorResponse):
-            raise AirflowRuntimeError(msg)
+        resp = SUPERVISOR_COMMS.send(msg)
+        if isinstance(resp, ErrorResponse):
+            raise AirflowRuntimeError(resp)
 
         if TYPE_CHECKING:
-            assert isinstance(msg, AssetEventsResult)
+            assert isinstance(resp, AssetEventsResult)
 
-        return list(msg.iter_asset_event_results())
+        return list(resp.iter_asset_event_results())
 
 
 @cache  # Prevent multiple API access.
@@ -613,8 +602,7 @@ def get_previous_dagrun_success(ti_id: UUID) -> PrevSuccessfulDagRunResponse:
     )
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    SUPERVISOR_COMMS.send_request(log=log, msg=GetPrevSuccessfulDagRun(ti_id=ti_id))
-    msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send(GetPrevSuccessfulDagRun(ti_id=ti_id))
 
     if TYPE_CHECKING:
         assert isinstance(msg, PrevSuccessfulDagRunResult)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -28,16 +28,14 @@ import time
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import suppress
 from datetime import datetime, timezone
-from io import FileIO
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, TextIO, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-import aiologic
 import attrs
 import lazy_object_proxy
 import structlog
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, TypeAdapter
+from pydantic import AwareDatetime, ConfigDict, Field, JsonValue
 
 from airflow.dag_processing.bundles.base import BaseDagBundle, BundleVersionLock
 from airflow.dag_processing.bundles.manager import DagBundlesManager
@@ -59,6 +57,7 @@ from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 from airflow.sdk.execution_time.callback_runner import create_executable_runner
 from airflow.sdk.execution_time.comms import (
     AssetEventDagRunReferenceResult,
+    CommsDecoder,
     DagRunStateResult,
     DeferTask,
     DRCount,
@@ -410,10 +409,9 @@ class RuntimeTaskInstance(TaskInstance):
 
         log.debug("Requesting first reschedule date from supervisor")
 
-        SUPERVISOR_COMMS.send_request(
-            log=log, msg=GetTaskRescheduleStartDate(ti_id=self.id, try_number=first_try_number)
+        response = SUPERVISOR_COMMS.send(
+            msg=GetTaskRescheduleStartDate(ti_id=self.id, try_number=first_try_number)
         )
-        response = SUPERVISOR_COMMS.get_message()
 
         if TYPE_CHECKING:
             assert isinstance(response, TaskRescheduleStartDate)
@@ -431,22 +429,17 @@ class RuntimeTaskInstance(TaskInstance):
         states: list[str] | None = None,
     ) -> int:
         """Return the number of task instances matching the given criteria."""
-        log = structlog.get_logger(logger_name="task")
-
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetTICount(
-                    dag_id=dag_id,
-                    map_index=map_index,
-                    task_ids=task_ids,
-                    task_group_id=task_group_id,
-                    logical_dates=logical_dates,
-                    run_ids=run_ids,
-                    states=states,
-                ),
-            )
-            response = SUPERVISOR_COMMS.get_message()
+        response = SUPERVISOR_COMMS.send(
+            GetTICount(
+                dag_id=dag_id,
+                map_index=map_index,
+                task_ids=task_ids,
+                task_group_id=task_group_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+                states=states,
+            ),
+        )
 
         if TYPE_CHECKING:
             assert isinstance(response, TICount)
@@ -463,21 +456,16 @@ class RuntimeTaskInstance(TaskInstance):
         run_ids: list[str] | None = None,
     ) -> dict[str, Any]:
         """Return the task states matching the given criteria."""
-        log = structlog.get_logger(logger_name="task")
-
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetTaskStates(
-                    dag_id=dag_id,
-                    map_index=map_index,
-                    task_ids=task_ids,
-                    task_group_id=task_group_id,
-                    logical_dates=logical_dates,
-                    run_ids=run_ids,
-                ),
-            )
-            response = SUPERVISOR_COMMS.get_message()
+        response = SUPERVISOR_COMMS.send(
+            GetTaskStates(
+                dag_id=dag_id,
+                map_index=map_index,
+                task_ids=task_ids,
+                task_group_id=task_group_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+            ),
+        )
 
         if TYPE_CHECKING:
             assert isinstance(response, TaskStatesResult)
@@ -492,19 +480,14 @@ class RuntimeTaskInstance(TaskInstance):
         states: list[str] | None = None,
     ) -> int:
         """Return the number of DAG runs matching the given criteria."""
-        log = structlog.get_logger(logger_name="task")
-
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=GetDRCount(
-                    dag_id=dag_id,
-                    logical_dates=logical_dates,
-                    run_ids=run_ids,
-                    states=states,
-                ),
-            )
-            response = SUPERVISOR_COMMS.get_message()
+        response = SUPERVISOR_COMMS.send(
+            GetDRCount(
+                dag_id=dag_id,
+                logical_dates=logical_dates,
+                run_ids=run_ids,
+                states=states,
+            ),
+        )
 
         if TYPE_CHECKING:
             assert isinstance(response, DRCount)
@@ -514,10 +497,7 @@ class RuntimeTaskInstance(TaskInstance):
     @staticmethod
     def get_dagrun_state(dag_id: str, run_id: str) -> str:
         """Return the state of the DAG run with the given Run ID."""
-        log = structlog.get_logger(logger_name="task")
-        with SUPERVISOR_COMMS.lock:
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetDagRunState(dag_id=dag_id, run_id=run_id))
-            response = SUPERVISOR_COMMS.get_message()
+        response = SUPERVISOR_COMMS.send(msg=GetDagRunState(dag_id=dag_id, run_id=run_id))
 
         if TYPE_CHECKING:
             assert isinstance(response, DagRunStateResult)
@@ -619,62 +599,6 @@ def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
     )
 
 
-SendMsgType = TypeVar("SendMsgType", bound=BaseModel)
-ReceiveMsgType = TypeVar("ReceiveMsgType", bound=BaseModel)
-
-
-@attrs.define()
-class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
-    """Handle communication between the task in this process and the supervisor parent process."""
-
-    input: TextIO
-
-    request_socket: FileIO = attrs.field(init=False, default=None)
-
-    # We could be "clever" here and set the default to this based type parameters and a custom
-    # `__class_getitem__`, but that's a lot of code the one subclass we've got currently. So we'll just use a
-    # "sort of wrong default"
-    decoder: TypeAdapter[ReceiveMsgType] = attrs.field(factory=lambda: TypeAdapter(ToTask), repr=False)
-
-    lock: aiologic.Lock = attrs.field(factory=aiologic.Lock, repr=False)
-
-    def get_message(self) -> ReceiveMsgType:
-        """
-        Get a message from the parent.
-
-        This will block until the message has been received.
-        """
-        line = None
-
-        # TODO: Investigate why some empty lines are sent to the processes stdin.
-        #   That was highlighted when working on https://github.com/apache/airflow/issues/48183
-        #   and is maybe related to deferred/triggerer only context.
-        while not line:
-            line = self.input.readline()
-
-        try:
-            msg = self.decoder.validate_json(line)
-        except Exception:
-            structlog.get_logger(logger_name="CommsDecoder").exception("Unable to decode message", line=line)
-            raise
-
-        if isinstance(msg, StartupDetails):
-            # If we read a startup message, pull out the FDs we care about!
-            if msg.requests_fd > 0:
-                self.request_socket = os.fdopen(msg.requests_fd, "wb", buffering=0)
-        elif isinstance(msg, ErrorResponse) and msg.error == ErrorType.API_SERVER_ERROR:
-            structlog.get_logger(logger_name="task").error("Error response from the API Server")
-            raise AirflowRuntimeError(error=msg)
-
-        return msg
-
-    def send_request(self, log: Logger, msg: SendMsgType):
-        encoded_msg = msg.model_dump_json().encode() + b"\n"
-
-        log.debug("Sending request", json=encoded_msg)
-        self.request_socket.write(encoded_msg)
-
-
 # This global variable will be used by Connection/Variable/XCom classes, or other parts of the task's execution,
 # to send requests back to the supervisor process.
 #
@@ -694,30 +618,32 @@ SUPERVISOR_COMMS: CommsDecoder[ToTask, ToSupervisor]
 
 
 def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
-    msg = SUPERVISOR_COMMS.get_message()
+    # The parent sends us a StartupDetails message un-prompted. After this, every single message is only sent
+    # in response to us sending a request.
+    msg = SUPERVISOR_COMMS._get_response()
+
+    if not isinstance(msg, StartupDetails):
+        raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")
 
     log = structlog.get_logger(logger_name="task")
+
+    # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
+    os_type = sys.platform
+    if os_type == "darwin":
+        log.debug("Mac OS detected, skipping setproctitle")
+    else:
+        from setproctitle import setproctitle
+
+        setproctitle(f"airflow worker -- {msg.ti.id}")
 
     try:
         get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
     except Exception:
         log.exception("error calling listener")
 
-    if isinstance(msg, StartupDetails):
-        # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
-        os_type = sys.platform
-        if os_type == "darwin":
-            log.debug("Mac OS detected, skipping setproctitle")
-        else:
-            from setproctitle import setproctitle
-
-            setproctitle(f"airflow worker -- {msg.ti.id}")
-
-        with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
-            ti = parse(msg, log)
-        log.debug("DAG file parsed", file=msg.dag_rel_path)
-    else:
-        raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")
+    with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
+        ti = parse(msg, log)
+    log.debug("DAG file parsed", file=msg.dag_rel_path)
 
     return ti, ti.get_template_context(), log
 
@@ -765,7 +691,7 @@ def _prepare(ti: RuntimeTaskInstance, log: Logger, context: Context) -> ToSuperv
 
     if rendered_fields := _serialize_rendered_fields(ti.task):
         # so that we do not call the API unnecessarily
-        SUPERVISOR_COMMS.send_request(log=log, msg=SetRenderedFields(rendered_fields=rendered_fields))
+        SUPERVISOR_COMMS.send(msg=SetRenderedFields(rendered_fields=rendered_fields))
 
     _validate_task_inlets_and_outlets(ti=ti, log=log)
 
@@ -785,8 +711,7 @@ def _validate_task_inlets_and_outlets(*, ti: RuntimeTaskInstance, log: Logger) -
     if not ti.task.inlets and not ti.task.outlets:
         return
 
-    SUPERVISOR_COMMS.send_request(msg=ValidateInletsAndOutlets(ti_id=ti.id), log=log)
-    inactive_assets_resp = SUPERVISOR_COMMS.get_message()
+    inactive_assets_resp = SUPERVISOR_COMMS.send(msg=ValidateInletsAndOutlets(ti_id=ti.id))
     if TYPE_CHECKING:
         assert isinstance(inactive_assets_resp, InactiveAssetsResult)
     if inactive_assets := inactive_assets_resp.inactive_assets:
@@ -882,7 +807,7 @@ def run(
     except DownstreamTasksSkipped as skip:
         log.info("Skipping downstream tasks.")
         tasks_to_skip = skip.tasks if isinstance(skip.tasks, list) else [skip.tasks]
-        SUPERVISOR_COMMS.send_request(log=log, msg=SkipDownstreamTasks(tasks=tasks_to_skip))
+        SUPERVISOR_COMMS.send(msg=SkipDownstreamTasks(tasks=tasks_to_skip))
         msg, state = _handle_current_task_success(context, ti)
     except DagRunTriggerException as drte:
         msg, state = _handle_trigger_dag_run(drte, context, ti, log)
@@ -942,7 +867,7 @@ def run(
         error = e
     finally:
         if msg:
-            SUPERVISOR_COMMS.send_request(msg=msg, log=log)
+            SUPERVISOR_COMMS.send(msg=msg)
 
     # Return the message to make unit tests easier too
     ti.state = state
@@ -980,9 +905,8 @@ def _handle_trigger_dag_run(
 ) -> tuple[ToSupervisor, TaskInstanceState]:
     """Handle exception from TriggerDagRunOperator."""
     log.info("Triggering Dag Run.", trigger_dag_id=drte.trigger_dag_id)
-    SUPERVISOR_COMMS.send_request(
-        log=log,
-        msg=TriggerDagRun(
+    comms_msg = SUPERVISOR_COMMS.send(
+        TriggerDagRun(
             dag_id=drte.trigger_dag_id,
             run_id=drte.dag_run_id,
             logical_date=drte.logical_date,
@@ -991,7 +915,6 @@ def _handle_trigger_dag_run(
         ),
     )
 
-    comms_msg = SUPERVISOR_COMMS.get_message()
     if isinstance(comms_msg, ErrorResponse) and comms_msg.error == ErrorType.DAGRUN_ALREADY_EXISTS:
         if drte.skip_when_already_exists:
             log.info(
@@ -1046,10 +969,9 @@ def _handle_trigger_dag_run(
             )
             time.sleep(drte.poke_interval)
 
-            SUPERVISOR_COMMS.send_request(
-                log=log, msg=GetDagRunState(dag_id=drte.trigger_dag_id, run_id=drte.dag_run_id)
+            comms_msg = SUPERVISOR_COMMS.send(
+                GetDagRunState(dag_id=drte.trigger_dag_id, run_id=drte.dag_run_id)
             )
-            comms_msg = SUPERVISOR_COMMS.get_message()
             if TYPE_CHECKING:
                 assert isinstance(comms_msg, DagRunStateResult)
             if comms_msg.state in drte.failed_states:
@@ -1238,10 +1160,7 @@ def finalize(
     if getattr(ti.task, "overwrite_rtif_after_execution", False):
         log.debug("Overwriting Rendered template fields.")
         if ti.task.template_fields:
-            SUPERVISOR_COMMS.send_request(
-                log=log,
-                msg=SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)),
-            )
+            SUPERVISOR_COMMS.send(SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)))
 
     log.debug("Running finalizers", ti=ti)
     if state == TaskInstanceState.SUCCESS:
@@ -1282,9 +1201,11 @@ def finalize(
 
 
 def main():
-    # TODO: add an exception here, it causes an oof of a stack trace!
+    # TODO: add an exception here, it causes an oof of a stack trace if it happens to early!
+    log = structlog.get_logger(logger_name="task")
+
     global SUPERVISOR_COMMS
-    SUPERVISOR_COMMS = CommsDecoder[ToTask, ToSupervisor](input=sys.stdin)
+    SUPERVISOR_COMMS = CommsDecoder[ToTask, ToSupervisor](log=log)
 
     try:
         ti, context, log = startup()
@@ -1295,19 +1216,17 @@ def main():
             state, msg, error = run(ti, context, log)
             finalize(ti, state, context, log, error)
     except KeyboardInterrupt:
-        log = structlog.get_logger(logger_name="task")
         log.exception("Ctrl-c hit")
         exit(2)
     except Exception:
-        log = structlog.get_logger(logger_name="task")
         log.exception("Top level error")
         exit(1)
     finally:
         # Ensure the request socket is closed on the child side in all circumstances
         # before the process fully terminates.
-        if SUPERVISOR_COMMS and SUPERVISOR_COMMS.request_socket:
+        if SUPERVISOR_COMMS and SUPERVISOR_COMMS.socket:
             with suppress(Exception):
-                SUPERVISOR_COMMS.request_socket.close()
+                SUPERVISOR_COMMS.socket.close()
 
 
 if __name__ == "__main__":

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -205,7 +205,7 @@ class TestBaseSensor:
         time_machine.coordinates.shift(sensor.poke_interval)
 
         # Mocking values from DB/API-server
-        mock_supervisor_comms.get_message.return_value = TaskRescheduleStartDate(start_date=date1)
+        mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(start_date=date1)
         state, msg, error = run_task(task=sensor, context_update={"task_reschedule_count": 1})
 
         assert state == State.FAILED
@@ -227,7 +227,7 @@ class TestBaseSensor:
         time_machine.coordinates.shift(sensor.poke_interval)
 
         # Mocking values from DB/API-server
-        mock_supervisor_comms.get_message.return_value = TaskRescheduleStartDate(start_date=date1)
+        mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(start_date=date1)
         state, msg, _ = run_task(task=sensor, context_update={"task_reschedule_count": 1})
         assert state == State.SKIPPED
 
@@ -254,7 +254,7 @@ class TestBaseSensor:
             return (timezone.utcnow() - task_start_date).total_seconds()
 
         new_interval = 0
-        mock_supervisor_comms.get_message.return_value = TaskRescheduleStartDate(start_date=task_start_date)
+        mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(start_date=task_start_date)
 
         # loop poke returns false
         for _poke_count in range(1, false_count + 1):
@@ -516,9 +516,9 @@ class TestBaseSensor:
             # For timeout calculation, we need to use the first reschedule date
             # This ensures the timeout is calculated from the start of the task
             if test_state["first_reschedule_date"] is None:
-                mock_supervisor_comms.get_message.return_value = TaskRescheduleStartDate(start_date=None)
+                mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(start_date=None)
             else:
-                mock_supervisor_comms.get_message.return_value = TaskRescheduleStartDate(
+                mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(
                     start_date=test_state["first_reschedule_date"]
                 )
 

--- a/task-sdk/tests/task_sdk/definitions/conftest.py
+++ b/task-sdk/tests/task_sdk/definitions/conftest.py
@@ -36,12 +36,12 @@ def run_ti(create_runtime_ti, mock_supervisor_comms):
 
         log = structlog.get_logger(__name__)
 
-        mock_supervisor_comms.send_request.reset_mock()
+        mock_supervisor_comms.send.reset_mock()
         ti = create_runtime_ti(dag.task_dict[task_id], map_index=map_index)
         run(ti, ti.get_template_context(), log)
 
-        for call in mock_supervisor_comms.send_request.mock_calls:
-            msg = call.kwargs["msg"]
+        for call in mock_supervisor_comms.send.mock_calls:
+            msg = call.kwargs.get("msg") or call.args[0]
             if isinstance(msg, (TaskState, SucceedTask)):
                 return msg.state
         raise RuntimeError("Unable to find call to TaskState")

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -295,7 +295,7 @@ class Test_AssetMainOperator:
             example_asset_func_with_valid_arg_as_inlet_asset
         )
 
-        mock_supervisor_comms.get_message.side_effect = [
+        mock_supervisor_comms.send.side_effect = [
             AssetResult(
                 name="example_asset_func",
                 uri="s3://bucket/object",
@@ -326,12 +326,9 @@ class Test_AssetMainOperator:
         }
 
         assert mock_supervisor_comms.mock_calls == [
-            mock.call.send_request(mock.ANY, GetAssetByName(name="example_asset_func")),
-            mock.call.get_message(),
-            mock.call.send_request(mock.ANY, GetAssetByName(name="inlet_asset_1")),
-            mock.call.get_message(),
-            mock.call.send_request(mock.ANY, GetAssetByName(name="inlet_asset_2")),
-            mock.call.get_message(),
+            mock.call.send(GetAssetByName(name="example_asset_func")),
+            mock.call.send(GetAssetByName(name="inlet_asset_1")),
+            mock.call.send(GetAssetByName(name="inlet_asset_2")),
         ]
 
     @mock.patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True)
@@ -342,7 +339,7 @@ class Test_AssetMainOperator:
     ):
         asset_definition = asset(schedule=None)(example_asset_func_with_valid_arg_as_inlet_asset_and_default)
 
-        mock_supervisor_comms.get_message.side_effect = [
+        mock_supervisor_comms.send.side_effect = [
             AssetResult(name="inlet_asset_1", uri="s3://bucket/object1", group="asset", extra=None),
         ]
 
@@ -360,6 +357,5 @@ class Test_AssetMainOperator:
         }
 
         assert mock_supervisor_comms.mock_calls == [
-            mock.call.send_request(mock.ANY, GetAssetByName(name="inlet_asset_1")),
-            mock.call.get_message(),
+            mock.call.send(GetAssetByName(name="inlet_asset_1")),
         ]

--- a/task-sdk/tests/task_sdk/definitions/test_connections.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connections.py
@@ -104,7 +104,7 @@ class TestConnections:
 
     def test_conn_get(self, mock_supervisor_comms):
         conn_result = ConnectionResult(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
-        mock_supervisor_comms.get_message.return_value = conn_result
+        mock_supervisor_comms.send.return_value = conn_result
 
         conn = Connection.get(conn_id="mysql_conn")
         assert conn is not None

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -51,7 +51,7 @@ class TestVariables:
     )
     def test_var_get(self, deserialize_json, value, expected_value, mock_supervisor_comms):
         var_result = VariableResult(key="my_key", value=value)
-        mock_supervisor_comms.get_message.return_value = var_result
+        mock_supervisor_comms.send.return_value = var_result
 
         var = Variable.get(key="my_key", deserialize_json=deserialize_json)
         assert var is not None
@@ -83,8 +83,7 @@ class TestVariables:
         if serialize_json:
             expected_value = json.dumps(value, indent=2)
 
-        mock_supervisor_comms.send_request.assert_called_once_with(
-            log=mock.ANY,
+        mock_supervisor_comms.send.assert_called_once_with(
             msg=PutVariable(
                 key=key, value=expected_value, description=description, serialize_json=serialize_json
             ),

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -52,7 +52,7 @@ def test_xcom_map(run_ti: RunTI, mock_supervisor_comms):
     assert set(dag.task_dict) == {"push", "pull"}
 
     # Mock xcom result from push task
-    mock_supervisor_comms.get_message.return_value = XComResult(key="return_value", value=["a", "b", "c"])
+    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["a", "b", "c"])
 
     for map_index in range(3):
         assert run_ti(dag, "pull", map_index) == TaskInstanceState.SUCCESS
@@ -81,7 +81,7 @@ def test_xcom_map_transform_to_none(run_ti: RunTI, mock_supervisor_comms):
         pull.expand(value=push().map(c_to_none))
 
     # Mock xcom result from push task
-    mock_supervisor_comms.get_message.return_value = XComResult(key="return_value", value=["a", "b", "c"])
+    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["a", "b", "c"])
 
     # Run "pull". This should automatically convert "c" to None.
     for map_index in range(3):
@@ -111,7 +111,7 @@ def test_xcom_convert_to_kwargs_fails_task(run_ti: RunTI, mock_supervisor_comms,
         pull.expand_kwargs(push().map(c_to_none))
 
     # Mock xcom result from push task
-    mock_supervisor_comms.get_message.return_value = XComResult(key="return_value", value=["a", "b", "c"])
+    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["a", "b", "c"])
 
     # The first two "pull" tis should succeed.
     for map_index in range(2):
@@ -165,7 +165,7 @@ def test_xcom_map_error_fails_task(mock_supervisor_comms, run_ti, captured_logs)
         pull.expand_kwargs(push().map(does_not_work_with_c))
 
     # Mock xcom result from push task
-    mock_supervisor_comms.get_message.return_value = XComResult(key="return_value", value=["a", "b", "c"])
+    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["a", "b", "c"])
     # The third one (for "c") will fail.
     assert run_ti(dag, "pull", 2) == TaskInstanceState.FAILED
 
@@ -209,7 +209,7 @@ def test_xcom_map_nest(mock_supervisor_comms, run_ti):
         pull.expand_kwargs(converted)
 
     # Mock xcom result from push task
-    mock_supervisor_comms.get_message.return_value = XComResult(key="return_value", value=["a", "b", "c"])
+    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["a", "b", "c"])
 
     # Now "pull" should apply the mapping functions in order.
     for map_index in range(3):
@@ -243,20 +243,18 @@ def test_xcom_map_zip_nest(mock_supervisor_comms, run_ti):
 
         pull.expand(value=combined.map(convert_zipped))
 
-    def xcom_get():
-        # TODO: Tidy this after #45927 is reopened and fixed properly
-        last_request = mock_supervisor_comms.send_request.mock_calls[-1].kwargs["msg"]
-        if not isinstance(last_request, GetXCom):
+    def xcom_get(msg):
+        if not isinstance(msg, GetXCom):
             return mock.DEFAULT
-        if last_request.task_id == "push_letters":
+        if msg.task_id == "push_letters":
             value = push_letters.function()
             return XComResult(key="return_value", value=value)
-        if last_request.task_id == "push_numbers":
+        if msg.task_id == "push_numbers":
             value = push_numbers.function()
             return XComResult(key="return_value", value=value)
         return mock.DEFAULT
 
-    mock_supervisor_comms.get_message.side_effect = xcom_get
+    mock_supervisor_comms.send.side_effect = xcom_get
 
     # Run "pull".
     for map_index in range(4):
@@ -286,7 +284,7 @@ def test_xcom_map_raise_to_skip(run_ti, mock_supervisor_comms):
         forward.expand_kwargs(push().map(skip_c))
 
     # Mock xcom result from push task
-    mock_supervisor_comms.get_message.return_value = XComResult(key="return_value", value=["a", "b", "c"])
+    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["a", "b", "c"])
 
     # Run "forward". This should automatically skip "c".
     states = [run_ti(dag, "forward", map_index) for map_index in range(3)]
@@ -341,20 +339,18 @@ def test_xcom_concat(run_ti, mock_supervisor_comms):
         pull_one.expand(value=pushed_values)
         pull_all(pushed_values)
 
-    def xcom_get():
-        # TODO: Tidy this after #45927 is reopened and fixed properly
-        last_request = mock_supervisor_comms.send_request.mock_calls[-1].kwargs["msg"]
-        if not isinstance(last_request, GetXCom):
+    def xcom_get(msg):
+        if not isinstance(msg, GetXCom):
             return mock.DEFAULT
-        if last_request.task_id == "push_letters":
+        if msg.task_id == "push_letters":
             value = push_letters.function()
             return XComResult(key="return_value", value=value)
-        if last_request.task_id == "push_numbers":
+        if msg.task_id == "push_numbers":
             value = push_numbers.function()
             return XComResult(key="return_value", value=value)
         return mock.DEFAULT
 
-    mock_supervisor_comms.get_message.side_effect = xcom_get
+    mock_supervisor_comms.send.side_effect = xcom_get
 
     # Run "pull_one" and "pull_all".
     assert run_ti(dag, "pull_all", None) == TaskInstanceState.SUCCESS

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import uuid
+from socket import socketpair
+
+import msgspec
+import pytest
+
+from airflow.sdk.execution_time.comms import BundleInfo, StartupDetails, _ResponseFrame
+from airflow.sdk.execution_time.task_runner import CommsDecoder
+from airflow.utils import timezone
+
+
+class TestCommsDecoder:
+    """Test the communication between the subprocess and the "supervisor"."""
+
+    @pytest.mark.usefixtures("disable_capturing")
+    def test_recv_StartupDetails(self):
+        r, w = socketpair()
+
+        msg = {
+            "type": "StartupDetails",
+            "ti": {
+                "id": uuid.UUID("4d828a62-a417-4936-a7a6-2b3fabacecab"),
+                "task_id": "a",
+                "try_number": 1,
+                "run_id": "b",
+                "dag_id": "c",
+            },
+            "ti_context": {
+                "dag_run": {
+                    "dag_id": "c",
+                    "run_id": "b",
+                    "logical_date": "2024-12-01T01:00:00Z",
+                    "data_interval_start": "2024-12-01T00:00:00Z",
+                    "data_interval_end": "2024-12-01T01:00:00Z",
+                    "start_date": "2024-12-01T01:00:00Z",
+                    "run_after": "2024-12-01T01:00:00Z",
+                    "end_date": None,
+                    "run_type": "manual",
+                    "conf": None,
+                    "consumed_asset_events": [],
+                },
+                "max_tries": 0,
+                "should_retry": False,
+                "variables": None,
+                "connections": None,
+            },
+            "file": "/dev/null",
+            "start_date": "2024-12-01T01:00:00Z",
+            "dag_rel_path": "/dev/null",
+            "bundle_info": {"name": "any-name", "version": "any-version"},
+        }
+        bytes = msgspec.msgpack.encode(_ResponseFrame(0, msg, None))
+        w.sendall(len(bytes).to_bytes(4, byteorder="big") + bytes)
+
+        decoder = CommsDecoder(socket=r, log=None)
+
+        msg = decoder._get_response()
+        assert isinstance(msg, StartupDetails)
+        assert msg.ti.id == uuid.UUID("4d828a62-a417-4936-a7a6-2b3fabacecab")
+        assert msg.ti.task_id == "a"
+        assert msg.ti.dag_id == "c"
+        assert msg.dag_rel_path == "/dev/null"
+        assert msg.bundle_info == BundleInfo(name="any-name", version="any-version")
+        assert msg.start_date == timezone.datetime(2024, 12, 1, 1)

--- a/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import ANY, Mock, call
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -66,121 +66,109 @@ class CustomXCom(BaseXCom):
 
 
 def test_len(mock_supervisor_comms, lazy_sequence):
-    mock_supervisor_comms.get_message.return_value = XComCountResponse(len=3)
+    mock_supervisor_comms.send.return_value = XComCountResponse(len=3)
     assert len(lazy_sequence) == 3
-    assert mock_supervisor_comms.send_request.mock_calls == [
-        call(log=ANY, msg=GetXComCount(key="return_value", dag_id="dag", task_id="task", run_id="run")),
-    ]
+    mock_supervisor_comms.send.assert_called_once_with(
+        msg=GetXComCount(key="return_value", dag_id="dag", task_id="task", run_id="run"),
+    )
 
 
 def test_iter(mock_supervisor_comms, lazy_sequence):
     it = iter(lazy_sequence)
 
-    mock_supervisor_comms.get_message.side_effect = [
+    mock_supervisor_comms.send.side_effect = [
         XComSequenceIndexResult(root="f"),
         ErrorResponse(error=ErrorType.XCOM_NOT_FOUND, detail={"oops": "sorry!"}),
     ]
     assert list(it) == ["f"]
-    assert mock_supervisor_comms.send_request.mock_calls == [
-        call(
-            log=ANY,
-            msg=GetXComSequenceItem(
-                key="return_value",
-                dag_id="dag",
-                task_id="task",
-                run_id="run",
-                offset=0,
+    mock_supervisor_comms.send.assert_has_calls(
+        [
+            call(
+                msg=GetXComSequenceItem(
+                    key="return_value",
+                    dag_id="dag",
+                    task_id="task",
+                    run_id="run",
+                    offset=0,
+                ),
             ),
-        ),
-        call(
-            log=ANY,
-            msg=GetXComSequenceItem(
-                key="return_value",
-                dag_id="dag",
-                task_id="task",
-                run_id="run",
-                offset=1,
+            call(
+                msg=GetXComSequenceItem(
+                    key="return_value",
+                    dag_id="dag",
+                    task_id="task",
+                    run_id="run",
+                    offset=1,
+                ),
             ),
-        ),
-    ]
+        ]
+    )
 
 
 def test_getitem_index(mock_supervisor_comms, lazy_sequence):
-    mock_supervisor_comms.get_message.return_value = XComSequenceIndexResult(root="f")
+    mock_supervisor_comms.send.return_value = XComSequenceIndexResult(root="f")
     assert lazy_sequence[4] == "f"
-    assert mock_supervisor_comms.send_request.mock_calls == [
-        call(
-            log=ANY,
-            msg=GetXComSequenceItem(
-                key="return_value",
-                dag_id="dag",
-                task_id="task",
-                run_id="run",
-                offset=4,
-            ),
+    mock_supervisor_comms.send.assert_called_once_with(
+        GetXComSequenceItem(
+            key="return_value",
+            dag_id="dag",
+            task_id="task",
+            run_id="run",
+            offset=4,
         ),
-    ]
+    )
 
 
 @conf_vars({("core", "xcom_backend"): "task_sdk.execution_time.test_lazy_sequence.CustomXCom"})
 def test_getitem_calls_correct_deserialise(monkeypatch, mock_supervisor_comms, lazy_sequence):
-    mock_supervisor_comms.get_message.return_value = XComSequenceIndexResult(root="some-value")
+    mock_supervisor_comms.send.return_value = XComSequenceIndexResult(root="some-value")
 
     xcom = resolve_xcom_backend()
     assert xcom.__name__ == "CustomXCom"
     monkeypatch.setattr(airflow.sdk.execution_time.xcom, "XCom", xcom)
 
     assert lazy_sequence[4] == "Made with CustomXCom: some-value"
-    assert mock_supervisor_comms.send_request.mock_calls == [
-        call(
-            log=ANY,
-            msg=GetXComSequenceItem(
-                key="return_value",
-                dag_id="dag",
-                task_id="task",
-                run_id="run",
-                offset=4,
-            ),
+    mock_supervisor_comms.send.assert_called_once_with(
+        GetXComSequenceItem(
+            key="return_value",
+            dag_id="dag",
+            task_id="task",
+            run_id="run",
+            offset=4,
         ),
-    ]
+    )
 
 
 def test_getitem_indexerror(mock_supervisor_comms, lazy_sequence):
-    mock_supervisor_comms.get_message.return_value = ErrorResponse(
+    mock_supervisor_comms.send.return_value = ErrorResponse(
         error=ErrorType.XCOM_NOT_FOUND,
         detail={"oops": "sorry!"},
     )
     with pytest.raises(IndexError) as ctx:
         lazy_sequence[4]
     assert ctx.value.args == (4,)
-    assert mock_supervisor_comms.send_request.mock_calls == [
-        call(
-            log=ANY,
-            msg=GetXComSequenceItem(
-                key="return_value",
-                dag_id="dag",
-                task_id="task",
-                run_id="run",
-                offset=4,
-            ),
+    mock_supervisor_comms.send.assert_called_once_with(
+        GetXComSequenceItem(
+            key="return_value",
+            dag_id="dag",
+            task_id="task",
+            run_id="run",
+            offset=4,
         ),
-    ]
+    )
 
 
 def test_getitem_slice(mock_supervisor_comms, lazy_sequence):
-    mock_supervisor_comms.get_message.return_value = XComSequenceSliceResult(root=[6, 4, 1])
+    mock_supervisor_comms.send.return_value = XComSequenceSliceResult(root=[6, 4, 1])
     assert lazy_sequence[:5] == [6, 4, 1]
-    assert mock_supervisor_comms.send_request.mock_calls == [
-        call(
-            log=ANY,
-            msg=GetXComSequenceSlice(
-                key="return_value",
-                dag_id="dag",
-                task_id="task",
-                run_id="run",
-                start=None,
-                stop=5,
-                step=None,
-            ),
+    mock_supervisor_comms.send.assert_called_once_with(
+        GetXComSequenceSlice(
+            key="return_value",
+            dag_id="dag",
+            task_id="task",
+            run_id="run",
+            start=None,
+            stop=5,
+            step=None,
         ),
-    ]
+    )


### PR DESCRIPTION
* Switch the Supervisor/task process from line-based to length-prefixed

The existing JSON Lines based approach had two major drawbacks

1. In the case of really large lines (in the region of 10 or 20MB) the python
   line buffering could _sometimes_ result in a partial read
2. The JSON based approach didn't have the ability to add any metadata (such
   as errors).
3. Not every message type/call-site waited for a response, which meant those
   client functions could never get told about an error

One of the ways this line-based approach fell down was if you suddenly tried
to run 100s of triggers at the same time you would get an error like this:

```
Traceback (most recent call last):
  File "/Users/ash/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/streams.py", line 568, in readline
    line = await self.readuntil(sep)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ash/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/streams.py", line 663, in readuntil
    raise exceptions.LimitOverrunError(
asyncio.exceptions.LimitOverrunError: Separator is found, but chunk is longer than limit
```

The other way this caused problems was if you parse a large dag (as in one
with 20k tasks or more) the DagFileProcessor could end up getting a partial
read which would be invalid JSON.

This changes the communications protocol in in a couple of ways.

First off at the python level the separate send and receive methods in the
client/task side have been removed and replaced with a single `send()` that
sends the request, reads the response and raises an error if one is returned.
(But note, right now almost nothing in the supervisor side sets the error,
that will be a future PR.)

Secondly the JSON Lines approach has been changed from a line-based protocol
to a binary "frame" one. The protocol (which is the same for whichever side is
sending) is length-prefixed, i.e. we first send the length of the data as a
4byte big-endian integer, followed by the data itself. This should remove the
possibility of JSON parse errors due to reading incomplete lines

Finally the last change made in this PR is to remove the "extra" requests
socket/channel. Upon closer examination with this comms path I realised that
this socket is unnecessary: Since we are in 100% control of the client side we
can make use of the bi-directional nature of `socketpair` and save file
handles. This also happens to help the `run_as_user` feature which is
currently broken, as without extra config to `sudoers` file, `sudo` will close
all filehandles other than stdin, stdout, and stderr -- so by introducing this
change we make it easier to re-add run_as_user support.

In order to support this in the DagFileProcessor (as the fact that the proc
manager uses a single selector for multiple processes) means I have moved the
`on_close` callback to be part of the object we store in the `selector` object
in the supervisors, previoulsy it was the "on_read" callback, now we store a
tuple of `(on_read, on_close)` and on_close is called once universally.

This also changes the way comms are handled from the (async) TriggerRunner
process. Previously we had a sync+async lock, but that made it possible to end
up deadlocking things. The change now is to have `send` on
`TriggerCommsDecoder` "go back" to the async even loop via `async_to_sync`, so
that only async code deals with the socket, and we can use an async lock
(rather than the hybrid sync and async lock we tried before). This seems to
help the deadlock issue, but I'm not 100% sure it will remove it entirely, but
it makes it much much harder to hit - I've not been able to reprouce it with
this change

* Deal with compat in tests

This compat issue is only in tests, as nothing in the runtime of airflow-core
imports/calls methods directly on SUPERVISOR_COMMS, we are only importing it
in tests to mkae assertions about the behavour/to stub the return values.

(cherry picked from commit 492518edfae38bfdb00fc0f088a3524e102ec8f1)
