### PR TITLE
Fix ENV variable in ui CONTRIBUTING.md, ensure app runs on expected port.

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 5174",
+    "dev": "vite --port 5174 --strictPort",
     "build": "vite build",
     "lint": "eslint --quiet && tsc --p tsconfig.app.json",
     "lint:fix": "eslint --fix && tsc --p tsconfig.app.json",

--- a/airflow-core/src/airflow/ui/CONTRIBUTING.md
+++ b/airflow-core/src/airflow/ui/CONTRIBUTING.md
@@ -26,7 +26,7 @@ With Breeze:
 
 Manually:
 
-- Have the `dev-mode` environment variable enabled
+- Have the `DEV_MODE` environment variable set to `true` when starting airflow api-server
 - Run `pnpm install && pnpm dev`
 - Note: Make sure to access the UI via the Airflow localhost port (8080 or 28080) and not the vite port (5173)
 

--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "homepage": "/ui",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 5173 --strictPort",
     "build": "vite build",
     "lint": "eslint --quiet && tsc --p tsconfig.app.json",
     "lint:fix": "eslint --fix && tsc --p tsconfig.app.json",


### PR DESCRIPTION
- `dev-mode` is invalid bash variable name -> fixing the name
- document better the usage, port 5173 is default, but vite assign other one when in use already
  - this adds `--strictPort` to fail instead (in both UI and simple auth manager)