### PR TITLE
Fixing `ruff` static check failures on main

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
@@ -120,6 +120,7 @@ def lineage_root_run_id(task_instance: TaskInstance):
         clear_number=_get_dag_run_clear_number(task_instance),
     )
 
+
 def _get_dag_run_clear_number(task_instance: TaskInstance):
     # todo: remove when min airflow version >= 3.0
     if AIRFLOW_V_3_0_PLUS:
@@ -130,8 +131,6 @@ def _get_dag_run_clear_number(task_instance: TaskInstance):
             dag_run = context["dag_run"]
         return dag_run.clear_number
     return task_instance.dag_run.clear_number
-
-
 
 
 def _get_logical_date(task_instance):

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_macros.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_macros.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from unittest import mock
-from unittest.mock import patch
 
 import pytest
 
@@ -28,8 +27,6 @@ from airflow.providers.openlineage.plugins.macros import (
     lineage_job_name,
     lineage_job_namespace,
     lineage_parent_id,
-    lineage_root_job_name,
-    lineage_root_parent_id,
     lineage_root_run_id,
     lineage_run_id,
 )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixing failures on main:
```
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/providers/openlineage/tests/unit/openlineage/plugins/test_macros.py b/providers/openlineage/tests/unit/openlineage/plugins/test_macros.py
index 759e59e..2bfa74e 100644
--- a/providers/openlineage/tests/unit/openlineage/plugins/test_macros.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_macros.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from unittest import mock
-from unittest.mock import patch
 
 import pytest
 
@@ -28,8 +27,6 @@ from airflow.providers.openlineage.plugins.macros import (
     lineage_job_name,
     lineage_job_namespace,
     lineage_parent_id,
-    lineage_root_job_name,
-    lineage_root_parent_id,
     lineage_root_run_id,
     lineage_run_id,
 )

This error means that you have to fix the issues listed above:
```


Example: https://github.com/apache/airflow/actions/runs/15760052569/job/44424787656?pr=51936

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
