### PR TITLE
Fix yarn lint command

### DIFF
--- a/airflow-core/src/airflow/ui/eslint.config.js
+++ b/airflow-core/src/airflow/ui/eslint.config.js
@@ -36,7 +36,7 @@ import { unicornRules } from "./rules/unicorn.js";
  */
 export default /** @type {const} @satisfies {ReadonlyArray<FlatConfig.Config>} */ ([
   // Global ignore of dist directory
-  { ignores: ["**/dist/", "**coverage/"] },
+  { ignores: ["**/dist/", "**coverage/", "**/openapi-gen/"] },
   // Base rules
   coreRules,
   typescriptRules,

--- a/scripts/ci/pre_commit/ts_compile_lint_ui.py
+++ b/scripts/ci/pre_commit/ts_compile_lint_ui.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     files = [
         file[len(relative_dir.as_posix()) + 1 :]
         for file in original_files
-        if Path(file).is_relative_to(relative_dir) and "openapi-gen/" not in file
+        if Path(file).is_relative_to(relative_dir)
     ]
     all_non_yaml_files = [file for file in files if not file.endswith(".yaml")]
     print("All non-YAML files:", all_non_yaml_files)


### PR DESCRIPTION
The ignore of `generated` files for UI linting was done directly in the pre-commit hook, but this left the `yarn lint` command still linting those files and generating thousands of useless errors (import / key ordering).

Add the generated files to the eslint ignore, remove this part from the pre-commit hook now that this is done at the eslint level.