### PR TITLE
Run Task failure callbacks on DAG Processor when task is externally killed

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -301,7 +301,7 @@ class TIRunContext(BaseModel):
     dag_run: DagRun
     """DAG run information for the task instance."""
 
-    task_reschedule_count: Annotated[int, Field(default=0)]
+    task_reschedule_count: int = 0
     """How many times the task has been rescheduled."""
 
     max_tries: int
@@ -327,7 +327,7 @@ class TIRunContext(BaseModel):
     xcom_keys_to_clear: Annotated[list[str], Field(default_factory=list)]
     """List of Xcom keys that need to be cleared and purged on by the worker."""
 
-    should_retry: bool
+    should_retry: bool = False
     """If the ti encounters an error, whether it should enter retry or failed state."""
 
 

--- a/airflow-core/src/airflow/callbacks/callback_requests.py
+++ b/airflow-core/src/airflow/callbacks/callback_requests.py
@@ -61,6 +61,8 @@ class TaskCallbackRequest(BaseCallbackRequest):
     """Simplified Task Instance representation"""
     task_callback_type: TaskInstanceState | None = None
     """Whether on success, on failure, on retry"""
+    context_from_server: ti_datamodel.TIRunContext | None = None
+    """Task execution context from the Server"""
     type: Literal["TaskCallbackRequest"] = "TaskCallbackRequest"
 
     @property

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -262,6 +262,7 @@ def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: F
             dag_id=request.ti.dag_id,
             task_id=request.ti.task_id,
             run_id=request.ti.run_id,
+            ti_id=request.ti.id,
         )
         return
 

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -16,11 +16,12 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import importlib
 import os
 import sys
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, BinaryIO, ClassVar, Literal
 
@@ -45,9 +46,11 @@ from airflow.sdk.execution_time.comms import (
     VariableResult,
 )
 from airflow.sdk.execution_time.supervisor import WatchedSubprocess
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.stats import Stats
 from airflow.utils.file import iter_airflow_imports
+from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger
@@ -201,10 +204,7 @@ def _execute_callbacks(
     for request in callback_requests:
         log.debug("Processing Callback Request", request=request.to_json())
         if isinstance(request, TaskCallbackRequest):
-            raise NotImplementedError(
-                "Haven't coded Task callback yet - https://github.com/apache/airflow/issues/44354!"
-            )
-            # _execute_task_callbacks(dagbag, request)
+            _execute_task_callbacks(dagbag, request, log)
         if isinstance(request, DagCallbackRequest):
             _execute_dag_callbacks(dagbag, request, log)
 
@@ -236,6 +236,66 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
         except Exception:
             log.exception("Callback failed", dag_id=request.dag_id)
             Stats.incr("dag.callback_exceptions", tags={"dag_id": request.dag_id})
+
+
+def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: FilteringBoundLogger) -> None:
+    if not request.is_failure_callback:
+        log.warning(
+            "Task callback requested but is not a failure callback",
+            dag_id=request.ti.dag_id,
+            task_id=request.ti.task_id,
+            run_id=request.ti.run_id,
+        )
+        return
+
+    dag = dagbag.dags[request.ti.dag_id]
+    task = dag.get_task(request.ti.task_id)
+
+    if request.task_callback_type is TaskInstanceState.UP_FOR_RETRY:
+        callbacks = task.on_retry_callback
+    else:
+        callbacks = task.on_failure_callback
+
+    if not callbacks:
+        log.warning(
+            "Callback requested but no callback found",
+            dag_id=request.ti.dag_id,
+            task_id=request.ti.task_id,
+            run_id=request.ti.run_id,
+        )
+        return
+
+    callbacks = callbacks if isinstance(callbacks, Sequence) else [callbacks]
+    ctx_from_server = request.context_from_server
+
+    if ctx_from_server is not None:
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **request.ti.model_dump(exclude_unset=True),
+            task=task,
+            _ti_context_from_server=ctx_from_server,
+            max_tries=ctx_from_server.max_tries,
+        )
+    else:
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **request.ti.model_dump(exclude_unset=True),
+            task=task,
+        )
+    context = runtime_ti.get_template_context()
+
+    def get_callback_representation(callback):
+        with contextlib.suppress(AttributeError):
+            return callback.__name__
+        with contextlib.suppress(AttributeError):
+            return callback.__class__.__name__
+        return callback
+
+    for idx, callback in enumerate(callbacks):
+        callback_repr = get_callback_representation(callback)
+        log.info("Executing Task callback at index %d: %s", idx, callback_repr)
+        try:
+            callback(context)
+        except Exception:
+            log.exception("Error in callback at index %d: %s", idx, callback_repr)
 
 
 def in_process_api_server() -> InProcessExecutionAPI:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -38,6 +38,7 @@ from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, sele
 from sqlalchemy.sql import expression
 
 from airflow import settings
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
 from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallbackRequest
 from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
