### PR TITLE
Upgrade singledispatch usages to Python 3.10

### DIFF
--- a/airflow-core/src/airflow/models/baseoperator.py
+++ b/airflow-core/src/airflow/models/baseoperator.py
@@ -29,9 +29,10 @@ import operator
 from collections.abc import Collection, Iterable, Iterator
 from datetime import datetime
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 # Keeping this file at all is a temp thing as we migrate the repo to the task sdk as the base, but to keep
 # main working and useful for others to develop against we use the TaskSDK here but keep this file around
@@ -60,9 +61,8 @@ from airflow.utils import timezone
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
     from airflow.models.dag import DAG as SchedulerDAG
+    from airflow.models.expandinput import SchedulerExpandInput
     from airflow.models.operator import Operator
     from airflow.sdk import BaseOperatorLink, Context
     from airflow.sdk.definitions._internal.node import DAGNode
@@ -423,100 +423,68 @@ class BaseOperator(TaskSDKBaseOperator):
         """
         return self.start_trigger_args
 
-    if TYPE_CHECKING:
+    @singledispatchmethod
+    @classmethod
+    def get_mapped_ti_count(cls, task: DAGNode, run_id: str, *, session: Session) -> int:
+        """
+        Return the number of mapped TaskInstances that can be created at run time.
 
-        @classmethod
-        def get_mapped_ti_count(
-            cls, node: DAGNode | MappedTaskGroup, run_id: str, *, session: Session
-        ) -> int:
-            """
-            Return the number of mapped TaskInstances that can be created at run time.
+        This considers both literal and non-literal mapped arguments, and the
+        result is therefore available when all depended tasks have finished. The
+        return value should be identical to ``parse_time_mapped_ti_count`` if
+        all mapped arguments are literal.
 
-            This considers both literal and non-literal mapped arguments, and the
-            result is therefore available when all depended tasks have finished. The
-            return value should be identical to ``parse_time_mapped_ti_count`` if
-            all mapped arguments are literal.
+        :raise NotFullyPopulated: If upstream tasks are not all complete yet.
+        :raise NotMapped: If the operator is neither mapped, nor has any parent
+            mapped task groups.
+        :return: Total number of mapped TIs this task should have.
+        """
+        raise NotImplementedError(f"Not implemented for {type(task)}")
 
-            :raise NotFullyPopulated: If upstream tasks are not all complete yet.
-            :raise NotMapped: If the operator is neither mapped, nor has any parent
-                mapped task groups.
-            :return: Total number of mapped TIs this task should have.
-            """
-    else:
+    @get_mapped_ti_count.register
+    @classmethod
+    def _(cls, task: TaskSDKAbstractOperator, run_id: str, *, session: Session) -> int:
+        group = task.get_closest_mapped_task_group()
+        if group is None:
+            raise NotMapped()
+        return cls.get_mapped_ti_count(group, run_id, session=session)
 
-        @singledispatchmethod
-        @classmethod
-        def get_mapped_ti_count(cls, task: DAGNode, run_id: str, *, session: Session) -> int:
-            raise NotImplementedError(f"Not implemented for {type(task)}")
+    @get_mapped_ti_count.register
+    @classmethod
+    def _(cls, task: MappedOperator, run_id: str, *, session: Session) -> int:
+        # TODO (GH-52141): 'task' here should be scheduler-bound and returns scheduler expand input.
+        exp_input = cast("SchedulerExpandInput", task._get_specified_expand_input())
+        current_count = exp_input.get_total_map_length(run_id, session=session)
 
-        # https://github.com/python/cpython/issues/86153
-        # While we support Python 3.9 we can't rely on the type hint, we need to pass the type explicitly to
-        # register.
-        @get_mapped_ti_count.register(TaskSDKAbstractOperator)
-        @classmethod
-        def _(cls, task: TaskSDKAbstractOperator, run_id: str, *, session: Session) -> int:
-            group = task.get_closest_mapped_task_group()
-            if group is None:
-                raise NotMapped()
-            return cls.get_mapped_ti_count(group, run_id, session=session)
+        group = task.get_closest_mapped_task_group()
+        if group is None:
+            return current_count
+        parent_count = cls.get_mapped_ti_count(group, run_id, session=session)
+        return parent_count * current_count
 
-        @get_mapped_ti_count.register(MappedOperator)
-        @classmethod
-        def _(cls, task: MappedOperator, run_id: str, *, session: Session) -> int:
-            from airflow.serialization.serialized_objects import BaseSerialization, _ExpandInputRef
+    @get_mapped_ti_count.register
+    @classmethod
+    def _(cls, group: TaskGroup, run_id: str, *, session: Session) -> int:
+        """
+        Return the number of instances a task in this group should be mapped to at run time.
 
