### PR TITLE
Fix log for skipped tasks

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -6608,7 +6608,7 @@ paths:
         required: true
         schema:
           type: integer
-          exclusiveMinimum: 0
+          minimum: 0
           title: Try Number
       - name: full_content
         in: query

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
@@ -22,7 +22,7 @@ import textwrap
 
 from fastapi import Depends, HTTPException, Request, Response, status
 from itsdangerous import BadSignature, URLSafeSerializer
-from pydantic import PositiveInt
+from pydantic import NonNegativeInt, PositiveInt
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
@@ -75,7 +75,7 @@ def get_log(
     dag_id: str,
     dag_run_id: str,
     task_id: str,
-    try_number: PositiveInt,
+    try_number: NonNegativeInt,
     accept: HeaderAcceptJsonOrNdjson,
     request: Request,
     dag_bag: DagBagDep,

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -91,7 +91,7 @@ export const Logs = () => {
     logLevelFilters,
     sourceFilters,
     taskInstance,
-    tryNumber: tryNumber === 0 ? 1 : tryNumber,
+    tryNumber,
   });
 
   const externalLogName = useConfig("external_log_name") as string;

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -482,6 +482,15 @@ class FileTaskHandler(logging.Handler):
         """
         if try_number is None:
             try_number = task_instance.try_number
+
+        if task_instance.state == TaskInstanceState.SKIPPED:
+            logs = [
+                StructuredLogMessage(  # type: ignore[call-arg]
+                    event="Task was skipped, no logs available."
+                )
+            ]
+            return logs, {"end_of_log": True}
+
         if try_number is None or try_number < 1:
             logs = [
                 StructuredLogMessage(  # type: ignore[call-arg]


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/53002

Following: https://github.com/apache/airflow/pull/51592/ we are now filtering on the `try_number`.

Skipped task have a try number of 0 and UI was defaulting to 1, the skipped task couldn't be found and this cause the 404. Before that related PR, we would find the TI, and request to fetch logs with try_number 1 for a Skipped tasks, that would end up in an invalid url, without hostname, which wasn't great either something like this:
![Screenshot 2025-07-08 at 13 49 42](https://github.com/user-attachments/assets/1a40b3ef-183e-4d80-bf04-77f0396a3a17)

Only the `Empty Operator` had a special case handling:
![Screenshot 2025-07-08 at 13 50 36](https://github.com/user-attachments/assets/06cef70f-e5ff-4e69-bcd7-9a0bfbbd3d67)



Now the UI tries to fetch the `TaskInstance.try_number`, even if this means that try_number is 0 because the TaskInstance.state is 'skipped'. Allow the backend to take `0` as a value. The TI will be found and the `log_reader`will then try to read log and return early with a validation check:
![Screenshot 2025-07-08 at 13 40 39](https://github.com/user-attachments/assets/ff91cb41-ff30-448f-af2b-144c3efc76b7)

This is enough to not make the UI not crash. And display a useful message. That's for core log reader. Other log reader will fail with a simple "Error fetching the logs. Try number {try_number} is invalid." (google cloud logs) or any other check implemented in the provider.

We could probably also do this in the google provider, to give a better message. (Separate PR because it's provider related)
