### PR TITLE
Fix Tinkerpop integration tests execution envrionment variable name

### DIFF
--- a/scripts/ci/docker-compose/integration-tinkerpop.yml
+++ b/scripts/ci/docker-compose/integration-tinkerpop.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - gremlin
     environment:
-      - INTEGRATION_GREMLIN=true
+      - INTEGRATION_TINKERPOP=true
     stdin_open: true
 volumes:
   graph-data:

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -188,7 +188,7 @@ if [[ ${INTEGRATION_YDB} == "true" ]]; then
     check_service "YDB Cluster" "run_nc ydb 2136" 50
 fi
 
-if [[ ${INTEGRATION_GREMLIN} == "true" ]]; then
+if [[ ${INTEGRATION_TINKERPOP} == "true" ]]; then
     check_service "gremlin" "run_nc gremlin 8182" 100 30
 fi
 


### PR DESCRIPTION
We have fixed integration test discovery to discover only provided integration, here https://github.com/apache/airflow/pull/52462 , I have missed updating env vars casuing the tests skipping 😞 

This fixes them now.

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/1cd19c20-f1c0-40c1-bb53-1dd291d5b383" />

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
