### PR TITLE
Don't provide default values for PDBs in chart.

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1126,3 +1126,14 @@ capabilities:
             app: keda-operator
   {{- end }}
 {{- end }}
+
+{{- define "airflow.podDisruptionBudgetConfig" -}}
+  {{- $config := .config | default dict }}
+
+  {{- if $config.minAvailable }}
+  minAvailable: {{ $config.minAvailable }}
+  {{- end }}
+  {{- if or $config.maxUnavailable (not $config.minAvailable)}}
+  maxUnavailable: {{ $config.maxUnavailable | default 1 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/api-server/api-server-poddisruptionbudget.yaml
+++ b/chart/templates/api-server/api-server-poddisruptionbudget.yaml
@@ -41,6 +41,6 @@ spec:
       tier: airflow
       component: api-server
       release: {{ .Release.Name }}
-  {{- toYaml .Values.apiServer.podDisruptionBudget.config | nindent 2 }}
+  {{- include "airflow.podDisruptionBudgetConfig" (dict "config" .Values.apiServer.podDisruptionBudget.config) }}
 {{- end }}
 {{- end }}

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -16,10 +16,10 @@
  specific language governing permissions and limitations
  under the License.
 */}}
-
 ################################
 ## Pgbouncer PodDisruptionBudget
 #################################
+
 {{- if and .Values.pgbouncer.enabled .Values.pgbouncer.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -40,5 +40,5 @@ spec:
       tier: airflow
       component: pgbouncer
       release: {{ .Release.Name }}
-  {{- toYaml .Values.pgbouncer.podDisruptionBudget.config | nindent 2 }}
+  {{- include "airflow.podDisruptionBudgetConfig" (dict "config" .Values.pgbouncer.podDisruptionBudget.config) }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -41,6 +41,6 @@ spec:
       tier: airflow
       component: scheduler
       release: {{ .Release.Name }}
-  {{- toYaml .Values.scheduler.podDisruptionBudget.config | nindent 2 }}
+  {{- include "airflow.podDisruptionBudgetConfig" (dict "config" .Values.scheduler.podDisruptionBudget.config) }}
 {{- end }}
 {{- end }}

--- a/chart/templates/webserver/webserver-poddisruptionbudget.yaml
+++ b/chart/templates/webserver/webserver-poddisruptionbudget.yaml
@@ -41,6 +41,6 @@ spec:
       tier: airflow
       component: webserver
       release: {{ .Release.Name }}
-  {{- toYaml .Values.webserver.podDisruptionBudget.config | nindent 2 }}
+  {{- include "airflow.podDisruptionBudgetConfig" (dict "config" .Values.webserver.podDisruptionBudget.config) }}
 {{- end }}
 {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2856,7 +2856,8 @@
                                     "description": "Max unavailable pods for scheduler.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
                                     "default": 1
                                 },
@@ -2864,9 +2865,10 @@
                                     "description": "Min available pods for scheduler.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
-                                    "default": 1
+                                    "default": null
                                 }
                             }
                         }
@@ -5145,7 +5147,8 @@
                                     "description": "Max unavailable pods for API server.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
                                     "default": 1
                                 },
@@ -5153,9 +5156,10 @@
                                     "description": "Min available pods for API server.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
-                                    "default": 1
+                                    "default": null
                                 }
                             }
                         }
@@ -5949,7 +5953,8 @@
                                     "description": "Max unavailable pods for webserver.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
                                     "default": 1
                                 },
@@ -5957,9 +5962,10 @@
                                     "description": "Min available pods for webserver.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
-                                    "default": 1
+                                    "default": null
                                 }
                             }
                         }
@@ -7511,7 +7517,8 @@
                                     "description": "Max unavailable pods for PgBouncer.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
                                     "default": 1
                                 },
@@ -7519,9 +7526,10 @@
                                     "description": "Min available pods for PgBouncer.",
                                     "type": [
                                         "integer",
-                                        "string"
+                                        "string",
+                                        "null"
                                     ],
-                                    "default": 1
+                                    "default": null
                                 }
                             }
                         }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1106,10 +1106,10 @@ scheduler:
     enabled: false
 
     # PDB configuration
-    config:
-      # minAvailable and maxUnavailable are mutually exclusive
-      maxUnavailable: 1
-      # minAvailable: 1
+    # minAvailable and maxUnavailable are mutually exclusive
+    # config:
+    #   maxUnavailable: 1
+    #   # minAvailable: 1
 
   resources: {}
   #  limits:
@@ -1452,10 +1452,10 @@ apiServer:
     enabled: false
 
     # PDB configuration
-    config:
-      # minAvailable and maxUnavailable are mutually exclusive
-      maxUnavailable: 1
-      # minAvailable: 1
+    # minAvailable and maxUnavailable are mutually exclusive
+    # config:
+    #   maxUnavailable: 1
+    #   # minAvailable: 1
 
   # Allow overriding Update Strategy for API server
   strategy: ~
@@ -1659,10 +1659,10 @@ webserver:
     enabled: false
 
     # PDB configuration
