### PR TITLE
bug fix - evicted pod not inclued in creating pod

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -579,9 +579,6 @@ class KubernetesPodOperator(BaseOperator):
             pod = self.find_pod(pod_request_obj.metadata.namespace, context=context)
             if pod:
                 # If pod is terminated then delete the pod an create a new as not possible to get xcom
-                pod_phase = (
-                    pod.status.phase if hasattr(pod, "status") and hasattr(pod.status, "phase") else None
-                )
                 pod_phase = pod.status.phase if pod.status and pod.status.phase else None
                 pod_reason = pod.status.reason.lower() if pod.status and pod.status.reason else ""
                 if pod_phase not in (PodPhase.SUCCEEDED, PodPhase.FAILED) and pod_reason != "evicted":

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -582,7 +582,15 @@ class KubernetesPodOperator(BaseOperator):
                 pod_phase = (
                     pod.status.phase if hasattr(pod, "status") and hasattr(pod.status, "phase") else None
                 )
-                if pod_phase and pod_phase not in (PodPhase.SUCCEEDED, PodPhase.FAILED):
+                pod_phase = pod.status.phase if pod.status and pod.status.phase else None
+                pod_reason = pod.status.reason.lower() if pod.status and pod.status.reason else ""
+                if pod_phase not in (PodPhase.SUCCEEDED, PodPhase.FAILED) and pod_reason != "evicted":
+                    self.log.info(
+                        "Reusing existing pod '%s' (phase=%s, reason=%s) since it is not terminated or evicted.",
+                        pod.metadata.name,
+                        pod_phase,
+                        pod_reason,
+                    )
                     return pod
 
                 self.log.info(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -66,7 +66,6 @@ else:
 
 pytestmark = pytest.mark.db_test
 
-
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
 KPO_MODULE = "airflow.providers.cncf.kubernetes.operators.pod"
 POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
@@ -704,6 +703,61 @@ class TestKubernetesPodOperator:
             context=context,
         )
         if pod_phase == PodPhase.RUNNING:
+            mock_create_pod.assert_not_called()
+            mock_process_pod_deletion.assert_not_called()
+            assert result == mock_found_pod
+        else:
+            mock_process_pod_deletion.assert_called_once_with(mock_found_pod)
+            mock_create_pod.assert_called_once_with(pod=mock_pod_request_obj)
+            assert result == mock_pod_request_obj
+
+    @pytest.mark.parametrize(
+        "pod_phase, pod_reason, should_reuse",
+        [
+            ("Running", "", True),
+            ("Running", "Evicted", False),
+            ("Succeeded", None, False),
+            ("Failed", None, False),
+        ],
+        ids=["running", "evicted", "succeeded", "failed"],
+    )
+    @patch(f"{KPO_MODULE}.PodManager.create_pod")
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.process_pod_deletion")
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod")
+    def test_get_or_create_pod_reattach_with_evicted(
+        self,
+        mock_find,
+        mock_process_pod_deletion,
+        mock_create_pod,
+        pod_phase,
+        pod_reason,
+        should_reuse,
+    ):
+        """Test that get_or_create_pod reattaches or recreates pod based on phase and reason."""
+        k = KubernetesPodOperator(
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            task_id="task",
+            name="hello",
+            log_pod_spec_on_failure=False,
+        )
+        k.reattach_on_restart = True
+        context = create_context(k)
+        mock_pod_request_obj = MagicMock()
+        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "test-pod"}}
+
+        mock_found_pod = MagicMock()
+        mock_found_pod.status.phase = pod_phase
+        mock_found_pod.status.reason = pod_reason
+        mock_find.return_value = mock_found_pod
+
+        result = k.get_or_create_pod(
+            pod_request_obj=mock_pod_request_obj,
+            context=context,
+        )
+
+        if should_reuse:
             mock_create_pod.assert_not_called()
             mock_process_pod_deletion.assert_not_called()
             assert result == mock_found_pod


### PR DESCRIPTION
Closes: #53015 

yet, I'm not assined, If is problem, I will closed pr. in advance Thanks

##  Context
Previously, if a pod was in the Running phase, it was always reused when reattach_on_restart=True, regardless of its reason. However, in certain cases like eviction (status.reason == "Evicted"), the pod is not reusable in practice, especially when it cannot produce or expose XComs.

##  What was changed
- Updated `get_or_create_pod()` to exclude pods with reason="Evicted" from being reused, even if their phase is Running.
- This prevents attempting to reattach to a pod that was evicted and cannot be interacted with.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
