### PR TITLE
Re-create PR for Enable Serde for Pydantic BaseModel and Subclasses

### DIFF
--- a/airflow-core/src/airflow/serialization/serde.py
+++ b/airflow-core/src/airflow/serialization/serde.py
@@ -29,12 +29,12 @@ from re import Pattern
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import attr
+from pydantic import BaseModel
 
 import airflow.serialization.serializers
 from airflow.configuration import conf
 from airflow.stats import Stats
 from airflow.utils.module_loading import import_string, iter_namespace, qualname
-from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -357,7 +357,7 @@ def _is_pydantic_basemodel(o: Any) -> bool:
     """
     # __pydantic_fields__ is always present on Pydantic V2 models and is a dict[str, FieldInfo]
     # __pydantic_validator__ is an internal validator object, always set after model build
-    return hasattr(o, '__pydantic_fields__') and hasattr(o, '__pydantic_validator__')
+    return hasattr(o, "__pydantic_fields__") and hasattr(o, "__pydantic_validator__")
 
 
 def _register():

--- a/airflow-core/src/airflow/serialization/serializers/bignum.py
+++ b/airflow-core/src/airflow/serialization/serializers/bignum.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.utils.module_loading import qualname
 
@@ -47,7 +47,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return float(o), name, __version__, True
 
 
-def deserialize(classname: str, version: int, data: object) -> decimal.Decimal:
+def deserialize(classname: str, version: int, data: object, cls: Any | None = None) -> decimal.Decimal:
     from decimal import Decimal
 
     if version > __version__:

--- a/airflow-core/src/airflow/serialization/serializers/bignum.py
+++ b/airflow-core/src/airflow/serialization/serializers/bignum.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
 
@@ -47,13 +47,13 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return float(o), name, __version__, True
 
 
-def deserialize(classname: str, version: int, data: object, cls: Any | None = None) -> decimal.Decimal:
+def deserialize(cls: type, version: int, data: object) -> decimal.Decimal:
     from decimal import Decimal
 
     if version > __version__:
-        raise TypeError(f"serialized {version} of {classname} > {__version__}")
+        raise TypeError(f"serialized {version} of {qualname(cls)} > {__version__}")
 
-    if classname != qualname(Decimal):
-        raise TypeError(f"{classname} != {qualname(Decimal)}")
+    if cls is not Decimal:
+        raise TypeError(f"do not know how to deserialize {qualname(cls)}")
 
     return Decimal(str(data))

--- a/airflow-core/src/airflow/serialization/serializers/builtin.py
+++ b/airflow-core/src/airflow/serialization/serializers/builtin.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from airflow.utils.module_loading import qualname
 
@@ -35,7 +35,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return list(cast("list", o)), qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: list) -> tuple | set | frozenset:
+def deserialize(classname: str, version: int, data: list, cls: Any | None = None) -> tuple | set | frozenset:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 

--- a/airflow-core/src/airflow/serialization/serializers/builtin.py
+++ b/airflow-core/src/airflow/serialization/serializers/builtin.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from airflow.utils.module_loading import qualname
 
@@ -35,20 +35,20 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return list(cast("list", o)), qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: list, cls: Any | None = None) -> tuple | set | frozenset:
+def deserialize(cls: type, version: int, data: list) -> tuple | set | frozenset:
     if version > __version__:
-        raise TypeError("serialized version is newer than class version")
+        raise TypeError(f"serialized version {version} is newer than class version {__version__}")
 
-    if classname == qualname(tuple):
+    if cls is tuple:
         return tuple(data)
 
-    if classname == qualname(set):
+    if cls is set:
         return set(data)
 
-    if classname == qualname(frozenset):
+    if cls is frozenset:
         return frozenset(data)
 
-    raise TypeError(f"do not know how to deserialize {classname}")
+    raise TypeError(f"do not know how to deserialize {qualname(cls)}")
 
 
 def stringify(classname: str, version: int, data: list) -> str:

--- a/airflow-core/src/airflow/serialization/serializers/datetime.py
+++ b/airflow-core/src/airflow/serialization/serializers/datetime.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.serialization.serializers.timezone import (
     deserialize as deserialize_timezone,
@@ -59,9 +59,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(
-    classname: str, version: int, data: dict | str, cls: Any | None = None
-) -> datetime.date | datetime.timedelta:
+def deserialize(cls: type, version: int, data: dict | str) -> datetime.date | datetime.timedelta:
     import datetime
 
     from pendulum import DateTime
@@ -88,16 +86,16 @@ def deserialize(
                 else None
             )
 
-    if classname == qualname(datetime.datetime) and isinstance(data, dict):
+    if cls is datetime.datetime and isinstance(data, dict):
         return datetime.datetime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
-    if classname == qualname(DateTime) and isinstance(data, dict):
+    if cls is DateTime and isinstance(data, dict):
         return DateTime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
-    if classname == qualname(datetime.timedelta) and isinstance(data, (str, float)):
+    if classname == qualname(datetime.timedelta) and isinstance(data, str | float):
         return datetime.timedelta(seconds=float(data))
 
-    if classname == qualname(datetime.date) and isinstance(data, str):
+    if cls is datetime.date and isinstance(data, str):
         return datetime.date.fromisoformat(data)
 
-    raise TypeError(f"unknown date/time format {classname}")
+    raise TypeError(f"unknown date/time format {qualname(cls)}")

--- a/airflow-core/src/airflow/serialization/serializers/datetime.py
+++ b/airflow-core/src/airflow/serialization/serializers/datetime.py
@@ -92,7 +92,7 @@ def deserialize(cls: type, version: int, data: dict | str) -> datetime.date | da
     if cls is DateTime and isinstance(data, dict):
         return DateTime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
-    if classname == qualname(datetime.timedelta) and isinstance(data, str | float):
+    if cls is datetime.timedelta and isinstance(data, str | float):
         return datetime.timedelta(seconds=float(data))
 
     if cls is datetime.date and isinstance(data, str):

--- a/airflow-core/src/airflow/serialization/serializers/datetime.py
+++ b/airflow-core/src/airflow/serialization/serializers/datetime.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.serialization.serializers.timezone import (
     deserialize as deserialize_timezone,
@@ -59,7 +59,9 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: dict | str) -> datetime.date | datetime.timedelta:
+def deserialize(
+    classname: str, version: int, data: dict | str, cls: Any | None = None
+) -> datetime.date | datetime.timedelta:
     import datetime
 
     from pendulum import DateTime

--- a/airflow-core/src/airflow/serialization/serializers/deltalake.py
+++ b/airflow-core/src/airflow/serialization/serializers/deltalake.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
 
@@ -55,7 +55,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return data, qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: dict, cls: Any | None = None):
+def deserialize(cls: type, version: int, data: dict):
     from deltalake.table import DeltaTable
 
     from airflow.models.crypto import get_fernet
@@ -63,7 +63,7 @@ def deserialize(classname: str, version: int, data: dict, cls: Any | None = None
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    if classname == qualname(DeltaTable):
+    if cls is DeltaTable:
         fernet = get_fernet()
         properties = {}
         for k, v in data["storage_options"].items():
@@ -76,4 +76,4 @@ def deserialize(classname: str, version: int, data: dict, cls: Any | None = None
 
         return DeltaTable(data["table_uri"], version=data["version"], storage_options=storage_options)
 
-    raise TypeError(f"do not know how to deserialize {classname}")
+    raise TypeError(f"do not know how to deserialize {qualname(cls)}")

--- a/airflow-core/src/airflow/serialization/serializers/deltalake.py
+++ b/airflow-core/src/airflow/serialization/serializers/deltalake.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.utils.module_loading import qualname
 
@@ -55,7 +55,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return data, qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: dict):
+def deserialize(classname: str, version: int, data: dict, cls: Any | None = None):
     from deltalake.table import DeltaTable
 
     from airflow.models.crypto import get_fernet

--- a/airflow-core/src/airflow/serialization/serializers/iceberg.py
+++ b/airflow-core/src/airflow/serialization/serializers/iceberg.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.utils.module_loading import qualname
 
@@ -55,7 +55,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return data, qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: dict):
+def deserialize(classname: str, version: int, data: dict, cls: Any | None = None):
     from pyiceberg.catalog import load_catalog
     from pyiceberg.table import Table
 

--- a/airflow-core/src/airflow/serialization/serializers/iceberg.py
+++ b/airflow-core/src/airflow/serialization/serializers/iceberg.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
 
@@ -55,7 +55,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return data, qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: dict, cls: Any | None = None):
+def deserialize(cls: type, version: int, data: dict):
     from pyiceberg.catalog import load_catalog
     from pyiceberg.table import Table
 
@@ -64,7 +64,7 @@ def deserialize(classname: str, version: int, data: dict, cls: Any | None = None
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    if classname == qualname(Table):
+    if cls is Table:
         fernet = get_fernet()
         properties = {}
         for k, v in data["catalog_properties"].items():
@@ -73,4 +73,4 @@ def deserialize(classname: str, version: int, data: dict, cls: Any | None = None
         catalog = load_catalog(data["identifier"][0], **properties)
         return catalog.load_table((data["identifier"][1], data["identifier"][2]))
 
-    raise TypeError(f"do not know how to deserialize {classname}")
+    raise TypeError(f"do not know how to deserialize {qualname(cls)}")

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -32,7 +32,6 @@ serializers = [
     "numpy.uint32",
     "numpy.uint64",
     "numpy.bool_",
-    "numpy.bool",  # numpy version compatibility
     "numpy.float64",
     "numpy.float16",
     "numpy.complex128",

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -78,7 +78,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: str) -> Any:
+def deserialize(classname: str, version: int, data: str, cls: Any | None = None) -> Any:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -78,11 +78,13 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: str, cls: Any | None = None) -> Any:
+def deserialize(cls: type, version: int, data: str) -> Any:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    if classname not in deserializers:
-        raise TypeError(f"unsupported {classname} found for numpy deserialization")
+    allowed_deserialize_classes = [import_string(classname) for classname in deserializers]
 
-    return import_string(classname)(data)
+    if cls not in allowed_deserialize_classes:
+        raise TypeError(f"unsupported {qualname(cls)} found for numpy deserialization")
+
+    return cls(data)

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -32,7 +32,7 @@ serializers = [
     "numpy.uint32",
     "numpy.uint64",
     "numpy.bool_",
-    "numpy.bool", # numpy version compatibility
+    "numpy.bool",  # numpy version compatibility
     "numpy.float64",
     "numpy.float16",
     "numpy.complex128",

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -32,6 +32,7 @@ serializers = [
     "numpy.uint32",
     "numpy.uint64",
     "numpy.bool_",
+    "numpy.bool", # numpy version compatibility
     "numpy.float64",
     "numpy.float16",
     "numpy.complex128",

--- a/airflow-core/src/airflow/serialization/serializers/pandas.py
+++ b/airflow-core/src/airflow/serialization/serializers/pandas.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
 
@@ -53,16 +53,21 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return buf.getvalue().hex().decode("utf-8"), qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: object, cls: Any | None = None) -> pd.DataFrame:
+def deserialize(cls: type, version: int, data: object) -> pd.DataFrame:
     if version > __version__:
-        raise TypeError(f"serialized {version} of {classname} > {__version__}")
+        raise TypeError(f"serialized {version} of {qualname(cls)} > {__version__}")
 
-    from pyarrow import parquet as pq
+    import pandas as pd
+
+    if cls is not pd.DataFrame:
+        raise TypeError(f"do not know how to deserialize {qualname(cls)}")
 
     if not isinstance(data, str):
-        raise TypeError(f"serialized {classname} has wrong data type {type(data)}")
+        raise TypeError(f"serialized {qualname(cls)} has wrong data type {type(data)}")
 
     from io import BytesIO
+
+    from pyarrow import parquet as pq
 
     with BytesIO(bytes.fromhex(data)) as buf:
         df = pq.read_table(buf).to_pandas()

--- a/airflow-core/src/airflow/serialization/serializers/pandas.py
+++ b/airflow-core/src/airflow/serialization/serializers/pandas.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.utils.module_loading import qualname
 
@@ -53,7 +53,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return buf.getvalue().hex().decode("utf-8"), qualname(o), __version__, True
 
 
-def deserialize(classname: str, version: int, data: object) -> pd.DataFrame:
+def deserialize(classname: str, version: int, data: object, cls: Any | None = None) -> pd.DataFrame:
     if version > __version__:
         raise TypeError(f"serialized {version} of {classname} > {__version__}")
 

--- a/airflow-core/src/airflow/serialization/serializers/pydantic.py
+++ b/airflow-core/src/airflow/serialization/serializers/pydantic.py
@@ -17,14 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from airflow.serialization.typing import is_pydantic_model
 from airflow.utils.module_loading import qualname
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel
-
     from airflow.serialization.serde import U
 
 serializers = [
@@ -48,8 +46,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     if not is_pydantic_model(o):
         return "", "", 0, False
 
-    model = cast("BaseModel", o)  # for mypy
-    data = model.model_dump()
+    data = o.model_dump()  # type: ignore
 
     return data, qualname(o), __version__, True
 
@@ -75,5 +72,4 @@ def deserialize(cls: type, version: int, data: dict):
         raise TypeError(f"No deserializer found for {qualname(cls)}")
 
     # Perform validation-based reconstruction
-    model = cast("BaseModel", cls)  # for mypy
-    return model.model_validate(data)
+    return cls.model_validate(data)  # type: ignore

--- a/airflow-core/src/airflow/serialization/serializers/pydantic.py
+++ b/airflow-core/src/airflow/serialization/serializers/pydantic.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from airflow.serialization.serde import _is_pydantic_model
-from airflow.utils.module_loading import import_string, qualname
+from airflow.utils.module_loading import import_string
 
 if TYPE_CHECKING:
     from airflow.serialization.serde import U

--- a/airflow-core/src/airflow/serialization/serializers/pydantic.py
+++ b/airflow-core/src/airflow/serialization/serializers/pydantic.py
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from importlib import import_module
+from airflow.utils.module_loading import qualname
+from pydantic import BaseModel
+from airflow.serialization.serde import _is_pydantic_basemodel
+
+if TYPE_CHECKING:
+    from airflow.serialization.serde import U
+
+serializers = [
+    "pydantic.main.BaseModel",
+]
+deserializers = serializers
+stringifiers = serializers
+
+__version__ = 1
+
+
+def _resolve_pydantic_class(qn: str):
+    module_name, class_name = qn.rsplit(".", 1)
+    module = import_module(module_name)
+    return getattr(module, class_name)
+
+
+def serialize(o: object) -> tuple[U, str, int, bool]:
+    if not _is_pydantic_basemodel(o):
+        return "", "", 0, False
+    
+    data = o.model_dump()
+    # Store the actual qualified name for the pydantic class. This classname will be used to import the module and load the data.
+    data["__class__"] = qualname(o)
+    
+    return data, qualname(BaseModel), __version__, True
+
+
+def deserialize(classname: str, version: int, data: dict):
+    if version > __version__:
+        raise TypeError(f"serialized {version} of {classname} > {__version__}")
+
+    # check if it the qualified name is pydantic.main.BaseModel.
+    if classname == qualname(BaseModel):
+        # the actual qualified name for the pydantic.main.BaseModel subclass is stored in this key.
+        if "__class__" not in data:
+            raise TypeError("Missing '__class__' in serialized Pydantic.main.BaseModel data")
+        
+        qn = data.pop("__class__")
+        cls = _resolve_pydantic_class(qn=qn)
+
+        if not _is_pydantic_basemodel(cls):
+            raise TypeError(f"{qn} is not a subclass of Pydantic.main.BaseModel")
+        return cls.model_validate(data)
+
+    # no deserializer available
+    raise TypeError(f"No deserializer found for {classname}")

--- a/airflow-core/src/airflow/serialization/serializers/pydantic.py
+++ b/airflow-core/src/airflow/serialization/serializers/pydantic.py
@@ -51,7 +51,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     model = cast("BaseModel", o)  # for mypy
     data = model.model_dump()
 
-    return data, qualname(BaseModel), __version__, True
+    return data, "pydantic.main.BaseModel", __version__, True
 
 
 def deserialize(classname: str, version: int, data: dict):

--- a/airflow-core/src/airflow/serialization/serializers/pydantic.py
+++ b/airflow-core/src/airflow/serialization/serializers/pydantic.py
@@ -23,6 +23,8 @@ from airflow.serialization.serde import _is_pydantic_model
 from airflow.utils.module_loading import import_string
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from airflow.serialization.serde import U
 
 serializers = [
@@ -43,8 +45,6 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     - version number
     - is_serialized flag (True if handled)
     """
