### PR TITLE
AIP-68 - Add iframe plugins as tabs on dag pages

### DIFF
--- a/airflow-core/src/airflow/ui/src/hooks/usePluginTabs.tsx
+++ b/airflow-core/src/airflow/ui/src/hooks/usePluginTabs.tsx
@@ -1,0 +1,64 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { ReactNode } from "react";
+import { LuPlug } from "react-icons/lu";
+
+import { usePluginServiceGetPlugins } from "openapi/queries";
+import type { ExternalViewResponse } from "openapi/requests/types.gen";
+import { useColorMode } from "src/context/colorMode";
+
+type TabPlugin = {
+  icon: ReactNode;
+  label: string;
+  value: string;
+};
+
+export const usePluginTabs = (destination: string): Array<TabPlugin> => {
+  const { colorMode } = useColorMode();
+  const { data: pluginData } = usePluginServiceGetPlugins();
+
+  // Get external views with the specified destination and ensure they have url_route
+  const externalViews =
+    pluginData?.plugins
+      .flatMap((plugin) => plugin.external_views)
+      .filter((view: ExternalViewResponse) => view.destination === destination && Boolean(view.url_route)) ??
+    [];
+
+  return externalViews.map((view) => {
+    // Choose icon based on theme - prefer dark mode icon if available and in dark mode
+    let iconSrc = view.icon;
+
+    if (colorMode === "dark" && view.icon_dark_mode !== undefined && view.icon_dark_mode !== null) {
+      iconSrc = view.icon_dark_mode;
+    }
+
+    const icon =
+      iconSrc !== undefined && iconSrc !== null ? (
+        <img alt={view.name} src={iconSrc} style={{ height: "1rem", width: "1rem" }} />
+      ) : (
+        <LuPlug />
+      );
+
+    return {
+      icon,
+      label: view.name,
+      value: `plugin/${view.url_route}`,
+    };
+  });
+};

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -180,7 +180,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 ) : undefined}
                 <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
                 <NavTabs tabs={tabs} />
-                <Box h="100%" overflow="auto" px={2}>
+                <Box flexGrow={1} overflow="auto" px={2}>
                   <Outlet />
                 </Box>
               </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -28,6 +28,7 @@ import { useParams } from "react-router-dom";
 import { useDagServiceGetDagDetails, useDagServiceGetDagsUi } from "openapi/queries";
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { TaskIcon } from "src/assets/TaskIcon";
+import { usePluginTabs } from "src/hooks/usePluginTabs";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { useRefreshOnNewDagRuns } from "src/queries/useRefreshOnNewDagRuns";
 import { isStatePending, useAutoRefresh } from "src/utils";
