### PR TITLE
Remove pytest.mark.db_test where possible from databricks provider.

### DIFF
--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -35,8 +35,6 @@ from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook, create_timeout_thread
 from airflow.utils.session import provide_session
 
-pytestmark = pytest.mark.db_test
-
 TASK_ID = "databricks-sql-operator"
 DEFAULT_CONN_ID = "databricks_default"
 HOST = "xx.cloud.databricks.com"

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -48,8 +48,6 @@ from airflow.providers.databricks.triggers.databricks import (
 )
 from airflow.providers.databricks.utils import databricks as utils
 
-pytestmark = pytest.mark.db_test
-
 DATE = "2017-04-20"
 TASK_ID = "databricks-operator"
 DEFAULT_CONN_ID = "databricks_default"
@@ -812,7 +810,6 @@ class TestDatabricksSubmitRunOperator:
         )
         assert expected == utils.normalise_json_content(op.json)
 
-    @pytest.mark.db_test
     def test_init_with_templating(self):
         json = {
             "new_cluster": NEW_CLUSTER,
@@ -1250,7 +1247,6 @@ class TestDatabricksRunNowOperator:
 
         assert expected == op.json
 
-    @pytest.mark.db_test
     def test_init_with_templating(self):
         json = {"notebook_params": NOTEBOOK_PARAMS, "jar_params": TEMPLATED_JAR_PARAMS}
 

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -34,8 +34,6 @@ from airflow.providers.databricks.operators.databricks_workflow import (
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils import timezone
 
-pytestmark = pytest.mark.db_test
-
 DEFAULT_DATE = timezone.datetime(2021, 1, 1)
 
 

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -152,7 +152,6 @@ def app():
         yield app
 
 
-@pytest.mark.db_test
 def test_get_task_instance(app):
     with app.app_context():
         operator = Mock()
@@ -170,7 +169,6 @@ def test_get_task_instance(app):
             assert result == dag_run
 
 
-@pytest.mark.db_test
 def test_get_return_url_dag_id_run_id(app):
     dag_id = "example_dag"
     run_id = "example_run"
@@ -182,7 +180,6 @@ def test_get_return_url_dag_id_run_id(app):
     assert actual_url == expected_url, f"Expected {expected_url}, got {actual_url}"
 
 
-@pytest.mark.db_test
 def test_workflow_job_run_link(app):
     with app.app_context():
         link = WorkflowJobRunLink()
@@ -220,7 +217,6 @@ def test_workflow_job_run_link(app):
 @pytest.mark.skipif(
     RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES, reason="Web plugin test doesn't work when not against sources"
 )
-@pytest.mark.db_test
 def test_workflow_job_repair_single_failed_link(app):
     with app.app_context():
         link = WorkflowJobRepairSingleTaskLink()


### PR DESCRIPTION
Still has some db test left
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:
closes: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


related: #52020


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
