### PR TITLE
Remove pytest db markers from common sql provider

### DIFF
--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
@@ -375,7 +375,6 @@ class TestColumnCheckOperator:
             == self.correct_generate_sql_query_with_partition.lstrip()
         )
 
-    @pytest.mark.db_test
     def test_generate_sql_query_with_templated_partitions(self, monkeypatch):
         checks = self.short_valid_column_mapping["X"]
         operator = self._construct_operator(monkeypatch, self.short_valid_column_mapping, ())
@@ -407,7 +406,6 @@ class TestColumnCheckOperator:
         )
         del self.short_valid_column_mapping["X"]["distinct_check"]["partition_clause"]
 
-    @pytest.mark.db_test
     @mock.patch.object(SQLColumnCheckOperator, "get_db_hook")
     def test_generated_sql_respects_templated_partitions(self, mock_get_db_hook):
         records = [
@@ -433,7 +431,6 @@ class TestColumnCheckOperator:
             self._full_check_sql(self.correct_generate_sql_query_with_partition),
         )
 
-    @pytest.mark.db_test
     @mock.patch.object(SQLColumnCheckOperator, "get_db_hook")
     def test_generated_sql_respects_templated_table(self, mock_get_db_hook):
         records = [
@@ -620,7 +617,6 @@ class TestTableCheckOperator:
             operator._generate_sql_query().lstrip() == self.correct_generate_sql_query_with_partition.lstrip()
         )
 
-    @pytest.mark.db_test
     def test_generate_sql_query_with_templated_partitions(self, monkeypatch):
         operator = self._construct_operator(monkeypatch, self.checks, ())
         operator.partition_clause = "{{ params.col }} > 10"
@@ -629,7 +625,6 @@ class TestTableCheckOperator:
             operator._generate_sql_query().lstrip() == self.correct_generate_sql_query_with_partition.lstrip()
         )
 
-    @pytest.mark.db_test
     def test_generate_sql_query_with_templated_table(self, monkeypatch):
         operator = self._construct_operator(monkeypatch, self.checks, ())
         operator.table = "{{ params.table }}"
@@ -811,7 +806,6 @@ class TestValueCheckOperator:
             tolerance=tolerance,
         )
 
-    @pytest.mark.db_test
     def test_pass_value_template_string(self):
         pass_value_str = "2018-03-22"
         operator = self._construct_operator("select date from tab1;", "{{ ds }}")
@@ -821,7 +815,6 @@ class TestValueCheckOperator:
         assert operator.task_id == self.task_id
         assert operator.pass_value == pass_value_str
 
-    @pytest.mark.db_test
     def test_pass_value_template_string_float(self):
         pass_value_float = 4.0
         operator = self._construct_operator("select date from tab1;", pass_value_float)
@@ -1080,7 +1073,6 @@ class TestThresholdCheckOperator:
             operator.execute(context=MagicMock())
 
 
-@pytest.mark.db_test
 class TestSqlBranch:
     """
     Test for SQL Branch Operator
@@ -1120,7 +1112,6 @@ class TestSqlBranch:
             dag=self.dag,
         )
 
-    @pytest.mark.db_test
     def test_unsupported_conn_type(self):
         """Check if BranchSQLOperator throws an exception for unsupported connection type"""
         op = BranchSQLOperator(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Part of #52020.

Still db tests left.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
