### PR TITLE
Enable LDAP users to generate an Airflow token with `FabAuthManager`

### DIFF
--- a/providers/fab/docs/auth-manager/token.rst
+++ b/providers/fab/docs/auth-manager/token.rst
@@ -40,3 +40,6 @@ Example
         }'
 
 This process will return a token that you can use in the Airflow public API requests.
+
+Only users from database (`AUTH_TYPE = AUTH_DB`) or from LDAP (`AUTH_TYPE = AUTH_LDAP`) can be used to generate a token.
+See :doc:`Airflow public API <webserver-authentication>` for more details.

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1723,7 +1723,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     --------------------
     """
 
-    def auth_user_ldap(self, username, password):
+    def auth_user_ldap(self, username, password, rotate_session_id=True):
         """
         Authenticate user with LDAP.
 
@@ -1890,7 +1890,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
             # LOGIN SUCCESS (only if user is now registered)
             if user:
-                self._rotate_session_id()
+                if rotate_session_id:
+                    self._rotate_session_id()
                 self.update_user_auth_stat(user)
                 return user
             return None
@@ -1919,7 +1920,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             return False
         return check_password_hash(user.password, password)
 
-    def auth_user_db(self, username, password):
+    def auth_user_db(self, username, password, rotate_session_id=True):
         """
         Authenticate user, auth db style.
 
@@ -1927,6 +1928,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             The username or registered email address
         :param password:
             The password, will be tested against hashed password on db
+        :param rotate_session_id:
+            Whether to rotate the session ID
         """
         if username is None or username == "":
             return None
@@ -1942,7 +1945,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, username)
             return None
         if check_password_hash(user.password, password):
-            self._rotate_session_id()
+            if rotate_session_id:
+                self._rotate_session_id()
             self.update_user_auth_stat(user, True)
             return user
         self.update_user_auth_stat(user, False)

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -17,16 +17,30 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from flask_appbuilder.const import AUTH_DB, AUTH_LDAP, AUTH_OID
 from starlette.exceptions import HTTPException
 
 from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin
 
-if TYPE_CHECKING:
-    from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
+
+@pytest.fixture
+def auth_manager():
+    return MagicMock()
+
+
+@pytest.fixture
+def security_manager():
+    return MagicMock()
+
+
+@pytest.fixture
+def user():
+    user = MagicMock()
+    user.password = "dummy"
+    return user
 
 
 @patch("airflow.providers.fab.auth_manager.api_fastapi.services.login.get_auth_manager")
@@ -34,71 +48,56 @@ class TestLogin:
     def setup_method(
         self,
     ):
-        self.dummy_auth_manager = MagicMock()
-        self.dummy_app_builder = MagicMock()
-        self.dummy_app = MagicMock()
-        self.dummy_login_body = MagicMock()
-        self.dummy_user = MagicMock()
-        self.dummy_user.password = "dummy"
-        self.dummy_security_manager = MagicMock()
-        self.dummy_login_body.username = "dummy"
-        self.dummy_login_body.password = "dummy"
+        self.login_body = MagicMock()
+        self.login_body.username = "username"
+        self.login_body.password = "password"
         self.dummy_token = "DUMMY_TOKEN"
 
-    def test_create_token(self, get_auth_manager):
-        get_auth_manager.return_value = self.dummy_auth_manager
-        self.dummy_auth_manager.security_manager = self.dummy_security_manager
-        self.dummy_security_manager.find_user.return_value = self.dummy_user
-        self.dummy_auth_manager.generate_jwt.return_value = self.dummy_token
-        self.dummy_security_manager.check_password.return_value = True
+    @pytest.mark.parametrize(
+        "auth_type, method",
+        [
+            [AUTH_DB, "auth_user_db"],
+            [AUTH_LDAP, "auth_user_ldap"],
+        ],
+    )
+    def test_create_token(self, get_auth_manager, auth_type, method, auth_manager, security_manager, user):
+        security_manager.auth_type = auth_type
+        getattr(security_manager, method).return_value = user
 
-        login_response: LoginResponse = FABAuthManagerLogin.create_token(
-            body=self.dummy_login_body,
-            expiration_time_in_seconds=1,
+        auth_manager.security_manager = security_manager
+        auth_manager.generate_jwt.return_value = self.dummy_token
+
+        get_auth_manager.return_value = auth_manager
+
+        result = FABAuthManagerLogin.create_token(
+            body=self.login_body,
         )
-        assert login_response.access_token == self.dummy_token
+        assert result.access_token == self.dummy_token
+        getattr(security_manager, method).assert_called_once_with(
+            self.login_body.username, self.login_body.password, rotate_session_id=False
+        )
+        auth_manager.generate_jwt.assert_called_once_with(user=user, expiration_time_in_seconds=ANY)
 
-    def test_create_token_invalid_username(self, get_auth_manager):
-        get_auth_manager.return_value = self.dummy_auth_manager
-        self.dummy_auth_manager.security_manager = self.dummy_security_manager
-        self.dummy_security_manager.find_user.return_value = None
-        self.dummy_security_manager.check_password.return_value = False
+    @pytest.mark.parametrize(
+        "auth_type, methods",
+        [
+            [AUTH_DB, ["auth_user_db"]],
+            [AUTH_LDAP, ["auth_user_ldap", "auth_user_db"]],
+            [AUTH_OID, ["auth_user_db"]],
+        ],
+    )
+    def test_create_token_no_user(
+        self, get_auth_manager, auth_type, methods, auth_manager, security_manager, user
+    ):
+        security_manager.auth_type = auth_type
+        for method in methods:
+            getattr(security_manager, method).return_value = None
+
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
 
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerLogin.create_token(
-                body=self.dummy_login_body,
-                expiration_time_in_seconds=1,
+                body=self.login_body,
             )
         assert ex.value.status_code == 401
-        assert ex.value.detail == "Invalid username"
-
-    def test_create_token_invalid_password(self, get_auth_manager):
-        get_auth_manager.return_value = self.dummy_auth_manager
-        self.dummy_auth_manager.security_manager = self.dummy_security_manager
-        self.dummy_security_manager.find_user.return_value = self.dummy_user
-        self.dummy_user.password = "invalid_password"
-        self.dummy_security_manager.check_password.return_value = False
-
-        with pytest.raises(HTTPException) as ex:
-            FABAuthManagerLogin.create_token(
-                body=self.dummy_login_body,
-                expiration_time_in_seconds=1,
-            )
-        assert ex.value.status_code == 401
-        assert ex.value.detail == "Invalid password"
-
-    def test_create_token_empty_user_password(self, get_auth_manager):
-        get_auth_manager.return_value = self.dummy_auth_manager
-        self.dummy_auth_manager.security_manager = self.dummy_security_manager
-        self.dummy_security_manager.find_user.return_value = self.dummy_user
-        self.dummy_login_body.username = ""
-        self.dummy_login_body.password = ""
-        self.dummy_security_manager.check_password.return_value = False
-
-        with pytest.raises(HTTPException) as ex:
-            FABAuthManagerLogin.create_token(
-                body=self.dummy_login_body,
-                expiration_time_in_seconds=1,
-            )
-        assert ex.value.status_code == 400
-        assert ex.value.detail == "Username and password must be provided"


### PR DESCRIPTION
Resolves #52103.

Today only users stored in DB can generate an Airflow JWT token in order to access Airflow API. This PRs adds capability for LDAP users to also generate a token.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
