### PR TITLE
Replace `models.BaseSensorOperator` to Task SDK one for Mongo

### DIFF
--- a/providers/mongo/src/airflow/providers/mongo/sensors/mongo.py
+++ b/providers/mongo/src/airflow/providers/mongo/sensors/mongo.py
@@ -21,12 +21,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.providers.mongo.hooks.mongo import MongoHook
-from airflow.providers.mongo.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+from airflow.providers.mongo.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/mongo/src/airflow/providers/mongo/version_compat.py
+++ b/providers/mongo/src/airflow/providers/mongo/version_compat.py
@@ -33,3 +33,10 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseSensorOperator
+else:
+    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+
+__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseSensorOperator"]


### PR DESCRIPTION
Replacing `models.BaseOperator` with `airflow.sdk BaseOperator`. All unit-tests ran successfully when testing.

As part of #52378.