### PR TITLE
Add Horizontal Pod Autoscaler (HPA) Support for Airflow API Server

### DIFF
--- a/chart/templates/api-server/api-server-hpa.yaml
+++ b/chart/templates/api-server/api-server-hpa.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Api-Server HPA
 #################################
-{{- if and .Values.apiServer.enabled .Values.apiServer.hpa.enabled }}
+{{- if .Values.apiServer.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/chart/templates/api-server/api-server-hpa.yaml
+++ b/chart/templates/api-server/api-server-hpa.yaml
@@ -1,0 +1,49 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow Api-Server HPA
+#################################
+{{- if and .Values.apiServer.enabled .Values.apiServer.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server
+  labels:
+    tier: airflow
+    component: api-server-horizontalpodautoscaler
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    deploymentName: {{ .Release.Name }}-api-server
+    {{- if or (.Values.labels) (.Values.apiServer.labels) }}
+      {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "airflow.fullname" . }}-api-server
+  minReplicas: {{ .Values.apiServer.hpa.minReplicaCount }}
+  maxReplicas: {{ .Values.apiServer.hpa.maxReplicaCount }}
+  metrics: {{- toYaml .Values.apiServer.hpa.metrics | nindent 4 }}
+  {{- with .Values.apiServer.hpa.behavior }}
+  behavior: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5135,12 +5135,12 @@
                             "default": false
                         },
                         "minReplicaCount": {
-                            "description": "Minimum number of apiServer replicas created by HPA if HPA enabled.",
+                            "description": "Minimum number of API server replicas created by HPA if HPA is enabled.",
                             "type": "integer",
                             "default": 1
                         },
                         "maxReplicaCount": {
-                            "description": "Maximum number of apiServer replicas created by HPA if HPA enabled.",
+                            "description": "Maximum number of API server replicas created by HPA if HPA is enabled.",
                             "type": "integer",
                             "default": 5
                         },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5124,6 +5124,53 @@
                     ],
                     "default": null
                 },
+                "hpa": {
+                    "description": "HPA configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Allow HPA autoscaling",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "minReplicaCount": {
+                            "description": "Minimum number of webservers created by HPA.",
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "maxReplicaCount": {
+                            "description": "Maximum number of webservers created by HPA.",
+                            "type": "integer",
+                            "default": 5
+                        },
+                        "metrics": {
+                            "description": "Specifications for which to use to calculate the desired replica count.",
+                            "type": "array",
+                            "default": [
+                                {
+                                    "type": "Resource",
+                                    "resource": {
+                                        "name": "cpu",
+                                        "target": {
+                                            "type": "Utilization",
+                                            "averageUtilization": 80
+                                        }
+                                    }
+                                }
+                            ],
+                            "items": {
+                                "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricSpec"
+                            }
+                        },
+                        "behavior": {
+                            "description": "HorizontalPodAutoscalerBehavior configures the scaling behavior of the target.",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior"
+                        }
+                    }
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5077,7 +5077,7 @@
                     }
                 },
                 "replicas": {
-                    "description": "How many Airflow API server replicas should run.",
+                    "description": "How many Airflow API server replicas should run. This setting is ignored when HPA (Horizontal Pod Autoscaler) is enabled",
                     "type": "integer",
                     "default": 1
                 },
@@ -5125,22 +5125,22 @@
                     "default": null
                 },
                 "hpa": {
-                    "description": "HPA configuration.",
+                    "description": "Horizontal Pod Autoscaler (HPA) configuration for apiServer. (optional)",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "enabled": {
-                            "description": "Allow HPA autoscaling",
+                            "description": "Enable HPA autoscaling for API server",
                             "type": "boolean",
                             "default": false
                         },
                         "minReplicaCount": {
-                            "description": "Minimum number of webservers created by HPA.",
+                            "description": "Minimum number of apiServer replicas created by HPA if HPA enabled.",
                             "type": "integer",
                             "default": 1
                         },
                         "maxReplicaCount": {
-                            "description": "Maximum number of webservers created by HPA.",
+                            "description": "Maximum number of apiServer replicas created by HPA if HPA enabled.",
                             "type": "integer",
                             "default": 5
                         },
@@ -5154,7 +5154,7 @@
                                         "name": "cpu",
                                         "target": {
                                             "type": "Utilization",
-                                            "averageUtilization": 80
+                                            "averageUtilization": 50
                                         }
                                     }
                                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1429,6 +1429,29 @@ apiServer:
   args: ["bash", "-c", "exec airflow api-server"]
   allowPodLogReading: true
   env: []
