### PR TITLE
Remove pytestmark from Pagerduty test files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -623,6 +623,7 @@ repos:
             ^providers/openai/.*\.py$|
             ^providers/openfaas/.*\.py$|
             ^providers/oracle/.*\.py$|
+            ^providers/pagerduty/.*\.py$|
             ^providers/pgvector/.*\.py$|
             ^providers/pinecone/.*\.py$|
             ^providers/postgres/.*\.py$|

--- a/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty.py
+++ b/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty.py
@@ -22,9 +22,6 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.pagerduty.hooks.pagerduty import PagerdutyHook
 
-pytestmark = pytest.mark.db_test
-
-
 DEFAULT_CONN_ID = "pagerduty_default"
 
 

--- a/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
+++ b/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
@@ -22,8 +22,6 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 
-pytestmark = pytest.mark.db_test
-
 DEFAULT_CONN_ID = "pagerduty_events_default"
 
 

--- a/providers/pagerduty/tests/unit/pagerduty/notifications/test_pagerduty.py
+++ b/providers/pagerduty/tests/unit/pagerduty/notifications/test_pagerduty.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+from airflow import DAG
 from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 from airflow.providers.pagerduty.notifications.pagerduty import (
     PagerdutyNotifier,
@@ -31,8 +32,6 @@ PAGERDUTY_API_DEFAULT_CONN_ID = PagerdutyEventsHook.default_conn_name
 class TestPagerdutyNotifier:
     @mock.patch("airflow.providers.pagerduty.notifications.pagerduty.PagerdutyEventsHook")
     def test_notifier(self, mock_pagerduty_event_hook):
-        from airflow.sdk.definitions.dag import DAG
-
         dag = DAG("test_notifier")
         notifier = send_pagerduty_notification(summary="DISK at 99%", severity="critical", action="trigger")
         notifier({"dag": dag})
@@ -52,8 +51,6 @@ class TestPagerdutyNotifier:
 
     @mock.patch("airflow.providers.pagerduty.notifications.pagerduty.PagerdutyEventsHook")
     def test_notifier_with_notifier_class(self, mock_pagerduty_event_hook):
-        from airflow.sdk.definitions.dag import DAG
-
         dag = DAG("test_notifier")
         notifier = PagerdutyNotifier(summary="DISK at 99%", severity="critical", action="trigger")
         notifier({"dag": dag})
@@ -73,8 +70,6 @@ class TestPagerdutyNotifier:
 
     @mock.patch("airflow.providers.pagerduty.notifications.pagerduty.PagerdutyEventsHook")
     def test_notifier_templated(self, mock_pagerduty_event_hook):
-        from airflow.sdk.definitions.dag import DAG
-
         dag = DAG("test_notifier")
 
         notifier = PagerdutyNotifier(

--- a/providers/pagerduty/tests/unit/pagerduty/notifications/test_pagerduty.py
+++ b/providers/pagerduty/tests/unit/pagerduty/notifications/test_pagerduty.py
@@ -19,26 +19,21 @@ from __future__ import annotations
 
 from unittest import mock
 
-import pytest
-
 from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 from airflow.providers.pagerduty.notifications.pagerduty import (
     PagerdutyNotifier,
     send_pagerduty_notification,
 )
-from airflow.providers.standard.operators.empty import EmptyOperator
-
-pytestmark = pytest.mark.db_test
-
 
 PAGERDUTY_API_DEFAULT_CONN_ID = PagerdutyEventsHook.default_conn_name
 
 
 class TestPagerdutyNotifier:
     @mock.patch("airflow.providers.pagerduty.notifications.pagerduty.PagerdutyEventsHook")
-    def test_notifier(self, mock_pagerduty_event_hook, dag_maker):
-        with dag_maker("test_notifier") as dag:
-            EmptyOperator(task_id="task1")
+    def test_notifier(self, mock_pagerduty_event_hook):
+        from airflow.sdk.definitions.dag import DAG
+
+        dag = DAG("test_notifier")
         notifier = send_pagerduty_notification(summary="DISK at 99%", severity="critical", action="trigger")
         notifier({"dag": dag})
         mock_pagerduty_event_hook.return_value.send_event.assert_called_once_with(
@@ -56,9 +51,10 @@ class TestPagerdutyNotifier:
         )
 
     @mock.patch("airflow.providers.pagerduty.notifications.pagerduty.PagerdutyEventsHook")
-    def test_notifier_with_notifier_class(self, mock_pagerduty_event_hook, dag_maker):
-        with dag_maker("test_notifier") as dag:
-            EmptyOperator(task_id="task1")
+    def test_notifier_with_notifier_class(self, mock_pagerduty_event_hook):
+        from airflow.sdk.definitions.dag import DAG
+
+        dag = DAG("test_notifier")
         notifier = PagerdutyNotifier(summary="DISK at 99%", severity="critical", action="trigger")
         notifier({"dag": dag})
         mock_pagerduty_event_hook.return_value.send_event.assert_called_once_with(
@@ -76,9 +72,10 @@ class TestPagerdutyNotifier:
         )
 
     @mock.patch("airflow.providers.pagerduty.notifications.pagerduty.PagerdutyEventsHook")
-    def test_notifier_templated(self, mock_pagerduty_event_hook, dag_maker):
-        with dag_maker("test_notifier") as dag:
-            EmptyOperator(task_id="task1")
+    def test_notifier_templated(self, mock_pagerduty_event_hook):
+        from airflow.sdk.definitions.dag import DAG
+
+        dag = DAG("test_notifier")
 
         notifier = PagerdutyNotifier(
             summary="DISK at 99% {{dag.dag_id}}",


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/52020
**clean**

Some tests did not require actual database interaction, so they were simplified (maintaining identical test coverage):
- Removed pytestmark = pytest.mark.db_test
- Replaced dag_maker fixture with simple DAG("test_notifier") objects
- Removed unused EmptyOperator imports and task creation



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
