### PR TITLE
Remove double call to plugin init

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -171,7 +171,6 @@ def init_plugins(app: FastAPI) -> None:
     from airflow import plugins_manager
 
     plugins_manager.initialize_fastapi_plugins()
-    plugins_manager.initialize_fastapi_plugins()
 
     # After calling initialize_fastapi_plugins, fastapi_apps cannot be None anymore.
     for subapp_dict in cast("list", plugins_manager.fastapi_apps):


### PR DESCRIPTION
Just realized the `initialize_fastapi_plugins` was called two times, unnecessarily.

That has no impact because second initialization will be bypassed while the plugin manager already has them initialized but that still should be removed. 