### PR TITLE
Add AwaitMessageTrigger for Redis PubSub

### DIFF
--- a/providers/redis/docs/index.rst
+++ b/providers/redis/docs/index.rst
@@ -36,6 +36,7 @@
 
     Connection types <connections>
     Logging <logging/index>
+    Triggers <triggers>
 
 .. toctree::
     :hidden:

--- a/providers/redis/docs/triggers.rst
+++ b/providers/redis/docs/triggers.rst
@@ -17,7 +17,7 @@
 
 
 Redis Triggers
-=====================
+==============
 
 .. _howto/triggers:AwaitMessageTrigger:
 

--- a/providers/redis/docs/triggers.rst
+++ b/providers/redis/docs/triggers.rst
@@ -22,7 +22,7 @@ Redis Triggers
 .. _howto/triggers:AwaitMessageTrigger:
 
 AwaitMessageTrigger
-------------------------
+-------------------
 
 The ``AwaitMessageTrigger`` is a trigger that asynchronously waits for a message to arrive on one or more specified Redis PubSub channels.
 

--- a/providers/redis/docs/triggers.rst
+++ b/providers/redis/docs/triggers.rst
@@ -1,0 +1,29 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Redis Triggers
+=====================
+
+.. _howto/triggers:AwaitMessageTrigger:
+
+AwaitMessageTrigger
+------------------------
+
+The ``AwaitMessageTrigger`` is a trigger that asynchronously waits for a message to arrive on one or more specified Redis PubSub channels.
+
+For parameter definitions take a look at :class:`~airflow.providers.redis.triggers.redis_await_message.AwaitMessageTrigger`.

--- a/providers/redis/provider.yaml
+++ b/providers/redis/provider.yaml
@@ -73,6 +73,11 @@ sensors:
       - airflow.providers.redis.sensors.redis_key
       - airflow.providers.redis.sensors.redis_pub_sub
 
+triggers:
+  - integration-name: Redis
+    python-modules:
+      - airflow.providers.redis.triggers.redis_await_message
+
 hooks:
   - integration-name: Redis
     python-modules:

--- a/providers/redis/src/airflow/providers/redis/get_provider_info.py
+++ b/providers/redis/src/airflow/providers/redis/get_provider_info.py
@@ -49,6 +49,12 @@ def get_provider_info():
                 ],
             }
         ],
+        "triggers": [
+            {
+                "integration-name": "Redis",
+                "python-modules": ["airflow.providers.redis.triggers.redis_await_message"],
+            }
+        ],
         "hooks": [{"integration-name": "Redis", "python-modules": ["airflow.providers.redis.hooks.redis"]}],
         "connection-types": [
             {"hook-class-name": "airflow.providers.redis.hooks.redis.RedisHook", "connection-type": "redis"}

--- a/providers/redis/src/airflow/providers/redis/triggers/__init__.py
+++ b/providers/redis/src/airflow/providers/redis/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/redis/src/airflow/providers/redis/triggers/redis_await_message.py
+++ b/providers/redis/src/airflow/providers/redis/triggers/redis_await_message.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from asgiref.sync import sync_to_async
+
 from airflow.providers.redis.hooks.redis import RedisHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
@@ -60,8 +62,9 @@ class AwaitMessageTrigger(BaseTrigger):
         hook = RedisHook(redis_conn_id=self.redis_conn_id).get_conn().pubsub()
         hook.subscribe(self.channels)
 
+        async_get_message = sync_to_async(hook.get_message)
         while True:
-            message = hook.get_message()
+            message = await async_get_message()
 
             if message and message["type"] == "message":
                 yield TriggerEvent(message)

--- a/providers/redis/src/airflow/providers/redis/triggers/redis_await_message.py
+++ b/providers/redis/src/airflow/providers/redis/triggers/redis_await_message.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from airflow.providers.redis.hooks.redis import RedisHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class AwaitMessageTrigger(BaseTrigger):
+    """
+    A trigger that waits for a message matching specific criteria to arrive in Redis.
+
+    The behavior of this trigger is as follows:
+    - poll the Redis pubsub for a message, if no message returned, sleep
+
+    :param channels: The channels that should be searched for messages
+    :param redis_conn_id: The connection object to use, defaults to "redis_default"
+    :param poll_interval: How long the trigger should sleep after reaching the end of the Redis log
+        (seconds), defaults to 60
+    """
+
+    def __init__(
+        self,
+        channels: list[str] | str,
+        redis_conn_id: str = "redis_default",
+        poll_interval: float = 60,
+    ) -> None:
+        self.channels = channels
+        self.redis_conn_id = redis_conn_id
+        self.poll_interval = poll_interval
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.redis.triggers.redis_await_message.AwaitMessageTrigger",
+            {
+                "channels": self.channels,
+                "redis_conn_id": self.redis_conn_id,
+                "poll_interval": self.poll_interval,
+            },
+        )
+
+    async def run(self):
+        hook = RedisHook(redis_conn_id=self.redis_conn_id).get_conn().pubsub()
+        hook.subscribe(self.channels)
+
+        while True:
+            message = hook.get_message()
+
+            if message and message["type"] == "message":
+                yield TriggerEvent(message)
+                break
+            await asyncio.sleep(self.poll_interval)