-    from pydantic import BaseModel
-
     if not _is_pydantic_model(o):
         return "", "", 0, False
 

--- a/airflow-core/src/airflow/serialization/serializers/pydantic.py
+++ b/airflow-core/src/airflow/serialization/serializers/pydantic.py
@@ -46,7 +46,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     from pydantic import BaseModel
 
     if not _is_pydantic_model(o):
-        return {}, "", 0, False
+        return "", "", 0, False
 
     model = cast("BaseModel", o)  # for mypy
     data = model.model_dump()

--- a/airflow-core/src/airflow/serialization/serializers/timezone.py
+++ b/airflow-core/src/airflow/serialization/serializers/timezone.py
@@ -68,6 +68,8 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
 
 
 def deserialize(cls: type, version: int, data: object) -> Any:
+    from zoneinfo import ZoneInfo
+
     from airflow.utils.timezone import parse_timezone
 
     if not isinstance(data, (str, int)):
@@ -76,9 +78,7 @@ def deserialize(cls: type, version: int, data: object) -> Any:
     if version > __version__:
         raise TypeError(f"serialized {version} of {qualname(cls)} > {__version__}")
 
-    if qualname(cls) == "backports.zoneinfo.ZoneInfo" and isinstance(data, str):
-        from zoneinfo import ZoneInfo
-
+    if cls is ZoneInfo and isinstance(data, str):
         return ZoneInfo(data)
 
     return parse_timezone(data)

