### PR TITLE
Fixing badly written test for user impersonation

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -686,7 +686,8 @@ def test_task_run_with_user_impersonation(
         actual_cmd = mock_execvp.call_args.args[1]
 
         assert actual_cmd[:5] == ["sudo", "-E", "-H", "-u", "airflowuser"]
-        assert "python -c" in actual_cmd[5] + " " + actual_cmd[6]
+        assert "python" in actual_cmd[5]
+        assert actual_cmd[6] == "-c"
         assert actual_cmd[7] == "from airflow.sdk.execution_time.task_runner import main; main()"
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There can be a possibility that the command can be run with python3 instead of python:

```
{"timestamp":"2024-12-03T10:00:00Z","level":"info","event":"Running command","command":["sudo","-E","-H","-u","airflowuser","/usr/local/bin/python3","-c","from airflow.sdk.execution_time.task_runner import main; main()"],"logger":"task"}
```

Asserting better to avoid issues like:
```
____________________ test_task_run_with_user_impersonation _____________________
[gw0] linux -- Python 3.12.11 /usr/local/bin/python3
task-sdk/tests/task_sdk/execution_time/test_task_runner.py:689: in test_task_run_with_user_impersonation
    assert "python -c" in actual_cmd[5] + " " + actual_cmd[6]
E   AssertionError: assert 'python -c' in (('/usr/local/bin/python3' + ' ') + '-c')
```

Fixes https://github.com/apache/airflow/actions/runs/15752220682/job/44400018685

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
