### PR TITLE
Fix ecs/EcsRunTaskOperator retry condition

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
@@ -47,6 +47,16 @@ class EcsOperatorError(Exception):
         """Return EcsOperator state and a tuple of failures list and message."""
         return EcsOperatorError, (self.failures, self.message)
 
+class EcsCannotPullContainerError(Exception):
+    """Raise when ECS cannot retrieve the specified container image."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+    def __reduce__(self):
+        return self.__class__, (self.message,)
+
 
 class S3HookUriParseFailure(AirflowException):
     """When parse_s3_url fails to parse URL, this error is thrown."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
@@ -47,6 +47,7 @@ class EcsOperatorError(Exception):
         """Return EcsOperator state and a tuple of failures list and message."""
         return EcsOperatorError, (self.failures, self.message)
 
+
 class EcsCannotPullContainerError(Exception):
     """Raise when ECS cannot retrieve the specified container image."""
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/ecs.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart, EcsCannotPullContainerError
+from airflow.providers.amazon.aws.exceptions import (
+    EcsCannotPullContainerError,
+    EcsOperatorError,
+    EcsTaskFailToStart,
+)
 from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 from airflow.providers.amazon.aws.utils import _StringCompareEnum
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
@@ -25,7 +25,11 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart, EcsCannotPullContainerError
+from airflow.providers.amazon.aws.exceptions import (
+    EcsCannotPullContainerError,
+    EcsOperatorError,
+    EcsTaskFailToStart,
+)
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.ecs import EcsClusterStates, EcsHook, should_retry_eni
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
@@ -701,8 +705,10 @@ class EcsRunTaskOperator(EcsBaseOperator):
 
         for task in response["tasks"]:
             if task.get("stopCode", "") == "TaskFailedToStart":
-                if "CannotPullContainerError" in task.get('stoppedReason', ''):
-                    raise EcsCannotPullContainerError(f"The task failed to start due to: {task.get('stoppedReason', '')}")
+                if "CannotPullContainerError" in task.get("stoppedReason", ""):
+                    raise EcsCannotPullContainerError(
+                        f"The task failed to start due to: {task.get('stoppedReason', '')}"
+                    )
 
                 # Reset task arn here otherwise the retry run will not start
                 # a new task but keep polling the old dead one

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_ecs.py
@@ -20,7 +20,11 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart, EcsCannotPullContainerError
+from airflow.providers.amazon.aws.exceptions import (
+    EcsCannotPullContainerError,
+    EcsOperatorError,
+    EcsTaskFailToStart,
+)
 from airflow.providers.amazon.aws.hooks.ecs import EcsHook, should_retry, should_retry_eni
 
 DEFAULT_CONN_ID: str = "aws_default"

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_ecs.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
+from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart, EcsCannotPullContainerError
 from airflow.providers.amazon.aws.hooks.ecs import EcsHook, should_retry, should_retry_eni
 
 DEFAULT_CONN_ID: str = "aws_default"
@@ -67,6 +67,13 @@ class TestShouldRetryEni:
             EcsTaskFailToStart(
                 "The task failed to start due to: "
                 "Timeout waiting for network interface provisioning to complete."
+            )
+        )
+        assert should_retry_eni(
+            EcsCannotPullContainerError(
+                "The task failed to start due to: "
+                "CannotStartContainerError: "
+                "ResourceInitializationError: failed to create new container runtime task"
             )
         )
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
@@ -28,9 +28,8 @@ from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.amazon.aws.exceptions import (
     EcsCannotPullContainerError,
     EcsOperatorError,
-    EcsTaskFailToStart    
+    EcsTaskFailToStart,
 )
-
 from airflow.providers.amazon.aws.hooks.ecs import EcsClusterStates, EcsHook
 from airflow.providers.amazon.aws.operators.ecs import (
     EcsBaseOperator,
@@ -465,7 +464,10 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         with pytest.raises(EcsCannotPullContainerError) as ctx:
             self.ecs._check_success_task()
 
-        assert str(ctx.value) == "The task failed to start due to: CannotPullContainerError: ResourceInitializationError: failed to create new container runtime task"
+        assert (
+            str(ctx.value)
+            == "The task failed to start due to: CannotPullContainerError: ResourceInitializationError: failed to create new container runtime task"
+        )
         client_mock.describe_tasks.assert_called_once_with(cluster="c", tasks=["arn"])
 
     @mock.patch.object(EcsBaseOperator, "client")


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/52943

Draft PR.

This PR adds a EcsCannotPullContainerError exception to handle scenarios where ECS tasks fail to start due to image pull issues (e.g., CannotPullContainerError).

Test added: ✅ test_should_retry_eni_false_for_pull_failure