### PR TITLE
Improve warning character in constraints version check

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
@@ -88,7 +88,7 @@ def get_status_emoji(constraint_date, latest_date, is_latest_version):
         if days_diff <= 5:
             return "📢 <5d          "
         if days_diff <= 30:
-            return "⚠ <30d          "
+            return "⚠️ <30d           "
         return f"🚨 >{days_diff}d".ljust(15)
     except Exception:
         return "📢 N/A           "
@@ -412,15 +412,16 @@ def print_package_table_row(
     color = (
         "green"
         if is_latest_version
-        else ("yellow" if status.startswith("📢") or status.startswith("⚠") else "red")
+        else ("yellow" if status.startswith("📢") or status.startswith("⚠️") else "red")
     )
+    offset = 1 if status.startswith("⚠️") else 0
     string_to_print = format_str.format(
         pkg,
         pinned_version[: col_widths["Constraint Version"]],
         constraint_release_date[: col_widths["Constraint Date"]],
         latest_version[: col_widths["Latest Version"]],
         latest_release_date[: col_widths["Latest Date"]],
-        status[: col_widths["📢 Status"]],
+        status[: (col_widths["📢 Status"] + offset)],
         versions_behind_str,
         pypi_link,
     )


### PR DESCRIPTION
The warning sign is now better matching other unicode characters and the waarning table entry is properly aligned, including the unicode length of the warning character.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
