### PR TITLE
Remove pytest db markers from microsoft azure provider where possible

### DIFF
--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -401,7 +401,6 @@ class TestResponseHandler:
     # TODO: Elad: review this after merging the bump 2.10 PR
     # We should not have specific provider test block the release
     @pytest.mark.xfail(reason="TODO: Remove")
-    @pytest.mark.db_test
     def test_when_provider_min_airflow_version_is_2_10_or_higher_remove_obsolete_code(self):
         """
         Once this test starts failing due to the fact that the minimum Airflow version is now 2.10.0 or higher

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adx.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adx.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from unittest import mock
 
-import pytest
 from azure.kusto.data._models import KustoResultTable
 
 from airflow.models import DAG
@@ -82,7 +81,6 @@ class TestAzureDataExplorerQueryOperator:
         )
 
 
-@pytest.mark.db_test
 @mock.patch.object(AzureDataExplorerHook, "run_query", return_value=MockResponse())
 @mock.patch.object(AzureDataExplorerHook, "get_conn")
 def test_azure_data_explorer_query_operator_xcom_push_and_pull(

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_msgraph.py
@@ -44,7 +44,6 @@ except ImportError:
 
 
 class TestMSGraphAsyncOperator(Base):
-    @pytest.mark.db_test
     def test_execute_with_old_result_processor_signature(self):
         users = load_json_from_resources(dirname(__file__), "..", "resources", "users.json")
         next_users = load_json_from_resources(dirname(__file__), "..", "resources", "next_users.json")
@@ -76,7 +75,6 @@ class TestMSGraphAsyncOperator(Base):
                 assert events[1].payload["type"] == "builtins.dict"
                 assert events[1].payload["response"] == json.dumps(next_users)
 
-    @pytest.mark.db_test
     def test_execute_with_new_result_processor_signature(self):
         users = load_json_from_resources(dirname(__file__), "..", "resources", "users.json")
         next_users = load_json_from_resources(dirname(__file__), "..", "resources", "next_users.json")
@@ -104,7 +102,6 @@ class TestMSGraphAsyncOperator(Base):
             assert events[1].payload["type"] == "builtins.dict"
             assert events[1].payload["response"] == json.dumps(next_users)
 
-    @pytest.mark.db_test
     def test_execute_with_old_paginate_function_signature(self):
         users = load_json_from_resources(dirname(__file__), "..", "resources", "users.json")
         next_users = load_json_from_resources(dirname(__file__), "..", "resources", "next_users.json")
@@ -139,7 +136,6 @@ class TestMSGraphAsyncOperator(Base):
                 assert events[1].payload["type"] == "builtins.dict"
                 assert events[1].payload["response"] == json.dumps(next_users)
 
-    @pytest.mark.db_test
     def test_execute_when_do_xcom_push_is_false(self):
         users = load_json_from_resources(dirname(__file__), "..", "resources", "users.json")
         users.pop("@odata.nextLink")
@@ -162,7 +158,6 @@ class TestMSGraphAsyncOperator(Base):
             assert events[0].payload["type"] == "builtins.dict"
             assert events[0].payload["response"] == json.dumps(users)
 
-    @pytest.mark.db_test
     def test_execute_when_an_exception_occurs(self):
         with self.patch_hook_and_request_adapter(AirflowException()):
             operator = MSGraphAsyncOperator(
@@ -175,7 +170,6 @@ class TestMSGraphAsyncOperator(Base):
             with pytest.raises(AirflowException):
                 execute_operator(operator)
 
-    @pytest.mark.db_test
     def test_execute_when_an_exception_occurs_on_custom_event_handler_with_old_signature(self):
         with self.patch_hook_and_request_adapter(AirflowException("An error occurred")):
 
@@ -205,7 +199,6 @@ class TestMSGraphAsyncOperator(Base):
                 assert events[0].payload["status"] == "failure"
                 assert events[0].payload["message"] == "An error occurred"
 
-    @pytest.mark.db_test
     def test_execute_when_an_exception_occurs_on_custom_event_handler_with_new_signature(self):
         with self.patch_hook_and_request_adapter(AirflowException("An error occurred")):
 
@@ -231,7 +224,6 @@ class TestMSGraphAsyncOperator(Base):
             assert events[0].payload["status"] == "failure"
             assert events[0].payload["message"] == "An error occurred"
 
-    @pytest.mark.db_test
     def test_execute_when_response_is_bytes(self):
         content = load_file_from_resources(
             dirname(__file__), "..", "resources", "dummy.pdf", mode="rb", encoding=None
@@ -259,7 +251,6 @@ class TestMSGraphAsyncOperator(Base):
             assert events[0].payload["type"] == "builtins.bytes"
             assert events[0].payload["response"] == base64_encoded_content
 
-    @pytest.mark.db_test
     def test_execute_with_lambda_parameter_when_response_is_bytes(self):
         content = load_file_from_resources(
             dirname(__file__), "..", "resources", "dummy.pdf", mode="rb", encoding=None


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue
- https://github.com/apache/airflow/issues/52020

## How
- Cleaned pytest db markers in microsoft azure where possible and verified tests
- Still db tests left

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
