### PR TITLE
Added functionality to only allow one auth method simultaneously in the TrinoHook

### DIFF
--- a/providers/trino/docs/changelog.rst
+++ b/providers/trino/docs/changelog.rst
@@ -23,9 +23,11 @@
 
 ``apache-airflow-providers-trino``
 
-
 Changelog
 ---------
+
+.. warning::
+    Make sure the connection you use to authenticate with Trino, has only one authentication method set (e.g password, jwt) otherwise the task will fail.
 
 6.3.2
 .....

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -161,7 +161,7 @@ class TrinoHook(DbApiHook):
             auth_methods.append("kerberos")
         if len(auth_methods) > 1:
             raise AirflowException(
-                f"Multiple authentication methods specified: {auth_methods}. Only one is allowed."
+                f"Multiple authentication methods specified: {', '.join(auth_methods)}. Only one is allowed."
             )
         if db.password:
             auth = trino.auth.BasicAuthentication(db.login, db.password)

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -109,7 +109,10 @@ class TestTrinoHookConn:
             extra=json.dumps(extras),
         )
         with pytest.raises(
-            AirflowException, match=re.escape("The 'kerberos' authorization type doesn't support password.")
+            AirflowException,
+            match=re.escape(
+                "Multiple authentication methods specified: ['password', 'kerberos']. Only one is allowed."
+            ),
         ):
             TrinoHook().get_conn()
 

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -111,7 +111,7 @@ class TestTrinoHookConn:
         with pytest.raises(
             AirflowException,
             match=re.escape(
-                "Multiple authentication methods specified: ['password', 'kerberos']. Only one is allowed."
+                "Multiple authentication methods specified: password, kerberos. Only one is allowed."
             ),
         ):
             TrinoHook().get_conn()


### PR DESCRIPTION
---

I haven't really found a standard way of how multiple auth types in connection are handled, but the Trino provider currently has some opaque behavior, is there an explanation why it is done this way?

currently:

- password and jwt auth can be set at the same time, but password will be preferred 
- password and kerberos can't 
- password and cert can't 
- jwt and kerberos or cert can, but jwt will be preferred   
- kerberos and cert can, but kerberos will be preferred 

I've simplified the logic so that only one authentication method may be specified per connection. If multiple are provided, an error is raised. This avoids silent misconfigurations and makes the behavior explicit and predictable. If someone thinks, that this is a bad idea and can explain me the rationale behind the current logic, please let me know :) 

Question: Could this change be considered a bugfix? I’m hesitant to introduce a breaking change for this issue. If this is considered breaking, I would prefer enhancing logging instead, to clearly inform users which authentication type is actually used