### PR TITLE
Clean some leftovers of Python 3.9 removal - Github pieces

### DIFF
--- a/.github/actions/install-pre-commit/action.yml
+++ b/.github/actions/install-pre-commit/action.yml
@@ -21,7 +21,7 @@ description: 'Installs pre-commit and related packages'
 inputs:
   python-version:
     description: 'Python version to use'
-    default: "3.9"
+    default: "3.10"
   uv-version:
     description: 'uv version to use'
     default: "0.7.16"  # Keep this comment to allow automatic replacement of uv version

--- a/.github/actions/prepare_all_ci_images/action.yml
+++ b/.github/actions/prepare_all_ci_images/action.yml
@@ -36,6 +36,7 @@ runs:
     #       this should be implemented in stash action as list of keys to download.
     #       That includes 3.9 - 3.12 as we are backporting it to v3-0-test branch
     #       This is captured in https://github.com/apache/airflow/issues/45268
+    #       So we actually need 3.9 even if 3.9 support on main is dropped!
     - name: "Restore CI docker image ${{ inputs.platform }}:3.9"
       uses: ./.github/actions/prepare_single_ci_image
       with:

--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -118,7 +118,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}
       INCLUDE_SUCCESS_OUTPUTS: false
-      PYTHON_MAJOR_MINOR_VERSION: 3.9
+      PYTHON_MAJOR_MINOR_VERSION: 3.10
       VERBOSE: "true"
       EXTRA_BUILD_OPTIONS: ${{ needs.build-info.outputs.extra-build-options }}
     steps:
@@ -187,7 +187,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}
       INCLUDE_SUCCESS_OUTPUTS: false
-      PYTHON_MAJOR_MINOR_VERSION: 3.9
+      PYTHON_MAJOR_MINOR_VERSION: 3.10
       VERBOSE: "true"
     steps:
       - name: "Cleanup repo"

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -29,7 +29,7 @@ on:  # yamllint disable-line rule:truthy
         default: false
       limitPythonVersions:
         type: string
-        description: 'Force python versions (e.g. "3.9 3.10")'
+        description: 'Force python versions (e.g. "3.10 3.11")'
         default: ''
 permissions:
   contents: read

--- a/.github/workflows/release_single_dockerhub_image.yml
+++ b/.github/workflows/release_single_dockerhub_image.yml
@@ -29,7 +29,7 @@ on:  # yamllint disable-line rule:truthy
         type: string
         required: true
       pythonVersion:
-        description: 'Python version (e.g. 3.8, 3.9, 3.10, 3.11)'
+        description: 'Python version (e.g. 3.10, 3.11)'
         type: string
         required: true
       skipLatest:


### PR DESCRIPTION
As #52364 is hard to get green, slicing the elephant into pieces - this are adjustments for `.github` folder