### PR TITLE
Bump pymssql version to 2.3.5

### DIFF
--- a/providers/microsoft/mssql/pyproject.toml
+++ b/providers/microsoft/mssql/pyproject.toml
@@ -59,13 +59,7 @@ requires-python = "~=3.9"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.23.0",
-    # pymssql 2.3.3 release to PyPI has been broken on 1st of April 2025
-    # and it is not possible to install it on Linux. We need to exclude it
-    # and either it will be fixed in the next release or we will need to
-    # remove the exclusion if it is fixed and missing packages are uploaded
-    # to PyPI.
-    # Issue: https://github.com/pymssql/pymssql/issues/927
-    "pymssql>=2.3.0,!=2.3.3",
+    "pymssql>=2.3.5",
     # The methodtools dependency can be removed with min airflow version >=2.9.1
     # as it was added in https://github.com/apache/airflow/pull/37757
     "methodtools>=0.4.7",


### PR DESCRIPTION
There is a problem with 2.3.4 that the .whl files for MacOS are broken / missing and when installing with Python 3.10 on MacOS, pymssql installation fails. Since this is only pymssql, we can easily bump it to 2.3.5 to avoid it - it is the latest version installed anyway in main now.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
