### PR TITLE
Reduce timeout for task-sdk/airflow-ctl tests job workflow

### DIFF
--- a/.github/workflows/airflow-distributions-tests.yml
+++ b/.github/workflows/airflow-distributions-tests.yml
@@ -61,11 +61,16 @@ on:  # yamllint disable-line rule:truthy
         description: "Whether local venv should be used for tests (true/false)"
         required: true
         type: string
+      test-timeout:
+        required: false
+        type: number
+        default: 60
+
 permissions:
   contents: read
 jobs:
   distributions-tests:
-    timeout-minutes: 80
+    timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
     name: ${{ inputs.distribution-name }}:P${{ matrix.python-version }} tests
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -784,7 +784,7 @@ jobs:
       distribution-cmd-format: "prepare-task-sdk-distributions"
       test-type: "task-sdk-tests"
       use-local-venv: 'false'
-      test-timeout: 15
+      test-timeout: 20
     if: >
       ( needs.build-info.outputs.run-task-sdk-tests == 'true' ||
       needs.build-info.outputs.run-tests == 'true' &&
@@ -845,7 +845,7 @@ jobs:
       distribution-cmd-format: "prepare-airflow-ctl-distributions"
       test-type: "airflow-ctl-tests"
       use-local-venv: 'true'
-      test-timeout: 15
+      test-timeout: 20
     if: >
       ( needs.build-info.outputs.run-airflow-ctl-tests == 'true' ||
       needs.build-info.outputs.run-tests == 'true' &&

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -784,6 +784,7 @@ jobs:
       distribution-cmd-format: "prepare-task-sdk-distributions"
       test-type: "task-sdk-tests"
       use-local-venv: 'false'
+      test-timeout: 15
     if: >
       ( needs.build-info.outputs.run-task-sdk-tests == 'true' ||
       needs.build-info.outputs.run-tests == 'true' &&
@@ -844,6 +845,7 @@ jobs:
       distribution-cmd-format: "prepare-airflow-ctl-distributions"
       test-type: "airflow-ctl-tests"
       use-local-venv: 'true'
+      test-timeout: 15
     if: >
       ( needs.build-info.outputs.run-airflow-ctl-tests == 'true' ||
       needs.build-info.outputs.run-tests == 'true' &&


### PR DESCRIPTION
Sometimes its taking very long time to pull image https://github.com/apache/airflow/actions/runs/15941988457/job/44971348437?pr=52394

On average these tests are taking 5 to 6min https://github.com/apache/airflow/actions/runs/15941867329/job/44971095926 , so i think adding timeout and we can look why its taking longer time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
