### PR TITLE
Fix broken main on release commands constraints

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -95,6 +95,7 @@ from airflow_breeze.global_constants import (
     ALLOWED_PLATFORMS,
     ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS,
     APACHE_AIRFLOW_GITHUB_REPOSITORY,
+    CONSTRAINTS_SOURCE_PROVIDERS,
     CURRENT_PYTHON_MAJOR_MINOR_VERSIONS,
     DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
     DESTINATION_LOCATIONS,
@@ -2778,6 +2779,7 @@ def get_airflow_versions_supported_by_python(
 def get_all_constraint_files(
     refresh_constraints: bool,
     python_version: str,
+    airflow_constraints_mode: str,
     github_token: str | None = None,
 ) -> tuple[list[str], dict[str, str]]:
     if refresh_constraints:
@@ -2798,6 +2800,7 @@ def get_all_constraint_files(
                     constraints_reference=f"constraints-{airflow_version}",
                     python_version=python_version,
                     github_token=github_token,
+                    airflow_constraints_mode=airflow_constraints_mode,
                     output_file=CONSTRAINTS_CACHE_PATH
                     / f"constraints-{airflow_version}-python-{python_version}.txt",
                 ):
@@ -2842,6 +2845,7 @@ def generate_providers_metadata(refresh_constraints: bool, github_token: str | N
     all_airflow_releases, airflow_release_dates = get_all_constraint_files(
         refresh_constraints=refresh_constraints,
         python_version=python,
+        airflow_constraints_mode=CONSTRAINTS_SOURCE_PROVIDERS,
         github_token=github_token,
     )
     constraints = load_constraints(python_version=python)


### PR DESCRIPTION
Attempting to fix https://github.com/apache/airflow/actions/runs/16029451484/job/45225970909

Seems the parameter `airflow_constraints_mode` is not correctly passed - unsure how this passed mypy and get to main... but also I am only 80% sure this is the right fix because I do not understand the parameter by reading the code :-(