### PR TITLE
add GithubApp to Auth git-sync

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -216,6 +216,14 @@ If release name contains chart name it will be used as a full name.
     defaultMode: 288
 {{- end }}
 
+{{/*  Git GitHub App secret volume */}}
+{{- define "git_sync_github_app_secret_volume" }}
+- name: github-app-secret
+  secret:
+    secretName: {{ template "git_sync_github_app_secret" . }}
+    defaultMode: 288
+{{- end }}
+
 {{/*  Git sync container */}}
 {{- define "git_sync_container" }}
 - name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
@@ -269,6 +277,25 @@ If release name contains chart name it will be used as a full name.
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_PASSWORD
+    {{ else if .Values.dags.gitSync.githubAppSecret }}
+    - name: GITSYNC_GITHUB_APP_PRIVATE_KEY_FILE
+      value: "/etc/git-secret/github-app"
+    {{- if .Values.dags.gitSync.githubAppId }}
+    - name: GITSYNC_GITHUB_APP_APPLICATION_ID
+      value: {{ .Values.dags.gitSync.githubAppId | quote }}
+    {{- end }}
+    {{- if .Values.dags.gitSync.githubAppClientId }}
+    - name: GITSYNC_GITHUB_APP_CLIENT_ID
+      value: {{ .Values.dags.gitSync.githubAppClientId | quote }}
+    {{- end }}
+    {{- if .Values.dags.gitSync.githubAppInstallationId }}
+    - name: GITSYNC_GITHUB_APP_INSTALLATION_ID
+      value: {{ .Values.dags.gitSync.githubAppInstallationId | quote }}
+    {{- end }}
+    {{- if .Values.dags.gitSync.githubAppBaseUrl }}
+    - name: GITSYNC_GITHUB_APP_BASE_URL
+      value: {{ .Values.dags.gitSync.githubAppBaseUrl | quote }}
+    {{- end }}
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}
@@ -330,6 +357,12 @@ If release name contains chart name it will be used as a full name.
     readOnly: true
     subPath: known_hosts
   {{- end }}
+  {{- end }}
+  {{- if .Values.dags.gitSync.githubAppSecret }}
+  - name: github-app-secret
+    mountPath: /etc/git-secret/github-app
+    readOnly: true
+    subPath: githubAppPrivateKey
   {{- end }}
   {{- if .Values.dags.gitSync.extraVolumeMounts }}
     {{- tpl (toYaml .Values.dags.gitSync.extraVolumeMounts) . | nindent 2 }}
@@ -466,6 +499,11 @@ If release name contains chart name it will be used as a full name.
 {{/* Create the name of the git sync ssh secret to use */}}
 {{- define "git_sync_ssh_key" -}}
   {{- default (printf "%s-ssh-secret" (include "airflow.fullname" .)) .Values.dags.gitSync.sshKeySecret }}
+{{- end }}
+
+{{/* Create the name of the git sync GitHub App secret to use */}}
+{{- define "git_sync_github_app_secret" -}}
+  {{- default (printf "%s-github-app-secret" (include "airflow.fullname" .)) .Values.dags.gitSync.githubAppSecret }}
 {{- end }}
 
 {{- define "celery_executor_namespace" -}}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -260,6 +260,9 @@ spec:
         {{- if and .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) }}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.githubAppSecret }}
+          {{- include "git_sync_github_app_secret_volume" . | indent 8 }}
+        {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -319,6 +319,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.githubAppSecret }}
+          {{- include "git_sync_github_app_secret_volume" . | indent 8 }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.volumes }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -289,6 +289,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | nindent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.githubAppSecret }}
+          {{- include "git_sync_github_app_secret_volume" . | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -283,6 +283,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.githubAppSecret }}
+          {{- include "git_sync_github_app_secret_volume" . | indent 8 }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.logs.persistence.enabled }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -431,6 +431,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.githubAppSecret }}
+          {{- include "git_sync_github_app_secret_volume" . | indent 8 }}
+        {{- end }}
         {{- end }}
   {{- if .Values.logs.persistence.enabled }}
         - name: logs

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -9104,6 +9104,46 @@
                                 "<host1>,<ip1> <key1>"
                             ]
                         },
