### PR TITLE
Fix Confirmation dialog for DagRun MarkAs and Clear Actions

### DIFF
--- a/airflow/www/static/js/dag/details/dagRun/MarkRunAs.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/MarkRunAs.tsx
@@ -95,6 +95,22 @@ const MarkRunAs = ({ runId, state, ...otherProps }: Props) => {
     markSuccess({ confirmed: true });
   };
 
+  const confirmMarkAsFailed = () => {
+    if (state !== "failed") {
+      if (!doNotShowAgain) {
+        dispatch({ type: "SHOW_CONFIRMATION_MODAL", payload: "failed" });
+      } else markAsFailed();
+    }
+  };
+
+  const confirmMarkAsSuccess = () => {
+    if (state !== "success") {
+      if (!doNotShowAgain) {
+        dispatch({ type: "SHOW_CONFIRMATION_MODAL", payload: "success" });
+      } else markAsSuccess();
+    }
+  };
+
   const confirmAction = () => {
     localStorage.setItem(
       "doNotShowMarkRunModal",
@@ -108,20 +124,8 @@ const MarkRunAs = ({ runId, state, ...otherProps }: Props) => {
     dispatch({ type: "HIDE_CONFIRMATION_MODAL" });
   };
 
-  useKeysPress(keyboardShortcutIdentifier.dagMarkSuccess, () => {
-    if (state !== "success") {
-      if (!doNotShowAgain) {
-        dispatch({ type: "SHOW_CONFIRMATION_MODAL", payload: "success" });
-      } else markAsSuccess();
-    }
-  });
-  useKeysPress(keyboardShortcutIdentifier.dagMarkFailed, () => {
-    if (state !== "failed") {
-      if (!doNotShowAgain) {
-        dispatch({ type: "SHOW_CONFIRMATION_MODAL", payload: "failed" });
-      } else markAsFailed();
-    }
-  });
+  useKeysPress(keyboardShortcutIdentifier.dagMarkSuccess, confirmMarkAsSuccess);
+  useKeysPress(keyboardShortcutIdentifier.dagMarkFailed, confirmMarkAsFailed);
 
   const markLabel = "Manually set dag run state";
   return (
@@ -138,16 +142,22 @@ const MarkRunAs = ({ runId, state, ...otherProps }: Props) => {
           mt={2}
         >
           <Flex>
-            Mark state as...
+            Mark run as...
             <MdArrowDropDown size="16px" />
           </Flex>
         </MenuButton>
         <MenuList>
-          <MenuItem onClick={markAsFailed} isDisabled={state === "failed"}>
+          <MenuItem
+            onClick={confirmMarkAsFailed}
+            isDisabled={state === "failed"}
+          >
             <SimpleStatus state="failed" mr={2} />
             failed
           </MenuItem>
-          <MenuItem onClick={markAsSuccess} isDisabled={state === "success"}>
+          <MenuItem
+            onClick={confirmMarkAsSuccess}
+            isDisabled={state === "success"}
+          >
             <SimpleStatus state="success" mr={2} />
             success
           </MenuItem>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

This fixes #51966. When clicking to mark a run as success or failed, the confirmation dialog was never shown. Kegboard shortcut are actually working correctly.

It's my first using typescript, this fixes the behavior, but i wonder if it would not be better to follow the pattern in [ClearRun.tsx](https://github.com/apache/airflow/blob/b1473eb64ba0082266eabe2be24c6b4889bd4e74/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx), at least for the sake of consistency?

Also, i'm doing this PR against `v2-11-stable` which is probably incorrect?