### PR TITLE
[OpenLineage] Added operator_provider_version to task event

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -133,7 +133,7 @@ def get_operator_provider_version(operator: BaseOperator | MappedOperator) -> st
     try:
         class_path = get_fully_qualified_class_name(operator)
 
-        if not class_path.startswith('airflow.providers.'):
+        if not class_path.startswith("airflow.providers."):
             return None
 
         from airflow.providers_manager import ProvidersManager
@@ -141,9 +141,11 @@ def get_operator_provider_version(operator: BaseOperator | MappedOperator) -> st
         providers_manager = ProvidersManager()
 
         for package_name, provider_info in providers_manager.providers.items():
-            if package_name.startswith('apache-airflow-providers-'):
-                provider_module_path = package_name.replace('apache-airflow-providers-', 'airflow.providers.').replace('-', '.')
-                if class_path.startswith(provider_module_path + '.'):
+            if package_name.startswith("apache-airflow-providers-"):
+                provider_module_path = package_name.replace(
+                    "apache-airflow-providers-", "airflow.providers."
+                ).replace("-", ".")
+                if class_path.startswith(provider_module_path + "."):
                     return provider_info.version
 
         return None

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -1703,7 +1703,7 @@ def test_task_info_complete():
     assert "'bash_command': 'exit 0;'" in str(result)
 
 
-@patch('airflow.providers.openlineage.utils.utils.get_fully_qualified_class_name')
+@patch("airflow.providers.openlineage.utils.utils.get_fully_qualified_class_name")
 def test_get_operator_provider_version_exception_handling(mock_class_name):
     mock_class_name.side_effect = Exception("Test exception")
     operator = MagicMock()
@@ -1717,7 +1717,7 @@ def test_get_operator_provider_version_for_core_operator():
     assert result is None
 
 
-@patch('airflow.providers_manager.ProvidersManager')
+@patch("airflow.providers_manager.ProvidersManager")
 def test_get_operator_provider_version_for_provider_operator(mock_providers_manager):
     """Test that get_operator_provider_version returns version for provider operators."""
     # Mock ProvidersManager
@@ -1726,27 +1726,27 @@ def test_get_operator_provider_version_for_provider_operator(mock_providers_mana
 
     # Mock providers data
     mock_manager_instance.providers = {
-        'apache-airflow-providers-standard': MagicMock(version='1.2.0'),
-        'apache-airflow-providers-amazon': MagicMock(version='8.12.0'),
-        'apache-airflow-providers-google': MagicMock(version='10.5.0'),
+        "apache-airflow-providers-standard": MagicMock(version="1.2.0"),
+        "apache-airflow-providers-amazon": MagicMock(version="8.12.0"),
+        "apache-airflow-providers-google": MagicMock(version="10.5.0"),
     }
 
     # Test with BashOperator (standard provider)
     operator = BashOperator(task_id="test_task", bash_command="echo test")
     result = get_operator_provider_version(operator)
-    assert result == '1.2.0'
+    assert result == "1.2.0"
 
 
-@patch('airflow.providers_manager.ProvidersManager')
+@patch("airflow.providers_manager.ProvidersManager")
 def test_get_operator_provider_version_provider_not_found(mock_providers_manager):
     """Test that get_operator_provider_version returns None when provider is not found."""
     # Mock ProvidersManager with no matching provider
     mock_manager_instance = MagicMock()
     mock_providers_manager.return_value = mock_manager_instance
     mock_manager_instance.providers = {
-        'apache-airflow-providers-amazon': MagicMock(version='8.12.0'),
-        'apache-airflow-providers-google': MagicMock(version='10.5.0'),
-        }
+        "apache-airflow-providers-amazon": MagicMock(version="8.12.0"),
+        "apache-airflow-providers-google": MagicMock(version="10.5.0"),
+    }
 
     operator = BashOperator(task_id="test_task", bash_command="echo test")
     result = get_operator_provider_version(operator)