--- a/airflow-core/src/airflow/serialization/serializers/timezone.py
+++ b/airflow-core/src/airflow/serialization/serializers/timezone.py
@@ -67,7 +67,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: object) -> Any:
+def deserialize(classname: str, version: int, data: object, cls: Any | None = None) -> Any:
     from airflow.utils.timezone import parse_timezone
 
     if not isinstance(data, (str, int)):

--- a/airflow-core/src/airflow/serialization/serializers/timezone.py
+++ b/airflow-core/src/airflow/serialization/serializers/timezone.py
@@ -67,16 +67,16 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: object, cls: Any | None = None) -> Any:
+def deserialize(cls: type, version: int, data: object) -> Any:
     from airflow.utils.timezone import parse_timezone
 
     if not isinstance(data, (str, int)):
         raise TypeError(f"{data} is not of type int or str but of {type(data)}")
 
     if version > __version__:
-        raise TypeError(f"serialized {version} of {classname} > {__version__}")
+        raise TypeError(f"serialized {version} of {qualname(cls)} > {__version__}")
 
-    if classname == "backports.zoneinfo.ZoneInfo" and isinstance(data, str):
+    if qualname(cls) == "backports.zoneinfo.ZoneInfo" and isinstance(data, str):
         from zoneinfo import ZoneInfo
 
         return ZoneInfo(data)

