### PR TITLE
Show tooltip when hovering on the button handling details panel

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -36,6 +36,7 @@ import { ProgressBar } from "src/components/ui";
 import { Toaster } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
 import { DAGWarningsModal } from "src/components/ui/DagWarningsModal";
+import { Tooltip } from "src/components/ui/Tooltip";
 import { OpenGroupsProvider } from "src/context/openGroups";
 
 import { DagBreadcrumb } from "./DagBreadcrumb";
@@ -82,21 +83,23 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
       <BackfillBanner dagId={dagId} />
       <Box flex={1} minH={0}>
         {isRightPanelCollapsed ? (
-          <IconButton
-            aria-label={translate("common:showDetailsPanel")}
-            bg="bg.surface"
-            borderRadius="full"
-            boxShadow="md"
-            cursor="pointer"
-            onClick={() => setIsRightPanelCollapsed(false)}
-            position="absolute"
-            right={0}
-            size="sm"
-            top="50%"
-            zIndex={10}
-          >
-            <FaChevronLeft />
-          </IconButton>
+          <Tooltip content={translate("common:showDetailsPanel")}>
+            <IconButton
+              aria-label={translate("common:showDetailsPanel")}
+              bg="bg.surface"
+              borderRadius="full"
+              boxShadow="md"
+              cursor="pointer"
+              onClick={() => setIsRightPanelCollapsed(false)}
+              position="absolute"
+              right={0}
+              size="sm"
+              top="50%"
+              zIndex={10}
+            >
+              <FaChevronLeft />
+            </IconButton>
+          </Tooltip>
         ) : undefined}
         <PanelGroup autoSaveId={dagId} direction="horizontal" ref={panelGroupRef}>
           <Panel defaultSize={dagView === "graph" ? 70 : 20} minSize={6}>
@@ -132,18 +135,20 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 position="relative"
                 w={0.5}
               >
-                <IconButton
-                  aria-label={translate("common:collapseDetailsPanel")}
-                  bg="bg.surface"
-                  borderRadius="full"
-                  boxShadow="md"
-                  cursor="pointer"
-                  onClick={() => setIsRightPanelCollapsed(true)}
-                  size="xs"
-                  zIndex={2}
-                >
-                  <FaChevronRight />
-                </IconButton>
+                <Tooltip content={translate("common:collapseDetailsPanel")}>
+                  <IconButton
+                    aria-label={translate("common:collapseDetailsPanel")}
+                    bg="bg.surface"
+                    borderRadius="full"
+                    boxShadow="md"
+                    cursor="pointer"
+                    onClick={() => setIsRightPanelCollapsed(true)}
+                    size="xs"
+                    zIndex={2}
+                  >
+                    <FaChevronRight />
+                  </IconButton>
+                </Tooltip>
               </Box>
             </PanelResizeHandle>
           )}


### PR DESCRIPTION
## Related PR
[#51946](https://github.com/apache/airflow/pull/51946)
## Why
Showing a tooltip when hovering on the buttons would better help the users understand their usages.
## How
Adding tooltips for the two buttons: Collapse Details Panel and Show Details Panel.
## Demo

https://github.com/user-attachments/assets/a5c38767-6d87-4d26-8506-f526e8f85fde



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
