### PR TITLE
Add SBOM generation to publish-docs workflows

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -47,6 +47,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
+      build-sboms:
+        description: "Build SBOMs"
+        required: false
+        default: 'false'
+        type: string
 
 permissions:
   contents: read
@@ -63,11 +68,13 @@ jobs:
       EXCLUDE_DOCS: ${{ inputs.exclude-docs }}
       DESTINATION: ${{ inputs.destination }}
       SKIP_WRITE_TO_STABLE_FOLDER: ${{ inputs.skip-write-to-stable-folder }}
+      BUILD_SBOMS: ${{ inputs.build-sboms }}
     outputs:
       include-docs: ${{ inputs.include-docs == 'all' && '' || inputs.include-docs }}
       destination-location: ${{ steps.parameters.outputs.destination-location }}
       destination: ${{ steps.parameters.outputs.destination }}
       extra-build-options: ${{ steps.parameters.outputs.extra-build-options }}
+      airflow-version: ${{ steps.parameters.outputs.airflow-version }}
       # yamllint disable rule:line-length
       skip-write-to-stable-folder: ${{ inputs.skip-write-to-stable-folder && '--skip-write-to-stable-folder' || '' }}
     if: contains(fromJSON('[
@@ -92,6 +99,7 @@ jobs:
           echo "Exclude docs: '${EXCLUDE_DOCS}'"
           echo "Destination: '${DESTINATION}'"
           echo "Skip write to stable folder: '${SKIP_WRITE_TO_STABLE_FOLDER}'"
+          echo "Build SBOMs: '${BUILD_SBOMS}'"
           if [[ "${DESTINATION}" == "auto" ]]; then
              if [[ "${REF}" =~ ^.*[0-9]*\.[0-9]*\.[0-9]*$ ]]; then
                 echo "${REF} looks like final release, using live destination"
@@ -106,6 +114,13 @@ jobs:
              echo "destination-location=s3://live-docs-airflow-apache-org/docs/" >> ${GITHUB_OUTPUT}
           else
              echo "destination-location=s3://staging-docs-airflow-apache-org/docs/" >> ${GITHUB_OUTPUT}
+          fi
+          if [[ " ${INCLUDE_DOCS} " =~ " apache-airflow " ]]; then
+             # get version from the ref
+              AIRFLOW_VERSION=$(echo "${REF}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+              echo "airflow-version=${AIRFLOW_VERSION}" >> ${GITHUB_OUTPUT}
+          else
+                echo "airflow-version=no-airflow" >> ${GITHUB_OUTPUT}
           fi
 
   build-docs:
@@ -154,6 +169,14 @@ jobs:
           INCLUDE_COMMITS: "true"
         run: >
           breeze build-docs ${INCLUDE_DOCS} --docs-only
+      - name: "Build SBOMS"
+        env:
+          AIRFLOW_VERSION: ${{ needs.build-info.outputs.airflow-version }}
+        run: >
+          breeze sbom update-sbom-information --airflow-version ${AIRFLOW_VERSION} \
+          --force --all-combinations --run-in-parallel --airflow-root-path "${GITHUB_WORKSPACE}"
+        if: inputs.build-sboms == 'true'
+
       - name: Check disk space available
         run: df -H
       # Here we will create temp airflow-site dir to publish docs

--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -116,11 +116,10 @@ jobs:
              echo "destination-location=s3://staging-docs-airflow-apache-org/docs/" >> ${GITHUB_OUTPUT}
           fi
           if [[ " ${INCLUDE_DOCS} " =~ " apache-airflow " ]]; then
-             # get version from the ref
-              AIRFLOW_VERSION=$(echo "${REF}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-              echo "airflow-version=${AIRFLOW_VERSION}" >> ${GITHUB_OUTPUT}
+             AIRFLOW_VERSION=$(echo "${REF}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+             echo "airflow-version=${AIRFLOW_VERSION}" >> ${GITHUB_OUTPUT}
           else
-                echo "airflow-version=no-airflow" >> ${GITHUB_OUTPUT}
+             echo "airflow-version=no-airflow" >> ${GITHUB_OUTPUT}
           fi
 
   build-docs:

--- a/dev/breeze/src/airflow_breeze/commands/sbom_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/sbom_commands.py
@@ -483,6 +483,7 @@ def core_jobs(
                     f"[warning]The {destination_dir} already exists and generation is not forced. "
                     f"Skipping for airflow version {airflow_v}"
                 )
+            destination_dir.mkdir(parents=True, exist_ok=True)
         if not destination_dirs:
             get_console().print(
                 f"[warning]All directories already exist and generation is not forced. Skipping {airflow_v}"

--- a/dev/breeze/src/airflow_breeze/commands/workflow_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/workflow_commands.py
@@ -122,6 +122,7 @@ def workflow_run_publish(
         "include-docs": " ".join(doc_packages),
         "exclude-docs": exclude_docs,
         "skip-write-to-stable-folder": skip_write_to_stable_folder,
+        "build-sboms": "true" if "apache-airflow" in doc_packages else "false",
     }
 
     trigger_workflow_and_monitor(

--- a/dev/breeze/src/airflow_breeze/utils/cdxgen.py
+++ b/dev/breeze/src/airflow_breeze/utils/cdxgen.py
@@ -371,15 +371,21 @@ class SbomCoreJob(SbomApplicationJob):
     def download_dependency_files(self, output: Output | None, github_token: str | None) -> bool:
         source_dir = self.get_files_directory(self.application_root_path)
         source_dir.mkdir(parents=True, exist_ok=True)
-        lock_file_relative_path = "airflow/www/yarn.lock"
+        version_number = int(self.airflow_version.split(".")[0])
+        lock_file_relative_path = (
+            "airflow-core/src/airflow/ui/package.json" if version_number >= 3 else "airflow/www/yarn.lock"
+        )
+        source_dir_with_file = (
+            (source_dir / "package.json") if version_number >= 3 else (source_dir / "yarn.lock")
+        )
         if self.include_npm:
             download_file_from_github(
                 reference=self.airflow_version,
                 path=lock_file_relative_path,
-                output_file=source_dir / "yarn.lock",
+                output_file=source_dir_with_file,
             )
         else:
-            (source_dir / "yarn.lock").unlink(missing_ok=True)
+            source_dir_with_file.unlink(missing_ok=True)
         if self.include_python:
             if not download_constraints_file(
                 constraints_reference=f"constraints-{self.airflow_version}",


### PR DESCRIPTION
Adding SBOM generation to publish docs workfows.

We have missed adding this when the docs publishing migration happend, updated back compat with old airflow version dir structure and npm files.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
