### PR TITLE
Remove unused LoggerMutationHelper

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -29,13 +29,11 @@ from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
-from unittest.mock import sentinel
 
 import pytest
 
 from airflow.cli import cli_parser
 from airflow.cli.commands import task_command
-from airflow.cli.commands.task_command import LoggerMutationHelper
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.configuration import conf
 from airflow.exceptions import DagRunNotFound
@@ -480,70 +478,3 @@ class TestLogsfromTaskRunCommand:
             # Example: [2020-06-24 17:07:00,482] {logging_mixin.py:91} INFO - Log from Print statement
             assert "logging_mixin.py" not in log_line
         return log_line
-
-
-class TestLoggerMutationHelper:
-    @pytest.mark.parametrize("target_name", ["test_apply_target", None])
-    def test_apply(self, target_name):
-        """
-        Handlers, level and propagate should be applied on target.
-        """
-        src = logging.getLogger(f"test_apply_source_{target_name}")
-        src.propagate = False
-        src.addHandler(sentinel.handler)
-        src.setLevel(-1)
-        obj = LoggerMutationHelper(src)
-        tgt = logging.getLogger("test_apply_target")
-        obj.apply(tgt)
-        assert tgt.handlers == [sentinel.handler]
-        assert tgt.propagate is False if target_name else True  # root propagate unchanged
-        assert tgt.level == -1
-
-    def test_apply_no_replace(self, clear_all_logger_handlers):
-        """
-        Handlers, level and propagate should be applied on target.
-        """
-        src = logging.getLogger("test_apply_source_no_repl")
-        tgt = logging.getLogger("test_apply_target_no_repl")
-        h1 = logging.Handler()
-        h1.name = "h1"
-        h2 = logging.Handler()
-        h2.name = "h2"
-        h3 = logging.Handler()
-        h3.name = "h3"
-        src.handlers[:] = [h1, h2]
-        tgt.handlers[:] = [h2, h3]
-        LoggerMutationHelper(src).apply(tgt, replace=False)
-        assert tgt.handlers == [h2, h3, h1]
-
-    def test_move(self):
-        """Move should apply plus remove source handler, set propagate to True"""
-        src = logging.getLogger("test_move_source")
-        src.propagate = False
-        src.addHandler(sentinel.handler)
-        src.setLevel(-1)
-        obj = LoggerMutationHelper(src)
-        tgt = logging.getLogger("test_apply_target")
-        obj.move(tgt)
-        assert tgt.handlers == [sentinel.handler]
-        assert tgt.propagate is False
-        assert tgt.level == -1
-        assert src.propagate is True
-        assert obj.propagate is False
-        assert src.level == obj.level
-        assert src.handlers == []
-        assert obj.handlers == tgt.handlers
-
-    def test_reset(self):
-        src = logging.getLogger("test_move_reset")
-        src.propagate = True
-        src.addHandler(sentinel.h1)
-        src.setLevel(-1)
-        obj = LoggerMutationHelper(src)
-        src.propagate = False
-        src.addHandler(sentinel.h2)
-        src.setLevel(-2)
-        obj.reset()
-        assert src.propagate is True
-        assert src.handlers == [sentinel.h1]
-        assert src.level == -1


### PR DESCRIPTION
This was removed in Airflow 3.0 as part of the TaskSDK rewrite and is not used
anymore
