### PR TITLE
add unit tests for google/common

### DIFF
--- a/providers/google/tests/unit/google/common/links/__init__.py
+++ b/providers/google/tests/unit/google/common/links/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/google/tests/unit/google/common/links/test_storage.py
+++ b/providers/google/tests/unit/google/common/links/test_storage.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.google.common.links.storage import FileDetailsLink, StorageLink
+
+
+class TestStorageLink:
+    def test_storage_link(self):
+        assert StorageLink.name == "GCS Storage"
+        assert StorageLink.key == "storage_conf"
+        assert (
+            StorageLink.format_str
+            == "https://console.cloud.google.com/storage/browser/{uri};tab=objects?project={project_id}"
+        )
+
+    def test_storage_link_format(self):
+        link = StorageLink()
+        url = link._format_link(uri="test-bucket/test-folder", project_id="test-id")
+        expected_url = "https://console.cloud.google.com/storage/browser/test-bucket/test-folder;tab=objects?project=test-id"
+        assert url == expected_url
+
+
+class TestFileDetailsLink:
+    def test_file_details_link_name_and_key(self):
+        assert FileDetailsLink.name == "GCS File Details"
+        assert FileDetailsLink.key == "file_details"
+        assert (
+            FileDetailsLink.format_str
+            == "https://console.cloud.google.com/storage/browser/_details/{uri};tab=live_object?project={project_id}"
+        )
+
+    def test_file_details_link_format(self):
+        link = FileDetailsLink()
+        url = link._format_link(uri="test-bucket/test-folder", project_id="test-id")
+        expected_url = "https://console.cloud.google.com/storage/browser/_details/test-bucket/test-folder;tab=live_object?project=test-id"
+        assert url == expected_url

--- a/providers/google/tests/unit/google/common/test_consts.py
+++ b/providers/google/tests/unit/google/common/test_consts.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from google.api_core.gapic_v1.client_info import ClientInfo
+
+from airflow import version
+from airflow.providers.google.common.consts import (
+    CLIENT_INFO,
+    GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME,
+)
+
+
+def test_google_default_deferrable_method_name():
+    assert GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME == "execute_complete"
+
+
+def test_client_info_instance():
+    assert isinstance(CLIENT_INFO, ClientInfo)
+    assert CLIENT_INFO.client_library_version == f"airflow_v{version.version}"


### PR DESCRIPTION
## Why
Related issue: [#35442](https://github.com/apache/airflow/issues/35442)
Some unit tests for google/common are missing.
## What
Add unit tests for google/common.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
