### PR TITLE
Clean up remaining DB-dependent tests from OpenSearch provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -624,8 +624,6 @@ repos:
             ^providers/openai/.*\.py$|
             ^providers/openfaas/.*\.py$|
             ^providers/oracle/.*\.py$|
-            ^providers/opensearch/tests/unit/opensearch/hooks/.*\.py$|
-            ^providers/opensearch/tests/unit/opensearch/operators/.*\.py$|
             ^providers/pagerduty/.*\.py$|
             ^providers/pgvector/.*\.py$|
             ^providers/pinecone/.*\.py$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -624,6 +624,7 @@ repos:
             ^providers/openai/.*\.py$|
             ^providers/openfaas/.*\.py$|
             ^providers/oracle/.*\.py$|
+            ^providers/opensearch/.*\.py$|
             ^providers/pagerduty/.*\.py$|
             ^providers/pgvector/.*\.py$|
             ^providers/pinecone/.*\.py$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -624,7 +624,8 @@ repos:
             ^providers/openai/.*\.py$|
             ^providers/openfaas/.*\.py$|
             ^providers/oracle/.*\.py$|
-            ^providers/opensearch/.*\.py$|
+            ^providers/opensearch/tests/unit/opensearch/hooks/.*\.py$|
+            ^providers/opensearch/tests/unit/opensearch/operators/.*\.py$|
             ^providers/pagerduty/.*\.py$|
             ^providers/pgvector/.*\.py$|
             ^providers/pinecone/.*\.py$|

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_json_formatter.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_json_formatter.py
@@ -29,7 +29,6 @@ from airflow.providers.opensearch.log.os_task_handler import (
 )
 
 opensearchpy = pytest.importorskip("opensearchpy")
-pytestmark = pytest.mark.db_test
 
 
 class TestOpensearchJSONFormatter:

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_response.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_response.py
@@ -31,7 +31,6 @@ from airflow.providers.opensearch.log.os_response import (
 from airflow.providers.opensearch.log.os_task_handler import OpensearchTaskHandler
 
 opensearchpy = pytest.importorskip("opensearchpy")
-pytestmark = pytest.mark.db_test
 
 
 class TestHitAndHitMetaAndOpenSearchResponse:

--- a/providers/opensearch/tests/unit/opensearch/operators/test_opensearch.py
+++ b/providers/opensearch/tests/unit/opensearch/operators/test_opensearch.py
@@ -28,7 +28,6 @@ from airflow.providers.opensearch.operators.opensearch import (
 from airflow.utils.timezone import datetime
 
 opensearchpy = pytest.importorskip("opensearchpy")
-pytestmark = pytest.mark.db_test
 
 
 TEST_DAG_ID = "unit_tests"


### PR DESCRIPTION
Part of #52020

---

^ Add meaningful description above  
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines) for more information.  
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.  
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html).  
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

--- related with https://github.com/apache/airflow/pull/52213