### PR TITLE
Cleanup duration typing grid summaries

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/common.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/common.py
@@ -81,7 +81,7 @@ class GridRunsResponse(BaseModel):
     run_type: DagRunType
 
     @computed_field
-    def duration(self) -> int | None:
+    def duration(self) -> int:
         if self.start_date:
             end_date = self.end_date or timezone.utcnow()
             return (end_date - self.start_date).seconds

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1953,9 +1953,7 @@ components:
         run_type:
           $ref: '#/components/schemas/DagRunType'
         duration:
-          anyOf:
-          - type: integer
-          - type: 'null'
+          type: integer
           title: Duration
           readOnly: true
       type: object

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -6989,14 +6989,7 @@ export const $GridRunsResponse = {
             '$ref': '#/components/schemas/DagRunType'
         },
         duration: {
-            anyOf: [
-                {
-                    type: 'integer'
-                },
-                {
-                    type: 'null'
-                }
-            ],
+            type: 'integer',
             title: 'Duration',
             readOnly: true
         }

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1778,7 +1778,7 @@ export type GridRunsResponse = {
     run_after: string;
     state: TaskInstanceState | null;
     run_type: DagRunType;
-    readonly duration: number | null;
+    readonly duration: number;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -65,7 +65,7 @@ export const Bar = ({ max, nodes, run }: Props) => {
           color="white"
           dagId={dagId}
           flexDir="column"
-          height={`${((run.duration ?? 0) / max) * BAR_HEIGHT}px`}
+          height={`${(run.duration / max) * BAR_HEIGHT}px`}
           justifyContent="flex-end"
           label={run.run_after}
           minHeight="14px"


### PR DESCRIPTION
Minor improvement.

Following https://github.com/apache/airflow/pull/53087, duration can't be `None` anymore.