### PR TITLE
Feature(call-back): Enhance DAG-level callback context with enriched metadata and test coverage

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -83,6 +83,11 @@ Variable                                    Type                  Description
                                             list[AssetEvent]]     | (there may be more than one, if there are multiple Assets with different frequencies).
                                                                   | Read more here :doc:`Assets <authoring-and-scheduling/asset-scheduling>`.
                                                                   | Added in version 2.4.
+``{{ mark_success_url }}``                  str | None            |URL to mark the DAG run as successful in the Airflow UI.
+``{{ log_url }}``                           str | None            |URL to the log for the current DAG run or task instance.
+``{{ dag_run_url }}``                       str | None            |URL to the DAG run details page in the Airflow UI.
+``{{ end_date }}``                          DateTime | None       |The end date/time of the DAG run.
+``{{ max_tries }}``                         int | None            |The maximum number of tries for the task instance.
 =========================================== ===================== ===================================================================
 
 The following are only available when the DagRun has a ``logical_date``

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1351,7 +1351,7 @@ class DagRun(Base, LoggingMixin):
         # or LocalTaskJob, so we don't want to "falsely advertise" we notify about that
 
     def handle_dag_callback(self, dag: SDKDAG, success: bool = True, reason: str = "success"):
-        """Handle DAG-level callbacks (on_success_callback, on_failure_callback) with enriched context."""
+        """Only needed for `dag.test` where `execute_callbacks=True` is passed to `update_state`."""
 
         task_instances = self.get_task_instances()
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1369,17 +1369,11 @@ class DagRun(Base, LoggingMixin):
         context: Context = {  # type: ignore[assignment]
             "dag": dag,
             "run_id": str(self.run_id),
-            "execution_date": self.logical_date,
             "start_date": self.start_date,
             "end_date": self.end_date,
             "data_interval_start": self.data_interval_start,
             "data_interval_end": self.data_interval_end,
             "reason": reason,
-            "run_duration": (
-                (self.end_date - self.start_date).total_seconds()
-                if self.start_date and self.end_date
-                else None
-            ),
         }
 
         # Add task-level metadata if available
@@ -1387,10 +1381,6 @@ class DagRun(Base, LoggingMixin):
             context.update(
                 task_instance=last_relevant_ti,
                 ti=last_relevant_ti,
-                try_number=last_relevant_ti.try_number,
-                max_tries=last_relevant_ti.max_tries,
-                log_url=last_relevant_ti.log_url,
-                mark_success_url=last_relevant_ti.mark_success_url,
             )
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1385,14 +1385,12 @@ class DagRun(Base, LoggingMixin):
         # Add task-level metadata if available
         if last_relevant_ti:
             context.update(
-                {
-                    "task_instance": last_relevant_ti,
-                    "ti": last_relevant_ti,
-                    "try_number": last_relevant_ti.try_number,
-                    "max_tries": last_relevant_ti.max_tries,
-                    "log_url": last_relevant_ti.log_url,
-                    "mark_success_url": last_relevant_ti.mark_success_url,
-                }
+                task_instance=last_relevant_ti,
+                ti=last_relevant_ti,
+                try_number=last_relevant_ti.try_number,
+                max_tries=last_relevant_ti.max_tries,
+                log_url=last_relevant_ti.log_url,
+                mark_success_url=last_relevant_ti.mark_success_url,
             )
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1352,7 +1352,6 @@ class DagRun(Base, LoggingMixin):
 
     def handle_dag_callback(self, dag: SDKDAG, success: bool = True, reason: str = "success"):
         """Only needed for `dag.test` where `execute_callbacks=True` is passed to `update_state`."""
-
         task_instances = self.get_task_instances()
 
         # Identify the most relevant task instance
@@ -1385,14 +1384,16 @@ class DagRun(Base, LoggingMixin):
 
         # Add task-level metadata if available
         if last_relevant_ti:
-            context.update({
-                "task_instance": last_relevant_ti,
-                "ti": last_relevant_ti,
-                "try_number": last_relevant_ti.try_number,
-                "max_tries": last_relevant_ti.max_tries,
-                "log_url": last_relevant_ti.log_url,
-                "mark_success_url": last_relevant_ti.mark_success_url,
-            })
+            context.update(
+                {
+                    "task_instance": last_relevant_ti,
+                    "ti": last_relevant_ti,
+                    "try_number": last_relevant_ti.try_number,
+                    "max_tries": last_relevant_ti.max_tries,
+                    "log_url": last_relevant_ti.log_url,
+                    "mark_success_url": last_relevant_ti.mark_success_url,
+                }
+            )
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback
         if not callbacks:

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1379,8 +1379,10 @@ class DagRun(Base, LoggingMixin):
         # Add task-level metadata if available
         if last_relevant_ti:
             context.update(
-                task_instance=last_relevant_ti,
-                ti=last_relevant_ti,
+                {
+                    "task_instance": last_relevant_ti,
+                    "ti": last_relevant_ti,
+                }
             )
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback

--- a/airflow-core/src/airflow/utils/context.py
+++ b/airflow-core/src/airflow/utils/context.py
@@ -86,6 +86,11 @@ KNOWN_CONTEXT_KEYS: set[str] = {
     "ts_nodash_with_tz",
     "try_number",
     "var",
+    "dag_run_url",
+    "end_date",
+    "log_url",
+    "mark_success_url",
+    "max_tries",
 }
 
 

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -80,11 +80,11 @@ class Context(TypedDict, total=False):
     var: Any
 
     # --- Added for enriched DAG-level callback context ---
-    end_date: DateTime
-    dag_run_url: str
+    end_date: DateTime | None
+    dag_run_url: str | None
     max_tries: int | None
-    log_url: str
-    mark_success_url: str
+    log_url: str | None
+    mark_success_url: str | None
 
 
 def get_current_context() -> Context:

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -80,9 +80,7 @@ class Context(TypedDict, total=False):
     var: Any
 
     # --- Added for enriched DAG-level callback context ---
-    execution_date: DateTime
     end_date: DateTime
-    run_duration: float | None
     dag_run_url: str
     max_tries: int | None
     log_url: str

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -89,7 +89,6 @@ class Context(TypedDict, total=False):
     mark_success_url: str
 
 
-
 def get_current_context() -> Context:
     """
     Retrieve the execution context dictionary without altering user method's signature.

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -79,6 +79,16 @@ class Context(TypedDict, total=False):
     ts_nodash_with_tz: str
     var: Any
 
+    # --- Added for enriched DAG-level callback context ---
+    execution_date: DateTime
+    end_date: DateTime
+    run_duration: float | None
+    dag_run_url: str
+    max_tries: int | None
+    log_url: str
+    mark_success_url: str
+
+
 
 def get_current_context() -> Context:
     """

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -193,6 +193,11 @@ class RuntimeTaskInstance(TaskInstance):
                 "value": VariableAccessor(deserialize_json=False),
             },
             "conn": ConnectionAccessor(),
+            "dag_run_url": None,  # Will be populated in callbacks
+            "end_date": None,  # Will be populated in callbacks
+            "log_url": None,  # Will be populated in callbacks
+            "mark_success_url": None,  # Will be populated in callbacks
+            "max_tries": None,  # Will be populated in callbacks
         }
         if from_server:
             dag_run = from_server.dag_run


### PR DESCRIPTION
### Summary
This PR enriches the context passed to DAG-level callbacks (on_success_callback and on_failure_callback) to better align with the structure and metadata typically available in task-level callbacks. While this logic is currently triggered via execute_callbacks=True during tests, it is structured to reflect what should be expected in production use cases as well.

Related
Closes: [#51402]
