### PR TITLE
Fix wrong translation of control key in German UI

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/dags.json
@@ -23,7 +23,7 @@
     },
     "clear": {
       "button": "{{type}} zurücksetzen",
-      "buttonTooltip": "STRG+C zum Zurücksetzen tippen",
+      "buttonTooltip": "Umschalttaste+C zum Zurücksetzen tippen",
       "error": "Fehler beim Zurücksetzen von {{type}}",
       "title": "{{type}} bereinigen und neu planen"
     },
@@ -43,8 +43,8 @@
     "markAs": {
       "button": "{{type}} markieren...",
       "buttonTooltip": {
-        "failed": "STRG+F tippen um als fehlgeschlagen zu markieren",
-        "success": "STRG+S tippen um als erfolgreich zu markieren"
+        "failed": "Umschalttaste+F tippen um als fehlgeschlagen zu markieren",
+        "success": "Umschalttaste+S tippen um als erfolgreich zu markieren"
       },
       "title": "{{type}} auf den Status {{state}} setzen"
     },


### PR DESCRIPTION
Ups, while reviewing another PR I noticed that the hotkeys were wrongly translated in German. They are using SHIFT+x and I translated STRG (==Control) initially. But actually this does not work... so direct translation of "Shift" in German is "Umschalttaste".

FYI @TJaniF @m1racoli

+need a official codeowner approval for the technical step of merging :-D