### PR TITLE
Fix HttpOperator(deferrable=True) crash when connection has login / password

### DIFF
--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -236,8 +236,8 @@ class HttpOperator(BaseOperator):
         """
         Resolve the authentication type for the HTTP request.
 
-        If auth_type is not explicitly set, attempt to infer it from the connection
-        configuration. For connections with login/password, default to BasicAuth.
+        If auth_type is not explicitly set, attempt to infer it from the connection configuration.
+        For connections with login/password, default to BasicAuth.
 
         :return: The resolved authentication type class, or None if no auth is needed.
         """

--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -22,6 +22,7 @@ import pickle
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
+from aiohttp import BasicAuth
 from requests import Response
 
 from airflow.configuration import conf
@@ -122,7 +123,7 @@ class HttpOperator(BaseOperator):
         request_kwargs: dict[str, Any] | None = None,
         http_conn_id: str = "http_default",
         log_response: bool = False,
-        auth_type: type[AuthBase] | None = None,
+        auth_type: type[AuthBase] | type[BasicAuth] | None = None,
         tcp_keep_alive: bool = True,
         tcp_keep_alive_idle: int = 120,
         tcp_keep_alive_count: int = 20,
@@ -221,7 +222,7 @@ class HttpOperator(BaseOperator):
         self.defer(
             trigger=HttpTrigger(
                 http_conn_id=self.http_conn_id,
-                auth_type=self.auth_type,
+                auth_type=self._resolve_auth_type(),
                 method=self.method,
                 endpoint=self.endpoint,
                 headers=self.headers,
@@ -230,6 +231,28 @@ class HttpOperator(BaseOperator):
             ),
             method_name="execute_complete",
         )
+
+    def _resolve_auth_type(self) -> type[AuthBase] | type[BasicAuth] | None:
+        """
+        Resolve the authentication type for the HTTP request.
+
+        If auth_type is not explicitly set, attempt to infer it from the connection
+        configuration. For connections with login/password, default to BasicAuth.
+
+        Returns:
+            The resolved authentication type class, or None if no auth is needed.
+        """
+        if self.auth_type is not None:
+            return self.auth_type
+
+        try:
+            conn = BaseHook.get_connection(self.http_conn_id)
+            if conn.login or conn.password:
+                return BasicAuth
+        except Exception as e:
+            self.log.warning("Failed to resolve auth type from connection: %s", e)
+
+        return None
 
     def process_response(self, context: Context, response: Response | list[Response]) -> Any:
         """Process the response."""

--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -29,7 +29,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator
-from airflow.providers.http.triggers.http import HttpTrigger
+from airflow.providers.http.triggers.http import HttpTrigger, serialize_auth_type
 from airflow.utils.helpers import merge_dicts
 
 if TYPE_CHECKING:
