### PR TITLE
Escape user.username in flash banners for admin password-reset via UI

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -62,7 +62,7 @@ from flask_babel import lazy_gettext
 from flask_jwt_extended import JWTManager
 from flask_login import LoginManager
 from itsdangerous import want_bytes
-from markupsafe import Markup
+from markupsafe import Markup, escape
 from sqlalchemy import func, inspect, or_, select
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import joinedload
@@ -547,8 +547,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             user_session_model = interface.sql_session_model
             num_sessions = session.query(user_session_model).count()
             if num_sessions > MAX_NUM_DATABASE_USER_SESSIONS:
+                safe_username = escape(user.username)
                 self._cli_safe_flash(
-                    f"The old sessions for user {user.username} have <b>NOT</b> been deleted!<br>"
+                    f"The old sessions for user {safe_username} have <b>NOT</b> been deleted!<br>"
                     f"You have a lot ({num_sessions}) of user sessions in the 'SESSIONS' table in "
                     f"your database.<br> "
                     "This indicates that this deployment might have an automated API calls that create "
@@ -565,9 +566,10 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                         session.delete(s)
                 session.commit()
         else:
+            safe_username = escape(user.username)
             self._cli_safe_flash(
                 "Since you are using `securecookie` session backend mechanism, we cannot prevent "
-                f"some old sessions for user {user.username} to be reused.<br> If you want to make sure "
+                f"some old sessions for user {safe_username} to be reused.<br> If you want to make sure "
                 "that the user is logged out from all sessions, you should consider using "
                 "`database` session backend mechanism.<br> You can also change the 'secret_key` "
                 "webserver configuration for all your webserver instances and restart the webserver. "


### PR DESCRIPTION
In `FabAirflowSecurityManagerOverride.reset_user_sessions()` two warning strings are built with an f-string that embeds `user.username`. Each string is passed to `_cli_safe_flash()`, which does `flash(Markup(text), level)`. `Markup()` tells Flask not to escape anything.

https://github.com/apache/airflow/blob/262cd8167da107618c3d3e5d7057530b5be3236b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py#L549-L552

https://github.com/apache/airflow/blob/262cd8167da107618c3d3e5d7057530b5be3236b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py#L2384-L2387

The code changes aim to prevent a theoretical XSS attack vector, even though, as pointed out by Airflow Security team, Airflow users have no influence on the username