### PR TITLE
Fix grammar error in logging-tasks documentation

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -57,7 +57,7 @@ In addition, you can supply a remote location to store current logs and backups.
 Writing to task logs from your code
 -----------------------------------
 
-Airflow uses standard the Python `logging <https://docs.python.org/3/library/logging.html>`_ framework to
+Airflow uses the standard Python `logging <https://docs.python.org/3/library/logging.html>`_ framework to
 write logs, and for the duration of a task, the root logger is configured to write to the task's log.
 
 Most operators will write logs to the task log automatically. This is because they

--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -113,7 +113,7 @@ When displaying the logs in web UI, the display of logs will be condensed:
    [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} ⯈ Non important details
    [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - Here is again some standard text.
 
-If you click on the log text label, the detailed log lies will be displayed.
+If you click on the log text label, the detailed log lines will be displayed.
 
 .. code-block:: text
 


### PR DESCRIPTION
Fixed a grammatical error, from 'standard the Python logging framework' to 'the standard python logging framework

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
