### PR TITLE
AIP-68 Add external view plugin categories to admin, browse, docs, user

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/AdminButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/AdminButton.tsx
@@ -18,12 +18,13 @@
  */
 import { useTranslation } from "react-i18next";
 import { FiSettings } from "react-icons/fi";
-import { Link } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
-import type { MenuItem } from "openapi/requests/types.gen";
+import type { MenuItem, ExternalViewResponse } from "openapi/requests/types.gen";
 import { Menu } from "src/components/ui";
 
 import { NavButton } from "./NavButton";
+import { PluginMenuItem } from "./PluginMenuItem";
 
 const links = [
   {
@@ -52,19 +53,25 @@ const links = [
   },
 ];
 
-export const AdminButton = ({ authorizedMenuItems }: { readonly authorizedMenuItems: Array<MenuItem> }) => {
+export const AdminButton = ({
+  authorizedMenuItems,
+  externalViews,
+}: {
+  readonly authorizedMenuItems: Array<MenuItem>;
+  readonly externalViews: Array<ExternalViewResponse>;
+}) => {
   const { t: translate } = useTranslation("common");
   const menuItems = links
     .filter(({ title }) => authorizedMenuItems.includes(title as MenuItem))
     .map((link) => (
       <Menu.Item asChild key={link.title} value={link.title}>
-        <Link aria-label={translate(`admin.${link.title}`)} to={link.href}>
+        <RouterLink aria-label={translate(`admin.${link.title}`)} to={link.href}>
           {translate(`admin.${link.title}`)}
-        </Link>
+        </RouterLink>
       </Menu.Item>
     ));
 
-  if (!menuItems.length) {
+  if (!menuItems.length && !externalViews.length) {
     return undefined;
   }
 
@@ -73,7 +80,12 @@ export const AdminButton = ({ authorizedMenuItems }: { readonly authorizedMenuIt
       <Menu.Trigger asChild>
         <NavButton icon={<FiSettings size="1.75rem" />} title={translate("nav.admin")} />
       </Menu.Trigger>
-      <Menu.Content>{menuItems}</Menu.Content>
+      <Menu.Content>
+        {menuItems}
+        {externalViews.map((view) => (
+          <PluginMenuItem {...view} key={view.name} />
+        ))}
+      </Menu.Content>
     </Menu.Root>
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/BrowseButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/BrowseButton.tsx
@@ -18,12 +18,13 @@
  */
 import { useTranslation } from "react-i18next";
 import { FiGlobe } from "react-icons/fi";
-import { Link } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
-import type { MenuItem } from "openapi/requests/types.gen";
+import type { MenuItem, ExternalViewResponse } from "openapi/requests/types.gen";
 import { Menu } from "src/components/ui";
 
 import { NavButton } from "./NavButton";
+import { PluginMenuItem } from "./PluginMenuItem";
 
 const links = [
   {
@@ -38,19 +39,25 @@ const links = [
   },
 ];
 
-export const BrowseButton = ({ authorizedMenuItems }: { readonly authorizedMenuItems: Array<MenuItem> }) => {
+export const BrowseButton = ({
+  authorizedMenuItems,
+  externalViews,
+}: {
+  readonly authorizedMenuItems: Array<MenuItem>;
+  readonly externalViews: Array<ExternalViewResponse>;
+}) => {
   const { t: translate } = useTranslation("common");
   const menuItems = links
     .filter(({ title }) => authorizedMenuItems.includes(title as MenuItem))
     .map((link) => (
       <Menu.Item asChild key={link.key} value={translate(`browse.${link.key}`)}>
-        <Link aria-label={translate(`browse.${link.key}`)} to={link.href}>
+        <RouterLink aria-label={translate(`browse.${link.key}`)} to={link.href}>
           {translate(`browse.${link.key}`)}
-        </Link>
+        </RouterLink>
       </Menu.Item>
     ));
 
-  if (!menuItems.length) {
+  if (!menuItems.length && !externalViews.length) {
     return undefined;
   }
 
@@ -59,7 +66,12 @@ export const BrowseButton = ({ authorizedMenuItems }: { readonly authorizedMenuI
       <Menu.Trigger asChild>
         <NavButton icon={<FiGlobe size="1.75rem" />} title={translate("nav.browse")} />
       </Menu.Trigger>
-      <Menu.Content>{menuItems}</Menu.Content>
+      <Menu.Content>
+        {menuItems}
+        {externalViews.map((view) => (
+          <PluginMenuItem {...view} key={view.name} />
+        ))}
+      </Menu.Content>
     </Menu.Root>
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -18,12 +18,14 @@
  */
 import { Link } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { FiBookOpen } from "react-icons/fi";
+import { FiBookOpen, FiExternalLink } from "react-icons/fi";
 
+import type { ExternalViewResponse } from "openapi/requests/types.gen";
 import { Menu } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig";
 
 import { NavButton } from "./NavButton";
+import { PluginMenuItem } from "./PluginMenuItem";
 
 const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
 
@@ -43,9 +45,11 @@ const links = [
 ];
 
 export const DocsButton = ({
+  externalViews,
   showAPI,
   version,
 }: {
+  readonly externalViews: Array<ExternalViewResponse>;
   readonly showAPI?: boolean;
   readonly version?: string;
 }) => {
@@ -71,6 +75,7 @@ export const DocsButton = ({
                 target="_blank"
               >
                 {translate(`docs.${link.key}`)}
+                <FiExternalLink />
               </Link>
             </Menu.Item>
           ))}
@@ -78,9 +83,13 @@ export const DocsButton = ({
           <Menu.Item asChild key={version} value={version}>
             <Link aria-label={version} href={versionLink} rel="noopener noreferrer" target="_blank">
               {version}
+              <FiExternalLink />
             </Link>
           </Menu.Item>
         )}
+        {externalViews.map((view) => (
+          <PluginMenuItem {...view} key={view.name} />
+        ))}
       </Menu.Content>
     </Menu.Root>
   );

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -21,7 +21,11 @@ import { useTranslation } from "react-i18next";
 import { FiDatabase, FiHome } from "react-icons/fi";
 import { NavLink } from "react-router-dom";
 
-import { useAuthLinksServiceGetAuthMenus, useVersionServiceGetVersion } from "openapi/queries";
+import {
+  useAuthLinksServiceGetAuthMenus,
+  useVersionServiceGetVersion,
+  usePluginServiceGetPlugins,
+} from "openapi/queries";
 import { AirflowPin } from "src/assets/AirflowPin";
 import { DagIcon } from "src/assets/DagIcon";
 
@@ -36,7 +40,20 @@ import { UserSettingsButton } from "./UserSettingsButton";
 export const Nav = () => {
   const { data } = useVersionServiceGetVersion();
   const { data: authLinks } = useAuthLinksServiceGetAuthMenus();
+  const { data: pluginData } = usePluginServiceGetPlugins();
   const { t: translate } = useTranslation("common");
+
+  // Get external views with nav destination
+  const navExternalViews =
+    pluginData?.plugins
+      .flatMap((plugin) => plugin.external_views)
+      .filter((view) => view.destination === "nav") ?? [];
+
+  // Categorize external views by their category
+  const browseViews = navExternalViews.filter((view) => view.category?.toLowerCase() === "browse");
+  const adminViews = navExternalViews.filter((view) => view.category?.toLowerCase() === "admin");
+  const docsViews = navExternalViews.filter((view) => view.category?.toLowerCase() === "docs");
+  const userViews = navExternalViews.filter((view) => view.category?.toLowerCase() === "user");
 
   return (
     <VStack
@@ -77,14 +94,24 @@ export const Nav = () => {
           title={translate("nav.assets")}
           to="assets"
         />
-        <BrowseButton authorizedMenuItems={authLinks?.authorized_menu_items ?? []} />
-        <AdminButton authorizedMenuItems={authLinks?.authorized_menu_items ?? []} />
+        <BrowseButton
+          authorizedMenuItems={authLinks?.authorized_menu_items ?? []}
+          externalViews={browseViews}
+        />
+        <AdminButton
+          authorizedMenuItems={authLinks?.authorized_menu_items ?? []}
+          externalViews={adminViews}
+        />
         <SecurityButton />
         <PluginMenus />
       </Flex>
       <Flex flexDir="column">
-        <DocsButton showAPI={authLinks?.authorized_menu_items.includes("Docs")} version={data?.version} />
-        <UserSettingsButton />
+        <DocsButton
+          externalViews={docsViews}
+          showAPI={authLinks?.authorized_menu_items.includes("Docs")}
+          version={data?.version}
+        />
+        <UserSettingsButton externalViews={userViews} />
       </Flex>
     </VStack>
   );

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Link, Image } from "@chakra-ui/react";
+import { Link, Image, Menu } from "@chakra-ui/react";
+import { FiExternalLink } from "react-icons/fi";
 import { LuPlug } from "react-icons/lu";
 import { RiArchiveStackLine } from "react-icons/ri";
 import { Link as RouterLink } from "react-router-dom";
@@ -28,24 +29,32 @@ import { NavButton } from "./NavButton";
 type Props = { readonly topLevel?: boolean } & ExternalViewResponse;
 
 export const PluginMenuItem = ({ href, icon, name, topLevel = false, url_route: urlRoute }: Props) => {
-  // External Link
-  if (urlRoute === undefined || urlRoute === null) {
-    return topLevel ? (
+  const pluginIcon =
+    typeof icon === "string" ? (
+      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={icon} width="1.25rem" />
+    ) : urlRoute === "legacy-fab-views" ? (
+      <RiArchiveStackLine size="1.25rem" style={{ marginRight: topLevel ? 0 : "8px" }} />
+    ) : (
+      <LuPlug size="1.25rem" style={{ marginRight: topLevel ? 0 : "8px" }} />
+    );
+
+  const isExternal = urlRoute === undefined || urlRoute === null;
+
+  if (topLevel) {
+    return (
       <NavButton
-        icon={
-          typeof icon === "string" ? (
-            <Image height="1.75rem" src={icon} width="1.75rem" />
-          ) : (
-            <LuPlug size="1.75rem" />
-          )
-        }
-        isExternal={true}
+        icon={pluginIcon}
+        isExternal={isExternal}
         key={name}
         title={name}
-        to={href}
+        to={isExternal ? href : `plugin/${urlRoute}`}
       />
-    ) : (
-      <Box alignItems="center" display="flex" width="100%">
+    );
+  }
+
+  return (
+    <Menu.Item asChild value={name}>
+      {isExternal ? (
         <Link
           aria-label={name}
           fontSize="sm"
@@ -55,44 +64,16 @@ export const PluginMenuItem = ({ href, icon, name, topLevel = false, url_route: 
           target="_blank"
           width="100%"
         >
+          {pluginIcon}
           {name}
+          <FiExternalLink />
         </Link>
-      </Box>
-    );
-  }
-
-  // Embedded External Link via iframes
-  if (topLevel) {
-    return (
-      <NavButton
-        icon={
-          typeof icon === "string" ? (
-            <Image height="1.75rem" src={icon} width="1.75rem" />
-          ) : (
-            <LuPlug size="1.75rem" />
-          )
-        }
-        key={name}
-        title={name}
-        to={`plugin/${urlRoute}`}
-      />
-    );
-  }
-
-  return (
-    <Box width="100%">
-      <RouterLink style={{ outline: "none" }} to={`plugin/${urlRoute}`}>
-        <Box alignItems="center" display="flex" fontSize="sm">
-          {typeof icon === "string" ? (
-            <Image height="1.25rem" src={icon} width="1.25rem" />
-          ) : urlRoute === "legacy-fab-views" ? (
-            <RiArchiveStackLine size="1.25rem" />
-          ) : (
-            <LuPlug size="1.25rem" />
-          )}
+      ) : (
+        <RouterLink style={{ outline: "none" }} to={`plugin/${urlRoute}`}>
+          {pluginIcon}
           {name}
-        </Box>
-      </RouterLink>
-    </Box>
+        </RouterLink>
+      )}
+    </Menu.Item>
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -28,6 +28,9 @@ import { Menu } from "src/components/ui";
 import { NavButton } from "./NavButton";
 import { PluginMenuItem } from "./PluginMenuItem";
 
+// Define existing button categories to filter out
+const existingCategories = ["user", "docs", "admin", "browse"];
+
 export const PluginMenus = () => {
   const { t: translate } = useTranslation("common");
   const { data } = usePluginServiceGetPlugins();
@@ -35,6 +38,13 @@ export const PluginMenus = () => {
   let menuPlugins =
     data?.plugins.flatMap((plugin) => plugin.external_views).filter((view) => view.destination === "nav") ??
     [];
+
+  // Filter out plugins with categories that match existing buttons
+  menuPlugins = menuPlugins.filter((view) => {
+    const category = view.category?.toLowerCase();
+
+    return category === undefined || !existingCategories.includes(category);
+  });
 
   const hasLegacyViews =
     (
@@ -61,10 +71,6 @@ export const PluginMenus = () => {
     return undefined;
   }
 
-  // Only show external plugins in menu if there are more than 2
-  const menuExternalViews = menuPlugins.length > 2 ? menuPlugins : [];
-  const directExternalViews = menuPlugins.length <= 2 ? menuPlugins : [];
-
   const categories: Record<string, Array<ExternalViewResponse>> = {};
   const buttons: Array<ExternalViewResponse> = [];
 
@@ -80,40 +86,32 @@ export const PluginMenus = () => {
     return undefined;
   }
 
-  return (
-    <>
-      {directExternalViews.map((externalView) => (
-        <PluginMenuItem {...externalView} key={externalView.name} topLevel={true} />
-      ))}
-      {menuExternalViews.length > 0 && (
-        <Menu.Root positioning={{ placement: "right" }}>
-          <Menu.Trigger>
-            <NavButton as={Box} icon={<LuPlug />} title={translate("nav.plugins")} />
-          </Menu.Trigger>
-          <Menu.Content>
-            {buttons.map((externalView) => (
-              <Menu.Item key={externalView.name} value={externalView.name}>
-                <PluginMenuItem {...externalView} />
-              </Menu.Item>
-            ))}
-            {Object.entries(categories).map(([key, menuButtons]) => (
-              <Menu.Root key={key} positioning={{ placement: "right" }}>
-                <Menu.TriggerItem display="flex" justifyContent="space-between">
-                  {key}
-                  <FiChevronRight />
-                </Menu.TriggerItem>
-                <Menu.Content>
-                  {menuButtons.map((externalView) => (
-                    <Menu.Item key={externalView.name} value={externalView.name}>
-                      <PluginMenuItem {...externalView} />
-                    </Menu.Item>
-                  ))}
-                </Menu.Content>
-              </Menu.Root>
-            ))}
-          </Menu.Content>
-        </Menu.Root>
-      )}
-    </>
+  // Show plugins in menu if there are more than 2
+  return menuPlugins.length > 2 ? (
+    <Menu.Root positioning={{ placement: "right" }}>
+      <Menu.Trigger>
+        <NavButton as={Box} icon={<LuPlug />} title={translate("nav.plugins")} />
+      </Menu.Trigger>
+      <Menu.Content>
+        {buttons.map((externalView) => (
+          <PluginMenuItem key={externalView.name} {...externalView} />
+        ))}
+        {Object.entries(categories).map(([key, menuButtons]) => (
+          <Menu.Root key={key} positioning={{ placement: "right" }}>
+            <Menu.TriggerItem display="flex" justifyContent="space-between">
+              {key}
+              <FiChevronRight />
+            </Menu.TriggerItem>
+            <Menu.Content>
+              {menuButtons.map((externalView) => (
+                <PluginMenuItem {...externalView} key={externalView.name} />
+              ))}
+            </Menu.Content>
+          </Menu.Root>
+        ))}
+      </Menu.Content>
+    </Menu.Root>
+  ) : (
+    menuPlugins.map((plugin) => <PluginMenuItem {...plugin} key={plugin.name} topLevel={true} />)
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneMenuItem.tsx
@@ -1,0 +1,55 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FiClock } from "react-icons/fi";
+
+import { Menu } from "src/components/ui";
+import { useTimezone } from "src/context/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const TimezoneMenuItem = ({ onOpen }: { readonly onOpen: () => void }) => {
+  const { t: translate } = useTranslation();
+  const { selectedTimezone } = useTimezone();
+  const [time, setTime] = useState(dayjs());
+
+  useEffect(() => {
+    const updateTime = () => {
+      setTime(dayjs());
+    };
+
+    updateTime();
+
+    const interval = setInterval(updateTime, 1000);
+
+    return () => clearInterval(interval);
+  }, [selectedTimezone]);
+
+  return (
+    <Menu.Item onClick={onOpen} value="timezone">
+      <FiClock size="1.25rem" style={{ marginRight: "8px" }} />
+      {translate("timezone")}: {dayjs(time).tz(selectedTimezone).format("HH:mm z (Z)")}
+    </Menu.Item>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -17,49 +17,33 @@
  * under the License.
  */
 import { useDisclosure } from "@chakra-ui/react";
-import dayjs from "dayjs";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiClock, FiGrid, FiLogOut, FiMoon, FiSun, FiUser, FiGlobe } from "react-icons/fi";
+import { FiGrid, FiLogOut, FiMoon, FiSun, FiUser, FiGlobe } from "react-icons/fi";
 import { MdOutlineAccountTree } from "react-icons/md";
 import { useLocalStorage } from "usehooks-ts";
 
+import type { ExternalViewResponse } from "openapi/requests/types.gen";
 import { Menu } from "src/components/ui";
 import { useColorMode } from "src/context/colorMode/useColorMode";
-import { useTimezone } from "src/context/timezone";
 
 import LanguageModal from "./LanguageModal";
 import LogoutModal from "./LogoutModal";
 import { NavButton } from "./NavButton";
+import { PluginMenuItem } from "./PluginMenuItem";
+import { TimezoneMenuItem } from "./TimezoneMenuItem";
 import TimezoneModal from "./TimezoneModal";
 
-dayjs.extend(utc);
-dayjs.extend(timezone);
-
-export const UserSettingsButton = () => {
+export const UserSettingsButton = ({
+  externalViews,
+}: {
+  readonly externalViews: Array<ExternalViewResponse>;
+}) => {
   const { t: translate } = useTranslation();
   const { colorMode, toggleColorMode } = useColorMode();
   const { onClose: onCloseTimezone, onOpen: onOpenTimezone, open: isOpenTimezone } = useDisclosure();
   const { onClose: onCloseLogout, onOpen: onOpenLogout, open: isOpenLogout } = useDisclosure();
   const { onClose: onCloseLanguage, onOpen: onOpenLanguage, open: isOpenLanguage } = useDisclosure();
-  const { selectedTimezone } = useTimezone();
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">("default_dag_view", "grid");
-
-  const [time, setTime] = useState(dayjs());
-
-  useEffect(() => {
-    const updateTime = () => {
-      setTime(dayjs());
-    };
-
-    updateTime();
-
-    const interval = setInterval(updateTime, 1000);
-
-    return () => clearInterval(interval);
-  }, [selectedTimezone]);
 
   return (
     <Menu.Root positioning={{ placement: "right" }}>
@@ -100,10 +84,10 @@ export const UserSettingsButton = () => {
             </>
           )}
         </Menu.Item>
-        <Menu.Item onClick={onOpenTimezone} value="timezone">
-          <FiClock size="1.25rem" style={{ marginRight: "8px" }} />
-          {translate("timezone")}: {dayjs(time).tz(selectedTimezone).format("HH:mm z (Z)")}
-        </Menu.Item>
+        <TimezoneMenuItem onOpen={onOpenTimezone} />
+        {externalViews.map((view) => (
+          <PluginMenuItem {...view} key={view.name} />
+        ))}
         <Menu.Item onClick={onOpenLogout} value="logout">
           <FiLogOut size="1.25rem" style={{ marginRight: "8px" }} />
           {translate("logout")}

--- a/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
@@ -26,7 +26,7 @@ import { ProgressBar } from "src/components/ui";
 import { ErrorPage } from "./Error";
 
 export const Iframe = ({ sandbox = "allow-same-origin allow-forms" }: { readonly sandbox: string }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const { page } = useParams();
   const { data: pluginData, isLoading } = usePluginServiceGetPlugins();
 


### PR DESCRIPTION
When a user sets an external_view to have a `category` that matches one of our existing menus in the Nav bar (Admin, Browse, User, and Docs). We add it to that menu.

- fixed how plugin icons render in a menu
- Added an external icon to make it clear which Nav buttons will show pages vs open a new tab


<img width="223" alt="Screenshot 2025-07-02 at 3 50 54 PM" src="https://github.com/user-attachments/assets/b0d09401-ea5b-447a-a757-be27340106da" />
<img width="188" alt="Screenshot 2025-07-02 at 3 51 05 PM" src="https://github.com/user-attachments/assets/888a8ff6-70be-4178-89f2-4f6c9cdd782a" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
