### PR TITLE
Refactor asana provider operator tests free from db access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -599,6 +599,7 @@ repos:
             ^providers/apache/iceberg/.*\.py$|
             ^providers/apache/kafka/.*\.py$|
             ^providers/arangodb/.*\.py$|
+            ^providers/asana/.*\.py$|
             ^providers/cloudant/.*\.py$|
             ^providers/cohere/.*\.py$|
             ^providers/common/compat/.*\.py$|

--- a/providers/asana/tests/unit/asana/operators/test_asana_tasks.py
+++ b/providers/asana/tests/unit/asana/operators/test_asana_tasks.py
@@ -16,26 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from airflow.models import Connection
-from airflow.models.dag import DAG
 from airflow.providers.asana.operators.asana_tasks import (
     AsanaCreateTaskOperator,
     AsanaDeleteTaskOperator,
     AsanaFindTaskOperator,
     AsanaUpdateTaskOperator,
 )
-from airflow.utils import timezone
-
-# The tests do not create dag runs, so db isolation tests are skipped
-
-DEFAULT_DATE = timezone.datetime(2015, 1, 1)
-TEST_DAG_ID = "unit_test_dag"
-asana_tasks_api_mock = MagicMock(name="asana_tasks_api_for_test")
 
 
 class TestAsanaTaskOperators:
@@ -45,72 +36,75 @@ class TestAsanaTaskOperators:
 
     @pytest.fixture(autouse=True)
     def setup_connections(self, create_connection_without_db):
-        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
-        dag = DAG(TEST_DAG_ID, schedule=timedelta(days=1), default_args=args)
-        self.dag = dag
         create_connection_without_db(Connection(conn_id="asana_test", conn_type="asana", password="test"))
 
-    @pytest.mark.db_test
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_create_task_operator(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_create_task_operator(self, mock_asana_hook):
         """
         Tests that the AsanaCreateTaskOperator makes the expected call to python-asana given valid arguments.
         """
 
-        mock_tasks_api.return_value.create_task.return_value = {"gid": "1"}
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
+        mock_hook_instance.create_task.return_value = {"gid": "1"}
+
         create_task = AsanaCreateTaskOperator(
             task_id="create_task",
             conn_id="asana_test",
             name="test",
             task_parameters={"workspace": "1"},
-            dag=self.dag,
         )
-        create_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        assert mock_tasks_api.return_value.create_task.called
+        result = create_task.execute({})
+        mock_hook_instance.create_task.assert_called_once_with("test", {"workspace": "1"})
+        assert result == "1"
 
-    @pytest.mark.db_test
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_find_task_operator(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_find_task_operator(self, mock_asana_hook):
         """
         Tests that the AsanaFindTaskOperator makes the expected call to python-asana given valid arguments.
         """
-        mock_tasks_api.return_value.tasks.create.return_value = {"gid": "1"}
-        find_task = AsanaFindTaskOperator(
+
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
+        mock_hook_instance.find_task.return_value = {"gid": "1"}
+
+        task = AsanaFindTaskOperator(
             task_id="find_task",
             conn_id="asana_test",
             search_parameters={"project": "test"},
-            dag=self.dag,
         )
-        find_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        assert mock_tasks_api.return_value.get_tasks.called
+        result = task.execute({})
+        mock_hook_instance.find_task.assert_called_once_with({"project": "test"})
+        assert result == {"gid": "1"}
 
-    @pytest.mark.db_test
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_update_task_operator(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_update_task_operator(self, mock_asana_hook):
         """
         Tests that the AsanaUpdateTaskOperator makes the expected call to python-asana given valid arguments.
         """
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
         update_task = AsanaUpdateTaskOperator(
             task_id="update_task",
             conn_id="asana_test",
             asana_task_gid="test",
             task_parameters={"completed": True},
-            dag=self.dag,
         )
-        update_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        assert mock_tasks_api.return_value.update_task.called
+        update_task.execute({})
+        mock_hook_instance.update_task.assert_called_once_with("test", {"completed": True})
 
-    @pytest.mark.db_test
-    @patch("airflow.providers.asana.hooks.asana.TasksApi", autospec=True, return_value=asana_tasks_api_mock)
-    def test_asana_delete_task_operator(self, mock_tasks_api):
+    @patch("airflow.providers.asana.operators.asana_tasks.AsanaHook")
+    def test_asana_delete_task_operator(self, mock_asana_hook):
         """
         Tests that the AsanaDeleteTaskOperator makes the expected call to python-asana given valid arguments.
         """
+        mock_hook_instance = MagicMock()
+        mock_asana_hook.return_value = mock_hook_instance
+
         delete_task = AsanaDeleteTaskOperator(
             task_id="delete_task",
             conn_id="asana_test",
             asana_task_gid="test",
-            dag=self.dag,
         )
-        delete_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        assert mock_tasks_api.return_value.delete_task.called
+        delete_task.execute({})
+        mock_hook_instance.delete_task.assert_called_once_with("test")


### PR DESCRIPTION
We dont really need to call the task run , in tests. updated tests to use mocks. its free from db access now ;)
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