@@ -927,10 +928,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         bundle_version=ti.dag_version.bundle_version,
                         ti=ti,
                         msg=msg,
+                        context_from_server=TIRunContext(
+                            dag_run=ti.dag_run,
+                            max_tries=ti.max_tries,
+                            variables=[],
+                            connections=[],
+                            xcom_keys_to_clear=[],
+                        ),
                     )
                     executor.send_callback(request)
-                else:
-                    ti.handle_failure(error=msg, session=session)
+                ti.handle_failure(error=msg, session=session)
 
         return len(event_buffer)
 
@@ -2283,6 +2290,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 bundle_version=ti.dag_run.bundle_version,
                 ti=ti,
                 msg=str(task_instance_heartbeat_timeout_message_details),
+                context_from_server=TIRunContext(
+                    dag_run=ti.dag_run,
+                    max_tries=ti.max_tries,
+                    variables=[],
+                    connections=[],
+                    xcom_keys_to_clear=[],
+                ),
             )
             session.add(
                 Log(

--- a/airflow-core/tests/unit/callbacks/test_callback_requests.py
+++ b/airflow-core/tests/unit/callbacks/test_callback_requests.py
@@ -29,7 +29,7 @@ from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.utils import timezone
-from airflow.utils.state import State
+from airflow.utils.state import State, TaskInstanceState
 
 pytestmark = pytest.mark.db_test
 
@@ -87,3 +87,30 @@ class TestCallbackRequest:
         json_str = input.to_json()
         result = TaskCallbackRequest.from_json(json_str)
         assert input == result
+
+    @pytest.mark.parametrize(
+        "task_callback_type,expected_is_failure",
+        [
+            (None, True),
+            (TaskInstanceState.FAILED, True),
+            (TaskInstanceState.UP_FOR_RETRY, True),
+            (TaskInstanceState.UPSTREAM_FAILED, True),
+            (TaskInstanceState.SUCCESS, False),
+            (TaskInstanceState.RUNNING, False),
+        ],
+    )
+    def test_is_failure_callback_property(
+        self, task_callback_type, expected_is_failure, create_task_instance
+    ):
+        """Test is_failure_callback property with different task callback types"""
+        ti = create_task_instance()
+
+        request = TaskCallbackRequest(
+            filepath="filepath",
+            ti=ti,
+            bundle_name="testing",
+            bundle_version=None,
+            task_callback_type=task_callback_type,
+        )
+
+        assert request.is_failure_callback == expected_is_failure

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -21,6 +21,7 @@ import inspect
 import pathlib
 import sys
 import textwrap
+import uuid
 from collections.abc import Callable
 from socket import socketpair
 from typing import TYPE_CHECKING
@@ -31,24 +32,27 @@ import structlog
 from pydantic import TypeAdapter
 
 from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+    TaskInstance as TIDataModel,
+    TIRunContext,
+)
 from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest, TaskCallbackRequest
-from airflow.configuration import conf
 from airflow.dag_processing.processor import (
     DagFileParseRequest,
     DagFileParsingResult,
     DagFileProcessorProcess,
+    _execute_task_callbacks,
     _parse_file,
     _pre_import_airflow_modules,
 )
-from airflow.models import DagBag, TaskInstance
+from airflow.models import DagBag, DagRun
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.serialized_dag import SerializedDagModel
+from airflow.sdk import DAG
 from airflow.sdk.api.client import Client
 from airflow.sdk.execution_time import comms
 from airflow.utils import timezone
 from airflow.utils.session import create_session
-from airflow.utils.state import DagRunState, TaskInstanceState
-from airflow.utils.types import DagRunTriggeredByType, DagRunType
+from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars, env_vars
 
@@ -92,42 +96,6 @@ class TestDagFileProcessor:
                 callback_requests=callback_requests or [],
             ),
             log=structlog.get_logger(),
