### PR TITLE
Make `logical_date` optional in TriggerDAGRunPostBody schema

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -94,7 +94,7 @@ class TriggerDAGRunPostBody(StrictBaseModel):
     dag_run_id: str | None = None
     data_interval_start: AwareDatetime | None = None
     data_interval_end: AwareDatetime | None = None
-    logical_date: AwareDatetime | None
+    logical_date: AwareDatetime | None = None
     run_after: datetime | None = Field(default_factory=timezone.utcnow)
 
     conf: dict = Field(default_factory=dict)

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -10869,8 +10869,6 @@ components:
           title: Note
       additionalProperties: false
       type: object
-      required:
-      - logical_date
       title: TriggerDAGRunPostBody
       description: Trigger DAG Run Serializer for POST body.
     TriggerResponse:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -5619,7 +5619,6 @@ export const $TriggerDAGRunPostBody = {
     },
     additionalProperties: false,
     type: 'object',
-    required: ['logical_date'],
     title: 'TriggerDAGRunPostBody',
     description: 'Trigger DAG Run Serializer for POST body.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1401,7 +1401,7 @@ export type TriggerDAGRunPostBody = {
     dag_run_id?: string | null;
     data_interval_start?: string | null;
     data_interval_end?: string | null;
-    logical_date: string | null;
+    logical_date?: string | null;
     run_after?: string | null;
     conf?: {
         [key: string]: unknown;


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #52627
related: #52627

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
To fix #52627, `logical_date` is not anymore mandatory, it is optional