@@ -1755,6 +1755,7 @@ def test_get_operator_provider_version_provider_not_found(mock_providers_manager
 
 def test_get_operator_provider_version_for_custom_operator():
     """Test that get_operator_provider_version returns None for custom operators."""
+
     # Create a custom operator that doesn't belong to any provider
     class CustomOperator(BaseOperator):
         def execute(self, context):
@@ -1765,7 +1766,7 @@ def test_get_operator_provider_version_for_custom_operator():
     assert result is None
 
 
-@patch('airflow.providers_manager.ProvidersManager')
+@patch("airflow.providers_manager.ProvidersManager")
 def test_get_operator_provider_version_for_mapped_operator(mock_providers_manager):
     """Test that get_operator_provider_version works with mapped operators."""
     # Mock ProvidersManager
@@ -1774,14 +1775,11 @@ def test_get_operator_provider_version_for_mapped_operator(mock_providers_manage
 
     # Mock providers data
     mock_manager_instance.providers = {
-        'apache-airflow-providers-standard': MagicMock(version='1.2.0'),
-        'apache-airflow-providers-amazon': MagicMock(version='8.12.0'),
+        "apache-airflow-providers-standard": MagicMock(version="1.2.0"),
+        "apache-airflow-providers-amazon": MagicMock(version="8.12.0"),
     }
 
     # Test with mapped BashOperator (standard provider)
     mapped_operator = BashOperator.partial(task_id="test_task").expand(bash_command=["echo 1", "echo 2"])
     result = get_operator_provider_version(mapped_operator)
-    assert result == '1.2.0'
-
-
-
+    assert result == "1.2.0"

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -54,6 +54,7 @@ from airflow.providers.openlineage.utils.utils import (
     get_fully_qualified_class_name,
     get_job_name,
     get_operator_class,
+    get_operator_provider_version,
     get_user_provided_run_facets,
 )
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -1600,6 +1601,7 @@ def test_task_info_af3():
         "multiple_outputs": False,
         "operator_class": "CustomOperator",
         "operator_class_path": get_fully_qualified_class_name(task_10),
+        "operator_provider_version": None,  # Custom operator doesn't have provider version
         "outlets": "[{'uri': 'uri2', 'extra': {'b': 2}}, {'uri': 'uri3', 'extra': {'c': 3}}]",
         "owner": "airflow",
         "priority_weight": 1,
@@ -1677,6 +1679,7 @@ def test_task_info_af2():
         "multiple_outputs": False,
         "operator_class": "CustomOperator",
         "operator_class_path": get_fully_qualified_class_name(task_10),
+        "operator_provider_version": None,  # Custom operator doesn't have provider version
         "outlets": "[{'uri': 'uri2', 'extra': {'b': 2}}, {'uri': 'uri3', 'extra': {'c': 3}}]",
         "owner": "airflow",
         "priority_weight": 1,
@@ -1698,3 +1701,87 @@ def test_task_info_complete():
     task_0 = BashOperator(task_id="task_0", bash_command="exit 0;")
     result = TaskInfoComplete(task_0)
     assert "'bash_command': 'exit 0;'" in str(result)
+
+
+@patch('airflow.providers.openlineage.utils.utils.get_fully_qualified_class_name')
+def test_get_operator_provider_version_exception_handling(mock_class_name):
+    mock_class_name.side_effect = Exception("Test exception")
+    operator = MagicMock()
+    assert get_operator_provider_version(operator) is None
+
+
+def test_get_operator_provider_version_for_core_operator():
+    """Test that get_operator_provider_version returns None for core operators."""
+    operator = BaseOperator(task_id="test_task")
+    result = get_operator_provider_version(operator)
+    assert result is None
+
+
+@patch('airflow.providers_manager.ProvidersManager')
+def test_get_operator_provider_version_for_provider_operator(mock_providers_manager):
+    """Test that get_operator_provider_version returns version for provider operators."""
+    # Mock ProvidersManager
+    mock_manager_instance = MagicMock()
+    mock_providers_manager.return_value = mock_manager_instance
+
+    # Mock providers data
+    mock_manager_instance.providers = {
+        'apache-airflow-providers-standard': MagicMock(version='1.2.0'),
+        'apache-airflow-providers-amazon': MagicMock(version='8.12.0'),
+        'apache-airflow-providers-google': MagicMock(version='10.5.0'),
+    }
+
+    # Test with BashOperator (standard provider)
+    operator = BashOperator(task_id="test_task", bash_command="echo test")
+    result = get_operator_provider_version(operator)
+    assert result == '1.2.0'
+
+
+@patch('airflow.providers_manager.ProvidersManager')
+def test_get_operator_provider_version_provider_not_found(mock_providers_manager):
+    """Test that get_operator_provider_version returns None when provider is not found."""
+    # Mock ProvidersManager with no matching provider
+    mock_manager_instance = MagicMock()
+    mock_providers_manager.return_value = mock_manager_instance
+    mock_manager_instance.providers = {
+        'apache-airflow-providers-amazon': MagicMock(version='8.12.0'),
+        'apache-airflow-providers-google': MagicMock(version='10.5.0'),
+        }
+
+    operator = BashOperator(task_id="test_task", bash_command="echo test")
+    result = get_operator_provider_version(operator)
+    assert result is None
+
+
+def test_get_operator_provider_version_for_custom_operator():
+    """Test that get_operator_provider_version returns None for custom operators."""
+    # Create a custom operator that doesn't belong to any provider
+    class CustomOperator(BaseOperator):
+        def execute(self, context):
+            pass
+
+    operator = CustomOperator(task_id="test_task")
+    result = get_operator_provider_version(operator)
+    assert result is None
+
+
+@patch('airflow.providers_manager.ProvidersManager')
+def test_get_operator_provider_version_for_mapped_operator(mock_providers_manager):
+    """Test that get_operator_provider_version works with mapped operators."""
+    # Mock ProvidersManager
+    mock_manager_instance = MagicMock()
+    mock_providers_manager.return_value = mock_manager_instance
+
+    # Mock providers data
+    mock_manager_instance.providers = {
+        'apache-airflow-providers-standard': MagicMock(version='1.2.0'),
+        'apache-airflow-providers-amazon': MagicMock(version='8.12.0'),
+    }
+
+    # Test with mapped BashOperator (standard provider)
+    mapped_operator = BashOperator.partial(task_id="test_task").expand(bash_command=["echo 1", "echo 2"])
+    result = get_operator_provider_version(mapped_operator)
+    assert result == '1.2.0'
+
+
+


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #52467
related: NA

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR adds the required `provider_operator_version` in `run.facets.airflow.task` alongside `operator_class_path` and `operator_class`

closes: #52467


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
