### PR TITLE
Introduced retries to the TableauSensor

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/sensors/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/sensors/tableau.py
@@ -40,7 +40,7 @@ class TableauJobStatusSensor(BaseSensorOperator):
     :param site_id: The id of the site where the workbook belongs to.
     :param tableau_conn_id: The :ref:`Tableau Connection id <howto/connection:tableau>`
         containing the credentials to authenticate to the Tableau Server.
-    :param retries_on_failure: How often to rerun get_job_status in case
+    :param max_status_retries: How often to rerun get_job_status in case
         of an error or cancellation, to account for transient errors.
     """
 
@@ -52,21 +52,21 @@ class TableauJobStatusSensor(BaseSensorOperator):
         job_id: str,
         site_id: str | None = None,
         tableau_conn_id: str = "tableau_default",
-        retries_on_failure: int = 0,
+        max_status_retries: int = 0,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.tableau_conn_id = tableau_conn_id
         self.job_id = job_id
         self.site_id = site_id
-        self.retries_on_failure = retries_on_failure
+        self.max_status_retries = max_status_retries
         self._retry_attempts = 0
 
     def poke(self, context: Context) -> bool:
         """
         Pokes until the job has successfully finished.
 
-        When retries_on_failure is set, the Sensor will retry
+        When max_status_retries is set, the Sensor will retry
         in case of a TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED before raising an Error.
 
         :param context: The task context during execution.
@@ -77,7 +77,7 @@ class TableauJobStatusSensor(BaseSensorOperator):
             self.log.info("Current finishCode is %s (%s)", finish_code.name, finish_code.value)
 
             if finish_code in (TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED):
-                if self._retry_attempts < self.retries_on_failure:
+                if self._retry_attempts < self.max_status_retries:
                     self.log.info("Retrying to get the job status")
                     self._retry_attempts += 1
                     return False

--- a/providers/tableau/src/airflow/providers/tableau/sensors/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/sensors/tableau.py
@@ -40,6 +40,8 @@ class TableauJobStatusSensor(BaseSensorOperator):
     :param site_id: The id of the site where the workbook belongs to.
     :param tableau_conn_id: The :ref:`Tableau Connection id <howto/connection:tableau>`
         containing the credentials to authenticate to the Tableau Server.
+    :param retries_on_failure: How often to rerun get_job_status in case
+        of an error or cancellation, to account for transient errors.
     """
 
     template_fields: Sequence[str] = ("job_id",)
@@ -50,16 +52,22 @@ class TableauJobStatusSensor(BaseSensorOperator):
         job_id: str,
         site_id: str | None = None,
         tableau_conn_id: str = "tableau_default",
+        retries_on_failure: int = 0,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.tableau_conn_id = tableau_conn_id
         self.job_id = job_id
         self.site_id = site_id
+        self.retries_on_failure = retries_on_failure
+        self._retry_attempts = 0
 
     def poke(self, context: Context) -> bool:
         """
         Pokes until the job has successfully finished.
+
+        When retries_on_failure is set, the Sensor will retry
+        in case of a TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED before raising an Error.
 
         :param context: The task context during execution.
         :return: True if it succeeded and False if not.
@@ -69,6 +77,10 @@ class TableauJobStatusSensor(BaseSensorOperator):
             self.log.info("Current finishCode is %s (%s)", finish_code.name, finish_code.value)
 
             if finish_code in (TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED):
+                if self._retry_attempts < self.retries_on_failure:
+                    self.log.info("Retrying to get the job status")
+                    self._retry_attempts += 1
+                    return False
                 message = "The Tableau Refresh Workbook Job failed!"
                 raise TableauJobFailedException(message)
 

--- a/providers/tableau/tests/unit/tableau/sensors/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/sensors/test_tableau.py
@@ -79,7 +79,7 @@ class TestTableauJobStatusSensor:
             TableauJobFinishCode.SUCCESS,
         ]
         mock_tableau_hook_class.return_value.__enter__.return_value = mock_tableau_hook
-        sensor = TableauJobStatusSensor(**self.kwargs, retries_on_failure=2)
+        sensor = TableauJobStatusSensor(**self.kwargs, max_status_retries=2)
 
         assert not sensor.poke({})
         assert not sensor.poke({})