-        )
-
-    @pytest.mark.xfail(reason="TODO: AIP-72")
-    @pytest.mark.parametrize(
-        ["has_serialized_dag"],
-        [pytest.param(True, id="dag_in_db"), pytest.param(False, id="no_dag_found")],
-    )
-    @patch.object(TaskInstance, "handle_failure")
-    def test_execute_on_failure_callbacks_without_dag(self, mock_ti_handle_failure, has_serialized_dag):
-        dagbag = DagBag(dag_folder="/dev/null", include_examples=True, read_dags_from_db=False)
-        with create_session() as session:
-            session.query(TaskInstance).delete()
-            dag = dagbag.get_dag("example_branch_operator")
-            assert dag is not None
-            dag.sync_to_db()
-            dagrun = dag.create_dagrun(
-                state=DagRunState.RUNNING,
-                logical_date=DEFAULT_DATE,
-                run_type=DagRunType.SCHEDULED,
-                data_interval=dag.infer_automated_data_interval(DEFAULT_DATE),
-                run_after=DEFAULT_DATE,
-                triggered_by=DagRunTriggeredByType.TEST,
-                session=session,
-            )
-            task = dag.get_task(task_id="run_this_first")
-            ti = TaskInstance(task, run_id=dagrun.run_id, state=TaskInstanceState.QUEUED)
-            session.add(ti)
-
-            if has_serialized_dag:
-                assert SerializedDagModel.write_dag(dag, bundle_name="testing", session=session) is True
-                session.flush()
-
-        requests = [TaskCallbackRequest(full_filepath="A", ti=ti, msg="Message")]
-        self._process_file(dag.fileloc, requests)
-        mock_ti_handle_failure.assert_called_once_with(
-            error="Message", test_mode=conf.getboolean("core", "unit_test_mode"), session=session
         )
 
     def test_dagbag_import_errors_captured(self, spy_agency: SpyAgency):
@@ -553,10 +521,7 @@ def test_parse_file_with_dag_callbacks(spy_agency):
     assert called is True
 
 
-@pytest.mark.xfail(reason="TODO: AIP-72: Task level callbacks not yet supported")
 def test_parse_file_with_task_callbacks(spy_agency):
-    from airflow import DAG
-
     called = False
 
     def on_failure(context):
@@ -571,15 +536,283 @@ def test_parse_file_with_task_callbacks(spy_agency):
 
     spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
 
+    # Create a minimal TaskInstance for the request
+    ti_data = TIDataModel(
+        id=uuid.uuid4(),
+        dag_id="a",
+        task_id="b",
+        run_id="test_run",
+        map_index=-1,
+        try_number=1,
+        dag_version_id=uuid.uuid4(),
+    )
+
     requests = [
         TaskCallbackRequest(
             filepath="A",
             msg="Message",
-            ti=None,
+            ti=ti_data,
             bundle_name="testing",
             bundle_version=None,
         )
     ]
-    _parse_file(DagFileParseRequest(file="A", callback_requests=requests), log=structlog.get_logger())
+    _parse_file(
+        DagFileParseRequest(file="A", bundle_path="test", callback_requests=requests),
+        log=structlog.get_logger(),
+    )
 
     assert called is True
