### PR TITLE
Fix log for skipped tasks follow up

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -483,7 +483,7 @@ class FileTaskHandler(logging.Handler):
         if try_number is None:
             try_number = task_instance.try_number
 
-        if task_instance.state == TaskInstanceState.SKIPPED:
+        if try_number == 0 and task_instance.state == TaskInstanceState.SKIPPED:
             logs = [
                 StructuredLogMessage(  # type: ignore[call-arg]
                     event="Task was skipped, no logs available."


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/53024

As mentioned by @jscheffl we should only fail early logs retrieval for Skipped task if this is an actual skip tasks (didn't run, i.e try_number is 0). If the skip occurs from a skip return code or anything else, logs should be available.