### PR TITLE
Replace `models.BaseOperator` to Task SDK one for Tableau, Telegram, and Teradata

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -20,12 +20,12 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.providers.tableau.hooks.tableau import (
     TableauHook,
     TableauJobFailedException,
     TableauJobFinishCode,
 )
+from airflow.providers.tableau.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/tableau/src/airflow/providers/tableau/sensors/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/sensors/tableau.py
@@ -24,12 +24,7 @@ from airflow.providers.tableau.hooks.tableau import (
     TableauJobFailedException,
     TableauJobFinishCode,
 )
-from airflow.providers.tableau.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+from airflow.providers.tableau.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/tableau/src/airflow/providers/tableau/version_compat.py
+++ b/providers/tableau/src/airflow/providers/tableau/version_compat.py
@@ -37,7 +37,7 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import BaseOperator, BaseSensorOperator
 else:
-    from airflow.models import BaseOperator
+    from airflow.models import BaseOperator  # type: ignore[no-redef]
     from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
 __all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "BaseSensorOperator"]

--- a/providers/telegram/src/airflow/providers/telegram/operators/telegram.py
+++ b/providers/telegram/src/airflow/providers/telegram/operators/telegram.py
@@ -23,8 +23,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.providers.telegram.hooks.telegram import TelegramHook
+from airflow.providers.telegram.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/telegram/src/airflow/providers/telegram/version_compat.py
+++ b/providers/telegram/src/airflow/providers/telegram/version_compat.py
@@ -35,9 +35,8 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
+    from airflow.sdk import BaseOperator
 else:
     from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
-__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "BaseSensorOperator"]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator"]

--- a/providers/telegram/src/airflow/providers/telegram/version_compat.py
+++ b/providers/telegram/src/airflow/providers/telegram/version_compat.py
@@ -37,6 +37,6 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import BaseOperator
 else:
-    from airflow.models import BaseOperator
+    from airflow.models import BaseOperator  # type: ignore[no-redef]
 
 __all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator"]

--- a/providers/teradata/src/airflow/providers/teradata/operators/bteq.py
+++ b/providers/teradata/src/airflow/providers/teradata/operators/bteq.py
@@ -36,10 +36,10 @@ if TYPE_CHECKING:
     except ImportError:
         from airflow.utils.context import Context
 
-from airflow.models import BaseOperator
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers.teradata.hooks.bteq import BteqHook
 from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.version_compat import BaseOperator
 
 
 def contains_template(parameter_value):

--- a/providers/teradata/src/airflow/providers/teradata/operators/teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/operators/teradata.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar
 
-from airflow.models import BaseOperator
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/teradata/src/airflow/providers/teradata/operators/teradata_compute_cluster.py
+++ b/providers/teradata/src/airflow/providers/teradata/operators/teradata_compute_cluster.py
@@ -23,9 +23,9 @@ from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
 from airflow.providers.teradata.hooks.teradata import TeradataHook
 from airflow.providers.teradata.utils.constants import Constants
+from airflow.providers.teradata.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/teradata/src/airflow/providers/teradata/transfers/azure_blob_to_teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/transfers/azure_blob_to_teradata.py
@@ -21,8 +21,6 @@ from collections.abc import Sequence
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
-
 try:
     from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 except ModuleNotFoundError as e:
@@ -31,6 +29,7 @@ except ModuleNotFoundError as e:
     raise AirflowOptionalProviderFeatureException(e)
 
 from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/teradata/src/airflow/providers/teradata/transfers/s3_to_teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/transfers/s3_to_teradata.py
@@ -21,8 +21,6 @@ from collections.abc import Sequence
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
-
 try:
     from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 except ModuleNotFoundError as e:
@@ -30,6 +28,7 @@ except ModuleNotFoundError as e:
 
     raise AirflowOptionalProviderFeatureException(e)
 from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/teradata/src/airflow/providers/teradata/transfers/teradata_to_teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/transfers/teradata_to_teradata.py
@@ -21,8 +21,8 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator
 from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/teradata/src/airflow/providers/teradata/version_compat.py
+++ b/providers/teradata/src/airflow/providers/teradata/version_compat.py
@@ -35,9 +35,8 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
+    from airflow.sdk import BaseOperator
 else:
     from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
-__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "BaseSensorOperator"]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator"]

--- a/providers/teradata/src/airflow/providers/teradata/version_compat.py
+++ b/providers/teradata/src/airflow/providers/teradata/version_compat.py
@@ -37,6 +37,6 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import BaseOperator
 else:
-    from airflow.models import BaseOperator
+    from airflow.models import BaseOperator  # type: ignore[no-redef]
 
 __all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator"]

--- a/providers/teradata/tests/unit/teradata/operators/test_bteq.py
+++ b/providers/teradata/tests/unit/teradata/operators/test_bteq.py
@@ -252,7 +252,7 @@ class TestBteqOperator:
         mock_execute_bteq_script.assert_called_once()
         assert result == 0
 
-    @mock.patch("airflow.models.BaseOperator.render_template")
+    @mock.patch("airflow.providers.teradata.version_compat.BaseOperator.render_template")
     def test_render_template_in_sql(self, mock_render):
         op = BteqOperator(task_id="render_test", sql="SELECT * FROM {{ params.table }};")
         mock_render.return_value = "SELECT * FROM my_table;"


### PR DESCRIPTION
Replacing `models.BaseOperator` with `airflow.sdk BaseOperator` for each of the three providers. All unit-tests ran successfully when testing.

As part of https://github.com/apache/airflow/issues/52378.