### PR TITLE
Revert partially GH-52506

### DIFF
--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -28,8 +28,8 @@ from requests import Response
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.models import BaseOperator
 from airflow.providers.http.triggers.http import HttpTrigger, serialize_auth_type
-from airflow.providers.http.version_compat import BaseOperator
 from airflow.utils.helpers import merge_dicts
 
 if TYPE_CHECKING:

--- a/providers/http/src/airflow/providers/http/version_compat.py
+++ b/providers/http/src/airflow/providers/http/version_compat.py
@@ -35,10 +35,9 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-    from airflow.sdk import BaseSensorOperator
+    from airflow.sdk import BaseOperator, BaseSensorOperator
 else:
-    from airflow.models import BaseOperator
+    from airflow.models import BaseOperator  # type: ignore[no-redef]
     from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
 __all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "BaseSensorOperator"]


### PR DESCRIPTION
This reverts the BaseOperator changes in http provider tests. Other parts of the PR is fine so I kept them.