### PR TITLE
mocking definition order FIX

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -263,15 +263,11 @@ class TestDbtCloudHook:
 
         assert hook.method == "GET"
 
-        expected_account_id = account_id or DEFAULT_ACCOUNT_ID
-
-        assert mock_http_run.call_count == 1
-        assert mock_http_run.call_args.args == ()
-        assert mock_http_run.call_args.kwargs == {
-            "endpoint": f"api/v2/accounts/{expected_account_id}/",
-            "data": None,
-            "extra_options": None,
-        }
+        _account_id = account_id or DEFAULT_ACCOUNT_ID
+        hook.run.assert_called_once_with(
+            endpoint=f"api/v2/accounts/{_account_id}/", data=None, extra_options=None
+        )
+        hook._paginate.assert_not_called()
 
         assert mock_paginate.call_count == 0
 

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -269,8 +269,6 @@ class TestDbtCloudHook:
         )
         hook._paginate.assert_not_called()
 
-        assert mock_paginate.call_count == 0
-
     @pytest.mark.parametrize(
         argnames="conn_id, account_id",
         argvalues=[(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -257,17 +257,23 @@ class TestDbtCloudHook:
     )
     @patch.object(DbtCloudHook, "run")
     @patch.object(DbtCloudHook, "_paginate")
-    def test_get_account(self, mock_http_run, mock_paginate, conn_id, account_id):
+    def test_get_account(self, mock_paginate, mock_http_run, conn_id, account_id):
         hook = DbtCloudHook(conn_id)
         hook.get_account(account_id=account_id)
 
         assert hook.method == "GET"
 
-        _account_id = account_id or DEFAULT_ACCOUNT_ID
-        hook.run.assert_called_once_with(
-            endpoint=f"api/v2/accounts/{_account_id}/", data=None, extra_options=None
-        )
-        hook._paginate.assert_not_called()
+        expected_account_id = account_id or DEFAULT_ACCOUNT_ID
+
+        assert mock_http_run.call_count == 1
+        assert mock_http_run.call_args.args == ()
+        assert mock_http_run.call_args.kwargs == {
+            "endpoint": f"api/v2/accounts/{expected_account_id}/",
+            "data": None,
+            "extra_options": None,
+        }
+
+        assert mock_paginate.call_count == 0
 
     @pytest.mark.parametrize(
         argnames="conn_id, account_id",


### PR DESCRIPTION
While reviewing the test, I noticed that the order of the mock arguments did not match the order of the @patch decorators. Since @patch decorators are applied from bottom to top, the corresponding mock arguments must follow the same order.

Originally, the test function was written as:
```python
@patch.object(DbtCloudHook, "run")
@patch.object(DbtCloudHook, "_paginate")
def test_get_account(self, mock_http_run, mock_paginate, conn_id, account_id):
```
However, this ordering is incorrect. The @patch for _paginate is applied after the one for run, meaning it becomes the first argument in the test function. Therefore, the correct version should be:
```python
@patch.object(DbtCloudHook, "run")
@patch.object(DbtCloudHook, "_paginate")
def test_get_account(self, mock_paginate, mock_http_run, conn_id, account_id):
```
This change ensures the mocks are injected in the correct order, avoiding subtle bugs and improving test clarity.





<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->




<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
