### PR TITLE
Bump pyarrow to 16.1.0 minimum version for several providers

### DIFF
--- a/providers/apache/beam/pyproject.toml
+++ b/providers/apache/beam/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = "~=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     'apache-beam>=2.60.0',
-    "pyarrow>=14.0.1",
+    "pyarrow>=16.1.0",
     "numpy>=1.26.0",
 
 ]

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "mergedeep>=1.3.4",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
-    "pyarrow>=14.0.1",
+    "pyarrow>=16.1.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -129,7 +129,7 @@ dependencies = [
     # further constrain it since older versions are buggy.
     "proto-plus>=1.19.6",
     # Used to write parquet files by BaseSqlToGCSOperator
-    "pyarrow>=14.0.1",
+    "pyarrow>=16.1.0",
     "python-slugify>=7.0.0",
     "PyOpenSSL>=23.0.0",
     "sqlalchemy-bigquery>=1.2.1",

--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "apache-airflow-providers-common-sql>=1.21.0",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
-    "pyarrow>=14.0.1",
+    "pyarrow>=16.1.0",
     "snowflake-connector-python>=3.7.1",
     "snowflake-sqlalchemy>=1.4.0",
     "snowflake-snowpark-python>=1.17.0;python_version<'3.12'",


### PR DESCRIPTION
Pyarrow < 16.1.0 does not play well with numpy 2. Bumping it to 16.1.0 as minimum version should make compatibility tests to not downgrade to versions that are not compoatible when numpy 2 is already installed. It should also prevent our users from accidentally downgrading pyarrow or not upgrading it when numpy is upgraded to >= 2.0.0.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
