### PR TITLE
Fix StopIteration in snowflake sql tests

### DIFF
--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -1107,7 +1107,9 @@ class TestSnowflakeSqlApiHook:
 
         # Simulate a query that keeps running and never finishes
         hook.get_sql_api_query_status = mock.MagicMock(return_value={"status": "running"})
-        time_mock.side_effect = list(range(5))
+
+        # More side effects to ensure we hit the timeout and avoid StopIteration error
+        time_mock.side_effect = list(range(10))
 
         qid = "qid-789"
         timeout = 3
@@ -1120,7 +1122,7 @@ class TestSnowflakeSqlApiHook:
         sleep_mock.assert_has_calls([mock.call(1)] * 3)
         assert hook.get_sql_api_query_status.call_count == 4
         hook.get_sql_api_query_status.assert_has_calls([mock.call(query_id=qid)] * 4)
-        assert time_mock.call_count == 5
+        assert time_mock.call_count >= 3
 
     @mock.patch(f"{HOOK_PATH}._make_api_call_with_retries")
     @mock.patch(f"{HOOK_PATH}._process_response")


### PR DESCRIPTION
We observed the tests fails sometimes with StopIteration in https://github.com/apache/airflow/pull/52072, just to be safe side we can increate side_effect cound and as we already have timeout 3 seconds so it should trigger TimeoutError

```
FAILED providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py::TestSnowflakeSqlApiHook::test_wait_for_query_timeout_error - StopIteration
= 1 failed, 12987 passed, 3709 skipped, 1 xfailed, 5 warnings in 603.92s (0:10:03) =
```
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
