### PR TITLE
Make sure default-python-version is quoted in GH action yaml files

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -122,8 +122,8 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners) }}
     env:
       UPGRADE_TO_NEWER_DEPENDENCIES: false
-      PYTHON_MAJOR_MINOR_VERSION: ${{ inputs.default-python-version }}
-      PYTHON_VERSION: ${{ inputs.default-python-version }}
+      PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
+      PYTHON_VERSION: "${{ inputs.default-python-version }}"
       GITHUB_REPOSITORY: ${{ github.repository }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -70,7 +70,7 @@ jobs:
       runners: ${{ inputs.runners }}
       platform: ${{ inputs.platform }}
       python-versions: "[ '${{ inputs.default-python-version }}' ]"
-      default-python-version: ${{ inputs.default-python-version }}
+      default-python-version: "${{ inputs.default-python-version }}"
       branch: ${{ inputs.default-branch }}
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ inputs.constraints-branch }}
@@ -85,7 +85,7 @@ jobs:
       runners: ${{ inputs.runners }}
       platform: ${{ inputs.platform }}
       python-versions: "[ '${{ inputs.default-python-version }}' ]"
-      default-python-version: ${{ inputs.default-python-version }}
+      default-python-version: "${{ inputs.default-python-version }}"
       branch: ${{ inputs.default-branch }}
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ inputs.constraints-branch }}
@@ -116,13 +116,13 @@ jobs:
         with:
           platform: ${{ inputs.platform }}
           image-type: "prod"
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Test examples of PROD image building"
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ inputs.default-branch }}
-          DEFAULT_PYTHON_VERSION: ${{ inputs.default-python-version }}
+          DEFAULT_PYTHON_VERSION: "${{ inputs.default-python-version }}"
         run: "
           cd ./docker-tests && \
           TEST_IMAGE=\"ghcr.io/$GITHUB_REPOSITORY/$DEFAULT_BRANCH\

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -209,7 +209,7 @@ jobs:
       run-ui-tests: ${{needs.build-info.outputs.run-ui-tests}}
       run-www-tests: ${{needs.build-info.outputs.run-www-tests}}
       needs-api-codegen: ${{needs.build-info.outputs.needs-api-codegen}}
-      default-python-version: ${{needs.build-info.outputs.default-python-version}}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       basic-checks-only: ${{needs.build-info.outputs.basic-checks-only}}
       skip-pre-commits: ${{needs.build-info.outputs.skip-pre-commits}}
       canary-run: ${{needs.build-info.outputs.canary-run}}