-    config:
-      # minAvailable and maxUnavailable are mutually exclusive
-      maxUnavailable: 1
-      # minAvailable: 1
+    # minAvailable and maxUnavailable are mutually exclusive
+    # config:
+    #   maxUnavailable: 1
+    #   # minAvailable: 1
 
   # Allow overriding Update Strategy for Webserver
   strategy: ~
@@ -2476,10 +2476,10 @@ pgbouncer:
     enabled: false
 
     # PDB configuration
-    config:
-      # minAvailable and maxUnavailable are mutually exclusive
-      maxUnavailable: 1
-      # minAvailable: 1
+    # minAvailable and maxUnavailable are mutually exclusive
+    # config:
+    #   maxUnavailable: 1
+    #   # minAvailable: 1
 
   # Limit the resources to PgBouncer.
   # When you specify the resource request the k8s scheduler uses this information to decide which node to

--- a/helm-tests/tests/helm_tests/airflow_core/test_pdb_scheduler.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_pdb_scheduler.py
@@ -62,3 +62,16 @@ class TestSchedulerPdb:
             },
             show_only=["templates/scheduler/scheduler-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param_only(self):
+        render_chart(
+            values={
+                "scheduler": {
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"minAvailable": 1},
+                    }
+                }
+            },
+            show_only=["templates/scheduler/scheduler-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised

--- a/helm-tests/tests/helm_tests/apiserver/test_pdb_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_pdb_apiserver.py
@@ -19,46 +19,44 @@ from __future__ import annotations
 from chart_utils.helm_template_generator import render_chart
 
 
-class TestPgbouncerPdb:
-    """Tests PgBouncer PDB."""
+class TestApiserverPdb:
+    """Tests api-server pdb."""
 
     def test_should_pass_validation_with_just_pdb_enabled_v1(self):
         render_chart(
-            values={"pgbouncer": {"enabled": True, "podDisruptionBudget": {"enabled": True}}},
-            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
+            values={"apiServer": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/api-server/api-server-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
 
     def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
         render_chart(
-            values={"pgbouncer": {"enabled": True, "podDisruptionBudget": {"enabled": True}}},
-            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
+            values={"apiServer": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/api-server/api-server-poddisruptionbudget.yaml"],
             kubernetes_version="1.16.0",
         )  # checks that no validation exception is raised
 
     def test_should_pass_validation_with_pdb_enabled_and_min_available_param(self):
         render_chart(
             values={
-                "pgbouncer": {
-                    "enabled": True,
+                "apiServer": {
                     "podDisruptionBudget": {
                         "enabled": True,
                         "config": {"maxUnavailable": None, "minAvailable": 1},
-                    },
+                    }
                 }
             },
-            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
+            show_only=["templates/api-server/api-server-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
 
     def test_should_pass_validation_with_pdb_enabled_and_min_available_param_only(self):
         render_chart(
             values={
-                "pgbouncer": {
-                    "enabled": True,
+                "apiServer": {
                     "podDisruptionBudget": {
                         "enabled": True,
                         "config": {"minAvailable": 1},
-                    },
+                    }
                 }
             },
-            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
+            show_only=["templates/api-server/api-server-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised

--- a/helm-tests/tests/helm_tests/webserver/test_pdb_webserver.py
+++ b/helm-tests/tests/helm_tests/webserver/test_pdb_webserver.py
@@ -62,3 +62,16 @@ class TestWebserverPdb:
             },
             show_only=["templates/webserver/webserver-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param_only(self):
+        render_chart(
+            values={
+                "webserver": {
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"minAvailable": 1},
+                    }
+                }
+            },
+            show_only=["templates/webserver/webserver-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised


### PR DESCRIPTION
- when minAvailable is used, maxUnavailable must be nullified on client side

currently 

```
apiServer:
  replicas: 2
  podDisruptionBudget:
    enabled: true
    config:
      minAvailable: 1
```

fails with

```
Error: UPGRADE FAILED: failed to create resource: PodDisruptionBudget.policy "integ-rad-airflow-api-server-pdb" is invalid: spec: Invalid value: policy.PodDisruptionBudgetSpec{MinAvailable:(*intstr.IntOrString)(0xc022377660), Selector:(*v1.LabelSelector)(0xc022377680), MaxUnavailable:(*intstr.IntOrString)(0xc022377640), UnhealthyPodEvictionPolicy:(*policy.UnhealthyPodEvictionPolicyType)(nil)}: minAvailable and maxUnavailable cannot be both set

```

since it is merged with default value of `maxUnavailable`

```
apiServer:
  replicas: 2
  podDisruptionBudget:
    enabled: true
    config:
      minAvailable: 1
      maxUnavailable: 1
```

resulting in unsupported setup

as a "bandaid" `null` can be used (which is not super friendly IMHO)

```
apiServer:
  replicas: 2
  podDisruptionBudget:
    enabled: true
    config:
      minAvailable: 1
      maxUnavailable: null
```