### PR TITLE
Bump google-cloud-bigquery>=3.24.0

### DIFF
--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -83,8 +83,7 @@ dependencies = [
     "google-cloud-bigquery-storage>=2.31.0; python_version >= '3.12'",
     "google-cloud-alloydb>=0.4.0",
     "google-cloud-automl>=2.12.0",
-    # Excluded versions contain bug https://github.com/apache/airflow/issues/39541 which is resolved in 3.24.0
-    "google-cloud-bigquery>=3.4.0,!=3.21.*,!=3.22.0,!=3.23.*",
+    "google-cloud-bigquery>=3.24.0",
     "google-cloud-bigquery-datatransfer>=3.13.0",
     "google-cloud-bigtable>=2.17.0",
     "google-cloud-build>=3.31.0",


### PR DESCRIPTION
3.4.0 is very old (released in 2022)
bumping min version to make pip resolution faster