### PR TITLE
Turn task-sdk into peer-citizen same as other doc packages

### DIFF
--- a/airflow-core/docs/index.rst
+++ b/airflow-core/docs/index.rst
@@ -39,7 +39,7 @@ Task SDK
 
 For Airflow Task SDK, see the standalone reference & tutorial site:
 
-   https://airflow.apache.org/docs/task-sdk/stable/
+:doc:`task-sdk:index`
 
 Dags
 -----------------------------------------

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
@@ -30,7 +30,7 @@ from airflow_breeze.utils.parallel import check_async_run_results, run_with_pool
 
 PROVIDER_NAME_FORMAT = "apache-airflow-providers-{}"
 
-NON_SHORT_NAME_PACKAGES = ["docker-stack", "helm-chart", "apache-airflow"]
+NON_SHORT_NAME_PACKAGES = ["docker-stack", "helm-chart", "apache-airflow", "task-sdk"]
 
 PACKAGES_METADATA_EXCLUDE_NAMES = ["docker-stack", "apache-airflow-providers"]
 

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -84,6 +84,7 @@ def test_get_available_packages_include_non_provider_doc_packages_and_all_provid
 def test_get_short_package_name():
     assert get_short_package_name("apache-airflow") == "apache-airflow"
     assert get_short_package_name("docker-stack") == "docker-stack"
+    assert get_short_package_name("task-sdk") == "task-sdk"
     assert get_short_package_name("apache-airflow-providers-amazon") == "amazon"
     assert get_short_package_name("apache-airflow-providers-apache-hdfs") == "apache.hdfs"
 
@@ -96,6 +97,7 @@ def test_error_on_get_short_package_name():
 def test_get_long_package_name():
     assert get_long_package_name("apache-airflow") == "apache-airflow"
     assert get_long_package_name("docker-stack") == "docker-stack"
+    assert get_long_package_name("task-sdk") == "task-sdk"
     assert get_long_package_name("amazon") == "apache-airflow-providers-amazon"
     assert get_long_package_name("apache.hdfs") == "apache-airflow-providers-apache-hdfs"
 

