### PR TITLE
Replace usage of os.environ with conf_vars in kafka integration tests

### DIFF
--- a/providers/apache/kafka/tests/integration/apache/kafka/operators/test_consume.py
+++ b/providers/apache/kafka/tests/integration/apache/kafka/operators/test_consume.py
@@ -18,18 +18,16 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 from typing import Any
 
 import pytest
 from confluent_kafka import Producer
 
-from airflow.models import Connection
-
 # Import Operator
 from airflow.providers.apache.kafka.operators.consume import ConsumeFromTopicOperator
+
+from tests_common.test_utils.config import conf_vars
 
 log = logging.getLogger(__name__)
 
@@ -52,31 +50,26 @@ def _basic_message_tester(message, test=None) -> Any:
 
 
 @pytest.mark.integration("kafka")
+@conf_vars(
+    {
+        (
+            "connections",
+            "operator.consumer.test.integration.test_1",
+        ): "kafka://broker:29092?socket.timeout.ms=10&bootstrap.servers=broker:29092&group.id=operator.consumer.test.integration.test_1&enable.auto.commit=False&auto.offset.reset=beginning",
+        (
+            "connections",
+            "operator.consumer.test.integration.test_2",
+        ): "kafka://broker:29092?socket.timeout.ms=10&bootstrap.servers=broker:29092&group.id=operator.consumer.test.integration.test_2&enable.auto.commit=False&auto.offset.reset=beginning",
+        (
+            "connections",
+            "operator.consumer.test.integration.test_3",
+        ): "kafka://broker:29092?socket.timeout.ms=10&bootstrap.servers=broker:29092&group.id=operator.consumer.test.integration.test_3&enable.auto.commit=False&auto.offset.reset=beginning",
+    }
+)
 class TestConsumeFromTopic:
     """
     test ConsumeFromTopicOperator
     """
-
-    def setup_method(self):
-        """Set up connections for each test method."""
-        # Create separate connections for each test
-        for num in (1, 2, 3):
-            conn = Connection(
-                conn_id=f"operator.consumer.test.integration.test_{num}",
-                conn_type="kafka",
-                extra=json.dumps(
-                    {
-                        "socket.timeout.ms": 10,
-                        "bootstrap.servers": "broker:29092",
-                        "group.id": f"operator.consumer.test.integration.test_{num}",
-                        "enable.auto.commit": False,
-                        "auto.offset.reset": "beginning",
-                    }
-                ),
-            )
-
-            env_var_name = f"AIRFLOW_CONN_{conn.conn_id.upper()}"
-            os.environ[env_var_name] = conn.get_uri()
 
     def test_consumer_operator_test_1(self):
         """test consumer works with string import"""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Its not a great idea to use actual `os.environ` for integration tests as it could seep into the system and affect something adversely. Replacing the usage with `conf_vars` instead (should be ok as its for the test duration)

Reference: https://github.com/apache/airflow/pull/51930#discussion_r2159042447

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
