### PR TITLE
Removed usage of pytest.mark.db_test from dbt tests where possible

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -38,8 +38,6 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
 )
 from airflow.utils import timezone
 
-pytestmark = pytest.mark.db_test
-
 ACCOUNT_ID_CONN = "account_id_conn"
 NO_ACCOUNT_ID_CONN = "no_account_id_conn"
 SINGLE_TENANT_CONN = "single_tenant_conn"

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -37,8 +37,6 @@ from airflow.utils import timezone
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
 
-pytestmark = pytest.mark.db_test
-
 DEFAULT_DATE = timezone.datetime(2021, 1, 1)
 TASK_ID = "run_job_op"
 ACCOUNT_ID_CONN = "account_id_conn"
@@ -647,6 +645,7 @@ class TestDbtCloudRunJobOperator:
         [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
         ids=["default_account", "explicit_account"],
     )
+    @pytest.mark.db_test
     def test_run_job_operator_link(
         self, conn_id, account_id, create_task_instance_of_operator, request, mock_supervisor_comms
     ):

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
@@ -30,9 +30,6 @@ from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunEx
 from airflow.providers.dbt.cloud.sensors.dbt import DbtCloudJobRunSensor
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 
-pytestmark = pytest.mark.db_test
-
-
 ACCOUNT_ID = 11111
 RUN_ID = 5555
 TOKEN = "token"


### PR DESCRIPTION
---

This PR is part of #52020 and removes `pytest.mark_db_test` where possible from the dbt provider tests.