### PR TITLE
Remove `MAX_XCOM_SIZE` hardcoded constant from Airflow core 

### DIFF
--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -50,7 +50,6 @@ from airflow.utils.sqlalchemy import UtcDateTime
 # XCom constants below are needed for providers backward compatibility,
 # which should import the constants directly after apache-airflow>=2.6.0
 from airflow.utils.xcom import (
-    MAX_XCOM_SIZE,  # noqa: F401
     XCOM_RETURN_KEY,
 )
 

--- a/airflow-core/src/airflow/utils/xcom.py
+++ b/airflow-core/src/airflow/utils/xcom.py
@@ -20,5 +20,4 @@
 # https://github.com/apache/airflow/pull/1618#discussion_r68249677
 from __future__ import annotations
 
-MAX_XCOM_SIZE = 49344
 XCOM_RETURN_KEY = "return_value"

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
@@ -24,7 +24,7 @@ import sys
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from airflow.models.xcom import MAX_XCOM_SIZE, XCOM_RETURN_KEY
+from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.version_compat import BaseOperator
 from airflow.providers.google.common.hooks.discovery_api import GoogleDiscoveryApiHook
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
     except ImportError:
         from airflow.models import TaskInstance as RuntimeTaskInstanceProtocol  # type: ignore[assignment]
     from airflow.utils.context import Context
+
+# MAX XCOM Size is 48KB
+# https://github.com/apache/airflow/pull/1618#discussion_r68249677
+MAX_XCOM_SIZE = 49344
 
 
 class GoogleApiToS3Operator(BaseOperator):

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_google_api_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_google_api_to_s3.py
@@ -22,8 +22,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from airflow import models
-from airflow.models.xcom import MAX_XCOM_SIZE
-from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import MAX_XCOM_SIZE, GoogleApiToS3Operator
 
 # This test mocks json.dumps so it won't work for database isolation mode
 

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -20,12 +20,14 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowException
-from airflow.models.xcom import MAX_XCOM_SIZE
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+
+# MAX XCOM Size is 48KB, check discussion: https://github.com/apache/airflow/pull/1618#discussion_r68249677
+MAX_XCOM_SIZE = 49344
 
 
 class GCSToLocalFilesystemOperator(BaseOperator):

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_local.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_local.py
@@ -22,8 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.models.xcom import MAX_XCOM_SIZE
-from airflow.providers.google.cloud.transfers.gcs_to_local import GCSToLocalFilesystemOperator
+from airflow.providers.google.cloud.transfers.gcs_to_local import MAX_XCOM_SIZE, GCSToLocalFilesystemOperator
 
 TASK_ID = "test-gcs-operator"
 TEST_BUCKET = "test-bucket"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

- MAX_XCOM_SIZE is a hardcoded implementation detail and is not really part of any API contract.
- The value is not configurable and is unlikely to change at any point of time.

Only the google and amazon transfers were importing it. I have hardcoded it in there.
Let me know if this needs a newsfragment.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
