### PR TITLE
Fix DagRun list

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -24,7 +24,6 @@ import type { TFunction } from "i18next";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
-import { useLocalStorage } from "usehooks-ts";
 
 import { useDagRunServiceGetDagRuns } from "openapi/queries";
 import type { DAGRunResponse, DagRunState, DagRunType } from "openapi/requests/types.gen";
@@ -163,13 +162,12 @@ export const DagRuns = () => {
   const endDate = searchParams.get(END_DATE_PARAM);
 
   const refetchInterval = useAutoRefresh({});
-  const [limit] = useLocalStorage<number>(`dag_runs_limit-${dagId}`, 10);
 
   const { data, error, isLoading } = useDagRunServiceGetDagRuns(
     {
       dagId: dagId ?? "~",
       endDateLte: endDate ?? undefined,
-      limit,
+      limit: pagination.pageSize,
       offset: pagination.pageIndex * pagination.pageSize,
       orderBy,
       runType: filteredType === null ? undefined : [filteredType],


### PR DESCRIPTION
The pagination for listing the DagRuns should still follow the `page_size` config option.

Also in the current states the pagination was broken because we fetched `dag_runs_limit-${dagId}` from the backend, but the front-end pagination component `useTableURLState` was still based on the `useConfig("page_size")`.  If we wanted to make it work like this we would simply need to pass extra options to the `useTableURLState`.


## Before
10 items per page, only two pages in the pagination component (in reality there is more than 80 runs)
![Screenshot 2025-07-07 at 19 03 14](https://github.com/user-attachments/assets/9145ea7d-ee11-432a-963f-920d6e96b9c7)


## After
50 items per page, two pages
![Screenshot 2025-07-07 at 19 02 46](https://github.com/user-attachments/assets/159b0729-5812-4cfd-b40d-2e5f7ed8b597)
