### PR TITLE
Fix connection retrieval in triggerer for schema field, use by_alias=True for ConnectionResult

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -392,7 +392,8 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             if isinstance(conn, ConnectionResponse):
                 conn_result = ConnectionResult.from_conn_response(conn)
                 resp = conn_result
-                dump_opts = {"exclude_unset": True}
+                # `by_alias=True` is used to convert the `schema` field to `schema_` in the Connection model
+                dump_opts = {"exclude_unset": True, "by_alias": True}
             else:
                 resp = conn
         elif isinstance(msg, GetVariable):

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -645,7 +645,9 @@ async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_m
     task_instance.trigger_id = trigger_orm.id
 
     # Create the appropriate Connection, Variable and XCom
-    connection = Connection(conn_id="test_connection", conn_type="http")
+    connection = Connection(
+        conn_id="test_connection", conn_type="http", schema="https", login="user", password="pass"
+    )
     variable = Variable(key="test_variable", val="some_variable_value")
     XComModel.set(
         key="test_xcom",
@@ -676,9 +678,9 @@ async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_m
                 "conn_type": "http",
                 "description": None,
                 "host": None,
-                "schema": None,
-                "login": None,
-                "password": None,
+                "schema": "https",
+                "login": "user",
+                "password": "pass",
                 "port": None,
                 "extra": None,
             },

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -646,7 +646,14 @@ async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_m
 
     # Create the appropriate Connection, Variable and XCom
     connection = Connection(
-        conn_id="test_connection", conn_type="http", schema="https", login="user", password="pass"
+        conn_id="test_connection",
+        conn_type="http",
+        schema="https",
+        login="user",
+        password="pass",
+        extra={"key": "value"},
+        port=443,
+        host="example.com",
     )
     variable = Variable(key="test_variable", val="some_variable_value")
     XComModel.set(
@@ -677,12 +684,12 @@ async def test_trigger_can_access_variables_connections_and_xcoms(session, dag_m
                 "conn_id": "test_connection",
                 "conn_type": "http",
                 "description": None,
-                "host": None,
+                "host": "example.com",
                 "schema": "https",
                 "login": "user",
                 "password": "pass",
-                "port": None,
-                "extra": None,
+                "port": 443,
+                "extra": '{"key": "value"}',
             },
             "variable": "some_variable_value",
             "xcom": '"some_xcom_value"',


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/52319

closes: https://github.com/apache/airflow/pull/52585

We should use by_alias=True to convert schema_ for connection result. as the model has `schema_`

Note: After seeing the model here https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection.py#L25, we are missing connection `description` field, will try to get in different PR that change.

After change:

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/bc375321-1f6f-4d9e-8be3-cb63ef6162f9" />

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
