### PR TITLE
feat(helm): Conditionally render GIT_SYNC_* vs GITSYNC_* env vars based on Git Sync version

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -216,6 +216,34 @@ If release name contains chart name it will be used as a full name.
     defaultMode: 288
 {{- end }}
 
+{{/* Helper to render git-sync credentials envs for v3/v4 */}}
+{{- define "git_sync.env_credentials" }}
+{{- $tag := .Values.images.gitSync.tag | default "v4" }}
+{{- if regexMatch "^v3" $tag }}
+- name: GIT_SYNC_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+      key: GIT_SYNC_USERNAME
+- name: GIT_SYNC_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+      key: GIT_SYNC_PASSWORD
+{{- else }}
+- name: GITSYNC_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+      key: GITSYNC_USERNAME
+- name: GITSYNC_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+      key: GITSYNC_PASSWORD
+{{- end }}
+{{- end }}
+
 {{/*  Git sync container */}}
 {{- define "git_sync_container" }}
 - name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
@@ -249,26 +277,7 @@ If release name contains chart name it will be used as a full name.
       value: "false"
     {{- end }}
     {{ else if .Values.dags.gitSync.credentialsSecret }}
-    - name: GIT_SYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GIT_SYNC_USERNAME
-    - name: GITSYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_USERNAME
-    - name: GIT_SYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GIT_SYNC_PASSWORD
-    - name: GITSYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_PASSWORD
+    {{ include "git_sync.env_credentials" . | indent 4 }}
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}


### PR DESCRIPTION
This PR addresses [Issue #52320](https://github.com/apache/airflow/issues/52320) by introducing conditional logic in the Helm Chart to support both Git Sync v3 and v4 credential environment variable formats.

###  Background

In Git Sync:
- **v3** expects: `GIT_SYNC_USERNAME`, `GIT_SYNC_PASSWORD`
- **v4** expects: `GITSYNC_USERNAME`, `GITSYNC_PASSWORD`

Prior to this change, the Airflow Helm Chart rendered **all four variables**, regardless of which version of Git Sync was being used. This led to confusion and potential misconfigurations.

### What this PR changes

- **Added** a helper function `git_sync.env_credentials` in `_helpers.tpl`  
  to conditionally render environment variables for git-sync v3 (`GIT_SYNC_*`) and v4 (`GITSYNC_*`) based on image tag.

- **Replaced** hardcoded credential environment variable blocks in Helm templates  
  with the new `include`-based helper for better maintainability and correctness.

- **Added** two new parameterized unit tests:
  - `test_git_sync_credentials_env_vars` (for pod-template-file)
  - `test_scheduler_git_sync_env_vars` (for scheduler-deployment)
  Both test the expected env vars for v3 and v4 using `@pytest.mark.parametrize`.

### Motivation

Previously, git-sync credential environment variables were rendered unconditionally for both v3 and v4,
causing redundancy and potential YAML issues. Also, tests for those were hard to maintain and unclear
when failures occurred due to overlapping expectations.

### Benefits

- Cleaner and version-specific environment variable rendering
- Deterministic and clear testing logic per version
- Easier to maintain or extend in the future (e.g. sshKey or knownHosts support)



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
