### PR TITLE
Fix precommit lint ui

### DIFF
--- a/scripts/ci/pre_commit/ts_compile_lint_simple_auth_manager_ui.py
+++ b/scripts/ci/pre_commit/ts_compile_lint_simple_auth_manager_ui.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
     if any("/openapi/" in file for file in original_files):
         run_command(["pnpm", "codegen"], cwd=dir)
     if all_non_yaml_files:
-        run_command(["pnpm", "prettier", "--write", *all_non_yaml_files], cwd=dir)
         run_command(["pnpm", "eslint", "--fix", *all_non_yaml_files], cwd=dir)
+        run_command(["pnpm", "prettier", "--write", *all_non_yaml_files], cwd=dir)
     if all_ts_files:
         with temporary_tsc_project(dir / "tsconfig.app.json", all_ts_files) as tsc_project:
             run_command(["pnpm", "tsc", "--p", tsc_project.name], cwd=dir)

--- a/scripts/ci/pre_commit/ts_compile_lint_ui.py
+++ b/scripts/ci/pre_commit/ts_compile_lint_ui.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
     if any("/openapi/" in file for file in original_files):
         run_command(["pnpm", "codegen"], cwd=dir)
     if all_non_yaml_files:
-        run_command(["pnpm", "prettier", "--write", *all_non_yaml_files], cwd=dir)
         run_command(["pnpm", "eslint", "--fix", *all_non_yaml_files], cwd=dir)
+        run_command(["pnpm", "prettier", "--write", *all_non_yaml_files], cwd=dir)
     if all_ts_files:
         with temporary_tsc_project(dir / "tsconfig.app.json", all_ts_files) as tsc_project:
             run_command(["pnpm", "tsc", "--p", tsc_project.name], cwd=dir)


### PR DESCRIPTION
Reverse the order between linting and prettier.

The reason for that is because if the `json` file has linting error, poorly constructed, this will display the clear eslint errors. While currently prettier will just crash explaining that the json file can't be loaded. (also it probably makes more sense to first fix the files and then format it)