### PR TITLE
Bring back providers compatibility checks

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -732,7 +732,26 @@ DEFAULT_EXTRAS = [
     # END OF EXTRAS LIST UPDATED BY PRE COMMIT
 ]
 
-PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = []
+PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
+    {
+        "python-version": "3.10",
+        "airflow-version": "2.10.5",
+        "remove-providers": "common.messaging fab git keycloak",
+        "run-tests": "true",
+    },
+    {
+        "python-version": "3.10",
+        "airflow-version": "2.11.0",
+        "remove-providers": "common.messaging fab git keycloak",
+        "run-tests": "true",
+    },
+    {
+        "python-version": "3.10",
+        "airflow-version": "3.0.2",
+        "remove-providers": "",
+        "run-tests": "true",
+    },
+]
 
 # Number of slices for low dep tests
 NUMBER_OF_LOW_DEP_SLICES = 5

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery_dts.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery_dts.py
@@ -29,8 +29,6 @@ from airflow.providers.google.cloud.operators.bigquery_dts import (
     BigQueryDeleteDataTransferConfigOperator,
 )
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
 PROJECT_ID = "id"
 
 TRANSFER_CONFIG = {
@@ -73,10 +71,7 @@ class TestBigQueryCreateDataTransferOperator:
             retry=DEFAULT,
             timeout=None,
         )
-        if AIRFLOW_V_3_0_PLUS:
-            ti.xcom_push.assert_called_with(key="transfer_config_id", value="1a2b3c")
-        else:
-            ti.xcom_push.assert_called_with(key="transfer_config_id", value="1a2b3c", execution_date=None)
+        ti.xcom_push.assert_called_with(key="transfer_config_id", value="1a2b3c")
 
         assert "secret_access_key" not in return_value.get("params", {})
         assert "access_key_id" not in return_value.get("params", {})
@@ -131,10 +126,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
             retry=DEFAULT,
             timeout=None,
         )
-        if AIRFLOW_V_3_0_PLUS:
-            ti.xcom_push.assert_called_with(key="run_id", value="123")
-        else:
-            ti.xcom_push.assert_called_with(key="run_id", value="123", execution_date=None)
+        ti.xcom_push.assert_called_with(key="run_id", value="123")
 
     @mock.patch(
         f"{OPERATOR_MODULE_PATH}.BiqQueryDataTransferServiceHook",

--- a/providers/google/tests/unit/google/cloud/operators/test_datacatalog.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datacatalog.py
@@ -51,6 +51,8 @@ from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogUpdateTagTemplateOperator,
 )
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
 if TYPE_CHECKING:
     from google.api_core.gapic_v1.method import _MethodDefault
 
@@ -163,6 +165,8 @@ class TestCloudDataCatalogCreateEntryOperator:
             )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -205,6 +209,8 @@ class TestCloudDataCatalogCreateEntryOperator:
             )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -257,6 +263,8 @@ class TestCloudDataCatalogCreateEntryGroupOperator:
             )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -301,6 +309,8 @@ class TestCloudDataCatalogCreateTagOperator:
             )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -345,6 +355,8 @@ class TestCloudDataCatalogCreateTagTemplateOperator:
             )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -388,6 +400,8 @@ class TestCloudDataCatalogCreateTagTemplateFieldOperator:
             )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -32,6 +32,8 @@ from airflow.providers.google.cloud.operators.functions import (
 )
 from airflow.version import version
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
 EMPTY_CONTENT = b""
 MOCK_RESP_404 = httplib2.Response({"status": 404})
 
@@ -716,6 +718,8 @@ class TestGcfFunctionInvokeOperator:
         )
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = op
         op.execute(mock_context)
 
         mock_gcf_hook.assert_called_once_with(


### PR DESCRIPTION
The compatibility checks were removed in #52072 accidentally. This one brings them back:

* Python 3.10
* do not add cloudant (it was not working for Python 3.9)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
