### PR TITLE
Fix Error when viewing Dag details of a no longer configured bundle

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
@@ -41,7 +41,10 @@ class DagVersionResponse(BaseModel):
     @property
     def bundle_url(self) -> str | None:
         if self.bundle_name:
-            return DagBundlesManager().view_url(self.bundle_name, self.bundle_version)
+            try:
+                return DagBundlesManager().view_url(self.bundle_name, self.bundle_version)
+            except ValueError:
+                return "No link since this bundle is no longer configured"
         return None
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
@@ -44,7 +44,7 @@ class DagVersionResponse(BaseModel):
             try:
                 return DagBundlesManager().view_url(self.bundle_name, self.bundle_version)
             except ValueError:
-                return "No link since this bundle is no longer configured"
+                return None
         return None
 
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -108,6 +108,18 @@ class TestGetDagVersion(TestDagVersionEndpoint):
         assert response.status_code == 200
         assert response.json() == expected_response
 
+    @pytest.mark.usefixtures("make_dag_with_multiple_versions")
+    @mock.patch("airflow.dag_processing.bundles.manager.DagBundlesManager.view_url")
+    def test_get_dag_version_with_unconfigured_bundle(self, mock_view_url, test_client, dag_maker, session):
+        """Test that when a bundle is no longer configured, the bundle_url returns an error message."""
+        mock_view_url.side_effect = ValueError("Bundle not configured")
+
+        response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/1")
+        assert response.status_code == 200
+
+        response_data = response.json()
+        assert response_data["bundle_url"] == "No link since this bundle is no longer configured"
+
     def test_get_dag_version_404(self, test_client):
         response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/99")
         assert response.status_code == 404

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -118,7 +118,7 @@ class TestGetDagVersion(TestDagVersionEndpoint):
         assert response.status_code == 200
 
         response_data = response.json()
-        assert response_data["bundle_url"] == "No link since this bundle is no longer configured"
+        assert not response_data["bundle_url"]
 
     def test_get_dag_version_404(self, test_client):
         response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/99")


### PR DESCRIPTION
When a dag bundle is no longer configured, we raise error when accessing the dagbundle view url. This affects the UI and the fix I propose is to catch this error and return a message instead indicating that the bundle is no longer configured

Maybe we should be saving the view_url in the database?