+
+
+class TestExecuteTaskCallbacks:
+    """Test the _execute_task_callbacks function"""
+
+    def test_execute_task_callbacks_failure_callback(self, spy_agency):
+        """Test _execute_task_callbacks executes failure callbacks"""
+        called = False
+        context_received = None
+
+        def on_failure(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with DAG(dag_id="test_dag") as dag:
+            BaseOperator(task_id="test_task", on_failure_callback=on_failure)
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        request = TaskCallbackRequest(
+            filepath="test.py",
+            msg="Task failed",
+            ti=ti_data,
+            bundle_name="testing",
+            bundle_version=None,
+            task_callback_type=TaskInstanceState.FAILED,
+        )
+
+        log = structlog.get_logger()
+        _execute_task_callbacks(dagbag, request, log)
+
+        assert called is True
+        assert context_received is not None
+        assert context_received["dag"] == dag
+        assert "ti" in context_received
+
+    def test_execute_task_callbacks_retry_callback(self, spy_agency):
+        """Test _execute_task_callbacks executes retry callbacks"""
+        called = False
+        context_received = None
+
+        def on_retry(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with DAG(dag_id="test_dag") as dag:
+            BaseOperator(task_id="test_task", on_retry_callback=on_retry)
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+            state=TaskInstanceState.UP_FOR_RETRY,
+        )
+
+        request = TaskCallbackRequest(
+            filepath="test.py",
+            msg="Task retrying",
+            ti=ti_data,
+            bundle_name="testing",
+            bundle_version=None,
+            task_callback_type=TaskInstanceState.UP_FOR_RETRY,
+        )
+
+        log = structlog.get_logger()
+        _execute_task_callbacks(dagbag, request, log)
+
+        assert called is True
+        assert context_received is not None
+        assert context_received["dag"] == dag
+        assert "ti" in context_received
+
+    def test_execute_task_callbacks_with_context_from_server(self, spy_agency):
+        """Test _execute_task_callbacks with context_from_server creates full context"""
+        called = False
+        context_received = None
+
+        def on_failure(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with DAG(dag_id="test_dag") as dag:
+            BaseOperator(task_id="test_task", on_failure_callback=on_failure)
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        dag_run = DagRun(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=timezone.utcnow(),
+            start_date=timezone.utcnow(),
+            run_type="manual",
+        )
+        dag_run.run_after = timezone.utcnow()
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context_from_server = TIRunContext(
+            dag_run=dag_run,
+            max_tries=3,
+        )
+
+        request = TaskCallbackRequest(
+            filepath="test.py",
+            msg="Task failed",
+            ti=ti_data,
+            bundle_name="testing",
+            bundle_version=None,
+            task_callback_type=TaskInstanceState.FAILED,
+            context_from_server=context_from_server,
+        )
+
+        log = structlog.get_logger()
+        _execute_task_callbacks(dagbag, request, log)
+
+        assert called is True
+        assert context_received is not None
+        # When context_from_server is provided, we get a full RuntimeTaskInstance context
+        assert "dag_run" in context_received
+        assert "logical_date" in context_received
+
+    def test_execute_task_callbacks_not_failure_callback(self, spy_agency):
+        """Test _execute_task_callbacks when request is not a failure callback"""
+        called = False
+
+        def on_failure(context):
+            nonlocal called
+            called = True
+
+        with DAG(dag_id="test_dag") as dag:
+            BaseOperator(task_id="test_task", on_failure_callback=on_failure)
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+            state=TaskInstanceState.SUCCESS,
+        )
+
+        request = TaskCallbackRequest(
+            filepath="test.py",
+            msg="Task succeeded",
+            ti=ti_data,
+            bundle_name="testing",
+            bundle_version=None,
+            task_callback_type=TaskInstanceState.SUCCESS,
+        )
+
+        log = structlog.get_logger()
+        _execute_task_callbacks(dagbag, request, log)
+
+        # Should not call the callback since it's not a failure callback
+        assert called is False
+
+    def test_execute_task_callbacks_multiple_callbacks(self, spy_agency):
+        """Test _execute_task_callbacks with multiple callbacks"""
+        call_count = 0
+
+        def on_failure_1(context):
+            nonlocal call_count
+            call_count += 1
+
+        def on_failure_2(context):
+            nonlocal call_count
+            call_count += 1
+
+        with DAG(dag_id="test_dag") as dag:
+            BaseOperator(task_id="test_task", on_failure_callback=[on_failure_1, on_failure_2])
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+            state=TaskInstanceState.FAILED,
+        )
+
+        request = TaskCallbackRequest(
+            filepath="test.py",
+            msg="Task failed",
+            ti=ti_data,
+            bundle_name="testing",
+            bundle_version=None,
+            task_callback_type=TaskInstanceState.FAILED,
+        )
+
+        log = structlog.get_logger()
+        _execute_task_callbacks(dagbag, request, log)
+
+        assert call_count == 2

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -519,7 +519,7 @@ class TIRunContext(BaseModel):
     next_method: Annotated[str | None, Field(title="Next Method")] = None
     next_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Next Kwargs")] = None
     xcom_keys_to_clear: Annotated[list[str] | None, Field(title="Xcom Keys To Clear")] = None
