### PR TITLE
Provider Migration: Update Oracle for Airflow 3.0 compatibility

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -224,6 +224,7 @@ class TestProjectStructure:
             "providers/microsoft/azure/tests/unit/microsoft/azure/test_version_compat.py",
             "providers/openlineage/tests/unit/openlineage/test_version_compat.py",
             "providers/opensearch/tests/unit/opensearch/test_version_compat.py",
+            "providers/oracle/tests/unit/oracle/test_version_compat.py",
             "providers/presto/tests/unit/presto/test_version_compat.py",
             "providers/redis/tests/unit/redis/test_version_compat.py",
             "providers/sftp/tests/unit/sftp/test_version_compat.py",

--- a/providers/oracle/src/airflow/providers/oracle/operators/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/operators/oracle.py
@@ -23,8 +23,8 @@ from typing import TYPE_CHECKING
 
 import oracledb
 
-from airflow.models import BaseOperator
 from airflow.providers.oracle.hooks.oracle import OracleHook
+from airflow.providers.oracle.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/oracle/src/airflow/providers/oracle/operators/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/operators/oracle.py
@@ -27,11 +27,7 @@ from airflow.providers.oracle.hooks.oracle import OracleHook
 from airflow.providers.oracle.version_compat import BaseOperator
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.oracle.version_compat import Context
 
 
 class OracleStoredProcedureOperator(BaseOperator):

--- a/providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py
@@ -24,11 +24,7 @@ from airflow.providers.oracle.hooks.oracle import OracleHook
 from airflow.providers.oracle.version_compat import BaseOperator
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.oracle.version_compat import Context
 
 
 class OracleToOracleOperator(BaseOperator):

--- a/providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
 from airflow.providers.oracle.hooks.oracle import OracleHook
+from airflow.providers.oracle.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/oracle/src/airflow/providers/oracle/version_compat.py
+++ b/providers/oracle/src/airflow/providers/oracle/version_compat.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    from packaging.version import Version
+
+    from airflow import __version__
+
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
+
+
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "BaseOperator",
+]

--- a/providers/oracle/src/airflow/providers/oracle/version_compat.py
+++ b/providers/oracle/src/airflow/providers/oracle/version_compat.py
@@ -31,10 +31,13 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import BaseOperator
+    from airflow.sdk.definitions.context import Context
 else:
     from airflow.models import BaseOperator
+    from airflow.utils.context import Context
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "BaseOperator",
+    "Context",
 ]

--- a/providers/oracle/tests/unit/oracle/operators/test_oracle.py
+++ b/providers/oracle/tests/unit/oracle/operators/test_oracle.py
@@ -26,8 +26,7 @@ import pytest
 from airflow.models import TaskInstance
 from airflow.providers.oracle.hooks.oracle import OracleHook
 from airflow.providers.oracle.operators.oracle import OracleStoredProcedureOperator
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.oracle.version_compat import AIRFLOW_V_3_0_PLUS
 
 
 class TestOracleStoredProcedureOperator:


### PR DESCRIPTION
Follow-up of https://github.com/apache/airflow/pull/52292. Part of https://github.com/apache/airflow/issues/52378

Step 3: Fix BaseOperatorLink.persist methods
* didn't find `persist` method in the operator

Step 4: Update test patterns
* didn't find test invoke `operator.run()`
* find a task instance run as shown below. Wondering if any action is needed.

```python
dr = dag_maker.create_dagrun(run_id=task_id)
    ti = TaskInstance(task=task, run_id=dr.run_id)
    with pytest.raises(oracledb.DatabaseError, match=re.escape(error)):
        ti.run()
    assert ti.xcom_pull(task_ids=task.task_id, key="ORA") == ora_exit_code
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
