### PR TITLE
feat: Refactor Databricks error handling with utility functions

### DIFF
--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -2367,7 +2367,7 @@ class TestDatabricksNotebookOperator:
 
         with pytest.raises(AirflowException) as exec_info:
             operator.monitor_databricks_job()
-        exception_message = "Task failed. Final state FAILED. Reason: FAILURE"
+        exception_message = "Task failed. Final state FAILED. Reason: FAILURE. Errors: []"
         assert exception_message == str(exec_info.value)
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
@@ -2413,7 +2413,7 @@ class TestDatabricksNotebookOperator:
 
         with pytest.raises(AirflowException) as exc_info:
             operator.monitor_databricks_job()
-        exception_message = "Task failed. Final state FAILED. Reason: FAILURE"
+        exception_message = "Task failed. Final state FAILED. Reason: FAILURE. Errors: []"
         assert exception_message == str(exc_info.value)
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")

--- a/providers/databricks/tests/unit/databricks/utils/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/utils/test_databricks.py
@@ -17,14 +17,34 @@
 # under the License.
 from __future__ import annotations
 
+from unittest import mock
+from unittest.mock import MagicMock
+
 import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.providers.databricks.hooks.databricks import RunState
-from airflow.providers.databricks.utils.databricks import normalise_json_content, validate_trigger_event
+from airflow.providers.databricks.utils.databricks import (
+    extract_failed_task_errors,
+    extract_failed_task_errors_async,
+    normalise_json_content,
+    validate_trigger_event,
+)
 
 RUN_ID = 1
 RUN_PAGE_URL = "run-page-url"
+ERROR_MESSAGE = "Exception: Something went wrong"
+TASK_RUN_ID_1 = 101
+TASK_RUN_ID_2 = 102
+TASK_KEY_1 = "first_task"
+TASK_KEY_2 = "second_task"
+
+
+def mock_dict(d: dict):
+    """Helper function to create a MagicMock that returns a dict"""
+    m = MagicMock()
+    m.return_value = d
+    return m
 
 
 class TestDatabricksOperatorSharedFunctions:
@@ -61,3 +81,410 @@ class TestDatabricksOperatorSharedFunctions:
         event = {}
         with pytest.raises(AirflowException):
             validate_trigger_event(event)