+
+  # Allow HPA
+  hpa:
+    enabled: true
+
+    # Minimum number of api-servers created by HPA
+    minReplicaCount: 1
+
+    # Maximum number of api-servers created by HPA
+    maxReplicaCount: 5
+
+    # Specifications for which to use to calculate the desired replica count
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
+    # Scaling behavior of the target in both Up and Down directions
+    behavior: {}
+
   serviceAccount:
     # default value is true
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1416,6 +1416,8 @@ migrateDatabaseJob:
 apiServer:
   enabled: true
   # Number of Airflow API servers in the deployment
+  # This setting is ignored when HPA (Horizontal Pod Autoscaler) is enabled,
+  # as HPA will automatically manage the number of replicas based on the configured metrics.
   replicas: 1
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
@@ -1430,7 +1432,9 @@ apiServer:
   allowPodLogReading: true
   env: []
 
-  # Allow HPA
+  # Allow Horizontal Pod Autoscaler (HPA) configuration for apiServer. (optional)
+  # HPA automatically scales the number of apiServer pods based on observed metrics.
+  # HPA automatically adjusts apiServer replicas between minReplicaCount and maxReplicaCount based on metrics.
   hpa:
     enabled: false
 
@@ -1447,7 +1451,7 @@ apiServer:
           name: cpu
           target:
             type: Utilization
-            averageUtilization: 80
+            averageUtilization: 50
 
     # Scaling behavior of the target in both Up and Down directions
     behavior: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1432,7 +1432,7 @@ apiServer:
 
   # Allow HPA
   hpa:
-    enabled: true
+    enabled: false
 
     # Minimum number of api-servers created by HPA
     minReplicaCount: 1

