### PR TITLE
Mocked time.sleep in tableau test

### DIFF
--- a/providers/tableau/tests/unit/tableau/hooks/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/hooks/test_tableau.py
@@ -202,8 +202,9 @@ class TestTableauHook:
             jobs_status = tableau_hook.get_job_status(job_id="j1")
             assert jobs_status == expected_status
 
+    @patch("time.sleep", return_value=None)
     @patch("airflow.providers.tableau.hooks.tableau.Server")
-    def test_wait_for_state(self, mock_tableau_server):
+    def test_wait_for_state(self, mock_tableau_server, sleep_mock):
         """
         Test wait_for_state
         """


### PR DESCRIPTION

---

Noticed `test_wait_for_state` executes time.sleep even though it's not required to test the functionality, so I mocked it. Saves about 5 seconds of CI runtime.

Will check similar cases for more providers and follow it up with a larger PR if necessary.