--- a/devel-common/src/sphinx_exts/airflow_intersphinx.py
+++ b/devel-common/src/sphinx_exts/airflow_intersphinx.py
@@ -63,7 +63,7 @@ def _generate_provider_intersphinx_mapping() -> dict[str, tuple[str, tuple[str, 
             provider_base_url,
             (doc_inventory.as_posix() if doc_inventory.exists() else cache_inventory.as_posix(),),
         )
-    for pkg_name in ["apache-airflow", "helm-chart"]:
+    for pkg_name in ["apache-airflow", "helm-chart", "task-sdk"]:
         if os.environ.get("AIRFLOW_PACKAGE_NAME") == pkg_name:
             continue
         doc_inventory = GENERATED_PATH / "_build" / "docs" / pkg_name / current_version / "objects.inv"

--- a/devel-common/src/sphinx_exts/docs_build/dev_index_template.html.jinja2
+++ b/devel-common/src/sphinx_exts/docs_build/dev_index_template.html.jinja2
@@ -55,19 +55,16 @@
       </p>
     </div>
   </div>
-  <div class="row">
-    <div class="col">
-      <h2><a href="/docs/apache-airflow-providers/index.html">Providers packages</a></h2>
-      <p>
-        Providers packages include integrations with third party integrations. They are updated independently of the Apache Airflow core.
-      </p>
-      <ul class="list-providers">
-        {% for provider in providers %}
-        <li><a href="/docs/{{ provider['package-name'] }}/stable/index.html"><code>{{ provider['name'] }}</code></a></li>
-        {% endfor %}
-      </ul>
+
+    <div class="row">
+        <div class="col">
+            <h2><a href="/docs/task-sdk/stable/index.html">Task SDK</a></h2>
+            <p>
+                Task-SDK interface that is used to communicate with airflow core from other components.
+            </p>
+        </div>
     </div>
-  </div>
+
   <div class="row">
     <div class="col-md order-md-1">
       <img src="/docs/docker-stack/_images/docker-logo.png" alt="Docker - logo" width="100" height="86">
@@ -90,6 +87,19 @@
       </p>
     </div>
   </div>
+    <div class="row">
+        <div class="col">
+            <h2><a href="/docs/apache-airflow-providers/index.html">Providers packages</a></h2>
+            <p>
+                Providers packages include integrations with third party integrations. They are updated independently of the Apache Airflow core.
+            </p>
+            <ul class="list-providers">
+                {% for provider in providers %}
+                    <li><a href="/docs/{{ provider['package-name'] }}/stable/index.html"><code>{{ provider['name'] }}</code></a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/devel-common/src/sphinx_exts/docs_build/docs_builder.py
+++ b/devel-common/src/sphinx_exts/docs_build/docs_builder.py
@@ -49,6 +49,7 @@ class AirflowDocsBuilder:
         self.is_airflow = False
         self.is_chart = False
         self.is_docker_stack = False
+        self.is_task_sdk = False
         self.is_providers_summary = False
         self.is_autobuild = False
         if self.package_name.startswith("apache-airflow-providers-"):
@@ -61,6 +62,8 @@ class AirflowDocsBuilder:
             self.is_airflow = True
         if self.package_name == "helm-chart":
             self.is_chart = True
+        if self.package_name == "task-sdk":
+            self.is_task_sdk = True
         if self.package_name == "docker-stack":
             self.is_docker_stack = True
         if self.package_name == "apache-airflow-providers":

--- a/devel-common/src/sphinx_exts/docs_build/fetch_inventories.py
+++ b/devel-common/src/sphinx_exts/docs_build/fetch_inventories.py
@@ -94,7 +94,7 @@ def _is_outdated(path: str):
 
 
 def should_be_refreshed(pkg_name: str, refresh_airflow_inventories: bool) -> bool:
-    if pkg_name in ["helm-chart", "docker-stack"] or pkg_name.startswith("apache-airflow"):
+    if pkg_name in ["helm-chart", "docker-stack", "task-sdk"] or pkg_name.startswith("apache-airflow"):
         return refresh_airflow_inventories
     return False
 
@@ -117,7 +117,7 @@ def fetch_inventories(clean_build: bool, refresh_airflow_inventories: bool = Fal
                 (CACHE_PATH / pkg_name / "objects.inv").as_posix(),
             )
         )
-    for pkg_name in ["apache-airflow", "helm-chart"]:
+    for pkg_name in ["apache-airflow", "helm-chart", "task-sdk"]:
         to_download.append(
             (
                 pkg_name,

--- a/devel-common/src/sphinx_exts/docs_build/package_filter.py
+++ b/devel-common/src/sphinx_exts/docs_build/package_filter.py
@@ -58,6 +58,8 @@ def find_packages_to_build(available_packages: list[str], package_filters: list[
                     package_name = "apache-airflow"
                 elif folder_name == "chart":
                     package_name = "helm-chart"
+                elif folder_name == "task-sdk":
+                    package_name = "task-sdk"
                 else:
                     try:
                         import tomllib

--- a/task-sdk/docs/conf.py
+++ b/task-sdk/docs/conf.py
@@ -18,6 +18,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -35,9 +36,17 @@ CONF_DIR = Path(__file__).parent.absolute()
 sys.path.insert(0, str(CONF_DIR.parent.parent.joinpath("devel-common", "src", "sphinx_exts").resolve()))
 sys.path.insert(0, str(CONF_DIR.parent.joinpath("src").resolve()))
 
+PACKAGE_NAME = "task-sdk"
+os.environ["AIRFLOW_PACKAGE_NAME"] = PACKAGE_NAME
+
 PACKAGE_VERSION = airflow.sdk.__version__
 
 project = "Apache Airflow Task SDK"
+# # The version info for the project you're documenting
+version = PACKAGE_VERSION
+# The full version, including alpha/beta/rc tags.
+release = PACKAGE_VERSION
+
 
 language = "en"
 locale_dirs: list[str] = []


### PR DESCRIPTION
The task-sdk package did not have full integration with airflow docs:

* did not have inventory mapping
* did not have a way to refer to it via doc:`task-sdk:` directive 8 did not have a development link from the devel index

This PR fixes all that.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
