### PR TITLE
Removed pytest.mark_db_test from the docker provider completely

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -581,7 +581,6 @@ repos:
             (?x)
             ^providers/airbyte/.*\.py$|
             ^providers/cohere/.*\.py$|
-            ^providers/docker/.*\.py$|
             ^providers/facebook/.*\.py$|
             ^providers/grpc/.*\.py$|
             ^providers/hashicorp/.*\.py$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -581,6 +581,7 @@ repos:
             (?x)
             ^providers/airbyte/.*\.py$|
             ^providers/cohere/.*\.py$|
+            ^providers/docker/.*\.py$|
             ^providers/facebook/.*\.py$|
             ^providers/grpc/.*\.py$|
             ^providers/hashicorp/.*\.py$|
@@ -601,7 +602,6 @@ repos:
             ^providers/trino/.*\.py$|
             ^providers/vertica/.*\.py$|
             ^providers/yandex/.*\.py$
-            ^providers/docker/.*\.py$
       - id: check-links-to-example-dags-do-not-use-hardcoded-versions
         name: Verify no hard-coded version in example dags
         description: The links to example dags should use |version| as version specification

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -601,6 +601,7 @@ repos:
             ^providers/trino/.*\.py$|
             ^providers/vertica/.*\.py$|
             ^providers/yandex/.*\.py$
+            ^providers/docker/.*\.py$
       - id: check-links-to-example-dags-do-not-use-hardcoded-versions
         name: Verify no hard-coded version in example dags
         description: The links to example dags should use |version| as version specification


### PR DESCRIPTION
---

This PR is part of #52020 and removes `pytest.mark_db_test` where possible from the docker provider tests