### PR TITLE
Add support for the psycopg3 postgres driver

### DIFF
--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -32,7 +32,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection, crypto
 from airflow.sdk import BaseHook
 
-from tests_common.test_utils.version_compat import SQLALCHEMY_V_1_4
+from tests_common.test_utils.version_compat import SQLALCHEMY_V_1_4, SQLALCHEMY_V_2_0
 
 sqlite = pytest.importorskip("airflow.providers.sqlite.hooks.sqlite")
 
@@ -679,10 +679,20 @@ class TestConnection:
     def test_dbapi_get_uri(self):
         conn = BaseHook.get_connection(conn_id="test_uri")
         hook = conn.get_hook()
-        assert hook.get_uri() == "postgresql://username:password@ec2.compute.com:5432/the_database"
+
+        ppg3_mode: bool = SQLALCHEMY_V_2_0 and "psycopg" in hook.get_uri()
+        if ppg3_mode:
+            assert (
+                hook.get_uri() == "postgresql+psycopg://username:password@ec2.compute.com:5432/the_database"
+            )
+        else:
+            assert hook.get_uri() == "postgresql://username:password@ec2.compute.com:5432/the_database"
         conn2 = BaseHook.get_connection(conn_id="test_uri_no_creds")
         hook2 = conn2.get_hook()
