### PR TITLE
Provider Migration: Update Weaviate for Airflow 3.0 compatibility

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -239,6 +239,7 @@ class TestProjectStructure:
             "providers/standard/tests/unit/standard/utils/test_sensor_helper.py",
             "providers/tableau/tests/unit/tableau/test_version_compat.py",
             "providers/trino/tests/unit/trino/test_version_compat.py",
+            "providers/weaviate/tests/unit/weaviate/test_version_compat.py",
         ]
         modules_files: list[pathlib.Path] = list(
             AIRFLOW_PROVIDERS_ROOT_PATH.glob("**/src/airflow/providers/**/*.py")

--- a/providers/weaviate/src/airflow/providers/weaviate/operators/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/operators/weaviate.py
@@ -28,11 +28,7 @@ if TYPE_CHECKING:
     import pandas as pd
     from weaviate.types import UUID
 
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.weaviate.version_compat import Context
 
 
 class WeaviateIngestOperator(BaseOperator):

--- a/providers/weaviate/src/airflow/providers/weaviate/operators/weaviate.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/operators/weaviate.py
@@ -21,8 +21,8 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from airflow.models import BaseOperator
 from airflow.providers.weaviate.hooks.weaviate import WeaviateHook
+from airflow.providers.weaviate.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/providers/weaviate/src/airflow/providers/weaviate/version_compat.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/version_compat.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    from packaging.version import Version
+
+    from airflow import __version__
+
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
+
+
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "BaseOperator",
+]

--- a/providers/weaviate/src/airflow/providers/weaviate/version_compat.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/version_compat.py
@@ -31,10 +31,13 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import BaseOperator
+    from airflow.sdk.definitions.context import Context
 else:
     from airflow.models import BaseOperator
+    from airflow.utils.context import Context
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "BaseOperator",
+    "Context",
 ]

--- a/providers/weaviate/tests/unit/weaviate/operators/test_weaviate.py
+++ b/providers/weaviate/tests/unit/weaviate/operators/test_weaviate.py
@@ -50,7 +50,7 @@ class TestWeaviateIngestOperator:
     def test_execute_with_input_data(self, mock_log, operator):
         operator.hook.batch_data = MagicMock()
 
-        operator.execute(context=None)  # type: ignore[arg-type]
+        operator.execute(context=None)
 
         operator.hook.batch_data.assert_called_once_with(
             collection_name="my_collection",

--- a/providers/weaviate/tests/unit/weaviate/operators/test_weaviate.py
+++ b/providers/weaviate/tests/unit/weaviate/operators/test_weaviate.py
@@ -50,7 +50,7 @@ class TestWeaviateIngestOperator:
     def test_execute_with_input_data(self, mock_log, operator):
         operator.hook.batch_data = MagicMock()
 
-        operator.execute(context=None)
+        operator.execute(context=None)  # type: ignore[arg-type]
 
         operator.hook.batch_data.assert_called_once_with(
             collection_name="my_collection",


### PR DESCRIPTION
Follow-up of https://github.com/apache/airflow/pull/52292. Part of https://github.com/apache/airflow/issues/52378

Step 3: Fix BaseOperatorLink.persist methods
* didn't find persist method in the operator

Step 4: Update test patterns
* didn't find test invoke `operator.run()`, but found `operator.execute()`. Not sure if we need to take any action on it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
