### PR TITLE
Update telegram unit tests to use 'create_connection_without_db'

### DIFF
--- a/providers/telegram/tests/unit/telegram/hooks/test_telegram.py
+++ b/providers/telegram/tests/unit/telegram/hooks/test_telegram.py
@@ -26,7 +26,6 @@ import tenacity
 import airflow
 from airflow.models import Connection
 from airflow.providers.telegram.hooks.telegram import TelegramHook
-from airflow.utils import db
 
 pytestmark = pytest.mark.db_test
 
@@ -44,21 +43,22 @@ def telegram_error_side_effect(*args, **kwargs):
 
 
 class TestTelegramHook:
-    def setup_method(self):
-        db.merge_conn(
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
             Connection(
                 conn_id="telegram-webhook-without-token",
                 conn_type="http",
             )
         )
-        db.merge_conn(
+        create_connection_without_db(
             Connection(
                 conn_id="telegram_default",
                 conn_type="http",
                 password=TELEGRAM_TOKEN,
             )
         )
-        db.merge_conn(
+        create_connection_without_db(
             Connection(
                 conn_id="telegram-webhook-with-chat_id",
                 conn_type="http",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Ok it didn't work for some reason the other day!

Works now:
```
collecting ... collected 17 items / 3 deselected / 14 selected
run-last-failure: rerun previous 14 failures

unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_use_default_connection 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_raise_exception_if_conn_id_doesnt_contain_token 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_raise_exception_if_chat_id_is_not_provided_anywhere 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_raise_exception_if_message_text_is_not_provided 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_send_message_if_all_parameters_are_correctly_provided 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_send_message_if_chat_id_is_provided_through_constructor 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_send_message_if_chat_id_is_provided_in_connection 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_retry_when_any_telegram_error_is_encountered 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_raise_exception_if_chat_id_is_not_provided_anywhere_when_sending_file 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_raise_exception_if_file_path_is_not_provided_when_sending_file 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_send_file_if_all_parameters_are_correctly_provided 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_send_file_if_chat_id_is_provided_through_constructor 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_send_file_if_chat_id_is_provided_in_connection 
unit/telegram/hooks/test_telegram.py::TestTelegramHook::test_should_retry_on_telegram_error_when_sending_file 

================= 14 passed, 3 deselected, 1 warning in 9.88s ==================
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
