### PR TITLE
Fix KubernetesPodOperator loses connection to worker pod

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -32,6 +32,11 @@ from kubernetes import client
 from kubernetes.client import V1EnvVar, V1PodSecurityContext, V1SecurityContext, models as k8s
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.rest import ApiException
+from urllib3.exceptions import (
+    ConnectionError,
+    IncompleteRead,
+    ProtocolError,
+)
 
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.connection import Connection
@@ -239,6 +244,8 @@ class TestKubernetesPodOperatorSystem:
         )
         context = create_context(k)
         with pytest.raises(ApiException):
+            k.execute(context)
+        with pytest.raises((ProtocolError, ConnectionError, IncompleteRead)):
             k.execute(context)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Sometimes, KubernetesOperator faces urllib3.exceptions.ProtocolError if the pod execution time is too long. Add wait and retry mechanism would fix this, after just 1 or 2 attempts. Detail has been discussed in https://github.com/apache/airflow/issues/52865

Closes: #52865 

**Test evidence:**

I have implemented a KubernetesPodOperator based on the original one, with wait & retry mechanism. And, it works like a charm

Before implementing wait & retry:

![image](https://github.com/user-attachments/assets/c9906733-b2e6-4ad8-8c88-1a40eb419abe)

After implementing wait & retry:

![image](https://github.com/user-attachments/assets/59aec711-4dc9-4e80-87dd-f1bd5440f19a)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
