### PR TITLE
Add validation for commit_cadence in Kafka ConsumeFromTopicOperator

### DIFF
--- a/providers/apache/kafka/docs/operators/index.rst
+++ b/providers/apache/kafka/docs/operators/index.rst
@@ -1,4 +1,4 @@
- .. Licensed to the Apache Software Foundation (ASF) under one
+.. Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
     regarding copyright ownership.  The ASF licenses this file
@@ -29,6 +29,9 @@ The operator creates a Kafka Consumer that reads a batch of messages from the cl
 
 For parameter definitions take a look at :class:`~airflow.providers.apache.kafka.operators.consume.ConsumeFromTopicOperator`.
 
+.. important::
+    If you set the ``commit_cadence`` parameter, ensure that the ``enable.auto.commit`` option in the Kafka connection configuration is explicitly set to ``false``.
+    By default, ``enable.auto.commit`` is ``true``, which causes the consumer to auto-commit offsets every 5 seconds, potentially overriding the behavior defined by ``commit_cadence``.
 
 Using the operator
 """"""""""""""""""

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/consume.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/consume.py
@@ -203,6 +203,6 @@ class ConsumeFromTopicOperator(BaseOperator):
                 "'enable.auto.commit' should be set to 'false' in the Kafka connection configuration. "
                 "Currently, 'enable.auto.commit' is not explicitly set, so it defaults to 'true', which causes "
                 "the consumer to auto-commit offsets every 5 seconds. "
-                "See: https://kafka.apache.org/documentation/#consumerconfigs_enable.auto.commit",
+                "See: https://kafka.apache.org/documentation/#consumerconfigs_enable.auto.commit for more information",
                 self.commit_cadence,
             )

--- a/providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py
@@ -235,7 +235,7 @@ class TestConsumeFromTopic:
                     "'enable.auto.commit' should be set to 'false' in the Kafka connection configuration. "
                     "Currently, 'enable.auto.commit' is not explicitly set, so it defaults to 'true', which causes "
                     "the consumer to auto-commit offsets every 5 seconds. "
-                    "See: https://kafka.apache.org/documentation/#consumerconfigs_enable.auto.commit"
+                    "See: https://kafka.apache.org/documentation/#consumerconfigs_enable.auto.commit for more information"
                 )
                 mock_log.warning.assert_called_with(expected_warning_template, commit_cadence)
             else:


### PR DESCRIPTION

closes: #34213

## Why

Based on the discussion in the issue
- if we need to respect `commit_cadence="never", "end_of_batch", "end_of_operator"`
  - we should set `enable.auto.commit` option in Kafka Connection to `false`
  - otherwise `enable.auto.commit` would be on by default, and the consumer will auto commit the offset every 5 seconds.

## What

- Add validation for `commit_cadence` with `enable.auto.commit` option with corresponding Kafka Connection 
  - Will log warning if the `commit_cadence` is set but `enable.auto.commit` is not `false`
- Point out this behavior in the documentation as well 


