### PR TITLE
[FEATURE] Added response validation in HttpToGcsOperator

### DIFF
--- a/providers/google/tests/unit/google/cloud/transfers/test_http_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_http_to_gcs.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 from airflow.providers.google.cloud.transfers.http_to_gcs import HttpToGCSOperator
 
+TASK_CONTEXT = None
 TASK_ID = "test-http-to-gcs-operator"
 GCP_CONN_ID = "GCP_CONN_ID"
 HTTP_CONN_ID = "HTTP_CONN_ID"
@@ -69,7 +70,7 @@ class TestHttpToGCSOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        task.execute(None)
+        task.execute(TASK_CONTEXT)
 
         # GCS
         gcs_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
@@ -100,4 +101,7 @@ class TestHttpToGCSOperator:
         )
         task.http_hook.run.assert_called_once_with(
             endpoint=ENDPOINT, headers=HEADERS, data=DATA, extra_options=EXTRA_OPTIONS
+        )
+        task.process_response.assert_called_once_with(
+            context=TASK_CONTEXT, response=task.http_hook.run.return_value
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---

This PR introduces a small feature from the conversation in [this PR](https://github.com/apache/airflow/pull/49625).

Initially the `docstring` in the operator mentioned that there were two arguments available:
- `response_check` (callable)
- `response_filter` (callable)

Which later I chose not to include them in the first released version of the operator.

Now I'm including the functionality to check the HTTP response before writing the data into GCS
