### PR TITLE
Show info text at empty connections page.

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "اختر نوع الموَّصل",
       "standardFields": "حقول قياسية"
     },
-    "noRowMessage": "لا توجد موَّصلات متاحة",
+    "nothingFound": {
+        "title": "لا توجد موَّصلات متاحة"
+    },
     "searchPlaceholder": "البحث عن موَّصلات",
     "test": "اختبار الموَّصل",
     "testDisabled": "اختبار الموَّصل معطل. تواصل مع المسؤول لتفعيله.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "Verbindungstyp auswählen",
       "standardFields": "Standardfelder"
     },
-    "noRowMessage": "Keine Verbindungen gefunden",
+    "nothingFound": {
+        "title": "Keine Verbindungen gefunden!"
+    },
     "searchPlaceholder": "Verbindungen suchen",
     "test": "Verbindung testen",
     "testDisabled": "Das Testen von Verbindungen ist deaktiviert. Der Administrator kann via Konfiguration das Testen freischalten.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -39,7 +39,12 @@
       "selectConnectionType": "Select Connection Type",
       "standardFields": "Standard Fields"
     },
-    "noRowMessage": "No connections found",
+    "nothingFound": {
+        "title": "No connection found!",
+        "description": "Connections defined via environment variables or secrets managers are not listed here.",
+        "learnMore": "These are resolved at runtime and are not visible in the UI.",
+        "documentationLink": "Learn more in the Airflow documentation."
+    },
     "searchPlaceholder": "Search Connections",
     "test": "Test Connection",
     "testDisabled": "Test connection feature is disabled. Please contact an administrator to enable it.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "Sélectionner le Type de Connexion",
       "standardFields": "Champs Standards"
     },
-    "noRowMessage": "Aucune connexion trouvée",
+    "nothingFound": {
+        "title": "Aucune connexion trouvée!"
+    },
     "searchPlaceholder": "Rechercher les connexions",
     "test": "Test la connexion",
     "testDisabled": "Le test de connexion est désactivé. Veuillez contacter un administrateur pour l'activer.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "בחר סוג חיבור",
       "standardFields": "שדות סטנדרטיים"
     },
-    "noRowMessage": "לא נמצאו חיבורים",
+    "nothingFound": {
+        "title": "לא נמצאו חיבורים"
+    },
     "searchPlaceholder": "חפש חיבורים",
     "test": "בדוק חיבור",
     "testDisabled": "אפשרות זו אינה זמינה. פנו למנהל המערכת להפעלתה",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "연결 유형 선택",
       "standardFields": "기본 필드"
     },
-    "noRowMessage": "연결을 찾을 수 없습니다.",
+    "nothingFound": {
+        "title": "연결을 찾을 수 없습니다."
+    },
     "searchPlaceholder": "연결 검색",
     "test": "연결 테스트",
     "testDisabled": "연결 테스트 기능이 비활성화되어 있습니다. 관리자에게 활성화를 요청하세요.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "Wybierz typ połączenia",
       "standardFields": "Standardowe pola"
     },
-    "noRowMessage": "Nie znaleziono połączeń",
+    "nothingFound": {
+        "title": "Nie znaleziono połączeń!"
+    },
     "searchPlaceholder": "Szukaj połączeń",
     "test": "Test połączenia",
     "testDisabled": "Testowanie połączeń wyłączone. Skontaktuj się z administratorem, aby je włączyć.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/admin.json
@@ -39,7 +39,9 @@
       "selectConnectionType": "選擇連線類型",
       "standardFields": "標準欄位"
     },
-    "noRowMessage": "找不到連線",
+    "nothingFound": {
+        "title": "找不到連線"
+    },
     "searchPlaceholder": "搜尋連線",
     "test": "測試連線",
     "testDisabled": "測試連線功能已停用。請聯繫管理員以啟用。",

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -40,6 +40,7 @@ import AddConnectionButton from "./AddConnectionButton";
 import DeleteConnectionButton from "./DeleteConnectionButton";
 import DeleteConnectionsButton from "./DeleteConnectionsButton";
 import EditConnectionButton from "./EditConnectionButton";
+import { NothingFoundInfo } from "./NothingFoundInfo";
 import TestConnectionButton from "./TestConnectionButton";
 
 export type ConnectionBody = {
@@ -198,6 +199,7 @@ export const Connections = () => {
           isFetching={isFetching}
           isLoading={isLoading}
           modelName={translate("common:admin.Connections")}
+          noRowsMessage={<NothingFoundInfo />}
           onStateChange={setTableURLState}
           total={data?.total_entries ?? 0}
         />

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.tsx
@@ -1,0 +1,45 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Text, Link, Stack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { useVersionServiceGetVersion } from "openapi/queries";
+
+export const NothingFoundInfo = () => {
+  const { t: translate } = useTranslation("admin");
+  const { data } = useVersionServiceGetVersion();
+  const docsLink = `https://airflow.apache.org/docs/apache-airflow/${data?.version}/howto/connection.html#visibility-in-ui-and-cli`;
+
+  return (
+    <Box textAlign="center">
+      <Stack>
+        <Text fontSize="2xl" fontWeight="bold">
+          {translate("connections.nothingFound.title")}
+        </Text>
+        <Text>{translate("connections.nothingFound.description")}</Text>
+        <Text>
+          {translate("connections.nothingFound.learnMore")}{" "}
+          <Link href={docsLink} target="blank">
+            {translate("connections.nothingFound.documentationLink")}
+          </Link>
+        </Text>
+      </Stack>
+    </Box>
+  );
+};


### PR DESCRIPTION
@potiuk follow up to https://github.com/apache/airflow/pull/52014 (creating related link)

happy to repeat the same for variables (and DRY it a little)

![image](https://github.com/user-attachments/assets/a492f6c9-2179-40cd-9c78-0d3ea60cb152)

PS: Hyperlinks are not super easy to detect with current Chakra UI theme, but it is out of scope of this PR. They looks similar to text and just get underline on hover.