### PR TITLE
Move `XCOM_RETURN_KEY` constant into `BaseXCom`

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -43,6 +43,8 @@ class TIKeyProtocol(Protocol):
 class BaseXCom:
     """BaseXcom is an interface now to interact with XCom backends."""
 
+    XCOM_RETURN_KEY = "return_value"
+
     @classmethod
     def set(
         cls,

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import attrs
 import methodtools
 
+from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.abstractoperator import (
     DEFAULT_EXECUTOR,
     DEFAULT_IGNORE_FIRST_DEPENDS_ON_PAST,
@@ -53,7 +54,6 @@ from airflow.serialization.enums import DagAttributeTypes
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
 from airflow.typing_compat import Literal, TypeAlias, TypeGuard
 from airflow.utils.helpers import is_container, prevent_duplicates
-from airflow.utils.xcom import XCOM_RETURN_KEY
 
 if TYPE_CHECKING:
     import datetime
@@ -118,7 +118,7 @@ def ensure_xcomarg_return_value(arg: Any) -> None:
 
     if isinstance(arg, XComArg):
         for operator, key in arg.iter_references():
-            if key != XCOM_RETURN_KEY:
+            if key != BaseXCom.XCOM_RETURN_KEY:
                 raise ValueError(f"cannot map over XCom with custom key {key!r} from {operator}")
     elif not is_container(arg):
         return

--- a/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
+++ b/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
@@ -29,9 +29,9 @@ from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
 from airflow.sdk.definitions._internal.mixins import DependencyMixin, ResolveMixin
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
 from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
+from airflow.sdk.execution_time.xcom import BaseXCom
 from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.utils.xcom import XCOM_RETURN_KEY
 
 if TYPE_CHECKING:
     from airflow.sdk.bases.operator import BaseOperator
@@ -79,7 +79,7 @@ class XComArg(ResolveMixin, DependencyMixin):
     """
 
     @overload
-    def __new__(cls: type[XComArg], operator: Operator, key: str = XCOM_RETURN_KEY) -> XComArg:
+    def __new__(cls: type[XComArg], operator: Operator, key: str = BaseXCom.XCOM_RETURN_KEY) -> XComArg:
         """Execute when the user writes ``XComArg(...)`` directly."""
 
     @overload
@@ -207,7 +207,7 @@ class PlainXComArg(XComArg):
     :meta private:
     """
 
-    def __init__(self, operator: Operator, key: str = XCOM_RETURN_KEY):
+    def __init__(self, operator: Operator, key: str = BaseXCom.XCOM_RETURN_KEY):
         self.operator = operator
         self.key = key
 
@@ -238,7 +238,7 @@ class PlainXComArg(XComArg):
         raise TypeError("'XComArg' object is not iterable")
 
     def __repr__(self) -> str:
-        if self.key == XCOM_RETURN_KEY:
+        if self.key == BaseXCom.XCOM_RETURN_KEY:
             return f"XComArg({self.operator!r})"
         return f"XComArg({self.operator!r}, {self.key!r})"
 
@@ -318,17 +318,17 @@ class PlainXComArg(XComArg):
         yield self.operator, self.key
 
     def map(self, f: Callable[[Any], Any]) -> MapXComArg:
-        if self.key != XCOM_RETURN_KEY:
+        if self.key != BaseXCom.XCOM_RETURN_KEY:
             raise ValueError("cannot map against non-return XCom")
         return super().map(f)
 
     def zip(self, *others: XComArg, fillvalue: Any = NOTSET) -> ZipXComArg:
-        if self.key != XCOM_RETURN_KEY:
+        if self.key != BaseXCom.XCOM_RETURN_KEY:
             raise ValueError("cannot map against non-return XCom")
         return super().zip(*others, fillvalue=fillvalue)
 
     def concat(self, *others: XComArg) -> ConcatXComArg:
-        if self.key != XCOM_RETURN_KEY:
+        if self.key != BaseXCom.XCOM_RETURN_KEY:
             raise ValueError("cannot concatenate non-return XCom")
         return super().concat(*others)
 
@@ -352,7 +352,7 @@ class PlainXComArg(XComArg):
         )
         if not isinstance(result, ArgNotSet):
             return result
-        if self.key == XCOM_RETURN_KEY:
+        if self.key == BaseXCom.XCOM_RETURN_KEY:
             return None
         if getattr(self.operator, "multiple_outputs", False):
             # If the operator is set to have multiple outputs and it was not executed,

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -304,7 +304,7 @@ class AssetEventSourceTaskInstance:
     def xcom_pull(
         self,
         *,
-        key: str = "return_value",  # TODO: Make this a constant; see RuntimeTaskInstance.
+        key: str = "return_value",
         default: Any = None,
     ) -> Any:
         from airflow.sdk.execution_time.xcom import XCom

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -49,6 +49,7 @@ from airflow.sdk.api.datamodels._generated import (
     TIRunContext,
 )
 from airflow.sdk.bases.operator import BaseOperator, ExecutorSafeguard
+from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
@@ -288,7 +289,7 @@ class RuntimeTaskInstance(TaskInstance):
         self,
         task_ids: str | Iterable[str] | None = None,
         dag_id: str | None = None,
-        key: str = "return_value",  # TODO: Make this a constant (``XCOM_RETURN_KEY``)
+        key: str = BaseXCom.XCOM_RETURN_KEY,
         include_prior_dates: bool = False,
         *,
         map_indexes: int | Iterable[int] | None | ArgNotSet = NOTSET,
@@ -1221,8 +1222,7 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
         for k, v in result.items():
             ti.xcom_push(k, v)
 
-    # TODO: Use constant for XCom return key & use serialize_value from Task SDK
-    _xcom_push(ti, "return_value", result, mapped_length=mapped_length)
+    _xcom_push(ti, BaseXCom.XCOM_RETURN_KEY, result, mapped_length=mapped_length)
 
 
 def finalize(

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -21,6 +21,7 @@ import uuid
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
+from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
@@ -71,7 +72,7 @@ class RuntimeTaskInstanceProtocol(Protocol):
         self,
         task_ids: str | list[str] | None = None,
         dag_id: str | None = None,
-        key: str = "return_value",
+        key: str = BaseXCom.XCOM_RETURN_KEY,
         include_prior_dates: bool = False,
         *,
         map_indexes: int | Iterable[int] | None | ArgNotSet = NOTSET,

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -27,6 +27,7 @@ import pytest
 
 from airflow.sdk.api.datamodels._generated import TaskInstanceState
 from airflow.sdk.bases.operator import BaseOperator
+from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.xcom_arg import XComArg
@@ -252,7 +253,7 @@ def test_mapped_render_template_fields_validating_operator(
         )
         mapped = callable(mapped, task1.output)
 
-    mock_supervisor_comms.send.return_value = XComResult(key="return_value", value=["{{ ds }}"])
+    mock_supervisor_comms.send.return_value = XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=["{{ ds }}"])
 
     mapped_ti = create_runtime_ti(task=mapped, map_index=0, upstream_map_indexes={task1.task_id: 1})
 
@@ -301,7 +302,7 @@ def test_expand_kwargs_render_template_fields_validating_operator(
         mapped = MockOperator.partial(task_id="a", arg2="{{ ti.task_id }}").expand_kwargs(task1.output)
 
     mock_supervisor_comms.send.return_value = XComResult(
-        key="return_value", value=[{"arg1": "{{ ds }}"}, {"arg1": 2}]
+        key=BaseXCom.XCOM_RETURN_KEY, value=[{"arg1": "{{ ds }}"}, {"arg1": 2}]
     )
 
     ti = create_runtime_ti(task=mapped, map_index=map_index, upstream_map_indexes={})
@@ -433,7 +434,7 @@ def test_map_cross_product(run_ti: RunTI, mock_supervisor_comms):
             return mock.DEFAULT
         task = dag.get_task(msg.task_id)
         value = task.python_callable()
-        return XComResult(key="return_value", value=value)
+        return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=value)
 
     mock_supervisor_comms.send.side_effect = xcom_get
 
@@ -471,7 +472,7 @@ def test_map_product_same(run_ti: RunTI, mock_supervisor_comms):
             return mock.DEFAULT
         task = dag.get_task(msg.task_id)
         value = task.python_callable()
-        return XComResult(key="return_value", value=value)
+        return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=value)
 
     mock_supervisor_comms.send.side_effect = xcom_get
 
