### PR TITLE
fix: correct JWT secret name to match deployment environment

### DIFF
--- a/chart/templates/secrets/jwt-secret.yaml
+++ b/chart/templates/secrets/jwt-secret.yaml
@@ -26,7 +26,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "airflow.fullname" . }}-jwt-secret
+  name: {{ include "jwt_secret" . }}
   labels:
     tier: airflow
     component: api-server

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -71,7 +71,7 @@ DEFAULT_OBJECTS_STD_NAMING = OBJECTS_STD_NAMING.union(
         ("Deployment", "test-basic-airflow-dag-processor"),
         ("ServiceAccount", "test-basic-airflow-api-server"),
         ("ServiceAccount", "test-basic-airflow-dag-processor"),
-        ("Secret", "test-basic-airflow-jwt-secret"),
+        ("Secret", "test-basic-jwt-secret"),
     }
 )
 


### PR DESCRIPTION
**This PR fixes a Kubernetes deployment error (`CreateContainerConfigError`) caused by a mismatch in the JWT secret name.**

The issue stems from inconsistent prefixes used when referencing the secret:

* In the deployment environment, the JWT secret is referenced using the `jwt_secret` variable derived from `.Release.Name`.
* However, the actual secret was created using the `airflow.fullname` variable.

This mismatch led to the deployment failing to locate the expected secret.
To resolve this, the secret name has been updated to also use the `jwt_secret` variable, ensuring consistency between the secret's name and how it's referenced in the deployment.

## References
- https://github.com/apache/airflow/blob/main/chart/templates/_helpers.yaml#L406
- https://github.com/apache/airflow/blob/main/chart/templates/_helpers.yaml#L105
- https://github.com/apache/airflow/blob/main/chart/templates/_helpers.yaml#L25
- https://github.com/apache/airflow/blob/main/chart/templates/secrets/jwt-secret.yaml#L29