### PR TITLE
Doc update to install git in docker image prior 3.0.2

### DIFF
--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -83,7 +83,7 @@ For example, adding multiple dag bundles to your ``airflow.cfg`` file:
 You can also override the :ref:`config:dag_processor__refresh_interval` per dag bundle by passing it in kwargs.
 This controls how often the dag processor refreshes, or looks for new files, in the dag bundles.
 
-Starting Airflow 3.0.2 git is pre installed in the base image. However, if you are using versions prior 3.0.2, you would need to install git in your docker image. 
+Starting Airflow 3.0.2 git is pre installed in the base image. However, if you are using versions prior 3.0.2, you would need to install git in your docker image.
 
 .. code-block:: Dockerfile
 

--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -83,6 +83,15 @@ For example, adding multiple dag bundles to your ``airflow.cfg`` file:
 You can also override the :ref:`config:dag_processor__refresh_interval` per dag bundle by passing it in kwargs.
 This controls how often the dag processor refreshes, or looks for new files, in the dag bundles.
 
+Starting Airflow 3.0.2 git is pre installed in the base image. However, if you are using versions prior 3.0.2, you would need to install git in your docker image. 
+
+.. code-block:: Dockerfile
+
+  RUN apt-get update && apt-get install -y git
+  ENV GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
+  ENV GIT_PYTHON_REFRESH=quiet
+
+
 Writing custom dag bundles
 --------------------------
 


### PR DESCRIPTION
Prior to Airflow 3.0.2, docker image needs git installed on it to be able to use the git dag bundles feature. Adding this note to the docs