### PR TITLE
Use base AWS classes in Glue Trigger / Sensor and implement custom waiter

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/glue.py
@@ -46,7 +46,6 @@ class GlueJobHook(AwsBaseHook):
     :param script_location: path to etl script on s3
     :param retry_limit: Maximum number of times to retry this job if it fails
     :param num_of_dpus: Number of AWS Glue DPUs to allocate to this Job
-    :param region_name: aws region name (example: us-east-1)
     :param iam_role_name: AWS IAM Role for Glue Job Execution. If set `iam_role_arn` must equal None.
     :param iam_role_arn: AWS IAM Role ARN for Glue Job Execution, If set `iam_role_name` must equal None.
     :param create_job_kwargs: Extra arguments for Glue Job Creation

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -66,6 +66,8 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
     :param iam_role_arn: AWS IAM ARN for Glue Job Execution. If set `iam_role_name` must equal None.
     :param create_job_kwargs: Extra arguments for Glue Job Creation
     :param run_job_kwargs: Extra arguments for Glue Job Run
+    :param waiter_delay: Time in seconds to wait between status checks. (default: 60)
+    :param waiter_max_attempts: Maximum number of attempts to check for job completion. (default: 20)
     :param wait_for_completion: Whether to wait for job run completion. (default: True)
     :param deferrable: If True, the operator will wait asynchronously for the job to complete.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
@@ -259,7 +261,7 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
 
         if validated_event["status"] != "success":
             raise AirflowException(f"Error in glue job: {validated_event}")
-        return validated_event["value"]
+        return validated_event["run_id"]
 
     def on_kill(self):
         """Cancel the running AWS Glue Job."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -122,9 +122,11 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
         verbose: bool = False,
         replace_script_file: bool = False,
         update_config: bool = False,
-        job_poll_interval: int | float = 6,
+        waiter_delay: int = 60,
+        waiter_max_attempts: int = 20,
         stop_job_run_on_kill: bool = False,
         sleep_before_return: int = 0,
+        job_poll_interval: int | float = 6,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -147,6 +149,8 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
         self.update_config = update_config
         self.replace_script_file = replace_script_file
         self.deferrable = deferrable
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
         self.job_poll_interval = job_poll_interval
         self.stop_job_run_on_kill = stop_job_run_on_kill
         self._job_run_id: str | None = None
@@ -231,7 +235,8 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
                     run_id=self._job_run_id,
                     verbose=self.verbose,
                     aws_conn_id=self.aws_conn_id,
-                    job_poll_interval=self.job_poll_interval,
+                    waiter_delay=int(self.waiter_delay),
+                    waiter_max_attempts=self.waiter_max_attempts,
                 ),
                 method_name="execute_complete",
             )

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
@@ -54,7 +54,7 @@ class GlueJobSensor(AwsBaseSensor[GlueJobHook]):
         module to be installed.
         (default: False, but can be overridden in config file by setting default_deferrable to True)
     :param poke_interval: Polling period in seconds to check for the status of the job. (default: 120)
-    :param max_retries: Number of times before returning the current state. (default: 60)
+
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from functools import cached_property
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
@@ -28,16 +28,16 @@ from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.triggers.glue import (
     GlueDataQualityRuleRecommendationRunCompleteTrigger,
     GlueDataQualityRuleSetEvaluationRunCompleteTrigger,
+    GlueJobCompleteTrigger,
 )
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
-from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class GlueJobSensor(BaseSensorOperator):
+class GlueJobSensor(AwsBaseSensor[GlueJobHook]):
     """
     Waits for an AWS Glue Job to reach any of the status below.
 
@@ -50,9 +50,28 @@ class GlueJobSensor(BaseSensorOperator):
     :param job_name: The AWS Glue Job unique name
     :param run_id: The AWS Glue current running job identifier
     :param verbose: If True, more Glue Job Run logs show in the Airflow Task Logs.  (default: False)
