### PR TITLE
Reset grid dagrun query cache on trigger so that the new dagrun is fetched,

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -26,6 +26,7 @@ import {
   useDagServiceGetDagsUiKey,
   UseGridServiceGridDataKeyFn,
   UseTaskInstanceServiceGetTaskInstancesKeyFn,
+  UseGridServiceGetGridRunsKeyFn,
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
@@ -40,6 +41,7 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
       UseDagRunServiceGetDagRunsKeyFn({ dagId }, [{ dagId }]),
       UseTaskInstanceServiceGetTaskInstancesKeyFn({ dagId, dagRunId: "~" }, [{ dagId, dagRunId: "~" }]),
       UseGridServiceGridDataKeyFn({ dagId }, [{ dagId }]),
+      UseGridServiceGetGridRunsKeyFn({ dagId }, [{ dagId }]),
     ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));


### PR DESCRIPTION
Closes #52907

After #51805, the grid API is split into structure, dagruns, grid data for graph and task instance summaries, Whenever a new dag is triggered through the UI reset the query cache for grid dagrun key so that the new active dagrun is fetched along with corresponding task instance summaries.