### PR TITLE
Fix GitDagBundle materialize version folder for DAG callbacks work  (#52040)

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -213,7 +213,9 @@ class GitDagBundle(BaseDagBundle):
             if self.supports_versioning:
                 new_version = self.get_current_version()
                 if new_version != pre_version:
-                    self._log.info("New version detected for %s: %s (was %s)", self.name, new_version, pre_version)
+                    self._log.info(
+                        "New version detected for %s: %s (was %s)", self.name, new_version, pre_version
+                    )
                     try:
                         self._materialize_version(new_version)
                     except Exception as exc:
@@ -260,10 +262,7 @@ class GitDagBundle(BaseDagBundle):
         return None
 
     def _materialize_version(self, version: str) -> None:
-        """
-        Ensure versions/<version> exists and is checked out to that commit.
-        Needed by the DAG Processor to import the DAG for callbacks.
-        """
+        """Clone and checkout the commit into versions/<version> for DAG Processor callbacks."""
         version_path = self.versions_dir / version
         if version_path.exists():
             self._log.debug("Version folder already exists: %s", version_path)


### PR DESCRIPTION
### Problem
When `GitDagBundle` is used with `supports_versioning=True`, the DAG Processor
fails to execute DAG-level callbacks because the callback request points to
`versions/<commit>/…`, yet that folder does not exist (it is never materialised).

See #52040 for full context.
Closes: #52040

### Fix
* Extend **`GitDagBundle.refresh()`**
  * Detect a commit change after resetting the tracking repo.
  * Call the new helper function `_materialize_version(commit)` which:
    * ensures the bare repo exists and contains the commit  
    * clones a work-tree into `versions/<commit>`  
    * checks out the exact commit

### Tests
* **Manual** – verified in an Airflow 3.0.2 + GitLab environment (via the same
  logic as a monkey-patch): DAG callbacks now execute correctly.
* **Local CI** – `pre-commit run --all-files` and  
  `pytest providers/git/tests/unit/git/bundles/test_git.py` both pass.

### Notes
This change only touches `airflow.providers.git.bundles.git.GitDagBundle`
and has no effect on other bundles or on cases where
`supports_versioning=False`.

Closes #52040


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