@@ -222,7 +222,7 @@ class HttpOperator(BaseOperator):
         self.defer(
             trigger=HttpTrigger(
                 http_conn_id=self.http_conn_id,
-                auth_type=self._resolve_auth_type(),
+                auth_type=serialize_auth_type(self._resolve_auth_type()),
                 method=self.method,
                 endpoint=self.endpoint,
                 headers=self.headers,
@@ -239,8 +239,7 @@ class HttpOperator(BaseOperator):
         If auth_type is not explicitly set, attempt to infer it from the connection
         configuration. For connections with login/password, default to BasicAuth.
 
-        Returns:
-            The resolved authentication type class, or None if no auth is needed.
+        :return: The resolved authentication type class, or None if no auth is needed.
         """
         if self.auth_type is not None:
             return self.auth_type
@@ -314,7 +313,7 @@ class HttpOperator(BaseOperator):
             self.defer(
                 trigger=HttpTrigger(
                     http_conn_id=self.http_conn_id,
-                    auth_type=self.auth_type,
+                    auth_type=serialize_auth_type(self._resolve_auth_type()),
                     method=self.method,
                     **self._merge_next_page_parameters(next_page_params),
                 ),

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -33,6 +33,7 @@ from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
     from aiohttp.client_reqrep import ClientResponse
+    from requests.auth import AuthBase
 
 
 class HttpTrigger(BaseTrigger):
@@ -66,11 +67,22 @@ class HttpTrigger(BaseTrigger):
         super().__init__()
         self.http_conn_id = http_conn_id
         self.method = method
-        self.auth_type = auth_type
+        self.auth_type = self._resolve_auth_type(auth_type)
         self.endpoint = endpoint
         self.headers = headers
         self.data = data
         self.extra_options = extra_options
+
+    def _resolve_auth_type(self, auth_type: type[AuthBase] | str | None) -> type[AuthBase] | None:
+        if auth_type is None or not isinstance(auth_type, str):
+            return auth_type
+
+        try:
+            module_path, class_name = auth_type.rsplit(".", 1)
+            module = __import__(module_path, fromlist=[class_name])
+            return getattr(module, class_name)
+        except (ValueError, ImportError, AttributeError) as e:
+            raise ImportError(f"Cannot import auth_type: {auth_type}") from e
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize HttpTrigger arguments and classpath."""
@@ -79,13 +91,24 @@ class HttpTrigger(BaseTrigger):
             {
                 "http_conn_id": self.http_conn_id,
                 "method": self.method,
-                "auth_type": self.auth_type,
+                "auth_type": self._serialize_auth_type(),
                 "endpoint": self.endpoint,
                 "headers": self.headers,
                 "data": self.data,
                 "extra_options": self.extra_options,
             },
         )
+
+    def _serialize_auth_type(self) -> str | None:
+        """
+        Serialize auth_type to string representation for trigger serialization.
+
+        Returns:
+            String representation of the auth_type class or None
+        """
+        if self.auth_type is None:
+            return None
+        return f"{self.auth_type.__module__}.{self.auth_type.__qualname__}"
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make a series of asynchronous http calls via a http hook."""

--- a/providers/http/tests/unit/http/operators/test_http.py
+++ b/providers/http/tests/unit/http/operators/test_http.py
@@ -95,6 +95,7 @@ class TestHttpOperator:
         result = operator.execute({})
         assert result == {"value": 5}
 
+    @pytest.mark.db_test
     def test_async_defer_successfully(self, requests_mock):
         operator = HttpOperator(
             task_id="test_HTTP_op",
@@ -189,6 +190,7 @@ class TestHttpOperator:
 
         assert result == [5, 10]
 
+    @pytest.mark.db_test
     def test_async_pagination(self, requests_mock):
         """
         Test that the HttpOperator calls asynchronously and repetitively

--- a/providers/http/tests/unit/http/operators/test_http.py
+++ b/providers/http/tests/unit/http/operators/test_http.py
@@ -21,18 +21,21 @@ import base64
 import contextlib
 import json
 import pickle
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import call, patch
 
 import pytest
 import tenacity
+from aiohttp import BasicAuth
 from requests import Response
 from requests.models import RequestEncodingMixin
 
 from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.hooks import base
 from airflow.providers.http.hooks.http import HttpHook
 from airflow.providers.http.operators.http import HttpOperator
-from airflow.providers.http.triggers.http import HttpTrigger
+from airflow.providers.http.triggers.http import HttpTrigger, serialize_auth_type
 
 
 @mock.patch.dict("os.environ", AIRFLOW_CONN_HTTP_EXAMPLE="http://www.example.com")
@@ -300,3 +303,53 @@ class TestHttpOperator:
         )
 
         assert mock_run_with_advanced_retry.call_count == 2
+
+    def _capture_defer(self, monkeypatch):
+        captured = {}
+
+        def _fake_defer(self, *, trigger, method_name, **kwargs):
+            captured["trigger"] = trigger
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(HttpOperator, "defer", _fake_defer)
+        return captured
+
+    @pytest.mark.parametrize(
+        "login, password, auth_type, expect_cls",
+        [
+            ("user", "password", None, BasicAuth),
+            (None, None, None, type(None)),
+            ("user", "password", BasicAuth, BasicAuth),
+        ],
+    )
+    def test_auth_type_is_serialised_as_string(self, monkeypatch, login, password, auth_type, expect_cls):
+        monkeypatch.setattr(
+            base.BaseHook, "get_connection", lambda _cid: SimpleNamespace(login=login, password=password)
+        )
+        captured = self._capture_defer(monkeypatch)
+
+        HttpOperator(task_id="test_HTTP_op", deferrable=True, auth_type=auth_type).execute(context={})
+
+        trigger = captured["trigger"]
+        kwargs = captured["trigger"].serialize()[1]
+
+        expected_str = serialize_auth_type(expect_cls) if expect_cls is not type(None) else None
+        assert kwargs["auth_type"] == expected_str
+
+        assert trigger.auth_type == expect_cls or (trigger.auth_type is None and expect_cls is type(None))
+
+    def test_resolve_auth_type_variants(self, monkeypatch):
+        monkeypatch.setattr(
+            base.BaseHook, "get_connection", lambda _cid: SimpleNamespace(login="user", password="password")
+        )
+        assert HttpOperator(task_id="test_HTTP_op_1")._resolve_auth_type() is BasicAuth
+
+        class DummyAuth:
+            def __init__(self, *_, **__): ...
+
+        assert HttpOperator(task_id="test_HTTP_op_2", auth_type=DummyAuth)._resolve_auth_type() is DummyAuth
+
+        monkeypatch.setattr(
+            base.BaseHook, "get_connection", lambda _cid: SimpleNamespace(login=None, password=None)
+        )
+        assert HttpOperator(task_id="test_HTTP_op_3")._resolve_auth_type() is None


