### PR TITLE
Remove pytestmark and add db_test marker to relevant tests in opsgenie

### DIFF
--- a/providers/opsgenie/tests/unit/opsgenie/hooks/test_opsgenie.py
+++ b/providers/opsgenie/tests/unit/opsgenie/hooks/test_opsgenie.py
@@ -26,8 +26,6 @@ from opsgenie_sdk.exceptions import AuthenticationException
 from airflow.models import Connection
 from airflow.providers.opsgenie.hooks.opsgenie import OpsgenieAlertHook
 
-pytestmark = pytest.mark.db_test
-
 
 class TestOpsgenieAlertHook:
     conn_id = "opsgenie_conn_id_test"
@@ -83,6 +81,7 @@ class TestOpsgenieAlertHook:
         api_key = hook._get_api_key()
         assert api_key == "eb243592-faa2-4ba2-a551q-1afdf565c889"
 
+    @pytest.mark.db_test
     def test_get_conn_defaults_host(self):
         hook = OpsgenieAlertHook()
         assert hook.get_conn().api_client.configuration.host == "https://api.opsgenie.com"
@@ -108,6 +107,7 @@ class TestOpsgenieAlertHook:
             == "eb243592-faa2-4ba2-a551q-1afdf565c889"
         )
 
+    @pytest.mark.db_test
     def test_create_alert_api_key_not_set(self):
         hook = OpsgenieAlertHook()
         with pytest.raises(AuthenticationException):

--- a/providers/opsgenie/tests/unit/opsgenie/notifications/test_opsgenie.py
+++ b/providers/opsgenie/tests/unit/opsgenie/notifications/test_opsgenie.py
@@ -25,8 +25,6 @@ from airflow.providers.opsgenie.hooks.opsgenie import OpsgenieAlertHook
 from airflow.providers.opsgenie.notifications.opsgenie import OpsgenieNotifier, send_opsgenie_notification
 from airflow.providers.standard.operators.empty import EmptyOperator
 
-pytestmark = pytest.mark.db_test
-
 
 class TestOpsgenieNotifier:
     _config = {
@@ -76,6 +74,7 @@ class TestOpsgenieNotifier:
     }
 
     @mock.patch.object(OpsgenieAlertHook, "get_conn")
+    @pytest.mark.db_test
     def test_notifier(self, mock_opsgenie_alert_hook, dag_maker):
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
@@ -84,6 +83,7 @@ class TestOpsgenieNotifier:
         mock_opsgenie_alert_hook.return_value.create_alert.assert_called_once_with(self.expected_payload_dict)
 
     @mock.patch.object(OpsgenieAlertHook, "get_conn")
+    @pytest.mark.db_test
     def test_notifier_with_notifier_class(self, mock_opsgenie_alert_hook, dag_maker):
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
@@ -92,6 +92,7 @@ class TestOpsgenieNotifier:
         mock_opsgenie_alert_hook.return_value.create_alert.assert_called_once_with(self.expected_payload_dict)
 
     @mock.patch.object(OpsgenieAlertHook, "get_conn")
+    @pytest.mark.db_test
     def test_notifier_templated(self, mock_opsgenie_alert_hook, dag_maker):
         dag_id = "test_notifier"
         with dag_maker(dag_id) as dag:

--- a/providers/opsgenie/tests/unit/opsgenie/typing/test_opsgenie.py
+++ b/providers/opsgenie/tests/unit/opsgenie/typing/test_opsgenie.py
@@ -17,11 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-import pytest
-
 from airflow.providers.opsgenie.typing.opsgenie import CreateAlertPayload
-
-pytestmark = pytest.mark.db_test
 
 
 class TestCreateAlertPayload:


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/52020

still db tests left

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