+
+
+class TestExtractFailedTaskErrors:
+    """Test cases for the extract_failed_task_errors utility function (synchronous version)"""
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_success_run(self, mock_hook_class):
+        """Test that no errors are extracted for successful runs"""
+        hook = mock_hook_class.return_value
+        run_state = RunState("TERMINATED", "SUCCESS", "")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "SUCCESS",
+                "state_message": "",
+            },
+            "tasks": [],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        assert result == []
+        hook.get_run_output.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_failed_run_no_tasks(self, mock_hook_class):
+        """Test that no errors are extracted for failed runs with no tasks"""
+        hook = mock_hook_class.return_value
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        assert result == []
+        hook.get_run_output.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_single_failed_task_with_error_output(self, mock_hook_class):
+        """Test extracting errors from a single failed task with error in run output"""
+        hook = mock_hook_class.return_value
+        hook.get_run_output = mock_dict({"error": ERROR_MESSAGE})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Task failed",
+                    },
+                }
+            ],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_1,
+                "run_id": TASK_RUN_ID_1,
+                "error": ERROR_MESSAGE,
+            }
+        ]
+        assert result == expected
+        hook.get_run_output.assert_called_once_with(TASK_RUN_ID_1)
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_single_failed_task_without_error_output(self, mock_hook_class):
+        """Test extracting errors from a single failed task without error in run output"""
+        hook = mock_hook_class.return_value
+        hook.get_run_output = mock_dict({})  # No error in output
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed with general message")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed with general message",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Task failed",
+                    },
+                }
+            ],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_1,
+                "run_id": TASK_RUN_ID_1,
+                "error": "Job failed with general message",  # Falls back to run state message
+            }
+        ]
+        assert result == expected
+        hook.get_run_output.assert_called_once_with(TASK_RUN_ID_1)
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_multiple_failed_tasks(self, mock_hook_class):
+        """Test extracting errors from multiple failed tasks"""
+        hook = mock_hook_class.return_value
+        hook.get_run_output = mock_dict({"error": ERROR_MESSAGE})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "First task failed",
+                    },
+                },
+                {
+                    "run_id": TASK_RUN_ID_2,
+                    "task_key": TASK_KEY_2,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Second task failed",
+                    },
+                },
+            ],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_1,
+                "run_id": TASK_RUN_ID_1,
+                "error": ERROR_MESSAGE,
+            },
+            {
+                "task_key": TASK_KEY_2,
+                "run_id": TASK_RUN_ID_2,
+                "error": ERROR_MESSAGE,
+            },
+        ]
+        assert result == expected
+        assert hook.get_run_output.call_count == 2
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_mixed_task_states(self, mock_hook_class):
+        """Test extracting errors when some tasks succeed and some fail"""
+        hook = mock_hook_class.return_value
+        hook.get_run_output = mock_dict({"error": ERROR_MESSAGE})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "SUCCESS",  # This task succeeded
+                        "state_message": "Task completed",
+                    },
+                },
+                {
+                    "run_id": TASK_RUN_ID_2,
+                    "task_key": TASK_KEY_2,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",  # This task failed
+                        "state_message": "Task failed",
+                    },
+                },
+            ],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_2,
+                "run_id": TASK_RUN_ID_2,
+                "error": ERROR_MESSAGE,
+            }
+        ]
+        assert result == expected
+        hook.get_run_output.assert_called_once_with(TASK_RUN_ID_2)
+
+
+class TestExtractFailedTaskErrorsAsync:
+    """Test cases for the extract_failed_task_errors_async utility function (asynchronous version)"""
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    @pytest.mark.asyncio
+    async def test_extract_failed_task_errors_async_success_run(self, mock_hook_class):
+        """Test that no errors are extracted for successful runs (async)"""
+        hook = mock_hook_class.return_value
+        hook.a_get_run_output = mock.AsyncMock()
+
+        run_state = RunState("TERMINATED", "SUCCESS", "")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "SUCCESS",
+                "state_message": "",
+            },
+            "tasks": [],
+        }
+
+        result = await extract_failed_task_errors_async(hook, run_info, run_state)
+
+        assert result == []
+        hook.a_get_run_output.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    @pytest.mark.asyncio
+    async def test_extract_failed_task_errors_async_single_failed_task(self, mock_hook_class):
+        """Test extracting errors from a single failed task (async)"""
+        hook = mock_hook_class.return_value
+        hook.a_get_run_output = mock.AsyncMock(return_value={"error": ERROR_MESSAGE})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Task failed",
+                    },
+                }
+            ],
+        }
+
+        result = await extract_failed_task_errors_async(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_1,
+                "run_id": TASK_RUN_ID_1,
+                "error": ERROR_MESSAGE,
+            }
+        ]
+        assert result == expected
+        hook.a_get_run_output.assert_called_once_with(TASK_RUN_ID_1)
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    @pytest.mark.asyncio
+    async def test_extract_failed_task_errors_async_multiple_failed_tasks(self, mock_hook_class):
+        """Test extracting errors from multiple failed tasks (async)"""
+        hook = mock_hook_class.return_value
+        hook.a_get_run_output = mock.AsyncMock(return_value={"error": ERROR_MESSAGE})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "First task failed",
+                    },
+                },
+                {
+                    "run_id": TASK_RUN_ID_2,
+                    "task_key": TASK_KEY_2,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Second task failed",
+                    },
+                },
+            ],
+        }
+
+        result = await extract_failed_task_errors_async(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_1,
+                "run_id": TASK_RUN_ID_1,
+                "error": ERROR_MESSAGE,
+            },
+            {
+                "task_key": TASK_KEY_2,
+                "run_id": TASK_RUN_ID_2,
+                "error": ERROR_MESSAGE,
+            },
+        ]
+        assert result == expected
+        assert hook.a_get_run_output.call_count == 2
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    @pytest.mark.asyncio
+    async def test_extract_failed_task_errors_async_fallback_to_state_message(self, mock_hook_class):
+        """Test async function falls back to state message when no error in output"""
+        hook = mock_hook_class.return_value
+        hook.a_get_run_output = mock.AsyncMock(return_value={})  # No error in output
+
+        run_state = RunState("TERMINATED", "FAILED", "General failure message")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "General failure message",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Task failed",
+                    },
+                }
+            ],
+        }
+
+        result = await extract_failed_task_errors_async(hook, run_info, run_state)
+
+        expected = [
+            {
+                "task_key": TASK_KEY_1,
+                "run_id": TASK_RUN_ID_1,
+                "error": "General failure message",  # Falls back to run state message
+            }
+        ]
+        assert result == expected
+        hook.a_get_run_output.assert_called_once_with(TASK_RUN_ID_1)
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    @pytest.mark.asyncio
+    async def test_extract_failed_task_errors_async_edge_case_empty_tasks(self, mock_hook_class):
+        """Test async function with failed run but empty tasks list"""
+        hook = mock_hook_class.return_value
+        hook.a_get_run_output = mock.AsyncMock()
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [],  # Empty tasks list
+        }
+
+        result = await extract_failed_task_errors_async(hook, run_info, run_state)
+
+        assert result == []
+        hook.a_get_run_output.assert_not_called()


