### PR TITLE
Remove language flags

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -22,15 +22,15 @@ import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 
 export const supportedLanguages = [
-  { code: "ar", flag: "🇸🇦", name: "العربية" },
-  { code: "de", flag: "🇩🇪", name: "Deutsch" },
-  { code: "en", flag: "🇺🇸", name: "English" },
-  { code: "he", flag: "🇮🇱", name: "עברית" },
-  { code: "ko", flag: "🇰🇷", name: "한국어" },
-  { code: "nl", flag: "🇳🇱", name: "Nederlands" },
-  { code: "pl", flag: "🇵🇱", name: "Polski" },
-  { code: "zh-TW", flag: "🇹🇼", name: "繁體中文" },
-  { code: "fr", flag: "🇫🇷", name: "Français" },
+  { code: "en", name: "English" },
+  { code: "ar", name: "العربية" },
+  { code: "de", name: "Deutsch" },
+  { code: "fr", name: "Français" },
+  { code: "he", name: "עברית" },
+  { code: "ko", name: "한국어" },
+  { code: "nl", name: "Nederlands" },
+  { code: "pl", name: "Polski" },
+  { code: "zh-TW", name: "繁體中文" },
 ] as const;
 
 export const defaultLanguage = "en";

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/LanguageSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/LanguageSelector.tsx
@@ -28,7 +28,7 @@ const LanguageSelector: React.FC = () => {
   const options = useMemo(
     () =>
       supportedLanguages.map((lang) => ({
-        label: `${lang.flag} ${lang.name}`,
+        label: lang.name,
         value: lang.code,
       })),
     [],


### PR DESCRIPTION
Let's avoid national conflicts by removing flags from our language selector. Also, update the order so english is always top of the list since that is the primary language Airflow is written in.

<img width="288" alt="Screenshot 2025-07-01 at 5 27 12 PM" src="https://github.com/user-attachments/assets/bd46c77d-762f-4aa1-b594-b43a962ef9cf" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
