### PR TITLE
Remove residual occurences of 'merge_conn' from cncf tests

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -37,7 +37,6 @@ from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook, KubernetesHook
-from airflow.utils.db import merge_conn
 
 from tests_common.test_utils.db import clear_db_connections
 from tests_common.test_utils.providers import get_provider_min_airflow_version
@@ -840,9 +839,9 @@ class TestAsyncKubernetesHook:
 
     @staticmethod
     @pytest.fixture
-    def kubernetes_connection():
+    def kubernetes_connection(create_connection_without_db):
         extra = {"kube_config": '{"test": "kube"}'}
-        merge_conn(
+        create_connection_without_db(
             Connection(
                 conn_type="kubernetes",
                 conn_id=CONN_ID,
@@ -910,12 +909,12 @@ class TestAsyncKubernetesHook:
     @mock.patch(INCLUSTER_CONFIG_LOADER)
     @mock.patch(KUBE_CONFIG_MERGER)
     async def test_load_config_with_conn_id_kube_config_path(
-        self, kube_config_merger, incluster_config, kube_config_loader, tmp_path
+        self, kube_config_merger, incluster_config, kube_config_loader, tmp_path, create_connection_without_db
     ):
         file_name = f"{tmp_path}/config"
         extra = {"kube_config_path": file_name}
         try:
-            merge_conn(
+            create_connection_without_db(
                 Connection(
                     conn_type="kubernetes",
                     conn_id=CONN_ID,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Yikes, there are also refs with just `merge_conn` instead of `db.merge_conn`!

One of many i guess here.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