--- a/airflow-core/src/airflow/serialization/typing.py
+++ b/airflow-core/src/airflow/serialization/typing.py
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from typing import Any
 
 

--- a/airflow-core/src/airflow/serialization/typing.py
+++ b/airflow-core/src/airflow/serialization/typing.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+
+
+def is_pydantic_model(cls: Any) -> bool:
+    """
+    Return True if the class is a pydantic.main.BaseModel.
+
+    Checking is done by attributes as it is significantly faster than
+    using isinstance.
+    """
+    # __pydantic_fields__ is always present on Pydantic V2 models and is a dict[str, FieldInfo]
+    # __pydantic_validator__ is an internal validator object, always set after model build
+    return hasattr(cls, "__pydantic_fields__") and hasattr(cls, "__pydantic_validator__")

--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -574,15 +574,15 @@ class TestSerializers:
     def test_timezone_deserialize_zoneinfo(self):
         from airflow.serialization.serializers.timezone import deserialize
 
-        zi = deserialize("backports.zoneinfo.ZoneInfo", 1, "Asia/Taipei")
+        zi = deserialize(ZoneInfo, 1, "Asia/Taipei")
         assert isinstance(zi, ZoneInfo)
         assert zi.key == "Asia/Taipei"
 
     @pytest.mark.parametrize(
         "klass, version, data, msg",
         [
-            (pendulum.tz.timezone.FixedTimezone, 1, 1.23, "is not of type int or str"),
-            (pendulum.tz.timezone.FixedTimezone, 999, "UTC", "serialized 999 .* > 1"),
+            (FixedTimezone, 1, 1.23, "is not of type int or str"),
+            (FixedTimezone, 999, "UTC", "serialized 999 .* > 1"),
         ],
     )
     def test_timezone_deserialize_errors(self, klass, version, data, msg):

