### PR TITLE
[v3-0-test] Fix links to SBOMS to be versioned (#52827)

### DIFF
--- a/airflow-core/docs/conf.py
+++ b/airflow-core/docs/conf.py
@@ -221,6 +221,7 @@ manual_substitutions_in_generated_html = [
     "installation/installing-from-sources.html",
     "administration-and-deployment/logging-monitoring/advanced-logging-configuration.html",
     "howto/docker-compose/index.html",
+    "security/sbom.html",
 ]
 
 html_css_files = ["custom.css"]

--- a/airflow-core/docs/security/sbom.rst
+++ b/airflow-core/docs/security/sbom.rst
@@ -25,7 +25,7 @@ of the software dependencies.
 The general use case for such files is to help assess and manage risks. For instance a quick lookup against your SBOM files can help identify if a CVE (Common Vulnerabilities and Exposures) in a
 library is affecting you.
 
-By default, Apache Airflow SBOM files are generated for airflow core with all providers. In the near future we aim at generating SBOM files per provider and also provide them for docker standard images.
+By default, Apache Airflow SBOM files are generated for Airflow core with all providers. In the near future we aim at generating SBOM files per provider and also provide them for docker standard images.
 
 Each airflow version has its own SBOM files, one for each supported python version.
-You can find them `here <https://airflow.apache.org/docs/apache-airflow/stable/sbom>`_.
+You can find them `here <https://airflow.apache.org/docs/apache-airflow/|version|/sbom/>`_.


### PR DESCRIPTION
The SBOM links generated in Airflow docs were using the "stable" version in their links. This was wrong - each of the versioned documentation in "security/sbom" page should link to the exact folder where SBOMS are stored for particular airflow version.

This has been fixed in the generated documentation for past versions of airflow already, but this change implements proper link for future documentation generation.
(cherry picked from commit 8c77a01f89835b62d7836935fbe071833a879275)


Fixes: #51791

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
