### PR TITLE
Adding some intelligence to classifying provider commits

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -195,6 +195,49 @@ TYPE_OF_CHANGE_DESCRIPTION = {
 }
 
 
+def classification_result(changed_files):
+    if not changed_files:
+        return "other"
+
+    has_docs = any(re.match(r"^providers/[^/]+/docs/", f) and f.endswith(".rst") for f in changed_files)
+
+    has_test_or_example_only = all(
+        re.match(r"^providers/[^/]+/tests/", f)
+        or re.match(r"^providers/[^/]+/src/airflow/providers/[^/]+/example_dags/", f)
+        for f in changed_files
+    )
+
+    if has_docs:
+        return "documentation"
+    if has_test_or_example_only:
+        return "test_or_example_only"
+    return "other"
+
+
+def classify_provider_pr_files(commit_hash: str) -> str:
+    """
+    Classify a provider commit based on changed files.
+
+    - Returns 'documentation' if any provider doc files are present.
+    - Returns 'test_or_example_only' if only test/example DAGs changed.
+    - Returns 'other' otherwise.
+    """
+    try:
+        result = run_command(
+            ["git", "diff", "--name-only", f"{commit_hash}^", commit_hash],
+            cwd=AIRFLOW_ROOT_PATH,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        changed_files = result.stdout.strip().splitlines()
+    except subprocess.CalledProcessError:
+        # safe to return other here
+        return "other"
+
+    return classification_result(changed_files)
+
+
 def _get_git_log_command(
     folder_paths: list[Path] | None = None, from_commit: str | None = None, to_commit: str | None = None
 ) -> list[str]:
@@ -715,39 +758,6 @@ def _update_commits_rst(
     )
 
 
-def _is_test_or_example_dag_only_changes(commit_hash: str) -> bool:
-    """
-    Check if a commit contains only test-related or example DAG changes
-    by using the git diff command.
-
-    Considers files in airflow/providers/{provider}/tests/
-    and airflow/providers/{provider}/src/airflow/providers/{provider}/example_dags/
-    as test/example-only files.
-
-    :param commit_hash: The full commit hash to check
-    :return: True if changes are only in test/example files, False otherwise
-    """
-    try:
-        result = run_command(
-            ["git", "diff", "--name-only", f"{commit_hash}^", commit_hash],
-            cwd=AIRFLOW_ROOT_PATH,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        changed_files = result.stdout.strip().splitlines()
-
-        for file_path in changed_files:
-            if not (
-                re.match(r"providers/[^/]+/tests/", file_path)
-                or re.match(r"providers/[^/]+/src/airflow/providers/[^/]+/example_dags/", file_path)
-            ):
-                return False
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
-
 def update_release_notes(
     provider_id: str,
     reapply_templates_only: bool,
@@ -817,9 +827,16 @@ def update_release_notes(
                 )
                 change = list_of_list_of_changes[0][table_iter]
 
-                if change.pr and _is_test_or_example_dag_only_changes(change.full_hash):
+                classification = classify_provider_pr_files(change.full_hash)
+                if classification == "documentation":
                     get_console().print(
-                        f"[green]Automatically classifying change as SKIPPED since it only contains test changes:[/]\n"
+                        f"[green]Automatically classifying change as DOCUMENTATION since it contains only doc changes:[/]\n"
+                        f"[blue]{formatted_message}[/]"
+                    )
+                    type_of_change = TypeOfChange.DOCUMENTATION
+                elif classification == "test_or_example_only":
+                    get_console().print(
+                        f"[green]Automatically classifying change as SKIPPED since it only contains test/example changes:[/]\n"
                         f"[blue]{formatted_message}[/]"
                     )
                     type_of_change = TypeOfChange.SKIP


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Added some intelligence to classify things before hand for trivial cases. I already had a `_is_test_or_example_dag_only_changes` in place which did some of the work but not entirely.

For example:

PR https://github.com/apache/airflow/pull/51107/files is included in tagging though it's only docs/tests

The PR linked above had
`['providers/google/docs/operators/cloud/kubernetes_engine.rst', 'providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_ray.py']`

which is doc and tests.
our current rules are:
- tests to Skip
- docs to doc-only templating
which I guess is why we didn't catch the automation and asked RM to classify

So the idea here is to do this automatically. We check for precedence here, if docs and `test_or_example` are present, docs has higher precedence.


Overall precedence order is:

ask > doc-only > skip.

Added some tests that can help.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
