### PR TITLE
Remove legacy methods on `models.BaseOperator`

### DIFF
--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -23,7 +23,6 @@ import random
 import pytest
 from sqlalchemy import select
 
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstance as TI, clear_task_instances
@@ -676,67 +675,3 @@ class TestClearTasks:
                 assert ti.state == State.SUCCESS
                 assert ti.try_number == 2
                 assert ti.max_tries == 1
-
-    def test_operator_clear(self, dag_maker, session):
-        class ClearOperator(BaseOperator):
-            def execute(self, context):
-                pass
-
-        with dag_maker("test_operator_clear"):
-            op1 = ClearOperator(task_id="test1")
-            op2 = ClearOperator(task_id="test2", retries=1)
-            op1 >> op2
-
-        dr = dag_maker.create_dagrun(
-            state=State.RUNNING,
-            run_type=DagRunType.SCHEDULED,
-        )
-
-        def _get_ti(old_ti):
-            return session.scalar(
-                select(TI).where(
-                    TI.dag_id == old_ti.dag_id,
-                    TI.task_id == old_ti.task_id,
-                    TI.map_index == old_ti.map_index,
-                    TI.run_id == old_ti.run_id,
-                )
-            )
-
-        ti1, ti2 = sorted(dr.get_task_instances(session=session), key=lambda ti: ti.task_id)
-        ti1.task = op1
-        ti2.task = op2
-        ti2.refresh_from_db(session=session)
-        ti2.try_number += 1
-        session.commit()
-
-        # Dependency not met
-        assert ti2.try_number == 1
-        assert ti2.max_tries == 1
-
-        ti1.refresh_from_db(session=session)
-        assert ti1.max_tries == 0
-        assert ti1.try_number == 0
-
-        op2.clear(upstream=True, session=session)
-        ti1.refresh_from_db(session)
-        ti2.refresh_from_db(session)
-        ti1.task = op1
-        ti2.task = op2
-        # max tries will be set to retries + curr try number == 1 + 1 == 2
-        assert ti2.max_tries == 2
-
-        ti1.refresh_from_db(session)
-        ti2.refresh_from_db(session)
-        assert ti1.try_number == 0
-
-        ti2 = _get_ti(ti2)
-        ti2.try_number += 1
-        ti2.refresh_from_task(op1)
-        session.commit()
-        ti2.run(ignore_ti_state=True, session=session)
-        ti2.refresh_from_db(session)
-        # max_tries is 0 because there is no task instance in db for ti1
-        # so clear won't change the max_tries.
-        assert ti1.max_tries == 0
-        assert ti2.try_number == 2
-        assert ti2.max_tries == 2  # max tries has not changed since it was updated when op2.clear called

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -800,12 +800,12 @@ class TestTaskInstance:
         ti.task = task
 
         # depends_on_past prevents the run
-        task.run(start_date=run_date, end_date=run_date, ignore_first_depends_on_past=False)
+        dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=False)
         ti.refresh_from_db()
         assert ti.state is None
 
         # ignore first depends_on_past to allow the run
-        task.run(start_date=run_date, end_date=run_date, ignore_first_depends_on_past=True)
+        dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=True)
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
@@ -837,7 +837,7 @@ class TestTaskInstance:
         # With catchup=False, depends_on_past behavior is different:
         # The task ignores historical dependencies since catchup=False means
         # "only consider runs from now forward"
-        task.run(start_date=run_date, end_date=run_date, ignore_first_depends_on_past=False)
+        dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=False)
         ti.refresh_from_db()
 
         # The task runs successfully even with depends_on_past=True because
@@ -845,7 +845,7 @@ class TestTaskInstance:
         assert ti.state == State.SUCCESS
 
         # ignore_first_depends_on_past should still allow the run with catchup=False
-        task.run(start_date=run_date, end_date=run_date, ignore_first_depends_on_past=True)
+        dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=True)
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 

--- a/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
@@ -482,7 +482,6 @@ class TestTriggerRuleDep:
             done=2,
             normal_tasks=["FakeTaskID", "OtherFakeTaskID"],
         )
-        ti.task.xcom_pull.return_value = None
         xcom_mock = Mock(return_value=None)
         with mock.patch("airflow.models.taskinstance.TaskInstance.xcom_pull", xcom_mock):
             _test_trigger_rule(
@@ -516,7 +515,6 @@ class TestTriggerRuleDep:
             done=2,
             normal_tasks=["FakeTaskID", "OtherFakeTaskID"],
         )
-        ti.task.xcom_pull.return_value = None
         xcom_mock = Mock(return_value=True)
         with mock.patch("airflow.models.taskinstance.TaskInstance.xcom_pull", xcom_mock):
             _test_trigger_rule(
@@ -1569,7 +1567,6 @@ def test_setup_constraint_wait_for_past_depends_before_skipping(
         setup_tasks=["FakeTaskID", "OtherFakeTaskID"],
     )
 
-    ti.task.xcom_pull.return_value = None
     xcom_mock = Mock(return_value=True if past_depends_met else None)
     with mock.patch("airflow.models.taskinstance.TaskInstance.xcom_pull", xcom_mock):
         _test_trigger_rule(


### PR DESCRIPTION
These methods don't need to exists and makes https://github.com/apache/airflow/pull/52234 simpler.
These methods aren't used anywhere in the code anymore, there usages was mainly in Core tests since providers were fixed as part of [#52378](https://github.com/apache/airflow/issues/52378.)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
