### PR TITLE
Clean up messy default connection overrides in provider tests

### DIFF
--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -33,7 +33,6 @@ from airflow.models import Connection
 from airflow.providers.common.sql.dialects.dialect import Dialect
 from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.common.sql.hooks.sql import DbApiHook, resolve_dialects
-from airflow.utils.session import provide_session
 
 from tests_common.test_utils.common_sql import mock_db_hook
 from tests_common.test_utils.providers import get_provider_min_airflow_version
@@ -49,15 +48,18 @@ class DBApiHookForTests(DbApiHook):
     get_conn = MagicMock(name="conn")
 
 
-@provide_session
 @pytest.fixture(autouse=True)
-def create_connection(session):
-    conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-    conn.host = HOST
-    conn.login = None
-    conn.password = PASSWORD
-    conn.extra = None
-    session.commit()
+def create_connection(create_connection_without_db):
+    create_connection_without_db(
+        Connection(
+            conn_id=DEFAULT_CONN_ID,
+            conn_type="sqlite",
+            host=HOST,
+            login=None,
+            password=PASSWORD,
+            extra=None,
+        )
+    )
 
 
 def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_azure_workload_identity_async.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_azure_workload_identity_async.py
@@ -28,7 +28,6 @@ from azure.core.credentials import AccessToken
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.hooks.databricks_base import DEFAULT_AZURE_CREDENTIAL_SETTING_KEY
-from airflow.utils.session import provide_session
 
 
 def create_successful_response_mock(content):
@@ -53,16 +52,20 @@ DEFAULT_RETRY_ARGS = dict(
 
 @pytest.mark.db_test
 class TestDatabricksHookAadTokenWorkloadIdentityAsync:
-    @provide_session
-    def setup_method(self, method, session=None):
-        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-        conn.host = HOST
-        conn.extra = json.dumps(
-            {
-                DEFAULT_AZURE_CREDENTIAL_SETTING_KEY: True,
-            }
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id=DEFAULT_CONN_ID,
+                conn_type="databricks",
+                host=HOST,
+                extra=json.dumps(
+                    {
+                        DEFAULT_AZURE_CREDENTIAL_SETTING_KEY: True,
+                    }
+                ),
+            )
         )
-        session.commit()
 
     @pytest.mark.asyncio
     @mock.patch(

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -33,7 +33,6 @@ from airflow.exceptions import AirflowException, AirflowOptionalProviderFeatureE
 from airflow.models import Connection
 from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook, create_timeout_thread
-from airflow.utils.session import provide_session
 
 TASK_ID = "databricks-sql-operator"
 DEFAULT_CONN_ID = "databricks_default"
@@ -42,15 +41,18 @@ HOST_WITH_SCHEME = "https://xx.cloud.databricks.com"
 TOKEN = "token"
 
 
-@provide_session
 @pytest.fixture(autouse=True)
-def create_connection(session):
-    conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-    conn.host = HOST
-    conn.login = None
-    conn.password = TOKEN
-    conn.extra = None
-    session.commit()
+def create_connection(create_connection_without_db):
+    create_connection_without_db(
+        Connection(
+            conn_id=DEFAULT_CONN_ID,
+            conn_type="databricks",
+            host=HOST,
+            login=None,
+            password=TOKEN,
+            extra=None,
+        )
+    )
 
 
 @pytest.fixture

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -29,7 +29,6 @@ from airflow.providers.databricks.triggers.databricks import (
     DatabricksSQLStatementExecutionTrigger,
 )
 from airflow.triggers.base import TriggerEvent
-from airflow.utils.session import provide_session
 
 pytestmark = pytest.mark.db_test
 
@@ -121,14 +120,18 @@ GET_RUN_RESPONSE_TERMINATED_WITH_FAILED = {
 
 
 class TestDatabricksExecutionTrigger:
-    @provide_session
-    def setup_method(self, method, session=None):
-        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-        conn.host = HOST
-        conn.login = LOGIN
-        conn.password = PASSWORD
-        conn.extra = None
-        session.commit()
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id=DEFAULT_CONN_ID,
+                conn_type="databricks",
+                host=HOST,
+                login=LOGIN,
+                password=PASSWORD,
+                extra=None,
+            )
+        )
 
         self.trigger = DatabricksExecutionTrigger(
             run_id=RUN_ID,
@@ -258,15 +261,19 @@ class TestDatabricksExecutionTrigger:
 
 
 class TestDatabricksSQLStatementExecutionTrigger:
-    @provide_session
-    def setup_method(self, method, session=None):
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
         self.end_time = time.time() + 60
-        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-        conn.host = HOST
-        conn.login = LOGIN
-        conn.password = PASSWORD
-        conn.extra = None
-        session.commit()
+        create_connection_without_db(
+            Connection(
+                conn_id=DEFAULT_CONN_ID,
+                conn_type="databricks",
+                host=HOST,
+                login=LOGIN,
+                password=PASSWORD,
+                extra=None,
+            )
+        )
 
         self.trigger = DatabricksSQLStatementExecutionTrigger(
             statement_id=STATEMENT_ID,

--- a/providers/exasol/tests/unit/exasol/hooks/test_sql.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_sql.py
@@ -27,7 +27,6 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from airflow.providers.exasol.hooks.exasol import ExasolHook
-from airflow.utils.session import provide_session
 
 TASK_ID = "sql-operator"
 HOST = "host"
@@ -40,17 +39,18 @@ class ExasolHookForTests(ExasolHook):
     get_conn = MagicMock(name="conn")
 
 
-@provide_session
 @pytest.fixture(autouse=True)
-def create_connection(session):
-    conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-    if conn is None:
-        conn = Connection(conn_id=DEFAULT_CONN_ID)
-    conn.host = HOST
-    conn.login = None
-    conn.password = PASSWORD
-    conn.extra = None
-    session.commit()
+def create_connection(create_connection_without_db):
+    create_connection_without_db(
+        Connection(
+            conn_id=DEFAULT_CONN_ID,
+            conn_type="exasol",
+            host=HOST,
+            login=None,
+            password=PASSWORD,
+            extra=None,
+        )
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While working on https://github.com/apache/airflow/pull/52129/files, i saw this pattern in many places.

Pattern of this type:
```
    @provide_session
    def setup_method(self, method, session=None):
        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
        conn.host = HOST
        conn.schema = None
        conn.port = None
        conn.login = None
        conn.password = None
        conn.extra = json.dumps({"token": TOKEN, "host": HOST})

        session.commit()

        self.hook = DatabricksHook()
```

We should not be overriding default connections this way at ALL, it will make migration of providers to use task sdk extremely hard / annoying. Cleaning up that pattern to use the fixture introduced in #51930

I am introducing a way for tests to only use connections from env via #52129, which will follow this one

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
