### PR TITLE
Replace airflow.models.baseoperator to airflow.sdk for Microsoft PSRP

### DIFF
--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -25,8 +25,8 @@ from jinja2.nativetypes import NativeEnvironment
 from pypsrp.serializer import TaggedValue
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
 from airflow.providers.microsoft.psrp.hooks.psrp import PsrpHook
+from airflow.providers.microsoft.psrp.version_compat import BaseOperator
 from airflow.settings import json
 from airflow.utils.helpers import exactly_one
 

--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/version_compat.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/version_compat.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+
+def get_base_airflow_version_tuple() -> tuple[int, int, int]:
+    from packaging.version import Version
+
+    from airflow import __version__
+
+    airflow_version = Version(__version__)
+    return airflow_version.major, airflow_version.minor, airflow_version.micro
+
+
+AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "BaseOperator",
+]

--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/version_compat.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/version_compat.py
@@ -32,7 +32,7 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import BaseOperator
 else:
-    from airflow.models import BaseOperator
+    from airflow.models import BaseOperator  # type: ignore[no-redef]
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",

--- a/providers/microsoft/psrp/tests/unit/microsoft/psrp/operators/test_psrp.py
+++ b/providers/microsoft/psrp/tests/unit/microsoft/psrp/operators/test_psrp.py
@@ -25,8 +25,8 @@ from jinja2.nativetypes import NativeEnvironment
 from pypsrp.powershell import Command, PowerShell
 
 from airflow.exceptions import AirflowException
-from airflow.models.baseoperator import BaseOperator
 from airflow.providers.microsoft.psrp.operators.psrp import PsrpOperator
+from airflow.providers.microsoft.psrp.version_compat import BaseOperator
 from airflow.settings import json
 
 CONNECTION_ID = "conn_id"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Follow-up of https://github.com/apache/airflow/pull/52292 for Microsoft PSRP
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
