### PR TITLE
Add link to filter dags by owner when owner_links is not defined.

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -25,6 +25,7 @@ export enum SearchParamsKeys {
   LOG_LEVEL = "log_level",
   NAME_PATTERN = "name_pattern",
   OFFSET = "offset",
+  OWNERS = "owners",
   PAUSED = "paused",
   POOL = "pool",
   RUN_TYPE = "run_type",

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link, Text } from "@chakra-ui/react";
+import { Link } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { Link as RouterLink } from "react-router-dom";
 
 import { LimitedItemsList } from "src/components/LimitedItemsList";
 
@@ -33,14 +34,15 @@ export const DagOwners = ({
 }) => {
   const { t: translate } = useTranslation("dags");
   const items = owners.map((owner) => {
-    const link = ownerLinks?.[owner];
-    const hasOwnerLink = link !== undefined;
+    const ownerLink = ownerLinks?.[owner];
+    const ownerFilterLink = `/dags?owners=${owner}`;
+    const hasOwnerLink = ownerLink !== undefined;
 
     return hasOwnerLink ? (
       <Link
         aria-label={translate("ownerLink", { owner })}
         color="fg.info"
-        href={link}
+        href={ownerLink}
         key={owner}
         rel="noopener noreferrer"
         target="_blank"
@@ -48,9 +50,9 @@ export const DagOwners = ({
         {owner}
       </Link>
     ) : (
-      <Text as="span" key={owner}>
-        {owner}
-      </Text>
+      <Link asChild color="fg.info" key={owner}>
+        <RouterLink to={ownerFilterLink}>{owner}</RouterLink>
+      </Link>
     );
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -150,7 +150,7 @@ const createColumns = (
   },
 ];
 
-const { FAVORITE, LAST_DAG_RUN_STATE, NAME_PATTERN, PAUSED, TAGS, TAGS_MATCH_MODE } = SearchParamsKeys;
+const { FAVORITE, LAST_DAG_RUN_STATE, NAME_PATTERN, OWNERS, PAUSED, TAGS, TAGS_MATCH_MODE } = SearchParamsKeys;
 
 const cardDef: CardDef<DAGWithLatestDagRunsResponse> = {
   card: ({ row }) => <DagCard dag={row} />,
@@ -176,6 +176,7 @@ export const DagsList = () => {
   const lastDagRunState = searchParams.get(LAST_DAG_RUN_STATE) as DagRunState;
   const selectedTags = searchParams.getAll(TAGS);
   const selectedMatchMode = searchParams.get(TAGS_MATCH_MODE) as "all" | "any";
+  const owners = searchParams.getAll(OWNERS);
 
   const { setTableURLState, tableURLState } = useTableURLState();
 
@@ -228,6 +229,7 @@ export const DagsList = () => {
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
     orderBy,
+    owners,
     paused,
     tags: selectedTags,
     tagsMatchMode: selectedMatchMode,

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -150,7 +152,8 @@ const createColumns = (
   },
 ];
 
-const { FAVORITE, LAST_DAG_RUN_STATE, NAME_PATTERN, OWNERS, PAUSED, TAGS, TAGS_MATCH_MODE } = SearchParamsKeys;
+const { FAVORITE, LAST_DAG_RUN_STATE, NAME_PATTERN, OWNERS, PAUSED, TAGS, TAGS_MATCH_MODE } =
+  SearchParamsKeys;
 
 const cardDef: CardDef<DAGWithLatestDagRunsResponse> = {
   card: ({ row }) => <DagCard dag={row} />,


### PR DESCRIPTION
In the absence of `owners_link` defined in a dag add a link to filter the dags list by the owner.

Closes #52273 