@@ -254,7 +254,7 @@ jobs:
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       branch: ${{ needs.build-info.outputs.default-branch }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       skip-pre-commits: ${{ needs.build-info.outputs.skip-pre-commits }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
@@ -297,7 +297,7 @@ jobs:
       python-versions-list-as-string: ${{ needs.build-info.outputs.python-versions-list-as-string }}
       branch: ${{ needs.build-info.outputs.default-branch }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       docs-list-as-string: ${{ needs.build-info.outputs.docs-list-as-string }}
       latest-versions-only: ${{ needs.build-info.outputs.latest-versions-only }}
       basic-checks-only: ${{ needs.build-info.outputs.basic-checks-only }}
@@ -330,7 +330,7 @@ jobs:
       runners: ${{ needs.build-info.outputs.amd-runners }}
       platform: "linux/amd64"
       canary-run: ${{ needs.build-info.outputs.canary-run }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       selected-providers-list-as-string: ${{ needs.build-info.outputs.selected-providers-list-as-string }}
       # yamllint disable rule:line-length
@@ -353,7 +353,7 @@ jobs:
       runners: ${{ needs.build-info.outputs.amd-runners }}
       platform: "linux/amd64"
       helm-test-packages: ${{ needs.build-info.outputs.helm-test-packages }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: >
       needs.build-info.outputs.needs-helm-tests == 'true' &&
@@ -613,7 +613,7 @@ jobs:
       providers-test-types-list-as-strings-in-json: >
         ${{ needs.build-info.outputs.providers-test-types-list-as-strings-in-json }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       default-postgres-version: ${{ needs.build-info.outputs.default-postgres-version }}
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
@@ -637,7 +637,7 @@ jobs:
       testable-core-integrations: ${{ needs.build-info.outputs.testable-core-integrations }}
       testable-providers-integrations: ${{ needs.build-info.outputs.testable-providers-integrations }}
       run-system-tests: ${{ needs.build-info.outputs.run-tests }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       default-postgres-version: ${{ needs.build-info.outputs.default-postgres-version }}
       default-mysql-version: ${{ needs.build-info.outputs.default-mysql-version }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
@@ -722,7 +722,7 @@ jobs:
       upload-image-artifact: "true"
       upload-package-artifact: "true"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       branch: ${{ needs.build-info.outputs.default-branch }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
@@ -743,7 +743,7 @@ jobs:
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       disable-airflow-repo-cache: ${{ needs.build-info.outputs.disable-airflow-repo-cache }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       canary-run: ${{ needs.build-info.outputs.canary-run }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: needs.build-info.outputs.prod-image-build == 'true'
@@ -777,7 +777,7 @@ jobs:
     with:
       runners: ${{ needs.build-info.outputs.amd-runners }}
       platform: "linux/amd64"
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
@@ -845,7 +845,7 @@ jobs:
     with:
       runners: ${{ needs.build-info.outputs.amd-runners }}
       platform: "linux/amd64"
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
@@ -899,7 +899,7 @@ jobs:
       python-versions-list-as-string: ${{ needs.build-info.outputs.python-versions-list-as-string }}
       branch: ${{ needs.build-info.outputs.default-branch }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
@@ -958,7 +958,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
-          python-version: ${{ inputs.default-python-version }}
+          python-version: "${{ inputs.default-python-version }}"
       - name: "Summarize all warnings"
         run: |
           ./scripts/ci/testing/summarize_captured_warnings.py ./artifacts \

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -171,7 +171,7 @@ jobs:
       run-ui-tests: ${{needs.build-info.outputs.run-ui-tests}}
       run-www-tests: ${{needs.build-info.outputs.run-www-tests}}
       needs-api-codegen: ${{needs.build-info.outputs.needs-api-codegen}}
-      default-python-version: ${{needs.build-info.outputs.default-python-version}}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       basic-checks-only: ${{needs.build-info.outputs.basic-checks-only}}
       skip-pre-commits: ${{needs.build-info.outputs.skip-pre-commits}}
       canary-run: ${{needs.build-info.outputs.canary-run}}
@@ -216,7 +216,7 @@ jobs:
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       branch: ${{ needs.build-info.outputs.default-branch }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       skip-pre-commits: ${{ needs.build-info.outputs.skip-pre-commits }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
@@ -258,7 +258,7 @@ jobs:
       runners: ${{ needs.build-info.outputs.arm-runners }}
       platform: "linux/arm64"
       canary-run: ${{ needs.build-info.outputs.canary-run }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       selected-providers-list-as-string: ${{ needs.build-info.outputs.selected-providers-list-as-string }}
       # yamllint disable rule:line-length
@@ -281,7 +281,7 @@ jobs:
       runners: ${{ needs.build-info.outputs.arm-runners }}
       platform: "linux/arm64"
       helm-test-packages: ${{ needs.build-info.outputs.helm-test-packages }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       use-uv: ${{ needs.build-info.outputs.use-uv }}
     if: >
       needs.build-info.outputs.needs-helm-tests == 'true' &&
@@ -480,7 +480,7 @@ jobs:
       upload-image-artifact: "true"
       upload-package-artifact: "true"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       branch: ${{ needs.build-info.outputs.default-branch }}
       use-uv: ${{ needs.build-info.outputs.use-uv }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
@@ -576,7 +576,7 @@ jobs:
       python-versions-list-as-string: ${{ needs.build-info.outputs.python-versions-list-as-string }}
       branch: ${{ needs.build-info.outputs.default-branch }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
-      default-python-version: ${{ needs.build-info.outputs.default-python-version }}
+      default-python-version: "${{ needs.build-info.outputs.default-python-version }}"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -180,7 +180,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
         id: breeze
       - name: "Install pre-commit"
@@ -223,7 +223,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
         id: breeze
       - name: "Install pre-commit"
@@ -271,7 +271,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Restore docs inventory cache"
         uses: apache/infrastructure-actions/stash/restore@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
@@ -334,7 +334,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Download docs prepared as artifacts"
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
@@ -417,7 +417,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Generate airflow python client"
         run: >

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -75,7 +75,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Helm Unit Tests: ${{ matrix.helm-test-package }}"
         env:

--- a/.github/workflows/integration-system-tests.yml
+++ b/.github/workflows/integration-system-tests.yml
@@ -104,7 +104,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Integration: core ${{ matrix.integration }}"
         env:
@@ -115,7 +115,7 @@ jobs:
         uses: ./.github/actions/post_tests_success
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          python-version: ${{ inputs.default-python-version }}
+          python-version: "${{ inputs.default-python-version }}"
       - name: "Post Tests failure"
         uses: ./.github/actions/post_tests_failure
         if: failure()
@@ -153,7 +153,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Integration: providers ${{ matrix.integration }}"
         env:
@@ -163,7 +163,7 @@ jobs:
         uses: ./.github/actions/post_tests_success
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          python-version: ${{ inputs.default-python-version }}
+          python-version: "${{ inputs.default-python-version }}"
       - name: "Post Tests failure"
         uses: ./.github/actions/post_tests_failure
         if: failure()
@@ -197,7 +197,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "System Tests"
         run: >
@@ -206,7 +206,7 @@ jobs:
         uses: ./.github/actions/post_tests_success
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          python-version: ${{ inputs.default-python-version }}
+          python-version: "${{ inputs.default-python-version }}"
       - name: "Post Tests failure"
         uses: ./.github/actions/post_tests_failure
         if: failure()

--- a/.github/workflows/prod-image-extra-checks.yml
+++ b/.github/workflows/prod-image-extra-checks.yml
@@ -69,7 +69,7 @@ jobs:
       upload-package-artifact: "false"
       install-mysql-client-type: "mysql"
       python-versions: ${{ inputs.python-versions }}
-      default-python-version: ${{ inputs.default-python-version }}
+      default-python-version: "${{ inputs.default-python-version }}"
       branch: ${{ inputs.branch }}
       # Always build images during the extra checks and never push them
       push-image: "false"
@@ -90,7 +90,7 @@ jobs:
       upload-package-artifact: "false"
       install-mysql-client-type: "mysql"
       python-versions: ${{ inputs.python-versions }}
-      default-python-version: ${{ inputs.default-python-version }}
+      default-python-version: "${{ inputs.default-python-version }}"
       branch: ${{ inputs.branch }}
       # Always build images during the extra checks and never push them
       push-image: "false"

--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -172,13 +172,12 @@ jobs:
         env:
           AIRFLOW_VERSION: ${{ needs.build-info.outputs.airflow-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYTHON_VERSION: ${{ needs.build-info.outputs.default-python-version }}
+          PYTHON_VERSION: "${{ needs.build-info.outputs.default-python-version }}"
           FORCE: "true"
         run: >
           breeze sbom update-sbom-information --airflow-version ${AIRFLOW_VERSION}
           --all-combinations --run-in-parallel --airflow-root-path "${GITHUB_WORKSPACE}"
         if: inputs.build-sboms == 'true'
-
       - name: Check disk space available
         run: df -H
       # Here we will create temp airflow-site dir to publish docs

--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -96,7 +96,7 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
         with:
           platform: ${{ inputs.platform }}
-          python: ${{ inputs.default-python-version }}
+          python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*


### PR DESCRIPTION
This is a nice (?) feature of yaml that it interpretes the type of passed value and tries to determine it automatically. Which is a bummer if you pass python version = 3.10 without quotes, because it is interpreted as 3.1 float rather than "3.10" string

And we have now 3.10 as default python version so we have to quote it in order to make sure it is interpreted correctly.

It did not cause problems for now because breeze automatically switches to a default ("3.10") python version when you specify a version that is not valid, but we had a number of warnings in CI:

```
The value 3.1 is not allowed for parameter python. Setting default value to 3.10
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
