### PR TITLE
Update `apache-airflow-providers-ssh>=4.0.0` dependency

### DIFF
--- a/providers/sftp/pyproject.toml
+++ b/providers/sftp/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = "~=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-ssh>=2.1.0",
+    "apache-airflow-providers-ssh>=4.0.0",
     "paramiko>=2.9.0",
     "asyncssh>=2.12.0",
 ]


### PR DESCRIPTION
As specified in #53084, starting in v5.0.0, the  `apache-airflow-providers-sftp` is using keyword argument introduced in `apache-airflow-providers-ssh` v4.0.0. Thus, the minimum version of `apache-airflow-providers-ssh` was updated to be `>=4.0.0`.

closes: #53084 