@@ -38,6 +39,9 @@ export const Dag = () => {
   const { t: translate } = useTranslation("dag");
   const { dagId = "" } = useParams();
 
+  // Get external views with dag destination
+  const externalTabs = usePluginTabs("dag");
+
   const tabs = [
     { icon: <LuChartColumn />, label: translate("tabs.overview"), value: "" },
     { icon: <FiBarChart />, label: translate("tabs.runs"), value: "runs" },
@@ -46,6 +50,7 @@ export const Dag = () => {
     { icon: <MdOutlineEventNote />, label: translate("tabs.auditLog"), value: "events" },
     { icon: <FiCode />, label: translate("tabs.code"), value: "code" },
     { icon: <MdDetails />, label: translate("tabs.details"), value: "details" },
+    ...externalTabs,
   ];
 
   const {

--- a/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
@@ -27,7 +27,7 @@ import { ErrorPage } from "./Error";
 
 export const Iframe = ({ sandbox = "allow-same-origin allow-forms" }: { readonly sandbox: string }) => {
   const { t: translate } = useTranslation();
-  const { dagId, page, runId, taskId } = useParams();
+  const { dagId, mapIndex, page, runId, taskId } = useParams();
   const { data: pluginData, isLoading } = usePluginServiceGetPlugins();
 
   const iframeView =
@@ -55,13 +55,16 @@ export const Iframe = ({ sandbox = "allow-same-origin allow-forms" }: { readonly
   if (iframeView.destination !== undefined && iframeView.destination !== "nav") {
     // Check if the href contains placeholders that need to be replaced
     if (dagId !== undefined) {
-      src = src.replaceAll("{dag_id}", dagId);
+      src = src.replaceAll("{DAG_ID}", dagId);
     }
     if (runId !== undefined) {
-      src = src.replaceAll("{run_id}", runId);
+      src = src.replaceAll("{RUN_ID}", runId);
     }
     if (taskId !== undefined) {
-      src = src.replaceAll("{task_id}", taskId);
+      src = src.replaceAll("{TASK_ID}", taskId);
+    }
+    if (mapIndex !== undefined) {
+      src = src.replaceAll("{MAP_INDEX}", mapIndex);
     }
   }
 

--- a/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Iframe.tsx
@@ -27,7 +27,7 @@ import { ErrorPage } from "./Error";
 
 export const Iframe = ({ sandbox = "allow-same-origin allow-forms" }: { readonly sandbox: string }) => {
   const { t: translate } = useTranslation();
-  const { page } = useParams();
+  const { dagId, page, runId, taskId } = useParams();
   const { data: pluginData, isLoading } = usePluginServiceGetPlugins();
 
   const iframeView =
@@ -49,12 +49,38 @@ export const Iframe = ({ sandbox = "allow-same-origin allow-forms" }: { readonly
     return <ErrorPage />;
   }
 
+  // Build the href URL with context parameters if the view has a destination
+  let src = iframeView.href;
+
+  if (iframeView.destination !== undefined && iframeView.destination !== "nav") {
+    // Check if the href contains placeholders that need to be replaced
+    if (dagId !== undefined) {
+      src = src.replaceAll("{dag_id}", dagId);
+    }
+    if (runId !== undefined) {
+      src = src.replaceAll("{run_id}", runId);
+    }
+    if (taskId !== undefined) {
+      src = src.replaceAll("{task_id}", taskId);
+    }
+  }
+
   return (
-    <Box flexGrow={1} m={-3}>
+    <Box
+      flexGrow={1}
+      height="100%"
+      m={-2} // Compensate for parent padding
+      minHeight={0}
+    >
       <iframe
         sandbox={sandbox}
-        src={iframeView.href}
-        style={{ height: "100%", width: "100%" }}
+        src={src}
+        style={{
+          border: "none",
+          display: "block",
+          height: "100%",
+          width: "100%",
+        }}
         title={iframeView.name}
       />
     </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Run/Run.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Run.tsx
@@ -23,6 +23,7 @@ import { MdDetails, MdOutlineEventNote, MdOutlineTask } from "react-icons/md";
 import { useParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRun, useDagServiceGetDagDetails } from "openapi/queries";
+import { usePluginTabs } from "src/hooks/usePluginTabs";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -32,12 +33,16 @@ export const Run = () => {
   const { t: translate } = useTranslation("dag");
   const { dagId = "", runId = "" } = useParams();
 
+  // Get external views with dag_run destination
+  const externalTabs = usePluginTabs("dag_run");
+
   const tabs = [
     { icon: <MdOutlineTask />, label: translate("tabs.taskInstances"), value: "" },
     { icon: <FiDatabase />, label: translate("tabs.assetEvents"), value: "asset_events" },
     { icon: <MdOutlineEventNote />, label: translate("tabs.auditLog"), value: "events" },
     { icon: <FiCode />, label: translate("tabs.code"), value: "code" },
     { icon: <MdDetails />, label: translate("tabs.details"), value: "details" },
+    ...externalTabs,
   ];
 
   const refetchInterval = useAutoRefresh({ dagId });

--- a/airflow-core/src/airflow/ui/src/pages/Task/Task.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Task.tsx
@@ -23,6 +23,7 @@ import { MdOutlineEventNote, MdOutlineTask } from "react-icons/md";
 import { useParams } from "react-router-dom";
 
 import { useDagServiceGetDagDetails, useTaskServiceGetTask } from "openapi/queries";
+import { usePluginTabs } from "src/hooks/usePluginTabs";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { useGridStructure } from "src/queries/useGridStructure.ts";
 import { getGroupTask } from "src/utils/groupTask";
@@ -34,10 +35,14 @@ export const Task = () => {
   const { t: translate } = useTranslation("dag");
   const { dagId = "", groupId, taskId } = useParams();
 
+  // Get external views with task destination
+  const externalTabs = usePluginTabs("task");
+
   const tabs = [
     { icon: <LuChartColumn />, label: translate("tabs.overview"), value: "" },
     { icon: <MdOutlineTask />, label: translate("tabs.taskInstances"), value: "task_instances" },
     { icon: <MdOutlineEventNote />, label: translate("tabs.auditLog"), value: "events" },
+    ...externalTabs,
   ];
 
   const displayTabs = groupId === undefined ? tabs : tabs.filter((tab) => tab.value !== "events");

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -28,6 +28,7 @@ import {
   useGridServiceGridData,
   useTaskInstanceServiceGetMappedTaskInstance,
 } from "openapi/queries";
+import { usePluginTabs } from "src/hooks/usePluginTabs";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -36,6 +37,9 @@ import { Header } from "./Header";
 export const TaskInstance = () => {
   const { t: translate } = useTranslation("dag");
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
+
+  // Get external views with task_instance destination
+  const externalTabs = usePluginTabs("task_instance");
 
   const tabs = [
     { icon: <MdReorder />, label: translate("tabs.logs"), value: "" },
@@ -49,6 +53,7 @@ export const TaskInstance = () => {
     { icon: <MdOutlineEventNote />, label: translate("tabs.auditLog"), value: "events" },
     { icon: <FiCode />, label: translate("tabs.code"), value: "code" },
     { icon: <MdDetails />, label: translate("tabs.details"), value: "details" },
+    ...externalTabs,
   ];
 
   const refetchInterval = useAutoRefresh({ dagId });

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -60,6 +60,16 @@ import { XCom } from "src/pages/XCom";
 
 import { client } from "./queryClient";
 
+const iframeRoute = {
+  // The following iframe sandbox setting is intentionally less restrictive.
+  // This is considered safe because the framed content originates from the Plugins,
+  // which is part of the deployment of Airflow and trusted as per our security policy.
+  // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+  // They are not user provided plugins.
+  element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+  path: "plugin/:page",
+};
+
 const taskInstanceRoutes = [
   { element: <Logs />, index: true },
   { element: <Events />, path: "events" },
@@ -69,6 +79,7 @@ const taskInstanceRoutes = [
   { element: <RenderedTemplates />, path: "rendered_templates" },
   { element: <TaskInstances />, path: "task_instances" },
   { element: <TaskInstanceAssetEvents />, path: "asset_events" },
+  iframeRoute,
 ];
 
 export const routerConfig = [
@@ -142,15 +153,7 @@ export const routerConfig = [
         element: <Connections />,
         path: "connections",
       },
-      {
-        // The following iframe sandbox setting is intentionally less restrictive.
-        // This is considered safe because the framed content originates from the Plugins,
-        // which is part of the deployment of Airflow and trusted as per our security policy.
-        // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-        // They are not user provided plugins.
-        element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-        path: "plugin/:page",
-      },
+      iframeRoute,
       {
         children: [
           { element: <Overview />, index: true },
@@ -160,15 +163,7 @@ export const routerConfig = [
           { element: <Events />, path: "events" },
           { element: <Code />, path: "code" },
           { element: <DagDetails />, path: "details" },
-          {
-            // The following iframe sandbox setting is intentionally less restrictive.
-            // This is considered safe because the framed content originates from the Plugins,
-            // which is part of the deployment of Airflow and trusted as per our security policy.
-            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-            // They are not user provided plugins.
-            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-            path: "plugin/:page",
-          },
+          iframeRoute,
         ],
         element: <Dag />,
         path: "dags/:dagId",
@@ -180,32 +175,13 @@ export const routerConfig = [
           { element: <Code />, path: "code" },
           { element: <DagRunDetails />, path: "details" },
           { element: <DagRunAssetEvents />, path: "asset_events" },
-          {
-            // The following iframe sandbox setting is intentionally less restrictive.
-            // This is considered safe because the framed content originates from the Plugins,
-            // which is part of the deployment of Airflow and trusted as per our security policy.
-            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-            // They are not user provided plugins.
-            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-            path: "plugin/:page",
-          },
+          iframeRoute,
         ],
         element: <Run />,
         path: "dags/:dagId/runs/:runId",
       },
       {
-        children: [
-          ...taskInstanceRoutes,
-          {
-            // The following iframe sandbox setting is intentionally less restrictive.
-            // This is considered safe because the framed content originates from the Plugins,
-            // which is part of the deployment of Airflow and trusted as per our security policy.
-            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-            // They are not user provided plugins.
-            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-            path: "plugin/:page",
-          },
-        ],
+        children: taskInstanceRoutes,
         element: <TaskInstance />,
         path: "dags/:dagId/runs/:runId/tasks/:taskId",
       },
@@ -223,32 +199,13 @@ export const routerConfig = [
         children: [
           { element: <TaskOverview />, index: true },
           { element: <TaskInstances />, path: "task_instances" },
-          {
-            // The following iframe sandbox setting is intentionally less restrictive.
-            // This is considered safe because the framed content originates from the Plugins,
-            // which is part of the deployment of Airflow and trusted as per our security policy.
-            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-            // They are not user provided plugins.
-            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-            path: "plugin/:page",
-          },
+          iframeRoute,
         ],
         element: <Task />,
         path: "dags/:dagId/tasks/group/:groupId",
       },
       {
-        children: [
-          ...taskInstanceRoutes,
-          {
-            // The following iframe sandbox setting is intentionally less restrictive.
-            // This is considered safe because the framed content originates from the Plugins,
-            // which is part of the deployment of Airflow and trusted as per our security policy.
-            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-            // They are not user provided plugins.
-            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-            path: "plugin/:page",
-          },
-        ],
+        children: taskInstanceRoutes,
         element: <TaskInstance />,
         path: "dags/:dagId/runs/:runId/tasks/:taskId/mapped/:mapIndex",
       },
@@ -257,15 +214,7 @@ export const routerConfig = [
           { element: <TaskOverview />, index: true },
           { element: <TaskInstances />, path: "task_instances" },
           { element: <Events />, path: "events" },
-          {
-            // The following iframe sandbox setting is intentionally less restrictive.
-            // This is considered safe because the framed content originates from the Plugins,
-            // which is part of the deployment of Airflow and trusted as per our security policy.
-            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
-            // They are not user provided plugins.
-            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
-            path: "plugin/:page",
-          },
+          iframeRoute,
         ],
         element: <Task />,
         path: "dags/:dagId/tasks/:taskId",

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -160,6 +160,15 @@ export const routerConfig = [
           { element: <Events />, path: "events" },
           { element: <Code />, path: "code" },
           { element: <DagDetails />, path: "details" },
+          {
+            // The following iframe sandbox setting is intentionally less restrictive.
+            // This is considered safe because the framed content originates from the Plugins,
+            // which is part of the deployment of Airflow and trusted as per our security policy.
+            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+            // They are not user provided plugins.
+            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+            path: "plugin/:page",
+          },
         ],
         element: <Dag />,
         path: "dags/:dagId",
@@ -171,12 +180,32 @@ export const routerConfig = [
           { element: <Code />, path: "code" },
           { element: <DagRunDetails />, path: "details" },
           { element: <DagRunAssetEvents />, path: "asset_events" },
+          {
+            // The following iframe sandbox setting is intentionally less restrictive.
+            // This is considered safe because the framed content originates from the Plugins,
+            // which is part of the deployment of Airflow and trusted as per our security policy.
+            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+            // They are not user provided plugins.
+            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+            path: "plugin/:page",
+          },
         ],
         element: <Run />,
         path: "dags/:dagId/runs/:runId",
       },
       {
-        children: taskInstanceRoutes,
+        children: [
+          ...taskInstanceRoutes,
+          {
+            // The following iframe sandbox setting is intentionally less restrictive.
+            // This is considered safe because the framed content originates from the Plugins,
+            // which is part of the deployment of Airflow and trusted as per our security policy.
+            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+            // They are not user provided plugins.
+            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+            path: "plugin/:page",
+          },
+        ],
         element: <TaskInstance />,
         path: "dags/:dagId/runs/:runId/tasks/:taskId",
       },
@@ -194,12 +223,32 @@ export const routerConfig = [
         children: [
           { element: <TaskOverview />, index: true },
           { element: <TaskInstances />, path: "task_instances" },
+          {
+            // The following iframe sandbox setting is intentionally less restrictive.
+            // This is considered safe because the framed content originates from the Plugins,
+            // which is part of the deployment of Airflow and trusted as per our security policy.
+            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+            // They are not user provided plugins.
+            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+            path: "plugin/:page",
+          },
         ],
         element: <Task />,
         path: "dags/:dagId/tasks/group/:groupId",
       },
       {
-        children: taskInstanceRoutes,
+        children: [
+          ...taskInstanceRoutes,
+          {
+            // The following iframe sandbox setting is intentionally less restrictive.
+            // This is considered safe because the framed content originates from the Plugins,
+            // which is part of the deployment of Airflow and trusted as per our security policy.
+            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+            // They are not user provided plugins.
+            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+            path: "plugin/:page",
+          },
+        ],
         element: <TaskInstance />,
         path: "dags/:dagId/runs/:runId/tasks/:taskId/mapped/:mapIndex",
       },
@@ -208,6 +257,15 @@ export const routerConfig = [
           { element: <TaskOverview />, index: true },
           { element: <TaskInstances />, path: "task_instances" },
           { element: <Events />, path: "events" },
+          {
+            // The following iframe sandbox setting is intentionally less restrictive.
+            // This is considered safe because the framed content originates from the Plugins,
+            // which is part of the deployment of Airflow and trusted as per our security policy.
+            // https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+            // They are not user provided plugins.
+            element: <Iframe sandbox="allow-scripts allow-same-origin allow-forms" />,
+            path: "plugin/:page",
+          },
         ],
         element: <Task />,
         path: "dags/:dagId/tasks/:taskId",


### PR DESCRIPTION
If an external_view plugin has a destination of "dag", "dag_run", "task_instance" or "task", we will add it as a tab for those pages.

The icon will appear when the details panel is condensed

We will fill in `{dag_id}`, `{run_id}`, `{task_id}`, if they exist, in the href to pass to the iframe component to show details specific to that dag, run, task.

Below: using Airflow as a plugin inside of Airflow
<img width="1437" alt="Screenshot 2025-07-03 at 11 20 11 AM" src="https://github.com/user-attachments/assets/5ea7bca5-c1df-47fe-9825-a1be56469a0b" />
<img width="1431" alt="Screenshot 2025-07-03 at 11 20 24 AM" src="https://github.com/user-attachments/assets/e6a466ff-4e3c-42c7-a87c-93a2dea7a3d1" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
