### PR TITLE
Use appropriate namespace in translation key.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -157,7 +157,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
           onChange={() => setUnpause(!unpause)}
           wordBreak="break-all"
         >
-          {translate("triggerDag.unpause", { dagDisplayName })}
+          {translate("components:triggerDag.unpause", { dagDisplayName })}
         </Checkbox>
       ) : undefined}
       <ErrorAlert error={errors.date ?? errorTrigger} />


### PR DESCRIPTION
The key was incorrect and was not rendering the translated value for unpause text near checkbox in trigger dag form. Use the namespace prefixed key like other instances of usage in the file.