--- a/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
@@ -48,7 +48,7 @@ class TestAPIServerHPA:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "min_replicas, max_replicas",
+        ("min_replicas", "max_replicas"),
         [
             (None, None),
             (2, 8),
@@ -95,7 +95,7 @@ class TestAPIServerHPA:
         assert jmespath.search("spec.behavior", docs[0]) == expected_behavior
 
     @pytest.mark.parametrize(
-        "metrics, expected_metrics",
+        ("metrics", "expected_metrics"),
         [
             # default metrics
             (

--- a/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+import pytest
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestAPIServerHPA:
+    """Tests HPA."""
+
+    def test_hpa_disabled_by_default(self):
+        """Disabled by default."""
+        docs = render_chart(
+            values={},
+            show_only=["templates/api-server/api-server-hpa.yaml"],
+        )
+        assert docs == []
+
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.2",
+                "apiServer": {
+                    "hpa": {"enabled": True},
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/api-server/api-server-hpa.yaml"],
+        )
+
+        assert "test_label" in jmespath.search("metadata.labels", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    @pytest.mark.parametrize(
+        "min_replicas, max_replicas",
+        [
+            (None, None),
+            (2, 8),
+        ],
+    )
+    def test_min_max_replicas(self, min_replicas, max_replicas):
+        """Verify minimum and maximum replicas."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.2",
+                "apiServer": {
+                    "hpa": {
+                        "enabled": True,
+                        **({"minReplicaCount": min_replicas} if min_replicas else {}),
+                        **({"maxReplicaCount": max_replicas} if max_replicas else {}),
+                    }
+                },
+            },
+            show_only=["templates/api-server/api-server-hpa.yaml"],
+        )
+        assert jmespath.search("spec.minReplicas", docs[0]) == 1 if min_replicas is None else min_replicas
+        assert jmespath.search("spec.maxReplicas", docs[0]) == 5 if max_replicas is None else max_replicas
+
+    def test_hpa_behavior(self):
+        """Verify HPA behavior."""
+        expected_behavior = {
+            "scaleDown": {
+                "stabilizationWindowSeconds": 300,
+                "policies": [{"type": "Percent", "value": 100, "periodSeconds": 15}],
+            }
+        }
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.2",
+                "apiServer": {
+                    "hpa": {
+                        "enabled": True,
+                        "behavior": expected_behavior,
+                    },
+                },
+            },
+            show_only=["templates/api-server/api-server-hpa.yaml"],
+        )
+        assert jmespath.search("spec.behavior", docs[0]) == expected_behavior
+
+    @pytest.mark.parametrize(
+        "metrics, expected_metrics",
+        [
+            # default metrics
+            (
+                None,
+                {
+                    "type": "Resource",
+                    "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 80}},
+                },
+            ),
+            # custom metric
+            (
+                [
+                    {
+                        "type": "Pods",
+                        "pods": {
+                            "metric": {"name": "custom"},
+                            "target": {"type": "Utilization", "averageUtilization": 80},
+                        },
+                    }
+                ],
+                {
+                    "type": "Pods",
+                    "pods": {
+                        "metric": {"name": "custom"},
+                        "target": {"type": "Utilization", "averageUtilization": 80},
+                    },
+                },
+            ),
+        ],
+    )
+    def test_should_use_hpa_metrics(self, metrics, expected_metrics):
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.2",
+                "apiServer": {
+                    "hpa": {"enabled": True, **({"metrics": metrics} if metrics else {})},
+                },
+            },
+            show_only=["templates/api-server/api-server-hpa.yaml"],
+        )
+        assert expected_metrics == jmespath.search("spec.metrics[0]", docs[0])

--- a/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
@@ -102,7 +102,7 @@ class TestAPIServerHPA:
                 None,
                 {
                     "type": "Resource",
-                    "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 80}},
+                    "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 50}},
                 },
             ),
             # custom metric
@@ -112,7 +112,7 @@ class TestAPIServerHPA:
                         "type": "Pods",
                         "pods": {
                             "metric": {"name": "custom"},
-                            "target": {"type": "Utilization", "averageUtilization": 80},
+                            "target": {"type": "Utilization", "averageUtilization": 50},
                         },
                     }
                 ],
@@ -120,7 +120,7 @@ class TestAPIServerHPA:
                     "type": "Pods",
                     "pods": {
                         "metric": {"name": "custom"},
-                        "target": {"type": "Utilization", "averageUtilization": 80},
+                        "target": {"type": "Utilization", "averageUtilization": 50},
                     },
                 },
             ),

--- a/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py
@@ -136,4 +136,4 @@ class TestAPIServerHPA:
             },
             show_only=["templates/api-server/api-server-hpa.yaml"],
         )
-        assert expected_metrics == jmespath.search("spec.metrics[0]", docs[0])
+        assert jmespath.search("spec.metrics[0]", docs[0]) == expected_metrics


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Description:
This pull request introduces Horizontal Pod Autoscaler (HPA) support for the Airflow API server in the Helm chart, enabling automatic scaling of API server pods based on resource utilization or custom metrics. The changes enhance the chart's flexibility and scalability, allowing users to configure autoscaling for the API server to handle varying workloads efficiently.

## Changes:
1. **Added HPA Configuration Template**
Created `chart/templates/api-server/api-server-hpa.yaml `to define the HPA resource for the API server.
2. **Updated Values Schema**
Modified `chart/values.schema.json` to include a new hpa section under apiServer.
3. **Updated Default Values**
Added HPA configuration in `chart/values.yaml` under apiServer.hpa with sensible defaults
4. **Added Unit Tests**:
Introduced `helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py` to validate HPA behavior

## How to Test:
1. Enable HPA with `apiServer.hpa.enabled=true` and verify the HPA resource is created with default settings.
2. Override `minReplicaCount`, `maxReplicaCount`, `metrics`, or `behavior` in values.yaml and confirm the HPA resource reflects the changes.
3. Run unit tests with pytest `helm-tests/tests/helm_tests/apiserver/test_hpa_apiserver.py` to validate logic.

## Additional Notes:
![Screenshot 2025-06-28 at 3 15 04 PM](https://github.com/user-attachments/assets/d255c629-f9d9-4767-bc4f-70c664f31be2)
Included deployment and HPA status screenshot from kubectl displaying an Airflow API server deployment with 4 pods running.

## Related Issues:
#51935 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
