### PR TITLE
 Relax ASCII restriction for asset identifiers except for MySQL

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -190,7 +190,6 @@ def _sanitize_uri(inp: str | ObjectStoragePath) -> str:
 
 
 def _validate_identifier(instance, attribute, value):
-    is_mysql_backend = "mysql" in SQL_ALCHEMY_CONN
     if not isinstance(value, str):
         raise ValueError(f"{type(instance).__name__} {attribute.name} must be a string")
     if len(value) > 1500:
@@ -199,7 +198,7 @@ def _validate_identifier(instance, attribute, value):
         raise ValueError(f"{type(instance).__name__} {attribute.name} cannot be just whitespace")
     ## We use latin1_general_cs to store the name (and group, asset values etc) on MySQL.
     ## relaxing this check for non mysql backend
-    if is_mysql_backend and not value.isascii():
+    if SQL_ALCHEMY_CONN.startswith("mysql") and not value.isascii():
         raise ValueError(f"{type(instance).__name__} {attribute.name} must only consist of ASCII characters")
     return value
 

--- a/task-sdk/tests/task_sdk/definitions/test_asset.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset.py
@@ -46,31 +46,59 @@ ASSET_MODULE_PATH = "airflow.sdk.definitions.asset"
 
 
 @pytest.mark.parametrize(
-    ["name"],
+    "sql_conn_value, name, should_raise",
     [
-        pytest.param("", id="empty"),
-        pytest.param("\n\t", id="whitespace"),
-        pytest.param("a" * 1501, id="too_long"),
-        pytest.param("😊", id="non-ascii"),
+        pytest.param("mysql://localhost/db", "", True, id="mysql-empty"),
+        pytest.param("mysql://localhost/db", "\n\t", True, id="mysql-whitespace"),
+        pytest.param("mysql://localhost/db", "a" * 1501, True, id="mysql-too-long"),
+        pytest.param("mysql://localhost/db", "😊", True, id="mysql-non-ascii"),
+        pytest.param("sqlite:///:memory:", "", True, id="sqlite-empty"),
+        pytest.param("sqlite:///:memory:", "\n\t", True, id="sqlite-whitespace"),
+        pytest.param("sqlite:///:memory:", "a" * 1501, True, id="sqlite-too-long"),
+        pytest.param("sqlite:///:memory:", "😊", False, id="sqlite-non-ascii"),
+        pytest.param("postgresql://localhost/db", "", True, id="postgres-empty"),
+        pytest.param("postgresql://localhost/db", "\n\t", True, id="postgres-whitespace"),
+        pytest.param("postgresql://localhost/db", "a" * 1501, True, id="postgres-too-long"),
+        pytest.param("postgresql://localhost/db", "😊", False, id="postgres-non-ascii"),
     ],
 )
-def test_invalid_names(name):
-    with pytest.raises(ValueError):
+def test_invalid_names(sql_conn_value, name, should_raise, monkeypatch):
+    monkeypatch.setattr("airflow.sdk.definitions.asset.SQL_ALCHEMY_CONN", sql_conn_value)
+    if should_raise:
+        with pytest.raises(ValueError):
+            Asset(name=name)
+    else:
         Asset(name=name)
 
 
 @pytest.mark.parametrize(
-    ["uri"],
+    "sql_conn_value, uri, should_raise",
     [
-        pytest.param("", id="empty"),
-        pytest.param("\n\t", id="whitespace"),
-        pytest.param("a" * 1501, id="too_long"),
-        pytest.param("airflow://xcom/dag/task", id="reserved_scheme"),
-        pytest.param("😊", id="non-ascii"),
+        pytest.param("mysql://localhost/db", "", True, id="mysql-empty"),
+        pytest.param("mysql://localhost/db", "\n\t", True, id="mysql-whitespace"),
+        pytest.param("mysql://localhost/db", "a" * 1501, True, id="mysql-too-long"),
+        pytest.param("mysql://localhost/db", "airflow://xcom/dag/task", True, id="mysql-reserved-scheme"),
+        pytest.param("mysql://localhost/db", "😊", True, id="mysql-non-ascii"),
+        pytest.param("sqlite:///:memory:", "", True, id="sqlite-empty"),
+        pytest.param("sqlite:///:memory:", "\n\t", True, id="sqlite-whitespace"),
+        pytest.param("sqlite:///:memory:", "a" * 1501, True, id="sqlite-too-long"),
+        pytest.param("sqlite:///:memory:", "airflow://xcom/dag/task", True, id="sqlite-reserved-scheme"),
+        pytest.param("sqlite:///:memory:", "😊", False, id="sqlite-non-ascii"),
+        pytest.param("postgresql://localhost/db", "", True, id="postgres-empty"),
+        pytest.param("postgresql://localhost/db", "\n\t", True, id="postgres-whitespace"),
+        pytest.param("postgresql://localhost/db", "a" * 1501, True, id="postgres-too-long"),
+        pytest.param(
+            "postgresql://localhost/db", "airflow://xcom/dag/task", True, id="postgres-reserved-scheme"
+        ),
+        pytest.param("postgresql://localhost/db", "😊", False, id="postgres-non-ascii"),
     ],
 )
-def test_invalid_uris(uri):
-    with pytest.raises(ValueError):
+def test_invalid_uris(sql_conn_value, uri, should_raise, monkeypatch):
+    monkeypatch.setattr("airflow.sdk.definitions.asset.SQL_ALCHEMY_CONN", sql_conn_value)
+    if should_raise:
+        with pytest.raises(ValueError):
+            Asset(uri=uri)
+    else:
         Asset(uri=uri)
 
 


### PR DESCRIPTION
This PR updates the asset validation logic to enforce ASCII-only characters only when using MySQL as the backend. Previously, non-ASCII characters would raise ValueError regardless of the database used, which restricted this  for PostgreSQL and SQLite as well.


**Testing(with MYSQL):**
Still getting Import error

![image](https://github.com/user-attachments/assets/2dfc8f3c-3bb9-4b21-b6d8-d5c2a6628ffb)

**Testing (with Postgres)**
No Import error
![image](https://github.com/user-attachments/assets/dbce5f66-419c-46f7-90d7-d84ba175ebe4)

closes: https://github.com/apache/airflow/issues/51566

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
