### PR TITLE
Add a button to collapse/expand the information panel

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -17,6 +17,7 @@
     "auditLog": "Audit Log",
     "xcoms": "XComs"
   },
+  "collapseDetailsPanel": "Collapse Details Panel",
   "createdAssetEvent_one": "Created Asset Event",
   "createdAssetEvent_other": "Created Asset Events",
   "dag_one": "Dag",
@@ -144,6 +145,7 @@
     "users": "Users"
   },
   "selectLanguage": "Select Language",
+  "showDetailsPanel": "Show Details Panel",
   "sourceAssetEvent_one": "Source Asset Event",
   "sourceAssetEvent_other": "Source Asset Events",
   "startDate": "Start Date",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -17,6 +17,7 @@
     "auditLog": "審計日誌",
     "xcoms": "XComs"
   },
+  "collapseDetailsPanel": "收合詳細資訊",
   "createdAssetEvent_one": "已建立資源事件",
   "createdAssetEvent_other": "已建立資源事件",
   "dag_one": "Dag",
@@ -144,6 +145,7 @@
     "users": "使用者"
   },
   "selectLanguage": "選擇語言",
+  "showDetailsPanel": "展開詳細資訊",
   "sourceAssetEvent_one": "來源資源事件",
   "sourceAssetEvent_other": "來源資源事件",
   "startDate": "開始日期",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -17,7 +17,7 @@
     "auditLog": "審計日誌",
     "xcoms": "XComs"
   },
-  "collapseDetailsPanel": "收合詳細資訊",
+  "collapseDetailsPanel": "收起詳細資訊",
   "createdAssetEvent_one": "已建立資源事件",
   "createdAssetEvent_other": "已建立資源事件",
   "dag_one": "Dag",
@@ -145,7 +145,7 @@
     "users": "使用者"
   },
   "selectLanguage": "選擇語言",
-  "showDetailsPanel": "展開詳細資訊",
+  "showDetailsPanel": "顯示詳細資訊",
   "sourceAssetEvent_one": "來源資源事件",
   "sourceAssetEvent_other": "來源資源事件",
   "startDate": "開始日期",

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -83,7 +83,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
       <Box flex={1} minH={0}>
         {isRightPanelCollapsed ? (
           <IconButton
-            aria-label="Show details panel"
+            aria-label={translate("common:showDetailsPanel")}
             bg="bg.surface"
             borderRadius="full"
             boxShadow="md"
@@ -133,7 +133,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 w={0.5}
               >
                 <IconButton
-                  aria-label="Collapse details panel"
+                  aria-label={translate("common:collapseDetailsPanel")}
                   bg="bg.surface"
                   borderRadius="full"
                   boxShadow="md"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Flex, useDisclosure } from "@chakra-ui/react";
+import { Box, HStack, Flex, useDisclosure, IconButton } from "@chakra-ui/react";
 import { useReactFlow } from "@xyflow/react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import type { PropsWithChildren, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { LuFileWarning } from "react-icons/lu";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Outlet, useParams } from "react-router-dom";
@@ -66,6 +67,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
     dagId,
   });
   const { onClose, onOpen, open } = useDisclosure();
