### PR TITLE
Replace occurences of `get_password` with `password` to ease migration

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/chime.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/chime.py
@@ -66,7 +66,7 @@ class ChimeWebhookHook(HttpHook):
         :return: Endpoint(str) for chime webhook.
         """
         conn = self.get_connection(conn_id)
-        token = conn.get_password()
+        token = conn.password
         if token is None:
             raise AirflowException("Webhook token field is missing and is required.")
         url = conn.schema + "://" + conn.host

--- a/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -84,7 +84,7 @@ class PagerdutyHook(BaseHook):
 
         if pagerduty_conn_id is not None:
             conn = self.get_connection(pagerduty_conn_id)
-            password = conn.get_password()
+            password = conn.password
             if password is not None:
                 self.token = password
 

--- a/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py
+++ b/providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py
@@ -66,7 +66,7 @@ class PagerdutyEventsHook(BaseHook):
 
         if pagerduty_events_conn_id is not None:
             conn = self.get_connection(pagerduty_events_conn_id)
-            password = conn.get_password()
+            password = conn.password
             if password is not None:
                 self.integration_key = password
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


I am working on https://github.com/apache/airflow/pull/51873 and there are some occurrences in providers where they use `get_password` in place of just using `password`.


The SDK connection doesn't have `get_password` and no need to have it because it only exists cos of:

```
    @declared_attr
    def password(cls):
        """Password. The value is decrypted/encrypted when reading/setting the value."""
        return synonym("_password", descriptor=property(cls.get_password, cls.set_password))
```

It defined a dynamic password attribute in a SQLA to Map to the _password column (synonym), not relevant anymore as its a class now.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
