### PR TITLE
Bugfix/return DataflowJobMessagesSensor and DataflowJobAutoScalingEventsSensor result with xcom_value

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
@@ -37,8 +37,7 @@ from airflow.providers.google.cloud.triggers.dataflow import (
     DataflowJobStatusTrigger,
 )
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
-from airflow.providers.google.version_compat import BaseSensorOperator
-from airflow.sdk import PokeReturnValue
+from airflow.providers.google.version_compat import BaseSensorOperator, PokeReturnValue
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
@@ -361,6 +361,10 @@ class DataflowJobMessagesSensor(BaseSensorOperator):
             location=self.location,
         )
         result = result if self.callback is None else self.callback(result)
+
+        if isinstance(result, PokeReturnValue):
+            return result
+
         if bool(result):
             return PokeReturnValue(
                 is_done=True,
@@ -488,6 +492,9 @@ class DataflowJobAutoScalingEventsSensor(BaseSensorOperator):
             location=self.location,
         )
         result = result if self.callback is None else self.callback(result)
+        if isinstance(result, PokeReturnValue):
+            return result
+
         if bool(result):
             return PokeReturnValue(
                 is_done=True,

--- a/providers/google/src/airflow/providers/google/version_compat.py
+++ b/providers/google/src/airflow/providers/google/version_compat.py
@@ -52,10 +52,11 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import (
         BaseOperatorLink,
         BaseSensorOperator,
+        PokeReturnValue,
     )
 else:
     from airflow.models import BaseOperatorLink  # type: ignore[no-redef]
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+    from airflow.sensors.base import BaseSensorOperator, PokeReturnValue  # type: ignore[no-redef]
 
 # Explicitly export these imports to protect them from being removed by linters
 __all__ = [
@@ -65,4 +66,5 @@ __all__ = [
     "BaseOperator",
     "BaseSensorOperator",
     "BaseOperatorLink",
+    "PokeReturnValue",
 ]

--- a/providers/google/tests/unit/google/cloud/sensors/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_dataflow.py
@@ -376,7 +376,7 @@ class TestDataflowJobMessagesSensor:
 
         results = task.poke(mock.MagicMock())
 
-        assert callback.return_value == results
+        assert callback.return_value == results.xcom_value
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -552,7 +552,7 @@ class TestDataflowJobAutoScalingEventsSensor:
 
         results = task.poke(mock.MagicMock())
 
-        assert callback.return_value == results
+        assert callback.return_value == results.xcom_value
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,


### PR DESCRIPTION
Part of https://github.com/apache/airflow/pull/52997

Currently these sensors returns output not the bool, we should use the `PokeReturnValue ` to return output.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
