### PR TITLE
Making PMC testing instructions more explicit for providers

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -757,7 +757,7 @@ script to verify that all expected files are present in SVN. This script will pr
 may help with verifying installation of the packages.
 
 ```shell script
-# Copy the list of packages (pypi urls) into `packages.txt` then run:
+# Copy the list of packages (pypi urls) from email into a `packages.txt` then run:
 uv run check_files.py providers -p {PATH_TO_SVN}
 ```
 

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -756,8 +756,10 @@ Optionally you can use the [`check_files.py`](https://github.com/apache/airflow/
 script to verify that all expected files are present in SVN. This script will produce a `Dockerfile.pmc` which
 may help with verifying installation of the packages.
 
+Once you have cloned/updated the SVN repository, copy the pypi URLs shared in the email to a file called `packages.txt` in the $AIRFLOW_REPO_ROOT/dev
+directory and cd into it.
+
 ```shell script
-# Copy the list of packages (pypi urls) from email into a `packages.txt` then run:
 uv run check_files.py providers -p {PATH_TO_SVN}
 ```
 
@@ -888,7 +890,9 @@ where `.rat-excludes` is the file in the root of Airflow source code.
 Make sure you have imported into your GPG the PGP key of the person signing the release. You can find the valid keys in
 [KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
 
-You can import the whole KEYS file:
+Download the KEYS file from the above link and save it locally.
+
+You can import the whole KEYS file into gpg by running the following command:
 
 ```shell script
 gpg --import KEYS


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

It wasn't too explicit to me atleast, i was trying to copy from svn link and wasn't sure of the format either


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
