### PR TITLE
Fixing bad cadwyn migration for upstream map indexes

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
@@ -63,8 +63,15 @@ class TestTIUpdateState:
                 id="list of ints",
             ),
             pytest.param(
+                [
+                    ("task_a", None),
+                ],
+                {"task_a": None},
+                id="task has no upstreams",
+            ),
+            pytest.param(
                 [("task_a", None), ("task_b", [6, 7]), ("task_c", 2)],
-                {"task_a": -1, "task_b": 6, "task_c": 2},
+                {"task_a": None, "task_b": 6, "task_c": 2},
                 id="mixed types",
             ),
         ],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Problem

Mapped tasks on old client of version (1.0.1) and new airflow API server (3.0.2) started failing.

Example DAG:
```
import datetime

from airflow.decorators import dag
from airflow.decorators import task

@dag(start_date=datetime.datetime(2024, 10, 1), schedule=None, catchup=False)
def dynamic_xcom():
    @task
    def task_1():
        print("task_1")

    @task
    def task_2(x):
        print("task_2")
        print(x)
        return x

    @task
    def task_3(y):
        print("task_3")
        print(y)

    t1 = task_1()
    t2 = task_2.expand(x=[0, 1, 2])
    t1 >> t2
    task_3.expand(y=t2)
dynamic_xcom()
```

Failure:
![image](https://github.com/user-attachments/assets/afd982a8-936b-4a41-91ae-7c8727ebf07c)


The issue was in the Cadwyn version downgrade logic that converts API responses for older clients. When `_get_upstream_map_indexes` correctly returned `{"task_2": None}`, the `downgrade_upstream_map_indexes` function was incorrectly converting None to -1 as it seemed semantically right. This conversion was breaking the Task SDK's mapped task expansion logic.

The task SDK's `get_task_map_length` function expects None values in `upstream_map_indexes`. However, when None was converted to -1, the function calculated (-1 or 1) * len(resolved_val) = -1 * 3 = -3, which triggered the "cannot expand field mapped to length -3". 

## Fix and testing

DAG:
```
import datetime

from airflow.decorators import dag
from airflow.decorators import task

@dag(start_date=datetime.datetime(2024, 10, 1), schedule=None, catchup=False)
def dynamic_xcom():
    @task
    def task_1():
        print("task_1")

    @task
    def task_2(x):
        print("task_2")
        print(x)
        return x

    @task
    def task_3(y):
        print("task_3")
        print(y)

    t1 = task_1()
    t2 = task_2.expand(x=[0, 1, 2])
    t1 >> t2
    task_3.expand(y=t2)
dynamic_xcom()
```

![image](https://github.com/user-attachments/assets/b2a7bdfa-da54-406a-b8d8-51acd1094c54)


- Also added a test case that checks for this explictly.
- This fix will ensure that sdk like 1.0.1 can still work with latest airflow API server (3.0.2+)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
