### PR TITLE
Add default conn name to asana provider operators

### DIFF
--- a/providers/asana/src/airflow/providers/asana/operators/asana_tasks.py
+++ b/providers/asana/src/airflow/providers/asana/operators/asana_tasks.py
@@ -53,9 +53,9 @@ class AsanaCreateTaskOperator(BaseOperator):
     def __init__(
         self,
         *,
-        conn_id: str,
         name: str,
         task_parameters: dict | None = None,
+        conn_id: str = "asana_default",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -92,9 +92,9 @@ class AsanaUpdateTaskOperator(BaseOperator):
     def __init__(
         self,
         *,
-        conn_id: str,
         asana_task_gid: str,
         task_parameters: dict,
+        conn_id: str = "asana_default",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -124,8 +124,8 @@ class AsanaDeleteTaskOperator(BaseOperator):
     def __init__(
         self,
         *,
-        conn_id: str,
         asana_task_gid: str,
+        conn_id: str = "asana_default",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -160,8 +160,8 @@ class AsanaFindTaskOperator(BaseOperator):
     def __init__(
         self,
         *,
-        conn_id: str,
         search_parameters: dict | None = None,
+        conn_id: str = "asana_default",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/providers/asana/tests/unit/asana/operators/test_asana_tasks.py
+++ b/providers/asana/tests/unit/asana/operators/test_asana_tasks.py
@@ -37,6 +37,22 @@ class TestAsanaTaskOperators:
     @pytest.fixture(autouse=True)
     def setup_connections(self, create_connection_without_db):
         create_connection_without_db(Connection(conn_id="asana_test", conn_type="asana", password="test"))
+        create_connection_without_db(Connection(conn_id="asana_default", conn_type="asana", password="test"))
+
+    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
+    def test_asana_create_task_operator_with_default_conn(self, mock_tasks_api):
+        """
+        Tests that the AsanaCreateTaskOperator uses the default connection.
+        """
+
+        mock_tasks_api.return_value.create_task.return_value = {"gid": "1"}
+        create_task = AsanaCreateTaskOperator(
+            task_id="create_task",
+            name="test",
+            task_parameters={"workspace": "1"},
+        )
+        assert create_task.conn_id == "asana_default"
+        create_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_create_task_operator(self, mock_asana_hook):
@@ -58,6 +74,19 @@ class TestAsanaTaskOperators:
         mock_hook_instance.create_task.assert_called_once_with("test", {"workspace": "1"})
         assert result == "1"
 
+    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
+    def test_asana_find_task_operator_with_default_conn(self, mock_tasks_api):
+        """
+        Tests that the AsanaFindTaskOperator uses the default connection.
+        """
+        mock_tasks_api.return_value.tasks.create.return_value = {"gid": "1"}
+        find_task = AsanaFindTaskOperator(
+            task_id="find_task",
+            search_parameters={"project": "test"},
+        )
+        assert find_task.conn_id == "asana_default"
+        find_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_find_task_operator(self, mock_asana_hook):
         """
@@ -77,6 +106,19 @@ class TestAsanaTaskOperators:
         mock_hook_instance.find_task.assert_called_once_with({"project": "test"})
         assert result == {"gid": "1"}
 
+    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
+    def test_asana_update_task_operator_default_conn(self, mock_tasks_api):
+        """
+        Tests that the AsanaUpdateTaskOperator uses the default connection.
+        """
+        update_task = AsanaUpdateTaskOperator(
+            task_id="update_task",
+            asana_task_gid="test",
+            task_parameters={"completed": True},
+        )
+        assert update_task.conn_id == "asana_default"
+        assert mock_tasks_api.return_value.update_task.called
+
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_update_task_operator(self, mock_asana_hook):
         """
@@ -92,6 +134,23 @@ class TestAsanaTaskOperators:
         )
         update_task.execute({})
         mock_hook_instance.update_task.assert_called_once_with("test", {"completed": True})
+
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_delete_task_operator_with_default_conn(self, mock_asana_hook):
+        """
+        Tests that the AsanaDeleteTaskOperator uses the default connection.
+        """
+
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
+
+        delete_task = AsanaDeleteTaskOperator(
+            task_id="delete_task",
+            asana_task_gid="test",
+        )
+        delete_task.execute({})
+        assert delete_task.conn_id == "asana_default"
+        mock_hook_instance.delete_task.assert_called_once_with("test")
 
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_delete_task_operator(self, mock_asana_hook):

--- a/providers/asana/tests/unit/asana/operators/test_asana_tasks.py
+++ b/providers/asana/tests/unit/asana/operators/test_asana_tasks.py
@@ -39,20 +39,25 @@ class TestAsanaTaskOperators:
         create_connection_without_db(Connection(conn_id="asana_test", conn_type="asana", password="test"))
         create_connection_without_db(Connection(conn_id="asana_default", conn_type="asana", password="test"))
 
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_create_task_operator_with_default_conn(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_create_task_operator_with_default_conn(self, mock_asana_hook):
         """
         Tests that the AsanaCreateTaskOperator uses the default connection.
         """
 
-        mock_tasks_api.return_value.create_task.return_value = {"gid": "1"}
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
+        mock_hook_instance.create_task.return_value = {"gid": "1"}
+
         create_task = AsanaCreateTaskOperator(
             task_id="create_task",
             name="test",
             task_parameters={"workspace": "1"},
         )
+        result = create_task.execute({})
         assert create_task.conn_id == "asana_default"
-        create_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        mock_hook_instance.create_task.assert_called_once_with("test", {"workspace": "1"})
+        assert result == "1"
 
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_create_task_operator(self, mock_asana_hook):
@@ -74,18 +79,25 @@ class TestAsanaTaskOperators:
         mock_hook_instance.create_task.assert_called_once_with("test", {"workspace": "1"})
         assert result == "1"
 
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_find_task_operator_with_default_conn(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_find_task_operator_with_default_conn(self, mock_asana_hook):
         """
         Tests that the AsanaFindTaskOperator uses the default connection.
         """
-        mock_tasks_api.return_value.tasks.create.return_value = {"gid": "1"}
+
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
+        mock_hook_instance.find_task.return_value = {"gid": "1"}
+
         find_task = AsanaFindTaskOperator(
             task_id="find_task",
             search_parameters={"project": "test"},
         )
         assert find_task.conn_id == "asana_default"
-        find_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        result = find_task.execute({})
+        mock_hook_instance.find_task.assert_called_once_with({"project": "test"})
+        assert result == {"gid": "1"}
 
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_find_task_operator(self, mock_asana_hook):
@@ -106,18 +118,22 @@ class TestAsanaTaskOperators:
         mock_hook_instance.find_task.assert_called_once_with({"project": "test"})
         assert result == {"gid": "1"}
 
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_update_task_operator_default_conn(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_update_task_operator_default_conn(self, mock_asana_hook):
         """
         Tests that the AsanaUpdateTaskOperator uses the default connection.
         """
+
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
         update_task = AsanaUpdateTaskOperator(
             task_id="update_task",
             asana_task_gid="test",
             task_parameters={"completed": True},
         )
         assert update_task.conn_id == "asana_default"
-        assert mock_tasks_api.return_value.update_task.called
+        update_task.execute({})
+        mock_hook_instance.update_task.assert_called_once_with("test", {"completed": True})
 
     @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
     def test_asana_update_task_operator(self, mock_asana_hook):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