@@ -95,7 +95,7 @@ class TestTableauJobStatusSensor:
             TableauJobFinishCode.ERROR,
         ]
         mock_tableau_hook_class.return_value.__enter__.return_value = mock_tableau_hook
-        sensor = TableauJobStatusSensor(**self.kwargs, retries_on_failure=2, poke_interval=10.0)
+        sensor = TableauJobStatusSensor(**self.kwargs, max_status_retries=2, poke_interval=10.0)
         assert not sensor.poke({})
         assert not sensor.poke({})
         with pytest.raises(TableauJobFailedException, match="The Tableau Refresh Workbook Job failed!"):

--- a/providers/tableau/tests/unit/tableau/sensors/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/sensors/test_tableau.py
@@ -22,6 +22,7 @@ import pytest
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.tableau.sensors.tableau import (
+    TableauJobFailedException,
     TableauJobFinishCode,
     TableauJobStatusSensor,
 )
@@ -68,3 +69,35 @@ class TestTableauJobStatusSensor:
         with pytest.raises(AirflowException):
             sensor.poke({})
         mock_tableau_hook.get_job_status.assert_called_once_with(job_id=sensor.job_id)
+
+    @patch("airflow.providers.tableau.sensors.tableau.TableauHook")
+    def test_poke_succeeds_on_last_try(self, mock_tableau_hook_class):
+        mock_tableau_hook = Mock()
+        mock_tableau_hook.get_job_status.side_effect = [
+            TableauJobFinishCode.ERROR,
+            TableauJobFinishCode.CANCELED,
+            TableauJobFinishCode.SUCCESS,
+        ]
+        mock_tableau_hook_class.return_value.__enter__.return_value = mock_tableau_hook
+        sensor = TableauJobStatusSensor(**self.kwargs, retries_on_failure=2)
+
+        assert not sensor.poke({})
+        assert not sensor.poke({})
+        assert sensor.poke({})
+        assert mock_tableau_hook.get_job_status.call_count == 3
+
+    @patch("airflow.providers.tableau.sensors.tableau.TableauHook")
+    def test_poke_failed_on_last_try(self, mock_tableau_hook_class):
+        mock_tableau_hook = Mock()
+        mock_tableau_hook.get_job_status.side_effect = [
+            TableauJobFinishCode.ERROR,
+            TableauJobFinishCode.CANCELED,
+            TableauJobFinishCode.ERROR,
+        ]
+        mock_tableau_hook_class.return_value.__enter__.return_value = mock_tableau_hook
+        sensor = TableauJobStatusSensor(**self.kwargs, retries_on_failure=2, poke_interval=10.0)
+        assert not sensor.poke({})
+        assert not sensor.poke({})
+        with pytest.raises(TableauJobFailedException, match="The Tableau Refresh Workbook Job failed!"):
+            sensor.poke({})
+        assert mock_tableau_hook.get_job_status.call_count == 3


### PR DESCRIPTION

---
closes: #32799
I opened this as a draft since I’m unsure about the pattern used and made some compromises —> would appreciate feedback.

@hussein-awala , I like your idea of retrying on certain error codes (e.g., 408, 5xx). However, requests to Tableau’s get_by_id endpoint don’t expose status codes, and many exceptions don’t either. Error messages have them in plain text like:
```
409093: Resource Conflict
Job for 'Main Transactions Dashboard' is already queued. Not queuing a duplicate.
```
Parsing strings for status codes feels fragile. We could catch exceptions that have `response.status_code` and retry on likely transient codes, but many don’t.
*My suggestion*: add an optional retries_on_failure parameter to the sensor. It retries a set number of times on any failure, then raises an AirflowException. This keeps logic simple. The only other sensor that allows for configuring retries by itself is the [BashSensor](https://github.com/apache/airflow/blob/main/providers/standard/src/airflow/providers/standard/sensors/bash.py#L51).

Handling job cancellations on failure, as described in the issue, seems better suited for `on_failure_callback`. 
Additionally the TableauOperator comes with a param `blocking_refresh` which could lead to the same problem, I wanted to address the sensor first and get some feedback.