### PR DESCRIPTION
Closes: #46863

# Why

If an HTTP connection contains login/password and the user doesn't set `auth_type`, the sync path works (the hook auto-defaults to HTTPBasicAuth), but the deferrable path crashes:

https://github.com/apache/airflow/blob/a8a9fc5ead28ab4902a328a6911fe2c95e737776/providers/http/src/airflow/providers/http/operators/http.py#L220-L224

passes `None` to `auth_type`, store it in the `trigger` table.
```markdown
 id |                    classpath                     |                                                                                                                           kwargs                                                                                                                            |         created_date         | triggerer_id
----+--------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+--------------
  3 | airflow.providers.http.triggers.http.HttpTrigger | {"__var": {"http_conn_id": "http_default", "method": "GET", "auth_type": null, "endpoint": "get", "headers": {"__var": {}, "__type": "dict"}, "data": {"__var": {}, "__type": "dict"}, "extra_options": {"__var": {}, "__type": "dict"}}, "__type": "dict"} | 2025-06-18 04:01:51.49263+00 |            3
(1 row)
```

after deserialization, `None` is passed here, causing `'NoneType' object is not callable` error.

https://github.com/apache/airflow/blob/a8a9fc5ead28ab4902a328a6911fe2c95e737776/providers/http/src/airflow/providers/http/hooks/http.py#L439-L440

# How

1. Add `_resolve_auth_type()` to **HttpOperator**; 
  it auto-picks `aiohttp.BasicAuth` (when the conn has login/password) before deferral.

2. Add `serialize_auth_type()`; always store the fully-qualified class path or `None`.

3. Add `deserialize_auth_type()`;
  `HttpTrigger.__init__()` uses it to turn the stored string back **into the class object** at runtime.

4. Serialize `auth_type` when `HttpOperator.execute_async()` and deserialises it when `HttpTrigger.__init__()`, 
  so internal logic remains unchanged.

# What

Test DAG
```python
from airflow import DAG
from airflow.providers.http.operators.http import HttpOperator
import pendulum

with DAG(
    dag_id="http_deferrable_bug_demo",
    start_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
    schedule=None,
    catchup=False,
) as dag:
    HttpOperator(
        task_id="call_httpbin",
        http_conn_id="http_default",
        endpoint="get",
        method="GET",
        deferrable=True,
    )
```

Test connection
```console
airflow connections add 'http_default' \
  --conn-type http \
  --conn-host 'https://httpbin.org' \
  --conn-login 'user' \
  --conn-password 'pass'
```

before
<img width="1816" alt="截圖 2025-06-22 auth_type is None" src="https://github.com/user-attachments/assets/7a5eb3d3-0c51-47c3-9570-0728ddc33aef" />

after
<img width="1817" alt="截圖 2025-06-22 auth_type is not None" src="https://github.com/user-attachments/assets/648171a4-b281-44cd-87e5-98cab99f6d26" />

the `auth_type` in the `trigger` table
```markdown
 id |                    classpath                     |                                                                                                                                       kwargs                                                                                                                                       |         created_date          | triggerer_id
----+--------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+--------------
  1 | airflow.providers.http.triggers.http.HttpTrigger | {"__var": {"http_conn_id": "http_default", "method": "GET", "auth_type": "aiohttp.helpers.BasicAuth", "endpoint": "get", "headers": {"__var": {}, "__type": "dict"}, "data": {"__var": {}, "__type": "dict"}, "extra_options": {"__var": {}, "__type": "dict"}}, "__type": "dict"} | 2025-06-19 22:52:32.606647+00 |            2
(1 row)
```