+  const [isRightPanelCollapsed, setIsRightPanelCollapsed] = useState(false);
 
   return (
     <OpenGroupsProvider dagId={dagId}>
@@ -79,6 +81,24 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
       <Toaster />
       <BackfillBanner dagId={dagId} />
       <Box flex={1} minH={0}>
+        {isRightPanelCollapsed ? (
+          <IconButton
+            aria-label="Show details panel"
+            bg="bg.surface"
+            borderRadius="full"
+            boxShadow="md"
+            cursor="pointer"
+            onClick={() => setIsRightPanelCollapsed(false)}
+            position="absolute"
+            right={0}
+            size="sm"
+            top="50%"
+            transform="translateY(-50%)"
+            zIndex={10}
+          >
+            <FaChevronLeft />
+          </IconButton>
+        ) : undefined}
         <PanelGroup autoSaveId={dagId} direction="horizontal" ref={panelGroupRef}>
           <Panel defaultSize={dagView === "graph" ? 70 : 20} minSize={6}>
             <Box height="100%" overflowY="auto" position="relative" pr={2}>
@@ -92,50 +112,76 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
               {dagView === "graph" ? <Graph /> : <Grid limit={limit} />}
             </Box>
           </Panel>
-          <PanelResizeHandle
-            className="resize-handle"
-            onDragging={(isDragging) => {
-              if (!isDragging) {
-                const zoom = getZoom();
+          {!isRightPanelCollapsed && (
+            <PanelResizeHandle
+              className="resize-handle"
+              onDragging={(isDragging) => {
+                if (!isDragging) {
+                  const zoom = getZoom();
 
-                void fitView({ maxZoom: zoom, minZoom: zoom });
-              }
-            }}
-          >
-            <Box bg="fg.subtle" cursor="col-resize" h="100%" transition="background 0.2s" w={0.5} />
-          </PanelResizeHandle>
-          <Panel defaultSize={dagView === "graph" ? 30 : 80} minSize={20}>
-            <Box display="flex" flexDirection="column" h="100%">
-              {children}
-              {Boolean(error) || (warningData?.dag_warnings.length ?? 0) > 0 ? (
-                <>
-                  <ActionButton
-                    actionName={translate("common:dagWarnings")}
-                    colorPalette={Boolean(error) ? "red" : "orange"}
-                    icon={<LuFileWarning />}
-                    margin="2"
-                    marginBottom="-1"
-                    onClick={onOpen}
-                    rounded="full"
-                    text={String(warningData?.total_entries ?? 0 + Number(error))}
-                    variant="solid"
-                  />
-
-                  <DAGWarningsModal
-                    error={error}
-                    onClose={onClose}
-                    open={open}
-                    warnings={warningData?.dag_warnings}
-                  />
-                </>
-              ) : undefined}
-              <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
-              <NavTabs tabs={tabs} />
-              <Box h="100%" overflow="auto" px={2}>
-                <Outlet />
+                  void fitView({ maxZoom: zoom, minZoom: zoom });
+                }
+              }}
+            >
+              <Box
+                alignItems="center"
+                bg="fg.subtle"
+                cursor="col-resize"
+                display="flex"
+                h="100%"
+                justifyContent="center"
+                position="relative"
+                w={2}
+              >
+                <IconButton
+                  aria-label="Collapse details panel"
+                  bg="bg.surface"
+                  borderRadius="full"
+                  boxShadow="md"
+                  cursor="pointer"
+                  onClick={() => setIsRightPanelCollapsed(true)}
+                  size="xs"
+                  zIndex={2}
+                >
+                  <FaChevronRight />
+                </IconButton>
               </Box>
-            </Box>
-          </Panel>
+            </PanelResizeHandle>
+          )}
+          {!isRightPanelCollapsed && (
+            <Panel defaultSize={dagView === "graph" ? 30 : 80} minSize={20}>
+              <Box display="flex" flexDirection="column" h="100%">
+                {children}
+                {Boolean(error) || (warningData?.dag_warnings.length ?? 0) > 0 ? (
+                  <>
+                    <ActionButton
+                      actionName={translate("common:dagWarnings")}
+                      colorPalette={Boolean(error) ? "red" : "orange"}
+                      icon={<LuFileWarning />}
+                      margin="2"
+                      marginBottom="-1"
+                      onClick={onOpen}
+                      rounded="full"
+                      text={String(warningData?.total_entries ?? 0 + Number(error))}
+                      variant="solid"
+                    />
+
+                    <DAGWarningsModal
+                      error={error}
+                      onClose={onClose}
+                      open={open}
+                      warnings={warningData?.dag_warnings}
+                    />
+                  </>
+                ) : undefined}
+                <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
+                <NavTabs tabs={tabs} />
+                <Box h="100%" overflow="auto" px={2}>
+                  <Outlet />
+                </Box>
+              </Box>
+            </Panel>
+          )}
         </PanelGroup>
       </Box>
     </OpenGroupsProvider>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -130,7 +130,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 h="100%"
                 justifyContent="center"
                 position="relative"
-                w={2}
+                w={0.5}
               >
                 <IconButton
                   aria-label="Collapse details panel"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -93,7 +93,6 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
             right={0}
             size="sm"
             top="50%"
-            transform="translateY(-50%)"
             zIndex={10}
           >
             <FaChevronLeft />


### PR DESCRIPTION
## Add a button to collapse/expand the information panel for better visualizing DAG
Related issue: [#51907](https://github.com/apache/airflow/issues/51907)
### Why
The right information panel takes much space, leading to smaller place for showing DAG graph.
### How
Add a button to collapse/expand the right information panel.
### Demo
https://github.com/user-attachments/assets/a7a93f06-a816-4ce0-8ba4-987539ff4244


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
