### PR TITLE
Remove redundant macros integration in Scheduler Context

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -84,7 +84,6 @@ from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.xcom import LazyXComSelectSequence, XComModel
-from airflow.plugins_manager import integrate_macros_plugins
 from airflow.settings import task_instance_mutation_hook
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
@@ -1906,7 +1905,6 @@ class TaskInstance(Base, LoggingMixin):
         if not session:
             session = settings.Session()
 
-        from airflow import macros
         from airflow.models.abstractoperator import NotMapped
         from airflow.models.baseoperator import BaseOperator
         from airflow.sdk.api.datamodels._generated import (
@@ -1921,8 +1919,6 @@ class TaskInstance(Base, LoggingMixin):
             OutletEventAccessors,
             VariableAccessor,
         )
-
-        integrate_macros_plugins()
 
         task = self.task
         if TYPE_CHECKING:
@@ -1999,7 +1995,6 @@ class TaskInstance(Base, LoggingMixin):
             {
                 "outlet_events": OutletEventAccessors(),
                 "inlet_events": InletEventsAccessors(task.inlets),
-                "macros": macros,
                 "params": validated_params,
                 "prev_data_interval_start_success": get_prev_data_interval_start_success(),
                 "prev_data_interval_end_success": get_prev_data_interval_end_success(),


### PR DESCRIPTION
`macros` key is already available via `RuntimeTaskInstance.get_template_context`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