-        assert hook2.get_uri() == "postgresql://ec2.compute.com/the_database"
+        if ppg3_mode:
+            assert hook2.get_uri() == "postgresql+psycopg://ec2.compute.com/the_database"
+        else:
+            assert hook2.get_uri() == "postgresql://ec2.compute.com/the_database"
 
     @mock.patch.dict(
         "os.environ",
@@ -695,7 +705,12 @@ class TestConnection:
         conn = BaseHook.get_connection(conn_id="test_uri")
         hook = conn.get_hook()
         engine = hook.get_sqlalchemy_engine()
-        expected = "postgresql://username:password@ec2.compute.com:5432/the_database"
+
+        if SQLALCHEMY_V_2_0 and "psycopg" in hook.get_uri():
+            expected = "postgresql+psycopg://username:password@ec2.compute.com:5432/the_database"
+        else:
+            expected = "postgresql://username:password@ec2.compute.com:5432/the_database"
+
         assert isinstance(engine, sqlalchemy.engine.Engine)
         if SQLALCHEMY_V_1_4:
             assert str(engine.url) == expected

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -248,6 +248,7 @@ def get_autodoc_mock_imports() -> list[str]:
         "pandas_gbq",
         "paramiko",
         "pinotdb",
+        "psycopg",
         "psycopg2",
         "pydruid",
         "pyhive",

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -810,6 +810,9 @@ class DbApiHook(BaseHook):
             self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
 
         if parameters:
+            # If we're using psycopg3, we might need to handle parameters differently
+            if hasattr(cur, "__module__") and "psycopg" in cur.__module__ and isinstance(parameters, list):
+                parameters = tuple(parameters)
             cur.execute(sql_statement, parameters)
         else:
             cur.execute(sql_statement)

--- a/providers/common/sql/tests/unit/common/sql/sensors/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/sensors/test_sql.py
@@ -80,8 +80,8 @@ class TestSqlSensor:
         op2 = SqlSensor(
             task_id="sql_sensor_check_2",
             conn_id="postgres_default",
-            sql="SELECT count(%s) FROM INFORMATION_SCHEMA.TABLES",
-            parameters=["table_name"],
+            sql="SELECT count(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = %s",
+            parameters=["information_schema"],
             dag=self.dag,
         )
         op2.execute({})

--- a/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -1175,9 +1175,9 @@ class CloudSQLDatabaseHook(BaseHook):
                 raise ValueError("The db_hook should be set")
             if not isinstance(self.db_hook, PostgresHook):
                 raise ValueError(f"The db_hook should be PostgresHook and is {type(self.db_hook)}")
-            conn = getattr(self.db_hook, "conn")
-            if conn and conn.notices:
-                for output in self.db_hook.conn.notices:
+            conn = getattr(self.db_hook, "conn", None)
+            if conn and hasattr(conn, "notices") and conn.notices:
+                for output in conn.notices:
                     self.log.info(output)
 
     def reserve_free_tcp_port(self) -> None:

--- a/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
+++ b/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
@@ -385,6 +385,17 @@ class TestJdbcHook:
             ),
             pytest.param(
                 {
+                    "conn_params": {
+                        "extra": json.dumps(
+                            {"sqlalchemy_scheme": "postgresql", "sqlalchemy_driver": "psycopg"}
+                        )
+                    }
+                },
+                "postgresql+psycopg://login:password@host:1234/schema",
+                id="sqlalchemy-scheme-with-driver-ppg3",
+            ),
+            pytest.param(
+                {
                     "login": "user@domain",
                     "password": "pass/word",
                     "schema": "my/db",

--- a/providers/postgres/docs/connections/postgres.rst
+++ b/providers/postgres/docs/connections/postgres.rst
@@ -75,6 +75,7 @@ Extra (optional)
       - ``namedtuplecursor``: Returns query results as named tuples using ``psycopg2.extras.NamedTupleCursor``.
 
       For more information, refer to the psycopg2 documentation on `connection and cursor subclasses <https://www.psycopg.org/docs/extras.html#connection-and-cursor-subclasses>`_.
+      If using psycopg (v3), refer to the documentation on `connection classes <https://www.psycopg.org/psycopg3/docs/api/connections.html>`_.
 
     More details on all Postgres parameters supported can be found in
     `Postgres documentation <https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING>`_.

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -80,6 +80,9 @@ dependencies = [
 "polars" = [
     "polars>=1.26.0"
 ]
+"psycopg" = [
+    "psycopg[binary]>=3.2.9",
+]
 
 [dependency-groups]
 dev = [
@@ -92,6 +95,7 @@ dev = [
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas]",
     "apache-airflow-providers-common-sql[polars]",
+    "psycopg[binary]>=3.2.9",
 ]
 
 # To build docs:

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -18,13 +18,12 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
+from types import SimpleNamespace
 from unittest import mock
 
 import pandas as pd
 import polars as pl
-import psycopg2.extras
 import pytest
 import sqlalchemy
 
@@ -40,7 +39,68 @@ from tests_common.test_utils.version_compat import SQLALCHEMY_V_1_4
 INSERT_SQL_STATEMENT = "INSERT INTO connection (id, conn_id, conn_type, description, host, {}, login, password, port, is_encrypted, is_extra_encrypted, extra) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)"
 
 
+USE_PSYCOPG3: bool
+try:
+    from importlib.util import find_spec
+
+    import sqlalchemy
+    from packaging.version import Version
+
+    is_psycopg3 = find_spec("psycopg") is not None
+    sqlalchemy_version = Version(sqlalchemy.__version__)
+    is_sqla2 = (sqlalchemy_version.major, sqlalchemy_version.minor, sqlalchemy_version.micro) >= (2, 0, 0)
+
+    USE_PSYCOPG3 = is_psycopg3 and is_sqla2
+except (ImportError, ModuleNotFoundError):
+    USE_PSYCOPG3 = False
+
+if USE_PSYCOPG3:
+    import psycopg.rows
+else:
+    import psycopg2.extras
+
+
+@pytest.fixture
+def postgres_hook_setup():
+    """Set up mock PostgresHook for testing."""
+    table = "test_postgres_hook_table"
+    cur = mock.MagicMock(rowcount=0)
+    conn = mock.MagicMock()
+    conn.cursor.return_value = cur
+
+    class UnitTestPostgresHook(PostgresHook):
+        conn_name_attr = "test_conn_id"
+
+        def get_conn(self):
+            return conn
+
+    db_hook = UnitTestPostgresHook()
+
+    # Return a namespace with all the objects
+    setup = SimpleNamespace(table=table, cur=cur, conn=conn, db_hook=db_hook)
+
+    yield setup
+
+    # Teardown - only for real database tests
+    try:
+        with PostgresHook().get_conn() as real_conn:
+            with real_conn.cursor() as real_cur:
+                real_cur.execute(f"DROP TABLE IF EXISTS {table}")
+    except Exception:
+        pass  # Ignore cleanup errors for unit tests
+
+
+@pytest.fixture
+def mock_connect(mocker):
+    """Mock the connection object according to the correct psycopg version."""
+    if USE_PSYCOPG3:
+        return mocker.patch("airflow.providers.postgres.hooks.postgres.psycopg.connection.Connection.connect")
+    return mocker.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
+
+
 class TestPostgresHookConn:
+    """PostgresHookConn tests that are common to psycopg2 and psycopg3."""
+
     def setup_method(self):
         self.connection = Connection(login="login", password="password", host="host", schema="database")
 
@@ -51,29 +111,384 @@ class TestPostgresHookConn:
         self.db_hook.get_connection = mock.Mock()
         self.db_hook.get_connection.return_value = self.connection
 
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
+    def test_sqlalchemy_url_with_wrong_sqlalchemy_query_value(self):
+        conn = Connection(
+            login="login-conn",
+            password="password-conn",
+            host="host",
+            schema="database",
+            extra=dict(sqlalchemy_query="wrong type"),
+        )
+        hook = PostgresHook(connection=conn)
+
+        with pytest.raises(AirflowException):
+            hook.sqlalchemy_url
+
+    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
+    @pytest.mark.parametrize("port", [5432, 5439, None])
+    @pytest.mark.parametrize(
+        "host,conn_cluster_identifier,expected_host",
+        [
+            (
+                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
+                NOTSET,
+                "cluster-identifier.us-east-1",
+            ),
+            (
+                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
+                "different-identifier",
+                "different-identifier.us-east-1",
+            ),
+        ],
+    )
+    def test_openlineage_methods_with_redshift(
+        self,
+        mocker,
+        aws_conn_id,
+        port,
+        host,
+        conn_cluster_identifier,
+        expected_host,
+    ):
+        mock_aws_hook_class = mocker.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
+
+        mock_conn_extra = {
+            "iam": True,
+            "redshift": True,
+        }
+        if aws_conn_id is not NOTSET:
+            mock_conn_extra["aws_conn_id"] = aws_conn_id
+        if conn_cluster_identifier is not NOTSET:
+            mock_conn_extra["cluster-identifier"] = conn_cluster_identifier
+
+        self.connection.extra = json.dumps(mock_conn_extra)
+        self.connection.host = host
+        self.connection.port = port
+
+        # Mock AWS Connection
+        mock_aws_hook_instance = mock_aws_hook_class.return_value
+        mock_aws_hook_instance.region_name = "us-east-1"
+
+        assert (
+            self.db_hook._get_openlineage_redshift_authority_part(self.connection)
+            == f"{expected_host}:{port or 5439}"
+        )
+
     def test_get_conn_non_default_id(self, mock_connect):
         self.db_hook.test_conn_id = "non_default"
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            user="login", password="password", host="host", dbname="database", port=None
+            user="login",
+            password="password",
+            host="host",
+            dbname="database",
+            port=None,
         )
         self.db_hook.get_connection.assert_called_once_with("non_default")
 
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
     def test_get_conn(self, mock_connect):
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            user="login", password="password", host="host", dbname="database", port=None
+            user="login",
+            password="password",
+            host="host",
+            dbname="database",
+            port=None,
         )
 
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
     def test_get_uri(self, mock_connect):
         self.connection.conn_type = "postgres"
         self.connection.port = 5432
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "postgresql://login:password@host:5432/database"
+        assert (
+            self.db_hook.get_uri()
+            == f"postgresql{'+psycopg' if USE_PSYCOPG3 else ''}://login:password@host:5432/database"
+        )
+
+    @pytest.mark.usefixtures("mock_connect")
+    def test_get_conn_with_invalid_cursor(self):
+        self.connection.extra = '{"cursor": "mycursor"}'
+        with pytest.raises(ValueError):
+            self.db_hook.get_conn()
+
+    def test_get_conn_from_connection(self, mock_connect):
+        conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
+        hook = PostgresHook(connection=conn)
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user="login-conn",
+            password="password-conn",
+            host="host",
+            dbname="database",
+            port=None,
+        )
+
+    def test_get_conn_from_connection_with_database(self, mock_connect):
+        conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
+        hook = PostgresHook(connection=conn, database="database-override")
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user="login-conn",
+            password="password-conn",
+            host="host",
+            dbname="database-override",
+            port=None,
+        )
+
+    def test_get_conn_from_connection_with_options(self, mock_connect):
+        conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
+        hook = PostgresHook(connection=conn, options="-c statement_timeout=3000ms")
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user="login-conn",
+            password="password-conn",
+            host="host",
+            dbname="database",
+            port=None,
+            options="-c statement_timeout=3000ms",
+        )
+
+    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
+    @pytest.mark.parametrize("port", [65432, 5432, None])
+    def test_get_conn_rds_iam_postgres(self, mocker, mock_connect, aws_conn_id, port):
+        mock_aws_hook_class = mocker.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
+
+        mock_conn_extra = {"iam": True}
+        if aws_conn_id is not NOTSET:
+            mock_conn_extra["aws_conn_id"] = aws_conn_id
+        self.connection.extra = json.dumps(mock_conn_extra)
+        self.connection.port = port
+        mock_db_token = "aws_token"
+
+        # Mock AWS Connection
+        mock_aws_hook_instance = mock_aws_hook_class.return_value
+        mock_client = mocker.MagicMock()
+        mock_client.generate_db_auth_token.return_value = mock_db_token
+        type(mock_aws_hook_instance).conn = mocker.PropertyMock(return_value=mock_client)
+
+        self.db_hook.get_conn()
+        # Check AwsHook initialization
+        mock_aws_hook_class.assert_called_once_with(
+            # If aws_conn_id not set than fallback to aws_default
+            aws_conn_id=aws_conn_id if aws_conn_id is not NOTSET else "aws_default",
+            client_type="rds",
+        )
+        # Check boto3 'rds' client method `generate_db_auth_token` call args
+        mock_client.generate_db_auth_token.assert_called_once_with(
+            self.connection.host, (port or 5432), self.connection.login
+        )
+        # Check expected psycopg2 connection call args
+        mock_connect.assert_called_once_with(
+            user=self.connection.login,
+            password=mock_db_token,
+            host=self.connection.host,
+            dbname=self.connection.schema,
+            port=(port or 5432),
+        )
+
+    def test_get_conn_extra(self, mock_connect):
+        self.connection.extra = '{"connect_timeout": 3}'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user="login", password="password", host="host", dbname="database", port=None, connect_timeout=3
+        )
+
+    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
+    @pytest.mark.parametrize("port", [5432, 5439, None])
+    @pytest.mark.parametrize(
+        "host,conn_cluster_identifier,expected_cluster_identifier",
+        [
+            (
+                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
+                NOTSET,
+                "cluster-identifier",
+            ),
+            (
+                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
+                "different-identifier",
+                "different-identifier",
+            ),
+        ],
+    )
+    def test_get_conn_rds_iam_redshift(
+        self,
+        mocker,
+        mock_connect,
+        aws_conn_id,
+        port,
+        host,
+        conn_cluster_identifier,
+        expected_cluster_identifier,
+    ):
+        mock_aws_hook_class = mocker.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
+
+        mock_conn_extra = {
+            "iam": True,
+            "redshift": True,
+        }
+        if aws_conn_id is not NOTSET:
+            mock_conn_extra["aws_conn_id"] = aws_conn_id
+        if conn_cluster_identifier is not NOTSET:
+            mock_conn_extra["cluster-identifier"] = conn_cluster_identifier
+
+        self.connection.extra = json.dumps(mock_conn_extra)
+        self.connection.host = host
+        self.connection.port = port
+        mock_db_user = f"IAM:{self.connection.login}"
+        mock_db_pass = "aws_token"
+
+        # Mock AWS Connection
+        mock_aws_hook_instance = mock_aws_hook_class.return_value
+        mock_client = mocker.MagicMock()
+        mock_client.get_cluster_credentials.return_value = {
+            "DbPassword": mock_db_pass,
+            "DbUser": mock_db_user,
+        }
+        type(mock_aws_hook_instance).conn = mocker.PropertyMock(return_value=mock_client)
+
+        self.db_hook.get_conn()
+        # Check AwsHook initialization
+        mock_aws_hook_class.assert_called_once_with(
+            # If aws_conn_id not set than fallback to aws_default
+            aws_conn_id=aws_conn_id if aws_conn_id is not NOTSET else "aws_default",
+            client_type="redshift",
+        )
+        # Check boto3 'redshift' client method `get_cluster_credentials` call args
+        mock_client.get_cluster_credentials.assert_called_once_with(
+            DbUser=self.connection.login,
+            DbName=self.connection.schema,
+            ClusterIdentifier=expected_cluster_identifier,
+            AutoCreate=False,
+        )
+        # Check expected psycopg2 connection call args
+        mock_connect.assert_called_once_with(
+            user=mock_db_user,
+            password=mock_db_pass,
+            host=host,
+            dbname=self.connection.schema,
+            port=(port or 5439),
+        )
+
+    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
+    @pytest.mark.parametrize("port", [5432, 5439, None])
+    @pytest.mark.parametrize(
+        "host,conn_workgroup_name,expected_workgroup_name",
+        [
+            (
+                "serverless-workgroup.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
+                NOTSET,
+                "serverless-workgroup",
+            ),
+            (
+                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
+                "different-workgroup",
+                "different-workgroup",
+            ),
+        ],
+    )
+    def test_get_conn_rds_iam_redshift_serverless(
+        self,
+        mocker,
+        mock_connect,
+        aws_conn_id,
+        port,
+        host,
+        conn_workgroup_name,
+        expected_workgroup_name,
+    ):
+        mock_aws_hook_class = mocker.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
+
+        mock_conn_extra = {
+            "iam": True,
+            "redshift-serverless": True,
+        }
+        if aws_conn_id is not NOTSET:
+            mock_conn_extra["aws_conn_id"] = aws_conn_id
+        if conn_workgroup_name is not NOTSET:
+            mock_conn_extra["workgroup-name"] = conn_workgroup_name
+
+        self.connection.extra = json.dumps(mock_conn_extra)
+        self.connection.host = host
+        self.connection.port = port
+        mock_db_user = f"IAM:{self.connection.login}"
+        mock_db_pass = "aws_token"
+
+        # Mock AWS Connection
+        mock_aws_hook_instance = mock_aws_hook_class.return_value
+        mock_client = mocker.MagicMock()
+        mock_client.get_credentials.return_value = {
+            "dbPassword": mock_db_pass,
+            "dbUser": mock_db_user,
+        }
+        type(mock_aws_hook_instance).conn = mocker.PropertyMock(return_value=mock_client)
+
+        self.db_hook.get_conn()
+        # Check AwsHook initialization
+        mock_aws_hook_class.assert_called_once_with(
+            # If aws_conn_id not set than fallback to aws_default
+            aws_conn_id=aws_conn_id if aws_conn_id is not NOTSET else "aws_default",
+            client_type="redshift-serverless",
+        )
+        # Check boto3 'redshift' client method `get_cluster_credentials` call args
+        mock_client.get_credentials.assert_called_once_with(
+            dbName=self.connection.schema,
+            workgroupName=expected_workgroup_name,
+        )
+        # Check expected psycopg2 connection call args
+        mock_connect.assert_called_once_with(
+            user=mock_db_user,
+            password=mock_db_pass,
+            host=host,
+            dbname=self.connection.schema,
+            port=(port or 5439),
+        )
+
+    def test_get_uri_from_connection_without_database_override(self, mocker):
+        expected: str = f"postgresql{'+psycopg' if USE_PSYCOPG3 else ''}://login:password@host:1/database"
+        self.db_hook.get_connection = mocker.MagicMock(
+            return_value=Connection(
+                conn_type="postgres",
+                host="host",
+                login="login",
+                password="password",
+                schema="database",
+                port=1,
+            )
+        )
+        assert self.db_hook.get_uri() == expected
+
+    def test_get_uri_from_connection_with_database_override(self, mocker):
+        expected: str = (
+            f"postgresql{'+psycopg' if USE_PSYCOPG3 else ''}://login:password@host:1/database-override"
+        )
+        hook = PostgresHook(database="database-override")
+        hook.get_connection = mocker.MagicMock(
+            return_value=Connection(
+                conn_type="postgres",
+                host="host",
+                login="login",
+                password="password",
+                schema="database",
+                port=1,
+            )
+        )
+        assert hook.get_uri() == expected
+
+
+@pytest.mark.skipif(USE_PSYCOPG3, reason="psycopg v3 is available")
+class TestPostgresHookConnPPG2:
+    """PostgresHookConn tests that are specific to psycopg2."""
+
+    def setup_method(self):
+        self.connection = Connection(login="login", password="password", host="host", schema="database")
+
+        class UnitTestPostgresHook(PostgresHook):
+            conn_name_attr = "test_conn_id"
+
+        self.db_hook = UnitTestPostgresHook()
+        self.db_hook.get_connection = mock.Mock()
+        self.db_hook.get_connection.return_value = self.connection
 
     def test_sqlalchemy_url(self):
         conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
