### PR TITLE
fix(provider): progress_callback was repeatedly called with the first log line

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -524,10 +524,10 @@ class PodManager(LoggingMixin):
                                 message_timestamp = line_timestamp
                                 progress_callback_lines.append(line)
                             else:  # previous log line is complete
-                                for line in progress_callback_lines:
+                                for progress_line in progress_callback_lines:
                                     for callback in self._callbacks:
                                         callback.progress_callback(
-                                            line=line, client=self._client, mode=ExecutionMode.SYNC
+                                            line=progress_line, client=self._client, mode=ExecutionMode.SYNC
                                         )
                                 if message_to_log is not None:
                                     if is_log_group_marker(message_to_log):


### PR DESCRIPTION
I realized that there was a bug in the way that the PodManager calls the `progress_callback` with its log lines. Due to the log line variable being called `line` and the loop variable that loops over the `progress_callback_lines` also being called `line` led, in the case that all log lines have a timestamp, to the `progress_callback` always being called with the first log line received.

I added a test case and verified that it fails with the code as it was on the main branch. I also applied a minimal fix that fixes the problem and the test case.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
