### PR TITLE
Remove pytest db markers from apache hive provider

### DIFF
--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
@@ -34,9 +34,8 @@ DEFAULT_DATE = datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 
-pytestmark = pytest.mark.db_test
 
-
+@pytest.mark.db_test
 class TestNamedHivePartitionSensor:
     def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}

--- a/providers/apache/hive/tests/unit/apache/hive/transfers/test_s3_to_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/transfers/test_s3_to_hive.py
@@ -39,7 +39,6 @@ moto = pytest.importorskip("moto")
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.db_test
 class TestS3ToHiveTransfer:
     @pytest.fixture(autouse=True)
     def setup_attrs(self):
@@ -196,6 +195,7 @@ class TestS3ToHiveTransfer:
         fn_bz2 = self._get_fn(".bz2", False)
         assert self._check_file_equality(bz2_txt_nh, fn_bz2, ".bz2"), "bz2 Compressed file not as expected"
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.apache.hive.transfers.s3_to_hive.HiveCliHook")
     @moto.mock_aws
     def test_execute(self, mock_hiveclihook):
@@ -229,6 +229,7 @@ class TestS3ToHiveTransfer:
             s32hive = S3ToHiveOperator(**self.kwargs)
             s32hive.execute(None)
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.apache.hive.transfers.s3_to_hive.HiveCliHook")
     @moto.mock_aws
     def test_execute_with_select_expression(self, mock_hiveclihook):

--- a/providers/apache/hive/tests/unit/apache/hive/transfers/test_vertica_to_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/transfers/test_vertica_to_hive.py
@@ -25,8 +25,6 @@ import pytest
 from airflow.models.dag import DAG
 from airflow.providers.apache.hive.transfers.vertica_to_hive import VerticaToHiveOperator
 
-pytestmark = pytest.mark.db_test
-
 
 def mock_get_conn():
     commit_mock = mock.MagicMock()
@@ -48,6 +46,7 @@ class TestVerticaToHiveTransfer:
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", schedule=None, default_args=args)
 
+    @pytest.mark.db_test
     @mock.patch(
         "airflow.providers.apache.hive.transfers.vertica_to_hive.VerticaHook.get_conn",
         side_effect=mock_get_conn,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Part of #52020. 

Still db tests left.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
