### PR TITLE
Replace models.BaseOperator to Task SDK one for Slack Provider

### DIFF
--- a/providers/slack/src/airflow/providers/slack/operators/slack.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack.py
@@ -25,12 +25,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import Literal
 
 from airflow.providers.slack.hooks.slack import SlackHook
-from airflow.providers.slack.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
+from airflow.providers.slack.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler

--- a/providers/slack/src/airflow/providers/slack/operators/slack.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack.py
@@ -24,8 +24,13 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Literal
 
-from airflow.models import BaseOperator
 from airflow.providers.slack.hooks.slack import SlackHook
+from airflow.providers.slack.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler

--- a/providers/slack/src/airflow/providers/slack/operators/slack_webhook.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack_webhook.py
@@ -22,12 +22,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
-from airflow.providers.slack.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
+from airflow.providers.slack.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler

--- a/providers/slack/src/airflow/providers/slack/operators/slack_webhook.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack_webhook.py
@@ -21,8 +21,13 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
+from airflow.providers.slack.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler

--- a/providers/slack/src/airflow/providers/slack/transfers/base_sql_to_slack.py
+++ b/providers/slack/src/airflow/providers/slack/transfers/base_sql_to_slack.py
@@ -21,7 +21,12 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.models import BaseOperator
+from airflow.providers.slack.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/providers/slack/src/airflow/providers/slack/transfers/base_sql_to_slack.py
+++ b/providers/slack/src/airflow/providers/slack/transfers/base_sql_to_slack.py
@@ -21,12 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.providers.slack.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
+from airflow.providers.slack.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/providers/slack/src/airflow/providers/slack/version_compat.py
+++ b/providers/slack/src/airflow/providers/slack/version_compat.py
@@ -17,35 +17,14 @@
 
 from __future__ import annotations
 
-from functools import cache
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from airflow.version import version
-
-    # noinspection PyUnusedLocal
-    version = version
-
-
-@cache
 def get_base_airflow_version_tuple() -> tuple[int, int, int]:
-    """
-    Get the base Airflow version tuple from the airflow.version module.
+    from packaging.version import Version
 
-    :return: Tuple of (major, minor, micro) version numbers
-    """
-    try:
-        from airflow.version import version
+    from airflow import __version__
 
-        parts = version.split(".")[:3]
-        # Ensure we always have exactly 3 parts, padding with "0" if necessary
-        while len(parts) < 3:
-            parts.append("0")
-        return (int(parts[0]), int(parts[1]), int(parts[2]))
-    except (ImportError, ValueError):
-        # If we can't import the version or parse it, assume we're running
-        # on Airflow 2.x to maintain backward compatibility
-        return (2, 0, 0)
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)

--- a/providers/slack/src/airflow/providers/slack/version_compat.py
+++ b/providers/slack/src/airflow/providers/slack/version_compat.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from functools import cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from airflow.version import version
+
+    # noinspection PyUnusedLocal
+    version = version
+
+
+@cache
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    """
+    Get the base Airflow version tuple from the airflow.version module.
+
+    :return: Tuple of (major, minor, micro) version numbers
+    """
+    try:
+        from airflow.version import version
+
+        parts = version.split(".")[:3]
+        # Ensure we always have exactly 3 parts, padding with "0" if necessary
+        while len(parts) < 3:
+            parts.append("0")
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except (ImportError, ValueError):
+        # If we can't import the version or parse it, assume we're running
+        # on Airflow 2.x to maintain backward compatibility
+        return (2, 0, 0)
+
+
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)

--- a/providers/slack/src/airflow/providers/slack/version_compat.py
+++ b/providers/slack/src/airflow/providers/slack/version_compat.py
@@ -14,7 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+#
+# NOTE! THIS FILE IS COPIED MANUALLY IN OTHER PROVIDERS DELIBERATELY TO AVOID ADDING UNNECESSARY
+# DEPENDENCIES BETWEEN PROVIDERS. IF YOU WANT TO ADD CONDITIONAL CODE IN YOUR PROVIDER THAT DEPENDS
+# ON AIRFLOW VERSION, PLEASE COPY THIS FILE TO THE ROOT PACKAGE OF YOUR PROVIDER AND IMPORT
+# THOSE CONSTANTS FROM IT RATHER THAN IMPORTING THEM FROM ANOTHER PROVIDER OR TEST CODE
+#
 from __future__ import annotations
 
 
@@ -28,3 +33,13 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "BaseOperator",
+]


### PR DESCRIPTION
The Providers should use the BaseOperator from Task SDK for Airflow 3.0+.

Related: https://github.com/apache/airflow/pull/52292
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