### PR DESCRIPTION
## Refactor Databricks error handling with reusable utility functions

### Problem
The Databricks provider currently has duplicate error extraction logic scattered across multiple operators and triggers:
- `DatabricksNotebookOperator.monitor_databricks_job()` 
- `DatabricksRunNowOperator.execute_complete()`
- `DatabricksExecutionTrigger.run()`

This duplication leads to:
- Code maintenance overhead
- Inconsistent error handling patterns
- Potential bugs when logic diverges between implementations

### Solution
This PR introduces two new utility functions in `databricks/utils/databricks.py`:

**1. `extract_failed_task_errors()` - Synchronous version**
- Extracts failed task errors from Databricks run information
- Used by operators like `DatabricksNotebookOperator`
- Handles both error outputs and fallback to state messages

**2. `extract_failed_task_errors_async()` - Asynchronous version** 
- Async version for triggers and async operations
- Used by `DatabricksExecutionTrigger`
- Maintains the same error extraction logic as sync version

### Changes Made
- ✅ **Created utility functions**: Added both sync and async error extraction utilities
- ✅ **Updated operators**: Modified `DatabricksNotebookOperator.monitor_databricks_job()` to use new utilities
- ✅ **Updated triggers**: Modified `DatabricksExecutionTrigger.run()` to use async utilities  
- ✅ **Eliminated duplication**: Removed duplicate error extraction code across multiple files
- ✅ **Added comprehensive tests**: 12+ test scenarios covering both sync/async versions
- ✅ **Improved consistency**: Standardized error handling patterns across Databricks components

### Testing
Added comprehensive test coverage in `tests/unit/databricks/utils/test_databricks.py`:
- Success scenarios (no errors to extract)
- Single failed task scenarios  
- Multiple failed task scenarios
- Mixed task states (some succeed, some fail)
- Error output vs state message fallback
- Both synchronous and asynchronous versions

### Benefits
- **🔧 Maintainability**: Single source of truth for error extraction logic
- **🚀 Consistency**: Unified error handling across all Databricks components
- **🧪 Testability**: Isolated utility functions are easier to test comprehensively
- **📦 Reusability**: Other Databricks operators can easily adopt the same pattern

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->