### PR TITLE
Unify connection not found exceptions between AF2 and AF3

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -487,7 +487,7 @@ class Connection(Base, LoggingMixin):
                 return conn
             except AirflowRuntimeError as e:
                 if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
-                    raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+                    raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined") from None
                 raise
 
         # check cache first

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -354,7 +354,7 @@ class TestDagFileProcessor:
         assert result is not None
         assert result.import_errors != {}
         if result.import_errors:
-            assert "CONNECTION_NOT_FOUND" in next(iter(result.import_errors.values()))
+            assert "The conn_id `my_conn` isn't defined" in next(iter(result.import_errors.values()))
 
     def test_import_module_in_bundle_root(self, tmp_path: pathlib.Path, inprocess_client):
         tmp_path.joinpath("util.py").write_text("NAME = 'dag_name'")

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -154,7 +154,7 @@ class Connection:
             return _get_connection(conn_id)
         except AirflowRuntimeError as e:
             if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
-                raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+                raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined") from None
             raise
 
     @property

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -24,7 +24,8 @@ from typing import Any
 
 import attrs
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 
 log = logging.getLogger(__name__)
 
@@ -149,7 +150,12 @@ class Connection:
     def get(cls, conn_id: str) -> Any:
         from airflow.sdk.execution_time.context import _get_connection
 
-        return _get_connection(conn_id)
+        try:
+            return _get_connection(conn_id)
+        except AirflowRuntimeError as e:
+            if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
+                raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+            raise
 
     @property
     def extra_dejson(self) -> dict:

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 import attrs
 import structlog
 
-from airflow.exceptions import AirflowNotFoundException
 from airflow.sdk.definitions._internal.contextmanager import _CURRENT_CONTEXT
 from airflow.sdk.definitions._internal.types import NOTSET
 from airflow.sdk.definitions.asset import (
@@ -273,12 +272,9 @@ class ConnectionAccessor:
     """Wrapper to access Connection entries in template."""
 
     def __getattr__(self, conn_id: str) -> Any:
-        try:
-            return _get_connection(conn_id)
-        except AirflowRuntimeError as e:
-            if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
-                raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined") from None
-            raise
+        from airflow.sdk.definitions.connection import Connection
+
+        return Connection.get(conn_id)
 
     def __repr__(self) -> str:
         return "<ConnectionAccessor (dynamic access)>"

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -277,7 +277,7 @@ class ConnectionAccessor:
             return _get_connection(conn_id)
         except AirflowRuntimeError as e:
             if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
-                raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+                raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined") from None
             raise
 
     def __repr__(self) -> str:

--- a/task-sdk/tests/task_sdk/bases/test_hook.py
+++ b/task-sdk/tests/task_sdk/bases/test_hook.py
@@ -19,8 +19,9 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.exceptions import AirflowNotFoundException
 from airflow.sdk import BaseHook
-from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import ConnectionResult, ErrorResponse, GetConnection
 
 from tests_common.test_utils.config import conf_vars
@@ -64,7 +65,7 @@ class TestBaseHook:
         hook = BaseHook()
         mock_supervisor_comms.send.return_value = ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND)
 
-        with pytest.raises(AirflowRuntimeError, match="CONNECTION_NOT_FOUND"):
+        with pytest.raises(AirflowNotFoundException, match="The conn_id `test_conn` isn't defined"):
             hook.get_connection(conn_id=conn_id)
 
     def test_get_connection_secrets_backend_configured(self, mock_supervisor_comms, tmp_path):

--- a/task-sdk/tests/task_sdk/definitions/test_connections.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connections.py
@@ -23,9 +23,10 @@ from urllib.parse import urlparse
 import pytest
 
 from airflow.configuration import initialize_secrets_backends
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.sdk import Connection
-from airflow.sdk.execution_time.comms import ConnectionResult
+from airflow.sdk.exceptions import ErrorType
+from airflow.sdk.execution_time.comms import ConnectionResult, ErrorResponse
 from airflow.secrets import DEFAULT_SECRETS_SEARCH_PATH_WORKERS
 
 from tests_common.test_utils.config import conf_vars
@@ -120,6 +121,13 @@ class TestConnections:
             port=3306,
             extra=None,
         )
+
+    def test_conn_get_not_found(self, mock_supervisor_comms):
+        error_response = ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND)
+        mock_supervisor_comms.send.return_value = error_response
+
+        with pytest.raises(AirflowNotFoundException, match="The conn_id `mysql_conn` isn't defined"):
+            _ = Connection.get(conn_id="mysql_conn")
 
 
 class TestConnectionsFromSecrets:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/52880

## Problem
Accessing a connection from SDK (Connection or using context) in airflow 3 and if connection isn't found it raises: `AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}`

This is the case when pure SDK is used: `airflow.sdk.Connection` (airflow.models will work fine as we wrap it well)

