### PR TITLE
Removed usage of pytest.mark.db_test from the redis provider

### DIFF
--- a/providers/redis/tests/unit/redis/hooks/test_redis.py
+++ b/providers/redis/tests/unit/redis/hooks/test_redis.py
@@ -24,10 +24,9 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.redis.hooks.redis import RedisHook
 
-pytestmark = pytest.mark.db_test
-
 
 class TestRedisHook:
+    @pytest.mark.db_test
     def test_get_conn(self):
         hook = RedisHook(redis_conn_id="redis_default")
         assert hook.redis is None
@@ -78,6 +77,7 @@ class TestRedisHook:
             ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"],
         )
 
+    @pytest.mark.db_test
     def test_get_conn_password_stays_none(self):
         hook = RedisHook(redis_conn_id="redis_default")
         hook.get_conn()

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -32,8 +32,6 @@ from airflow.utils.timezone import datetime
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
-pytestmark = pytest.mark.db_test
-
 
 class TestRedisTaskHandler:
     @pytest.fixture
@@ -74,6 +72,7 @@ class TestRedisTaskHandler:
         with create_session() as session:
             session.query(DagRun).delete()
 
+    @pytest.mark.db_test
     @conf_vars({("logging", "remote_log_conn_id"): "redis_default"})
     def test_write(self, ti):
         handler = RedisTaskHandler("any", max_lines=5, ttl_seconds=2)
@@ -94,6 +93,7 @@ class TestRedisTaskHandler:
         pipeline.return_value.expire.assert_called_once_with(key, time=2)
         pipeline.return_value.execute.assert_called_once_with()
 
+    @pytest.mark.db_test
     @conf_vars({("logging", "remote_log_conn_id"): "redis_default"})
     def test_read(self, ti):
         handler = RedisTaskHandler("any")


### PR DESCRIPTION

---

This PR is part of https://github.com/apache/airflow/issues/52020 and removes `pytest.mark_db_test` from the redis provider tests where possible.
