### PR TITLE
Small accessor refactor for external views

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/plugins.py
@@ -130,7 +130,7 @@ class PluginResponse(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def convert_external_views(cls, data: Any) -> Any:
-        data["external_views"] = [*data["external_views"], *data.get("appbuilder_menu_items", [])]
+        data["external_views"] = [*data["external_views"], *data["appbuilder_menu_items"]]
         return data
 
 


### PR DESCRIPTION

Really small improvement. This is called only on a plugin manager `get_plugin_info` method, so those fields will always be defined and never None.

And it's consistent with the accessor right next to it.