### PR TITLE
Helm: add custom annotations to jwt secret

### DIFF
--- a/chart/templates/secrets/jwt-secret.yaml
+++ b/chart/templates/secrets/jwt-secret.yaml
@@ -36,6 +36,10 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.jwtSecretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   jwt-secret: {{ (default $generated_secret_key .Values.jwtSecret) | b64enc | quote }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1482,6 +1482,15 @@
             "x-docsSection": "Airflow",
             "default": null
         },
+        "jwtSecretAnnotations": {
+            "description": "Annotations to add to the JWT secret.",
+            "type": "object",
+            "x-docsSection": "Common",
+            "default": {},
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "webserverSecretKey": {
             "description": "The Flask secret key for Airflow Webserver to encrypt browser session.",
             "type": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -559,6 +559,8 @@ webserverSecretKeySecretName: ~
 
 # Secret key used to encode and decode JWTs: `[api_auth] jwt_secret` in airflow.cfg
 jwtSecret: ~
+# Add custom annotations to the JWT secret
+jwtSecretAnnotations: {}
 jwtSecretName: ~
 
 # In order to use kerberos you need to create secret containing the keytab file

--- a/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
@@ -75,3 +75,18 @@ class TestAPIServerDeployment:
             "subPath": "webserver_config.py",
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+
+
+class TestAPIServerJWTSecret:
+    """Tests API Server JWT secret."""
+
+    def test_should_add_annotations_to_jwt_secret(self):
+        docs = render_chart(
+            values={
+                "jwtSecretAnnotations": {"test_annotation": "test_annotation_value"},
+            },
+            show_only=["templates/secrets/jwt-secret.yaml"],
+        )[0]
+
+        assert "annotations" in jmespath.search("metadata", docs)
+        assert jmespath.search("metadata.annotations", docs)["test_annotation"] == "test_annotation_value"


### PR DESCRIPTION
This PR adds possibility to set custom annotations for JWT secret in the same way as it is already possible for webserverSecretKey .

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
