### PR TITLE
Remove db tests from fab provider

### DIFF
--- a/providers/fab/tests/unit/fab/auth_manager/api/auth/backend/test_basic_auth.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api/auth/backend/test_basic_auth.py
@@ -59,7 +59,6 @@ def function_decorated():
     mock_call()
 
 
-@pytest.mark.db_test
 class TestBasicAuth:
     def setup_method(self) -> None:
         mock_call.reset_mock()

--- a/providers/fab/tests/unit/fab/auth_manager/api/auth/backend/test_session.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api/auth/backend/test_session.py
@@ -38,7 +38,6 @@ def function_decorated():
     mock_call()
 
 
-@pytest.mark.db_test
 class TestSessionAuth:
     def setup_method(self) -> None:
         mock_call.reset_mock()

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -19,12 +19,9 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
-
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginBody, LoginResponse
 
 
-@pytest.mark.db_test
 class TestLogin:
     dummy_login_body = LoginBody(username="dummy", password="dummy")
     dummy_token = LoginResponse(access_token="DUMMY_TOKEN")

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
 
 
-@pytest.mark.db_test
 @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
 class TestLogin:
     def setup_method(

--- a/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_utils.py
+++ b/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_utils.py
@@ -32,8 +32,6 @@ from tests_common.test_utils.config import conf_vars
 with ignore_provider_compatibility_error("2.9.0+", __file__):
     from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
 
-pytestmark = pytest.mark.db_test
-
 
 @pytest.fixture
 def flask_app():

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -154,7 +154,6 @@ class TestFabAuthManager:
         result = auth_manager_with_appbuilder.serialize_user(user)
         assert result == {"sub": str(user.id)}
 
-    @pytest.mark.db_test
     @mock.patch.object(FabAuthManager, "get_user")
     def test_is_logged_in(self, mock_get_user, auth_manager_with_appbuilder):
         user = Mock()
@@ -163,7 +162,6 @@ class TestFabAuthManager:
 
         assert auth_manager_with_appbuilder.is_logged_in() is False
 
-    @pytest.mark.db_test
     @mock.patch.object(FabAuthManager, "get_user")
     def test_is_logged_in_with_inactive_user(self, mock_get_user, auth_manager_with_appbuilder):
         user = Mock()
@@ -690,11 +688,9 @@ class TestFabAuthManager:
 
         delete_user(flask_app, "username")
 
-    @pytest.mark.db_test
     def test_security_manager_return_fab_security_manager_override(self, auth_manager_with_appbuilder):
         assert isinstance(auth_manager_with_appbuilder.security_manager, FabAirflowSecurityManagerOverride)
 
-    @pytest.mark.db_test
     def test_security_manager_return_custom_provided(self, flask_app, auth_manager_with_appbuilder):
         class TestSecurityManager(FabAirflowSecurityManagerOverride):
             pass
@@ -702,7 +698,6 @@ class TestFabAuthManager:
         flask_app.config["SECURITY_MANAGER_CLASS"] = TestSecurityManager
         assert isinstance(auth_manager_with_appbuilder.security_manager, TestSecurityManager)
 
-    @pytest.mark.db_test
     def test_security_manager_wrong_inheritance_raise_exception(
         self, flask_app, auth_manager_with_appbuilder
     ):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Part of https://github.com/apache/airflow/issues/52020
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