+                        "githubAppSecret": {
+                            "description": "Name of a Secret containing the GitHub App private key for authentication.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "githubAppId": {
+                            "description": "The application ID of the GitHub App used for authentication.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "githubAppClientId": {
+                            "description": "The client ID of the GitHub App used for authentication (alternative to githubAppId).",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "githubAppInstallationId": {
+                            "description": "The installation ID of the GitHub App used for authentication.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "githubAppBaseUrl": {
+                            "description": "The GitHub base URL for GitHub App authentication requests (defaults to https://api.github.com/).",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
                         "env": {
                             "description": "Environment variables for git sync container.",
                             "type": "array",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3008,6 +3008,29 @@ dags:
     #    <host1>,<ip1> <key1>
     #    <host2>,<ip2> <key2>
 
+    # GitHub App authentication (requires git-sync v4.3.0+)
+    #   ---
+    #   apiVersion: v1
+    #   kind: Secret
+    #   metadata:
+    #     name: github-app-secret
+    #   type: Opaque
+    #   data:
+    #     githubAppPrivateKey: <base64_encoded_private_key>
+    #
+    # Configure the values below
+    # githubAppSecret: github-app-secret
+    # githubAppId: 123456 
+    # githubAppInstallationId: 789012
+    # githubAppBaseUrl: https://api.github.com/  # Optional
+    #
+    # githubAppClientId: 654321 # Either use this or githubAppId (not both)
+    githubAppSecret: ~
+    githubAppId: ~
+    githubAppClientId: ~
+    githubAppInstallationId: ~
+    githubAppBaseUrl: ~
+
     # interval between git sync attempts in seconds
     # high values are more likely to cause DAGs to become out of sync between different components
     # low values cause more traffic to the remote git repository

--- a/helm-tests/tests/helm_tests/other/test_git_github_app_secret.py
+++ b/helm-tests/tests/helm_tests/other/test_git_github_app_secret.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestGitHubAppSecret:
+    """Tests GitHub App secret functionality for git-sync authentication."""
+
+    def test_github_app_secret_template_helper(self):
+        """Test that the GitHub App secret helper template function works correctly."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "githubAppSecret": "my-github-app-secret",
+                        "githubAppId": 123456,
+                        "githubAppInstallationId": 789012,
+                    },
+                    "persistence": {"enabled": True},
+                }
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        # Verify that the GitHub App secret volume is created with correct name
+        volumes = jmespath.search("spec.template.spec.volumes", docs[0])
+        github_app_volume = None
+        for volume in volumes:
+            if volume.get("name") == "github-app-secret":
+                github_app_volume = volume
+                break
+        
+        assert github_app_volume is not None
+        assert github_app_volume["secret"]["secretName"] == "my-github-app-secret"
+        assert github_app_volume["secret"]["defaultMode"] == 288
+
+    def test_github_app_volume_mount(self):
+        """Test that GitHub App secret is mounted correctly in git-sync container."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "githubAppSecret": "my-github-app-secret",
+                        "githubAppId": 123456,
+                        "githubAppInstallationId": 789012,
+                    },
+                    "persistence": {"enabled": True},
+                }
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        # Check that the GitHub App secret is mounted in the git-sync container
+        git_sync_container = None
+        containers = jmespath.search("spec.template.spec.containers", docs[0])
+        for container in containers:
+            if container.get("name") == "git-sync":
+                git_sync_container = container
+                break
+        
+        assert git_sync_container is not None
+        volume_mounts = git_sync_container.get("volumeMounts", [])
+        github_app_mount = None
+        for mount in volume_mounts:
+            if mount.get("name") == "github-app-secret":
+                github_app_mount = mount
+                break
+        
+        assert github_app_mount is not None
+        assert github_app_mount["mountPath"] == "/etc/git-secret/github-app"
+        assert github_app_mount["readOnly"] is True
+        assert github_app_mount["subPath"] == "githubAppPrivateKey"
+
+    def test_github_app_secret_not_created_when_disabled(self):
+        """Test that GitHub App secret volume is not created when GitHub App authentication is disabled."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        # No GitHub App configuration
+                    },
+                    "persistence": {"enabled": True},
+                }
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        # Verify that no GitHub App secret volume is created
+        volumes = jmespath.search("spec.template.spec.volumes", docs[0]) or []
+        github_app_volumes = [v for v in volumes if v.get("name") == "github-app-secret"]
+        assert len(github_app_volumes) == 0 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---
This PR adds support for GitHub App authentication in the Airflow Helm chart's git-sync configuration, providing a more secure and scalable alternative to SSH keys and personal access tokens for accessing private GitHub repositories.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
