### PR TITLE
Triggerer: Support loading triggers from zip archives

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -24,6 +24,7 @@ import selectors
 import signal
 import sys
 import time
+import zipfile
 from collections import deque
 from collections.abc import Generator, Iterable
 from contextlib import suppress

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1160,7 +1160,7 @@ class TriggerRunner:
                         if sys.modules.pop(module2, None):
                             self.log.info("Removed %s from sys.modules", module2)
                     else:
-                        if sys.modules.pop(p.stem, None)
+                        if sys.modules.pop(p.stem, None):
                             self.log.info("Removed %s from sys.modules", p.stem)
 
     def import_classpath_maybe_zip(self, classpath):

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1141,11 +1141,11 @@ class TriggerRunner:
         """
         Clear the import cache (sys.modules) of the modules found in zip_file.
 
-        This is done so that triggers from different versions of a dag, with
+        This is done so that triggers from different versions of the same dag, with
         different versions of the same library are imported correctly.
 
         If this is not performed then the triggerer process can (will) load
-        the wrong version of the library from the cache.
+        the wrong version of the library from the sys.modules cache.
         """
         with zipfile.ZipFile(zip_file) as zf:
             for zip_info in zf.infolist():

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -28,6 +28,7 @@ import zipfile
 from collections import deque
 from collections.abc import Generator, Iterable
 from contextlib import suppress
+from pathlib import Path
 from socket import socket
 from traceback import format_exception
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, TypedDict

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -27,7 +27,7 @@ import typing
 from collections.abc import AsyncIterator
 from socket import socket
 from typing import TYPE_CHECKING, Any
-from unittest.mock import ANY, AsyncMock, MagicMock, patch, call
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pendulum
 import pytest
@@ -457,7 +457,7 @@ class TestTriggerRunner:
 
         assert cls is not None
         clear_modules_mock.assert_not_called()
-        import_mock.assert_not_called()
+        import_mock.assert_called_once_with(classpath)
 
     @patch("airflow.jobs.triggerer_job_runner.os")
     @patch("airflow.jobs.triggerer_job_runner.sys")

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -27,7 +27,7 @@ import typing
 from collections.abc import AsyncIterator
 from socket import socket
 from typing import TYPE_CHECKING, Any
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch, call
 
 import pendulum
 import pytest

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -467,12 +467,8 @@ class TestTriggerRunner:
         zip_file = "/path/to/zipfile.zip"
 
         zip_info_list = [
-            MagicMock(
-                filename="path/to/file1.py"
-            ),
-            MagicMock(
-                filename="longer/path/to/file2.py"
-            ),
+            MagicMock(filename="path/to/file1.py"),
+            MagicMock(filename="longer/path/to/file2.py"),
         ]
         zipfile_mock.return_value.__enter__.return_value.infolist.return_value = zip_info_list
 
@@ -488,8 +484,6 @@ class TestTriggerRunner:
                 call("longer.path.to.file2", None),
             ]
         )
-
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---
Currently airflow's scheduler supports executing DAGs defined in a zip archive. However the triggerer does not yet support this functionality. We propose these changes so that triggerer can support loading/executing triggers from a specified zip archive, similar to how scheduler does it.

The sys.modules cache is cleared of relevant libraries before performing an import, so that if there are multiple zip archives which contain the same library with different versions, the correct version will be loaded from disk instead of the global sys.modules cache.