### PR TITLE
Fix connection recovery from uri when host has protocol

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -266,11 +266,20 @@ class Connection(Base, LoggingMixin):
 
         if self.host and "://" in self.host:
             protocol, host = self.host.split("://", 1)
+            # If the protocol in host matches the connection type, don't add it again
+            if protocol == self.conn_type:
+                host_to_use = self.host
+                protocol_to_add = None
+            else:
+                # Different protocol, add it to the URI
+                host_to_use = host
+                protocol_to_add = protocol
         else:
-            protocol, host = None, self.host
+            host_to_use = self.host
+            protocol_to_add = None
 
-        if protocol:
-            uri += f"{protocol}://"
+        if protocol_to_add:
+            uri += f"{protocol_to_add}://"
 
         authority_block = ""
         if self.login is not None:
@@ -285,8 +294,8 @@ class Connection(Base, LoggingMixin):
             uri += authority_block
 
         host_block = ""
-        if host:
-            host_block += quote(host, safe="")
+        if host_to_use:
+            host_block += quote(host_to_use, safe="")
 
         if self.port:
             if host_block == "" and authority_block == "":

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -255,6 +255,23 @@ class TestConnection:
     def test_sanitize_conn_id(self, connection, expected_conn_id):
         assert connection.conn_id == expected_conn_id
 
+    @pytest.mark.parametrize(
+        "conn_type, host",
+        [
+            # same protocol to type
+            ("http", "http://host"),
+            # different protocol to type
+            ("https", "http://host"),
+        ],
+    )
+    def test_connection_uri_recovery(self, conn_type, host):
+        original = Connection(conn_id="test", conn_type=conn_type, host=host)
+        uri = original.get_uri()
+
+        recovered = Connection(uri=uri)
+        assert recovered.conn_type == original.conn_type
+        assert recovered.host == original.host
+
     def test_extra_dejson(self):
         extra = (
             '{"trust_env": false, "verify": false, "stream": true, "headers":'

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -74,10 +74,20 @@ class Connection:
 
         if self.host and "://" in self.host:
             protocol, host = self.host.split("://", 1)
+            # If the protocol in host matches the connection type, don't add it again
+            if protocol == self.conn_type:
+                host_to_use = self.host
+                protocol_to_add = None
+            else:
+                # Different protocol, add it to the URI
+                host_to_use = host
+                protocol_to_add = protocol
         else:
-            protocol, host = None, self.host or ""
-        if protocol:
-            uri += f"{protocol}://"
+            host_to_use = self.host  # type: ignore[assignment]
+            protocol_to_add = None
+
+        if protocol_to_add:
+            uri += f"{protocol_to_add}://"
 
         authority_block = ""
         if self.login is not None:
@@ -89,8 +99,8 @@ class Connection:
             uri += authority_block
 
         host_block = ""
-        if host != "":
-            host_block += quote(host, safe="")
+        if host_to_use:
+            host_block += quote(host_to_use, safe="")
         if self.port:
             if host_block == "" and authority_block == "":
                 host_block += f"@:{self.port}"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


While working on https://github.com/apache/airflow/pull/51930, realised that connections cannot recover using the uri of the same connection when hosts have protocols.

Example:
```
from airflow.models import Connection
Connection(conn_id="default_port", conn_type="http", host="http://host/")
Out[13]: default_port
x = Connection(conn_id="default_port", conn_type="http", host="http://host/")
x
Out[15]: default_port
x.host
Out[16]: 'http://host/'
x.as_json()
Out[17]: '{"conn_type": "http", "host": "http://host/"}'
x.get_uri()
Out[18]: 'http://host/'
y = Connection(uri=x.get_uri())
y.host
Out[20]: 'host'
```


This should not be the case, information should be preserved (as_json does it)

After fix:
```
from airflow.models import Connection
x = Connection(conn_id="default_port", conn_type="http", host="http://host")
x.as_json()
Out[5]: '{"conn_type": "http", "host": "http://host"}'
x.host
Out[6]: 'http://host'
y = Connection(uri=x.get_uri())
y.host
Out[8]: 'http://host'
```


We have enough test coverage in `test_get_uri` and related methods.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
