### PR TITLE
Airbyte test fixes, make mock JobResponse response id as int

### DIFF
--- a/providers/airbyte/tests/unit/airbyte/hooks/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/hooks/test_airbyte.py
@@ -97,7 +97,7 @@ class TestAirbyteHook:
         mock_response = mock.AsyncMock()
         mock_response.job_response = JobResponse(
             connection_id="connection-mock",
-            job_id="1",
+            job_id=1,
             start_time="today",
             job_type=JobTypeEnum.SYNC,
             status=JobStatusEnum.RUNNING,
@@ -111,7 +111,7 @@ class TestAirbyteHook:
         mock_response = mock.Mock()
         mock_response.job_response = JobResponse(
             connection_id="connection-mock",
-            job_id="1",
+            job_id=1,
             start_time="today",
             job_type=JobTypeEnum.SYNC,
             status=JobStatusEnum.CANCELLED,

--- a/providers/airbyte/tests/unit/airbyte/triggers/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/triggers/test_airbyte.py
@@ -229,9 +229,7 @@ class TestAirbyteSyncTrigger:
         ],
     )
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
-    async def test_airbyte_job_is_still_running_success(
-        self, mock_get_job_status, mock_response, expected_status
-    ):
+    async def test_airbyte_job_is_still_running_success(self, mock_response, expected_status):
         """Test is_still_running with mocked response job status and assert
         the return response with expected value"""
         hook = mock.AsyncMock(AirbyteHook)
@@ -253,9 +251,7 @@ class TestAirbyteSyncTrigger:
         ],
     )
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
-    async def test_airbyte_sync_run_is_still_running(
-        self, mock_get_job_status, mock_response, expected_status
-    ):
+    async def test_airbyte_sync_run_is_still_running(self, mock_response, expected_status):
         """Test is_still_running with mocked response job status and assert
         the return response with expected value"""
         airbyte_hook = mock.AsyncMock(AirbyteHook)

--- a/providers/airbyte/tests/unit/airbyte/triggers/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/triggers/test_airbyte.py
@@ -229,7 +229,9 @@ class TestAirbyteSyncTrigger:
         ],
     )
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
-    async def test_airbyte_job_is_still_running_success(self, mock_response, expected_status):
+    async def test_airbyte_job_is_still_running_success(
+        self, mock_get_job_status, mock_response, expected_status
+    ):
         """Test is_still_running with mocked response job status and assert
         the return response with expected value"""
         hook = mock.AsyncMock(AirbyteHook)
@@ -251,7 +253,9 @@ class TestAirbyteSyncTrigger:
         ],
     )
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
-    async def test_airbyte_sync_run_is_still_running(self, mock_response, expected_status):
+    async def test_airbyte_sync_run_is_still_running(
+        self, mock_get_job_status, mock_response, expected_status
+    ):
         """Test is_still_running with mocked response job status and assert
         the return response with expected value"""
         airbyte_hook = mock.AsyncMock(AirbyteHook)


### PR DESCRIPTION
As per airbyte_api model, the job id is int type https://github.com/airbytehq/airbyte-api-python-sdk/blob/main/src/airbyte_api/models/jobresponse.py#L17

Updating tests to align model.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
