### PR TITLE
Remove Legacy Query Object Usage from airflow-models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -534,7 +534,11 @@ repos:
         files: >
             (?x)
             ^airflow-ctl.*\.py$|
+<<<<<<< HEAD
             ^providers/fab.*\.py$|
+=======
+            ^airflow-core.src.airflow.models.*\.py$|
+>>>>>>> a0db4e42ed (add path to pre-commit hook)
             ^task_sdk.*\.py$
         pass_filenames: true
       - id: update-supported-versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -535,10 +535,14 @@ repos:
             (?x)
             ^airflow-ctl.*\.py$|
 <<<<<<< HEAD
+<<<<<<< HEAD
             ^providers/fab.*\.py$|
 =======
             ^airflow-core.src.airflow.models.*\.py$|
 >>>>>>> a0db4e42ed (add path to pre-commit hook)
+=======
+            ^airflow-core/src/airflow/models/.*\.py$|
+>>>>>>> 68f94dfb9c (use / in path)
             ^task_sdk.*\.py$
         pass_filenames: true
       - id: update-supported-versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -534,15 +534,8 @@ repos:
         files: >
             (?x)
             ^airflow-ctl.*\.py$|
-<<<<<<< HEAD
-<<<<<<< HEAD
-            ^providers/fab.*\.py$|
-=======
-            ^airflow-core.src.airflow.models.*\.py$|
->>>>>>> a0db4e42ed (add path to pre-commit hook)
-=======
             ^airflow-core/src/airflow/models/.*\.py$|
->>>>>>> 68f94dfb9c (use / in path)
+            ^providers/fab/.*\.py$|
             ^task_sdk.*\.py$
         pass_filenames: true
       - id: update-supported-versions

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -494,6 +494,7 @@ def wait_dag_run_until_finished(
         run_id=dag_run_id,
         interval=interval,
         result_task_ids=result_task_ids,
+        session=session,
     )
     return StreamingResponse(waiter.wait())
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -93,7 +93,7 @@ def get_xcom_entry(
     # We use `BaseXCom.get_many` to fetch XComs directly from the database, bypassing the XCom Backend.
     # This avoids deserialization via the backend (e.g., from a remote storage like S3) and instead
     # retrieves the raw serialized value from the database.
-    result = session.scalars(xcom_query).first()
+    result = session.execute(xcom_query.with_only_columns(XComModel.value)).first()
 
     if result is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"XCom entry with key: `{xcom_key}` not found")
@@ -251,7 +251,7 @@ def create_xcom_entry(
         map_indexes=request_body.map_index,
         session=session,
     )
-    result = session.scalars(already_existing_query.with_only_columns(XComModel.value)).first()
+    result = session.execute(already_existing_query.with_only_columns(XComModel.value)).first()
     if result:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -93,7 +93,7 @@ def get_xcom_entry(
     # We use `BaseXCom.get_many` to fetch XComs directly from the database, bypassing the XCom Backend.
     # This avoids deserialization via the backend (e.g., from a remote storage like S3) and instead
     # retrieves the raw serialized value from the database.
-    result = session.execute(xcom_query.with_only_columns(XComModel.value)).first()
+    result = session.scalars(xcom_query).first()
 
     if result is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"XCom entry with key: `{xcom_key}` not found")

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -93,7 +93,7 @@ def get_xcom_entry(
     # We use `BaseXCom.get_many` to fetch XComs directly from the database, bypassing the XCom Backend.
     # This avoids deserialization via the backend (e.g., from a remote storage like S3) and instead
     # retrieves the raw serialized value from the database.
-    result = xcom_query.limit(1).first()
+    result = session.execute(xcom_query.limit(1)).first()
 
     if result is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"XCom entry with key: `{xcom_key}` not found")
@@ -251,7 +251,7 @@ def create_xcom_entry(
         map_indexes=request_body.map_index,
         session=session,
     )
-    result = already_existing_query.with_entities(XComModel.value).first()
+    result = session.execute(already_existing_query.with_only_columns(XComModel.value)).first()
     if result:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -93,7 +93,7 @@ def get_xcom_entry(
     # We use `BaseXCom.get_many` to fetch XComs directly from the database, bypassing the XCom Backend.
     # This avoids deserialization via the backend (e.g., from a remote storage like S3) and instead
     # retrieves the raw serialized value from the database.
-    result = session.execute(xcom_query.limit(1)).first()
+    result = session.scalars(xcom_query).first()
 
     if result is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"XCom entry with key: `{xcom_key}` not found")
@@ -251,7 +251,7 @@ def create_xcom_entry(
         map_indexes=request_body.map_index,
         session=session,
     )
-    result = session.execute(already_existing_query.with_only_columns(XComModel.value)).first()
+    result = session.scalars(already_existing_query.with_only_columns(XComModel.value)).first()
     if result:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -86,7 +86,6 @@ def get_xcom_entry(
         task_ids=task_id,
         dag_ids=dag_id,
         map_indexes=map_index,
-        session=session,
         limit=1,
     )
 
@@ -249,7 +248,6 @@ def create_xcom_entry(
         dag_ids=dag_id,
         run_id=dag_run_id,
         map_indexes=request_body.map_index,
-        session=session,
     )
     result = session.execute(already_existing_query.with_only_columns(XComModel.value)).first()
     if result:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -35,8 +35,6 @@ from airflow.utils.state import State
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterator
 
-session = SessionDep()
-
 
 @attrs.define
 class DagRunWaiter:
@@ -46,6 +44,7 @@ class DagRunWaiter:
     run_id: str
     interval: float
     result_task_ids: list[str] | None
+    session: SessionDep
 
     async def _get_dag_run(self) -> DagRun:
         async with create_session_async() as session:
@@ -58,7 +57,7 @@ class DagRunWaiter:
             task_ids=self.result_task_ids,
             dag_ids=self.dag_id,
         )
-        xcom_query = session.scalars(xcom_query.order_by(XComModel.task_id, XComModel.map_index)).all()
+        xcom_query = self.session.scalars(xcom_query.order_by(XComModel.task_id, XComModel.map_index)).all()
 
         def _group_xcoms(g: Iterator[XComModel]) -> Any:
             entries = list(g)

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -48,9 +48,7 @@ class DagRunWaiter:
         async with create_session_async() as session:
             return await session.scalar(select(DagRun).filter_by(dag_id=self.dag_id, run_id=self.run_id))
 
