### PR TITLE
bugfix: removed cache for proxycommand in SFTPHook

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -148,6 +148,7 @@ class SFTPHook(SSHHook):
                 self._sftp_conn = None
                 self._ssh_conn.close()
                 self._ssh_conn = None
+                del self.host_proxy
 
     def get_conn_count(self) -> int:
         """Get the number of open connections."""

--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -148,7 +148,8 @@ class SFTPHook(SSHHook):
                 self._sftp_conn = None
                 self._ssh_conn.close()
                 self._ssh_conn = None
-                del self.host_proxy
+                if hasattr(self, "host_proxy"):
+                    del self.host_proxy
 
     def get_conn_count(self) -> int:
         """Get the number of open connections."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #52289
related: #52289 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

A possible fix to the related issue, removed the cache for the proxy command as it becomes invalid after the connection is closed (as the contextmanager autocloses the connection and the socket becomes closed)
for issue #52289 

closes: #52289 