### PR TITLE
Fix KEDA Query to Use executor Field Instead of queue for Multiple Executors

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1820,7 +1820,7 @@
                         "query": {
                             "description": "Query to use for KEDA autoscaling. Must return a single integer.",
                             "type": "string",
-                            "default": "SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }}) FROM task_instance WHERE (state='running' OR state='queued') {{- if or (contains \"CeleryKubernetesExecutor\" .Values.executor) (contains \"KubernetesExecutor\" .Values.executor) }} AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}' {{- end }}"
+                            "default": "SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }}) FROM task_instance WHERE (state='running' OR state='queued') {{- if contains \"CeleryKubernetesExecutor\" .Values.executor }} AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}' {{- else if contains \"KubernetesExecutor\" .Values.executor }} AND executor != 'KubernetesExecutor' {{- end }}"
                         },
                         "usePgbouncer": {
                             "description": "Weather to use PGBouncer to connect to the database or not when it is enabled. This configuration will be ignored if PGBouncer is not enabled.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -732,9 +732,10 @@ workers:
       SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
       FROM task_instance
       WHERE (state='running' OR state='queued')
-      {{- if or (contains "CeleryKubernetesExecutor" .Values.executor)
-      (contains "KubernetesExecutor" .Values.executor) }}
+      {{- if contains "CeleryKubernetesExecutor" .Values.executor }}
       AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'
+      {{- else if contains "KubernetesExecutor" .Values.executor }}
+      AND executor != 'KubernetesExecutor'
       {{- end }}
 
     # Weather to use PGBouncer to connect to the database or not when it is enabled

--- a/helm-tests/tests/helm_tests/other/test_keda.py
+++ b/helm-tests/tests/helm_tests/other/test_keda.py
@@ -103,8 +103,11 @@ class TestKeda:
             f"SELECT ceil(COUNT(*)::decimal / {concurrency}) "
             "FROM task_instance WHERE (state='running' OR state='queued')"
         )
-        if "CeleryKubernetesExecutor" in executor or "KubernetesExecutor" in executor:
-            query += f" AND queue != '{queue or 'kubernetes'}'"
+        if "CeleryKubernetesExecutor" in executor:
+            queue_value = queue or "kubernetes"
+            query += f" AND queue != '{queue_value}'"
+        elif "KubernetesExecutor" in executor:
+            query += " AND executor != 'KubernetesExecutor'"
         return query
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Description:
When multiple executors (e.g., `CeleryExecutor,KubernetesExecutor`) are configured, the worker default `KEDA` query uses the `queue` column in the Airflow metadata database to determine Celery worker scaling.
However, task routing in Airflow is based on the `executor` attribute, not `queue`. This causes Celery workers to scale up unnecessarily for tasks explicitly configured with `executor='KubernetesExecutor'` but using the `default` queue

## Changes:
This PR updates the KEDA query logic in `values.yaml` to correctly filter tasks based on the executor field when multiple `executors` are configured:
- For `CeleryKubernetesExecutor`, the existing logic is retained, using `queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'`.
- For configurations including `KubernetesExecutor` (alone or with `CeleryExecutor`), the query is updated to use `executor != 'KubernetesExecutor'` ensuring tasks assigned to `KubernetesExecutor` not trigger Celery worker scaling.

## Testing Steps
1. Deploy Airflow using Helm Chart with `KEDA` enabled and multiple executors:
```
executor: CeleryExecutor,KubernetesExecutor
workers:
  keda:
    enabled: true
``` 
2. Create a DAG with tasks explicitly using `KubernetesExecutor` and `queue='default'`
3. Verify that Celery workers do not scale up for tasks with `executor='KubernetesExecutor'`

## Additional Notes:
![image](https://github.com/user-attachments/assets/11f78f76-c11a-4ecf-a78f-8991c145b280)


## Related Issues:
Closes: #49001 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
