### PR TITLE
Converting int account IDs to str in DBT Cloud connections

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -156,7 +156,7 @@ class TestDbtCloudHook:
         account_id_conn = Connection(
             conn_id=ACCOUNT_ID_CONN,
             conn_type=DbtCloudHook.conn_type,
-            login=DEFAULT_ACCOUNT_ID,
+            login=str(DEFAULT_ACCOUNT_ID),
             password=TOKEN,
         )
 
@@ -171,7 +171,7 @@ class TestDbtCloudHook:
         host_conn = Connection(
             conn_id=SINGLE_TENANT_CONN,
             conn_type=DbtCloudHook.conn_type,
-            login=DEFAULT_ACCOUNT_ID,
+            login=str(DEFAULT_ACCOUNT_ID),
             password=TOKEN,
             host=SINGLE_TENANT_DOMAIN,
         )
@@ -180,7 +180,7 @@ class TestDbtCloudHook:
         proxy_conn = Connection(
             conn_id=PROXY_CONN,
             conn_type=DbtCloudHook.conn_type,
-            login=DEFAULT_ACCOUNT_ID,
+            login=str(DEFAULT_ACCOUNT_ID),
             password=TOKEN,
             host=SINGLE_TENANT_DOMAIN,
             extra=EXTRA_PROXIES,

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -102,7 +102,7 @@ def setup_module():
     conn_account_id = Connection(
         conn_id=ACCOUNT_ID_CONN,
         conn_type=DbtCloudHook.conn_type,
-        login=DEFAULT_ACCOUNT_ID,
+        login=str(DEFAULT_ACCOUNT_ID),
         password=TOKEN,
     )
 

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
@@ -56,7 +56,9 @@ class TestDbtCloudJobRunSensor:
         )
 
         # Connection
-        conn = Connection(conn_id="dbt", conn_type=DbtCloudHook.conn_type, login=ACCOUNT_ID, password=TOKEN)
+        conn = Connection(
+            conn_id="dbt", conn_type=DbtCloudHook.conn_type, login=str(ACCOUNT_ID), password=TOKEN
+        )
 
         db.merge_conn(conn)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While working on https://github.com/apache/airflow/pull/51930, realised another thing: we define login as "str | None" and define those as str for DBT cloud connection type. If that's the case, the connection can never be converted to a uri and fails like so:

```
ERROR providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py::TestDbtCloudHook::test_trigger_job_run_with_retry_from_failure[get_job_runs_data1-False-explicit_account] - TypeError: quote_from_bytes() expected bytes
```

Hence, instead of modifying the login type in connection model, we should convert that to string while creating the DBT connections. A later follow up can be actually taking input as a string in the hook.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