@@ -100,20 +515,6 @@ class TestPostgresHookConn:
         else:
             assert hook.sqlalchemy_url.render_as_string(hide_password=False) == expected
 
-    def test_sqlalchemy_url_with_wrong_sqlalchemy_query_value(self):
-        conn = Connection(
-            login="login-conn",
-            password="password-conn",
-            host="host",
-            schema="database",
-            extra=dict(sqlalchemy_query="wrong type"),
-        )
-        hook = PostgresHook(connection=conn)
-
-        with pytest.raises(AirflowException):
-            hook.sqlalchemy_url
-
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
     def test_get_conn_cursor(self, mock_connect):
         self.connection.extra = '{"cursor": "dictcursor", "sqlalchemy_query": {"gssencmode": "disable"}}'
         self.db_hook.get_conn()
@@ -126,319 +527,64 @@ class TestPostgresHookConn:
             port=None,
         )
 
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    def test_get_conn_with_invalid_cursor(self, mock_connect):
-        self.connection.extra = '{"cursor": "mycursor"}'
-        with pytest.raises(ValueError):
-            self.db_hook.get_conn()
 
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    def test_get_conn_from_connection(self, mock_connect):
+@pytest.mark.skipif(not USE_PSYCOPG3, reason="psycopg v3 or sqlalchemy v2 not available")
+class TestPostgresHookConnPPG3:
+    """PostgresHookConn tests that are specific to psycopg3."""
+
+    def setup_method(self):
+        self.connection = Connection(login="login", password="password", host="host", schema="database")
+
+        class UnitTestPostgresHook(PostgresHook):
+            conn_name_attr = "test_conn_id"
+
+        self.db_hook = UnitTestPostgresHook()
+        self.db_hook.get_connection = mock.Mock()
+        self.db_hook.get_connection.return_value = self.connection
+
+    def test_sqlalchemy_url(self):
         conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
         hook = PostgresHook(connection=conn)
