### PR TITLE
Replace `models.BaseOperator` to Task SDK one for Apache Pig

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -94,6 +94,7 @@ class TestProjectStructure:
             "providers/apache/hive/tests/unit/apache/hive/test_version_compat.py",
             "providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py",
             "providers/apache/livy/tests/unit/apache/livy/test_version_compat.py",
+            "providers/apache/pig/tests/unit/apache/pig/test_version_compat.py",
             "providers/apache/spark/tests/unit/apache/spark/test_version_compat.py",
             "providers/arangodb/tests/unit/arangodb/test_version_compat.py",
             "providers/atlassian/jira/tests/unit/atlassian/jira/test_version_compat.py",

--- a/providers/apache/pig/src/airflow/providers/apache/pig/operators/pig.py
+++ b/providers/apache/pig/src/airflow/providers/apache/pig/operators/pig.py
@@ -21,8 +21,8 @@ import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.models import BaseOperator
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
+from airflow.providers.apache.pig.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/pig/src/airflow/providers/apache/pig/version_compat.py
+++ b/providers/apache/pig/src/airflow/providers/apache/pig/version_compat.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# NOTE! THIS FILE IS COPIED MANUALLY IN OTHER PROVIDERS DELIBERATELY TO AVOID ADDING UNNECESSARY
+# DEPENDENCIES BETWEEN PROVIDERS. IF YOU WANT TO ADD CONDITIONAL CODE IN YOUR PROVIDER THAT DEPENDS
+# ON AIRFLOW VERSION, PLEASE COPY THIS FILE TO THE ROOT PACKAGE OF YOUR PROVIDER AND IMPORT
+# THOSE CONSTANTS FROM IT RATHER THAN IMPORTING THEM FROM ANOTHER PROVIDER OR TEST CODE
+#
+from __future__ import annotations
+
+
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    from packaging.version import Version
+
+    from airflow import __version__
+
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
+
+
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "BaseOperator",
+]


### PR DESCRIPTION
Follow-up of https://github.com/apache/airflow/pull/52292. Part of https://github.com/apache/airflow/issues/52378

