### PR TITLE
Ignore mypy errors for deprecated executors

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -39,7 +39,10 @@ if TYPE_CHECKING:
     from airflow.callbacks.base_callback_sink import BaseCallbackSink
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.executors.base_executor import EventBufferValueType
-    from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
+    from airflow.models.taskinstance import (
+        SimpleTaskInstance,  # type: ignore[attr-defined]
+        TaskInstance,
+    )
     from airflow.models.taskinstancekey import TaskInstanceKey
 
     CommandType = Sequence[str]
@@ -180,7 +183,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         **kwargs,
     ) -> None:
         """Queues task instance via celery or kubernetes executor."""
-        from airflow.models.taskinstance import SimpleTaskInstance
+        from airflow.models.taskinstance import SimpleTaskInstance  # type: ignore[attr-defined]
 
         executor = self._router(SimpleTaskInstance.from_ti(task_instance))
         self.log.debug(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -33,7 +33,11 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.executors.base_executor import EventBufferValueType
     from airflow.executors.local_executor import LocalExecutor
-    from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
+    from airflow.models.taskinstance import (
+        SimpleTaskInstance,  # type: ignore[attr-defined]
+        TaskInstance,
+        TaskInstanceKey,
+    )
 
     CommandType = Sequence[str]
 
@@ -171,7 +175,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         **kwargs,
     ) -> None:
         """Queues task instance via local or kubernetes executor."""
-        from airflow.models.taskinstance import SimpleTaskInstance
+        from airflow.models.taskinstance import SimpleTaskInstance  # type: ignore[attr-defined]
 
         executor = self._router(SimpleTaskInstance.from_ti(task_instance))
         self.log.debug(


### PR DESCRIPTION
I removed SimpleTaskInstance in https://github.com/apache/airflow/pull/52176 since it isn't used in Airflow 3. This caused failure in hybrid executors like `LocalKubernetesExecutor` and `CeleryKubernetesExecutor` -- which aren't suported in Airflow 3. Hence we can ignore mypy errors.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
