### PR TITLE
Deserialize response of `get_all` when we call `XCom.get_all`

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -309,13 +309,6 @@ class BaseXCom:
 
         result = deserialize(msg.root)
         if not result:
-            log.warning(
-                "No XCom value(s) found; defaulting to None.",
-                key=key,
-                dag_id=dag_id,
-                task_id=task_id,
-                run_id=run_id,
-            )
             return None
         return result
 

--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -306,7 +306,9 @@ class BaseXCom:
         if not isinstance(msg, XComSequenceSliceResult):
             raise TypeError(f"Expected XComSequenceSliceResult, received: {type(msg)} {msg}")
 
-        return msg.root
+        from airflow.serialization.serde import deserialize
+
+        return deserialize(msg.root)
 
     @staticmethod
     def serialize_value(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -351,17 +351,19 @@ class RuntimeTaskInstance(TaskInstance):
 
         # If map_indexes is not specified, pull xcoms from all map indexes for each task
         if isinstance(map_indexes, ArgNotSet):
-            xcoms = [
-                value
-                for t_id in task_ids
-                for value in XCom.get_all(
+            xcoms: list[Any] = []
+            for t_id in task_ids:
+                values = XCom.get_all(
                     run_id=run_id,
                     key=key,
                     task_id=t_id,
                     dag_id=dag_id,
                 )
-            ]
 
+                if values is None:
+                    xcoms.append(None)
+                else:
+                    xcoms.extend(values)
             # For single task pulling from unmapped task, return single value
             if single_task_requested and len(xcoms) == 1:
                 return xcoms[0]

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1512,6 +1512,54 @@ class TestRuntimeTaskInstance:
                 assert mock_get_one.called
                 assert not mock_get_all.called
 
+    @pytest.mark.parametrize(
+        "api_return_value",
+        [
+            pytest.param(("data", "test_value"), id="api returns tuple"),
+            pytest.param({"data": "test_value"}, id="api returns dict"),
+            pytest.param(None, id="api returns None, no xcom found"),
+        ],
+    )
+    def test_xcom_pull_with_no_map_index(
+        self,
+        api_return_value,
+        create_runtime_ti,
+        mock_supervisor_comms,
+    ):
+        """
+        Test xcom_pull when map_indexes is not specified, so that XCom.get_all is called.
+        The test also tests if the response is deserialized and returned.
+        """
+        test_task_id = "pull_task"
+        task = BaseOperator(task_id=test_task_id)
+        runtime_ti = create_runtime_ti(task=task)
+
+        ser_value = BaseXCom.serialize_value(api_return_value)
+
+        def mock_send_side_effect(*args, **kwargs):
+            msg = kwargs.get("msg") or args[0]
+            if isinstance(msg, GetXComSequenceSlice):
+                return XComSequenceSliceResult(root=[ser_value])
+            return XComResult(key="test_key", value=None)
+
+        mock_supervisor_comms.send.side_effect = mock_send_side_effect
+        result = runtime_ti.xcom_pull(key="test_key", task_ids="task_a")
+
+        # if the API returns a tuple or dict, the below assertion assures that the value is deserialized correctly by XCom.get_all
+        assert result == api_return_value
+
+        mock_supervisor_comms.send.assert_called_once_with(
+            msg=GetXComSequenceSlice(
+                key="test_key",
+                dag_id=runtime_ti.dag_id,
+                run_id=runtime_ti.run_id,
+                task_id="task_a",
+                start=None,
+                stop=None,
+                step=None,
+            ),
+        )
+
     def test_get_param_from_context(
         self, mocked_parse, make_ti_context, mock_supervisor_comms, create_runtime_ti
     ):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/53018

The data returned from the api comes in without deserialisation as the contract between task sdk and the api server is simple: json objects.

So the returned data must be deserialised.

DAG used:
```
from airflow.sdk import DAG
from airflow.providers.standard.operators.python import PythonOperator

from datetime import datetime, timedelta

twos_day = datetime.now() - timedelta(days=2)

def native_obj_false(x, y):
    return x, y


def check_type(**context):
    ti = context["ti"]
    pulled_value = ti.xcom_pull(
        task_ids="py_native_obj_false", key="return_value"
    )
    print(f"This is the datatype for the pulled xcom value: {type(pulled_value)}")
    print(f"This is datatype for the 0th index of the xcom value: {type(pulled_value[0])}")
    print(f"This is datatype for the 1st index of the xcom value: {type(pulled_value[0])}")
    assert type(pulled_value[0]) == str and type(pulled_value[1]) == str


default_args = {"owner": "airflow", "depends_on_past": True}

with DAG(
    dag_id="native_obj_false",
    start_date=twos_day,
    schedule=None,
    # when set to false only the __str__() method is returned
    render_template_as_native_obj=False,
    tags=["core", "negative"],
    user_defined_macros={
        "says_hi": "Hello World!",
        "the_planets": [
            "Mercury",
            "Venus",
            "Earth",
            "Mars",
            "Jupiter",
            "Saturn",
            "Neptune",
        ],
        "ints": [1, 2, 3, 4, 5],
    },
) as dag:

    t1 = PythonOperator(
        task_id="py_native_obj_false",
        python_callable=native_obj_false,
        op_args=["{{ says_hi }}", "{{ ints }}"],
    )

    t2 = PythonOperator(
        task_id="check_xcoms",
        python_callable=check_type,
    )

t1 >> t2

```

Before:
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/d67e367a-926c-43b6-9e50-ee9e90ae0305" />


After changes, dag run:
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/1a45ce06-08ad-4d72-9c93-d25ef8d8b49c" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
