### PR TITLE
Fix deferrable HttpSensor: HttpAsyncHook falls back to https when port == 443

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -462,7 +462,7 @@ class HttpAsyncHook(BaseHook):
                 self.base_url = conn.host
             else:
                 # schema defaults to HTTP
-                schema = conn.schema if conn.schema else "http"
+                schema = conn.schema if conn.schema else ("https" if conn.port == 443 else "http")
                 host = conn.host if conn.host else ""
                 self.base_url = schema + "://" + host
 


### PR DESCRIPTION
Related: #52319

# Why

`HttpSensor` in deferrable mode fails after the task is resumed by the Triggerer: the schema field is missing, so `HttpAsyncHook` silently downgrades `https://host` to `http://host`.

https://github.com/apache/airflow/blob/eac9a920fb82ea9c750cf9b36608660cf42a0740/providers/http/src/airflow/providers/http/hooks/http.py#L465

The root cause seems to be here. I guess Triggerer fetches the connection from the metadata DB on the first run and then serves subsequent requests from its cache. However, cache no longer contains `schema_` in `3.0.0` somehow. In `2.11.0` the same DAG still works.

(The explanation above is my current understanding based on quick code-reading and logs. If I've misinterpreted how the Triggerer caches connections, please feel free to correct me, feedback is very welcome 😄)

https://github.com/apache/airflow/blob/d3a33da891f6a31cfe6b7e0c67fda142f13fcf5f/task-sdk/src/airflow/sdk/execution_time/context.py#L155

```console
# first run
SUPERVISOR_COMMS msg: conn_id='conn_id' conn_type='http' host='dummyjson.com' schema_='https' login=None password=None port=443 extra=None type='ConnectionResult'

# second ... Nth run
SUPERVISOR_COMMS msg: conn_id='conn_id' conn_type='http' host='dummyjson.com' schema_=None login=None password=None port=443 extra=None type='ConnectionResult
```

The example DAG in the issue works as expected on 2.11.0 but not on 3.0.0. Here is how the DAG runs on 2.11.0:
![schema_success_in_2_11_0](https://github.com/user-attachments/assets/e324d421-a9c0-4174-9803-4edde4c29c6a)

# How

+ Short Term Solution

`conn.port` is still present in every run, so fall back to `https` when `port == 443`.

+ Long Term Solution

Investigate why `schema_` disappears in the Triggerer cache, maybe open a follow-up issue if needed.

# What

With this patch the OP’s example DAG now uses `https`.
![schema_can_get_https](https://github.com/user-attachments/assets/eeadaa2c-a13c-44ea-b3bc-469d31aa6823)