-            exp_input = task._get_specified_expand_input()
-            if isinstance(exp_input, _ExpandInputRef):
-                exp_input = exp_input.deref(task.dag)
-            # TODO: TaskSDK This is only needed to support `dag.test()` etc until we port it over to use the
-            # task sdk runner.
-            if not hasattr(exp_input, "get_total_map_length"):
-                exp_input = _ExpandInputRef(
-                    type(exp_input).EXPAND_INPUT_TYPE,
-                    BaseSerialization.deserialize(BaseSerialization.serialize(exp_input.value)),
-                )
-                exp_input = exp_input.deref(task.dag)
+        This considers both literal and non-literal mapped arguments, and the
+        result is therefore available when all depended tasks have finished. The
+        return value should be identical to ``parse_time_mapped_ti_count`` if
+        all mapped arguments are literal.
 
-            current_count = exp_input.get_total_map_length(run_id, session=session)
+        If this group is inside mapped task groups, all the nested counts are
+        multiplied and accounted.
 
-            group = task.get_closest_mapped_task_group()
-            if group is None:
-                return current_count
-            parent_count = cls.get_mapped_ti_count(group, run_id, session=session)
-            return parent_count * current_count
+        :raise NotFullyPopulated: If upstream tasks are not all complete yet.
+        :return: Total number of mapped TIs this task should have.
+        """
 
-        @get_mapped_ti_count.register(TaskGroup)
-        @classmethod
-        def _(cls, group: TaskGroup, run_id: str, *, session: Session) -> int:
-            """
-            Return the number of instances a task in this group should be mapped to at run time.
+        def iter_mapped_task_group_lengths(group) -> Iterator[int]:
+            while group is not None:
+                if isinstance(group, MappedTaskGroup):
+                    exp_input = group._expand_input
+                    yield exp_input.get_total_map_length(run_id, session=session)
+                group = group.parent_group
 
-            This considers both literal and non-literal mapped arguments, and the
-            result is therefore available when all depended tasks have finished. The
-            return value should be identical to ``parse_time_mapped_ti_count`` if
-            all mapped arguments are literal.
-
-            If this group is inside mapped task groups, all the nested counts are
-            multiplied and accounted.
-
-            :raise NotFullyPopulated: If upstream tasks are not all complete yet.
-            :return: Total number of mapped TIs this task should have.
-            """
-            from airflow.serialization.serialized_objects import BaseSerialization, _ExpandInputRef
-
-            def iter_mapped_task_group_lengths(group) -> Iterator[int]:
-                while group is not None:
-                    if isinstance(group, MappedTaskGroup):
-                        exp_input = group._expand_input
-                        # TODO: TaskSDK This is only needed to support `dag.test()` etc until we port it over to use the
-                        # task sdk runner.
-                        if not hasattr(exp_input, "get_total_map_length"):
-                            exp_input = _ExpandInputRef(
-                                type(exp_input).EXPAND_INPUT_TYPE,
-                                BaseSerialization.deserialize(BaseSerialization.serialize(exp_input.value)),
-                            )
-                            exp_input = exp_input.deref(group.dag)
-                        yield exp_input.get_total_map_length(run_id, session=session)
-                    group = group.parent_group
-
-            return functools.reduce(operator.mul, iter_mapped_task_group_lengths(group))
+        return functools.reduce(operator.mul, iter_mapped_task_group_lengths(group))


### PR DESCRIPTION
Remove leftover code for dag.test() compat.

Now that we've removed 3.9 support, it is also possible to simply some single-dispatch regiatration code. Unfortunately this actually requires us moving some imports *out of* the type-checking block since those types are now inspected at runtime. I'm not entirely sure this is a net improvement. Discussion needed.