### PR TITLE
Remove gunicorn daemonize for api-server

### DIFF
--- a/airflow-core/newsfragments/52860.significant.rst
+++ b/airflow-core/newsfragments/52860.significant.rst
@@ -1,0 +1,17 @@
+Replace API server ``access_logfile`` configuration with ``log_config``
+
+The API server configuration option ``[api] access_logfile`` has been replaced with ``[api] log_config`` to align with uvicorn's logging configuration instead of the legacy gunicorn approach.
+The new ``log_config`` option accepts a path to a logging configuration file compatible with ``logging.config.fileConfig``, providing more flexible logging configuration for the API server.
+
+This change also removes the dependency on gunicorn for daemonization, making the API server ``--daemon`` option consistent with other Airflow components like scheduler and triggerer.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [x] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -635,8 +635,8 @@ ARG_API_SERVER_HOSTNAME = Arg(
 )
 ARG_API_SERVER_LOG_CONFIG = Arg(
     ("--log-config",),
-    default=conf.get("api", "log_config"),
-    help="Path to the logging configuration file for the uvicorn server. If not set, the default uvicorn logging configuration will be used.",
+    default=conf.get("api", "log_config", fallback=None),
+    help="(Optional) Path to the logging configuration file for the uvicorn server. If not set, the default uvicorn logging configuration will be used.",
 )
 ARG_API_SERVER_APPS = Arg(
     ("--apps",),

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -633,10 +633,10 @@ ARG_API_SERVER_HOSTNAME = Arg(
     default=conf.get("api", "host"),
     help="Set the host on which to run the API server",
 )
-ARG_API_SERVER_ACCESS_LOGFILE = Arg(
-    ("-A", "--access-logfile"),
-    default=conf.get("api", "access_logfile"),
-    help="The logfile to store the access log. Use '-' to print to stdout",
+ARG_API_SERVER_LOG_CONFIG = Arg(
+    ("--log-config",),
+    default=conf.get("api", "log_config"),
+    help="Path to the logging configuration file for the uvicorn server. If not set, the default uvicorn logging configuration will be used.",
 )
 ARG_API_SERVER_APPS = Arg(
     ("--apps",),
@@ -1864,7 +1864,7 @@ core_commands: list[CLICommand] = [
             ARG_DAEMON,
             ARG_STDOUT,
             ARG_STDERR,
-            ARG_API_SERVER_ACCESS_LOGFILE,
+            ARG_API_SERVER_LOG_CONFIG,
             ARG_API_SERVER_APPS,
             ARG_LOG_FILE,
             ARG_SSL_CERT,

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -40,9 +40,7 @@ log = logging.getLogger(__name__)
 # more info here: https://github.com/benoitc/gunicorn/issues/1877#issuecomment-1911136399
 
 
-def _run_api_server(
-    args, apps: str, access_logfile: str, num_workers: int, worker_timeout: int, proxy_headers: bool
-):
+def _run_api_server(args, apps: str, num_workers: int, worker_timeout: int, proxy_headers: bool):
     """Run the API server."""
     log.info(
         textwrap.dedent(
@@ -52,7 +50,7 @@ def _run_api_server(
             Workers: {num_workers}
             Host: {args.host}:{args.port}
             Timeout: {worker_timeout}
-            Logfiles: {access_logfile}
+            Logfiles: {args.log_file or "-"}
             ================================================================="""
         )
     )
@@ -72,12 +70,13 @@ def _run_api_server(
         "airflow.api_fastapi.main:app",
         host=args.host,
         port=args.port,
+        log_config=args.log_config,
         workers=num_workers,
         timeout_keep_alive=worker_timeout,
         timeout_graceful_shutdown=worker_timeout,
         ssl_keyfile=ssl_key,
         ssl_certfile=ssl_cert,
-        access_log=access_logfile,  # type: ignore[arg-type]
+        access_log=True,
         proxy_headers=proxy_headers,
     )
 
@@ -89,7 +88,6 @@ def api_server(args):
     print(settings.HEADER)
 
     apps = args.apps
-    access_logfile = args.access_logfile or "-"
     num_workers = args.workers
     worker_timeout = args.worker_timeout
     proxy_headers = args.proxy_headers
@@ -137,7 +135,6 @@ def api_server(args):
             callback=lambda: _run_api_server(
                 args=args,
                 apps=apps,
-                access_logfile=access_logfile,
                 num_workers=num_workers,
                 worker_timeout=worker_timeout,
                 proxy_headers=proxy_headers,

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -136,10 +136,6 @@ def api_server(args):
             process.wait()
         os.environ.pop("AIRFLOW_API_APPS")
     else:
-        # We leave the logs here intentionally, since run_command_with_daemon_option will first daemonize the process, then run the callback
-        if args.daemon:
-            log.info("Daemonized the API server process PID: %s", os.getpid())
-
         run_command_with_daemon_option(
             args=args,
             process_name="api_server",
@@ -150,7 +146,6 @@ def api_server(args):
                 worker_timeout=worker_timeout,
                 proxy_headers=proxy_headers,
             ),
-            should_setup_logging=False,
         )
 
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1371,13 +1371,14 @@ api:
       type: integer
       example: ~
       default: "120"
-    access_logfile:
+    log_config:
       description: |
-        Log files for the api server. '-' means log to stderr.
+        Path to the logging configuration file for the uvicorn server.
+        If not set, the default uvicorn logging configuration will be used.
       version_added: ~
       type: string
-      example: ~
-      default: "-"
+      example: path/to/logging_config.yaml
+      default: ~
     ssl_cert:
       description: |
         Paths to the SSL certificate and key for the api server. When both are

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -373,6 +373,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "require_confirmation_dag_change"): ("webserver", "require_confirmation_dag_change", "3.1.0"),
         ("api", "instance_name"): ("webserver", "instance_name", "3.1.0"),
         ("dag_processor", "parsing_pre_import_modules"): ("scheduler", "parsing_pre_import_modules", "3.1.0"),
+        ("api", "log_config"): ("api", "access_logfile", "3.1.0"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/airflow-core/tests/unit/cli/commands/_common_cli_classes.py
+++ b/airflow-core/tests/unit/cli/commands/_common_cli_classes.py
@@ -33,7 +33,7 @@ from airflow.utils.cli import setup_locations
 console = Console(width=400, color_system="standard")
 
 
-class _CommonCLIGunicornTestClass:
+class _CommonCLIUvicornTestClass:
     main_process_regexp: str = "process_to_look_for"
 
     @pytest.fixture(autouse=True)
@@ -49,12 +49,12 @@ class _CommonCLIGunicornTestClass:
         # Confirm that nmain procss hasn't been launched.
         # pgrep returns exit status 1 if no process matched.
         # Use more specific regexps (^) to avoid matching pytest run when running specific method.
-        # For instance, we want to be able to do: pytest -k 'gunicorn'
+        # For instance, we want to be able to do: pytest -k 'uvicorn'
         airflow_internal_api_pids = self._find_all_processes(self.main_process_regexp)
-        gunicorn_pids = self._find_all_processes(r"gunicorn: ")
-        if airflow_internal_api_pids or gunicorn_pids:
+        uvicorn_pids = self._find_all_processes(r"uvicorn: ")
+        if airflow_internal_api_pids or uvicorn_pids:
             console.print("[blue]Some processes are still running")
-            for pid in gunicorn_pids + airflow_internal_api_pids:
+            for pid in uvicorn_pids + airflow_internal_api_pids:
                 with suppress(NoSuchProcess):
                     console.print(psutil.Process(pid).as_dict(attrs=["pid", "name", "cmdline"]))
             console.print("[blue]Here list of processes ends")
@@ -63,9 +63,9 @@ class _CommonCLIGunicornTestClass:
                 for pid in airflow_internal_api_pids:
                     with suppress(NoSuchProcess):
                         psutil.Process(pid).kill()
-            if gunicorn_pids:
-                console.print("[yellow]Forcefully killing all gunicorn processes")
-                for pid in gunicorn_pids:
+            if uvicorn_pids:
+                console.print("[yellow]Forcefully killing all uvicorn processes")
+                for pid in uvicorn_pids:
                     with suppress(NoSuchProcess):
                         psutil.Process(pid).kill()
             if not ignore_running:

--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -217,9 +217,10 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
     @mock.patch("airflow.cli.commands.daemon_utils.TimeoutPIDLockFile")
     @mock.patch("airflow.cli.commands.daemon_utils.setup_locations")
     @mock.patch("airflow.cli.commands.daemon_utils.daemon")
+    @mock.patch("airflow.cli.commands.daemon_utils.check_if_pidfile_process_is_running")
     @mock.patch("airflow.cli.commands.api_server_command.uvicorn")
     def test_run_command_daemon(
-        self, mock_uvicorn, mock_daemon, mock_setup_locations, mock_pid_file, demonize
+        self, mock_uvicorn, _, mock_daemon, mock_setup_locations, mock_pid_file, demonize
     ):
         mock_setup_locations.return_value = (
             mock.MagicMock(name="pidfile"),
@@ -254,7 +255,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             timeout_graceful_shutdown=60,
             ssl_keyfile=None,
             ssl_certfile=None,
-            access_log="-",
+            access_log=True,
             proxy_headers=False,
         )
 


### PR DESCRIPTION
related: #52581

## Why

When I attempt to remove `gunicorn` dependency in #52581, I found that we are still using `gunicorn` for daemonization.

## What

- Replace `gunicorn.daemonize` with `run_command_with_daemon_option`, this also align the behavior of `--daemon` option for scheduler, triggerer ... and **api-server**
- Add test for api-server with `--daemon` as well
  - Rename `_CommonCLIGunicornTestClass` to `_CommonCLIUvicornTestClass`, since we are using `uvicorn` instead of `gunicorn` for api-server now.
- Replace `[api/access_logfile]` config with `[api/log_config]`, detail in  https://github.com/apache/airflow/pull/52860#discussion_r2185721521

