### PR TITLE
Bumping min version of pagerduty to 2.3.0

### DIFF
--- a/providers/pagerduty/pyproject.toml
+++ b/providers/pagerduty/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.6.1",
-    "pagerduty>=1.0.0",
+    "pagerduty>=2.3.0",
 ]
 
 [dependency-groups]

--- a/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -76,23 +76,26 @@ class PagerdutyHook(BaseHook):
             ),
         }
 
-    def __init__(self, token: str | None = None, pagerduty_conn_id: str | None = None) -> None:
+    def __init__(self, token: str = "", pagerduty_conn_id: str | None = None) -> None:
         super().__init__()
         self.routing_key = None
-        self._client = None
+        self.token = ""
+        self._client: pagerduty.RestApiV2Client | None = None
 
         if pagerduty_conn_id is not None:
             conn = self.get_connection(pagerduty_conn_id)
-            self.token = conn.get_password()
+            password = conn.get_password()
+            if password is not None:
+                self.token = password
 
             routing_key = conn.extra_dejson.get("routing_key")
             if routing_key:
                 self.routing_key = routing_key
 
-        if token is not None:  # token takes higher priority
+        if token != "":  # token takes higher priority
             self.token = token
 
-        if self.token is None:
+        if self.token == "":
             raise AirflowException("Cannot get token: No valid api token nor pagerduty_conn_id supplied.")
 
     def client(self) -> pagerduty.RestApiV2Client:

--- a/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py
+++ b/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py
@@ -61,17 +61,19 @@ class PagerdutyEventsHook(BaseHook):
         self, integration_key: str | None = None, pagerduty_events_conn_id: str | None = None
     ) -> None:
         super().__init__()
-        self.integration_key = None
+        self.integration_key = ""
         self._client = None
 
         if pagerduty_events_conn_id is not None:
             conn = self.get_connection(pagerduty_events_conn_id)
-            self.integration_key = conn.get_password()
+            password = conn.get_password()
+            if password is not None:
+                self.integration_key = password
 
         if integration_key is not None:  # token takes higher priority
             self.integration_key = integration_key
 
-        if self.integration_key is None:
+        if self.integration_key == "":
             raise AirflowException(
                 "Cannot get token: No valid integration key nor pagerduty_events_conn_id supplied."
             )
@@ -89,7 +91,7 @@ class PagerdutyEventsHook(BaseHook):
         class_type: str | None = None,
         images: list[Any] | None = None,
         links: list[Any] | None = None,
-    ) -> dict:
+    ) -> str:
         """
         Create event for service integration.
 
@@ -193,7 +195,7 @@ class PagerdutyEventsHook(BaseHook):
         custom_details: Any | None = None,
         timestamp: datetime | None = None,
         links: list[Any] | None = None,
-    ) -> dict:
+    ) -> str:
         """
         Create change event for service integration.
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

CI is failing with:
```
providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py:135: error:
Argument 1 to "EventsApiV2Client" has incompatible type "Optional[str]";
expected "str"  [arg-type]
            client = pagerduty.EventsApiV2Client(self.integration_key)
                                                 ^~~~~~~~~~~~~~~~~~~~
providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py:136: error:
Incompatible return value type (got "str", expected "dict[Any, Any]") 
[return-value]
            return client.send_event(**data)
                   ^~~~~~~~~~~~~~~~~~~~~~~~~
providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py:228: error:
Argument 1 to "EventsApiV2Client" has incompatible type "Optional[str]";
expected "str"  [arg-type]
            client = pagerduty.EventsApiV2Client(self.integration_key)
                                                 ^~~~~~~~~~~~~~~~~~~~
providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py:105: error:
Incompatible types in assignment (expression has type "RestApiV2Client",
variable has type "None")  [assignment]
            self._client = pagerduty.RestApiV2Client(self.token)
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py:105: error:
Argument 1 to "RestApiV2Client" has incompatible type "Optional[str]"; expected
"str"  [arg-type]
            self._client = pagerduty.RestApiV2Client(self.token)
                                                     ^~~~~~~~~~
providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py:106: error:
Incompatible return value type (got "None", expected "RestApiV2Client") 
[return-value]
            return self._client
```

Example: https://github.com/apache/airflow/actions/runs/15865684564

Pagerduty seems to have had a breaking change in 2.3.0 which changes some types. Using this opportunity to fix that and bump to 2.3.0

![image](https://github.com/user-attachments/assets/14e0dc6c-2291-46eb-a254-fdb544eaf2c0)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