-    should_retry: Annotated[bool, Field(title="Should Retry")]
+    should_retry: Annotated[bool | None, Field(title="Should Retry")] = False
 
 
 class TITerminalStatePayload(BaseModel):


### PR DESCRIPTION


Until https://github.com/apache/airflow/issues/44354 is implemented, tasks killed externally or when supervisor process dies unexpectedly, users have no way of knowing this happened.

This has been a blocker for Airflow 3.0 adoption for some:

- https://github.com/apache/airflow/issues/44354
- https://apache-airflow.slack.com/archives/C07813CNKA8/p1751057525231389

https://github.com/apache/airflow/issues/44354 is more involved and we might not get to it for Airflow 3.1 -- so this is a good fix until then similar to how we run Dag Run callback.

Ran a example DAG:

```py
import time

from airflow.sdk import dag
from airflow.providers.standard.operators.python import PythonOperator
@dag
def my_dag():

    def fail_cb(context):
        print("From inside the callback")
        print(context)

    def n_s():
        time.sleep(3000)

    t = PythonOperator(
        task_id="my_task",
        python_callable=n_s,
        on_failure_callback=fail_cb
    )

    t

my_dag()

```


DAG Processor Logs after I killed the Supervisor & task process when the task is running:

```
{"timestamp":"2025-07-08T22:48:31.568171Z","level":"info","event":"{'dag': <DAG: my_dag>, 'inlets': [], 'map_index_template': None, 'outlets': [], 'run_id': 'manual__2025-07-08T22:44:37.346022+00:00', 'task': <Task(PythonOperator): my_task>, 'task_instance': RuntimeTaskInstance(id=UUID('0197ec36-656a-75b7-814a-c409886945e2'), task_id='my_task', dag_id='my_dag', run_id='manual__2025-07-08T22:44:37.346022+00:00', try_number=2, dag_version_id=UUID('0197ec0c-669e-7e05-80e3-97c3549dbfda'), map_index=-1, hostname='c9bd6c415dbf', context_carrier={}, task=<Task(PythonOperator): my_task>, max_tries=0, end_date=None, state=None, is_mapped=None, rendered_map_index=None, log_url=None), 'ti': RuntimeTaskInstance(id=UUID('0197ec36-656a-75b7-814a-c409886945e2'), task_id='my_task', dag_id='my_dag', run_id='manual__2025-07-08T22:44:37.346022+00:00', try_number=2, dag_version_id=UUID('0197ec0c-669e-7e05-80e3-97c3549dbfda'), map_index=-1, hostname='c9bd6c415dbf', context_carrier={}, task=<Task(PythonOperator): my_task>, max_tries=0, end_date=None, state=None, is_mapped=None, rendered_map_index=None, log_url=None), 'outlet_events': <airflow.sdk.execution_time.context.OutletEventAccessors object at 0xffff6cb48880>, 'inlet_events': InletEventsAccessors(_inlets=[], _assets={}, _asset_aliases={}), 'macros': <MacrosAccessor (dynamic access to macros)>, 'params': {}, 'var': {'json': <VariableAccessor (dynamic access)>, 'value': <VariableAccessor (dynamic access)>}, 'conn': <ConnectionAccessor (dynamic access)>, 'dag_run': DagRun(dag_id='my_dag', run_id='manual__2025-07-08T22:44:37.346022+00:00', logical_date=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), data_interval_start=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), data_interval_end=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), run_after=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), start_date=datetime.datetime(2025, 7, 8, 22, 44, 44, 227565, tzinfo=Timezone('UTC')), end_date=None, clear_number=0, run_type=<DagRunType.MANUAL: 'manual'>, conf={}, consumed_asset_events=[]), 'triggering_asset_events': TriggeringAssetEventsAccessor(_events=defaultdict(<class 'list'>, {})), 'task_instance_key_str': 'my_dag__my_task__20250708', 'task_reschedule_count': 0, 'prev_start_date_success': <Proxy at 0xffff6cb48cd0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c494280>>, 'prev_end_date_success': <Proxy at 0xffff6cb48d30 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c8e5120>>, 'logical_date': DateTime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), 'ds': '2025-07-08', 'ds_nodash': '20250708', 'ts': '2025-07-08T22:44:35.842000+00:00', 'ts_nodash': '20250708T224435', 'ts_nodash_with_tz': '20250708T224435.842000+0000', 'data_interval_end': DateTime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), 'data_interval_start': DateTime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), 'prev_data_interval_start_success': <Proxy at 0xffff6cb48dc0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c8e51b0>>, 'prev_data_interval_end_success': <Proxy at 0xffff6cb48df0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c8e5240>>}","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-08T22:48:31.568235Z","level":"info","event":"From inside the callback","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-08T22:48:31.572041Z","level":"info","event":"{'dag': <DAG: my_dag>, 'inlets': [], 'map_index_template': None, 'outlets': [], 'run_id': 'manual__2025-07-08T22:44:37.346022+00:00', 'task': <Task(PythonOperator): my_task>, 'task_instance': RuntimeTaskInstance(id=UUID('0197ec36-656a-75b7-814a-c409886945e2'), task_id='my_task', dag_id='my_dag', run_id='manual__2025-07-08T22:44:37.346022+00:00', try_number=2, dag_version_id=UUID('0197ec0c-669e-7e05-80e3-97c3549dbfda'), map_index=-1, hostname='c9bd6c415dbf', context_carrier={}, task=<Task(PythonOperator): my_task>, max_tries=0, end_date=None, state=None, is_mapped=None, rendered_map_index=None, log_url=None), 'ti': RuntimeTaskInstance(id=UUID('0197ec36-656a-75b7-814a-c409886945e2'), task_id='my_task', dag_id='my_dag', run_id='manual__2025-07-08T22:44:37.346022+00:00', try_number=2, dag_version_id=UUID('0197ec0c-669e-7e05-80e3-97c3549dbfda'), map_index=-1, hostname='c9bd6c415dbf', context_carrier={}, task=<Task(PythonOperator): my_task>, max_tries=0, end_date=None, state=None, is_mapped=None, rendered_map_index=None, log_url=None), 'outlet_events': <airflow.sdk.execution_time.context.OutletEventAccessors object at 0xffff6cb48e20>, 'inlet_events': InletEventsAccessors(_inlets=[], _assets={}, _asset_aliases={}), 'macros': <MacrosAccessor (dynamic access to macros)>, 'params': {}, 'var': {'json': <VariableAccessor (dynamic access)>, 'value': <VariableAccessor (dynamic access)>}, 'conn': <ConnectionAccessor (dynamic access)>, 'dag_run': DagRun(dag_id='my_dag', run_id='manual__2025-07-08T22:44:37.346022+00:00', logical_date=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), data_interval_start=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), data_interval_end=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), run_after=datetime.datetime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), start_date=datetime.datetime(2025, 7, 8, 22, 44, 44, 227565, tzinfo=Timezone('UTC')), end_date=None, clear_number=0, run_type=<DagRunType.MANUAL: 'manual'>, conf={}, consumed_asset_events=[]), 'triggering_asset_events': TriggeringAssetEventsAccessor(_events=defaultdict(<class 'list'>, {})), 'task_instance_key_str': 'my_dag__my_task__20250708', 'task_reschedule_count': 0, 'prev_start_date_success': <Proxy at 0xffff6cb48ca0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c494280>>, 'prev_end_date_success': <Proxy at 0xffff6cb48c70 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c8e52d0>>, 'logical_date': DateTime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), 'ds': '2025-07-08', 'ds_nodash': '20250708', 'ts': '2025-07-08T22:44:35.842000+00:00', 'ts_nodash': '20250708T224435', 'ts_nodash_with_tz': '20250708T224435.842000+0000', 'data_interval_end': DateTime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), 'data_interval_start': DateTime(2025, 7, 8, 22, 44, 35, 842000, tzinfo=Timezone('UTC')), 'prev_data_interval_start_success': <Proxy at 0xffff6cb488e0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c8e5240>>, 'prev_data_interval_end_success': <Proxy at 0xffff6cb48880 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffff6c8e51b0>>}","chan":"stdout","logger":"processor"}
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