--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import numpy as np
+import pandas as pd
 import pendulum
 import pendulum.tz
 import pytest
@@ -36,7 +37,6 @@ from pydantic import BaseModel, Field
 from airflow.sdk.definitions.param import Param, ParamsDict
 from airflow.serialization.serde import CLASSNAME, DATA, VERSION, _stringify, decode, deserialize, serialize
 from airflow.serialization.serializers import builtin
-from airflow.utils.module_loading import qualname
 
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
@@ -198,20 +198,26 @@ class TestSerializers:
 
         assert serialize(12345) == ("", "", 0, False)
 
+    def test_bignum_deserialize_decimal(self):
+        from airflow.serialization.serializers.bignum import deserialize
+
+        res = deserialize(decimal.Decimal, 1, decimal.Decimal(12345))
+        assert res == decimal.Decimal(12345)
+
     @pytest.mark.parametrize(
         ("klass", "version", "payload", "msg"),
         [
             (
-                "decimal.Decimal",
+                decimal.Decimal,
                 999,
                 "0",
-                r"serialized 999 of decimal\.Decimal",  # newer version
+                r"serialized 999 of decimal\.Decimal > 1",  # newer version
             ),
             (
-                "wrong.ClassName",
+                str,
                 1,
                 "0",
-                r"wrong\.ClassName != .*Decimal",  # wrong classname
+                r"do not know how to deserialize builtins\.str",  # wrong classname
             ),
         ],
     )
