### PR TITLE
Include fixed navbar for anchor position calculation in docs.

### DIFF
--- a/devel-common/sphinx_design/static/custom.css
+++ b/devel-common/sphinx_design/static/custom.css
@@ -45,7 +45,7 @@ div.admonition.warning {
 /* Needs to be cleaned in a follow-up to source this from the origin style in */
 /* https://github.com/apache/airflow-site/blob/main/landing-pages/site/assets/scss/_rst-content.scss */
 .base-layout {
-  padding-top: 123px !important;
+  padding-top: 163px !important; /* banner + navbar + 2px padding */
 }
 
 section {
@@ -65,4 +65,19 @@ a.headerlink {
 a.headerlink::after {
   content: " [link]" !important;  /* Theme image not existing */
   visibility: visible !important;
+}
+
+/* compensate for sticky headers for anchored links */
+:target::before {
+  content: "";
+  display: block;
+  height: 161px; /* 40px banner + 121px navbar */
+  margin: -161px 0 0; /* negative fixed header height */
+}
+
+@media (max-width: 1280px) {
+  :target::before {
+    height: 117px; /* 40px banner + 77px mobile navbar */
+    margin: -117px 0 0; /* negative fixed header height */
+  }
 }


### PR DESCRIPTION
During work on some docs changes, I have noticed anchor links are partially broken, since they scroll to content hidden behind navbar.

currently navigating to https://airflow.apache.org/docs/apache-airflow/stable/index.html#workflows-as-code shows

![image](https://github.com/user-attachments/assets/4858bbd7-805e-41a6-9d76-7851e41bfe48)

with this fix, it scrolls properly

![image](https://github.com/user-attachments/assets/66ac1ac7-da72-4af8-82ee-9afee3fb5f34)

I have fixed also missing top padding (due to banner). I wasn't able to find out logic behind loading the banner, but it is fixed 40px in all viewports (seems so). I have added it whenever needed for calculations and made clear comments on what's happening. In case of banner is removed, those number should be recalculated, there is probably no simple automated way currently to do that.

This whole problem could be fixed also by making content own scroll context (instead of fixed navbar), but it will involve a lot of layout changes I'm not brave enough to provide (I wasn't able to find out even basic layout setup). This fixes the problem with minimal code changes.