-        hook.get_conn()
-        mock_connect.assert_called_once_with(
-            user="login-conn", password="password-conn", host="host", dbname="database", port=None
-        )
+        expected = "postgresql+psycopg://login-conn:password-conn@host/database"
+        if SQLALCHEMY_V_1_4:
+            assert str(hook.sqlalchemy_url) == expected
+        else:
+            assert hook.sqlalchemy_url.render_as_string(hide_password=False) == expected
 
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    def test_get_conn_from_connection_with_database(self, mock_connect):
-        conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
-        hook = PostgresHook(connection=conn, database="database-override")
-        hook.get_conn()
-        mock_connect.assert_called_once_with(
-            user="login-conn", password="password-conn", host="host", dbname="database-override", port=None
-        )
-
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    def test_get_conn_from_connection_with_options(self, mock_connect):
-        conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
-        hook = PostgresHook(connection=conn, options="-c statement_timeout=3000ms")
-        hook.get_conn()
-        mock_connect.assert_called_once_with(
-            user="login-conn",
+    def test_sqlalchemy_url_with_sqlalchemy_query(self):
+        conn = Connection(
+            login="login-conn",
             password="password-conn",
+            host="host",
+            schema="database",
+            extra=dict(sqlalchemy_query={"gssencmode": "disable"}),
+        )
+        hook = PostgresHook(connection=conn)
+
+        expected = "postgresql+psycopg://login-conn:password-conn@host/database?gssencmode=disable"
+        if SQLALCHEMY_V_1_4:
+            assert str(hook.sqlalchemy_url) == expected
+        else:
+            assert hook.sqlalchemy_url.render_as_string(hide_password=False) == expected
+
+    def test_get_conn_cursor(self, mocker):
+        mock_connect = mocker.patch("psycopg.connection.Connection.connect")
+        self.connection.extra = '{"cursor": "dictcursor", "sqlalchemy_query": {"gssencmode": "disable"}}'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(
+            row_factory=psycopg.rows.dict_row,
+            user="login",
+            password="password",
             host="host",
             dbname="database",
             port=None,
-            options="-c statement_timeout=3000ms",
-        )
-
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
-    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
-    @pytest.mark.parametrize("port", [65432, 5432, None])
-    def test_get_conn_rds_iam_postgres(self, mock_aws_hook_class, mock_connect, aws_conn_id, port):
-        mock_conn_extra = {"iam": True}
-        if aws_conn_id is not NOTSET:
-            mock_conn_extra["aws_conn_id"] = aws_conn_id
-        self.connection.extra = json.dumps(mock_conn_extra)
-        self.connection.port = port
-        mock_db_token = "aws_token"
-
-        # Mock AWS Connection
-        mock_aws_hook_instance = mock_aws_hook_class.return_value
-        mock_client = mock.MagicMock()
-        mock_client.generate_db_auth_token.return_value = mock_db_token
-        type(mock_aws_hook_instance).conn = mock.PropertyMock(return_value=mock_client)
-
-        self.db_hook.get_conn()
-        # Check AwsHook initialization
-        mock_aws_hook_class.assert_called_once_with(
-            # If aws_conn_id not set than fallback to aws_default
-            aws_conn_id=aws_conn_id if aws_conn_id is not NOTSET else "aws_default",
-            client_type="rds",
-        )
-        # Check boto3 'rds' client method `generate_db_auth_token` call args
-        mock_client.generate_db_auth_token.assert_called_once_with(
-            self.connection.host, (port or 5432), self.connection.login
-        )
-        # Check expected psycopg2 connection call args
-        mock_connect.assert_called_once_with(
-            user=self.connection.login,
-            password=mock_db_token,
-            host=self.connection.host,
-            dbname=self.connection.schema,
-            port=(port or 5432),
-        )
-
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    def test_get_conn_extra(self, mock_connect):
-        self.connection.extra = '{"connect_timeout": 3}'
-        self.db_hook.get_conn()
-        mock_connect.assert_called_once_with(
-            user="login", password="password", host="host", dbname="database", port=None, connect_timeout=3
-        )
-
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
-    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
-    @pytest.mark.parametrize("port", [5432, 5439, None])
-    @pytest.mark.parametrize(
-        "host,conn_cluster_identifier,expected_cluster_identifier",
-        [
-            (
-                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
-                NOTSET,
-                "cluster-identifier",
-            ),
-            (
-                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
-                "different-identifier",
-                "different-identifier",
-            ),
-        ],
-    )
-    def test_get_conn_rds_iam_redshift(
-        self,
-        mock_aws_hook_class,
-        mock_connect,
-        aws_conn_id,
-        port,
-        host,
-        conn_cluster_identifier,
-        expected_cluster_identifier,
-    ):
-        mock_conn_extra = {
-            "iam": True,
-            "redshift": True,
-        }
-        if aws_conn_id is not NOTSET:
-            mock_conn_extra["aws_conn_id"] = aws_conn_id
-        if conn_cluster_identifier is not NOTSET:
-            mock_conn_extra["cluster-identifier"] = conn_cluster_identifier
-
-        self.connection.extra = json.dumps(mock_conn_extra)
-        self.connection.host = host
-        self.connection.port = port
-        mock_db_user = f"IAM:{self.connection.login}"
-        mock_db_pass = "aws_token"
-
-        # Mock AWS Connection
-        mock_aws_hook_instance = mock_aws_hook_class.return_value
-        mock_client = mock.MagicMock()
-        mock_client.get_cluster_credentials.return_value = {
-            "DbPassword": mock_db_pass,
-            "DbUser": mock_db_user,
-        }
-        type(mock_aws_hook_instance).conn = mock.PropertyMock(return_value=mock_client)
-
-        self.db_hook.get_conn()
-        # Check AwsHook initialization
-        mock_aws_hook_class.assert_called_once_with(
-            # If aws_conn_id not set than fallback to aws_default
-            aws_conn_id=aws_conn_id if aws_conn_id is not NOTSET else "aws_default",
-            client_type="redshift",
-        )
-        # Check boto3 'redshift' client method `get_cluster_credentials` call args
-        mock_client.get_cluster_credentials.assert_called_once_with(
-            DbUser=self.connection.login,
-            DbName=self.connection.schema,
-            ClusterIdentifier=expected_cluster_identifier,
-            AutoCreate=False,
-        )
-        # Check expected psycopg2 connection call args
-        mock_connect.assert_called_once_with(
-            user=mock_db_user,
-            password=mock_db_pass,
-            host=host,
-            dbname=self.connection.schema,
-            port=(port or 5439),
-        )
-
-    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
-    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
-    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
-    @pytest.mark.parametrize("port", [5432, 5439, None])
-    @pytest.mark.parametrize(
-        "host,conn_workgroup_name,expected_workgroup_name",
-        [
-            (
-                "serverless-workgroup.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
-                NOTSET,
-                "serverless-workgroup",
-            ),
-            (
-                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
-                "different-workgroup",
-                "different-workgroup",
-            ),
-        ],
-    )
-    def test_get_conn_rds_iam_redshift_serverless(
-        self,
-        mock_aws_hook_class,
-        mock_connect,
-        aws_conn_id,
-        port,
-        host,
-        conn_workgroup_name,
-        expected_workgroup_name,
-    ):
-        mock_conn_extra = {
-            "iam": True,
-            "redshift-serverless": True,
-        }
-        if aws_conn_id is not NOTSET:
-            mock_conn_extra["aws_conn_id"] = aws_conn_id
-        if conn_workgroup_name is not NOTSET:
-            mock_conn_extra["workgroup-name"] = conn_workgroup_name
-
-        self.connection.extra = json.dumps(mock_conn_extra)
-        self.connection.host = host
-        self.connection.port = port
-        mock_db_user = f"IAM:{self.connection.login}"
-        mock_db_pass = "aws_token"
-
-        # Mock AWS Connection
-        mock_aws_hook_instance = mock_aws_hook_class.return_value
-        mock_client = mock.MagicMock()
-        mock_client.get_credentials.return_value = {
-            "dbPassword": mock_db_pass,
-            "dbUser": mock_db_user,
-        }
-        type(mock_aws_hook_instance).conn = mock.PropertyMock(return_value=mock_client)
-
-        self.db_hook.get_conn()
-        # Check AwsHook initialization
-        mock_aws_hook_class.assert_called_once_with(
-            # If aws_conn_id not set than fallback to aws_default
-            aws_conn_id=aws_conn_id if aws_conn_id is not NOTSET else "aws_default",
-            client_type="redshift-serverless",
-        )
-        # Check boto3 'redshift' client method `get_cluster_credentials` call args
-        mock_client.get_credentials.assert_called_once_with(
-            dbName=self.connection.schema,
-            workgroupName=expected_workgroup_name,
-        )
-        # Check expected psycopg2 connection call args
-        mock_connect.assert_called_once_with(
-            user=mock_db_user,
-            password=mock_db_pass,
-            host=host,
-            dbname=self.connection.schema,
-            port=(port or 5439),
-        )
-
-    def test_get_uri_from_connection_without_database_override(self):
-        self.db_hook.get_connection = mock.MagicMock(
-            return_value=Connection(
-                conn_type="postgres",
-                host="host",
-                login="login",
-                password="password",
-                schema="database",
-                port=1,
-            )
-        )
-        assert self.db_hook.get_uri() == "postgresql://login:password@host:1/database"
-
-    def test_get_uri_from_connection_with_database_override(self):
-        hook = PostgresHook(database="database-override")
-        hook.get_connection = mock.MagicMock(
-            return_value=Connection(
-                conn_type="postgres",
-                host="host",
-                login="login",
-                password="password",
-                schema="database",
-                port=1,
-            )
-        )
-        assert hook.get_uri() == "postgresql://login:password@host:1/database-override"
-
-    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
-    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
-    @pytest.mark.parametrize("port", [5432, 5439, None])
-    @pytest.mark.parametrize(
-        "host,conn_cluster_identifier,expected_host",
-        [
-            (
-                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
-                NOTSET,
-                "cluster-identifier.us-east-1",
-            ),
-            (
-                "cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com",
-                "different-identifier",
-                "different-identifier.us-east-1",
-            ),
-        ],
-    )
-    def test_openlineage_methods_with_redshift(
-        self,
-        mock_aws_hook_class,
-        aws_conn_id,
-        port,
-        host,
-        conn_cluster_identifier,
-        expected_host,
-    ):
-        mock_conn_extra = {
-            "iam": True,
-            "redshift": True,
-        }
-        if aws_conn_id is not NOTSET:
-            mock_conn_extra["aws_conn_id"] = aws_conn_id
-        if conn_cluster_identifier is not NOTSET:
-            mock_conn_extra["cluster-identifier"] = conn_cluster_identifier
-
-        self.connection.extra = json.dumps(mock_conn_extra)
-        self.connection.host = host
-        self.connection.port = port
-
-        # Mock AWS Connection
-        mock_aws_hook_instance = mock_aws_hook_class.return_value
-        mock_aws_hook_instance.region_name = "us-east-1"
-
-        assert (
-            self.db_hook._get_openlineage_redshift_authority_part(self.connection)
-            == f"{expected_host}:{port or 5439}"
         )
 
 
 @pytest.mark.backend("postgres")
 class TestPostgresHook:
+    """Tests that are identical between psycopg2 and psycopg3."""
+
     table = "test_postgres_hook_table"
 
     def setup_method(self):
@@ -458,22 +604,6 @@ class TestPostgresHook:
         with PostgresHook().get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(f"DROP TABLE IF EXISTS {self.table}")
-
-    def test_copy_expert(self):
-        open_mock = mock.mock_open(read_data='{"some": "json"}')
-        with mock.patch("airflow.providers.postgres.hooks.postgres.open", open_mock):
-            statement = "SQL"
-            filename = "filename"
-
-            self.cur.fetchall.return_value = None
-
-            assert self.db_hook.copy_expert(statement, filename) is None
-
-            assert self.conn.close.call_count == 1
-            assert self.cur.close.call_count == 1
-            assert self.conn.commit.call_count == 1
-            self.cur.copy_expert.assert_called_once_with(statement, open_mock.return_value)
-            assert open_mock.call_args.args == (filename, "r+")
 
     def test_bulk_load(self, tmp_path):
         hook = PostgresHook()
@@ -515,19 +645,20 @@ class TestPostgresHook:
             ("polars", pl.DataFrame),
         ],
     )
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook._get_polars_df")
-    @mock.patch("pandas.io.sql.read_sql")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.get_sqlalchemy_engine")
-    def test_get_df_with_df_type(
-        self, mock_get_engine, mock_read_sql, mock_polars_df, df_type, expected_type
-    ):
+    def test_get_df_with_df_type(self, mocker, df_type, expected_type):
+        mock_polars_df = mocker.patch("airflow.providers.postgres.hooks.postgres.PostgresHook._get_polars_df")
+        mock_read_sql = mocker.patch("pandas.io.sql.read_sql")
+        mock_get_engine = mocker.patch(
+            "airflow.providers.postgres.hooks.postgres.PostgresHook.get_sqlalchemy_engine"
+        )
+
         hook = mock_db_hook(PostgresHook)
         mock_read_sql.return_value = pd.DataFrame()
         mock_polars_df.return_value = pl.DataFrame()
         sql = "SELECT * FROM table"
         if df_type == "pandas":
