### PR TITLE
Revert "Provider Migration: Replace `models.BaseOperator` to Task SDK for apache/http"

### DIFF
--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -28,8 +28,8 @@ from requests import Response
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.models import BaseOperator
 from airflow.providers.http.triggers.http import HttpTrigger, serialize_auth_type
-from airflow.providers.http.version_compat import BaseOperator
 from airflow.utils.helpers import merge_dicts
 
 if TYPE_CHECKING:

--- a/providers/http/src/airflow/providers/http/sensors/http.py
+++ b/providers/http/src/airflow/providers/http/sensors/http.py
@@ -25,7 +25,12 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
 from airflow.providers.http.triggers.http import HttpSensorTrigger
-from airflow.providers.http.version_compat import AIRFLOW_V_3_0_PLUS, BaseSensorOperator
+from airflow.providers.http.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseSensorOperator
+else:
+    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
     try:

--- a/providers/http/src/airflow/providers/http/version_compat.py
+++ b/providers/http/src/airflow/providers/http/version_compat.py
@@ -33,12 +33,3 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-
-__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "BaseSensorOperator"]


### PR DESCRIPTION
Reverts apache/airflow#52506