### PR TITLE
Bump ibmcloudant>=0.10.0

### DIFF
--- a/providers/cloudant/pyproject.toml
+++ b/providers/cloudant/pyproject.toml
@@ -57,9 +57,7 @@ requires-python = "~=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` can generate a
-    # full lock file when building lock file from provider sources
-    "ibmcloudant==0.9.1;python_version>=\"3.10\"",
+    "ibmcloudant>=0.10.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
It was limited in https://github.com/apache/airflow/pull/43217 but now that we no longer have Python 3.9 we can better handle the versions