### PR TITLE
AIP-68 Improve plugins menu items

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
@@ -45,11 +45,12 @@ export const PluginMenuItem = ({ href, icon, name, topLevel = false, url_route: 
         to={href}
       />
     ) : (
-      <Box alignItems="center" display="flex" gap={2} outline="none" px={2} py="6px">
+      <Box alignItems="center" display="flex" width="100%">
         <Link
           aria-label={name}
           fontSize="sm"
           href={href}
+          outline="none"
           rel="noopener noreferrer"
           target="_blank"
           width="100%"
@@ -79,17 +80,19 @@ export const PluginMenuItem = ({ href, icon, name, topLevel = false, url_route: 
   }
 
   return (
-    <RouterLink to={`plugin/${urlRoute}`}>
-      <Box alignItems="center" display="flex" fontSize="sm" gap={2} px={2} py="6px">
-        {typeof icon === "string" ? (
-          <Image height="1.25rem" src={icon} width="1.25rem" />
-        ) : urlRoute === "legacy-fab-views" ? (
-          <RiArchiveStackLine size="1.25rem" />
-        ) : (
-          <LuPlug size="1.25rem" />
-        )}
-        {name}
-      </Box>
-    </RouterLink>
+    <Box width="100%">
+      <RouterLink style={{ outline: "none" }} to={`plugin/${urlRoute}`}>
+        <Box alignItems="center" display="flex" fontSize="sm">
+          {typeof icon === "string" ? (
+            <Image height="1.25rem" src={icon} width="1.25rem" />
+          ) : urlRoute === "legacy-fab-views" ? (
+            <RiArchiveStackLine size="1.25rem" />
+          ) : (
+            <LuPlug size="1.25rem" />
+          )}
+          {name}
+        </Box>
+      </RouterLink>
+    </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -92,7 +92,7 @@ export const PluginMenus = () => {
           </Menu.Trigger>
           <Menu.Content>
             {buttons.map((externalView) => (
-              <Menu.Item asChild key={externalView.name} value={externalView.name}>
+              <Menu.Item key={externalView.name} value={externalView.name}>
                 <PluginMenuItem {...externalView} />
               </Menu.Item>
             ))}
@@ -104,7 +104,7 @@ export const PluginMenus = () => {
                 </Menu.TriggerItem>
                 <Menu.Content>
                   {menuButtons.map((externalView) => (
-                    <Menu.Item asChild key={externalView.name} value={externalView.name}>
+                    <Menu.Item key={externalView.name} value={externalView.name}>
                       <PluginMenuItem {...externalView} />
                     </Menu.Item>
                   ))}


### PR DESCRIPTION
Few improvements for the plugin menu items:
- Similarly to other menus in the application, close the menu once we click on an item
- Adjust the style to me more consistent with normal menu items (hovering effect, spacing, no outline (even if this hurt accessibility this should really behave like a menu item, no outline))



https://github.com/user-attachments/assets/82ce41f4-3e42-42c9-862c-643b0faf6f50

