### PR TITLE
Remove pytest.mark.db_test where possible from google provider

### DIFF
--- a/providers/google/tests/unit/google/cloud/hooks/test_compute_ssh.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_compute_ssh.py
@@ -30,9 +30,6 @@ from airflow.models import Connection
 from airflow.providers.google.cloud.hooks.compute_ssh import ComputeEngineSSHHook
 from airflow.providers.google.cloud.hooks.os_login import OSLoginHook
 
-pytestmark = pytest.mark.db_test
-
-
 TEST_PROJECT_ID = "test-project-id"
 
 TEST_INSTANCE_NAME = "test-instance"
@@ -56,6 +53,7 @@ class TestComputeEngineHookWithPassedProjectId:
         assert ComputeEngineSSHHook(gcp_conn_id="gcpssh")._oslogin_hook
         mock_os_login_hook.assert_called_with(gcp_conn_id="gcpssh")
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh._GCloudAuthorizedSSHClient")
@@ -112,6 +110,7 @@ class TestComputeEngineHookWithPassedProjectId:
             ]
         )
 
+    @pytest.mark.db_test
     @pytest.mark.parametrize(
         "exception_type, error_message",
         [(SSHException, r"Error occurred when establishing SSH connection using Paramiko")],
@@ -156,6 +155,7 @@ class TestComputeEngineHookWithPassedProjectId:
         assert error_message in caplog.text
         assert "Failed establish SSH connection" in caplog.text
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -214,6 +214,7 @@ class TestComputeEngineHookWithPassedProjectId:
 
         mock_os_login_hook.return_value.import_ssh_public_key.assert_not_called()
 
+    @pytest.mark.db_test
     @pytest.mark.parametrize(
         "exception_type, error_message",
         [
@@ -257,6 +258,7 @@ class TestComputeEngineHookWithPassedProjectId:
         assert error_message in caplog.text
         assert "Failed establish SSH connection" in caplog.text
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -287,6 +289,7 @@ class TestComputeEngineHookWithPassedProjectId:
             zone=TEST_ZONE,
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -315,6 +318,7 @@ class TestComputeEngineHookWithPassedProjectId:
             hostname=INTERNAL_IP, look_for_keys=mock.ANY, pkey=mock.ANY, sock=mock.ANY, username=mock.ANY
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -343,6 +347,7 @@ class TestComputeEngineHookWithPassedProjectId:
             username=mock.ANY,
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -372,6 +377,7 @@ class TestComputeEngineHookWithPassedProjectId:
             f"--zone={TEST_ZONE} --verbosity=warning"
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -407,6 +413,7 @@ class TestComputeEngineHookWithPassedProjectId:
             f"--zone={TEST_ZONE} --verbosity=warning --impersonate-service-account={IMPERSONATION_CHAIN}"
         )
 
+    @pytest.mark.db_test
     @pytest.mark.parametrize(
         "exception_type, error_message",
         [(SSHException, r"Error occurred when establishing SSH connection using Paramiko")],
@@ -442,6 +449,7 @@ class TestComputeEngineHookWithPassedProjectId:
         assert error_message in caplog.text
         assert "Failed establish SSH connection" in caplog.text
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataflow.py
@@ -1695,7 +1695,6 @@ class TestDataflow:
         )
         assert found_job_id is None
 
-    @pytest.mark.db_test
     @mock.patch("subprocess.Popen")
     @mock.patch("select.select")
     def test_dataflow_wait_for_done_logging(self, mock_select, mock_popen, caplog):

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataform.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataform.py
@@ -28,9 +28,6 @@ from airflow.providers.google.cloud.hooks.dataform import DataformHook
 
 from unit.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
-pytestmark = pytest.mark.db_test
-
-
 BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 DATAFORM_STRING = "airflow.providers.google.cloud.hooks.dataform.{}"
 

--- a/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
@@ -596,7 +596,6 @@ class TestGCSHook:
         mock_service.return_value.bucket.assert_called_once_with(test_bucket, user_project=None)
         mock_service.return_value.bucket.return_value.delete.assert_called_once()
 
-    @pytest.mark.db_test
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     def test_delete_nonexisting_bucket(self, mock_service, caplog):
         mock_service.return_value.bucket.return_value.delete.side_effect = exceptions.NotFound(

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -82,9 +82,6 @@ from airflow.providers.google.cloud.triggers.bigquery import (
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.timezone import datetime
 
-pytestmark = pytest.mark.db_test
-
-
 TASK_ID = "test-bq-generic-operator"
 TEST_DATASET = "test-dataset"
 TEST_DATASET_LOCATION = "EU"
@@ -1820,6 +1817,7 @@ class TestBigQueryInsertJobOperator:
             "Trigger is not a BigQueryInsertJobTrigger"
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_bigquery_insert_job_operator_async_inherits_hook_project_id_when_non_given(
         self, mock_hook, create_task_instance_of_operator
@@ -2202,6 +2200,7 @@ class TestBigQueryInsertJobOperator:
         op._add_job_labels()
         assert "labels" not in configuration
 
+    @pytest.mark.db_test
     def test_dag_label_too_big(self, dag_maker):
         configuration = {
             "query": {
@@ -2219,6 +2218,7 @@ class TestBigQueryInsertJobOperator:
         op._add_job_labels()
         assert "labels" not in configuration
 
+    @pytest.mark.db_test
     def test_labels_lowercase(self, dag_maker):
         configuration = {
             "query": {
@@ -2237,6 +2237,7 @@ class TestBigQueryInsertJobOperator:
         assert configuration["labels"]["airflow-dag"] == "yelling_dag_name"
         assert configuration["labels"]["airflow-task"] == "yelling_task_id"
 
+    @pytest.mark.db_test
     def test_labels_starting_with_numbers(self, dag_maker):
         configuration = {
             "query": {
@@ -2255,6 +2256,7 @@ class TestBigQueryInsertJobOperator:
         assert configuration["labels"]["airflow-dag"] == "123_dag"
         assert configuration["labels"]["airflow-task"] == "123_task"
 
+    @pytest.mark.db_test
     def test_labels_starting_with_underscore(self, dag_maker):
         configuration = {
             "query": {
@@ -2274,6 +2276,7 @@ class TestBigQueryInsertJobOperator:
         assert configuration["labels"]["airflow-dag"] == "_dag_starting_with_underscore"
         assert configuration["labels"]["airflow-task"] == "_task_starting_with_underscore"
 
+    @pytest.mark.db_test
     def test_labels_starting_with_hyphen(self, dag_maker):
         configuration = {
             "query": {
@@ -2309,6 +2312,7 @@ class TestBigQueryInsertJobOperator:
         op._add_job_labels()
         assert "labels" not in configuration
 
+    @pytest.mark.db_test
     def test_labels_replace_dots_with_hyphens(self, dag_maker):
         configuration = {
             "query": {
@@ -2341,6 +2345,7 @@ class TestBigQueryInsertJobOperator:
         assert configuration["labels"]["airflow-dag"] == "dag_with_taskgroup"
         assert configuration["labels"]["airflow-task"] == "task_group-task_name"
 
+    @pytest.mark.db_test
     def test_labels_with_task_group_prefix_group_id(self, dag_maker):
         configuration = {
             "query": {

--- a/providers/google/tests/unit/google/cloud/operators/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataflow.py
@@ -575,7 +575,6 @@ class TestDataflowCreatePipelineOperator:
         with pytest.raises(AirflowException):
             DataflowCreatePipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.dataflow.DataflowHook")
     def test_response_409(self, mock_hook, create_operator):
         """
@@ -595,7 +594,6 @@ class TestDataflowCreatePipelineOperator:
         )
 
 
-@pytest.mark.db_test
 class TestDataflowRunPipelineOperator:
     @pytest.fixture
     def run_operator(self):
@@ -627,6 +625,7 @@ class TestDataflowRunPipelineOperator:
             location=TEST_LOCATION,
         )
 
+    @pytest.mark.db_test
     def test_invalid_data_pipeline_name(self):
         """
         Test that AirflowException is raised if Run Operator is not given a data pipeline name.
@@ -641,6 +640,7 @@ class TestDataflowRunPipelineOperator:
         with pytest.raises(AirflowException):
             DataflowRunPipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
+    @pytest.mark.db_test
     def test_invalid_project_id(self):
         """
         Test that AirflowException is raised if Run Operator is not given a project ID.
@@ -655,6 +655,7 @@ class TestDataflowRunPipelineOperator:
         with pytest.raises(AirflowException):
             DataflowRunPipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
+    @pytest.mark.db_test
     def test_invalid_location(self):
         """
         Test that AirflowException is raised if Run Operator is not given a location.
@@ -685,7 +686,6 @@ class TestDataflowRunPipelineOperator:
                 "error": {"message": "example error"}
             }
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.dataflow.DataflowHook")
     def test_response_404(self, mock_hook, run_operator):
         """
@@ -702,7 +702,6 @@ class TestDataflowRunPipelineOperator:
         )
 
 
-@pytest.mark.db_test
 class TestDataflowDeletePipelineOperator:
     @pytest.fixture
     def run_operator(self):
@@ -736,6 +735,7 @@ class TestDataflowDeletePipelineOperator:
             location=TEST_LOCATION,
         )
 
+    @pytest.mark.db_test
     def test_invalid_data_pipeline_name(self):
         """
         Test that AirflowException is raised if Delete Operator is not given a data pipeline name.
@@ -750,6 +750,7 @@ class TestDataflowDeletePipelineOperator:
         with pytest.raises(AirflowException):
             DataflowDeletePipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
+    @pytest.mark.db_test
     def test_invalid_project_id(self):
         """
         Test that AirflowException is raised if Delete Operator is not given a project ID.
@@ -764,6 +765,7 @@ class TestDataflowDeletePipelineOperator:
         with pytest.raises(AirflowException):
             DataflowDeletePipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
+    @pytest.mark.db_test
     def test_invalid_location(self):
         """
         Test that AirflowException is raised if Delete Operator is not given a location.
@@ -778,6 +780,7 @@ class TestDataflowDeletePipelineOperator:
         with pytest.raises(AirflowException):
             DataflowDeletePipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
+    @pytest.mark.db_test
     def test_invalid_response(self):
         """
         Test that AirflowException is raised if Delete Operator fails execution and returns error.

--- a/providers/google/tests/unit/google/cloud/operators/test_datapipeline.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datapipeline.py
@@ -84,7 +84,6 @@ class TestDataflowCreatePipelineOperator:
         )
 
 
-@pytest.mark.db_test
 class TestDataflowRunPipelineOperator:
     @pytest.fixture
     def run_operator(self):

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -342,7 +342,6 @@ class TestGcfFunctionDeploy:
         with pytest.raises(AirflowException, match=message):
             op.execute(None)
 
-    @pytest.mark.db_test
     @pytest.mark.parametrize(
         "source_code, message",
         [

--- a/providers/google/tests/unit/google/cloud/secrets/test_secret_manager.py
+++ b/providers/google/tests/unit/google/cloud/secrets/test_secret_manager.py
@@ -28,8 +28,6 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.google.cloud.secrets.secret_manager import CloudSecretManagerBackend
 
-pytestmark = pytest.mark.db_test
-
 CREDENTIALS = "test-creds"
 KEY_FILE = "test-file.json"
 PROJECT_ID = "test-project-id"

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1620,13 +1620,13 @@ def create_task_instance(create_task_instance_of_operator, session):
     )
 
 
-@pytest.mark.db_test
 class TestAsyncGCSToBigQueryOperator:
     def _set_execute_complete(self, session, ti, **next_kwargs):
         ti.next_method = "execute_complete"
         ti.next_kwargs = next_kwargs
         session.flush()
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_without_external_table_async_should_execute_successfully(
         self, hook, create_task_instance, session
@@ -1658,6 +1658,7 @@ class TestAsyncGCSToBigQueryOperator:
         trigger_cls = session.scalar(select(Trigger.classpath).where(Trigger.id == ti.trigger_id))
         assert trigger_cls == "airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger"
 
+    @pytest.mark.db_test
     def test_execute_without_external_table_async_should_throw_ex_when_event_status_error(
         self, create_task_instance, session
     ):
@@ -1710,6 +1711,7 @@ class TestAsyncGCSToBigQueryOperator:
             "%s completed with response %s ", "test-gcs-to-bq-operator", "Job completed"
         )
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_without_external_table_generate_job_id_async_should_execute_successfully(
         self, hook, create_task_instance, session
@@ -1749,6 +1751,7 @@ class TestAsyncGCSToBigQueryOperator:
             force_rerun=True,
         )
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_without_external_table_reattach_async_should_execute_successfully(
         self, hook, create_task_instance, session
@@ -1788,6 +1791,7 @@ class TestAsyncGCSToBigQueryOperator:
             project_id=JOB_PROJECT_ID,
         )
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_without_external_table_force_rerun_async_should_execute_successfully(
         self, hook, create_task_instance
@@ -1836,6 +1840,7 @@ class TestAsyncGCSToBigQueryOperator:
             project_id=JOB_PROJECT_ID,
         )
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_without_external_table_async_should_execute_successfully(
@@ -1897,6 +1902,7 @@ class TestAsyncGCSToBigQueryOperator:
 
         bq_hook.return_value.insert_job.assert_has_calls(calls)
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_int_without_external_table_async_should_execute_successfully(
@@ -1963,6 +1969,7 @@ class TestAsyncGCSToBigQueryOperator:
 
         bq_hook.return_value.insert_job.assert_has_calls(calls)
 
+    @pytest.mark.db_test
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_complete_reassigns_job_id(self, bq_hook, create_task_instance, session):
         """Assert that we use job_id from event after deferral."""

--- a/providers/google/tests/unit/google/cloud/transfers/test_local_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_local_to_gcs.py
@@ -31,8 +31,6 @@ from airflow.providers.common.compat.openlineage.facet import (
 )
 from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 
-pytestmark = pytest.mark.db_test
-
 
 class TestFileToGcsOperator:
     _config = {

--- a/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
@@ -40,9 +40,6 @@ from airflow.providers.google.cloud.triggers.bigquery import (
 )
 from airflow.triggers.base import TriggerEvent
 
-pytestmark = pytest.mark.db_test
-
-
 TEST_CONN_ID = "bq_default"
 TEST_JOB_ID = "1234"
 TEST_GCP_PROJECT_ID = "test-project"

--- a/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
@@ -154,7 +154,6 @@ def async_get_operation():
     return func
 
 
-@pytest.mark.db_test
 class TestDataprocClusterTrigger:
     def test_async_cluster_trigger_serialization_should_execute_successfully(self, cluster_trigger):
         classpath, kwargs = cluster_trigger.serialize()
@@ -169,6 +168,7 @@ class TestDataprocClusterTrigger:
             "delete_on_error": True,
         }
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_cluster")
     async def test_async_cluster_triggers_on_success_should_execute_successfully(
@@ -193,6 +193,7 @@ class TestDataprocClusterTrigger:
         )
         assert expected_event == actual_event
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_cluster")
     @mock.patch(
@@ -227,6 +228,7 @@ class TestDataprocClusterTrigger:
         assert trigger_event.payload["cluster_name"] == TEST_CLUSTER_NAME
         assert trigger_event.payload["cluster_state"] == ClusterStatus.State.DELETING
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_cluster")
     async def test_cluster_run_loop_is_still_running(
@@ -293,6 +295,7 @@ class TestDataprocClusterTrigger:
         except Exception as e:
             pytest.fail(f"Unexpected exception raised: {e}")
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_cluster")
     async def test_fetch_cluster_status(self, mock_get_cluster, cluster_trigger, async_get_cluster):
@@ -303,6 +306,7 @@ class TestDataprocClusterTrigger:
 
         assert cluster.status.state == ClusterStatus.State.RUNNING, "The cluster state should be RUNNING"
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.delete_cluster")
     async def test_delete_when_error_occurred(self, mock_delete_cluster, cluster_trigger):
@@ -363,7 +367,6 @@ class TestDataprocClusterTrigger:
         mock_delete_cluster.assert_not_called()
 
 
-@pytest.mark.db_test
 class TestDataprocBatchTrigger:
     def test_async_create_batch_trigger_serialization_should_execute_successfully(self, batch_trigger):
         """
@@ -382,6 +385,7 @@ class TestDataprocBatchTrigger:
             "polling_interval_seconds": TEST_POLL_INTERVAL,
         }
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_batch")
     async def test_async_create_batch_trigger_triggers_on_success_should_execute_successfully(
@@ -407,6 +411,7 @@ class TestDataprocBatchTrigger:
         await asyncio.sleep(0.5)
         assert expected_event == actual_event
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_batch")
     async def test_async_create_batch_trigger_run_returns_failed_event(
@@ -428,6 +433,7 @@ class TestDataprocBatchTrigger:
         await asyncio.sleep(0.5)
         assert expected_event == actual_event
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_batch")
     async def test_create_batch_run_returns_cancelled_event(self, mock_hook, batch_trigger, async_get_batch):
@@ -447,6 +453,7 @@ class TestDataprocBatchTrigger:
         await asyncio.sleep(0.5)
         assert expected_event == actual_event
 
+    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_batch")
     async def test_create_batch_run_loop_is_still_running(
@@ -540,7 +547,6 @@ class TestDataprocOperationTrigger:
         assert expected_event == actual_event
 
 
-@pytest.mark.db_test
 class TestDataprocSubmitTrigger:
     def test_submit_trigger_serialization(self, submit_trigger):
         """Test that the trigger serializes its configuration correctly."""

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -328,7 +328,6 @@ def async_get_operation_result():
     return func
 
 
-@pytest.mark.db_test
 class TestGKEOperationTrigger:
     def test_serialize(self, operation_trigger):
         classpath, trigger_init_kwargs = operation_trigger.serialize()

--- a/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
@@ -176,7 +176,6 @@ class TestProvideGcpConnAndCredentials:
         assert os.environ[CREDENTIALS] == ENV_VALUE
 
 
-@pytest.mark.db_test
 class TestGetGcpCredentialsAndProjectId:
     test_scopes = _DEFAULT_SCOPES
     test_key_file = "KEY_PATH.json"

--- a/providers/google/tests/unit/google/common/hooks/test_discovery_api.py
+++ b/providers/google/tests/unit/google/common/hooks/test_discovery_api.py
@@ -24,8 +24,6 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.google.common.hooks.discovery_api import GoogleDiscoveryApiHook
 
-pytestmark = pytest.mark.db_test
-
 
 class TestGoogleDiscoveryApiHook:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Part of #52020.

There are still db tests in google provider.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
