### PR TITLE
fixes the grid service method when current node is none _merge_node_d…

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
@@ -299,7 +299,7 @@ def _merge_node_dicts(current, new) -> None:
         if node["id"] in current_ids:
             current_node = _get_node_by_id(current, node["id"])
             # if we have children, merge those as well
-            if "children" in current_node:
+            if current_node.get("children"):
                 _merge_node_dicts(current_node["children"], node["children"])
         else:
             current.append(node)


### PR DESCRIPTION
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/api_fastapi/core_api/services/ui/grid.py", line 298, in _merge_node_dicts
if "children" in current_node:
TypeError: 'NoneType' object is not iterable