### PR TITLE
Handle invalid execution API urls in supervisor

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1633,12 +1633,18 @@ def supervise(
     :param subprocess_logs_to_stdout: Should task logs also be sent to stdout via the main logger.
     :param client: Optional preconfigured client for communication with the server (Mostly for tests).
     :return: Exit code of the process.
+    :raises ValueError: If server URL is empty or invalid.
     """
     # One or the other
     from airflow.sdk.execution_time.secrets_masker import reset_secrets_masker
 
-    if not client and ((not server) ^ dry_run):
-        raise ValueError(f"Can only specify one of {server=} or {dry_run=}")
+    if not client:
+        if dry_run and server:
+            raise ValueError(f"Can only specify one of {server=} or {dry_run=}")
+        if not dry_run and (not server or not server.startswith(("http://", "https://"))):
+            raise ValueError(
+                "Invalid execution API server URL. Please ensure that a valid URL is configured."
+            )
 
     if not dag_rel_path:
         raise ValueError("dag_path is required")

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -24,8 +24,6 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow.sdk.execution_time.secrets_masker import SecretsMasker
-
 pytest_plugins = "tests_common.pytest_plugin"
 
 # Task SDK does not need access to the Airflow database
@@ -278,6 +276,8 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
 
 @pytest.fixture
 def patched_secrets_masker():
+    from airflow.sdk.execution_time.secrets_masker import SecretsMasker
+
     secrets_masker = SecretsMasker()
     with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
         yield secrets_masker

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -20,8 +20,11 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
+from unittest.mock import patch
 
 import pytest
+
+from airflow.sdk.execution_time.secrets_masker import SecretsMasker
 
 pytest_plugins = "tests_common.pytest_plugin"
 
@@ -271,3 +274,10 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
         return context.model_dump(exclude_unset=True, mode="json")
 
     return _make_context_dict
+
+
+@pytest.fixture
+def patched_secrets_masker():
+    secrets_masker = SecretsMasker()
+    with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+        yield secrets_masker

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -149,7 +149,6 @@ def client_with_ti_start(make_ti_context):
 
 @pytest.mark.usefixtures("disable_capturing")
 class TestSupervisor:
-    # @patch("airflow.sdk.execution_time.supervisor.mask_secret")
     @pytest.mark.parametrize(
         "server, dry_run, error_pattern",
         [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/53033

Came across a case in the issue attached where the `base_url` was set to empty and due to us not handling it well enough, it was getting through to later stages and resulting in execution API url being `/execution`which is not a good user experiences.

The hidden issue is that conf.get returns an empty string "" instead of using the fallback value when empty string is set. This could be corrected over time, but is not needed as of now as it could have hidden effects and in most cases it is handled better further down.

Whatever the reason might be, the supervisor must account for this, and throw a better error message than just failing.

I am handling the case here by checking for valid URLs before creating the SDK client.

![image](https://github.com/user-attachments/assets/d3aedb0a-bc1f-44fb-a04e-0459639bdc09)

When its not provided.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
