### PR TITLE
Move `EdgeInfoType` to Task SDK

### DIFF
--- a/airflow-core/src/airflow/utils/types.py
+++ b/airflow-core/src/airflow/utils/types.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import airflow.sdk.definitions._internal.types
 
@@ -55,12 +55,6 @@ class DagRunType(str, enum.Enum):
             if run_id and run_id.startswith(f"{run_type.value}__"):
                 return run_type
         return DagRunType.MANUAL
-
-
-class EdgeInfoType(TypedDict):
-    """Extra metadata that the DAG can store about an edge, usually generated from an EdgeModifier."""
-
-    label: str | None
 
 
 class DagRunTriggeredByType(enum.Enum):

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -76,10 +76,9 @@ if TYPE_CHECKING:
 
     from airflow.sdk.definitions.abstractoperator import Operator
     from airflow.sdk.definitions.decorators import TaskDecoratorCollection
+    from airflow.sdk.definitions.edges import EdgeInfoType
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.typing_compat import Self
-    from airflow.utils.types import EdgeInfoType
-
 
 log = logging.getLogger(__name__)
 

--- a/task-sdk/src/airflow/sdk/definitions/edges.py
+++ b/task-sdk/src/airflow/sdk/definitions/edges.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from airflow.sdk.definitions._internal.mixins import DependencyMixin
 
@@ -187,3 +187,9 @@ class EdgeModifier(DependencyMixin):
 def Label(label: str):
     """Create an EdgeModifier that sets a human-readable label on the edge."""
     return EdgeModifier(label=label)
+
+
+class EdgeInfoType(TypedDict):
+    """Extra metadata that the DAG can store about an edge, usually generated from an EdgeModifier."""
+
+    label: str | None


### PR DESCRIPTION
This is an internal class -- moving it where it belongs. Doesn't need newsfragment.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
