### PR TITLE
[v2-11-test]Allow more empty loops before stopping log streaming

### DIFF
--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -39,7 +39,7 @@ class TaskLogReader:
     STREAM_LOOP_SLEEP_SECONDS = 1
     """Time to sleep between loops while waiting for more logs"""
 
-    STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS = 5
+    STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS = 10
     """Number of empty loop iterations before stopping the stream"""
 
     def read_log_chunks(

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -229,11 +229,7 @@ class TestLogView:
     def test_read_log_stream_no_end_of_log_marker(self, mock_read):
         mock_read.side_effect = [
             ([[("", "hello")]], [{"end_of_log": False}]),
-            ([[]], [{"end_of_log": False}]),
-            ([[]], [{"end_of_log": False}]),
-            ([[]], [{"end_of_log": False}]),
-            ([[]], [{"end_of_log": False}]),
-            ([[]], [{"end_of_log": False}]),
+            *[([[]], [{"end_of_log": False}]) for _ in range(10)],
         ]
 
         self.ti.state = TaskInstanceState.SUCCESS
@@ -244,7 +240,7 @@ class TestLogView:
             "\nhello\n",
             "\n(Log stream stopped - End of log marker not found; logs may be incomplete.)\n",
         ]
-        assert mock_read.call_count == 6
+        assert mock_read.call_count == 11
 
     def test_supports_external_link(self):
         task_log_reader = TaskLogReader()


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/50715 we starting short-circuiting if we hit 5 iterations of no new log messages. This works well, except in the scenario where there are no log messages at all. ES log handler has it's own short-circuit for that scenario, but it triggers based on time and that works out to ~7 iterations. Let's let ES have the first crack at it so the user gets a better message.

Backport of https://github.com/apache/airflow/pull/52614
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
