### PR TITLE
Remove db tests from cloudant provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -580,6 +580,7 @@ repos:
         files: >
             (?x)
             ^providers/airbyte/.*\.py$|
+            ^providers/cloudant/.*\.py$|
             ^providers/cohere/.*\.py$|
             ^providers/datadog/.*\.py$|
             ^providers/discord/.*\.py$|
@@ -604,7 +605,6 @@ repos:
             ^providers/trino/.*\.py$|
             ^providers/vertica/.*\.py$|
             ^providers/yandex/.*\.py$|
-            ^providers/cloudant/.*\.py$|
             ^providers/zendesk/.*\.py$
       - id: check-links-to-example-dags-do-not-use-hardcoded-versions
         name: Verify no hard-coded version in example dags

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -604,6 +604,7 @@ repos:
             ^providers/trino/.*\.py$|
             ^providers/vertica/.*\.py$|
             ^providers/yandex/.*\.py$|
+            ^providers/cloudant/.*\.py$|
             ^providers/zendesk/.*\.py$
       - id: check-links-to-example-dags-do-not-use-hardcoded-versions
         name: Verify no hard-coded version in example dags

--- a/providers/cloudant/tests/unit/cloudant/hooks/test_cloudant.py
+++ b/providers/cloudant/tests/unit/cloudant/hooks/test_cloudant.py
@@ -25,7 +25,6 @@ import pytest
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 
-pytestmark = [pytest.mark.db_test]
 
 if sys.version_info < (3, 10):
     pytestmark.append(

--- a/providers/cloudant/tests/unit/cloudant/hooks/test_cloudant.py
+++ b/providers/cloudant/tests/unit/cloudant/hooks/test_cloudant.py
@@ -25,6 +25,7 @@ import pytest
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 
+pytestmark = []
 
 if sys.version_info < (3, 10):
     pytestmark.append(


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/52020

`pytest.mark.db_test` is removed from the `pytestmark`, but still keep this variable because it will be used to skip tests for Python <= 3.9. I think we have a plan to drop support for it, and should be able to remove it at that moment. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