@@ -597,11 +598,11 @@ def test_operator_mapped_task_group_receives_value(create_runtime_ti, mock_super
         key = (msg.task_id, msg.map_index)
         if key in expected_values:
             value = expected_values[key]
-            return XComResult(key="return_value", value=value)
+            return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=value)
         if msg.map_index is None:
             # Get all mapped XComValues for this ti
             value = [v for k, v in expected_values.items() if k[0] == msg.task_id]
-            return XComResult(key="return_value", value=value)
+            return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=value)
         return mock.DEFAULT
 
     mock_supervisor_comms.send.side_effect = xcom_get

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -24,6 +24,7 @@ import pytest
 
 from airflow.sdk import BaseOperator, get_current_context
 from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
+from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions.asset import (
     Asset,
     AssetAlias,
@@ -534,12 +535,12 @@ class TestTriggeringAssetEventsAccessor:
 
         mock_supervisor_comms.reset_mock()
         mock_supervisor_comms.send.side_effect = [
-            XComResult(key="return_value", value="__example_xcom_value__"),
+            XComResult(key=BaseXCom.XCOM_RETURN_KEY, value="__example_xcom_value__"),
         ]
         assert source.xcom_pull() == "__example_xcom_value__"
         mock_supervisor_comms.send.assert_called_once_with(
             msg=GetXCom(
-                key="return_value",
+                key=BaseXCom.XCOM_RETURN_KEY,
                 dag_id="d1",
                 run_id="r1",
                 task_id="t2",
@@ -718,12 +719,12 @@ class TestInletEventAccessor:
 
         mock_supervisor_comms.reset_mock()
         mock_supervisor_comms.send.side_effect = [
-            XComResult(key="return_value", value="__example_xcom_value__"),
+            XComResult(key=BaseXCom.XCOM_RETURN_KEY, value="__example_xcom_value__"),
         ]
         assert source.xcom_pull() == "__example_xcom_value__"
         mock_supervisor_comms.send.assert_called_once_with(
             msg=GetXCom(
-                key="return_value",
+                key=BaseXCom.XCOM_RETURN_KEY,
                 dag_id="__dag__",
                 run_id="__run__",
                 task_id="__task__",

--- a/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
@@ -46,7 +46,7 @@ def mock_operator():
 
 @pytest.fixture
 def mock_xcom_arg(mock_operator):
-    return Mock(spec=["operator", "key"], operator=mock_operator, key="return_value")
+    return Mock(spec=["operator", "key"], operator=mock_operator, key=BaseXCom.XCOM_RETURN_KEY)
 
 
 @pytest.fixture
@@ -69,7 +69,7 @@ def test_len(mock_supervisor_comms, lazy_sequence):
     mock_supervisor_comms.send.return_value = XComCountResponse(len=3)
     assert len(lazy_sequence) == 3
     mock_supervisor_comms.send.assert_called_once_with(
-        msg=GetXComCount(key="return_value", dag_id="dag", task_id="task", run_id="run"),
+        msg=GetXComCount(key=BaseXCom.XCOM_RETURN_KEY, dag_id="dag", task_id="task", run_id="run"),
     )
 
 
@@ -85,7 +85,7 @@ def test_iter(mock_supervisor_comms, lazy_sequence):
         [
             call(
                 msg=GetXComSequenceItem(
-                    key="return_value",
+                    key=BaseXCom.XCOM_RETURN_KEY,
                     dag_id="dag",
                     task_id="task",
                     run_id="run",
@@ -94,7 +94,7 @@ def test_iter(mock_supervisor_comms, lazy_sequence):
             ),
             call(
                 msg=GetXComSequenceItem(
-                    key="return_value",
+                    key=BaseXCom.XCOM_RETURN_KEY,
                     dag_id="dag",
                     task_id="task",
                     run_id="run",
@@ -110,7 +110,7 @@ def test_getitem_index(mock_supervisor_comms, lazy_sequence):
     assert lazy_sequence[4] == "f"
     mock_supervisor_comms.send.assert_called_once_with(
         GetXComSequenceItem(
-            key="return_value",
+            key=BaseXCom.XCOM_RETURN_KEY,
             dag_id="dag",
             task_id="task",
             run_id="run",
@@ -130,7 +130,7 @@ def test_getitem_calls_correct_deserialise(monkeypatch, mock_supervisor_comms, l
     assert lazy_sequence[4] == "Made with CustomXCom: some-value"
     mock_supervisor_comms.send.assert_called_once_with(
         GetXComSequenceItem(
-            key="return_value",
+            key=BaseXCom.XCOM_RETURN_KEY,
             dag_id="dag",
             task_id="task",
             run_id="run",
@@ -149,7 +149,7 @@ def test_getitem_indexerror(mock_supervisor_comms, lazy_sequence):
     assert ctx.value.args == (4,)
     mock_supervisor_comms.send.assert_called_once_with(
         GetXComSequenceItem(
-            key="return_value",
+            key=BaseXCom.XCOM_RETURN_KEY,
             dag_id="dag",
             task_id="task",
             run_id="run",
@@ -163,7 +163,7 @@ def test_getitem_slice(mock_supervisor_comms, lazy_sequence):
     assert lazy_sequence[:5] == [6, 4, 1]
     mock_supervisor_comms.send.assert_called_once_with(
         GetXComSequenceSlice(
-            key="return_value",
+            key=BaseXCom.XCOM_RETURN_KEY,
             dag_id="dag",
             task_id="task",
             run_id="run",

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1795,7 +1795,9 @@ class TestXComAfterTaskExecution:
         spy_agency.assert_spy_called(_push_xcom_if_needed)
 
         if should_push_xcom:
-            spy_agency.assert_spy_called_with(_xcom_push, runtime_ti, "return_value", expected_xcom_value)
+            spy_agency.assert_spy_called_with(
+                _xcom_push, runtime_ti, BaseXCom.XCOM_RETURN_KEY, expected_xcom_value
+            )
         else:
             spy_agency.assert_spy_not_called(_xcom_push)
 
@@ -1819,7 +1821,7 @@ class TestXComAfterTaskExecution:
         expected_calls = [
             ("key1", "value1"),
             ("key2", "value2"),
-            ("return_value", result),
+            (BaseXCom.XCOM_RETURN_KEY, result),
         ]
         spy_agency.assert_spy_call_count(_xcom_push, len(expected_calls))
         for key, value in expected_calls:
@@ -1841,9 +1843,9 @@ class TestXComAfterTaskExecution:
         runtime_ti = create_runtime_ti(task=task)
 
         with mock.patch.object(XCom, "set") as mock_xcom_set:
-            _xcom_push(runtime_ti, "return_value", result, 7)
+            _xcom_push(runtime_ti, BaseXCom.XCOM_RETURN_KEY, result, 7)
             mock_xcom_set.assert_called_once_with(
-                key="return_value",
+                key=BaseXCom.XCOM_RETURN_KEY,
                 value=result,
                 dag_id=runtime_ti.dag_id,
                 task_id=runtime_ti.task_id,
@@ -1911,7 +1913,7 @@ class TestXComAfterTaskExecution:
         run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
 
         mock_xcom_backend.set.assert_called_once_with(
-            key="return_value",
+            key=BaseXCom.XCOM_RETURN_KEY,
             value="pushing to xcom backend!",
             dag_id="test_dag",
             task_id="pull_task",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/53065

Through this PR, I am starting an effort to clean up the airflow.utils.xcom module which as most utils has become a dumping ground. This PR refactors the location of the `XCOM_RETURN_KEY` constant within the task sdk, moving it from the `airflow.utils.xcom` module to the `BaseXCom` class in `bases.xcom`.

The move to have it in the BaseXCom class seems to be the right move because the constant is semantically tied to XCom functionality and belongs with the XCom class hierarchy logically. Constant is now colocated with related XCom functionality (encapsulation).

Can be accessed as both `BaseXCom.XCOM_RETURN_KEY` and `XCom.XCOM_RETURN_KEY` for custom backends.

The tests that I have changed already utilise the new location, so there is no real need for new tests. Verified with a simple dag if it pushes as expected.

![image](https://github.com/user-attachments/assets/76fa2430-acf2-49b1-b295-969dcb67aef2)




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
