### PR TITLE
Respect `apps` flags for api_server_command

### DIFF
--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -23,17 +23,27 @@ import os
 import subprocess
 import sys
 import textwrap
+from collections.abc import Callable
+from functools import wraps
+from typing import TYPE_CHECKING, TypeVar
 
 import uvicorn
 
 from airflow import settings
 from airflow.cli.commands.daemon_utils import run_command_with_daemon_option
 from airflow.exceptions import AirflowConfigException
+from airflow.typing_compat import ParamSpec
 from airflow.utils import cli as cli_utils
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 
+PS = ParamSpec("PS")
+RT = TypeVar("RT")
+AIRFLOW_API_APPS = "AIRFLOW_API_APPS"
+
 log = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 # This shouldn't be necessary but there seems to be an issue in uvloop that causes bad file descriptor
 # errors when shutting down workers. Despite the 'closed' status of the issue it is not solved,
@@ -89,9 +99,32 @@ def _run_api_server(args, apps: str, num_workers: int, worker_timeout: int, prox
     )
 
 
+def with_api_apps_env(func: Callable[[Namespace], RT]) -> Callable[[Namespace], RT]:
+    """We use AIRFLOW_API_APPS to specify which apps are initialized in the API server."""
+
+    @wraps(func)
+    def wrapper(args: Namespace) -> RT:
+        apps: str = args.apps
+        original_value = os.environ.get(AIRFLOW_API_APPS)
+        try:
+            log.debug("Setting AIRFLOW_API_APPS to: %s", apps)
+            os.environ[AIRFLOW_API_APPS] = apps
+            return func(args)
+        finally:
+            if original_value is not None:
+                os.environ[AIRFLOW_API_APPS] = original_value
+                log.debug("Restored AIRFLOW_API_APPS to: %s", original_value)
+            else:
+                os.environ.pop(AIRFLOW_API_APPS, None)
+                log.debug("Removed AIRFLOW_API_APPS from environment")
+
+    return wrapper
+
+
 @cli_utils.action_cli
 @providers_configuration_loaded
-def api_server(args):
+@with_api_apps_env
+def api_server(args: Namespace):
     """Start Airflow API server."""
     print(settings.HEADER)
 
@@ -125,16 +158,11 @@ def api_server(args):
         if args.log_config and args.log_config != "-":
             run_args.extend(["--log-config", args.log_config])
 
-        # There is no way to pass the apps to airflow/api_fastapi/main.py in the development mode
-        # because fastapi dev command does not accept any additional arguments
-        # so environment variable is being used to pass it
-        os.environ["AIRFLOW_API_APPS"] = apps
         with subprocess.Popen(
             run_args,
             close_fds=True,
         ) as process:
             process.wait()
-        os.environ.pop("AIRFLOW_API_APPS")
     else:
         run_command_with_daemon_option(
             args=args,


### PR DESCRIPTION


related: #52860

## Why

- While working on #52860, I found that current api-server only respect `--apps` flag with `--dev` mode.
  - We use `AIRFLOW_API_APPS` environment to specify which apps are going to initialize in `create_app` call.
- Also the `AIRFLOW_API_APPS` env is no restored properly, we should set back to original value if it's set before the `airlow api-server` run.

## What

 - Add `with_api_apps_env` decorator with proper teardown
 - Refactor `test_api_apps_env` test with more scenario including all apps currently available, dev mode or not, and original env is set or not.
