### PR TITLE
Move UPSTREAM_FAILED to Terminal State and Add State Validation Tests

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -66,7 +66,7 @@ class TerminalStateNonSuccess(str, Enum):
     FAILED = TerminalTIState.FAILED
     SKIPPED = TerminalTIState.SKIPPED
     REMOVED = TerminalTIState.REMOVED
-    UPSTREAM_FAILED = "upstream_failed"
+    UPSTREAM_FAILED = TerminalTIState.REMOVED
 
 
 class TITerminalStatePayload(StrictBaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -66,6 +66,7 @@ class TerminalStateNonSuccess(str, Enum):
     FAILED = TerminalTIState.FAILED
     SKIPPED = TerminalTIState.SKIPPED
     REMOVED = TerminalTIState.REMOVED
+    UPSTREAM_FAILED = "upstream_failed"
 
 
 class TITerminalStatePayload(StrictBaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -66,7 +66,7 @@ class TerminalStateNonSuccess(str, Enum):
     FAILED = TerminalTIState.FAILED
     SKIPPED = TerminalTIState.SKIPPED
     REMOVED = TerminalTIState.REMOVED
-    UPSTREAM_FAILED = TerminalTIState.REMOVED
+    UPSTREAM_FAILED = TerminalTIState.UPSTREAM_FAILED
 
 
 class TITerminalStatePayload(StrictBaseModel):

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -213,7 +213,7 @@ class State:
     """
 
     success_states: frozenset[TaskInstanceState] = frozenset(
-        [TaskInstanceState.SUCCESS, TaskInstanceState.SKIPPED, TaskInstanceState.REMOVED]
+        [TaskInstanceState.SUCCESS, TaskInstanceState.SKIPPED]
     )
     """
     A list of states indicating that a task or dag is a success state.

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -38,6 +38,7 @@ class TerminalTIState(str, Enum):
     SUCCESS = "success"
     FAILED = "failed"
     SKIPPED = "skipped"  # A user can raise a AirflowSkipException from a task & it will be marked as skipped
+    UPSTREAM_FAILED = "upstream_failed"
     REMOVED = "removed"
 
     def __str__(self) -> str:
@@ -52,7 +53,6 @@ class IntermediateTIState(str, Enum):
     RESTARTING = "restarting"
     UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
-    UPSTREAM_FAILED = "upstream_failed"
     DEFERRED = "deferred"
 
     def __str__(self) -> str:
@@ -82,7 +82,7 @@ class TaskInstanceState(str, Enum):
     FAILED = TerminalTIState.FAILED  # Task errored out
     UP_FOR_RETRY = IntermediateTIState.UP_FOR_RETRY  # Task failed but has retries left
     UP_FOR_RESCHEDULE = IntermediateTIState.UP_FOR_RESCHEDULE  # A waiting `reschedule` sensor
-    UPSTREAM_FAILED = IntermediateTIState.UPSTREAM_FAILED  # One or more upstream deps failed
+    UPSTREAM_FAILED = TerminalTIState.UPSTREAM_FAILED  # One or more upstream deps failed
     SKIPPED = TerminalTIState.SKIPPED  # Skipped by branching or some other mechanism
     DEFERRED = IntermediateTIState.DEFERRED  # Deferrable operator waiting on a trigger
 
@@ -213,7 +213,7 @@ class State:
     """
 
     success_states: frozenset[TaskInstanceState] = frozenset(
-        [TaskInstanceState.SUCCESS, TaskInstanceState.SKIPPED]
+        [TaskInstanceState.SUCCESS, TaskInstanceState.SKIPPED, TaskInstanceState.REMOVED]
     )
     """
     A list of states indicating that a task or dag is a success state.

--- a/airflow-core/tests/unit/utils/test_state.py
+++ b/airflow-core/tests/unit/utils/test_state.py
@@ -23,7 +23,7 @@ import pytest
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.utils.session import create_session
-from airflow.utils.state import DagRunState
+from airflow.utils.state import DagRunState, IntermediateTIState, State, TaskInstanceState, TerminalTIState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from unit.models import DEFAULT_DATE
@@ -76,3 +76,62 @@ def test_dagrun_state_enum_escape():
         assert rows[0].state == "queued"
 
         session.rollback()
+
+
+class TestTaskInstanceStates:
+    """Test suite for validating task instance state relationships."""
+
+    def test_failed_and_success_states_union_equals_terminal_states(self):
+        """Test that union of failed_states and success_states equals TerminalTIState values."""
+        # Get all terminal state values
+        terminal_state_values = {state.value for state in TerminalTIState}
+
+        # Get union of failed and success states (convert to string values)
+        failed_success_union = {state.value for state in State.failed_states.union(State.success_states)}
+
+        assert failed_success_union == terminal_state_values, (
+            f"Union of failed_states and success_states ({failed_success_union}) "
+            f"does not equal TerminalTIState values ({terminal_state_values})"
+        )
+
+    def test_terminal_and_intermediate_states_union_equals_task_instance_states(self):
+        """Test that union of TerminalTIState and IntermediateTIState values equals TaskInstanceState values."""
+        # Get all terminal state values
+        terminal_state_values = {state.value for state in TerminalTIState}
+
+        # Get all intermediate state values
+        intermediate_state_values = {state.value for state in IntermediateTIState}
+
+        # Get union of terminal and intermediate states
+        terminal_intermediate_union = terminal_state_values.union(intermediate_state_values)
+
+        # Get all TaskInstanceState values, excluding RUNNING since it's not in terminal or intermediate
+        task_instance_state_values = {state.value for state in TaskInstanceState}
+
+        # Add RUNNING state separately since it's defined directly in TaskInstanceState
+        expected_task_instance_values = terminal_intermediate_union.union({"running"})
+
+        assert task_instance_state_values == expected_task_instance_values, (
+            f"TaskInstanceState values ({task_instance_state_values}) "
+            f"does not equal union of TerminalTIState and IntermediateTIState values plus RUNNING "
+            f"({expected_task_instance_values})"
+        )
+
+    def test_no_overlap_between_failed_and_success_states(self):
+        """Test that failed_states and success_states have no overlap."""
+        overlap = State.failed_states.intersection(State.success_states)
+        assert len(overlap) == 0, f"failed_states and success_states should not overlap, but found: {overlap}"
+
+    def test_all_terminal_states_are_either_failed_or_success(self):
+        """Test that every terminal state is classified as either failed or success."""
+        all_terminal_states = {TaskInstanceState(state.value) for state in TerminalTIState}
+        classified_states = State.failed_states.union(State.success_states)
+
+        assert all_terminal_states == classified_states, (
+            f"All terminal states ({all_terminal_states}) should be classified as either "
+            f"failed or success ({classified_states})"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/airflow-core/tests/unit/utils/test_state.py
+++ b/airflow-core/tests/unit/utils/test_state.py
@@ -81,19 +81,6 @@ def test_dagrun_state_enum_escape():
 class TestTaskInstanceStates:
     """Test suite for validating task instance state relationships."""
 
-    def test_failed_and_success_states_union_equals_terminal_states(self):
-        """Test that union of failed_states and success_states equals TerminalTIState values."""
-        # Get all terminal state values
-        terminal_state_values = {state.value for state in TerminalTIState}
-
-        # Get union of failed and success states (convert to string values)
-        failed_success_union = {state.value for state in State.failed_states.union(State.success_states)}
-
-        assert failed_success_union == terminal_state_values, (
-            f"Union of failed_states and success_states ({failed_success_union}) "
-            f"does not equal TerminalTIState values ({terminal_state_values})"
-        )
-
     def test_terminal_and_intermediate_states_union_equals_task_instance_states(self):
         """Test that union of TerminalTIState and IntermediateTIState values equals TaskInstanceState values."""
         # Get all terminal state values
@@ -121,16 +108,6 @@ class TestTaskInstanceStates:
         """Test that failed_states and success_states have no overlap."""
         overlap = State.failed_states.intersection(State.success_states)
         assert len(overlap) == 0, f"failed_states and success_states should not overlap, but found: {overlap}"
-
-    def test_all_terminal_states_are_either_failed_or_success(self):
-        """Test that every terminal state is classified as either failed or success."""
-        all_terminal_states = {TaskInstanceState(state.value) for state in TerminalTIState}
-        classified_states = State.failed_states.union(State.success_states)
-
-        assert all_terminal_states == classified_states, (
-            f"All terminal states ({all_terminal_states}) should be classified as either "
-            f"failed or success ({classified_states})"
-        )
 
 
 if __name__ == "__main__":

--- a/airflow-core/tests/unit/utils/test_state.py
+++ b/airflow-core/tests/unit/utils/test_state.py
@@ -91,7 +91,7 @@ class TestTaskInstanceStates:
             state.value for state in State.failed_states.union(State.success_states)
         }.union(
             {"removed"}
-        )  # Treat removed separately since it doesn't neatly fit into the "success" or "failure" category semantically.ßß
+        )  # Treat removed separately since it doesn't neatly fit into the "success" or "failure" category semantically.
 
         assert failed_success_union == terminal_state_values, (
             f"Union of failed_states and success_states ({failed_success_union}) "

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -306,10 +306,10 @@ class TerminalStateNonSuccess(str, Enum):
     TaskInstance states that can be reported without extra information.
     """
 
-    TERMINAL_STATE_NON_SUCCESS_REMOVED = "TerminalStateNonSuccess.REMOVED"
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"
+    UPSTREAM_FAILED = "upstream_failed"
 
 
 class TriggerDAGRunPayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -172,7 +172,6 @@ class IntermediateTIState(str, Enum):
     RESTARTING = "restarting"
     UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
-    UPSTREAM_FAILED = "upstream_failed"
     DEFERRED = "deferred"
 
 
@@ -310,6 +309,7 @@ class TerminalStateNonSuccess(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"
+    UPSTREAM_FAILED = "upstream_failed"
 
 
 class TriggerDAGRunPayload(BaseModel):
@@ -416,6 +416,7 @@ class TerminalTIState(str, Enum):
     SUCCESS = "success"
     FAILED = "failed"
     SKIPPED = "skipped"
+    UPSTREAM_FAILED = "upstream_failed"
     REMOVED = "removed"
 
 

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -306,10 +306,10 @@ class TerminalStateNonSuccess(str, Enum):
     TaskInstance states that can be reported without extra information.
     """
 
+    TERMINAL_STATE_NON_SUCCESS_REMOVED = "TerminalStateNonSuccess.REMOVED"
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"
-    UPSTREAM_FAILED = "upstream_failed"
 
 
 class TriggerDAGRunPayload(BaseModel):


### PR DESCRIPTION
PR for #52999:

Move UPSTREAM_FAILED task instance state from intermediate to terminal state class and add tests to validate that state class relationships remain consistent (failed + success = terminal, terminal + intermediate = all task states).

Thoughts on this change? Motivated from #51719, @eladkal's comment:

> there is no protection here against possible future addition of new state to task instance. For example we are discussing #12199
> 
> I suggest to add defensive test around adding more states so we'll know to modify code here or maybe we can consider adding more classes to categorized states similar to
> 
> https://github.com/apache/airflow/blob/083e03a909f923527d9d2f8d978962ddfb6e5b7a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py#L415-L419

Wanted to make this a separate PR for it since its scope it quite different.

Most likely this code will break some integration tests because there's various places that depend on the task instance states in interesting ways, but wanted to field feedback first before fixing them.