### PR TITLE
Set snowflake-snowpark-python for Python 3.12

### DIFF
--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "snowflake-connector-python>=3.7.1",
     "snowflake-sqlalchemy>=1.4.0",
     "snowflake-snowpark-python>=1.17.0;python_version<'3.12'",
-    "snowflake-snowpark-python>=1.27.0;python_version>='3.12' and python_version<'3.13'",
+    "snowflake-snowpark-python>=1.27.0;python_version>='3.12'",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "snowflake-connector-python>=3.7.1",
     "snowflake-sqlalchemy>=1.4.0",
     "snowflake-snowpark-python>=1.17.0;python_version<'3.12'",
+    "snowflake-snowpark-python>=1.27.0;python_version>='3.12' and python_version<'3.13'",
 ]
 
 # The optional dependencies should be modified in place in the generated file


### PR DESCRIPTION
https://pypi.org/project/snowflake-snowpark-python/1.27.0/

version 1.27.0 has classifier for Python 3.12
From what I can tell they don't support Python 3.13 yet