@@ -243,8 +249,8 @@ class TestSerializers:
     @pytest.mark.parametrize(
         ("klass", "ver", "value", "msg"),
         [
-            ("numpy.int32", 999, 123, r"serialized version is newer"),
-            ("numpy.float32", 1, 123, r"unsupported numpy\.float32"),
+            (np.int32, 999, 123, r"serialized version is newer"),
+            (np.float32, 1, 123, r"unsupported numpy\.float32"),
         ],
     )
     def test_numpy_deserialize_errors(self, klass, ver, value, msg):
@@ -273,17 +279,23 @@ class TestSerializers:
         assert serialize(123) == ("", "", 0, False)
 
     @pytest.mark.parametrize(
-        ("version", "data", "msg"),
+        ("klass", "version", "data", "msg"),
         [
-            (999, "", r"serialized 999 .* > 1"),  # version too new
-            (1, 123, r"wrong data type .*<class 'int'>"),  # bad payload type
+            (pd.DataFrame, 999, "", r"serialized 999 of pandas.core.frame.DataFrame > 1"),  # version too new
+            (
+                pd.DataFrame,
+                1,
+                123,
+                r"serialized pandas.core.frame.DataFrame has wrong data type .*<class 'int'>",
+            ),  # bad payload type
+            (str, 1, "", r"do not know how to deserialize builtins.str"),  # bad class
         ],
     )
