### PR TITLE
feat(provider): pass parameters to Neo4j driver session

### DIFF
--- a/providers/neo4j/docs/operators/neo4j.rst
+++ b/providers/neo4j/docs/operators/neo4j.rst
@@ -54,3 +54,24 @@ the connection metadata is structured as follows:
     :dedent: 4
     :start-after: [START run_query_neo4j_operator]
     :end-before: [END run_query_neo4j_operator]
+
+Passing parameters into the query
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Neo4jOperator provides ``parameters`` argument to pass parameters into the
+query. This allows you to use placeholders in your parameterized query and
+substitute them with actual values at execution time.
+
+When using the ``parameters`` argument, you should prefix placeholders in your
+query using the ``$`` syntax. For example, if your query uses a placeholder
+like ``$name``, you would provide the parameters as ``{"name": "value"}`` in
+the operator. This allows you to write dynamic queries without having to
+concatenate strings. This is particularly useful when you want to execute
+the same query with different values, or use values from the Airflow
+context, such as task instance parameters or variables.
+
+.. exampleinclude:: /../../neo4j/tests/system/neo4j/example_neo4j_query.py
+    :language: python
+    :dedent: 4
+    :start-after: [START run_query_neo4j_operator]
+    :end-before: [END run_query_neo4j_operator]

--- a/providers/neo4j/src/airflow/providers/neo4j/hooks/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/hooks/neo4j.py
@@ -47,11 +47,13 @@ class Neo4jHook(BaseHook):
     conn_type = "neo4j"
     hook_name = "Neo4j"
 
