### PR TITLE
Clean some leftovers of Python 3.9 removal - Airflow core pieces

### DIFF
--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -105,7 +105,7 @@ You can create the URL to the file substituting the variables in the template be
 where:
 
 - ``AIRFLOW_VERSION`` - Airflow version (e.g. :subst-code:`|version|`) or ``main``, ``2-0``, for latest development version
-- ``PYTHON_VERSION`` Python version e.g. ``3.9``, ``3.10``
+- ``PYTHON_VERSION`` Python version e.g. ``3.10``, ``3.11``
 
 The examples below assume that you want to use install Airflow in a reproducible way with the ``celery`` extra,
 but you can pick your own set of extras and providers to install.
@@ -321,9 +321,9 @@ dependencies compatible with just Airflow core at the moment Airflow was release
 
     AIRFLOW_VERSION=|version|
     PYTHON_VERSION="$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-    # For example: 3.9
+    # For example: 3.10
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-no-providers-${PYTHON_VERSION}.txt"
-    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-no-providers-3.9.txt
+    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-no-providers-3.10.txt
     pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
 Troubleshooting
@@ -347,7 +347,7 @@ Symbol not found: ``_Py_GetArgcArgv``
 =====================================
 
 If you see ``Symbol not found: _Py_GetArgcArgv`` while starting or importing ``airflow``, this may mean that you are using an incompatible version of Python.
-For a homebrew installed version of Python, this is generally caused by using Python in ``/usr/local/opt/bin`` rather than the Frameworks installation (e.g. for ``python 3.9``: ``/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9``).
+For a homebrew installed version of Python, this is generally caused by using Python in ``/usr/local/opt/bin`` rather than the Frameworks installation (e.g. for ``python 3.10``: ``/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10``).
 
 The crux of the issue is that a library Airflow depends on, ``setproctitle``, uses a non-public Python API
 which is not available from the standard installation ``/usr/local/opt/`` (which symlinks to a path under ``/usr/local/Cellar``).
@@ -356,9 +356,9 @@ An easy fix is just to ensure you use a version of Python that has a dylib of th
 
 .. code-block:: bash
 
-  # Note: these instructions are for python3.9 but can be loosely modified for other versions
-  brew install python@3.9
-  virtualenv -p /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/bin/python3 .toy-venv
+  # Note: these instructions are for python3.10 but can be loosely modified for other versions
+  brew install python@3.10
+  virtualenv -p /usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/bin/python3 .toy-venv
   source .toy-venv/bin/activate
   pip install apache-airflow
   python

--- a/airflow-core/docs/installation/prerequisites.rst
+++ b/airflow-core/docs/installation/prerequisites.rst
@@ -20,7 +20,7 @@ Prerequisites
 
 Airflow® is tested with:
 
-* Python: 3.9, 3.10, 3.11, 3.12
+* Python: 3.10, 3.11, 3.12
 
 * Databases:
 

--- a/airflow-core/docs/start.rst
+++ b/airflow-core/docs/start.rst
@@ -24,7 +24,7 @@ This quick start guide will help you bootstrap an Airflow standalone instance on
 
 .. note::
 
-   Successful installation requires a Python 3 environment. Starting with Airflow 2.7.0, Airflow supports Python 3.9, 3.10, 3.11, and 3.12.
+   Successful installation requires a Python 3 environment. Starting with Airflow 3.1.0, Airflow supports Python 3.10, 3.11, and 3.12.
 
    Officially supported installation methods is with``pip`.
 

--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -35,7 +35,7 @@ name = "apache-airflow-core"
 description = "Core packages for Apache Airflow, schedule and API server"
 readme = { file = "README.md", content-type = "text/markdown" }
 license-files.globs = ["LICENSE", "3rd-party-licenses/*.txt", "NOTICE"]
-requires-python = "~=3.9,<3.13"
+requires-python = "~=3.10,<3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]
@@ -51,7 +51,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -47,7 +47,7 @@ class ConnectionResponse(BaseModel):
     def redact_password(cls, v: str | None, field_info: ValidationInfo) -> str | None:
         if v is None:
             return None
-        return redact(v, field_info.field_name)
+        return str(redact(v, field_info.field_name))
 
     @field_validator("extra", mode="before")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -46,7 +46,7 @@ class VariableResponse(BaseModel):
             return self
         except json.JSONDecodeError:
             # value is not a serialized string representation of a dict.
-            self.val = redact(self.val, self.key)
+            self.val = str(redact(self.val, self.key))
             return self
 
 


### PR DESCRIPTION
As https://github.com/apache/airflow/pull/52364 is hard to get green, slicing the elephant into pieces - this are adjustments for `airflow-core` folder