### PR TITLE
remove ECS Operator retry mechanism on task failed to start

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/ecs.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
+from airflow.providers.amazon.aws.exceptions import EcsOperatorError
 from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 from airflow.providers.amazon.aws.utils import _StringCompareEnum
 
@@ -34,16 +34,6 @@ def should_retry(exception: Exception):
             quota_reason in failure["reason"]
             for quota_reason in ["RESOURCE:MEMORY", "RESOURCE:CPU"]
             for failure in exception.failures
-        )
-    return False
-
-
-def should_retry_eni(exception: Exception):
-    """Check if exception is related to ENI (Elastic Network Interfaces)."""
-    if isinstance(exception, EcsTaskFailToStart):
-        return any(
-            eni_reason in exception.message
-            for eni_reason in ["network interface provisioning", "ResourceInitializationError"]
         )
     return False
 

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_ecs.py
@@ -20,8 +20,8 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
-from airflow.providers.amazon.aws.hooks.ecs import EcsHook, should_retry, should_retry_eni
+from airflow.providers.amazon.aws.exceptions import EcsOperatorError
+from airflow.providers.amazon.aws.hooks.ecs import EcsHook, should_retry
 
 DEFAULT_CONN_ID: str = "aws_default"
 REGION: str = "us-east-1"
@@ -59,22 +59,3 @@ class TestShouldRetry:
 
     def test_return_false_on_invalid_reason(self):
         assert not should_retry(EcsOperatorError([{"reason": "CLUSTER_NOT_FOUND"}], "Foo"))
-
-
-class TestShouldRetryEni:
-    def test_return_true_on_valid_reason(self):
-        assert should_retry_eni(
-            EcsTaskFailToStart(
-                "The task failed to start due to: "
-                "Timeout waiting for network interface provisioning to complete."
-            )
-        )
-
-    def test_return_false_on_invalid_reason(self):
-        assert not should_retry_eni(
-            EcsTaskFailToStart(
-                "The task failed to start due to: "
-                "CannotPullContainerError: "
-                "ref pull has been retried 5 time(s): failed to resolve reference"
-            )
-        )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: [#52943](https://github.com/apache/airflow/issues/52943)
related: [#52943](https://github.com/apache/airflow/issues/52943)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Draft PR.

Closes: https://github.com/apache/airflow/issues/52943

Currently, in the case of an `EcsTaskFailToStart` error, the `EcsOperator` performs a retry of the _check_success_task function (and not the task) with an empty `self.arn` parameter, which returns None, leads Airflow to mark the DAG as successful despite the task failing to start.
Since no actual task retry was performed, I suggest removing all the "retry" logic, which will result in Airflow marking the task as failed.

Copying relevant context from the issue:
> The code currently doesn't attempt to retry the task; it only retries the _check_success_task function call (which is pointless). The implemented retry mechanism doesn't support deferrable and wait_for_completion flags, which would be pretty complicated to add, as you would need to pass the current retry number to the new task outside of the standard Airflow retry policy. No other Amazon operator has a retry policy for task failed to start errors (any service can have initialization issues), so I suggest aligning the same approach with the ECS operator.
As mentioned in the document you attached, the solution to solve the Fargate start task error is to use Step Function (Step Function operator in Airflow), which will allow an independent retry mechanism.
