### PR TITLE
Clean some leftovers of Python 3.9 removal - Files in root

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -237,8 +237,7 @@ repos:
         entry: ./scripts/ci/pre_commit/check_deferrable_default.py
         pass_filenames: false
         # libcst doesn't have source wheels for all PY except PY3.12, excluding it
-        # libcst 1.8.1 doesn't include typing-extensions which is needed for Python 3.9
-        additional_dependencies: ['libcst>=1.1.0,!=1.8.0,!=1.8.1']
+        additional_dependencies: ['libcst>=1.8.1']
         files: ^(providers/.*/)?airflow/.*/(sensors|operators)/.*\.py$
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.19.1
@@ -247,7 +246,6 @@ repos:
         name: Run black on docs
         args:
           - --line-length=110
-          - --target-version=py39
           - --target-version=py310
           - --target-version=py311
           - --target-version=py312

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,7 +20,7 @@ formats: []
 sphinx:
     configuration: devel-common/src/docs/rtd-deprecation/conf.py
 python:
-    version: "3.9"
+    version: "3.10"
     install:
         - method: pip
           path: .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ how to set up the environment, run checks, build docs and follow the PR workflow
 
 ## Running tests
 
-- [`03_contributors_quick_start.rst`](contributing-docs/03_contributors_quick_start.rst) shows running tests inside Breeze. Use `pytest` inside the container for individual files or invoke `breeze testing` commands to run full suites, e.g. `breeze --backend postgres --python 3.9 testing tests --test-type All`.
+- [`03_contributors_quick_start.rst`](contributing-docs/03_contributors_quick_start.rst) shows running tests inside Breeze. Use `pytest` inside the container for individual files or invoke `breeze testing` commands to run full suites, e.g. `breeze --backend postgres --python 3.10 testing tests --test-type All`.
 
 ## Building documentation
 

--- a/INSTALL
+++ b/INSTALL
@@ -229,15 +229,15 @@ to avoid "works-for-me" syndrome, where you use different versions of dependenci
 that are used in main CI tests and by other contributors.
 
 There are different constraint files for different Python versions. For example, this command will install
-all basic devel requirements and requirements of Google provider as last successfully tested for Python 3.9:
+all basic devel requirements and requirements of Google provider as last successfully tested for Python 3.10:
 
    uv pip install -e ".[devel,google]"" \
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.9.txt"
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.10.txt"
 
 Using the 'constraints-no-providers' constraint files, you can upgrade Airflow without paying attention to the provider's dependencies. This allows you to keep installed provider dependencies and install the latest supported ones using pure Airflow core.
 
   uv pip install -e ".[devel]" \
-     --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-no-providers-3.9.txt"
+     --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-no-providers-3.10.txt"
 
 Note that you can also use `pip install` if you do not use `uv`.
 

--- a/README.md
+++ b/README.md
@@ -178,14 +178,14 @@ them to the appropriate format and workflow that your tool requires.
 
 ```bash
 pip install 'apache-airflow==3.0.2' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.9.txt"
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.10.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
 pip install 'apache-airflow[postgres,google]==3.0.2' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.9.txt"
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.10.txt"
 ```
 
 For information on installing provider distributions, check
@@ -323,7 +323,7 @@ They are based on the official release schedule of Python and Kubernetes, nicely
 1. We drop support for Python and Kubernetes versions when they reach EOL. Except for Kubernetes, a
    version stays supported by Airflow if two major cloud providers still provide support for it. We drop
    support for those EOL versions in main right after EOL date, and it is effectively removed when we release
-   the first new MINOR (Or MAJOR if there is no new MINOR version) of Airflow. For example, for Python 3.9 it
+   the first new MINOR (Or MAJOR if there is no new MINOR version) of Airflow. For example, for Python 3.10 it
    means that we will drop support in main right after 27.06.2023, and the first MAJOR or MINOR version of
    Airflow released after will not have it.
 

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -131,14 +131,14 @@ them to the appropriate format and workflow that your tool requires.
 
 ```bash
 pip install 'apache-airflow==3.0.2' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.9.txt"
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.10.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
 pip install 'apache-airflow[postgres,google]==3.0.2' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.9.txt"
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.10.txt"
 ```
 
 For information on installing provider distributions, check

--- a/setup_idea.py
+++ b/setup_idea.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # /// script
-# requires-python = ">=3.9"
+# requires-python = ">=3.10"
 # dependencies = [
 #   "rich>=13.6.0",
 # ]
@@ -45,7 +45,7 @@ iml_xml_template = """<?xml version="1.0" encoding="UTF-8"?>
         <excludeFolder url="file://$MODULE_DIR$/generated/" />
         <excludeFolder url="file://$MODULE_DIR$/dev/breeze/.venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.9 (airflow)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (airflow)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">


### PR DESCRIPTION
As https://github.com/apache/airflow/pull/52364 is hard to get green, slicing the elephant into pieces - this are adjustments for some files in root of Git.

closes: #52364