--- a/providers/redis/tests/unit/redis/triggers/__init__.py
+++ b/providers/redis/tests/unit/redis/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/redis/tests/unit/redis/triggers/test_redis_await_message.py
+++ b/providers/redis/tests/unit/redis/triggers/test_redis_await_message.py
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from airflow.providers.redis.triggers.redis_await_message import AwaitMessageTrigger
+
+
+class TestAwaitMessageTrigger:
+    def test_trigger_serialization(self):
+        trigger = AwaitMessageTrigger(
+            channels=["test_channel"],
+            redis_conn_id="redis_default",
+            poll_interval=30,
+        )
+
+        assert isinstance(trigger, AwaitMessageTrigger)
+
+        classpath, kwargs = trigger.serialize()
+
+        assert classpath == "airflow.providers.redis.triggers.redis_await_message.AwaitMessageTrigger"
+        assert kwargs == dict(
+            channels=["test_channel"],
+            redis_conn_id="redis_default",
+            poll_interval=30,
+        )
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
+    @pytest.mark.asyncio
+    async def test_trigger_run_succeed(self, mock_redis_conn):
+        trigger = AwaitMessageTrigger(
+            channels="test",
+            redis_conn_id="redis_default",
+            poll_interval=0.0001,
+        )
+
+        mock_redis_conn().pubsub().get_message.return_value = {
+            "type": "message",
+            "channel": "test",
+            "data": "d1",
+        }
+
+        trigger_gen = trigger.run()
+        task = asyncio.create_task(trigger_gen.__anext__())
+        event = await task
+        assert task.done() is True
+        assert event.payload["data"] == "d1"
+        assert event.payload["channel"] == "test"
+        asyncio.get_event_loop().stop()
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
+    @pytest.mark.asyncio
+    async def test_trigger_run_fail(self, mock_redis_conn):
+        trigger = AwaitMessageTrigger(
+            channels="test",
+            redis_conn_id="redis_default",
+            poll_interval=0.01,
+        )
+
+        mock_redis_conn().pubsub().get_message.return_value = {
+            "type": "subscribe",
+            "channel": "test",
+            "data": "d1",
+        }
+
+        trigger_gen = trigger.run()
+        task = asyncio.create_task(trigger_gen.__anext__())
+        await asyncio.sleep(1.0)
+        assert task.done() is False
+        task.cancel()
+        asyncio.get_event_loop().stop()


### PR DESCRIPTION
## Why
Related to [#52712](https://github.com/apache/airflow/issues/52712).
In order to implement Redis CommonMessageQueueProvider, a trigger for Redis PubSub is a foundational step.
## What
Introduces AwaitMessageTrigger for Redis PubSub, enabling async/deferrable sensor support for Redis message channels in Airflow.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
