### PR TITLE
[AIP-68] Allow Providers Iframe script execution

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
@@ -24,7 +24,7 @@ import { ProgressBar } from "src/components/ui";
 
 import { ErrorPage } from "./Error";
 
-export const Iframe = () => {
+export const Iframe = ({ sandbox = "allow-same-origin allow-forms" }: { readonly sandbox: string }) => {
   const { page } = useParams();
   const { data: pluginData, isLoading } = usePluginServiceGetPlugins();
 
@@ -43,10 +43,6 @@ export const Iframe = () => {
 
     return <ErrorPage />;
   }
-
-  // The following iframe sandbox setting is intentionally less restrictive.
-  // ONLY trusted contents can be framed within Iframe.
-  const sandbox = "allow-same-origin allow-forms";
 
   return (
     <Box flexGrow={1} m={-3}>

--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -24,6 +24,12 @@ import { ProgressBar } from "src/components/ui";
 
 import { ErrorPage } from "./Error";
 
+// The following iframe sandbox setting is intentionally less restrictive.
+// This is considered safe because the framed content originates from the Auth manager,
+// which is part of the deployment of Airflow and trusted as per our security policy.
+// https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+const SANDBOX = "allow-scripts allow-same-origin allow-forms";
+
 export const Security = () => {
   const { page } = useParams();
 
@@ -43,15 +49,9 @@ export const Security = () => {
     return <ErrorPage />;
   }
 
-  // The following iframe sandbox setting is intentionally less restrictive.
-  // This is considered safe because the framed content originates from the Auth manager,
-  // which is part of the deployment of Airflow and trusted as per our security policy.
-  //    https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-  const sandbox = "allow-scripts allow-same-origin allow-forms";
-
   return (
     <Box flexGrow={1} m={-3}>
-      <iframe sandbox={sandbox} src={link.href} style={{ height: "100%", width: "100%" }} title={link.text} />
+      <iframe sandbox={SANDBOX} src={link.href} style={{ height: "100%", width: "100%" }} title={link.text} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -143,7 +143,12 @@ export const routerConfig = [
         path: "connections",
       },
       {
-        element: <Iframe />,
+        // The following iframe sandbox setting is intentionally less restrictive.
+        // This is considered safe because the framed content originates from the Plugins,
+        // which is part of the deployment of Airflow and trusted as per our security policy.
+        // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+        // They are not user provided plugins.
+        element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
         path: "plugin/:page",
       },
       {


### PR DESCRIPTION
Allow providers to execute script in framed content. Providers are considered trusted those are not user provided.