### PR TITLE
bug:updated gcp dataplex operator and hook docstring which was causing failure on building docs on local.

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataplex.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataplex.py
@@ -515,7 +515,7 @@ class DataplexHook(GoogleBaseHook, OperationHelper):
             fields are non-required and omitted in the request body, their values are emptied.
         :param allow_missing: Optional. If set to true and entry doesn't exist, the service will create it.
         :param delete_missing_aspects: Optional. If set to true and the aspect_keys specify aspect
-            ranges, the service deletes any existing aspects from that range that weren't provided
+            ranges, the service deletes any existing aspects from that range that were not provided
             in the request.
         :param aspect_keys: Optional. The map keys of the Aspects which the service should modify.
             It supports the following syntax:

--- a/providers/google/src/airflow/providers/google/cloud/operators/dataplex.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataplex.py
@@ -4043,7 +4043,7 @@ class DataplexCatalogUpdateEntryOperator(DataplexCatalogBaseOperator):
     :param entry_configuration: Required. The updated configuration body of the Entry.
     :param allow_missing: Optional. If set to true and entry doesn't exist, the service will create it.
     :param delete_missing_aspects: Optional. If set to true and the aspect_keys specify aspect
-        ranges, the service deletes any existing aspects from that range that weren't provided
+        ranges, the service deletes any existing aspects from that range that were not provided
         in the request.
     :param aspect_keys: Optional. The map keys of the Aspects which the service should modify.
         It supports the following syntax:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

[closes: #ISSUE
related: #ISSUE](https://apache-airflow.slack.com/archives/CCZRF2U5A/p1751048422214939)


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue while running command
```
breeze build-docs --package-filter apache-airflow-providers-google
```
was failing due to below error:-
![image](https://github.com/user-attachments/assets/e4dbfb44-a216-4b51-afd6-4fb2cfee39fa)

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