-    def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
+    def __init__(self, conn_id: str = default_conn_name, parameters=None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.neo4j_conn_id = conn_id
         self.connection = kwargs.pop("connection", None)
         self.client: Driver | None = None
+        self.parameters = parameters
+
 
     def get_conn(self) -> Driver:
         """Initiate a new Neo4j connection with username, password and database schema."""
@@ -113,19 +115,20 @@ class Neo4jHook(BaseHook):
 
         return f"{scheme}{encryption_scheme}://{conn.host}:{7687 if conn.port is None else conn.port}"
 
-    def run(self, query) -> list[Any]:
+    def run(self, query, parameters) -> list[Any]:
         """
         Create a neo4j session and execute the query in the session.
 
         :param query: Neo4j query
+        :param parameters: Optional parameters for the query
         :return: Result
         """
         driver = self.get_conn()
         if not self.connection.schema:
             with driver.session() as session:
-                result = session.run(query)
+                result = session.run(query, parameters)
                 return result.data()
         else:
             with driver.session(database=self.connection.schema) as session:
-                result = session.run(query)
+                result = session.run(query, parameters)
                 return result.data()

--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -42,9 +42,10 @@ class Neo4jOperator(BaseOperator):
     :param sql: the sql code to be executed. Can receive a str representing a
         sql statement
     :param neo4j_conn_id: Reference to :ref:`Neo4j connection id <howto/connection:neo4j>`.
+    :param parameters: the parameters to send to Neo4j driver session
     """
 
-    template_fields: Sequence[str] = ("sql",)
+    template_fields: Sequence[str] = ("sql", "parameters")
 
     def __init__(
         self,
@@ -61,5 +62,5 @@ class Neo4jOperator(BaseOperator):
 
     def execute(self, context: Context) -> None:
         self.log.info("Executing: %s", self.sql)
-        hook = Neo4jHook(conn_id=self.neo4j_conn_id)
+        hook = Neo4jHook(conn_id=self.neo4j_conn_id, parameters=self.parameters)
         hook.run(self.sql)

--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -62,5 +62,5 @@ class Neo4jOperator(BaseOperator):
 
     def execute(self, context: Context) -> None:
         self.log.info("Executing: %s", self.sql)
-        hook = Neo4jHook(conn_id=self.neo4j_conn_id, parameters=self.parameters)
-        hook.run(self.sql)
+        hook = Neo4jHook(conn_id=self.neo4j_conn_id)
+        hook.run(self.sql, self.parameters)

--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
@@ -52,7 +52,7 @@ class Neo4jOperator(BaseOperator):
         *,
         sql: str,
         neo4j_conn_id: str = "neo4j_default",
-        parameters: Iterable | Mapping[str, Any] | None = None,
+        parameters: dict[str, Any] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/providers/neo4j/tests/system/neo4j/example_neo4j_query.py
+++ b/providers/neo4j/tests/system/neo4j/example_neo4j_query.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example use of Neo4j related operators with parameters.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.neo4j.operators.neo4j import Neo4jOperator
+
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
+DAG_ID = "example_neo4j_query"
+
+with DAG(
+    DAG_ID,
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["example"],
+    catchup=False,
+) as dag:
+    # [START run_query_neo4j_operator]
+
+    neo4j_task = Neo4jOperator(
+        task_id="run_neo4j_query_with_parameters",
+        neo4j_conn_id="neo4j_conn_id",
+        parameters={"name": "Tom Hanks"},
+        sql='MATCH (actor {name: $name, date: "{{ds}}"}) RETURN actor',
+        dag=dag,
+    )
+
+    # [END run_query_neo4j_operator]
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py
@@ -97,8 +97,7 @@ class TestNeo4jHookConn:
                     mock.call.driver("bolt://host:7687", auth=("login", "password"), encrypted=False),
                     mock.call.driver().session(database="schema"),
                     mock.call.driver().session().__enter__(),
-                    mock.call.driver().session().__enter__().run(mock_sql),
-                    mock.call.driver().session().__enter__().run(mock_parameters),
+                    mock.call.driver().session().__enter__().run(mock_sql, mock_parameters),
                     mock.call.driver().session().__enter__().run().data(),
                     mock.call.driver().session().__exit__(None, None, None),
                 ]
@@ -149,8 +148,7 @@ class TestNeo4jHookConn:
                     mock.call.driver("bolt://host:7687", auth=("login", "password"), encrypted=False),
                     mock.call.driver().session(),
                     mock.call.driver().session().__enter__(),
-                    mock.call.driver().session().__enter__().run(mock_sql),
-                    mock.call.driver().session().__enter__().run(mock_parameters),
+                    mock.call.driver().session().__enter__().run(mock_sql, mock_parameters),
                     mock.call.driver().session().__enter__().run().data(),
                     mock.call.driver().session().__exit__(None, None, None),
                 ]

--- a/providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py
@@ -80,6 +80,33 @@ class TestNeo4jHookConn:
             assert op_result == session.run.return_value.data.return_value
 
     @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
+    def test_run_with_schema_and_params(self, mock_graph_database):
+        connection = Connection(
+            conn_type="neo4j", login="login", password="password", host="host", schema="schema"
+        )
+        mock_sql = mock.MagicMock(name="sql")
+        mock_parameters = mock.MagicMock(name="parameters")
+
+        # Use the environment variable mocking to test saving the configuration as a URI and
+        # to avoid mocking Airflow models class
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_NEO4J_DEFAULT=connection.get_uri()):
+            neo4j_hook = Neo4jHook()
+            op_result = neo4j_hook.run(mock_sql, mock_parameters)
+            mock_graph_database.assert_has_calls(
+                [
+                    mock.call.driver("bolt://host:7687", auth=("login", "password"), encrypted=False),
+                    mock.call.driver().session(database="schema"),
+                    mock.call.driver().session().__enter__(),
+                    mock.call.driver().session().__enter__().run(mock_sql),
+                    mock.call.driver().session().__enter__().run(mock_parameters),
+                    mock.call.driver().session().__enter__().run().data(),
+                    mock.call.driver().session().__exit__(None, None, None),
+                ]
+            )
+            session = mock_graph_database.driver.return_value.session.return_value.__enter__.return_value
+            assert op_result == session.run.return_value.data.return_value
+
+    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
     def test_run_without_schema(self, mock_graph_database):
         connection = Connection(
             conn_type="neo4j", login="login", password="password", host="host", schema=None
@@ -97,6 +124,33 @@ class TestNeo4jHookConn:
                     mock.call.driver().session(),
                     mock.call.driver().session().__enter__(),
                     mock.call.driver().session().__enter__().run(mock_sql),
+                    mock.call.driver().session().__enter__().run().data(),
+                    mock.call.driver().session().__exit__(None, None, None),
+                ]
+            )
+            session = mock_graph_database.driver.return_value.session.return_value.__enter__.return_value
+            assert op_result == session.run.return_value.data.return_value
+
+    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
+    def test_run_without_schema_and_params(self, mock_graph_database):
+        connection = Connection(
+            conn_type="neo4j", login="login", password="password", host="host", schema=None
+        )
+        mock_sql = mock.MagicMock(name="sql")
+        mock_parameters = mock.MagicMock(name="parameters")
+
+        # Use the environment variable mocking to test saving the configuration as a URI and
+        # to avoid mocking Airflow models class
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_NEO4J_DEFAULT=connection.get_uri()):
+            neo4j_hook = Neo4jHook()
+            op_result = neo4j_hook.run(mock_sql, mock_parameters)
+            mock_graph_database.assert_has_calls(
+                [
+                    mock.call.driver("bolt://host:7687", auth=("login", "password"), encrypted=False),
+                    mock.call.driver().session(),
+                    mock.call.driver().session().__enter__(),
+                    mock.call.driver().session().__enter__().run(mock_sql),
+                    mock.call.driver().session().__enter__().run(mock_parameters),
                     mock.call.driver().session().__enter__().run().data(),
                     mock.call.driver().session().__exit__(None, None, None),
                 ]

--- a/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
@@ -36,7 +36,7 @@ class TestNeo4jOperator:
         op = Neo4jOperator(task_id="basic_neo4j", sql=sql)
         op.execute(mock.MagicMock())
         mock_hook.assert_called_once_with(conn_id="neo4j_default")
-        mock_hook.return_value.run.assert_called_once_with(sql)
+        mock_hook.return_value.run.assert_called_once_with(sql, None)
 
     @mock.patch("airflow.providers.neo4j.operators.neo4j.Neo4jHook")
     def test_neo4j_operator_test_with_params(self, mock_hook):
@@ -47,5 +47,4 @@ class TestNeo4jOperator:
         op = Neo4jOperator(task_id="basic_neo4j", sql=sql, parameters=parameters, conn_id="test_conn")
         op.execute(mock.MagicMock())
         mock_hook.assert_called_once_with(conn_id="test_conn")
-        mock_hook.return_value.run.assert_called_once_with(sql=sql)
-        mock_hook.return_value.run.assert_called_once_with(parameters=parameters)
+        mock_hook.return_value.run.assert_called_once_with(sql, parameters)

--- a/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
@@ -37,3 +37,15 @@ class TestNeo4jOperator:
         op.execute(mock.MagicMock())
         mock_hook.assert_called_once_with(conn_id="neo4j_default")
         mock_hook.return_value.run.assert_called_once_with(sql)
+
+    @mock.patch("airflow.providers.neo4j.operators.neo4j.Neo4jHook")
+    def test_neo4j_operator_test_with_params(self, mock_hook):
+        sql = """
+            MATCH (actor {name: $name}) RETURN actor
+            """
+        parameters={ "name": "Tom Hanks"}
+        op = Neo4jOperator(task_id="basic_neo4j", sql=sql, parameters=parameters, conn_id="test_conn")
+        op.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(conn_id="test_conn")
+        mock_hook.return_value.run.assert_called_once_with(sql=sql)
+        mock_hook.return_value.run.assert_called_once_with(parameters=parameters)

--- a/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
@@ -43,8 +43,8 @@ class TestNeo4jOperator:
         sql = """
             MATCH (actor {name: $name}) RETURN actor
             """
-        parameters={ "name": "Tom Hanks"}
-        op = Neo4jOperator(task_id="basic_neo4j", sql=sql, parameters=parameters, conn_id="test_conn")
+        parameters = {"name": "Tom Hanks"}
+        op = Neo4jOperator(task_id="basic_neo4j", sql=sql, parameters=parameters)
         op.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(conn_id="test_conn")
+        mock_hook.assert_called_once_with(conn_id="neo4j_default")
         mock_hook.return_value.run.assert_called_once_with(sql, parameters)


### PR DESCRIPTION
Closes: #52723

Following up with a PR to fix issue.

# Why

1. When using the `Neo4jOperator` to execute cypher queries, the `parameters` argument is not being passed correctly. The operator is designed to accept a `parameters` argument, but this argument is not utilized.

2. The `Neo4jOperator` should correctly pass the `parameters` argument to the cypher query execution. This would allow for dynamic queries that can accept parameters at runtime.

# How

1. `Neo4jHook` hook to accept `parameters` when operator is executed.

2. Pass `parameters` argument to `Neo4j` driver session for queries with schema or schemaless operations.

3. Add `tests` for coverage.

## Deployment Details

```text
OS: macOS Sequoia Version 15.4.1 (24E263)
Docker: 20.10.14
Kubernetes: (Client Version: v1.22.5, Server Version: v1.33.1)
kind: v0.29.0 go1.24.2 darwin/arm64

Airflow: 2.10.5
Helm Chart: airflow-1.16.0 (2.10.5)

neo4j: 2025.04.0
Helm Chart: neo4j-2025.4.0  App Version: 2025.04.0  
```

```python
"""
Dag to fix the neo4j provider parameter issue in Airflow.
"""

## ....
## ....
## ....


# Define the default arguments
default_args = {
    "owner": "airflow",
    "start_date": datetime(2025, 7, 5),
    "retries": 3,
}


# Define the DAG
@dag(
    dag_id="oss_contrib_airflow_neo4j_pipeline",
    description="Neo4j provider sample",
    default_args=default_args,
    schedule_interval=None,
    start_date=datetime(2025, 7, 5),
    catchup=False,
    tags=["neo4j provider"],
)
def oss_contrib_airflow_neo4j_pipeline():
    """
    DAG to test parameters binding using Neo4jProvider in Airflow.
    """

    ## connection uri: 
    neo4j_bolt_vars = Variable.get("bolt_neo4j", default_var="{}", deserialize_json=True)

    start = EmptyOperator(task_id="start")

    update_graph_db = Neo4jOperator(
        task_id="upd_graph_db",
        parameters={"name": "Airflow"},
        neo4j_conn_id=neo4j_bolt_vars.get("conn_id", "bolt_neo4j"),
        sql="""
          // schema neo4j
          MERGE (a:Person {name: $name})
          ON CREATE SET a.created = timestamp()
          ON MATCH SET a.updated = timestamp()
        """,
    )

    end = EmptyOperator(task_id="end")

    start >> update_graph_db >> end


DAG_INSTANCE = oss_contrib_airflow_neo4j_pipeline()
```

## Result

```text
Connected to Neo4j using Bolt protocol version 5.8 at neo4j://localhost:7687.
Type :help for a list of available commands or :exit to exit the shell.
Note that Cypher queries must end with a semicolon.
@neo4j> MATCH (a:Person) RETURN a;
+-----------------------------------------------------+
| a                                                   |
+-----------------------------------------------------+
| (:Person {name: "Airflow", created: 1751911510657}) |
+-----------------------------------------------------+

1 row
ready to start consuming query after 76 ms, results consumed after another 3 ms
@neo4j> 
```

<details>
  <summary>Logs</summary>

```
[2025-07-07T18:04:48.747+0000] {dagbag.py:588} INFO - Filling up the DagBag from /opt/airflow/dags/oss_contrib_airflow_neo4j.py
<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)
<jemalloc>: (This is the expected behaviour if you are running under QEMU)
[2025-07-07T18:05:07.069+0000] {oss_contrib_airflow_neo4j.py:50} INFO - create_or_update_connection: Connection bolt_neo4j already exsits:
[2025-07-07T18:05:07.498+0000] {task_command.py:467} INFO - Running <TaskInstance: oss_contrib_airflow_neo4j_pipeline.upd_graph_db manual__2025-07-07T17:09:15.242788+00:00 [queued]> on host oss-contrib-airflow-neo4j-pipeline-upd-graph-db-zh43aw29
[2025-07-07T18:05:08.102+0000] {local_task_job_runner.py:123} INFO - ::group::Pre task execution logs
[2025-07-07T18:05:08.305+0000] {taskinstance.py:2614} INFO - Dependencies all met for dep_context=non-requeueable deps ti=<TaskInstance: oss_contrib_airflow_neo4j_pipeline.upd_graph_db manual__2025-07-07T17:09:15.242788+00:00 [queued]>
[2025-07-07T18:05:08.373+0000] {taskinstance.py:2614} INFO - Dependencies all met for dep_context=requeueable deps ti=<TaskInstance: oss_contrib_airflow_neo4j_pipeline.upd_graph_db manual__2025-07-07T17:09:15.242788+00:00 [queued]>
[2025-07-07T18:05:08.375+0000] {taskinstance.py:2867} INFO - Starting attempt 4 of 6
[2025-07-07T18:05:08.800+0000] {taskinstance.py:2890} INFO - Executing <Task(Neo4jOperator): upd_graph_db> on 2025-07-07 17:09:15.242788+00:00
[2025-07-07T18:05:08.843+0000] {standard_task_runner.py:72} INFO - Started process 41 to run task
[2025-07-07T18:05:08.851+0000] {standard_task_runner.py:104} INFO - Running: ['airflow', 'tasks', 'run', 'oss_contrib_airflow_neo4j_pipeline', 'upd_graph_db', 'manual__2025-07-07T17:09:15.242788+00:00', '--job-id', '236', '--raw', '--subdir', 'DAGS_FOLDER/oss_contrib_airflow_neo4j.py', '--cfg-path', '/tmp/tmpfututloq']
[2025-07-07T18:05:08.857+0000] {standard_task_runner.py:105} INFO - Job 236: Subtask upd_graph_db
[2025-07-07T18:05:09.447+0000] {task_command.py:467} INFO - Running <TaskInstance: oss_contrib_airflow_neo4j_pipeline.upd_graph_db manual__2025-07-07T17:09:15.242788+00:00 [running]> on host oss-contrib-airflow-neo4j-pipeline-upd-graph-db-zh43aw29
[2025-07-07T18:05:10.175+0000] {pod_generator.py:472} WARNING - Model file /opt/airflow/pod_templates/pod_template_file.yaml does not exist
[2025-07-07T18:05:10.526+0000] {taskinstance.py:3134} INFO - Exporting env vars: AIRFLOW_CTX_DAG_OWNER='airflow' AIRFLOW_CTX_DAG_ID='oss_contrib_airflow_neo4j_pipeline' AIRFLOW_CTX_TASK_ID='upd_graph_db' AIRFLOW_CTX_EXECUTION_DATE='2025-07-07T17:09:15.242788+00:00' AIRFLOW_CTX_TRY_NUMBER='4' AIRFLOW_CTX_DAG_RUN_ID='manual__2025-07-07T17:09:15.242788+00:00'
[2025-07-07T18:05:10.531+0000] {taskinstance.py:732} INFO - ::endgroup::
[2025-07-07T18:05:10.568+0000] {neo4j.py:159} INFO - Executing:
USE neo4j
MERGE (a:Person {name: $name})
ON CREATE SET a.created = timestamp()
ON MATCH SET a.updated = timestamp()
[2025-07-07T18:05:10.570+0000] {neo4j.py:160} INFO - Parameters: {'name': 'Airflow'}
[2025-07-07T18:05:10.576+0000] {neo4j.py:113} INFO - Run: {'name': 'Airflow'}
[2025-07-07T18:05:10.596+0000] {base.py:84} INFO - Retrieving connection 'bolt_neo4j'
[2025-07-07T18:05:10.604+0000] {neo4j.py:50} INFO - URI: bolt://neo4j.neo4j.svc.cluster.local:7687
[2025-07-07T18:05:10.940+0000] {taskinstance.py:341} INFO - ::group::Post task execution logs
[2025-07-07T18:05:10.945+0000] {taskinstance.py:353} INFO - Marking task as SUCCESS. dag_id=oss_contrib_airflow_neo4j_pipeline, task_id=upd_graph_db, run_id=manual__2025-07-07T17:09:15.242788+00:00, execution_date=20250707T170915, start_date=20250707T180508, end_date=20250707T180510
[2025-07-07T18:05:11.372+0000] {local_task_job_runner.py:266} INFO - Task exited with return code 0
[2025-07-07T18:05:11.524+0000] {local_task_job_runner.py:245} INFO - ::endgroup::
```
</details>

## Dag UI

![pr-fix](https://github.com/user-attachments/assets/23900149-7f54-4fa0-9249-55443b0e4b57)


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
