### PR TITLE
fix(docker/entrypoint_prod.sh): prevent the script from code 2 after db migrate success...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1620,6 +1620,11 @@ if [[ ${AIRFLOW_COMMAND} =~ ^(scheduler|celery)$ ]] \
     wait_for_celery_broker
 fi
 
+if [[ "$#" -eq 0 && "${_AIRFLOW_DB_MIGRATE}" == "true" ]]; then
+    echo "[INFO] No commands passed and _AIRFLOW_DB_MIGRATE=true. Exiting script with code 0."
+    exit 0
+fi
+
 exec "airflow" "${@}"
 EOF
 

--- a/docker-stack-docs/entrypoint.rst
+++ b/docker-stack-docs/entrypoint.rst
@@ -318,9 +318,12 @@ Upgrading Airflow DB
 If you set :envvar:`_AIRFLOW_DB_MIGRATE` variable to a non-empty value, the entrypoint will run
 the ``airflow db migrate`` command right after verifying the connection. You can also use this
 when you are running Airflow with internal SQLite database (default) to upgrade the db and create
-admin users at entrypoint, so that you can start the webserver immediately. Note - using SQLite is
-intended only for testing purpose, never use SQLite in production as it has severe limitations when it
-comes to concurrency.
+admin users at entrypoint, so that you can start the webserver immediately. If no command is
+provided to the container and :envvar:`_AIRFLOW_DB_MIGRATE` is set, the container will exit
+cleanly after completing the database migration. This allows one-off init containers
+(such as ``airflow-init``) to perform setup without requiring a placeholder command to suppress
+CLI errors. Note - using SQLite is intended only for testing purpose, never use SQLite in
+production as it has severe limitations when it comes to concurrency.
 
 Creating admin user
 ...................

--- a/scripts/docker/entrypoint_prod.sh
+++ b/scripts/docker/entrypoint_prod.sh
@@ -337,4 +337,10 @@ if [[ ${AIRFLOW_COMMAND} =~ ^(scheduler|celery)$ ]] \
     wait_for_celery_broker
 fi
 
+# Exit cleanly if the init was only intended to migrate DB
+if [[ "$#" -eq 0 && "${_AIRFLOW_DB_MIGRATE}" == "true" ]]; then
+    echo "[INFO] No commands passed and _AIRFLOW_DB_MIGRATE=true. Exiting script with code 0."
+    exit 0
+fi
+
 exec "airflow" "${@}"


### PR DESCRIPTION
> ...from the env '_AIRFLOW_DB_MIGRATE=true' but no commands passed in because the user's sole intention is to migrate db

### What this PR is

This PR improves the behavior of `airflow/scripts/docker/entrypoint_prod.sh` when `_AIRFLOW_DB_MIGRATE=true` is set but no command is explicitly passed to the container. It adds a conditional check that **exits cleanly** if:

* `_AIRFLOW_DB_MIGRATE` flag is set
* No `command:` is passed via Docker Compose (i.e., `$# -eq 0`)

Previously, the script would still fall through to `exec "airflow" "${@}"`, which results in a CLI error due to missing arguments (`GROUP_OR_COMMAND`), and exits with code 2.


### Why is the PR needed

Currently, when using `docker-compose.yml` to define an `airflow-init` container for bootstrapping (for example, running DB migration), the flag `_AIRFLOW_DB_MIGRATE=true` already run `migrate_db`; Even when db migration succeeds, the container still exits with an error if no commands are passed to the service:

```
airflow command error: the following arguments are required: GROUP_OR_COMMAND
```

This creates confusion, especially in CI environments or startup orchestration, where the exit code may be interpreted as a failed container, even though db migration succeed.

This PR prevents that misleading failure by exiting gracefully when the user's intent is only to "run migration and exit."


### How to reproduce the issue

Create a Compose service like this:

```yaml
airflow-init:
  image: apache/airflow:3.0.2
  environment:
    _AIRFLOW_DB_MIGRATE: "true"
  # no command specified
```

Run:

```bash
docker compose up airflow-init
```

**Observed (before):**

* DB migration runs successfully
* Then: `airflow command error: the following arguments are required: GROUP_OR_COMMAND`
* Container exits with code 2

**Expected (after this PR):**

* DB migration runs
* No command passed → interpreted as init-only use case
* Script logs an info message and exits cleanly with status 0