### PR TITLE
Run trigger expansion logic only when start_from_trigger is True

### DIFF
--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -62,11 +62,6 @@ class MappedOperator(TaskSDKMappedOperator):  # type: ignore[misc] # It complain
 
         :meta private:
         """
-        print(f"self.start_from_trigger {self.start_from_trigger}")
-        print(f"valis is {self.partial_kwargs.get('start_from_trigger', self.start_from_trigger)}")
-        print(f"type is {type(self.start_from_trigger)}")
-        print(f"type is {type(self.partial_kwargs.get('start_from_trigger', self.start_from_trigger))}")
-
         if not self.partial_kwargs.get("start_from_trigger", self.start_from_trigger):
             log.warning(
                 "Starting a mapped task from triggerer is currently unsupported",

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -70,7 +70,7 @@ class MappedOperator(TaskSDKMappedOperator):  # type: ignore[misc] # It complain
             )
             return False
         # start_from_trigger only makes sense when start_trigger_args exists.
-        if not self.start_trigger_args:
+        if self.start_trigger_args is not None:
             return False
 
         mapped_kwargs, _ = self._expand_mapped_kwargs(context)

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -62,7 +62,12 @@ class MappedOperator(TaskSDKMappedOperator):  # type: ignore[misc] # It complain
 
         :meta private:
         """
-        if self.partial_kwargs.get("start_from_trigger", self.start_from_trigger):
+        print(f"self.start_from_trigger {self.start_from_trigger}")
+        print(f"valis is {self.partial_kwargs.get('start_from_trigger', self.start_from_trigger)}")
+        print(f"type is {type(self.start_from_trigger)}")
+        print(f"type is {type(self.partial_kwargs.get('start_from_trigger', self.start_from_trigger))}")
+
+        if not self.partial_kwargs.get("start_from_trigger", self.start_from_trigger):
             log.warning(
                 "Starting a mapped task from triggerer is currently unsupported",
                 task_id=self.task_id,
@@ -70,7 +75,7 @@ class MappedOperator(TaskSDKMappedOperator):  # type: ignore[misc] # It complain
             )
             return False
         # start_from_trigger only makes sense when start_trigger_args exists.
-        if self.start_trigger_args is not None:
+        if not self.start_trigger_args:
             return False
 
         mapped_kwargs, _ = self._expand_mapped_kwargs(context)


### PR DESCRIPTION
This PR fixes a logic issue introduced in [#48006](https://github.com/apache/airflow/pull/48006). That PR was meant to prevent mapped tasks from starting directly from the triggerer, but it had a misplaced return False outside the if block, so it always returned early. At the time, the logic issue was hidden because of indentation.

Later, [#51701](https://github.com/apache/airflow/pull/51701) fixed the indentation, which made the earlier bug more obvious.

closes :https://github.com/apache/airflow/issues/52845 

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