-    def test_pandas_deserialize_errors(self, version, data, msg):
+    def test_pandas_deserialize_errors(self, klass, version, data, msg):
         from airflow.serialization.serializers.pandas import deserialize
 
         with pytest.raises(TypeError, match=msg):
-            deserialize("pandas.core.frame.DataFrame", version, data)
+            deserialize(klass, version, data)
 
     def test_iceberg(self):
         pytest.importorskip("pyiceberg", minversion="2.0.0")
@@ -382,6 +394,24 @@ class TestSerializers:
 
         assert m.banana == d.banana
         assert m.foo == d.foo
+
+    @pytest.mark.parametrize(
+        "klass, version, data, msg",
+        [
+            (
+                FooBarModel,
+                999,
+                FooBarModel(banana=3.14, foo="hello"),
+                "Serialized version 999 is newer than the supported version 1",
+            ),
+            (str, 1, "", r"No deserializer found for builtins\.str"),
+        ],
+    )
+    def test_pydantic_deserialize_errors(self, klass, version, data, msg):
+        from airflow.serialization.serializers.pydantic import deserialize
+
+        with pytest.raises(TypeError, match=msg):
+            deserialize(klass, version, data)
 
     @pytest.mark.skipif(not PENDULUM3, reason="Test case for pendulum~=3")
     @pytest.mark.parametrize(
@@ -551,8 +581,8 @@ class TestSerializers:
     @pytest.mark.parametrize(
         "klass, version, data, msg",
         [
-            ("pendulum.tz.timezone.FixedTimezone", 1, 1.23, "is not of type int or str"),
-            ("pendulum.tz.timezone.FixedTimezone", 999, "UTC", "serialized 999 .* > 1"),
+            (pendulum.tz.timezone.FixedTimezone, 1, 1.23, "is not of type int or str"),
+            (pendulum.tz.timezone.FixedTimezone, 999, "UTC", "serialized 999 .* > 1"),
         ],
     )
     def test_timezone_deserialize_errors(self, klass, version, data, msg):
@@ -586,14 +616,39 @@ class TestSerializers:
             load_dag_schema_dict()
         assert "Schema file schema.json does not exists" in str(ctx.value)
 
-    def test_builtin_deserialize_frozenset(self):
-        res = builtin.deserialize(qualname(frozenset), 1, [13, 14])
-        assert isinstance(res, frozenset)
-        assert res == frozenset({13, 14})
+    @pytest.mark.parametrize(
+        "klass, version, data",
+        [(tuple, 1, [11, 12]), (set, 1, [11, 12]), (frozenset, 1, [11, 12])],
+    )
+    def test_builtin_deserialize(self, klass, version, data):
+        res = builtin.deserialize(klass, version, klass(data))
+        assert isinstance(res, klass)
+        assert res == klass(data)
 
-    def test_builtin_deserialize_version_too_new(self):
-        with pytest.raises(TypeError, match="serialized version is newer than class version"):
-            builtin.deserialize(qualname(tuple), 999, [1, 2])
+    @pytest.mark.parametrize(
+        "klass, version, data, msg",
+        [
+            (tuple, 999, [11, 12], r"serialized version 999 is newer than class version 1"),
+            (set, 2, [11, 12], r"serialized version 2 is newer than class version 1"),
+            (frozenset, 13, [11, 12], r"serialized version 13 is newer than class version 1"),
+        ],
+    )
+    def test_builtin_deserialize_version_too_new(self, klass, version, data, msg):
+        with pytest.raises(TypeError, match=msg):
+            builtin.deserialize(klass, version, data)
+
+    @pytest.mark.parametrize(
+        "klass, version, data, msg",
+        [
+            (str, 1, "11, 12", r"do not know how to deserialize builtins\.str"),
+            (int, 1, 11, r"do not know how to deserialize builtins\.int"),
+            (bool, 1, True, r"do not know how to deserialize builtins\.bool"),
+            (float, 1, 0.999, r"do not know how to deserialize builtins\.float"),
+        ],
+    )
+    def test_builtin_deserialize_wrong_types(self, klass, version, data, msg):
+        with pytest.raises(TypeError, match=msg):
+            builtin.deserialize(klass, version, data)
 
     @pytest.mark.parametrize(
         "func, msg",

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -261,6 +261,21 @@ class TestSerDe:
 
     @conf_vars(
         {
+            ("core", "allowed_deserialization_classes"): "airflow.*",
+        }
+    )
+    @pytest.mark.usefixtures("recalculate_patterns")
+    def test_allow_list_for_deserialize_pydantic_model(self):
+        # for Pydantic model to be deserialized, it must be in `allowed_deserialization_classes`
+        i = U(x=7, v=V(w=W(x=42), s=["hello", "world"], t=(1, 2, 3), c=99), u=("extra", 123))
+        e = serialize(i)
+        with pytest.raises(ImportError) as ex:
+            deserialize(e)
+
+        assert f"{qualname(U)} was not found in allow list" in str(ex.value)
+
+    @conf_vars(
+        {
             ("core", "allowed_deserialization_classes"): "unit.airflow.*",
         }
     )


### PR DESCRIPTION
The chage in https://github.com/apache/airflow/pull/51059 broke canary tests in https://github.com/apache/airflow/actions/runs/15910813471/job/44877861492. The PR is reverted through https://github.com/apache/airflow/pull/52312.

Create this PR to fix the issue.

### The issue in #51059
First, the refactored `deserialize` take the actual class instead of classname. Therefore, the following test case is modified from `"zi = deserialize("backports.zoneinfo.ZoneInfo", 1, "Asia/Taipei")"` to `zi = deserialize(ZoneInfo, 1, "Asia/Taipei")`. I think the "backports.zoneinfo.ZoneInfo" is a backport of the standard library module `zoneinfo` in Python 3.9, to suppor lower version of Python.

In the `airflow-core/src/airflow/serialization/serializers/timezone.py`, the line below is looking for the backport ZoneInfo, instead of the standard library `zoneinfo`. Therefore, when a `ZoneInfo` class is passed into the `deserialize`, the `qualname(cls)` is resolved to "zoneinfo.ZoneInfo" instead of "backports.zoneinfo.ZoneInfo". Therefore, the data will be deserialized through `parse_timezone(data)`, resulting in a different object. Therefore the test case failed.

```python
if qualname(cls) == "backports.zoneinfo.ZoneInfo" and isinstance(data, str):
``` 

```python
def test_timezone_deserialize_zoneinfo(self):
    from airflow.serialization.serializers.timezone import deserialize

    zi = deserialize(ZoneInfo, 1, "Asia/Taipei")
    assert isinstance(zi, ZoneInfo)
    assert zi.key == "Asia/Taipei"
```

### Solution
To resolve this issue, I updated the if condition to `if cls is ZoneInfo and isinstance(data, str):`. I think the minimum version of Python we support is 3.9. So, "backports.zoneinfo.ZoneInfo" should probably be removed.

After making the changes, I ran the following tests and all checks passed.

<strike>breeze --python 3.9 testing core-tests --test-type Serialization</strike>
<strike>breeze --python 3.9 testing core-tests --test-type Serialization --downgrade-pendulum</strike>

breeze --python 3.10 testing core-tests --test-type Serialization
breeze --python 3.10 testing core-tests --test-type Serialization --downgrade-pendulum

breeze --python 3.11 testing core-tests --test-type Serialization
breeze --python 3.11 testing core-tests --test-type Serialization --downgrade-pendulum

but I got some container issues when running for 3.12. Will look into the full test results and action accordingly.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
