### PR TITLE
Fix error re <a> cannot appear as descedent of <a>

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
@@ -68,7 +68,7 @@ export const TaskNames = ({ nodes }: Props) => {
     >
       {node.isGroup ? (
         <Flex alignItems="center">
-          <Link data-testid={node.id} display="inline">
+          <Link asChild data-testid={node.id} display="inline">
             <RouterLink
               replace
               to={{


### PR DESCRIPTION
This was because RouterLink was nested in Link

It only showed up as warning in browser inspect console so not huge deal.  But, now it should be gone.