-    def _serialize_xcoms(
-        self,
-    ) -> dict[str, Any]:
+    def _serialize_xcoms(self) -> dict[str, Any]:
         with create_session() as session:
             xcom_query = XComModel.get_many(
                 run_id=self.run_id,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -212,7 +212,7 @@ def get_mapped_xcom_by_index(
     else:
         xcom_query = xcom_query.order_by(XComModel.map_index.desc()).offset(-1 - offset)
 
-    if (result := session.scalars(xcom_query.limit(1)).first()) is None:
+    if (result := session.scalars(xcom_query).first()) is None:
         message = (
             f"XCom with {key=} {offset=} not found for task {task_id!r} in DAG run {run_id!r} of {dag_id!r}"
         )
@@ -309,7 +309,7 @@ def get_mapped_xcom_by_slice(
             else:
                 query = query.slice(-stop, -start)
 
-    values = [row.value for row in session.scalars(query.with_only_columns(XComModel.value))]
+    values = [row.value for row in session.execute(query.with_only_columns(XComModel.value)).all()]
     if step != 1:
         values = values[::step]
     return XComSequenceSliceResponse(values)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -85,7 +85,6 @@ async def xcom_query(
         task_ids=task_id,
         dag_ids=dag_id,
         map_indexes=map_index,
-        session=session,
     )
     return query
 
@@ -151,7 +150,6 @@ def get_xcom(
         task_ids=task_id,
         dag_ids=dag_id,
         include_prior_dates=params.include_prior_dates,
-        session=session,
     )
     if params.offset is not None:
         xcom_query = xcom_query.where(XComModel.value.is_not(None)).order_by(None)
@@ -204,7 +202,6 @@ def get_mapped_xcom_by_index(
         key=key,
         task_ids=task_id,
         dag_ids=dag_id,
-        session=session,
     )
     xcom_query = xcom_query.order_by(None)
     if offset >= 0:
@@ -250,7 +247,6 @@ def get_mapped_xcom_by_slice(
         task_ids=task_id,
         dag_ids=dag_id,
         include_prior_dates=params.include_prior_dates,
-        session=session,
     )
     query = query.order_by(None)
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -167,7 +167,7 @@ def get_xcom(
     # retrieves the raw serialized value from the database. By not relying on `XCom.get_many` or `XCom.get_one`
     # (which automatically deserializes using the backend), we avoid potential
     # performance hits from retrieving large data files into the API server.
-    result = session.scalars(xcom_query.limit(1)).first()
+    result = session.scalars(xcom_query).first()
     if result is None:
         if params.offset is None:
             message = (

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -309,7 +309,7 @@ def get_mapped_xcom_by_slice(
             else:
                 query = query.slice(-stop, -start)
 
-    values = [row.value for row in query.with_only_columns(XComModel.value)]
+    values = [row.value for row in session.scalars(query.with_only_columns(XComModel.value))]
     if step != 1:
         values = values[::step]
     return XComSequenceSliceResponse(values)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -167,7 +167,7 @@ def get_xcom(
     # retrieves the raw serialized value from the database. By not relying on `XCom.get_many` or `XCom.get_one`
     # (which automatically deserializes using the backend), we avoid potential
     # performance hits from retrieving large data files into the API server.
-    result = session.execute(xcom_query.limit(1)).first()
+    result = session.scalars(xcom_query.limit(1)).first()
     if result is None:
         if params.offset is None:
             message = (
@@ -212,7 +212,7 @@ def get_mapped_xcom_by_index(
     else:
         xcom_query = xcom_query.order_by(XComModel.map_index.desc()).offset(-1 - offset)
 
-    if (result := session.execute(xcom_query.limit(1)).first()) is None:
+    if (result := session.scalars(xcom_query.limit(1)).first()) is None:
         message = (
             f"XCom with {key=} {offset=} not found for task {task_id!r} in DAG run {run_id!r} of {dag_id!r}"
         )

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -76,7 +76,6 @@ async def xcom_query(
     run_id: str,
     task_id: str,
     key: str,
-    session: SessionDep,
     map_index: Annotated[int | None, Query()] = None,
 ) -> Select:
     query = XComModel.get_many(

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -790,13 +790,12 @@ class DagRun(Base, LoggingMixin):
 
     def _check_last_n_dagruns_failed(self, dag_id, max_consecutive_failed_dag_runs, session):
         """Check if last N dags failed."""
-        dag_runs = (
-            session.query(DagRun)
-            .filter(DagRun.dag_id == dag_id)
+        dag_runs = session.scalars(
+            select(DagRun)
+            .where(DagRun.dag_id == dag_id)
             .order_by(DagRun.logical_date.desc())
             .limit(max_consecutive_failed_dag_runs)
-            .all()
-        )
+        ).all()
         """ Marking dag as paused, if needed"""
         to_be_paused = len(dag_runs) >= max_consecutive_failed_dag_runs and all(
             dag_run.state == DagRunState.FAILED for dag_run in dag_runs

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -164,9 +164,10 @@ class Deadline(Base):
 
         try:
             # Get deadlines which match the provided conditions and their associated DagRuns.
-            deadline_dagrun_pairs = (
-                session.query(Deadline, DagRun).join(DagRun).filter(and_(*filter_conditions)).all()
-            )
+            deadline_dagrun_pairs = session.execute(
+                select(Deadline, DagRun).join(DagRun).where(and_(*filter_conditions))
+            ).all()
+
         except AttributeError as e:
             logger.exception("Error resolving deadlines: %s", e)
             raise

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -476,8 +476,8 @@ class SerializedDagModel(Base):
         """
         # Subquery to get the latest serdag per dag_id
         latest_serdag_subquery = (
-            session.query(cls.dag_id, func.max(cls.created_at).label("created_at"))
-            .filter(cls.dag_id.in_(dag_ids))
+            select(cls.dag_id, func.max(cls.created_at).label("created_at"))
+            .where(cls.dag_id.in_(dag_ids))
             .group_by(cls.dag_id)
             .subquery()
         )
@@ -501,9 +501,7 @@ class SerializedDagModel(Base):
         :returns: a dict of DAGs read from database
         """
         latest_serialized_dag_subquery = (
-            session.query(cls.dag_id, func.max(cls.created_at).label("max_created"))
-            .group_by(cls.dag_id)
-            .subquery()
+            select(cls.dag_id, func.max(cls.created_at).label("max_created")).group_by(cls.dag_id).subquery()
         )
         serialized_dags = session.scalars(
             select(cls).join(

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1955,20 +1955,25 @@ class TaskInstance(Base, LoggingMixin):
         # call XCom.deserialize_value() manually.
 
         # We are only pulling one single task.
+        print("okkak")
         if (task_ids is None or isinstance(task_ids, str)) and not isinstance(map_indexes, Iterable):
-            first = session.scalars(
-                query.with_only_columns(
-                    XComModel.run_id,
-                    XComModel.task_id,
-                    XComModel.dag_id,
-                    XComModel.map_index,
-                    XComModel.value,
+            first = (
+                session.execute(
+                    query.with_only_columns(
+                        XComModel.run_id,
+                        XComModel.task_id,
+                        XComModel.dag_id,
+                        XComModel.map_index,
+                        XComModel.value,
+                    )
                 )
-            ).first()
+                .mappings()
+                .first()
+            )
 
             if first is None:  # No matching XCom at all.
                 return default
-            if map_indexes is not None or first.map_index < 0:
+            if map_indexes is not None or first["map_index"] < 0:
                 return XComModel.deserialize_value(first)
 
             # raise RuntimeError("Nothing should hit this anymore")

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1947,7 +1947,6 @@ class TaskInstance(Base, LoggingMixin):
             task_ids=task_ids,
             map_indexes=map_indexes,
             include_prior_dates=include_prior_dates,
-            session=session,
         )
 
         # NOTE: Since we're only fetching the value field and not the whole

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -658,7 +658,7 @@ class TaskInstance(Base, LoggingMixin):
     ) -> TaskInstance | None:
         query = (
             select(TaskInstance)
-            .options(lazyload(TaskInstance.dag_run))
+            .options(lazyload(TaskInstance.dag_run))  # lazy load dag run to avoid locking it
             .filter_by(
                 dag_id=dag_id,
                 run_id=run_id,
@@ -1955,7 +1955,6 @@ class TaskInstance(Base, LoggingMixin):
         # call XCom.deserialize_value() manually.
 
         # We are only pulling one single task.
-
         if (task_ids is None or isinstance(task_ids, str)) and not isinstance(map_indexes, Iterable):
             first = session.execute(
                 query.with_only_columns(
@@ -2015,7 +2014,7 @@ class TaskInstance(Base, LoggingMixin):
             num_running_task_instances_query = num_running_task_instances_query.where(
                 TaskInstance.run_id == self.run_id
             )
-        return session.execute(num_running_task_instances_query).scalar()
+        return session.scalar(num_running_task_instances_query)
 
     @staticmethod
     def filter_for_tis(tis: Iterable[TaskInstance | TaskInstanceKey]) -> BooleanClauseList | None:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1956,7 +1956,7 @@ class TaskInstance(Base, LoggingMixin):
 
         # We are only pulling one single task.
         if (task_ids is None or isinstance(task_ids, str)) and not isinstance(map_indexes, Iterable):
-            first = session.execute(
+            first = session.scalars(
                 query.with_only_columns(
                     XComModel.run_id,
                     XComModel.task_id,

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1955,25 +1955,21 @@ class TaskInstance(Base, LoggingMixin):
         # call XCom.deserialize_value() manually.
 
         # We are only pulling one single task.
-        print("okkak")
+
         if (task_ids is None or isinstance(task_ids, str)) and not isinstance(map_indexes, Iterable):
-            first = (
-                session.execute(
-                    query.with_only_columns(
-                        XComModel.run_id,
-                        XComModel.task_id,
-                        XComModel.dag_id,
-                        XComModel.map_index,
-                        XComModel.value,
-                    )
+            first = session.execute(
+                query.with_only_columns(
+                    XComModel.run_id,
+                    XComModel.task_id,
+                    XComModel.dag_id,
+                    XComModel.map_index,
+                    XComModel.value,
                 )
-                .mappings()
-                .first()
-            )
+            ).first()
 
             if first is None:  # No matching XCom at all.
                 return default
-            if map_indexes is not None or first["map_index"] < 0:
+            if map_indexes is not None or first.map_index < 0:
                 return XComModel.deserialize_value(first)
 
             # raise RuntimeError("Nothing should hit this anymore")

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1964,7 +1964,6 @@ class TaskInstance(Base, LoggingMixin):
                     XComModel.value,
                 )
             ).first()
-
             if first is None:  # No matching XCom at all.
                 return default
             if map_indexes is not None or first.map_index < 0:
@@ -2004,10 +2003,14 @@ class TaskInstance(Base, LoggingMixin):
     def get_num_running_task_instances(self, session: Session, same_dagrun: bool = False) -> int:
         """Return Number of running TIs from the DB."""
         # .count() is inefficient
-        num_running_task_instances_query = select(func.count()).where(
-            TaskInstance.dag_id == self.dag_id,
-            TaskInstance.task_id == self.task_id,
-            TaskInstance.state == TaskInstanceState.RUNNING,
+        num_running_task_instances_query = (
+            select(func.count())
+            .select_from(TaskInstance)
+            .where(
+                TaskInstance.dag_id == self.dag_id,
+                TaskInstance.task_id == self.task_id,
+                TaskInstance.state == TaskInstanceState.RUNNING,
+            )
         )
         if same_dagrun:
             num_running_task_instances_query = num_running_task_instances_query.where(

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1956,8 +1956,14 @@ class TaskInstance(Base, LoggingMixin):
 
         # We are only pulling one single task.
         if (task_ids is None or isinstance(task_ids, str)) and not isinstance(map_indexes, Iterable):
-            first = query.with_entities(
-                XComModel.run_id, XComModel.task_id, XComModel.dag_id, XComModel.map_index, XComModel.value
+            first = session.execute(
+                query.with_only_columns(
+                    XComModel.run_id,
+                    XComModel.task_id,
+                    XComModel.dag_id,
+                    XComModel.map_index,
+                    XComModel.value,
+                )
             ).first()
 
             if first is None:  # No matching XCom at all.

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -381,11 +381,11 @@ class XComModel(TaskInstanceDependencies):
         :param result: The XCom database row or object containing a ``value`` attribute.
         :return: The deserialized Python object.
         """
-        if result["value"] is None:
+        if result.value is None:
             return None
 
         try:
-            return json.loads(result["value"], cls=XComDecoder)
+            return json.loads(result.value, cls=XComDecoder)
         except (ValueError, TypeError):
             # Already deserialized (e.g., set via Task Execution API)
             return result.value

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -381,14 +381,14 @@ class XComModel(TaskInstanceDependencies):
         :param result: The XCom database row or object containing a ``value`` attribute.
         :return: The deserialized Python object.
         """
-        if result.value is None:
+        if result[value] is None:
             return None
 
         try:
-            return json.loads(result.value, cls=XComDecoder)
+            return json.loads(result[value], cls=XComDecoder)
         except (ValueError, TypeError):
             # Already deserialized (e.g., set via Task Execution API)
-            return result.value
+            return result[value]
 
 
 class LazyXComSelectSequence(LazySelectSequence[Any]):

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -188,9 +188,7 @@ class XComModel(TaskInstanceDependencies):
         if not run_id:
             raise ValueError(f"run_id must be passed. Passed run_id={run_id}")
 
-        dag_run_id = session.execute(
-            select(DagRun.id).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)
-        ).scalar()
+        dag_run_id = session.scalar(select(DagRun.id).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id))
         if dag_run_id is None:
             raise ValueError(f"DAG run not found on DAG {dag_id!r} with ID {run_id!r}")
 

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -381,14 +381,14 @@ class XComModel(TaskInstanceDependencies):
         :param result: The XCom database row or object containing a ``value`` attribute.
         :return: The deserialized Python object.
         """
-        if result[value] is None:
+        if result["value"] is None:
             return None
 
         try:
-            return json.loads(result[value], cls=XComDecoder)
+            return json.loads(result["value"], cls=XComDecoder)
         except (ValueError, TypeError):
             # Already deserialized (e.g., set via Task Execution API)
-            return result[value]
+            return result["value"]
 
 
 class LazyXComSelectSequence(LazySelectSequence[Any]):

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -37,7 +37,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import Query, relationship
+from sqlalchemy.orm import relationship
 
 from airflow._shared.timezones import timezone
 from airflow.models.base import COLLATION_ARGS, ID_LEN, TaskInstanceDependencies
@@ -144,11 +144,11 @@ class XComModel(TaskInstanceDependencies):
         if not run_id:
             raise ValueError(f"run_id must be passed. Passed run_id={run_id}")
 
-        query = session.query(cls).filter_by(dag_id=dag_id, task_id=task_id, run_id=run_id)
+        query = select(cls).where(cls.dag_id == dag_id, cls.task_id == task_id, cls.run_id == run_id)
         if map_index is not None:
-            query = query.filter_by(map_index=map_index)
+            query = query.where(cls.map_index == map_index)
 
-        for xcom in query:
+        for xcom in session.scalars(query):
             # print(f"Clearing XCOM {xcom} with value {xcom.value}")
             session.delete(xcom)
 
@@ -188,7 +188,9 @@ class XComModel(TaskInstanceDependencies):
         if not run_id:
             raise ValueError(f"run_id must be passed. Passed run_id={run_id}")
 
-        dag_run_id = session.query(DagRun.id).filter_by(dag_id=dag_id, run_id=run_id).scalar()
+        dag_run_id = session.execute(
+            select(DagRun.id).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)
+        ).scalar()
         if dag_run_id is None:
             raise ValueError(f"DAG run not found on DAG {dag_id!r} with ID {run_id!r}")
 
@@ -258,7 +260,7 @@ class XComModel(TaskInstanceDependencies):
         include_prior_dates: bool = False,
         limit: int | None = None,
         session: Session = NEW_SESSION,
-    ) -> Query:
+    ) -> Select:
         """
         Composes a query to get one or more XCom entries.
 
@@ -289,42 +291,42 @@ class XComModel(TaskInstanceDependencies):
         if not run_id:
             raise ValueError(f"run_id must be passed. Passed run_id={run_id}")
 
-        query = session.query(cls).join(XComModel.dag_run)
+        query = select(cls).join(XComModel.dag_run)
 
         if key:
-            query = query.filter(XComModel.key == key)
+            query = query.where(XComModel.key == key)
 
         if is_container(task_ids):
-            query = query.filter(cls.task_id.in_(task_ids))
+            query = query.where(cls.task_id.in_(task_ids))
         elif task_ids is not None:
-            query = query.filter(cls.task_id == task_ids)
+            query = query.where(cls.task_id == task_ids)
 
         if is_container(dag_ids):
-            query = query.filter(cls.dag_id.in_(dag_ids))
+            query = query.where(cls.dag_id.in_(dag_ids))
         elif dag_ids is not None:
-            query = query.filter(cls.dag_id == dag_ids)
+            query = query.where(cls.dag_id == dag_ids)
 
         if isinstance(map_indexes, range) and map_indexes.step == 1:
-            query = query.filter(cls.map_index >= map_indexes.start, cls.map_index < map_indexes.stop)
+            query = query.where(cls.map_index >= map_indexes.start, cls.map_index < map_indexes.stop)
         elif is_container(map_indexes):
-            query = query.filter(cls.map_index.in_(map_indexes))
+            query = query.where(cls.map_index.in_(map_indexes))
         elif map_indexes is not None:
-            query = query.filter(cls.map_index == map_indexes)
+            query = query.where(cls.map_index == map_indexes)
 
         if include_prior_dates:
             dr = (
-                session.query(
+                select(
                     func.coalesce(DagRun.logical_date, DagRun.run_after).label("logical_date_or_run_after")
                 )
-                .filter(DagRun.run_id == run_id)
+                .where(DagRun.run_id == run_id)
                 .subquery()
             )
 
-            query = query.filter(
+            query = query.where(
                 func.coalesce(DagRun.logical_date, DagRun.run_after) <= dr.c.logical_date_or_run_after
             )
         else:
-            query = query.filter(cls.run_id == run_id)
+            query = query.where(cls.run_id == run_id)
 
         query = query.order_by(DagRun.logical_date.desc(), cls.timestamp.desc())
         if limit:

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -246,7 +246,6 @@ class XComModel(TaskInstanceDependencies):
         session.flush()
 
     @classmethod
-    @provide_session
     def get_many(
         cls,
         *,
@@ -257,7 +256,6 @@ class XComModel(TaskInstanceDependencies):
         map_indexes: int | Iterable[int] | None = None,
         include_prior_dates: bool = False,
         limit: int | None = None,
-        session: Session = NEW_SESSION,
     ) -> Select:
         """
         Composes a query to get one or more XCom entries.

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -388,7 +388,7 @@ class XComModel(TaskInstanceDependencies):
             return json.loads(result["value"], cls=XComDecoder)
         except (ValueError, TypeError):
             # Already deserialized (e.g., set via Task Execution API)
-            return result["value"]
+            return result.value
 
 
 class LazyXComSelectSequence(LazySelectSequence[Any]):

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -3581,8 +3581,7 @@ class XComOperatorLink(LoggingMixin):
     name: str
     xcom_key: str
 
-
-    def get_link(self, session: Session,operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
+    def get_link(self, session: Session, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
         """
         Retrieve the link from the XComs.
 

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -3581,7 +3581,8 @@ class XComOperatorLink(LoggingMixin):
     name: str
     xcom_key: str
 
-    def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
+
+    def get_link(self, session: Session,operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
         """
         Retrieve the link from the XComs.
 
@@ -3592,12 +3593,14 @@ class XComOperatorLink(LoggingMixin):
         self.log.info(
             "Attempting to retrieve link from XComs with key: %s for task id: %s", self.xcom_key, ti_key
         )
-        value = XComModel.get_many(
-            key=self.xcom_key,
-            run_id=ti_key.run_id,
-            dag_ids=ti_key.dag_id,
-            task_ids=ti_key.task_id,
-            map_indexes=ti_key.map_index,
+        value = session.execute(
+            XComModel.get_many(
+                key=self.xcom_key,
+                run_id=ti_key.run_id,
+                dag_ids=ti_key.dag_id,
+                task_ids=ti_key.task_id,
+                map_indexes=ti_key.map_index,
+            )
         ).first()
         if not value:
             self.log.debug(

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -104,7 +104,6 @@ from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import NOTSET, ArgNotSet, DagRunTriggeredByType, DagRunType
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import create_session
-from airflow.utils.timezone import from_timestamp, parse_timezone
 from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -3596,15 +3596,19 @@ class XComOperatorLink(LoggingMixin):
             "Attempting to retrieve link from XComs with key: %s for task id: %s", self.xcom_key, ti_key
         )
         with create_session() as session:
-            value = session.scalars(
-                XComModel.get_many(
-                    key=self.xcom_key,
-                    run_id=ti_key.run_id,
-                    dag_ids=ti_key.dag_id,
-                    task_ids=ti_key.task_id,
-                    map_indexes=ti_key.map_index,
+            value = (
+                session.execute(
+                    XComModel.get_many(
+                        key=self.xcom_key,
+                        run_id=ti_key.run_id,
+                        dag_ids=ti_key.dag_id,
+                        task_ids=ti_key.task_id,
+                        map_indexes=ti_key.map_index,
+                    ).with_only_columns(XComModel.value)
                 )
-            ).first()
+                .mappings()
+                .first()
+            )
 
         if not value:
             self.log.debug(

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -3596,19 +3596,15 @@ class XComOperatorLink(LoggingMixin):
             "Attempting to retrieve link from XComs with key: %s for task id: %s", self.xcom_key, ti_key
         )
         with create_session() as session:
-            value = (
-                session.execute(
-                    XComModel.get_many(
-                        key=self.xcom_key,
-                        run_id=ti_key.run_id,
-                        dag_ids=ti_key.dag_id,
-                        task_ids=ti_key.task_id,
-                        map_indexes=ti_key.map_index,
-                    ).with_only_columns(XComModel.value)
-                )
-                .mappings()
-                .first()
-            )
+            value = session.execute(
+                XComModel.get_many(
+                    key=self.xcom_key,
+                    run_id=ti_key.run_id,
+                    dag_ids=ti_key.dag_id,
+                    task_ids=ti_key.task_id,
+                    map_indexes=ti_key.map_index,
+                ).with_only_columns(XComModel.value)
+            ).first()
 
         if not value:
             self.log.debug(

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -3597,7 +3597,7 @@ class XComOperatorLink(LoggingMixin):
             "Attempting to retrieve link from XComs with key: %s for task id: %s", self.xcom_key, ti_key
         )
         with create_session() as session:
-            value = session.execute(
+            value = session.scalars(
                 XComModel.get_many(
                     key=self.xcom_key,
                     run_id=ti_key.run_id,

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -99,12 +99,9 @@ from airflow.utils.db import LazySelectSequence
 from airflow.utils.docs import get_docs_url
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.module_loading import import_string, qualname
-from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import NOTSET, ArgNotSet, DagRunTriggeredByType, DagRunType
-from airflow.utils.operator_resources import Resources
-from airflow.utils.session import create_session
-from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from inspect import Parameter

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -3605,7 +3605,6 @@ class XComOperatorLink(LoggingMixin):
                     map_indexes=ti_key.map_index,
                 ).with_only_columns(XComModel.value)
             ).first()
-
         if not value:
             self.log.debug(
                 "No link with name: %s present in XCom as key: %s, returning empty link",

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -408,12 +408,14 @@ class TestXComsSetEndpoint:
 
         assert response.status_code == 201
 
-        stored_value = XComModel.get_many(
-            key="xcom_1",
-            dag_ids=ti.dag_id,
-            task_ids=ti.task_id,
-            run_id=ti.run_id,
-            session=session,
+        stored_value = session.execute(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=ti.dag_id,
+                task_ids=ti.task_id,
+                run_id=ti.run_id,
+                session=session,
+            )
         ).first()
         deserialized_value = XComModel.deserialize_value(stored_value)
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -408,14 +408,14 @@ class TestXComsSetEndpoint:
 
         assert response.status_code == 201
 
-        stored_value = session.scalars(
+        stored_value = session.execute(
             XComModel.get_many(
                 key="xcom_1",
                 dag_ids=ti.dag_id,
                 task_ids=ti.task_id,
                 run_id=ti.run_id,
                 session=session,
-            )
+            ).with_only_columns(XComModel.value)
         ).first()
         deserialized_value = XComModel.deserialize_value(stored_value)
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -414,7 +414,6 @@ class TestXComsSetEndpoint:
                 dag_ids=ti.dag_id,
                 task_ids=ti.task_id,
                 run_id=ti.run_id,
-                session=session,
             ).with_only_columns(XComModel.value)
         ).first()
         deserialized_value = XComModel.deserialize_value(stored_value)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -408,7 +408,7 @@ class TestXComsSetEndpoint:
 
         assert response.status_code == 201
 
-        stored_value = session.execute(
+        stored_value = session.scalars(
             XComModel.get_many(
                 key="xcom_1",
                 dag_ids=ti.dag_id,

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -127,17 +127,13 @@ class TestDeadline:
         # Set up the query chain to return a list of (Deadline, DagRun) pairs
         mock_dagrun = mock.Mock(spec=DagRun, end_date=datetime.now())
         mock_deadline = mock.Mock(spec=Deadline, deadline_time=mock_dagrun.end_date + timedelta(days=365))
-        mock_query = mock_session.query.return_value
-        mock_query.join.return_value = mock_query
-        mock_query.filter.return_value = mock_query
+        mock_query = mock_session.execute.return_value
         mock_query.all.return_value = [(mock_deadline, mock_dagrun)] if conditions else []
 
         result = Deadline.prune_deadlines(conditions=conditions, session=mock_session)
-
         assert result == expected_result
         if conditions:
-            mock_session.query.assert_called_once_with(Deadline, DagRun)
-            mock_session.query.return_value.filter.assert_called_once()  # Assert that the conditions are applied.
+            mock_session.execute.return_value.all.assert_called_once()
             mock_session.delete.assert_called_once_with(mock_deadline)
         else:
             mock_session.query.assert_not_called()

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -271,7 +271,9 @@ def test_submit_event_task_end(mock_utcnow, session, create_task_instance, event
     session.commit()
 
     def get_xcoms(ti):
-        return XComModel.get_many(dag_ids=[ti.dag_id], task_ids=[ti.task_id], run_id=ti.run_id).all()
+        return session.execute(
+            XComModel.get_many(dag_ids=[ti.dag_id], task_ids=[ti.task_id], run_id=ti.run_id)
+        ).all()
 
     # now for the real test
     # first check initial state

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -271,7 +271,7 @@ def test_submit_event_task_end(mock_utcnow, session, create_task_instance, event
     session.commit()
 
     def get_xcoms(ti):
-        return session.execute(
+        return session.scalars(
             XComModel.get_many(dag_ids=[ti.dag_id], task_ids=[ti.task_id], run_id=ti.run_id)
         ).all()
 

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -210,15 +210,19 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_one")
     def test_xcom_get_one(self, session, task_instance):
-        stored_value = session.scalars(
-            XComModel.get_many(
-                key="xcom_1",
-                dag_ids=task_instance.dag_id,
-                task_ids=task_instance.task_id,
-                run_id=task_instance.run_id,
-                session=session,
+        stored_value = (
+            session.execute(
+                XComModel.get_many(
+                    key="xcom_1",
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                ).with_only_columns(XComModel.value)
             )
-        ).first()
+            .mappings()
+            .first()
+        )
         assert XComModel.deserialize_value(stored_value) == {"key": "value"}
 
     @pytest.fixture
@@ -258,32 +262,40 @@ class TestXComGet:
 
     def test_xcom_get_one_from_prior_date(self, session, tis_for_xcom_get_one_from_prior_date):
         _, ti2 = tis_for_xcom_get_one_from_prior_date
-        retrieved_value = session.scalars(
-            XComModel.get_many(
-                run_id=ti2.run_id,
-                key="xcom_1",
-                task_ids="task_1",
-                dag_ids="dag",
-                include_prior_dates=True,
-                session=session,
+        retrieved_value = (
+            session.execute(
+                XComModel.get_many(
+                    run_id=ti2.run_id,
+                    key="xcom_1",
+                    task_ids="task_1",
+                    dag_ids="dag",
+                    include_prior_dates=True,
+                    session=session,
+                ).with_only_columns(XComModel.value)
             )
-        ).first()
+            .mappings()
+            .first()
+        )
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
 
     def test_xcom_get_one_from_prior_date_with_no_logical_dates(
         self, session, tis_for_xcom_get_one_from_prior_date_without_logical_date
     ):
         _, ti2 = tis_for_xcom_get_one_from_prior_date_without_logical_date
-        retrieved_value = session.scalars(
-            XComModel.get_many(
-                run_id=ti2.run_id,
-                key="xcom_1",
-                task_ids="task_1",
-                dag_ids="dag",
-                include_prior_dates=True,
-                session=session,
+        retrieved_value = (
+            session.execute(
+                XComModel.get_many(
+                    run_id=ti2.run_id,
+                    key="xcom_1",
+                    task_ids="task_1",
+                    dag_ids="dag",
+                    include_prior_dates=True,
+                    session=session,
+                ).with_only_columns(XComModel.value)
             )
-        ).first()
+            .mappings()
+            .first()
+        )
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
 
     @pytest.fixture
@@ -313,13 +325,15 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_many_multiple_tasks")
     def test_xcom_get_many_multiple_tasks(self, session, task_instance):
-        stored_xcoms = XComModel.get_many(
-            key="xcom_1",
-            dag_ids=task_instance.dag_id,
-            task_ids=["task_1", "task_2"],
-            run_id=task_instance.run_id,
-            session=session,
-        )
+        stored_xcoms = session.scalars(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=task_instance.dag_id,
+                task_ids=["task_1", "task_2"],
+                run_id=task_instance.run_id,
+                session=session,
+            )
+        ).all()
         sorted_values = [x.value for x in sorted(stored_xcoms, key=operator.attrgetter("task_id"))]
         assert sorted_values == [json.dumps({"key1": "value1"}), json.dumps({"key2": "value2"})]
 
@@ -336,14 +350,16 @@ class TestXComGet:
     def test_xcom_get_many_from_prior_dates(self, session, tis_for_xcom_get_many_from_prior_dates):
         ti1, ti2 = tis_for_xcom_get_many_from_prior_dates
         session.add(ti1)  # for some reason, ti1 goes out of the session scope
-        stored_xcoms = XComModel.get_many(
-            run_id=ti2.run_id,
-            key="xcom_1",
-            dag_ids="dag",
-            task_ids="task_1",
-            include_prior_dates=True,
-            session=session,
-        )
+        stored_xcoms = session.scalars(
+            XComModel.get_many(
+                run_id=ti2.run_id,
+                key="xcom_1",
+                dag_ids="dag",
+                task_ids="task_1",
+                include_prior_dates=True,
+                session=session,
+            )
+        ).all()
 
         # The retrieved XComs should be ordered by logical date, latest first.
         assert [x.value for x in stored_xcoms] == list(
@@ -480,15 +496,19 @@ class TestXComRoundTrip:
         """Test that XComModel serialization and deserialization work as expected."""
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value=value)
 
-        stored_value = session.scalars(
-            XComModel.get_many(
-                key="xcom_1",
-                dag_ids=task_instance.dag_id,
-                task_ids=task_instance.task_id,
-                run_id=task_instance.run_id,
-                session=session,
+        stored_value = (
+            session.execute(
+                XComModel.get_many(
+                    key="xcom_1",
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                ).with_only_columns(XComModel.value)
             )
-        ).first()
+            .mappings()
+            .first()
+        )
         deserialized_value = XComModel.deserialize_value(stored_value)
 
         assert deserialized_value == expected_value

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -210,19 +210,15 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_one")
     def test_xcom_get_one(self, session, task_instance):
-        stored_value = (
-            session.execute(
-                XComModel.get_many(
-                    key="xcom_1",
-                    dag_ids=task_instance.dag_id,
-                    task_ids=task_instance.task_id,
-                    run_id=task_instance.run_id,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            )
-            .mappings()
-            .first()
-        )
+        stored_value = session.execute(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            ).with_only_columns(XComModel.value)
+        ).first()
         assert XComModel.deserialize_value(stored_value) == {"key": "value"}
 
     @pytest.fixture
@@ -262,40 +258,32 @@ class TestXComGet:
 
     def test_xcom_get_one_from_prior_date(self, session, tis_for_xcom_get_one_from_prior_date):
         _, ti2 = tis_for_xcom_get_one_from_prior_date
-        retrieved_value = (
-            session.execute(
-                XComModel.get_many(
-                    run_id=ti2.run_id,
-                    key="xcom_1",
-                    task_ids="task_1",
-                    dag_ids="dag",
-                    include_prior_dates=True,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            )
-            .mappings()
-            .first()
-        )
+        retrieved_value = session.execute(
+            XComModel.get_many(
+                run_id=ti2.run_id,
+                key="xcom_1",
+                task_ids="task_1",
+                dag_ids="dag",
+                include_prior_dates=True,
+                session=session,
+            ).with_only_columns(XComModel.value)
+        ).first()
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
 
     def test_xcom_get_one_from_prior_date_with_no_logical_dates(
         self, session, tis_for_xcom_get_one_from_prior_date_without_logical_date
     ):
         _, ti2 = tis_for_xcom_get_one_from_prior_date_without_logical_date
-        retrieved_value = (
-            session.execute(
-                XComModel.get_many(
-                    run_id=ti2.run_id,
-                    key="xcom_1",
-                    task_ids="task_1",
-                    dag_ids="dag",
-                    include_prior_dates=True,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            )
-            .mappings()
-            .first()
-        )
+        retrieved_value = session.execute(
+            XComModel.get_many(
+                run_id=ti2.run_id,
+                key="xcom_1",
+                task_ids="task_1",
+                dag_ids="dag",
+                include_prior_dates=True,
+                session=session,
+            ).with_only_columns(XComModel.value)
+        ).first()
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
 
     @pytest.fixture
@@ -496,19 +484,15 @@ class TestXComRoundTrip:
         """Test that XComModel serialization and deserialization work as expected."""
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value=value)
 
-        stored_value = (
-            session.execute(
-                XComModel.get_many(
-                    key="xcom_1",
-                    dag_ids=task_instance.dag_id,
-                    task_ids=task_instance.task_id,
-                    run_id=task_instance.run_id,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            )
-            .mappings()
-            .first()
-        )
+        stored_value = session.execute(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            ).with_only_columns(XComModel.value)
+        ).first()
         deserialized_value = XComModel.deserialize_value(stored_value)
 
         assert deserialized_value == expected_value

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -210,12 +210,14 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_one")
     def test_xcom_get_one(self, session, task_instance):
-        stored_value = XComModel.get_many(
-            key="xcom_1",
-            dag_ids=task_instance.dag_id,
-            task_ids=task_instance.task_id,
-            run_id=task_instance.run_id,
-            session=session,
+        stored_value = session.execute(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            )
         ).first()
         assert XComModel.deserialize_value(stored_value) == {"key": "value"}
 
@@ -256,13 +258,15 @@ class TestXComGet:
 
     def test_xcom_get_one_from_prior_date(self, session, tis_for_xcom_get_one_from_prior_date):
         _, ti2 = tis_for_xcom_get_one_from_prior_date
-        retrieved_value = XComModel.get_many(
-            run_id=ti2.run_id,
-            key="xcom_1",
-            task_ids="task_1",
-            dag_ids="dag",
-            include_prior_dates=True,
-            session=session,
+        retrieved_value = session.execute(
+            XComModel.get_many(
+                run_id=ti2.run_id,
+                key="xcom_1",
+                task_ids="task_1",
+                dag_ids="dag",
+                include_prior_dates=True,
+                session=session,
+            )
         ).first()
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
 
@@ -270,13 +274,15 @@ class TestXComGet:
         self, session, tis_for_xcom_get_one_from_prior_date_without_logical_date
     ):
         _, ti2 = tis_for_xcom_get_one_from_prior_date_without_logical_date
-        retrieved_value = XComModel.get_many(
-            run_id=ti2.run_id,
-            key="xcom_1",
-            task_ids="task_1",
-            dag_ids="dag",
-            include_prior_dates=True,
-            session=session,
+        retrieved_value = session.execute(
+            XComModel.get_many(
+                run_id=ti2.run_id,
+                key="xcom_1",
+                task_ids="task_1",
+                dag_ids="dag",
+                include_prior_dates=True,
+                session=session,
+            )
         ).first()
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
 
@@ -286,12 +292,14 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_many_single_argument_value")
     def test_xcom_get_many_single_argument_value(self, session, task_instance):
-        stored_xcoms = XComModel.get_many(
-            key="xcom_1",
-            dag_ids=task_instance.dag_id,
-            task_ids=task_instance.task_id,
-            run_id=task_instance.run_id,
-            session=session,
+        stored_xcoms = session.execute(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            )
         ).all()
         assert len(stored_xcoms) == 1
         assert stored_xcoms[0].key == "xcom_1"
@@ -472,12 +480,14 @@ class TestXComRoundTrip:
         """Test that XComModel serialization and deserialization work as expected."""
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value=value)
 
-        stored_value = XComModel.get_many(
-            key="xcom_1",
-            dag_ids=task_instance.dag_id,
-            task_ids=task_instance.task_id,
-            run_id=task_instance.run_id,
-            session=session,
+        stored_value = session.execute(
+            XComModel.get_many(
+                key="xcom_1",
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            )
         ).first()
         deserialized_value = XComModel.deserialize_value(stored_value)
 

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -210,7 +210,7 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_one")
     def test_xcom_get_one(self, session, task_instance):
-        stored_value = session.execute(
+        stored_value = session.scalars(
             XComModel.get_many(
                 key="xcom_1",
                 dag_ids=task_instance.dag_id,
@@ -258,7 +258,7 @@ class TestXComGet:
 
     def test_xcom_get_one_from_prior_date(self, session, tis_for_xcom_get_one_from_prior_date):
         _, ti2 = tis_for_xcom_get_one_from_prior_date
-        retrieved_value = session.execute(
+        retrieved_value = session.scalars(
             XComModel.get_many(
                 run_id=ti2.run_id,
                 key="xcom_1",
@@ -274,7 +274,7 @@ class TestXComGet:
         self, session, tis_for_xcom_get_one_from_prior_date_without_logical_date
     ):
         _, ti2 = tis_for_xcom_get_one_from_prior_date_without_logical_date
-        retrieved_value = session.execute(
+        retrieved_value = session.scalars(
             XComModel.get_many(
                 run_id=ti2.run_id,
                 key="xcom_1",
@@ -292,7 +292,7 @@ class TestXComGet:
 
     @pytest.mark.usefixtures("setup_for_xcom_get_many_single_argument_value")
     def test_xcom_get_many_single_argument_value(self, session, task_instance):
-        stored_xcoms = session.execute(
+        stored_xcoms = session.scalars(
             XComModel.get_many(
                 key="xcom_1",
                 dag_ids=task_instance.dag_id,
@@ -480,7 +480,7 @@ class TestXComRoundTrip:
         """Test that XComModel serialization and deserialization work as expected."""
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value=value)
 
-        stored_value = session.execute(
+        stored_value = session.scalars(
             XComModel.get_many(
                 key="xcom_1",
                 dag_ids=task_instance.dag_id,

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -216,7 +216,6 @@ class TestXComGet:
                 dag_ids=task_instance.dag_id,
                 task_ids=task_instance.task_id,
                 run_id=task_instance.run_id,
-                session=session,
             ).with_only_columns(XComModel.value)
         ).first()
         assert XComModel.deserialize_value(stored_value) == {"key": "value"}
@@ -265,7 +264,6 @@ class TestXComGet:
                 task_ids="task_1",
                 dag_ids="dag",
                 include_prior_dates=True,
-                session=session,
             ).with_only_columns(XComModel.value)
         ).first()
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
@@ -281,7 +279,6 @@ class TestXComGet:
                 task_ids="task_1",
                 dag_ids="dag",
                 include_prior_dates=True,
-                session=session,
             ).with_only_columns(XComModel.value)
         ).first()
         assert XComModel.deserialize_value(retrieved_value) == {"key": "value"}
@@ -298,7 +295,6 @@ class TestXComGet:
                 dag_ids=task_instance.dag_id,
                 task_ids=task_instance.task_id,
                 run_id=task_instance.run_id,
-                session=session,
             )
         ).all()
         assert len(stored_xcoms) == 1
@@ -319,7 +315,6 @@ class TestXComGet:
                 dag_ids=task_instance.dag_id,
                 task_ids=["task_1", "task_2"],
                 run_id=task_instance.run_id,
-                session=session,
             )
         ).all()
         sorted_values = [x.value for x in sorted(stored_xcoms, key=operator.attrgetter("task_id"))]
@@ -345,7 +340,6 @@ class TestXComGet:
                 dag_ids="dag",
                 task_ids="task_1",
                 include_prior_dates=True,
-                session=session,
             )
         ).all()
 
@@ -363,7 +357,6 @@ class TestXComGet:
                 dag_ids=task_instance.dag_id,
                 task_ids=task_instance.task_id,
                 run_id=task_instance.run_id,
-                session=session,
             )
 
 
@@ -490,7 +483,6 @@ class TestXComRoundTrip:
                 dag_ids=task_instance.dag_id,
                 task_ids=task_instance.task_id,
                 run_id=task_instance.run_id,
-                session=session,
             ).with_only_columns(XComModel.value)
         ).first()
         deserialized_value = XComModel.deserialize_value(stored_value)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1463,7 +1463,10 @@ class TestKubernetesPodOperator:
 
         pod, _ = self.run_pod(k)
         if AIRFLOW_V_3_0_PLUS:
-            pod_name = XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_name").first()
+            with create_session() as session:
+                pod_name = session.scalars(
+                    XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_name")
+                ).first()
             pod_namespace = XCom.get_many(
                 run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
             ).first()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -51,10 +51,14 @@ from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
+<<<<<<< HEAD
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+=======
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+>>>>>>> 95bb79917c (fix tests)
 
-if AIRFLOW_V_3_0_PLUS:
+if AIRFLOW_V_3_0_PLUS or AIRFLOW_V_3_1_PLUS:
     from airflow.models.xcom import XComModel as XCom
 else:
     from airflow.models.xcom import XCom  # type: ignore[no-redef]
@@ -112,8 +116,43 @@ def create_context(task, persist_to_db=False, map_index=None):
         dag = DAG(dag_id="dag", schedule=None, start_date=pendulum.now())
         dag.add_task(task)
     now = timezone.utcnow()
+<<<<<<< HEAD
     if AIRFLOW_V_3_0_PLUS:
         sync_dag_to_db(dag)
+=======
+    if AIRFLOW_V_3_1_PLUS:
+        with create_session() as session:
+            from airflow.models.dagbundle import DagBundleModel
+
+            bundle_name = "testing"
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+            session.add(DagModel(dag_id=dag.dag_id, bundle_name=bundle_name))
+            session.commit()
+        dag.sync_to_db()
+        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        dag_run = DagRun(
+            run_id=DagRun.generate_run_id(
+                run_type=DagRunType.MANUAL, logical_date=DEFAULT_DATE, run_after=DEFAULT_DATE
+            ),
+            run_type=DagRunType.MANUAL,
+            dag_id=dag.dag_id,
+            logical_date=now,
+            data_interval=(now, now),
+            run_after=now,
+        )
+    elif AIRFLOW_V_3_0_PLUS:
+        with create_session() as session:
+            from airflow.models.dagbundle import DagBundleModel
+
+            bundle_name = "testing"
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+            session.add(DagModel(dag_id=dag.dag_id, bundle_name=bundle_name))
+            session.commit()
+        dag.sync_to_db()
+        SerializedDagModel.write_dag(dag, bundle_name="testing")
+>>>>>>> 95bb79917c (fix tests)
         dag_run = DagRun(
             run_id=DagRun.generate_run_id(
                 run_type=DagRunType.MANUAL, logical_date=DEFAULT_DATE, run_after=DEFAULT_DATE
@@ -1462,7 +1501,7 @@ class TestKubernetesPodOperator:
         )
 
         pod, _ = self.run_pod(k)
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             with create_session() as session:
                 pod_name = session.execute(
                     XCom.get_many(
@@ -1474,6 +1513,20 @@ class TestKubernetesPodOperator:
                         run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
                     ).with_only_columns(XCom.value)
                 ).first()
+
+            pod_name = XCom.deserialize_value(pod_name)
+            pod_namespace = XCom.deserialize_value(pod_namespace)
+        elif AIRFLOW_V_3_0_PLUS:
+            pod_name = (
+                XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_name")
+                .with_entities(XCom.value)
+                .first()
+            )
+            pod_namespace = (
+                XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace")
+                .with_entities(XCom.value)
+                .first()
+            )
 
             pod_name = XCom.deserialize_value(pod_name)
             pod_namespace = XCom.deserialize_value(pod_namespace)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -52,7 +52,6 @@ from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
 from tests_common.test_utils.dag import sync_dag_to_db
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS or AIRFLOW_V_3_1_PLUS:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -113,29 +113,8 @@ def create_context(task, persist_to_db=False, map_index=None):
         dag = DAG(dag_id="dag", schedule=None, start_date=pendulum.now())
         dag.add_task(task)
     now = timezone.utcnow()
-<<<<<<< HEAD
-<<<<<<< HEAD
     if AIRFLOW_V_3_0_PLUS:
         sync_dag_to_db(dag)
-=======
-    if AIRFLOW_V_3_1_PLUS:
-        with create_session() as session:
-            from airflow.models.dagbundle import DagBundleModel
-=======
->>>>>>> 0fe9e03c90 (adjust import statements and remove same code)
-
-    if AIRFLOW_V_3_0_PLUS:
-        with create_session() as session:
-            from airflow.models.dagbundle import DagBundleModel
-
-            bundle_name = "testing"
-            session.add(DagBundleModel(name=bundle_name))
-            session.flush()
-            session.add(DagModel(dag_id=dag.dag_id, bundle_name=bundle_name))
-            session.commit()
-        dag.sync_to_db()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
->>>>>>> 95bb79917c (fix tests)
         dag_run = DagRun(
             run_id=DagRun.generate_run_id(
                 run_type=DagRunType.MANUAL, logical_date=DEFAULT_DATE, run_after=DEFAULT_DATE
@@ -1484,33 +1463,24 @@ class TestKubernetesPodOperator:
         )
 
         pod, _ = self.run_pod(k)
-        if AIRFLOW_V_3_1_PLUS:
-            with create_session() as session:
-                pod_name = session.execute(
-                    XCom.get_many(
-                        run_id=self.dag_run.run_id, task_ids="task", key="pod_name"
-                    ).with_only_columns(XCom.value)
+        if AIRFLOW_V_3_0_PLUS:
+            if AIRFLOW_V_3_1_PLUS:
+                with create_session() as session:
+                    pod_name = session.execute(
+                        XCom.get_many(
+                            run_id=self.dag_run.run_id, task_ids="task", key="pod_name"
+                        ).with_only_columns(XCom.value)
+                    ).first()
+                    pod_namespace = session.execute(
+                        XCom.get_many(
+                            run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
+                        ).with_only_columns(XCom.value)
+                    ).first()
+            else:
+                pod_name = XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_name").first()
+                pod_namespace = XCom.get_many(
+                    run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
                 ).first()
-                pod_namespace = session.execute(
-                    XCom.get_many(
-                        run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
-                    ).with_only_columns(XCom.value)
-                ).first()
-
-            pod_name = XCom.deserialize_value(pod_name)
-            pod_namespace = XCom.deserialize_value(pod_namespace)
-        elif AIRFLOW_V_3_0_PLUS:
-            pod_name = (
-                XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_name")
-                .with_entities(XCom.value)
-                .first()
-            )
-            pod_namespace = (
-                XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace")
-                .with_entities(XCom.value)
-                .first()
-            )
-
             pod_name = XCom.deserialize_value(pod_name)
             pod_namespace = XCom.deserialize_value(pod_namespace)
         else:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1464,24 +1464,16 @@ class TestKubernetesPodOperator:
         pod, _ = self.run_pod(k)
         if AIRFLOW_V_3_0_PLUS:
             with create_session() as session:
-                pod_name = (
-                    session.execute(
-                        XCom.get_many(
-                            run_id=self.dag_run.run_id, task_ids="task", key="pod_name"
-                        ).with_only_columns(XCom.value)
-                    )
-                    .mappings()
-                    .first()
-                )
-            pod_namespace = (
-                session.execute(
+                pod_name = session.execute(
+                    XCom.get_many(
+                        run_id=self.dag_run.run_id, task_ids="task", key="pod_name"
+                    ).with_only_columns(XCom.value)
+                ).first()
+                pod_namespace = session.execute(
                     XCom.get_many(
                         run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
                     ).with_only_columns(XCom.value)
-                )
-                .mappings()
-                .first()
-            )
+                ).first()
 
             pod_name = XCom.deserialize_value(pod_name)
             pod_namespace = XCom.deserialize_value(pod_namespace)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -51,12 +51,9 @@ from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
-<<<<<<< HEAD
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-=======
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
->>>>>>> 95bb79917c (fix tests)
 
 if AIRFLOW_V_3_0_PLUS or AIRFLOW_V_3_1_PLUS:
     from airflow.models.xcom import XComModel as XCom
@@ -117,31 +114,17 @@ def create_context(task, persist_to_db=False, map_index=None):
         dag.add_task(task)
     now = timezone.utcnow()
 <<<<<<< HEAD
+<<<<<<< HEAD
     if AIRFLOW_V_3_0_PLUS:
         sync_dag_to_db(dag)
 =======
     if AIRFLOW_V_3_1_PLUS:
         with create_session() as session:
             from airflow.models.dagbundle import DagBundleModel
+=======
+>>>>>>> 0fe9e03c90 (adjust import statements and remove same code)
 
-            bundle_name = "testing"
-            session.add(DagBundleModel(name=bundle_name))
-            session.flush()
-            session.add(DagModel(dag_id=dag.dag_id, bundle_name=bundle_name))
-            session.commit()
-        dag.sync_to_db()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
-        dag_run = DagRun(
-            run_id=DagRun.generate_run_id(
-                run_type=DagRunType.MANUAL, logical_date=DEFAULT_DATE, run_after=DEFAULT_DATE
-            ),
-            run_type=DagRunType.MANUAL,
-            dag_id=dag.dag_id,
-            logical_date=now,
-            data_interval=(now, now),
-            run_after=now,
-        )
-    elif AIRFLOW_V_3_0_PLUS:
+    if AIRFLOW_V_3_0_PLUS:
         with create_session() as session:
             from airflow.models.dagbundle import DagBundleModel
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1464,12 +1464,24 @@ class TestKubernetesPodOperator:
         pod, _ = self.run_pod(k)
         if AIRFLOW_V_3_0_PLUS:
             with create_session() as session:
-                pod_name = session.scalars(
-                    XCom.get_many(run_id=self.dag_run.run_id, task_ids="task", key="pod_name")
-                ).first()
-            pod_namespace = XCom.get_many(
-                run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
-            ).first()
+                pod_name = (
+                    session.execute(
+                        XCom.get_many(
+                            run_id=self.dag_run.run_id, task_ids="task", key="pod_name"
+                        ).with_only_columns(XCom.value)
+                    )
+                    .mappings()
+                    .first()
+                )
+            pod_namespace = (
+                session.execute(
+                    XCom.get_many(
+                        run_id=self.dag_run.run_id, task_ids="task", key="pod_namespace"
+                    ).with_only_columns(XCom.value)
+                )
+                .mappings()
+                .first()
+            )
 
             pod_name = XCom.deserialize_value(pod_name)
             pod_namespace = XCom.deserialize_value(pod_namespace)

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -138,19 +138,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = (
-                session.execute(
-                    XComModel.get_many(
-                        key=XCOM_RETURN_KEY,
-                        dag_ids=task_instance.dag_id,
-                        task_ids=task_instance.task_id,
-                        run_id=task_instance.run_id,
-                        session=session,
-                    ).with_only_columns(XComModel.value)
-                )
-                .mappings()
-                .first()
-            )
+            res = session.execute(
+                XComModel.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                ).with_only_columns(XComModel.value)
+            ).first()
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -189,7 +185,7 @@ class TestXComObjectStorageBackend:
                 session=session,
             )
             assert str(p) == XComModel.deserialize_value(
-                session.execute(qry.with_only_columns(XComModel.value)).mappings().first()
+                session.execute(qry.with_only_columns(XComModel.value)).first()
             )
         else:
             qry = XCom.get_many(
@@ -230,19 +226,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = (
-                session.execute(
-                    XComModel.get_many(
-                        key=XCOM_RETURN_KEY,
-                        dag_ids=task_instance.dag_id,
-                        task_ids=task_instance.task_id,
-                        run_id=task_instance.run_id,
-                        session=session,
-                    ).with_only_columns(XComModel.value)
-                )
-                .mappings()
-                .first()
-            )
+            res = session.execute(
+                XComModel.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                ).with_only_columns(XComModel.value)
+            ).first()
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -285,19 +277,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 map_index=task_instance.map_index,
             )
-            value = (
-                session.execute(
-                    XComModel.get_many(
-                        key=XCOM_RETURN_KEY,
-                        dag_ids=task_instance.dag_id,
-                        task_ids=task_instance.task_id,
-                        run_id=task_instance.run_id,
-                        session=session,
-                    ).with_only_columns(XComModel.value)
-                )
-                .mappings()
-                .first()
-            )
+            value = session.execute(
+                XComModel.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                ).with_only_columns(XComModel.value)
+            ).first()
         else:
             XCom.clear(
                 dag_id=task_instance.dag_id,
@@ -339,19 +327,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = (
-                session.execute(
-                    XComModel.get_many(
-                        key=XCOM_RETURN_KEY,
-                        dag_ids=task_instance.dag_id,
-                        task_ids=task_instance.task_id,
-                        run_id=task_instance.run_id,
-                        session=session,
-                    ).with_only_columns(XComModel.value)
-                )
-                .mappings()
-                .first()
-            )
+            res = session.execute(
+                XComModel.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                ).with_only_columns(XComModel.value)
+            ).first()
             data = XComModel.deserialize_value(res)
         else:
             res = (

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -28,11 +28,11 @@ from airflow.utils import timezone
 
 from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, XCOM_RETURN_KEY
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS, XCOM_RETURN_KEY
 
 pytestmark = [pytest.mark.db_test]
 
-if AIRFLOW_V_3_0_PLUS:
+if AIRFLOW_V_3_1_PLUS:
     from airflow.models.xcom import XComModel
     from airflow.sdk import ObjectStoragePath
     from airflow.sdk.execution_time.comms import XComResult
@@ -104,7 +104,7 @@ class TestXComObjectStorageBackend:
             run_id=task_instance.run_id,
         )
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             # When using XComObjectStorageBackend, the value is stored in the db is serialized with json dumps
             # so we need to mimic that same behavior below.
             mock_supervisor_comms.send.return_value = XComResult(key="return_value", value={"key": "value"})
@@ -129,7 +129,7 @@ class TestXComObjectStorageBackend:
             run_id=task_instance.run_id,
         )
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             XComModel.set(
                 key=XCOM_RETURN_KEY,
                 value=self.path,
@@ -165,7 +165,7 @@ class TestXComObjectStorageBackend:
         p = XComObjectStorageBackend._get_full_path(data)
         assert p.exists() is True
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             mock_supervisor_comms.send.return_value = XComResult(
                 key=XCOM_RETURN_KEY, value={"key": "bigvaluebigvaluebigvalue" * 100}
             )
@@ -176,7 +176,7 @@ class TestXComObjectStorageBackend:
         )
         assert value == {"key": "bigvaluebigvaluebigvalue" * 100}
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             qry = XComModel.get_many(
                 key=XCOM_RETURN_KEY,
                 dag_ids=task_instance.dag_id,
@@ -211,7 +211,7 @@ class TestXComObjectStorageBackend:
             run_id=task_instance.run_id,
         )
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             if hasattr(mock_supervisor_comms, "send_request"):
                 # Back-compat of task-sdk. Only affects us when we manually create these objects in tests.
                 last_call = mock_supervisor_comms.send_request.call_args_list[-1]
@@ -252,7 +252,7 @@ class TestXComObjectStorageBackend:
         p = XComObjectStorageBackend._get_full_path(data)
         assert p.exists() is True
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             mock_supervisor_comms.send.return_value = XComResult(
                 key=XCOM_RETURN_KEY, value={"key": "superlargevalue" * 100}
             )
@@ -262,7 +262,7 @@ class TestXComObjectStorageBackend:
         )
         assert value
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             mock_supervisor_comms.send.return_value = XComResult(key=XCOM_RETURN_KEY, value=path)
             XCom.delete(
                 dag_id=task_instance.dag_id,
@@ -318,7 +318,7 @@ class TestXComObjectStorageBackend:
             run_id=task_instance.run_id,
         )
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             XComModel.set(
                 key=XCOM_RETURN_KEY,
                 value=self.path + ".gz",
@@ -353,7 +353,7 @@ class TestXComObjectStorageBackend:
 
         assert data.endswith(".gz")
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_1_PLUS:
             mock_supervisor_comms.send.return_value = XComResult(
                 key=XCOM_RETURN_KEY, value={"key": "superlargevalue" * 100}
             )

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -26,9 +26,9 @@ from airflow.providers.common.io.xcom.backend import XComObjectStorageBackend
 from airflow.providers.standard.operators.empty import EmptyOperator
 
 try:
-    from airflow.utils import timezone  # type: ignore[attr-defined]
-except ImportError:
     from airflow.sdk import timezone
+except ImportError:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -224,7 +224,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.scalars(
+            res = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
@@ -232,7 +232,7 @@ class TestXComObjectStorageBackend:
                     run_id=task_instance.run_id,
                     session=session,
                 ).with_only_columns(XComModel.value)
-            ).first()
+            ).mappings().first()
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -275,7 +275,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 map_index=task_instance.map_index,
             )
-            value = session.scalars(
+            value = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
@@ -283,7 +283,7 @@ class TestXComObjectStorageBackend:
                     run_id=task_instance.run_id,
                     session=session,
                 ).with_only_columns(XComModel.value)
-            ).first()
+            ).mappings().first()
         else:
             XCom.clear(
                 dag_id=task_instance.dag_id,
@@ -325,7 +325,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.scalars(
+            res = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
@@ -333,7 +333,7 @@ class TestXComObjectStorageBackend:
                     run_id=task_instance.run_id,
                     session=session,
                 ).with_only_columns(XComModel.value)
-            ).first()
+            ).mappings().first()
             data = XComModel.deserialize_value(res)
         else:
             res = (

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -24,7 +24,11 @@ import pytest
 import airflow.models.xcom
 from airflow.providers.common.io.xcom.backend import XComObjectStorageBackend
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.utils import timezone
+
+try:
+    from airflow.utils import timezone  # type: ignore[attr-defined]
+except ImportError:
+    from airflow.sdk import timezone
 
 from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars
@@ -146,7 +150,6 @@ class TestXComObjectStorageBackend:
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
-                    session=session,
                 ).with_only_columns(XComModel.value)
             ).first()
             data = XComModel.deserialize_value(res)
@@ -205,7 +208,6 @@ class TestXComObjectStorageBackend:
                 dag_ids=task_instance.dag_id,
                 task_ids=task_instance.task_id,
                 run_id=task_instance.run_id,
-                session=session,
             )
             assert str(p) == XComModel.deserialize_value(
                 session.execute(qry.with_only_columns(XComModel.value)).first()
@@ -264,7 +266,6 @@ class TestXComObjectStorageBackend:
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
-                    session=session,
                 ).with_only_columns(XComModel.value)
             ).first()
             data = XComModel.deserialize_value(res)
@@ -342,7 +343,6 @@ class TestXComObjectStorageBackend:
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
-                    session=session,
                 ).with_only_columns(XComModel.value)
             ).first()
         elif AIRFLOW_V_3_0_PLUS:
@@ -418,7 +418,6 @@ class TestXComObjectStorageBackend:
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
-                    session=session,
                 ).with_only_columns(XComModel.value)
             ).first()
             data = XComModel.deserialize_value(res)

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -441,8 +441,6 @@ class TestXComObjectStorageBackend:
                 .with_entities(XComModel.value)
                 .first()
             )
-            print(res)
-            print(type(res))
             data = XComModel.deserialize_value(res)
         else:
             res = (

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -138,7 +138,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.execute(
+            res = session.scalars(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
@@ -184,7 +184,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 session=session,
             )
-            assert str(p) == XComModel.deserialize_value(session.execute(qry).first())
+            assert str(p) == XComModel.deserialize_value(session.scalars(qry).first())
         else:
             qry = XCom.get_many(
                 key=XCOM_RETURN_KEY,
@@ -224,7 +224,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.execute(
+            res = session.scalars(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
@@ -275,7 +275,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 map_index=task_instance.map_index,
             )
-            value = session.execute(
+            value = session.scalars(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
@@ -325,7 +325,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.execute(
+            res = session.scalars(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -345,7 +345,7 @@ class TestXComObjectStorageBackend:
                     session=session,
                 ).with_only_columns(XComModel.value)
             ).first()
-        if AIRFLOW_V_3_0_PLUS:
+        elif AIRFLOW_V_3_0_PLUS:
             mock_supervisor_comms.send.return_value = XComResult(key=XCOM_RETURN_KEY, value=path)
             XCom.delete(
                 dag_id=task_instance.dag_id,
@@ -423,15 +423,9 @@ class TestXComObjectStorageBackend:
             ).first()
             data = XComModel.deserialize_value(res)
         elif AIRFLOW_V_3_0_PLUS:
-            session.add(task_instance)
-            session.commit()
-
-            XCom = resolve_xcom_backend()
-            airflow.models.xcom.XCom = XCom
-
-            XCom.set(
+            XComModel.set(
                 key=XCOM_RETURN_KEY,
-                value={"key": "superlargevalue" * 100},
+                value=self.path + ".gz",
                 dag_id=task_instance.dag_id,
                 task_id=task_instance.task_id,
                 run_id=task_instance.run_id,
@@ -448,6 +442,8 @@ class TestXComObjectStorageBackend:
                 .with_entities(XComModel.value)
                 .first()
             )
+            print(res)
+            print(type(res))
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -465,7 +461,7 @@ class TestXComObjectStorageBackend:
 
         assert data.endswith(".gz")
 
-        if AIRFLOW_V_3_1_PLUS:
+        if AIRFLOW_V_3_0_PLUS:
             mock_supervisor_comms.send.return_value = XComResult(
                 key=XCOM_RETURN_KEY, value={"key": "superlargevalue" * 100}
             )

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -138,17 +138,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = (
+            res = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
                     session=session,
-                )
-                .with_entities(XComModel.value)
-                .first()
-            )
+                ).with_only_columns(XComModel.value)
+            ).first()
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -186,7 +184,7 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 session=session,
             )
-            assert str(p) == XComModel.deserialize_value(qry.first())
+            assert str(p) == XComModel.deserialize_value(session.execute(qry).first())
         else:
             qry = XCom.get_many(
                 key=XCOM_RETURN_KEY,
@@ -226,17 +224,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = (
+            res = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
                     session=session,
-                )
-                .with_entities(XComModel.value)
-                .first()
-            )
+                ).with_only_columns(XComModel.value)
+            ).first()
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -279,17 +275,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 map_index=task_instance.map_index,
             )
-            value = (
+            value = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
                     session=session,
-                )
-                .with_entities(XComModel.value)
-                .first()
-            )
+                ).with_only_columns(XComModel.value)
+            ).first()
         else:
             XCom.clear(
                 dag_id=task_instance.dag_id,
@@ -331,17 +325,15 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = (
+            res = session.execute(
                 XComModel.get_many(
                     key=XCOM_RETURN_KEY,
                     dag_ids=task_instance.dag_id,
                     task_ids=task_instance.task_id,
                     run_id=task_instance.run_id,
                     session=session,
-                )
-                .with_entities(XComModel.value)
-                .first()
-            )
+                ).with_only_columns(XComModel.value)
+            ).first()
             data = XComModel.deserialize_value(res)
         else:
             res = (

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -224,15 +224,19 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.execute(
-                XComModel.get_many(
-                    key=XCOM_RETURN_KEY,
-                    dag_ids=task_instance.dag_id,
-                    task_ids=task_instance.task_id,
-                    run_id=task_instance.run_id,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            ).mappings().first()
+            res = (
+                session.execute(
+                    XComModel.get_many(
+                        key=XCOM_RETURN_KEY,
+                        dag_ids=task_instance.dag_id,
+                        task_ids=task_instance.task_id,
+                        run_id=task_instance.run_id,
+                        session=session,
+                    ).with_only_columns(XComModel.value)
+                )
+                .mappings()
+                .first()
+            )
             data = XComModel.deserialize_value(res)
         else:
             res = (
@@ -275,15 +279,19 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
                 map_index=task_instance.map_index,
             )
-            value = session.execute(
-                XComModel.get_many(
-                    key=XCOM_RETURN_KEY,
-                    dag_ids=task_instance.dag_id,
-                    task_ids=task_instance.task_id,
-                    run_id=task_instance.run_id,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            ).mappings().first()
+            value = (
+                session.execute(
+                    XComModel.get_many(
+                        key=XCOM_RETURN_KEY,
+                        dag_ids=task_instance.dag_id,
+                        task_ids=task_instance.task_id,
+                        run_id=task_instance.run_id,
+                        session=session,
+                    ).with_only_columns(XComModel.value)
+                )
+                .mappings()
+                .first()
+            )
         else:
             XCom.clear(
                 dag_id=task_instance.dag_id,
@@ -325,15 +333,19 @@ class TestXComObjectStorageBackend:
                 run_id=task_instance.run_id,
             )
 
-            res = session.execute(
-                XComModel.get_many(
-                    key=XCOM_RETURN_KEY,
-                    dag_ids=task_instance.dag_id,
-                    task_ids=task_instance.task_id,
-                    run_id=task_instance.run_id,
-                    session=session,
-                ).with_only_columns(XComModel.value)
-            ).mappings().first()
+            res = (
+                session.execute(
+                    XComModel.get_many(
+                        key=XCOM_RETURN_KEY,
+                        dag_ids=task_instance.dag_id,
+                        task_ids=task_instance.task_id,
+                        run_id=task_instance.run_id,
+                        session=session,
+                    ).with_only_columns(XComModel.value)
+                )
+                .mappings()
+                .first()
+            )
             data = XComModel.deserialize_value(res)
         else:
             res = (


### PR DESCRIPTION
Related discussion: [here](https://github.com/apache/airflow/pull/47275#issuecomment-2997115034)

This PR is part of the migration to SQLAlchemy 2.0

Replaced instances of session.query() with select() constructs
Updated methods like XComModel.get_many to return Select objects instead of Query objects
Adjusted dependent code to reflect the updated return types

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
