### PR TITLE
Make the update_installer_and_pre_commit script more resilient to re matches

### DIFF
--- a/scripts/ci/pre_commit/update_installers_and_pre_commit.py
+++ b/scripts/ci/pre_commit/update_installers_and_pre_commit.py
@@ -96,8 +96,8 @@ UV_PATTERNS: list[tuple[re.Pattern, Quoting]] = [
     (re.compile(r"(AIRFLOW_UV_VERSION=)([0-9.]+)"), Quoting.UNQUOTED),
     (re.compile(r"(uv>=)([0-9.]+)"), Quoting.UNQUOTED),
     (re.compile(r"(AIRFLOW_UV_VERSION = )(\"[0-9.]+\")"), Quoting.DOUBLE_QUOTED),
-    (re.compile(r"(UV_VERSION = )(\"[0-9.]+\")"), Quoting.DOUBLE_QUOTED),
-    (re.compile(r"(UV_VERSION=)(\"[0-9.]+\")"), Quoting.DOUBLE_QUOTED),
+    (re.compile(r"^(\s*UV_VERSION = )(\"[0-9.]+\")", re.MULTILINE), Quoting.DOUBLE_QUOTED),
+    (re.compile(r"^(\s*UV_VERSION=)(\"[0-9.]+\")", re.MULTILINE), Quoting.DOUBLE_QUOTED),
     (re.compile(r"(\| *`AIRFLOW_UV_VERSION` *\| *)(`[0-9.]+`)( *\|)"), Quoting.REVERSE_SINGLE_QUOTED),
     (
         re.compile(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As seen in https://github.com/apache/airflow/actions/runs/16107085605/job/45444460353, the script was supposed to update the version for `UV_VERSION`, but it also accidentally updated `PRE_COMMIT_UV_VERSION` because both names contain `UV_VERSION` and the regex used looked for any text that said `UV_VERSION` and changed the number after it. But it didn’t check if `UV_VERSION` was part of a longer name, like `PRE_COMMIT_UV_VERSION`.

ISSUE:
```
pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/Dockerfile.ci b/Dockerfile.ci
index 2282881..a8e47e4 100644
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1410,7 +1410,7 @@ ARG AIRFLOW_SETUPTOOLS_VERSION=80.9.0
 ARG AIRFLOW_UV_VERSION=0.7.19
 # TODO(potiuk): automate with upgrade check (possibly)
 ARG AIRFLOW_PRE_COMMIT_VERSION="4.2.0"
-ARG AIRFLOW_PRE_COMMIT_UV_VERSION="4.1.4"
+ARG AIRFLOW_PRE_COMMIT_UV_VERSION="0.7.19"
 
 ENV AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION} \
     AIRFLOW_SETUPTOOLS_VERSION=${AIRFLOW_SETUPTOOLS_VERSION} \
diff --git a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
index badf143..db9bcb1 100644
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -250,7 +250,7 @@ AIRFLOW_USE_UV = False
 GITPYTHON_VERSION = "3.1.44"
 RICH_VERSION = "14.0.0"
 PRE_COMMIT_VERSION = "4.2.0"
-PRE_COMMIT_UV_VERSION = "4.1.4"
+PRE_COMMIT_UV_VERSION = "0.7.19"
 HATCH_VERSION = "1.14.1"
 PYYAML_VERSION = "6.0.2"
``` 

This PR makes the script only look for lines that start with UV_VERSION (not lines like PRE_COMMIT_UV_VERSION). 

Simple script to check this behaviour:
```
import re

line = 'PRE_COMMIT_UV_VERSION = "4.1.4"'

# old pattern
old_pattern = re.compile(r'(UV_VERSION = )("[0-9.]+" )?')

# new pattern
new_pattern = re.compile(r'^(\s*UV_VERSION = )("[0-9.]+")', re.MULTILINE)

replacement = r'\1"0.7.19"'

old_result = old_pattern.sub(replacement, line)
new_result = new_pattern.sub(replacement, line)

print("Original:   ", line)
print("Old result: ", old_result)
print("New result: ", new_result)
```

Output: 
```
Original:    PRE_COMMIT_UV_VERSION = "4.1.4"
Old result:  PRE_COMMIT_UV_VERSION = "0.7.19"
New result:  PRE_COMMIT_UV_VERSION = "4.1.4"
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
