### PR TITLE
Add a script to report outdated versions in constraints

### DIFF
--- a/dev/constraints-updated-version-check.py
+++ b/dev/constraints-updated-version-check.py
@@ -1,0 +1,322 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import urllib.request
+from datetime import datetime
+from urllib.error import HTTPError, URLError
+
+from packaging import version
+
+
+def parse_constraints_generation_date(lines):
+    for line in lines[:5]:
+        if "automatically generated on" in line:
+            date_str = line.split("generated on")[-1].strip()
+            try:
+                return datetime.fromisoformat(date_str).replace(tzinfo=None)
+            except ValueError:
+                print(f"Warning: Could not parse constraints generation date from: {date_str}")
+                return None
+    return None
+
+
+def get_constraints_file(python_version):
+    url = f"https://raw.githubusercontent.com/apache/airflow/refs/heads/constraints-main/constraints-{python_version}.txt"
+    try:
+        response = urllib.request.urlopen(url)
+        return response.read().decode("utf-8").splitlines()
+    except HTTPError as e:
+        if e.code == 404:
+            print(f"Error: Constraints file for Python {python_version} not found.")
+            print(f"URL: {url}")
+            print("Please check if the Python version is correct and the file exists.")
+        else:
+            print(f"HTTP Error: {e.code} - {e.reason}")
+        exit(1)
+    except URLError as e:
+        print(f"Error connecting to GitHub: {e.reason}")
+        exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {str(e)}")
+        exit(1)
+
+
+def count_versions_between(releases, current_version, latest_version):
+    try:
+        current = version.parse(current_version)
+        latest = version.parse(latest_version)
+
+        if current == latest:
+            return 0
+
+        valid_versions = [
+            v
+            for v in releases.keys()
+            if releases[v] and not version.parse(v).is_prerelease and current < version.parse(v) <= latest
+        ]
+
+        return max(len(valid_versions), 1) if current < latest else 0
+    except Exception:
+        return 0
+
+
+def get_status_emoji(constraint_date, latest_date, is_latest_version):
+    """Determine status emoji based on how outdated the package is"""
+    if is_latest_version:
+        return "✅ OK             "  # Package is up to date (15 chars padding)
+
+    try:
+        constraint_dt = datetime.strptime(constraint_date, "%Y-%m-%d")
+        latest_dt = datetime.strptime(latest_date, "%Y-%m-%d")
+        days_diff = (latest_dt - constraint_dt).days
+
+        if days_diff <= 5:
+            return "📢 <5d          "
+        if days_diff <= 30:
+            return "⚠ <30d          "
+        return f"🚨 >{days_diff}d".ljust(15)
+    except Exception:
+        return "📢 N/A           "
+
+
+def get_max_package_length(packages):
+    return max(len(pkg) for pkg, _ in packages)
+
+
+def should_show_package(releases, latest_version, constraints_date, mode, is_latest_version):
+    if mode == "full":
+        return True
+    if mode == "diff-all":
+        return not is_latest_version
+    # diff-constraints
+    if is_latest_version:
+        return False
+
+    if not constraints_date:
+        return True
+
+    for version_info in releases.values():
+        if not version_info:
+            continue
+        try:
+            release_date = datetime.fromisoformat(
+                version_info[0]["upload_time_iso_8601"].replace("Z", "+00:00")
+            ).replace(tzinfo=None)
+            if release_date > constraints_date:
+                return False
+        except (KeyError, IndexError, ValueError):
+            continue
+
+    return True
+
+
+def get_first_newer_release_date_str(releases, current_version):
+    current = version.parse(current_version)
+    newer_versions = [
+        version.parse(v)
+        for v in releases
+        if version.parse(v) > current and releases[v] and not version.parse(v).is_prerelease
+    ]
+    if not newer_versions:
+        return None
+
+    first_newer_version = min(newer_versions)
+    upload_time_str = releases[str(first_newer_version)][0]["upload_time_iso_8601"]
+    return datetime.fromisoformat(upload_time_str.replace("Z", "+00:00")).strftime("%Y-%m-%d")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+Python Package Version Checker for Airflow Constraints
+
+This script checks Python package versions against the Airflow constraints file and reports:
+- Current constrained version vs latest available version
+- Release dates for both versions
+- Status indicator showing how outdated the package is
+- Number of versions between constrained and latest version
+- Direct PyPI link to the package
+
+Status Indicators:
+✅ OK          - Package is up to date
+📢 <5d         - Less than 5 days behind latest version
+⚠ <30d         - Between 5-30 days behind latest version
+🚨 >Xd         - More than X days behind latest version (X = actual days)
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--python-version", required=True, help="Python version to check constraints for (e.g., 3.12)"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["full", "diff-constraints", "diff-all"],
+        default="diff-constraints",
+        help="""
+Operation modes:
+  full            : Show all packages, including up-to-date ones
+  diff-constraints: (Default) Show only outdated packages with updates
+                   before constraints generation
+  diff-all       : Show all outdated packages regardless of update timing
+                       """,
+    )
+
+    args = parser.parse_args()
+
+    lines = get_constraints_file(args.python_version)
+
+    constraints_date = parse_constraints_generation_date(lines)
+    if constraints_date:
+        print(f"Constraints file generation date: {constraints_date.strftime('%Y-%m-%d %H:%M:%S')}")
+        print()
+
+    packages = []
+    for line in lines:
+        line = line.strip()
+        if line and not line.startswith("#") and "@" not in line:
+            match = re.match(r"^([a-zA-Z0-9_.\-]+)==([\w.\-]+)$", line)
+            if match:
+                packages.append((match.group(1), match.group(2)))
+
+    max_pkg_length = get_max_package_length(packages)
+
+    col_widths = {
+        "Library Name": max(35, max_pkg_length),
+        "Constraint Version": 18,
+        "Constraint Date": 12,
+        "Latest Version": 15,
+        "Latest Date": 12,
+        "Status": 15,
+        "# Versions Behind": 16,
+        "PyPI Link": 60,
+    }
+
+    format_str = (
+        f"{{:<{col_widths['Library Name']}}} | "
+        f"{{:<{col_widths['Constraint Version']}}} | "
+        f"{{:<{col_widths['Constraint Date']}}} | "
+        f"{{:<{col_widths['Latest Version']}}} | "
+        f"{{:<{col_widths['Latest Date']}}} | "
+        f"{{:<{col_widths['Status']}}} | "
+        f"{{:>15}} | "
+        f"{{:<{col_widths['PyPI Link']}}}"
+    )
+
+    headers = [
+        "Library Name",
+        "Constraint Version",
+        "Constraint Date",
+        "Latest Version",
+        "Latest Date",
+        "Status",
+        "# Versions Behind",
+        "PyPI Link",
+    ]
+
+    print(format_str.format(*headers))
+    total_width = sum(col_widths.values()) + (len(col_widths) - 1) * 3
+    print("=" * total_width)
+
+    outdated_count = 0
+    skipped_count = 0
+
+    for pkg, pinned_version in packages:
+        try:
+            pypi_url = f"https://pypi.org/pypi/{pkg}/json"
+            with urllib.request.urlopen(pypi_url) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+                latest_version = data["info"]["version"]
+                releases = data["releases"]
+
+                latest_release_date = "N/A"
+                constraint_release_date = "N/A"
+
+                if releases.get(latest_version):
+                    latest_release_date = (
+                        datetime.fromisoformat(
+                            releases[latest_version][0]["upload_time_iso_8601"].replace("Z", "+00:00")
+                        )
+                        .replace(tzinfo=None)
+                        .strftime("%Y-%m-%d")
+                    )
+
+                if releases.get(pinned_version):
+                    constraint_release_date = (
+                        datetime.fromisoformat(
+                            releases[pinned_version][0]["upload_time_iso_8601"].replace("Z", "+00:00")
+                        )
+                        .replace(tzinfo=None)
+                        .strftime("%Y-%m-%d")
+                    )
+
+                is_latest_version = pinned_version == latest_version
+                versions_behind = count_versions_between(releases, pinned_version, latest_version)
+                versions_behind_str = str(versions_behind) if versions_behind > 0 else ""
+
+                if should_show_package(
+                    releases, latest_version, constraints_date, args.mode, is_latest_version
+                ):
+                    # Use the first newer release date instead of latest version date
+                    first_newer_date_str = get_first_newer_release_date_str(releases, pinned_version)
+                    status = get_status_emoji(
+                        first_newer_date_str or constraint_release_date,
+                        datetime.utcnow().strftime("%Y-%m-%d"),  # noqa: TID251
+                        is_latest_version,
+                    )
+                    pypi_link = f"https://pypi.org/project/{pkg}/{latest_version}"
+
+                    print(
+                        format_str.format(
+                            pkg,
+                            pinned_version[: col_widths["Constraint Version"]],
+                            constraint_release_date[: col_widths["Constraint Date"]],
+                            latest_version[: col_widths["Latest Version"]],
+                            latest_release_date[: col_widths["Latest Date"]],
+                            status[: col_widths["Status"]],
+                            versions_behind_str,
+                            pypi_link,
+                        )
+                    )
+                    if not is_latest_version:
+                        outdated_count += 1
+                    else:
+                        skipped_count += 1
+
+        except HTTPError as e:
+            print(f"Error fetching {pkg} from PyPI: HTTP {e.code}")
+            continue
+        except URLError as e:
+            print(f"Error fetching {pkg} from PyPI: {e.reason}")
+            continue
+        except Exception as e:
+            print(f"Error processing {pkg}: {str(e)}")
+            continue
+
+    print("=" * total_width)
+    print(f"\nTotal packages checked: {len(packages)}")
+    print(f"Outdated packages found: {outdated_count}")
+    if args.mode == "diff-constraints":
+        print(f"Skipped packages (updated after constraints generation): {skipped_count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Example output:

```
➜  ~ python /Users/eladkal/PycharmProjects/airflow/files/versions-check.py --python-version 3.12 --mode diff-all
Constraints file generation date: 2025-06-26 19:59:38

Library Name                              | Constraint Version | Release Date | Latest Version  | Release Date | Status          | # Versions Behind | PyPI Link
===================================================================================================================================================================================================
Authlib                                   | 1.3.1              | 2024-06-04   | 1.6.0           | 2025-05-23   | 🚨 >353d         |               7 | https://pypi.org/project/Authlib/1.6.0
Flask-AppBuilder                          | 4.6.3              | 2025-05-05   | 4.7.0           | 2025-05-28   | ⚠ <30d          |               5 | https://pypi.org/project/Flask-AppBuilder/4.7.0
Flask-Babel                               | 2.0.0              | 2020-08-27   | 4.0.0           | 2023-10-02   | 🚨 >1131d        |               4 | https://pypi.org/project/Flask-Babel/4.0.0
Flask-SQLAlchemy                          | 2.5.1              | 2021-03-18   | 3.1.1           | 2023-09-11   | 🚨 >907d         |              10 | https://pypi.org/project/Flask-SQLAlchemy/3.1.1
Flask-Session                             | 0.5.0              | 2023-05-11   | 0.8.0           | 2024-03-26   | 🚨 >320d         |               6 | https://pypi.org/project/Flask-Session/0.8.0
Flask                                     | 2.2.5              | 2023-05-02   | 3.1.1           | 2025-05-13   | 🚨 >742d         |              10 | https://pypi.org/project/Flask/3.1.1
SQLAlchemy                                | 1.4.54             | 2024-09-05   | 2.0.41          | 2025-05-14   | 🚨 >251d         |              50 | https://pypi.org/project/SQLAlchemy/2.0.41
Werkzeug                                  | 2.2.3              | 2023-02-14   | 3.1.3           | 2024-11-08   | 🚨 >633d         |              20 | https://pypi.org/project/Werkzeug/3.1.3
analytics-python                          | 1.2.9              | 2017-11-29   | 1.4.post1       | 2023-03-22   | 🚨 >1939d        |               6 | https://pypi.org/project/analytics-python/1.4.post1
async-timeout                             | 4.0.3              | 2023-08-10   | 5.0.1           | 2024-11-06   | 🚨 >454d         |               2 | https://pypi.org/project/async-timeout/5.0.1
awswrangler                               | 3.11.0             | 2025-01-10   | 3.12.1          | 2025-06-18   | 🚨 >159d         |               2 | https://pypi.org/project/awswrangler/3.12.1
azure-datalake-store                      | 0.0.53             | 2023-05-10   | 1.0.1           | 2025-06-03   | 🚨 >755d         |               2 | https://pypi.org/project/azure-datalake-store/1.0.1
bitarray                                  | 2.9.3              | 2024-10-10   | 3.4.3           | 2025-06-23   | 🚨 >256d         |              11 | https://pypi.org/project/bitarray/3.4.3
boto3                                     | 1.38.27            | 2025-05-30   | 1.38.46         | 2025-06-27   | ⚠ <30d          |              19 | https://pypi.org/project/boto3/1.38.46
botocore                                  | 1.38.27            | 2025-05-30   | 1.38.46         | 2025-06-27   | ⚠ <30d          |              19 | https://pypi.org/project/botocore/1.38.46
cachetools                                | 5.5.2              | 2025-02-20   | 6.1.0           | 2025-06-16   | 🚨 >116d         |               2 | https://pypi.org/project/cachetools/6.1.0
connexion                                 | 2.14.2             | 2023-01-25   | 3.2.0           | 2025-01-08   | 🚨 >714d         |              19 | https://pypi.org/project/connexion/3.2.0
cryptography                              | 42.0.8             | 2024-06-04   | 45.0.4          | 2025-06-10   | 🚨 >371d         |              12 | https://pypi.org/project/cryptography/45.0.4
databricks-sqlalchemy                     | 1.0.5              | 2025-01-28   | 2.0.7           | 2025-06-23   | 🚨 >146d         |               7 | https://pypi.org/project/databricks-sqlalchemy/2.0.7
dill                                      | 0.3.1.1            | 2019-09-28   | 0.4.0           | 2025-04-16   | 🚨 >2027d        |              10 | https://pypi.org/project/dill/0.4.0
elasticsearch                             | 8.18.1             | 2025-04-29   | 9.0.2           | 2025-06-05   | 🚨 >37d          |               3 | https://pypi.org/project/elasticsearch/9.0.2
geomet                                    | 0.2.1.post1        | 2020-01-12   | 1.1.0           | 2023-11-14   | 🚨 >1402d        |               3 | https://pypi.org/project/geomet/1.1.0
google-cloud-aiplatform                   | 1.99.0             | 2025-06-24   | 1.100.0         | 2025-06-26   | 📢 <5d           |               1 | https://pypi.org/project/google-cloud-aiplatform/1.100.0
google-cloud-storage                      | 2.19.0             | 2024-12-05   | 3.1.1           | 2025-06-18   | 🚨 >195d         |               4 | https://pypi.org/project/google-cloud-storage/3.1.1
google-genai                              | 1.2.0              | 2025-02-12   | 1.23.0          | 2025-06-27   | 🚨 >135d         |              24 | https://pypi.org/project/google-genai/1.23.0
grpcio-health-checking                    | 1.62.3             | 2024-08-06   | 1.73.1          | 2025-06-26   | 🚨 >324d         |              42 | https://pypi.org/project/grpcio-health-checking/1.73.1
grpcio-status                             | 1.62.3             | 2024-08-06   | 1.73.1          | 2025-06-26   | 🚨 >324d         |              42 | https://pypi.org/project/grpcio-status/1.73.1
grpcio-tools                              | 1.62.3             | 2024-08-06   | 1.73.1          | 2025-06-26   | 🚨 >324d         |              42 | https://pypi.org/project/grpcio-tools/1.73.1
grpcio                                    | 1.65.5             | 2024-08-17   | 1.73.1          | 2025-06-26   | 🚨 >313d         |              27 | https://pypi.org/project/grpcio/1.73.1
httpx-sse                                 | 0.4.0              | 2023-12-22   | 0.4.1           | 2025-06-24   | 🚨 >550d         |               1 | https://pypi.org/project/httpx-sse/0.4.1
httpx                                     | 0.27.0             | 2024-02-21   | 0.28.1          | 2024-12-06   | 🚨 >289d         |               4 | https://pypi.org/project/httpx/0.28.1
ibm-cloud-sdk-core                        | 3.20.3             | 2024-07-11   | 3.24.2          | 2025-06-12   | 🚨 >336d         |              10 | https://pypi.org/project/ibm-cloud-sdk-core/3.24.2
ibmcloudant                               | 0.9.1              | 2024-07-11   | 0.10.4          | 2025-06-11   | 🚨 >335d         |               7 | https://pypi.org/project/ibmcloudant/0.10.4
importlib_metadata                        | 8.4.0              | 2024-08-20   | 8.7.0           | 2025-04-27   | 🚨 >250d         |               4 | https://pypi.org/project/importlib_metadata/8.7.0
jmespath                                  | 0.10.0             | 2020-05-12   | 1.0.1           | 2022-06-17   | 🚨 >766d         |               2 | https://pypi.org/project/jmespath/1.0.1
jsonpickle                                | 3.4.2              | 2024-11-06   | 4.1.1           | 2025-06-02   | 🚨 >208d         |               8 | https://pypi.org/project/jsonpickle/4.1.1
kubernetes                                | 32.0.1             | 2025-02-18   | 33.1.0          | 2025-06-09   | 🚨 >111d         |               3 | https://pypi.org/project/kubernetes/33.1.0
lxml                                      | 5.3.2              | 2025-04-05   | 6.0.0           | 2025-06-26   | 🚨 >82d          |               2 | https://pypi.org/project/lxml/6.0.0
marshmallow                               | 3.26.1             | 2025-02-03   | 4.0.0           | 2025-04-17   | 🚨 >73d          |               1 | https://pypi.org/project/marshmallow/4.0.0
microsoft-kiota-abstractions              | 1.9.3              | 2025-03-24   | 1.9.4           | 2025-06-27   | 🚨 >95d          |               1 | https://pypi.org/project/microsoft-kiota-abstractions/1.9.4
microsoft-kiota-authentication-azure      | 1.9.3              | 2025-03-24   | 1.9.4           | 2025-06-27   | 🚨 >95d          |               1 | https://pypi.org/project/microsoft-kiota-authentication-azure/1.9.4
microsoft-kiota-http                      | 1.9.3              | 2025-03-24   | 1.9.4           | 2025-06-27   | 🚨 >95d          |               1 | https://pypi.org/project/microsoft-kiota-http/1.9.4
microsoft-kiota-serialization-json        | 1.9.3              | 2025-03-24   | 1.9.4           | 2025-06-27   | 🚨 >95d          |               1 | https://pypi.org/project/microsoft-kiota-serialization-json/1.9.4
microsoft-kiota-serialization-text        | 1.9.3              | 2025-03-24   | 1.9.4           | 2025-06-27   | 🚨 >95d          |               1 | https://pypi.org/project/microsoft-kiota-serialization-text/1.9.4
msgraph-core                              | 1.3.4              | 2025-06-02   | 1.3.5           | 2025-06-27   | ⚠ <30d          |               1 | https://pypi.org/project/msgraph-core/1.3.5
multidict                                 | 6.5.1              | 2025-06-24   | 6.6.1           | 2025-06-28   | 📢 <5d           |               2 | https://pypi.org/project/multidict/6.6.1
mypy-boto3-rds                            | 1.38.43            | 2025-06-24   | 1.38.46         | 2025-06-27   | 📢 <5d           |               1 | https://pypi.org/project/mypy-boto3-rds/1.38.46
mypy                                      | 1.9.0              | 2024-03-08   | 1.16.1          | 2025-06-16   | 🚨 >465d         |              13 | https://pypi.org/project/mypy/1.16.1
numpy                                     | 1.26.4             | 2024-02-05   | 2.3.1           | 2025-06-21   | 🚨 >502d         |              18 | https://pypi.org/project/numpy/2.3.1
openai                                    | 1.92.2             | 2025-06-26   | 1.93.0          | 2025-06-27   | 📢 <5d           |               2 | https://pypi.org/project/openai/1.93.0
opentelemetry-api                         | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-api/1.34.1
opentelemetry-exporter-otlp-proto-common  | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-exporter-otlp-proto-common/1.34.1
opentelemetry-exporter-otlp-proto-grpc    | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-exporter-otlp-proto-grpc/1.34.1
opentelemetry-exporter-otlp-proto-http    | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/1.34.1
opentelemetry-exporter-otlp               | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-exporter-otlp/1.34.1
opentelemetry-exporter-prometheus         | 0.48b0             | 2024-08-28   | 0.55b1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-exporter-prometheus/0.55b1
opentelemetry-proto                       | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-proto/1.34.1
opentelemetry-sdk                         | 1.27.0             | 2024-08-28   | 1.34.1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-sdk/1.34.1
opentelemetry-semantic-conventions        | 0.48b0             | 2024-08-28   | 0.55b1          | 2025-06-10   | 🚨 >286d         |              13 | https://pypi.org/project/opentelemetry-semantic-conventions/0.55b1
oracledb                                  | 3.1.1              | 2025-05-15   | 3.2.0           | 2025-06-26   | 🚨 >42d          |               1 | https://pypi.org/project/oracledb/3.2.0
pandas                                    | 2.1.4              | 2023-12-08   | 2.3.0           | 2025-06-05   | 🚨 >545d         |               6 | https://pypi.org/project/pandas/2.3.0
pinecone                                  | 7.0.1              | 2025-05-21   | 7.3.0           | 2025-06-27   | 🚨 >37d          |               6 | https://pypi.org/project/pinecone/7.3.0
pinotdb                                   | 5.6.0              | 2024-07-14   | 5.7.0           | 2025-06-09   | 🚨 >330d         |               1 | https://pypi.org/project/pinotdb/5.7.0
portalocker                               | 2.10.1             | 2024-07-13   | 3.2.0           | 2025-06-14   | 🚨 >336d         |               4 | https://pypi.org/project/portalocker/3.2.0
protobuf                                  | 4.25.8             | 2025-05-28   | 6.31.1          | 2025-05-28   | 📢 <5d           |              39 | https://pypi.org/project/protobuf/6.31.1
pyarrow                                   | 16.1.0             | 2024-05-14   | 20.0.0          | 2025-04-27   | 🚨 >348d         |               6 | https://pypi.org/project/pyarrow/20.0.0
pyasn1_modules                            | 0.4.1              | 2024-09-11   | 0.4.2           | 2025-03-28   | 🚨 >198d         |               1 | https://pypi.org/project/pyasn1_modules/0.4.2
pydantic_core                             | 2.33.2             | 2025-04-23   | 2.35.2          | 2025-06-26   | 🚨 >64d          |               5 | https://pypi.org/project/pydantic_core/2.35.2
pydot                                     | 1.4.2              | 2021-02-15   | 4.0.1           | 2025-06-17   | 🚨 >1583d        |               8 | https://pypi.org/project/pydot/4.0.1
pymongo                                   | 4.10.1             | 2024-10-01   | 4.13.2          | 2025-06-16   | 🚨 >258d         |              10 | https://pypi.org/project/pymongo/4.13.2
pytest-asyncio                            | 0.25.0             | 2024-12-13   | 1.0.0           | 2025-05-26   | 🚨 >164d         |               6 | https://pypi.org/project/pytest-asyncio/1.0.0
redis                                     | 5.2.1              | 2024-12-06   | 6.2.0           | 2025-05-28   | 🚨 >173d         |              11 | https://pypi.org/project/redis/6.2.0
rich                                      | 13.9.4             | 2024-11-01   | 14.0.0          | 2025-03-30   | 🚨 >149d         |               1 | https://pypi.org/project/rich/14.0.0
ruff                                      | 0.11.13            | 2025-06-05   | 0.12.1          | 2025-06-26   | ⚠ <30d          |               2 | https://pypi.org/project/ruff/0.12.1
sendgrid                                  | 6.11.0             | 2023-12-01   | 6.12.4          | 2025-06-12   | 🚨 >559d         |               5 | https://pypi.org/project/sendgrid/6.12.4
sentry-sdk                                | 2.31.0             | 2025-06-24   | 2.32.0          | 2025-06-27   | 📢 <5d           |               1 | https://pypi.org/project/sentry-sdk/2.32.0
sqlalchemy-spanner                        | 1.13.1             | 2025-06-20   | 1.14.0          | 2025-06-27   | ⚠ <30d          |               1 | https://pypi.org/project/sqlalchemy-spanner/1.14.0
sqlalchemy_drill                          | 1.1.8              | 2025-02-28   | 1.1.9           | 2025-06-27   | 🚨 >119d         |               1 | https://pypi.org/project/sqlalchemy_drill/1.1.9
starlette                                 | 0.46.2             | 2025-04-13   | 0.47.1          | 2025-06-21   | 🚨 >69d          |               2 | https://pypi.org/project/starlette/0.47.1
thrift                                    | 0.16.0             | 2022-03-31   | 0.22.0          | 2025-05-23   | 🚨 >1149d        |               3 | https://pypi.org/project/thrift/0.22.0
typing_extensions                         | 4.13.2             | 2025-04-10   | 4.14.0          | 2025-06-02   | 🚨 >53d          |               2 | https://pypi.org/project/typing_extensions/4.14.0
uv                                        | 0.7.15             | 2025-06-25   | 0.7.16          | 2025-06-27   | 📢 <5d           |               1 | https://pypi.org/project/uv/0.7.16
validators                                | 0.34.0             | 2024-09-03   | 0.35.0          | 2025-05-01   | 🚨 >240d         |               1 | https://pypi.org/project/validators/0.35.0
weaviate-client                           | 4.9.6              | 2024-12-03   | 4.15.4          | 2025-06-26   | 🚨 >205d         |              34 | https://pypi.org/project/weaviate-client/4.15.4
websockets                                | 14.2               | 2025-01-19   | 15.0.1          | 2025-03-05   | 🚨 >45d          |               2 | https://pypi.org/project/websockets/15.0.1
xmlsec                                    | 1.3.14             | 2024-04-18   | 1.3.15          | 2025-03-11   | 🚨 >327d         |               1 | https://pypi.org/project/xmlsec/1.3.15
yandexcloud                               | 0.328.0            | 2024-12-09   | 0.350.0         | 2025-06-23   | 🚨 >196d         |              22 | https://pypi.org/project/yandexcloud/0.350.0
===================================================================================================================================================================================================

Total packages checked: 791
Outdated packages found: 87
```


```
➜  ~ python /Users/eladkal/PycharmProjects/airflow/files/versions-check.py --help
usage: versions-check.py [-h] --python-version PYTHON_VERSION [--mode {full,diff-constraints,diff-all}]

Python Package Version Checker for Airflow Constraints

This script checks Python package versions against the Airflow constraints file and reports:
- Current constrained version vs latest available version
- Release dates for both versions
- Status indicator showing how outdated the package is
- Number of versions between constrained and latest version
- Direct PyPI link to the package

Status Indicators:
✅ OK          - Package is up to date
📢 <5d         - Less than 5 days behind latest version
⚠ <30d         - Between 5-30 days behind latest version
🚨 >Xd         - More than X days behind latest version (X = actual days)


optional arguments:
  -h, --help            show this help message and exit
  --python-version PYTHON_VERSION
                        Python version to check constraints for (e.g., 3.12)
  --mode {full,diff-constraints,diff-all}
                        Operation modes: full : Show all packages, including up-to-date ones diff-constraints: (Default) Show only outdated packages with updates before constraints generation diff-all : Show all outdated packages
                        regardless of update timing
```