### PR TITLE
Remove db_tests from openlineage provider

### DIFF
--- a/providers/openlineage/tests/unit/openlineage/extractors/test_base.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_base.py
@@ -38,7 +38,7 @@ from tests_common.test_utils.compat import PythonOperator
 
 if TYPE_CHECKING:
     from openlineage.client.facet_v2 import RunFacet
-pytestmark = pytest.mark.db_test
+
 
 INPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
 OUTPUTS = [Dataset(namespace="database://host:port", name="inputtable")]

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_bash.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_bash.py
@@ -21,7 +21,6 @@ import warnings
 from datetime import datetime
 from unittest.mock import patch
 
-import pytest
 from openlineage.client.facet_v2 import source_code_job
 
 from airflow import DAG
@@ -29,8 +28,6 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.openlineage.extractors.bash import BashExtractor
 
 from tests_common.test_utils.compat import BashOperator
-
-pytestmark = pytest.mark.db_test
 
 with DAG(
     dag_id="test_dummy_dag",

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
@@ -324,7 +324,6 @@ def test_extractor_manager_does_not_use_hook_level_lineage_when_operator(
     assert metadata.outputs == []
 
 
-@pytest.mark.db_test
 @pytest.mark.skipif(
     AIRFLOW_V_3_0_PLUS,
     reason="Test for hook level lineage in Airflow < 3.0",

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_python.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_python.py
@@ -23,7 +23,6 @@ import warnings
 from datetime import datetime
 from unittest.mock import patch
 
-import pytest
 from openlineage.client.facet_v2 import source_code_job
 
 from airflow import DAG
@@ -31,8 +30,6 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.openlineage.extractors.python import PythonExtractor
 
 from tests_common.test_utils.compat import BashOperator, PythonOperator
-
-pytestmark = pytest.mark.db_test
 
 dag = DAG(
     dag_id="test_dummy_dag",

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -59,8 +59,6 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
-pytestmark = pytest.mark.db_test
-
 
 @pytest.mark.parametrize(
     "env_vars, expected_logging",

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_execution.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_execution.py
@@ -110,7 +110,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
 
             return job_runner.task_runner.return_code(timeout=60)
 
-        @pytest.mark.db_test
         @conf_vars({("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}'})
         def test_not_stalled_task_emits_proper_lineage(self):
             task_name = "execute_no_stall"
@@ -122,7 +121,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
             assert has_value_in_events(events, ["inputs", "name"], "on-start")
             assert has_value_in_events(events, ["inputs", "name"], "on-complete")
 
-        @pytest.mark.db_test
         @conf_vars({("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}'})
         def test_not_stalled_failing_task_emits_proper_lineage(self):
             task_name = "execute_fail"
@@ -139,7 +137,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 ("openlineage", "execution_timeout"): "15",
             }
         )
-        @pytest.mark.db_test
         def test_short_stalled_task_emits_proper_lineage(self):
             self.setup_job("execute_short_stall", "test_short_stalled_task_emits_proper_lineage")
             events = get_sorted_events(tmp_dir)
@@ -152,7 +149,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 ("openlineage", "execution_timeout"): "3",
             }
         )
-        @pytest.mark.db_test
         def test_short_stalled_task_extraction_with_low_execution_is_killed_by_ol_timeout(self):
             self.setup_job(
                 "execute_short_stall",
@@ -163,7 +159,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
             assert not has_value_in_events(events, ["inputs", "name"], "on-complete")
 
         @conf_vars({("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}'})
-        @pytest.mark.db_test
         def test_mid_stalled_task_is_killed_by_ol_timeout(self):
             self.setup_job("execute_mid_stall", "test_mid_stalled_task_is_killed_by_openlineage")
             events = get_sorted_events(tmp_dir)
@@ -177,7 +172,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 ("core", "task_success_overtime"): "3",
             }
         )
-        @pytest.mark.db_test
         def test_success_overtime_kills_tasks(self):
             # This test checks whether LocalTaskJobRunner kills OL listener which take
             # longer time than permitted by core.task_success_overtime setting

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -45,8 +45,6 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
-pytestmark = pytest.mark.db_test
-
 EXPECTED_TRY_NUMBER_1 = 1
 
 TRY_NUMBER_BEFORE_EXECUTION = 0
@@ -757,6 +755,7 @@ class TestOpenLineageListenerAirflow2:
         mock_executor.assert_called_once_with(max_workers=expected, initializer=mock.ANY)
         mock_executor.return_value.submit.assert_called_once()
 
+    @pytest.mark.db_test
     @pytest.mark.parametrize(
         ("method", "dag_run_state"),
         [
@@ -1574,6 +1573,7 @@ class TestOpenLineageListenerAirflow3:
         mock_executor.assert_called_once_with(max_workers=expected, initializer=mock.ANY)
         mock_executor.return_value.submit.assert_called_once()
 
+    @pytest.mark.db_test
     @pytest.mark.parametrize(
         ("method", "dag_run_state"),
         [

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -1436,7 +1436,6 @@ def test_dagrun_info_af3(mocked_dag_versions):
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 2 test")
-@pytest.mark.db_test
 def test_dagrun_info_af2():
     date = datetime.datetime(2024, 6, 1, tzinfo=datetime.timezone.utc)
     dag = DAG(


### PR DESCRIPTION
Part of #52020

Still some tests left.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
