### PR TITLE
Ensure Edge Plugin for API endpoint is only loaded on API-Server and AF2 Webserver

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
@@ -215,6 +215,10 @@ except AirflowConfigException:
     EDGE_EXECUTOR_ACTIVE = False
 
 # Load the API endpoint only on api-server (Airflow 3.x) or webserver (Airflow 2.x)
+# todo(jscheffl): Remove this check when the discussion in
+#                 https://lists.apache.org/thread/w170czq6r7bslkqp1tk6bjjjo0789wgl
+#                 resulted in a proper API to selective initialize. Maybe backcompat-shim
+#                 is also needed to support Airflow-versions prior the rework.
 if AIRFLOW_V_3_0_PLUS:
     RUNNING_ON_APISERVER = sys.argv[1] in ["api-server"] if len(sys.argv) > 1 else False
 else:

--- a/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
@@ -213,12 +214,18 @@ try:
 except AirflowConfigException:
     EDGE_EXECUTOR_ACTIVE = False
 
+# Load the API endpoint only on api-server (Airflow 3.x) or webserver (Airflow 2.x)
+if AIRFLOW_V_3_0_PLUS:
+    RUNNING_ON_APISERVER = sys.argv[1] in ["api-server"] if len(sys.argv) > 1 else False
+else:
+    RUNNING_ON_APISERVER = "gunicorn" in sys.argv[0] and "airflow-webserver" in sys.argv
+
 
 class EdgeExecutorPlugin(AirflowPlugin):
     """EdgeExecutor Plugin - provides API endpoints for Edge Workers in Webserver."""
 
     name = "edge_executor"
-    if EDGE_EXECUTOR_ACTIVE:
+    if EDGE_EXECUTOR_ACTIVE and RUNNING_ON_APISERVER:
         if AIRFLOW_V_3_0_PLUS:
             fastapi_apps = [_get_api_endpoint()]
         else:

--- a/providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py
+++ b/providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import importlib
+from unittest.mock import patch
 
 import pytest
 import time_machine
@@ -44,17 +45,20 @@ def test_plugin_inactive():
 
 
 @pytest.mark.db_test
-def test_plugin_active():
-    with conf_vars({("edge", "api_enabled"): "true"}):
+def test_plugin_active_apiserver():
+    mock_cli = ["airflow", "api-server"] if AIRFLOW_V_3_0_PLUS else ["gunicorn", "airflow-webserver"]
+    with conf_vars({("edge", "api_enabled"): "true"}), patch("sys.argv", mock_cli):
         importlib.reload(edge_executor_plugin)
 
         from airflow.providers.edge3.plugins.edge_executor_plugin import (
             EDGE_EXECUTOR_ACTIVE,
+            RUNNING_ON_APISERVER,
             EdgeExecutorPlugin,
         )
 
         rep = EdgeExecutorPlugin()
         assert EDGE_EXECUTOR_ACTIVE
+        assert RUNNING_ON_APISERVER
         if AIRFLOW_V_3_0_PLUS:
             assert len(rep.appbuilder_views) == 0
             assert len(rep.flask_blueprints) == 0
@@ -62,6 +66,27 @@ def test_plugin_active():
         else:
             assert len(rep.appbuilder_views) == 2
             assert len(rep.flask_blueprints) == 2
+
+
+@patch("sys.argv", ["airflow", "some-other-command"])
+def test_plugin_active_non_apiserver():
+    with conf_vars({("edge", "api_enabled"): "true"}):
+        importlib.reload(edge_executor_plugin)
+
+        from airflow.providers.edge3.plugins.edge_executor_plugin import (
+            EDGE_EXECUTOR_ACTIVE,
+            RUNNING_ON_APISERVER,
+            EdgeExecutorPlugin,
+        )
+
+        rep = EdgeExecutorPlugin()
+        assert EDGE_EXECUTOR_ACTIVE
+        assert not RUNNING_ON_APISERVER
+        assert len(rep.appbuilder_views) == 0
+        assert len(rep.flask_blueprints) == 0
+        assert len(rep.appbuilder_views) == 0
+        if AIRFLOW_V_3_0_PLUS:
+            assert len(rep.fastapi_apps) == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
closes: #52922

I have noticed during providers release testing July 2025 that API endpoint is started also on TaskSDK task runner and other components. But the API plugin endpoint should only be loaded and be active on API server on Airflow 3 and Webserver is running on Airflow 2.
Unfortuantely in plugins_manager there is currently no concept in detecting this, while this needs to be created a secondary check is added to check on which component the plugin is loaded.

Negative side effect: If you run `AIRFLOW__CORE__EXECUTOR=airflow.providers.edge3.executors.edge_executor.EdgeExecutor airflow plugins -o yaml` then the plugin is listed but is not providing the details of the endpoint. This is only provided on API server and webserver now.