### PR TITLE
Re-add back werkzeug dependency for sendgrid on Python 3.12

### DIFF
--- a/providers/sendgrid/pyproject.toml
+++ b/providers/sendgrid/pyproject.toml
@@ -58,9 +58,10 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     # workaround conflicts with fab for Python 3.12 https://github.com/apache/airflow/pull/50221#issuecomment-2926765112
-    # can be set to sendgrid>=6.12.3 when we upgrade to fab 5
+    # can be set to sendgrid>=6.12.3 when we upgrade to fab 5 and remove Werkzeug dependency
     "sendgrid>=6.12.3; python_version < '3.12'",
     "sendgrid>=6.0.0,<6.12.3; python_version >= '3.12'",
+    "werkzeug>=2.2,<4; python_version >= '3.12'",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Until we upgrade to FAB 5 we need to use older sendgrid library that depends on werkzeug for Python 3.12 - this dependency is implicit and not declared in those old sendgrid distributions and we need to add it manually.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
