### PR TITLE
Remove remnants of ~= used in requires-python.

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -35,7 +35,7 @@ name = "apache-airflow-core"
 description = "Core packages for Apache Airflow, schedule and API server"
 readme = { file = "README.md", content-type = "text/markdown" }
 license-files.globs = ["LICENSE", "3rd-party-licenses/*.txt", "NOTICE"]
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/chart/pyproject.toml
+++ b/chart/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 [project]
 name = "apache-airflow-helm-chart"
 description = "Programmatically author, schedule and monitor data pipelines"
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 description = "Apache Airflow API (Stable)"
 readme = "README.md"
 license-files.globs = ["LICENSE", "NOTICE"]
-requires-python = "~=3.10"
+requires-python = ">=3.10"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -26,7 +26,7 @@ description = "Development tools for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/docker-stack-docs/pyproject.toml
+++ b/docker-stack-docs/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 [project]
 name = "apache-airflow-docker-stack"
 description = "Programmatically author, schedule and monitor data pipelines"
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/docker-tests/pyproject.toml
+++ b/docker-tests/pyproject.toml
@@ -26,7 +26,7 @@ description = "Docker tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/helm-tests/pyproject.toml
+++ b/helm-tests/pyproject.toml
@@ -26,7 +26,7 @@ description = "Helm tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/kubernetes-tests/pyproject.toml
+++ b/kubernetes-tests/pyproject.toml
@@ -24,7 +24,7 @@ description = "Kubernetes tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/providers-summary-docs/pyproject.toml
+++ b/providers-summary-docs/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 [project]
 name = "apache-airflow-providers"
 description = "Programmatically author, schedule and monitor data pipelines"
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ name = "apache-airflow"
 description = "Programmatically author, schedule and monitor data pipelines"
 readme = { file = "generated/PYPI_README.md", content-type = "text/markdown" }
 license-files.globs = ["LICENSE"]
-requires-python = "~=3.10,!=3.13"
+requires-python = ">=3.10,!=3.13"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/scripts/ci/airflow_version_check.py
+++ b/scripts/ci/airflow_version_check.py
@@ -63,9 +63,9 @@ def check_airflow_version(airflow_version: Version) -> tuple[str, bool]:
             sys.exit(1)
         if airflow_version == latest_version:
             latest = True
-        # find requires-python = "~=VERSION" in pyproject.toml file of airflow
+        # find requires-python = ">=VERSION" in pyproject.toml file of airflow
         pyproject_toml_conntent = (Path(__file__).parents[2] / "pyproject.toml").read_text()
-        matched_version = re.search('requires-python = "~=([0-9]+.[0-9]+)', pyproject_toml_conntent)
+        matched_version = re.search('requires-python = ">=([0-9]+.[0-9]+)', pyproject_toml_conntent)
         if matched_version:
             min_version = matched_version.group(1)
         else:


### PR DESCRIPTION
Follow up after #52980 - there are still few more places where the ~= was used in requires-python.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
