### PR TITLE
Bugfix: StackdriverHook channel and policy assignments when creating/updating notifications and policy's

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/stackdriver.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/stackdriver.py
@@ -261,8 +261,9 @@ class StackdriverHook(GoogleBaseHook):
         channel_name_map = {}
 
         for channel in channels:
+            # This field is immutable, illegal to specifying non-default UNVERIFIED or VERIFIED, so setting default
             channel.verification_status = (
-                monitoring_v3.NotificationChannel.VerificationStatus.VERIFICATION_STATUS_UNSPECIFIED
+                monitoring_v3.NotificationChannel.VerificationStatus.VERIFICATION_STATUS_UNSPECIFIED  # type: ignore[assignment]
             )
 
             if channel.name in existing_channels:
@@ -274,7 +275,7 @@ class StackdriverHook(GoogleBaseHook):
                 )
             else:
                 old_name = channel.name
-                channel.name = None
+                del channel.name
                 new_channel = channel_client.create_notification_channel(
                     request={"name": f"projects/{project_id}", "notification_channel": channel},
                     retry=retry,
@@ -284,8 +285,8 @@ class StackdriverHook(GoogleBaseHook):
                 channel_name_map[old_name] = new_channel.name
 
         for policy in policies_:
-            policy.creation_record = None
-            policy.mutation_record = None
+            del policy.creation_record
+            del policy.mutation_record
 
             for i, channel in enumerate(policy.notification_channels):
                 new_channel = channel_name_map.get(channel)
@@ -301,9 +302,9 @@ class StackdriverHook(GoogleBaseHook):
                         metadata=metadata,
                     )
             else:
-                policy.name = None
+                del policy.name
                 for condition in policy.conditions:
-                    condition.name = None
+                    del condition.name
                 policy_client.create_alert_policy(
                     request={"name": f"projects/{project_id}", "alert_policy": policy},
                     retry=retry,
@@ -531,8 +532,9 @@ class StackdriverHook(GoogleBaseHook):
             channels_list.append(NotificationChannel(**channel))
 
         for channel in channels_list:
+            # This field is immutable, illegal to specifying non-default UNVERIFIED or VERIFIED, so setting default
             channel.verification_status = (
-                monitoring_v3.NotificationChannel.VerificationStatus.VERIFICATION_STATUS_UNSPECIFIED
+                monitoring_v3.NotificationChannel.VerificationStatus.VERIFICATION_STATUS_UNSPECIFIED  # type: ignore[assignment]
             )
 
             if channel.name in existing_channels:
@@ -544,7 +546,7 @@ class StackdriverHook(GoogleBaseHook):
                 )
             else:
                 old_name = channel.name
-                channel.name = None
+                del channel.name
                 new_channel = channel_client.create_notification_channel(
                     request={"name": f"projects/{project_id}", "notification_channel": channel},
                     retry=retry,


### PR DESCRIPTION
The assignments are wrongly declared, these should be deleted before calling the create and update notifications and policys

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
