### PR TITLE
remove: set_transport_variable import

### DIFF
--- a/providers/google/tests/system/google/conftest.py
+++ b/providers/google/tests/system/google/conftest.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 import pytest
 
-from system.openlineage.conftest import set_transport_variable  # noqa: F401
-
 REQUIRED_ENV_VARS = ("SYSTEM_TESTS_GCP_PROJECT",)
 
 


### PR DESCRIPTION
Hi i am making some function on dataproc and i found unnessary import in there.
I don't know why this import line added but whenever i run the system code, import error is always raised due to that line.
So i suggest removing that line for local testing. 

<img width="824" alt="Screenshot 2025-06-29 at 4 19 44 PM" src="https://github.com/user-attachments/assets/e8981f2b-d1b8-4a62-955e-e2224cc76305" />

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
