### PR TITLE
Add missing scheduledDags i18n key

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/assets.json
@@ -25,5 +25,6 @@
   "lastAssetEvent": "Last Asset Event",
   "name": "Name",
   "producingTasks": "Producing Tasks",
+  "scheduledDags": "Scheduled Dags",
   "searchPlaceholder": "Search Assets"
 }


### PR DESCRIPTION
I think this got lost in a rebase when we added Scheduled Dags to the UI at the same time as moving translations to the backend

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