+    :param deferrable: If True, the sensor will operate in deferrable mode. This mode requires aiobotocore
+        module to be installed.
+        (default: False, but can be overridden in config file by setting default_deferrable to True)
+    :param poke_interval: Polling period in seconds to check for the status of the job. (default: 120)
+    :param max_retries: Number of times before returning the current state. (default: 60)
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param botocore_config: Configuration dictionary (key-values) for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
     """
 
-    template_fields: Sequence[str] = ("job_name", "run_id")
+    SUCCESS_STATES = ("SUCCEEDED",)
+    FAILURE_STATES = ("FAILED", "STOPPED", "TIMEOUT")
+
+    aws_hook_class = GlueJobHook
+    template_fields: Sequence[str] = aws_template_fields("job_name", "run_id")
 
     def __init__(
         self,
@@ -60,6 +79,8 @@ class GlueJobSensor(BaseSensorOperator):
         job_name: str,
         run_id: str,
         verbose: bool = False,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        poke_interval: int = 120,
         aws_conn_id: str | None = "aws_default",
         **kwargs,
     ):
@@ -67,24 +88,49 @@ class GlueJobSensor(BaseSensorOperator):
         self.job_name = job_name
         self.run_id = run_id
         self.verbose = verbose
+        self.deferrable = deferrable
+        self.poke_interval = poke_interval
         self.aws_conn_id = aws_conn_id
-        self.success_states: list[str] = ["SUCCEEDED"]
-        self.errored_states: list[str] = ["FAILED", "STOPPED", "TIMEOUT"]
         self.next_log_tokens = GlueJobHook.LogContinuationTokens()
 
-    @cached_property
-    def hook(self):
-        return GlueJobHook(aws_conn_id=self.aws_conn_id)
+    def execute(self, context: Context) -> Any:
+        if self.deferrable:
+            self.defer(
+                trigger=GlueJobCompleteTrigger(
+                    job_name=self.job_name,
+                    run_id=self.run_id,
+                    verbose=self.verbose,
+                    aws_conn_id=self.aws_conn_id,
+                    job_poll_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+                timeout=timedelta(seconds=self.timeout),
+            )
+        else:
+            super().execute(context=context)
 
-    def poke(self, context: Context):
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
+        validated_event = validate_execute_complete_event(event)
+
+        if validated_event["status"] != "success":
+            message = f"Error: AWS Glue Job: {validated_event}"
+            raise AirflowException(message)
+
+        self.log.info(
+            "AWS Glue Job completed. Job Name: %s, Run ID: %s",
+            self.job_name,
+            self.run_id,
+        )
+
+    def poke(self, context: Context) -> bool:
         self.log.info("Poking for job run status :for Glue Job %s and ID %s", self.job_name, self.run_id)
         job_state = self.hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
 
         try:
-            if job_state in self.success_states:
+            if job_state in self.SUCCESS_STATES:
                 self.log.info("Exiting Job %s Run State: %s", self.run_id, job_state)
                 return True
-            if job_state in self.errored_states:
+            if job_state in self.FAILURE_STATES:
                 job_error_message = "Exiting Job %s Run State: %s", self.run_id, job_state
                 self.log.info(job_error_message)
                 raise AirflowException(job_error_message)

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
@@ -118,11 +118,7 @@ class GlueJobSensor(AwsBaseSensor[GlueJobHook]):
             message = f"Error: AWS Glue Job: {validated_event}"
             raise AirflowException(message)
 
-        self.log.info(
-            "AWS Glue Job completed. Job Name: %s, Run ID: %s",
-            self.job_name,
-            self.run_id,
-        )
+        self.log.info("AWS Glue Job completed.")
 
     def poke(self, context: Context) -> bool:
         self.log.info("Poking for job run status :for Glue Job %s and ID %s", self.job_name, self.run_id)

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -31,49 +31,63 @@ from airflow.providers.amazon.aws.triggers.base import AwsBaseWaiterTrigger
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 
-class GlueJobCompleteTrigger(BaseTrigger):
+class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
     """
     Watches for a glue job, triggers when it finishes.
 
     :param job_name: glue job name
     :param run_id: the ID of the specific run to watch for that job
     :param verbose: whether to print the job's logs in airflow logs or not
+    :param waiter_delay: The amount of time in seconds to wait between attempts. (default: 60)
+    :param waiter_max_attempts: The maximum number of attempts to be made. (default: 75)
     :param aws_conn_id: The Airflow connection used for AWS credentials
