### PR TITLE
Fix BlobWriter (GCS)  support for SFTP Streaming

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -29,7 +29,7 @@ from contextlib import contextmanager
 from fnmatch import fnmatch
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, cast
 
 import asyncssh
 from asgiref.sync import sync_to_async
@@ -293,9 +293,25 @@ class SFTPHook(SSHHook):
         """
         with self.get_managed_conn() as conn:
             if isinstance(local_full_path, BytesIO):
+                # It's a file-like object ( BytesIO), so use getfo().
+                self.log.info("Using streaming download for %s", remote_full_path)
                 conn.getfo(remote_full_path, local_full_path, prefetch=prefetch)
-            else:
+            # We use hasattr checking for 'write' for cases like google.cloud.storage.fileio.BlobWriter
+            elif hasattr(local_full_path, "write"):
+                self.log.info("Using streaming download for %s", remote_full_path)
+                # We need to cast to pass pre-commit checks
+                stream_full_path = cast("IO[bytes]", local_full_path)
+                conn.getfo(remote_full_path, stream_full_path, prefetch=prefetch)
+            elif isinstance(local_full_path, (str, bytes, os.PathLike)):
+                # It's a string path, so use get().
+                self.log.info("Using standard file download for %s", remote_full_path)
                 conn.get(remote_full_path, local_full_path, prefetch=prefetch)
+            # If it's neither, it's an unsupported type.
+            else:
+                raise TypeError(
+                    f"Unsupported type for local_full_path: {type(local_full_path)}. "
+                    "Expected a stream-like object or a path-like object."
+                )
 
     def store_file(self, remote_full_path: str, local_full_path: str, confirm: bool = True) -> None:
         """


### PR DESCRIPTION
resolves: #49801
related: #48107

Support for streaming was added for SFTP_to_GCS Operator. As mentioned in  #49801 it is not actually working as the object received in the SFTP hook a BlobWriter.

```
ERROR - Task failed with exception: source="task"
• TypeError: expected str, bytes or os. PathLike object, not BlobWriter
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper
File "/opt/airflow/providers/google/src/airflow/providers/google/cloud/transfers/sftp_to_gcs.py", line 159 in execute File "/opt/airflow/providers/google/src/airflow/providers/google/cloud/transfers/sftp_to_gcs.py", line 180 in _copy_single_object
File "/opt/airflow/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py", line 292 in retrieve_file File "/usr/local/lib/python3.10/site-packages/paramiko/sftp_client.py", line 839 in get
```

While the code can be changed in the SFTP_to_GCS Operator by calling the conn.getfo() directly there, it would break the abstraction. I think we can make the SFTP hook more robust to manage the BlobWriter for GCS and throw an exception for unknown types. 

---