Airflow 2 raises: `airflow.exceptions.AirflowNotFoundException: The conn_id `my_conn` isn't defined` . 


Now due to this, some dags / providers use this for various sorts of filtering and for catching exceptions to perform some logic. So long term, this current way of handling exceptions is not feasible. We will start seeing problems when we start migrating providers to Airflow 3 entirely. Example issues: https://github.com/apache/airflow/pull/52838 by amazon team and also https://github.com/apache/airflow/issues/52921 by bosch team.

## Testing the solution

DAG used:
```
from __future__ import annotations

from airflow.models.dag import dag
from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Connection


def get_conn_context(**context):
    conn = context["conn"].my_conn
    return conn

def get_conn_sdk(**context):
    return Connection.get("my_conn")


def get_conn_models(**context):
    from airflow.models import Connection
    return Connection.get_connection_from_secrets("my_conn")

@dag()
def get_connection():

    a = PythonOperator(
        task_id="context_conn",
        python_callable=get_conn_context,
    )

    b = PythonOperator(
        task_id="sdk_conn",
        python_callable=get_conn_sdk,
    )

    c = PythonOperator(
        task_id="models_conn",
        python_callable=get_conn_models,
    )

    [a, b, c]


get_connection()

```

Without the fix:

Accessing from context(task a):
```
[2025-07-07, 13:41:04] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-07-07, 13:41:04] INFO - Filling up the DagBag from /files/dags/get-connection.py: source="airflow.models.dagbag.DagBag"
[2025-07-07, 13:41:04] ERROR - Task failed with exception: source="task"
AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 217 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 240 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/get-connection.py", line 9 in get_conn_context

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 275 in __getattr__

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 158 in _get_connection
```


Accessing from Models (task c):
```
[2025-07-07, 13:41:04] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-07-07, 13:41:04] INFO - Filling up the DagBag from /files/dags/get-connection.py: source="airflow.models.dagbag.DagBag"
[2025-07-07, 13:41:04] ERROR - Task failed with exception: source="task"
AirflowNotFoundException: The conn_id `my_conn` isn't defined
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 217 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 240 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/get-connection.py", line 18 in get_conn_models

File "/opt/airflow/airflow-core/src/airflow/models/connection.py", line 490 in get_connection_from_secrets

AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}
File "/opt/airflow/airflow-core/src/airflow/models/connection.py", line 481 in get_connection_from_secrets

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 152 in get

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 158 in _get_connection
```

Accessing from SDK:
```
[2025-07-07, 13:41:04] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-07-07, 13:41:04] INFO - Filling up the DagBag from /files/dags/get-connection.py: source="airflow.models.dagbag.DagBag"
[2025-07-07, 13:41:04] ERROR - Task failed with exception: source="task"
AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 217 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 240 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/get-connection.py", line 13 in get_conn_sdk

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 152 in get

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 158 in _get_connection
```

After changes:

Accessing from context (task a):

```
[2025-07-07, 13:51:33] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-07-07, 13:51:33] INFO - Filling up the DagBag from /files/dags/get-connection.py: source="airflow.models.dagbag.DagBag"
[2025-07-07, 13:51:33] ERROR - Task failed with exception: source="task"
AirflowNotFoundException: The conn_id `my_conn` isn't defined
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 217 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 240 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/get-connection.py", line 9 in get_conn_context

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 280 in __getattr__

AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 277 in __getattr__

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 159 in _get_connection
```

Accessing from models (task b):
```
[2025-07-07, 13:51:33] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-07-07, 13:51:33] INFO - Filling up the DagBag from /files/dags/get-connection.py: source="airflow.models.dagbag.DagBag"
[2025-07-07, 13:51:33] ERROR - Task failed with exception: source="task"
AirflowNotFoundException: The conn_id `my_conn` isn't defined
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 217 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 240 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/get-connection.py", line 18 in get_conn_models

File "/opt/airflow/airflow-core/src/airflow/models/connection.py", line 481 in get_connection_from_secrets

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 156 in get

AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}
File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 153 in get

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 159 in _get_connection
```

Accessing from SDK (task c):
```
[2025-07-07, 13:51:33] INFO - DAG bundles loaded: dags-folder: source="airflow.dag_processing.bundles.manager.DagBundlesManager"
[2025-07-07, 13:51:33] INFO - Filling up the DagBag from /files/dags/get-connection.py: source="airflow.models.dagbag.DagBag"
[2025-07-07, 13:51:33] ERROR - Task failed with exception: source="task"
AirflowNotFoundException: The conn_id `my_conn` isn't defined
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 875 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1162 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 397 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 217 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 240 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/get-connection.py", line 13 in get_conn_sdk

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 156 in get

AirflowRuntimeError: CONNECTION_NOT_FOUND: {'conn_id': 'my_conn'}
File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 153 in get

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 159 in _get_connection
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