-    :param job_poll_interval: The interval in which to poll the status of a job
+    :param region_name: Optional aws region name (example: us-east-1). Uses region from connection
+        if not specified.
+    :param verify: Whether or not to verify SSL certificates.
+    :param botocore_config: Configuration dictionary (key-values) for botocore client.
     """
 
     def __init__(
         self,
         job_name: str,
         run_id: str,
-        verbose: bool,
-        aws_conn_id: str | None,
-        job_poll_interval: int | float,
+        verbose: bool = False,
+        waiter_delay: int = 60,
+        waiter_max_attempts: int = 75,
+        aws_conn_id: str | None = "aws_default",
+        region_name: str | None = None,
+        verify: bool | str | None = None,
+        botocore_config: dict | None = None,
     ):
-        super().__init__()
+        super().__init__(
+            serialized_fields={"job_name": job_name, "run_id": run_id, "verbose": verbose},
+            waiter_name="job_complete",
+            waiter_args={"JobName": job_name, "RunId": run_id},
+            failure_message="AWS Glue job failed.",
+            status_message="Status of AWS Glue job is",
+            status_queries=["JobRun.JobRunState"],
+            return_key="run_id",
+            return_value=run_id,
+            waiter_delay=waiter_delay,
+            waiter_max_attempts=waiter_max_attempts,
+            aws_conn_id=aws_conn_id,
+            region_name=region_name,
+            verify=verify,
+            botocore_config=botocore_config,
+        )
         self.job_name = job_name
         self.run_id = run_id
         self.verbose = verbose
-        self.aws_conn_id = aws_conn_id
-        self.job_poll_interval = job_poll_interval
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
 
-    def serialize(self) -> tuple[str, dict[str, Any]]:
-        return (
-            # dynamically generate the fully qualified name of the class
-            self.__class__.__module__ + "." + self.__class__.__qualname__,
-            {
-                "job_name": self.job_name,
-                "run_id": self.run_id,
-                "verbose": self.verbose,
-                "aws_conn_id": self.aws_conn_id,
-                "job_poll_interval": self.job_poll_interval,
-            },
+    def hook(self) -> AwsGenericHook:
+        return GlueJobHook(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.region_name,
+            verify=self.verify,
+            config=self.botocore_config,
         )
-
-    async def run(self) -> AsyncIterator[TriggerEvent]:
-        hook = GlueJobHook(aws_conn_id=self.aws_conn_id, job_poll_interval=self.job_poll_interval)
-        await hook.async_job_completion(self.job_name, self.run_id, self.verbose)
-        yield TriggerEvent({"status": "success", "message": "Job done", "value": self.run_id})
 
 
 class GlueCatalogPartitionTrigger(BaseTrigger):

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -78,8 +78,6 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
         self.job_name = job_name
         self.run_id = run_id
         self.verbose = verbose
-        self.waiter_delay = waiter_delay
-        self.waiter_max_attempts = waiter_max_attempts
 
     def hook(self) -> AwsGenericHook:
         return GlueJobHook(

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -38,7 +38,8 @@ class GlueJobCompleteTrigger(BaseTrigger):
     :param job_name: glue job name
     :param run_id: the ID of the specific run to watch for that job
     :param verbose: whether to print the job's logs in airflow logs or not
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
+    :param aws_conn_id: The Airflow connection used for AWS credentials
+    :param job_poll_interval: The interval in which to poll the status of a job
     """
 
     def __init__(

--- a/providers/amazon/src/airflow/providers/amazon/aws/waiters/glue.json
+++ b/providers/amazon/src/airflow/providers/amazon/aws/waiters/glue.json
@@ -1,6 +1,61 @@
 {
     "version": 2,
     "waiters": {
+        "job_complete": {
+            "operation": "GetJobRun",
+            "delay": 60,
+            "maxAttempts": 75,
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "STARTING",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "RUNNING",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "STOPPING",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "STOPPED",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "FAILED",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "ERROR",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "TIMEOUT",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "JobRun.JobRunState",
+                    "expected": "SUCCEEDED",
+                    "state": "success"
+                }
+            ]
+        },
         "crawler_ready": {
             "operation": "GetCrawler",
             "delay": 5,

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_glue.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import timedelta
 from unittest import mock
 from unittest.mock import ANY
 
@@ -177,10 +176,12 @@ class TestGlueJobSensor:
             run_id="job_run_id",
             deferrable=True,
             poke_interval=5,
+            max_retries=30,
         )
         with pytest.raises(TaskDeferred):
             sensor.execute({})
-        assert mock_defer.call_args[1]["timeout"] == timedelta(days=7)
+        call_kwargs = mock_defer.call_args.kwargs["trigger"]
+        assert call_kwargs.attempts == 30
         mock_defer.assert_called_once()
 
     def test_default_args(self):
@@ -207,10 +208,10 @@ class TestGlueJobSensor:
             deferrable=True,
             poke_interval=10,
             aws_conn_id="custom_conn",
-            timeout=120,
+            max_retries=20,
         )
         assert sensor.verbose is True
         assert sensor.deferrable is True
         assert sensor.poke_interval == 10
         assert sensor.aws_conn_id == "custom_conn"
-        assert sensor.timeout == 120
+        assert sensor.max_retries == 20

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_glue.py
@@ -169,7 +169,7 @@ class TestGlueJobSensor:
             sensor.execute({})
 
     @mock.patch.object(GlueJobSensor, "defer")
-    def test_max_retries_and_timeout(self, mock_defer):
+    def test_default_timeout(self, mock_defer):
         mock_defer.side_effect = TaskDeferred(trigger=mock.Mock(), method_name="execute_complete")
         sensor = GlueJobSensor(
             task_id="test_glue_job_sensor",


### PR DESCRIPTION

---

Part of #35278

I have implemented a custom waiter and ported the sensor and trigger to the base AWS classes. For the naming of parameters and what to include in the docstrings, I looked at the already existing Glue ones.

On that note: I noticed that all operators use the `max_attempts` and `poll_interval` parameters (although often named differently), that are later passed to the trigger. Wouldn't it make sense to move them to the `AWSBaseOperator` too?