### PR TITLE
Provider Migration: Replace `models.BaseOperator` to Task SDK for apache/hive

### DIFF
--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -95,7 +95,6 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-amazon",
-    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-microsoft-mssql",
     "apache-airflow-providers-mysql",

--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -39,17 +39,10 @@ import csv
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
-from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.apache.hive.version_compat import AIRFLOW_VAR_NAME_FORMAT_MAPPING
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.security import utils
 from airflow.utils.helpers import as_flattened_list
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import AIRFLOW_VAR_NAME_FORMAT_MAPPING
-else:
-    from airflow.utils.operator_helpers import (  # type: ignore[no-redef, attr-defined]
-        AIRFLOW_VAR_NAME_FORMAT_MAPPING,
-    )
 
 HIVE_QUEUE_PRIORITIES = ["VERY_HIGH", "HIGH", "NORMAL", "LOW", "VERY_LOW"]
 

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -24,17 +24,12 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import AIRFLOW_VAR_NAME_FORMAT_MAPPING, context_to_airflow_vars
-else:
-    from airflow.utils.operator_helpers import (  # type: ignore[no-redef, attr-defined]
-        AIRFLOW_VAR_NAME_FORMAT_MAPPING,
-        context_to_airflow_vars,
-    )
+from airflow.providers.apache.hive.version_compat import (
+    AIRFLOW_VAR_NAME_FORMAT_MAPPING,
+    BaseOperator,
+    context_to_airflow_vars,
+)
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive_stats.py
@@ -22,8 +22,8 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
+from airflow.providers.apache.hive.version_compat import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.presto.hooks.presto import PrestoHook
 

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py
@@ -21,12 +21,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
-from airflow.providers.apache.hive.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+from airflow.providers.apache.hive.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py
@@ -20,12 +20,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.apache.hive.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+from airflow.providers.apache.hive.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -23,16 +23,9 @@ from collections.abc import Sequence
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
-from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.apache.hive.version_compat import BaseOperator, context_to_airflow_vars
 from airflow.providers.mysql.hooks.mysql import MySqlHook
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import context_to_airflow_vars
-else:
-    from airflow.utils.operator_helpers import context_to_airflow_vars  # type: ignore[no-redef, attr-defined]
-
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_samba.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_samba.py
@@ -23,15 +23,9 @@ from collections.abc import Sequence
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
-from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.apache.hive.version_compat import BaseOperator, context_to_airflow_vars
 from airflow.providers.samba.hooks.samba import SambaHook
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import context_to_airflow_vars
-else:
-    from airflow.utils.operator_helpers import context_to_airflow_vars  # type: ignore[no-redef, attr-defined]
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -26,8 +26,8 @@ from typing import TYPE_CHECKING
 
 import pymssql
 
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
+from airflow.providers.apache.hive.version_compat import BaseOperator
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
 
 if TYPE_CHECKING:

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -36,8 +36,8 @@ except ImportError:
     )
 
 
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
+from airflow.providers.apache.hive.version_compat import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 
 if TYPE_CHECKING:

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/s3_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/s3_to_hive.py
@@ -29,9 +29,9 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
+from airflow.providers.apache.hive.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/vertica_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/vertica_to_hive.py
@@ -24,8 +24,8 @@ from collections.abc import Sequence
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any
 
-from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
+from airflow.providers.apache.hive.version_compat import BaseOperator
 from airflow.providers.vertica.hooks.vertica import VerticaHook
 
 if TYPE_CHECKING:

--- a/providers/apache/hive/src/airflow/providers/apache/hive/version_compat.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/version_compat.py
@@ -33,3 +33,23 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator, BaseSensorOperator
+    from airflow.sdk.execution_time.context import AIRFLOW_VAR_NAME_FORMAT_MAPPING, context_to_airflow_vars
+else:
+    from airflow.models import BaseOperator
+    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+    from airflow.utils.operator_helpers import (  # type: ignore[no-redef, attr-defined]
+        AIRFLOW_VAR_NAME_FORMAT_MAPPING,
+        context_to_airflow_vars,
+    )
+
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "BaseOperator",
+    "BaseSensorOperator",
+    "AIRFLOW_VAR_NAME_FORMAT_MAPPING",
+    "context_to_airflow_vars",
+]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Related #52378
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