-            mock_conn = mock.MagicMock()
-            mock_engine = mock.MagicMock()
+            mock_conn = mocker.MagicMock()
+            mock_engine = mocker.MagicMock()
             mock_engine.connect.return_value.__enter__.return_value = mock_conn
             mock_get_engine.return_value = mock_engine
             df = hook.get_df(sql, df_type="pandas")
@@ -537,6 +668,402 @@ class TestPostgresHook:
             df = hook.get_df(sql, df_type="polars")
             mock_polars_df.assert_called_once_with(sql, None)
             assert isinstance(df, expected_type)
+
+    def test_rowcount(self):
+        hook = PostgresHook()
+        input_data = ["foo", "bar", "baz"]
+
+        with hook.get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"CREATE TABLE {self.table} (c VARCHAR)")
+                values = ",".join(f"('{data}')" for data in input_data)
+                cur.execute(f"INSERT INTO {self.table} VALUES {values}")
+                conn.commit()
+                assert cur.rowcount == len(input_data)
+
+    def test_reserved_words(self):
+        hook = PostgresHook()
+        assert hook.reserved_words == sqlalchemy.dialects.postgresql.base.RESERVED_WORDS
+
+    def test_generate_insert_sql_without_already_escaped_column_name(self):
+        values = [
+            "1",
+            "mssql_conn",
+            "mssql",
+            "MSSQL connection",
+            "localhost",
+            "airflow",
+            "admin",
+            "admin",
+            1433,
+            False,
+            False,
+            {},
+        ]
+        target_fields = [
+            "id",
+            "conn_id",
+            "conn_type",
+            "description",
+            "host",
+            "schema",
+            "login",
+            "password",
+            "port",
+            "is_encrypted",
+            "is_extra_encrypted",
+            "extra",
+        ]
+        hook = PostgresHook()
+        assert hook._generate_insert_sql(
+            table="connection", values=values, target_fields=target_fields
+        ) == INSERT_SQL_STATEMENT.format("schema")
+
+    def test_generate_insert_sql_with_already_escaped_column_name(self):
+        values = [
+            "1",
+            "mssql_conn",
+            "mssql",
+            "MSSQL connection",
+            "localhost",
+            "airflow",
+            "admin",
+            "admin",
+            1433,
+            False,
+            False,
+            {},
+        ]
+        target_fields = [
+            "id",
+            "conn_id",
+            "conn_type",
+            "description",
+            "host",
+            '"schema"',
+            "login",
+            "password",
+            "port",
+            "is_encrypted",
+            "is_extra_encrypted",
+            "extra",
+        ]
+        hook = PostgresHook()
+        assert hook._generate_insert_sql(
+            table="connection", values=values, target_fields=target_fields
+        ) == INSERT_SQL_STATEMENT.format('"schema"')
+
+
+@pytest.mark.backend("postgres")
+@pytest.mark.skipif(USE_PSYCOPG3, reason="psycopg v3 is available")
+class TestPostgresHookPPG2:
+    """PostgresHook tests that are specific to psycopg2."""
+
+    table = "test_postgres_hook_table"
+
+    def setup_method(self):
+        self.cur = mock.MagicMock(rowcount=0)
+        self.conn = conn = mock.MagicMock()
+        self.conn.cursor.return_value = self.cur
+
+        class UnitTestPostgresHook(PostgresHook):
+            conn_name_attr = "test_conn_id"
+
+            def get_conn(self):
+                return conn
+
+        self.db_hook = UnitTestPostgresHook()
+
+    def teardown_method(self):
+        with PostgresHook().get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {self.table}")
+
+    def test_copy_expert(self, mocker):
+        open_mock = mocker.mock_open(read_data='{"some": "json"}')
+        mocker.patch("airflow.providers.postgres.hooks.postgres.open", open_mock)
+
+        statement = "SQL"
+        filename = "filename"
+
+        self.cur.fetchall.return_value = None
+
+        assert self.db_hook.copy_expert(statement, filename) is None
+
+        assert self.conn.close.call_count == 1
+        assert self.cur.close.call_count == 1
+        assert self.conn.commit.call_count == 1
+        self.cur.copy_expert.assert_called_once_with(statement, open_mock.return_value)
+        assert open_mock.call_args.args == (filename, "r+")
+
+    def test_insert_rows(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [("hello",), ("world",)]
+
+        setup.db_hook.insert_rows(table, rows)
+
+        assert setup.conn.close.call_count == 1
+        assert setup.cur.close.call_count == 1
+
+        commit_count = 2  # The first and last commit
+        assert commit_count == setup.conn.commit.call_count
+
+        sql = f"INSERT INTO {table}  VALUES (%s)"
+        setup.cur.executemany.assert_any_call(sql, rows)
+
+    def test_insert_rows_replace(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [
+            (
+                1,
+                "hello",
+            ),
+            (
+                2,
+                "world",
+            ),
+        ]
+        fields = ("id", "value")
+
+        setup.db_hook.insert_rows(table, rows, fields, replace=True, replace_index=fields[0])
+
+        assert setup.conn.close.call_count == 1
+        assert setup.cur.close.call_count == 1
+
+        commit_count = 2  # The first and last commit
+        assert commit_count == setup.conn.commit.call_count
+
+        sql = (
+            f"INSERT INTO {table} ({fields[0]}, {fields[1]}) VALUES (%s,%s) "
+            f"ON CONFLICT ({fields[0]}) DO UPDATE SET {fields[1]} = excluded.{fields[1]}"
+        )
+        setup.cur.executemany.assert_any_call(sql, rows)
+
+    def test_insert_rows_replace_missing_target_field_arg(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [
+            (
+                1,
+                "hello",
+            ),
+            (
+                2,
+                "world",
+            ),
+        ]
+        fields = ("id", "value")
+        with pytest.raises(ValueError) as ctx:
+            setup.db_hook.insert_rows(table, rows, replace=True, replace_index=fields[0])
+
+        assert str(ctx.value) == "PostgreSQL ON CONFLICT upsert syntax requires column names"
+
+    def test_insert_rows_replace_missing_replace_index_arg(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [
+            (
+                1,
+                "hello",
+            ),
+            (
+                2,
+                "world",
+            ),
+        ]
+        fields = ("id", "value")
+        with pytest.raises(ValueError) as ctx:
+            setup.db_hook.insert_rows(table, rows, fields, replace=True)
+
+        assert str(ctx.value) == "PostgreSQL ON CONFLICT upsert syntax requires an unique index"
+
+    def test_insert_rows_replace_all_index(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [
+            (
+                1,
+                "hello",
+            ),
+            (
+                2,
+                "world",
+            ),
+        ]
+        fields = ("id", "value")
+
+        setup.db_hook.insert_rows(table, rows, fields, replace=True, replace_index=fields)
+
+        assert setup.conn.close.call_count == 1
+        assert setup.cur.close.call_count == 1
+
+        commit_count = 2  # The first and last commit
+        assert commit_count == setup.conn.commit.call_count
+
+        sql = (
+            f"INSERT INTO {table} ({', '.join(fields)}) VALUES (%s,%s) "
+            f"ON CONFLICT ({', '.join(fields)}) DO NOTHING"
+        )
+        setup.cur.executemany.assert_any_call(sql, rows)
+
+    @pytest.mark.usefixtures("reset_logging_config")
+    def test_get_all_db_log_messages(self, mocker):
+        messages = ["a", "b", "c"]
+
+        class FakeLogger:
+            notices = messages
+
+        # Mock the logger
+        mock_logger = mocker.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.log")
+
+        hook = PostgresHook(enable_log_db_messages=True)
+        hook.get_db_log_messages(FakeLogger)
+
+        # Verify that info was called for each message
+        for msg in messages:
+            assert mocker.call(msg) in mock_logger.info.mock_calls
+
+    @pytest.mark.usefixtures("reset_logging_config")
+    def test_log_db_messages_by_db_proc(self, mocker):
+        proc_name = "raise_notice"
+        notice_proc = f"""
+        CREATE PROCEDURE {proc_name} (s text) LANGUAGE PLPGSQL AS
+        $$
+        BEGIN
+            raise notice 'Message from db: %', s;
+        END;
+        $$;
+        """
+
+        # Mock the logger
+        mock_logger = mocker.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.log")
+
+        hook = PostgresHook(enable_log_db_messages=True)
+        try:
+            hook.run(sql=notice_proc)
+            hook.run(sql=f"call {proc_name}('42')")
+
+            # Check if the notice message was logged
+            assert mocker.call("NOTICE:  Message from db: 42\n") in mock_logger.info.mock_calls
+        finally:
+            hook.run(sql=f"DROP PROCEDURE {proc_name} (s text)")
+
+    def test_dialect_name(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        assert setup.db_hook.dialect_name == "postgresql"
+
+    def test_dialect(self, postgres_hook_setup):
+        setup = postgres_hook_setup
+        assert isinstance(setup.db_hook.dialect, PostgresDialect)
+
+
+@pytest.mark.backend("postgres")
+@pytest.mark.skipif(not USE_PSYCOPG3, reason="psycopg v3 or sqlalchemy v2 are not available")
+class TestPostgresHookPPG3:
+    """PostgresHook tests that are specific to psycopg3."""
+
+    table = "test_postgres_hook_table"
+
+    def setup_method(self):
+        self.cur = mock.MagicMock(rowcount=0)
+        self.conn = conn = mock.MagicMock()
+        self.conn.cursor.return_value = self.cur
+
+        class UnitTestPostgresHook(PostgresHook):
+            conn_name_attr = "test_conn_id"
+
+            def get_conn(self):
+                return conn
+
+        self.db_hook = UnitTestPostgresHook()
+
+    def teardown_method(self):
+        with PostgresHook().get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {self.table}")
+
+    def test_copy_expert_from(self, mocker):
+        """Tests copy_expert with a 'COPY FROM STDIN' operation."""
+        statement = "COPY test_table FROM STDIN"
+        filename = "filename"
+
+        m_open = mocker.mock_open()
+        mocker.patch("airflow.providers.postgres.hooks.postgres.open", m_open)
+        mocker.patch("os.path.isfile", return_value=True)  # Mock file exists
+
+        # Configure the file handle for reading
+        m_open.return_value.read.side_effect = [b'{"some": "json"}', b""]
+
+        # Set up the context manager chain properly
+        # self.conn needs to support context manager
+        self.conn.__enter__ = mocker.Mock(return_value=self.conn)
+        self.conn.__exit__ = mocker.Mock(return_value=None)
+
+        # cursor() returns something that also supports context manager
+        mock_cursor = mocker.MagicMock()
+        mock_cursor.__enter__ = mocker.Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = mocker.Mock(return_value=None)
+        self.conn.cursor.return_value = mock_cursor
+
+        # cursor.copy() returns a context manager
+        mock_copy = mocker.MagicMock()
+        mock_copy.__enter__ = mocker.Mock(return_value=mock_copy)
+        mock_copy.__exit__ = mocker.Mock(return_value=None)
+        mock_cursor.copy.return_value = mock_copy
+
+        # Call the method under test
+        self.db_hook.copy_expert(statement, filename)
+
+        # Assert that the file was opened for reading in binary mode
+        m_open.assert_any_call(filename, "rb")
+
+        # Assert write was called with the data
+        mock_copy.write.assert_called_once_with(b'{"some": "json"}')
+        self.conn.commit.assert_called_once()
+
+    def test_copy_expert_to(self, mocker):
+        """Tests copy_expert with a 'COPY TO STDOUT' operation."""
+        statement = "COPY test_table TO STDOUT"
+        filename = "filename"
+
+        m_open = mocker.mock_open()
+        mocker.patch("airflow.providers.postgres.hooks.postgres.open", m_open)
+
+        # Set up the context manager chain properly
+        # self.conn needs to support context manager
+        self.conn.__enter__ = mocker.Mock(return_value=self.conn)
+        self.conn.__exit__ = mocker.Mock(return_value=None)
+
+        # cursor() returns something that also supports context manager
+        mock_cursor = mocker.MagicMock()
+        mock_cursor.__enter__ = mocker.Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = mocker.Mock(return_value=None)
+        self.conn.cursor.return_value = mock_cursor
+
+        # cursor.copy() returns a context manager that is iterable
+        mock_copy = mocker.MagicMock()
+        mock_copy.__enter__ = mocker.Mock(return_value=mock_copy)
+        mock_copy.__exit__ = mocker.Mock(return_value=None)
+        mock_copy.__iter__ = mocker.Mock(return_value=iter([b"db_data_1", b"db_data_2"]))
+        mock_cursor.copy.return_value = mock_copy
+
+        # Call the method under test
+        self.db_hook.copy_expert(statement, filename)
+
+        # Assert that the file was opened for writing in binary mode
+        m_open.assert_any_call(filename, "wb")
+
+        # Assert that the data from the DB was written to the file
+        handle = m_open.return_value
+        handle.write.assert_has_calls(
+            [
+                mocker.call(b"db_data_1"),
+                mocker.call(b"db_data_2"),
+            ]
+        )
+        self.conn.commit.assert_called_once()
 
     def test_insert_rows(self):
         table = "table"
@@ -645,33 +1172,12 @@ class TestPostgresHook:
         )
         self.cur.executemany.assert_any_call(sql, rows)
 
-    def test_rowcount(self):
-        hook = PostgresHook()
-        input_data = ["foo", "bar", "baz"]
-
-        with hook.get_conn() as conn:
-            with conn.cursor() as cur:
-                cur.execute(f"CREATE TABLE {self.table} (c VARCHAR)")
-                values = ",".join(f"('{data}')" for data in input_data)
-                cur.execute(f"INSERT INTO {self.table} VALUES {values}")
-                conn.commit()
-                assert cur.rowcount == len(input_data)
+    @pytest.mark.skip(reason="Notice handling is callback-based in psycopg3 and cannot be tested this way.")
+    def test_get_all_db_log_messages(self, mocker):
+        pass
 
     @pytest.mark.usefixtures("reset_logging_config")
-    def test_get_all_db_log_messages(self, caplog):
-        messages = ["a", "b", "c"]
-
-        class FakeLogger:
-            notices = messages
-
-        with caplog.at_level(logging.INFO):
-            hook = PostgresHook(enable_log_db_messages=True)
-            hook.get_db_log_messages(FakeLogger)
-            for msg in messages:
-                assert msg in caplog.text
-
-    @pytest.mark.usefixtures("reset_logging_config")
-    def test_log_db_messages_by_db_proc(self, caplog):
+    def test_log_db_messages_by_db_proc(self, mocker):
         proc_name = "raise_notice"
         notice_proc = f"""
         CREATE PROCEDURE {proc_name} (s text) LANGUAGE PLPGSQL AS
@@ -681,89 +1187,22 @@ class TestPostgresHook:
         END;
         $$;
         """
-        with caplog.at_level(logging.INFO):
-            hook = PostgresHook(enable_log_db_messages=True)
-            try:
-                hook.run(sql=notice_proc)
-                hook.run(sql=f"call {proc_name}('42')")
-                assert "NOTICE:  Message from db: 42" in caplog.text
-            finally:
-                hook.run(sql=f"DROP PROCEDURE {proc_name} (s text)")
+
+        # Mock the logger
+        mock_logger = mocker.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.log")
+
+        hook = PostgresHook(enable_log_db_messages=True)
+        try:
+            hook.run(sql=notice_proc)
+            hook.run(sql=f"call {proc_name}('42')")
+
+            # Check if the notice message was logged
+            mock_logger.info.assert_any_call("Message from db: 42")
+        finally:
+            hook.run(sql=f"DROP PROCEDURE {proc_name} (s text)")
 
     def test_dialect_name(self):
         assert self.db_hook.dialect_name == "postgresql"
 
     def test_dialect(self):
         assert isinstance(self.db_hook.dialect, PostgresDialect)
-
-    def test_reserved_words(self):
-        hook = PostgresHook()
-        assert hook.reserved_words == sqlalchemy.dialects.postgresql.base.RESERVED_WORDS
-
-    def test_generate_insert_sql_without_already_escaped_column_name(self):
-        values = [
-            "1",
-            "mssql_conn",
-            "mssql",
-            "MSSQL connection",
-            "localhost",
-            "airflow",
-            "admin",
-            "admin",
-            1433,
-            False,
-            False,
-            {},
-        ]
-        target_fields = [
-            "id",
-            "conn_id",
-            "conn_type",
-            "description",
-            "host",
-            "schema",
-            "login",
-            "password",
-            "port",
-            "is_encrypted",
-            "is_extra_encrypted",
-            "extra",
-        ]
-        hook = PostgresHook()
-        assert hook._generate_insert_sql(
-            table="connection", values=values, target_fields=target_fields
-        ) == INSERT_SQL_STATEMENT.format("schema")
-
-    def test_generate_insert_sql_with_already_escaped_column_name(self):
-        values = [
-            "1",
-            "mssql_conn",
-            "mssql",
-            "MSSQL connection",
-            "localhost",
-            "airflow",
-            "admin",
-            "admin",
-            1433,
-            False,
-            False,
-            {},
-        ]
-        target_fields = [
-            "id",
-            "conn_id",
-            "conn_type",
-            "description",
-            "host",
-            '"schema"',
-            "login",
-            "password",
-            "port",
-            "is_encrypted",
-            "is_extra_encrypted",
-            "extra",
-        ]
-        hook = PostgresHook()
-        assert hook._generate_insert_sql(
-            table="connection", values=values, target_fields=target_fields
-        ) == INSERT_SQL_STATEMENT.format('"schema"')


### PR DESCRIPTION
### Motivation
At the time of writing, the postgres driver `psycopg2` (hereinafter "PPG2") hasn't been updated for ~9 months. There exists a solution in the form of a new version, `psycopg` v3 (hereinafter "PPG3"):

> Psycopg 3 is the new implementation of Psycopg 2. It emerges from the experience of more than 10 years of development and support of psycopg2. It embraces the new possibilities offered by the more modern generations of the Python language and the PostgreSQL database and addresses the challenges offered by the current patterns in software development and deployment.

After merging #52233, sqlalchemy ("SQLA")  v2.x became the default version on python 3.13, which made it possible to experiment with PPG3. SQLA2 supports both PPG2 and PPG3, though it [offers some additional features](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg), most notably an async engine, on PPG3.

### Summary
This PR adds the optional `psycopg[binary]` dependency to the postgres provider. As a result, when PPG3 and SQLA2 are both detected, new code branches for business-logic and tests are used. If PPG3 is uninstalled or SQLA1.4 is detected - the existing PPG2-based implementation is used.

It is not currently possible to force the use of PPG2 when SQLA2+PPG3 are present.

### Test refactoring
Tests were modified to support dual psycopg versions where possible. In situations that needed significant restructuring between the versions, a version of the test was created under each of the corresponding `<TestClass>PPG2` and `<TestClass>PPG3` classes.

In a somewhat tangential effort, most of the postgres provider tests were restructured to use the `mocker` fixture instead of `unittest.mock`, and the use of `caplog` was removed in favor of mocking a logger object.

related: https://github.com/apache/airflow/issues/44452

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
