### PR TITLE
Refactor SchedularDagBag and use it across the API server

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -84,10 +84,8 @@ def create_app(apps: str = "all") -> FastAPI:
     dag_bag = create_dag_bag()
 
     if "execution" in apps_list or "all" in apps_list:
-        from airflow.jobs.scheduler_job_runner import SchedulerDagBag
-
         task_exec_api_app = create_task_execution_api_app()
-        task_exec_api_app.state.dag_bag = SchedulerDagBag()
+        task_exec_api_app.state.dag_bag = dag_bag
         init_error_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 

--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -20,16 +20,15 @@ from typing import Annotated
 
 from fastapi import Depends, Request
 
-from airflow.models.dagbag import DagBag
-from airflow.settings import DAGS_FOLDER
+from airflow.models.dagbag import SchedulerDagBag
 
 
-def create_dag_bag() -> DagBag:
+def create_dag_bag() -> SchedulerDagBag:
     """Create DagBag to retrieve DAGs from the database."""
-    return DagBag(DAGS_FOLDER, read_dags_from_db=True)
+    return SchedulerDagBag()
 
 
-def dag_bag_from_app(request: Request) -> DagBag:
+def dag_bag_from_app(request: Request) -> SchedulerDagBag:
     """
     FastAPI dependency resolver that returns the shared DagBag instance from app.state.
 
@@ -39,4 +38,4 @@ def dag_bag_from_app(request: Request) -> DagBag:
     return request.app.state.dag_bag
 
 
-DagBagDep = Annotated[DagBag, Depends(dag_bag_from_app)]
+DagBagDep = Annotated[SchedulerDagBag, Depends(dag_bag_from_app)]

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -57,7 +57,7 @@ class DAGRunClearBody(StrictBaseModel):
     only_failed: bool = False
     run_on_latest_version: bool = Field(
         default=False,
-        description="(Experimental) Run on the latest bundle version of the DAG after clearing the DAG Run.",
+        description="(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run.",
     )
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -181,7 +181,7 @@ class ClearTaskInstancesBody(StrictBaseModel):
     include_past: bool = False
     run_on_latest_version: bool = Field(
         default=False,
-        description="(Experimental) Run on the latest bundle version of the DAG after "
+        description="(Experimental) Run on the latest bundle version of the dag after "
         "clearing the task instances.",
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -8690,7 +8690,7 @@ components:
         run_on_latest_version:
           type: boolean
           title: Run On Latest Version
-          description: (Experimental) Run on the latest bundle version of the DAG
+          description: (Experimental) Run on the latest bundle version of the dag
             after clearing the task instances.
           default: false
       additionalProperties: false
@@ -9333,8 +9333,8 @@ components:
         run_on_latest_version:
           type: boolean
           title: Run On Latest Version
-          description: (Experimental) Run on the latest bundle version of the DAG
-            after clearing the DAG Run.
+          description: (Experimental) Run on the latest bundle version of the Dag
+            after clearing the Dag Run.
           default: false
       additionalProperties: false
       type: object

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -371,7 +371,7 @@ def materialize_asset(
         )
 
     dag: DAG | None
-    if not (dag := dag_bag.get_dag(dag_id)):
+    if not (dag := dag_bag.get_latest_version_of_dag(dag_id, session)):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with ID `{dag_id}` was not found")
 
     return dag.create_dagrun(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -423,7 +423,7 @@ def trigger_dag_run(
     try:
         dag = dag_bag.get_latest_version_of_dag(dag_id, session)
         if not dag:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with dag_id: '{dag_id}' not found")
         params = body.validate_context(dag)
 
         dag_run = dag.create_dagrun(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -79,7 +79,7 @@ from airflow.api_fastapi.core_api.services.public.dag_run import DagRunWaiter
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import ParamValidationError
 from airflow.listeners.listener import get_listener_manager
-from airflow.models import DAG, DagModel, DagRun
+from airflow.models import DagModel, DagRun
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
@@ -168,7 +168,7 @@ def patch_dag_run(
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
 
-    dag: DAG = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_dag_for_run(dag_run, session=session)
 
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
@@ -274,9 +274,11 @@ def clear_dag_run(
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
 
-    dag: DAG = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_dag_for_run(dag_run, session=session)
 
     if body.dry_run:
+        if not dag:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
         task_instances = dag.clear(
             run_id=dag_run_id,
             task_ids=None,
@@ -290,6 +292,8 @@ def clear_dag_run(
             task_instances=cast("list[TaskInstanceResponse]", task_instances),
             total_entries=len(task_instances),
         )
+    if not dag:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
     dag.clear(
         run_id=dag_run_id,
         task_ids=None,
@@ -352,7 +356,7 @@ def get_dag_runs(
     query = select(DagRun)
 
     if dag_id != "~":
-        dag: DAG = dag_bag.get_dag(dag_id)
+        dag = dag_bag.get_latest_version_of_dag(dag_id, session)
         if not dag:
             raise HTTPException(status.HTTP_404_NOT_FOUND, f"The DAG with dag_id: `{dag_id}` was not found")
 
@@ -417,7 +421,9 @@ def trigger_dag_run(
         )
 
     try:
-        dag: DAG = dag_bag.get_dag(dag_id)
+        dag = dag_bag.get_latest_version_of_dag(dag_id, session)
+        if not dag:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
         params = body.validate_context(dag)
 
         dag_run = dag.create_dagrun(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
@@ -39,7 +39,6 @@ from airflow.api_fastapi.core_api.datamodels.dag_versions import (
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_access_dag
-from airflow.models.dag import DAG
 from airflow.models.dag_version import DagVersion
 
 dag_versions_router = AirflowRouter(tags=["DagVersion"], prefix="/dags/{dag_id}/dagVersions")
@@ -112,7 +111,7 @@ def get_dag_versions(
     query = select(DagVersion).options(joinedload(DagVersion.dag_model))
 
     if dag_id != "~":
-        dag: DAG = dag_bag.get_dag(dag_id)
+        dag = dag_bag.get_latest_version_of_dag(dag_id, session)
         if not dag:
             raise HTTPException(status.HTTP_404_NOT_FOUND, f"The DAG with dag_id: `{dag_id}` was not found")
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -172,7 +172,7 @@ def get_dag(
     dag_bag: DagBagDep,
 ) -> DAGResponse:
     """Get basic information about a DAG."""
-    dag: DAG = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
 
@@ -199,8 +199,7 @@ def get_dag(
 )
 def get_dag_details(dag_id: str, session: SessionDep, dag_bag: DagBagDep) -> DAGDetailsResponse:
     """Get details of DAG."""
-    # todo: can we use lazy deser dag here?
-    dag: DAG = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -67,7 +67,7 @@ from airflow.api_fastapi.core_api.security import (
 )
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import AirflowException, DagNotFound
-from airflow.models import DAG, DagModel
+from airflow.models import DagModel
 from airflow.models.dag_favorite import DagFavorite
 from airflow.models.dagrun import DagRun
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py
@@ -139,7 +139,7 @@ def get_log(
         metadata["end_of_log"] = True
         raise HTTPException(status.HTTP_404_NOT_FOUND, "TaskInstance not found")
 
-    dag = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_dag_for_run(ti.dag_run, session=session)
     if dag:
         with contextlib.suppress(TaskNotFound):
             ti.task = dag.get_task(ti.task_id)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -712,8 +712,7 @@ def post_clear_task_instances(
         if len(dag.task_dict) > 1:
             # If we had upstream/downstream etc then also include those!
             task_ids.extend(tid for tid in dag.task_dict if tid != task_id)
-    if dag is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG {dag_id} not found")
+# Removed unreachable code
 
     # Prepare common parameters
     common_params = {

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -712,7 +712,6 @@ def post_clear_task_instances(
         if len(dag.task_dict) > 1:
             # If we had upstream/downstream etc then also include those!
             task_ids.extend(tid for tid in dag.task_dict if tid != task_id)
-    # Removed unreachable code
 
     # Prepare common parameters
     common_params = {

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -24,12 +24,12 @@ from fastapi import Depends, HTTPException, status
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.tasks import TaskCollectionResponse, TaskResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_access_dag
 from airflow.exceptions import TaskNotFound
-from airflow.models import DAG
 
 tasks_router = AirflowRouter(tags=["Task"], prefix="/dags/{dag_id}/tasks")
 
@@ -47,10 +47,11 @@ tasks_router = AirflowRouter(tags=["Task"], prefix="/dags/{dag_id}/tasks")
 def get_tasks(
     dag_id: str,
     dag_bag: DagBagDep,
+    session: SessionDep,
     order_by: str = "task_id",
 ) -> TaskCollectionResponse:
     """Get tasks for DAG."""
-    dag: DAG = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
     try:
@@ -73,9 +74,9 @@ def get_tasks(
     ),
     dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.TASK))],
 )
-def get_task(dag_id: str, task_id, dag_bag: DagBagDep) -> TaskResponse:
+def get_task(dag_id: str, task_id, session: SessionDep, dag_bag: DagBagDep) -> TaskResponse:
     """Get simplified representation of a task."""
-    dag: DAG = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
     try:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -211,7 +211,7 @@ def create_xcom_entry(
     if not dag_run:
         if not dag_run:
             raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"DAG Run with ID: `{dag_run_id}` not found for DAG: `{dag_id}`"
+                status.HTTP_404_NOT_FOUND, f"Dag Run with ID: `{dag_run_id}` not found for DAG: `{dag_id}`"
             )
 
     # Check existing XCom

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -204,14 +204,14 @@ def create_xcom_entry(
         dag.get_task(task_id)
     except TaskNotFound:
         raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"Task with ID: `{task_id}` not found in DAG: `{dag_id}`"
+            status.HTTP_404_NOT_FOUND, f"Task with ID: `{task_id}` not found in dag: `{dag_id}`"
         )
 
     # Validate DAG Run ID
     if not dag_run:
         if not dag_run:
             raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Dag Run with ID: `{dag_run_id}` not found for DAG: `{dag_id}`"
+                status.HTTP_404_NOT_FOUND, f"Dag Run with ID: `{dag_run_id}` not found for dag: `{dag_id}`"
             )
 
     # Check existing XCom

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -39,7 +39,7 @@ def next_run_assets(
     dag_bag: DagBagDep,
     session: SessionDep,
 ) -> dict:
-    dag = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
 
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"can't find dag {dag_id}")

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/calendar.py
@@ -61,7 +61,7 @@ def get_calendar(
     """Get calendar data for a DAG including historical and planned DAG runs."""
     dag = dag_bag.get_latest_version_of_dag(dag_id, session)
     if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with dag_id: '{dag_id}' not found")
     calendar_service = CalendarService()
 
     return calendar_service.get_calendar_data(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/calendar.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
+from starlette import status
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.dagbag import DagBagDep
@@ -58,7 +59,9 @@ def get_calendar(
     granularity: Literal["hourly", "daily"] = "daily",
 ) -> CalendarTimeRangeCollectionResponse:
     """Get calendar data for a DAG including historical and planned DAG runs."""
-    dag = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
+    if not dag:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
     calendar_service = CalendarService()
 
     return calendar_service.get_calendar_data(

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -56,7 +56,7 @@ def _patch_ti_validate_request(
     map_index: int | None = -1,
     update_mask: list[str] | None = Query(None),
 ) -> tuple[DAG, list[TI], dict]:
-    dag = dag_bag.get_dag(dag_id)
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG {dag_id} not found")
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -123,13 +123,13 @@ def clear_dag_run(
                 "message": f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
             },
         )
-    from airflow.jobs.scheduler_job_runner import SchedulerDagBag
+    from airflow.models.dagbag import SchedulerDagBag
 
     dag_run = session.scalar(
         select(DagRunModel).where(DagRunModel.dag_id == dag_id, DagRunModel.run_id == run_id)
     )
     dag_bag = SchedulerDagBag()
-    dag = dag_bag.get_dag(dag_run=dag_run, session=session)
+    dag = dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
     if not dag:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -37,9 +37,8 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
-from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow._shared.timezones import timezone
-from airflow.api_fastapi.common.dagbag import dag_bag_from_app
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -29,7 +29,7 @@ from uuid import UUID
 import attrs
 import structlog
 from cadwyn import VersionedAPIRouter
-from fastapi import Body, Depends, HTTPException, Query, status
+from fastapi import Body, HTTPException, Query, status
 from pydantic import JsonValue
 from sqlalchemy import func, or_, tuple_, update
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
@@ -37,6 +37,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow.api_fastapi.common.dagbag import DagBagDep
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.api_fastapi.common.db.common import SessionDep
@@ -59,7 +60,7 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
 from airflow.api_fastapi.execution_api.deps import JWTBearerTIPathDep
 from airflow.exceptions import TaskNotFound
 from airflow.models.asset import AssetActive
-from airflow.models.dagbag import DagBag
+from airflow.models.dagbag import SchedulerDagBag
 from airflow.models.dagrun import DagRun as DR
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
 from airflow.models.taskreschedule import TaskReschedule
@@ -75,10 +76,6 @@ if TYPE_CHECKING:
 
     from airflow.models.expandinput import SchedulerExpandInput
     from airflow.sdk.types import Operator
-
-from airflow.jobs.scheduler_job_runner import SchedulerDagBag
-
-SchedulerDagBagDep = Annotated[SchedulerDagBag, Depends(dag_bag_from_app)]
 
 router = VersionedAPIRouter()
 
@@ -107,7 +104,7 @@ def ti_run(
     task_instance_id: UUID,
     ti_run_payload: Annotated[TIEnterRunningPayload, Body()],
     session: SessionDep,
-    dag_bag: SchedulerDagBagDep,
+    dag_bag: DagBagDep,
 ) -> TIRunContext:
     """
     Run a TaskInstance.
@@ -258,7 +255,7 @@ def ti_run(
             or 0
         )
 
-        if dag := dag_bag.get_dag(dag_run=dr, session=session):
+        if dag := dag_bag.get_dag_for_run(dag_run=dr, session=session):
             upstream_map_indexes = dict(
                 _get_upstream_map_indexes(dag.get_task(ti.task_id), ti.map_index, ti.run_id, session)
             )
@@ -333,7 +330,7 @@ def ti_update_state(
     task_instance_id: UUID,
     ti_patch_payload: Annotated[TIStateUpdate, Body()],
     session: SessionDep,
-    dag_bag: SchedulerDagBagDep,
+    dag_bag: DagBagDep,
 ):
     """
     Update the state of a TaskInstance.
@@ -420,9 +417,9 @@ def ti_update_state(
         )
 
 
-def _handle_fail_fast_for_dag(ti: TI, dag_id: str, session: SessionDep, dag_bag: SchedulerDagBagDep) -> None:
+def _handle_fail_fast_for_dag(ti: TI, dag_id: str, session: SessionDep, dag_bag: DagBagDep) -> None:
     dr = ti.dag_run
-    ser_dag = dag_bag.get_dag(dag_run=dr, session=session)
+    ser_dag = dag_bag.get_dag_for_run(dag_run=dr, session=session)
     if ser_dag and getattr(ser_dag, "fail_fast", False):
         task_dict = getattr(ser_dag, "task_dict")
         task_teardown_map = {k: v.is_teardown for k, v in task_dict.items()}
@@ -436,7 +433,7 @@ def _create_ti_state_update_query_and_update_state(
     query: Update,
     updated_state,
     session: SessionDep,
-    dag_bag: SchedulerDagBagDep,
+    dag_bag: DagBagDep,
     dag_id: str,
 ) -> tuple[Update, TaskInstanceState]:
     if isinstance(ti_patch_payload, (TITerminalStatePayload, TIRetryStatePayload, TISuccessStatePayload)):
@@ -854,7 +851,7 @@ def _is_eligible_to_retry(state: str, try_number: int, max_tries: int) -> bool:
 
 def _get_group_tasks(dag_id: str, task_group_id: str, session: SessionDep, logical_dates=None, run_ids=None):
     # Get all tasks in the task group
-    dag = DagBag(read_dags_from_db=True).get_dag(dag_id, session)
+    dag = SchedulerDagBag().get_latest_version_of_dag(dag_id, session)
     if not dag:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
@@ -897,7 +894,7 @@ def _get_group_tasks(dag_id: str, task_group_id: str, session: SessionDep, logic
 def validate_inlets_and_outlets(
     task_instance_id: UUID,
     session: SessionDep,
-    dag_bag: SchedulerDagBagDep,
+    dag_bag: DagBagDep,
 ) -> InactiveAssetsResponse:
     """Validate whether there're inactive assets in inlets and outlets of a given task instance."""
     ti_id_str = str(task_instance_id)
@@ -916,7 +913,7 @@ def validate_inlets_and_outlets(
 
     if not ti.task:
         dr = ti.dag_run
-        dag = dag_bag.get_dag(dag_run=dr, session=session)
+        dag = dag_bag.get_dag_for_run(dag_run=dr, session=session)
         if dag:
             with contextlib.suppress(TaskNotFound):
                 ti.task = dag.get_task(ti.task_id)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -60,6 +60,7 @@ from airflow.models.asset import (
 from airflow.models.backfill import Backfill
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
+from airflow.models.dagbag import SchedulerDagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.serialized_dag import SerializedDagModel
@@ -102,48 +103,6 @@ DM = DagModel
 
 TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 """:meta private:"""
-
-
-class SchedulerDagBag:
-    """
-    Internal class for retrieving and caching dags in the scheduler.
-
-    :meta private:
-    """
-
-    def __init__(self):
-        self._dags: dict[str, DAG] = {}  # dag_version_id to dag
-
-    def _get_dag(self, version_id: str, session: Session) -> DAG | None:
-        if dag := self._dags.get(version_id):
-            return dag
-        dag_version = session.get(DagVersion, version_id, options=[joinedload(DagVersion.serialized_dag)])
-        if not dag_version:
-            return None
-        serdag = dag_version.serialized_dag
-        if not serdag:
-            return None
-        serdag.load_op_links = False
-        dag = serdag.dag
-        if not dag:
-            return None
-        self._dags[version_id] = dag
-        return dag
-
-    @staticmethod
-    def _version_from_dag_run(dag_run, latest, session):
-        if latest or not dag_run.bundle_version:
-            dag_version = DagVersion.get_latest_version(dag_id=dag_run.dag_id, session=session)
-            if dag_version:
-                return dag_version
-
-        return dag_run.created_dag_version
-
-    def get_dag(self, dag_run: DagRun, session: Session, latest=False) -> DAG | None:
-        version = self._version_from_dag_run(dag_run=dag_run, latest=latest, session=session)
-        if not version:
-            return None
-        return self._get_dag(version_id=version.id, session=session)
 
 
 def _get_current_dag(dag_id: str, session: Session) -> DAG | None:
@@ -253,7 +212,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if log:
             self._log = log
 
-        self.scheduler_dag_bag = SchedulerDagBag()
+        self.scheduler_dag_bag = SchedulerDagBag(load_op_links=False)
 
     @provide_session
     def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:
@@ -544,7 +503,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 if task_instance.dag_model.has_task_concurrency_limits:
                     # Many dags don't have a task_concurrency, so where we can avoid loading the full
                     # serialized DAG the better.
-                    serialized_dag = self.scheduler_dag_bag.get_dag(
+                    serialized_dag = self.scheduler_dag_bag.get_dag_for_run(
                         dag_run=task_instance.dag_run, session=session
                     )
                     # If the dag is missing, fail the task and continue to the next task.
@@ -905,7 +864,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
                 # Get task from the Serialized DAG
                 try:
-                    dag = scheduler_dag_bag.get_dag(dag_run=ti.dag_run, session=session)
+                    dag = scheduler_dag_bag.get_dag_for_run(dag_run=ti.dag_run, session=session)
                     cls.logger().error(
                         "DAG '%s' for task instance %s not found in serialized_dag table",
                         ti.dag_id,
@@ -1034,7 +993,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .group_by(DagRun)
             )
             for dag_run in paused_runs:
-                dag = self.scheduler_dag_bag.get_dag(dag_run=dag_run, session=session)
+                dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
                 if dag is not None:
                     dag_run.dag = dag
                     _, callback_to_run = dag_run.update_state(execute_callbacks=False, session=session)
@@ -1386,7 +1345,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # Send the callbacks after we commit to ensure the context is up to date when it gets run
         # cache saves time during scheduling of many dag_runs for same dag
         cached_get_dag: Callable[[DagRun], DAG | None] = lru_cache()(
-            partial(self.scheduler_dag_bag.get_dag, session=session)
+            partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
         for dag_run, callback_to_run in callback_tuples:
             dag = cached_get_dag(dag_run)
@@ -1728,7 +1687,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # cache saves time during scheduling of many dag_runs for same dag
         cached_get_dag: Callable[[DagRun], DAG | None] = lru_cache()(
-            partial(self.scheduler_dag_bag.get_dag, session=session)
+            partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
 
         span = Trace.get_current_span()
@@ -1818,7 +1777,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
             callback: DagCallbackRequest | None = None
 
-            dag = dag_run.dag = self.scheduler_dag_bag.get_dag(dag_run=dag_run, session=session)
+            dag = dag_run.dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
             dag_model = DM.get_dagmodel(dag_run.dag_id, session)
 
             if not dag or not dag_model:
@@ -1936,7 +1895,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.debug("DAG %s not changed structure, skipping dagrun.verify_integrity", dag_run.dag_id)
             return True
         # Refresh the DAG
-        dag_run.dag = self.scheduler_dag_bag.get_dag(dag_run=dag_run, session=session)
+        dag_run.dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
         if not dag_run.dag:
             return False
         # Select all TIs in State.unfinished and update the dag_version_id

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -1282,11 +1282,11 @@ class DAG(TaskSDKDag, LoggingMixin):
         only_running: bool = False,
         confirm_prompt: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
-        run_on_latest_version: bool = False,
         session: Session = NEW_SESSION,
         dag_bag: DagBag | None = None,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
         exclude_run_ids: frozenset[str] | None = frozenset(),
+        run_on_latest_version: bool = False,
     ) -> list[TaskInstance]: ...  # pragma: no cover
 
     @overload
@@ -1300,11 +1300,11 @@ class DAG(TaskSDKDag, LoggingMixin):
         confirm_prompt: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: Literal[False] = False,
-        run_on_latest_version: bool = False,
         session: Session = NEW_SESSION,
         dag_bag: DagBag | None = None,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
         exclude_run_ids: frozenset[str] | None = frozenset(),
+        run_on_latest_version: bool = False,
     ) -> int: ...  # pragma: no cover
 
     @overload
@@ -1319,11 +1319,11 @@ class DAG(TaskSDKDag, LoggingMixin):
         only_running: bool = False,
         confirm_prompt: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
-        run_on_latest_version: bool = False,
         session: Session = NEW_SESSION,
         dag_bag: DagBag | None = None,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
         exclude_run_ids: frozenset[str] | None = frozenset(),
+        run_on_latest_version: bool = False,
     ) -> list[TaskInstance]: ...  # pragma: no cover
 
     @overload
@@ -1338,11 +1338,11 @@ class DAG(TaskSDKDag, LoggingMixin):
         confirm_prompt: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: Literal[False] = False,
-        run_on_latest_version: bool = False,
         session: Session = NEW_SESSION,
         dag_bag: DagBag | None = None,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
         exclude_run_ids: frozenset[str] | None = frozenset(),
+        run_on_latest_version: bool = False,
     ) -> int: ...  # pragma: no cover
 
     @provide_session
@@ -1358,11 +1358,11 @@ class DAG(TaskSDKDag, LoggingMixin):
         confirm_prompt: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: bool = False,
-        run_on_latest_version: bool = False,
         session: Session = NEW_SESSION,
         dag_bag: DagBag | None = None,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
         exclude_run_ids: frozenset[str] | None = frozenset(),
+        run_on_latest_version: bool = False,
     ) -> int | Iterable[TaskInstance]:
         """
         Clear a set of task instances associated with the current dag for a specified date range.

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -37,6 +37,7 @@ from sqlalchemy import (
     Column,
     String,
 )
+from sqlalchemy.orm import joinedload
 from tabulate import tabulate
 
 from airflow import settings
@@ -52,6 +53,7 @@ from airflow.exceptions import (
 )
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.base import Base, StringID
+from airflow.models.dag_version import DagVersion
 from airflow.stats import Stats
 from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.docs import get_docs_url
@@ -71,6 +73,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
+    from airflow.models import DagRun
     from airflow.models.dag import DAG
     from airflow.models.dagwarning import DagWarning
     from airflow.utils.types import ArgNotSet
@@ -710,6 +713,66 @@ class DagBag(LoggingMixin):
             self.dag_warnings,
             session=session,
         )
+
+
+class SchedulerDagBag:
+    """
+    Internal class for retrieving and caching dags in the scheduler.
+
+    :meta private:
+    """
+
+    def __init__(self, load_op_links: bool = True):
+        self._dags: dict[str, DAG] = {}  # dag_version_id to dag
+        self.load_op_links = load_op_links
+
+    def _get_dag(self, version_id: str, session: Session) -> DAG | None:
+        if dag := self._dags.get(version_id):
+            return dag
+        dag_version = session.get(DagVersion, version_id, options=[joinedload(DagVersion.serialized_dag)])
+        if not dag_version:
+            return None
+        serdag = dag_version.serialized_dag
+        if not serdag:
+            return None
+        serdag.load_op_links = self.load_op_links
+        dag = serdag.dag
+        if not dag:
+            return None
+        self._dags[version_id] = dag
+        return dag
+
+    @staticmethod
+    def _version_from_dag_run(dag_run, session):
+        if not dag_run.bundle_version:
+            dag_version = DagVersion.get_latest_version(dag_id=dag_run.dag_id, session=session)
+            if dag_version:
+                return dag_version
+
+        return dag_run.created_dag_version
+
+    def get_dag_for_run(self, dag_run: DagRun, session: Session) -> DAG | None:
+        version = self._version_from_dag_run(dag_run=dag_run, session=session)
+        if not version:
+            return None
+        return self._get_dag(version_id=version.id, session=session)
+
+    def get_latest_version_of_dag(self, dag_id: str, session: Session) -> DAG | None:
+        """
+        Get the latest version of a DAG by its ID.
+
+        This method retrieves the latest version of the DAG with the given ID.
+        """
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        serdag = SerializedDagModel.get(dag_id, session=session)
+        if not serdag:
+            return None
+        serdag.load_op_links = self.load_op_links
+        dag = serdag.dag
+
+        self._dags[serdag.dag_version.id] = dag
+        return dag
 
 
 def generate_md5_hash(context):

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -223,9 +223,9 @@ def clear_task_instances(
     :meta private:
     """
     task_instance_ids: list[str] = []
-    from airflow.jobs.scheduler_job_runner import SchedulerDagBag
+    from airflow.models.dagbag import SchedulerDagBag
 
-    scheduler_dagbag = SchedulerDagBag()
+    scheduler_dagbag = SchedulerDagBag(load_op_links=False)
 
     for ti in tis:
         task_instance_ids.append(ti.id)
@@ -236,7 +236,10 @@ def clear_task_instances(
             ti.state = TaskInstanceState.RESTARTING
         else:
             dr = ti.dag_run
-            ti_dag = scheduler_dagbag.get_dag(dag_run=dr, session=session, latest=run_on_latest_version)
+            if run_on_latest_version:
+                ti_dag = scheduler_dagbag.get_latest_version_of_dag(ti.dag_id, session=session)
+            else:
+                ti_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
             if not ti_dag:
                 log.warning("No serialized dag found for dag '%s'", dr.dag_id)
             task_id = ti.task_id
@@ -279,7 +282,10 @@ def clear_task_instances(
             if dr.state in State.finished_dr_states:
                 dr.state = dag_run_state
                 dr.start_date = timezone.utcnow()
-                dr_dag = scheduler_dagbag.get_dag(dag_run=dr, session=session, latest=run_on_latest_version)
+                if run_on_latest_version:
+                    dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
+                else:
+                    dr_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
                 if not dr_dag:
                     log.warning("No serialized dag found for dag '%s'", dr.dag_id)
                 if dr_dag and not dr_dag.disable_bundle_versioning and run_on_latest_version:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1336,18 +1336,14 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
     def expand_start_trigger_args(self, *, context: Context) -> StartTriggerArgs | None:
         return self.start_trigger_args
 
-    def __getattribute__(self, name):
-        # We need to handle missing attributes with task_type instead of SerializedBaseOperator
-        try:
-            return super().__getattribute__(name)
-        except AttributeError:
-            # Only intercept AttributeError for missing attributes
-            # Don't intercept special methods that Python internals might check
-            if name.startswith("__") and name.endswith("__"):
-                # For special methods, raise the original error
-                raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
-            # For regular attributes, use task_type in the error message
-            raise AttributeError(f"'{self.task_type}' object has no attribute '{name}'")
+    def __getattr__(self, name):
+        # Handle missing attributes with task_type instead of SerializedBaseOperator
+        # Don't intercept special methods that Python internals might check
+        if name.startswith("__") and name.endswith("__"):
+            # For special methods, raise the original error
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+        # For regular attributes, use task_type in the error message
+        raise AttributeError(f"'{self.task_type}' object has no attribute '{name}'")
 
     @classmethod
     def serialize_mapped_operator(cls, op: MappedOperator) -> dict[str, Any]:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1209,7 +1209,7 @@ export const $ClearTaskInstancesBody = {
         run_on_latest_version: {
             type: 'boolean',
             title: 'Run On Latest Version',
-            description: '(Experimental) Run on the latest bundle version of the DAG after clearing the task instances.',
+            description: '(Experimental) Run on the latest bundle version of the dag after clearing the task instances.',
             default: false
         }
     },
@@ -2187,7 +2187,7 @@ export const $DAGRunClearBody = {
         run_on_latest_version: {
             type: 'boolean',
             title: 'Run On Latest Version',
-            description: '(Experimental) Run on the latest bundle version of the DAG after clearing the DAG Run.',
+            description: '(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run.',
             default: false
         }
     },

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -390,7 +390,7 @@ export type ClearTaskInstancesBody = {
     include_future?: boolean;
     include_past?: boolean;
     /**
-     * (Experimental) Run on the latest bundle version of the DAG after clearing the task instances.
+     * (Experimental) Run on the latest bundle version of the dag after clearing the task instances.
      */
     run_on_latest_version?: boolean;
 };
@@ -597,7 +597,7 @@ export type DAGRunClearBody = {
     dry_run?: boolean;
     only_failed?: boolean;
     /**
-     * (Experimental) Run on the latest bundle version of the DAG after clearing the DAG Run.
+     * (Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run.
      */
     run_on_latest_version?: boolean;
 };

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -48,13 +48,13 @@ class TestDagBagSingleton:
         """Patch DagBag once before app is created, and reset counter."""
         self.dagbag_call_counter["count"] = 0
 
-        from airflow.models.dagbag import DagBag as RealDagBag
+        from airflow.models.dagbag import SchedulerDagBag as RealDagBag
 
         def factory(*args, **kwargs):
             self.dagbag_call_counter["count"] += 1
             return RealDagBag(*args, **kwargs)
 
-        with mock.patch("airflow.api_fastapi.common.dagbag.DagBag", side_effect=factory):
+        with mock.patch("airflow.api_fastapi.common.dagbag.SchedulerDagBag", side_effect=factory):
             purge_cached_app()
             yield
 

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -170,10 +170,10 @@ def make_dag_with_multiple_versions(dag_maker, configure_git_connection_for_dag_
 
 @pytest.fixture(scope="module")
 def dagbag():
-    from airflow.models import DagBag
+    from airflow.models.dagbag import SchedulerDagBag
 
     parse_and_sync_to_db(os.devnull, include_examples=True)
-    return DagBag(read_dags_from_db=True)
+    return SchedulerDagBag()
 
 
 @pytest.fixture

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -24,7 +24,7 @@ import pytest
 from httpx import Response
 from sqlalchemy import select
 
-from airflow.models.dagbag import DagBag
+from airflow.models.dagbag import SchedulerDagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.state import DagRunState
@@ -46,9 +46,9 @@ TEST_DAG_DISPLAY_NAME = "example_simplest_dag"
 
 
 @pytest.fixture
-def test_dag():
+def test_dag(session):
     parse_and_sync_to_db(EXAMPLE_DAG_FILE, include_examples=False)
-    return DagBag(read_dags_from_db=True).get_dag(TEST_DAG_ID)
+    return SchedulerDagBag().get_latest_version_of_dag(TEST_DAG_ID, session)
 
 
 class TestGetDAGSource:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -16,15 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.api_fastapi.core_api.datamodels.extra_links import ExtraLinkCollectionResponse
-from airflow.dag_processing.bundles.manager import DagBundlesManager
-from airflow.models.dagbag import DagBag
+from airflow.models.dagbag import SchedulerDagBag
 from airflow.models.xcom import XComModel as XCom
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.state import DagRunState
@@ -92,14 +89,10 @@ class TestGetExtraLinks:
 
         self.dag = self._create_dag(dag_maker)
 
-        DagBundlesManager().sync_bundles_to_db()
-        dag_bag = DagBag(os.devnull, include_examples=False)
-        dag_bag.dags = {self.dag.dag_id: self.dag}
-
+        dag_bag = SchedulerDagBag()
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
-        dag_bag.sync_to_db("dags-folder", None)
 
-        self.dag.create_dagrun(
+        dag_maker.create_dagrun(
             run_id=self.dag_run_id,
             logical_date=self.default_time,
             run_type=DagRunType.MANUAL,
@@ -148,7 +141,7 @@ class TestGetExtraLinks:
         assert response.status_code == expected_status_code
         assert response.json() == expected_response
 
-    def test_should_respond_200(self, dag_maker, test_client):
+    def test_should_respond_200(self, test_client, session):
         XCom.set(
             key="search_query",
             value="TEST_LINK_VALUE",
@@ -163,7 +156,6 @@ class TestGetExtraLinks:
             dag_id=self.dag_id,
             run_id=self.dag_run_id,
         )
-
         response = test_client.get(
             f"/dags/{self.dag_id}/dagRuns/{self.dag_run_id}/taskInstances/{self.task_single_link}/links",
         )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -32,6 +32,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import create_dag_bag, dag_bag_from_app
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models.dag import DAG
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import task
 from airflow.utils.types import DagRunType
@@ -114,8 +115,6 @@ class TestTaskInstancesLog:
         session.commit()
 
         dagbag = create_dag_bag()
-        dagbag.bag_dag(dag)
-        dagbag.bag_dag(dummy_dag)
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dagbag
 
     @pytest.fixture
@@ -276,7 +275,8 @@ class TestTaskInstancesLog:
         # Recreate DAG without tasks
         dagbag = create_dag_bag()
         dag = DAG(self.DAG_ID, schedule=None, start_date=timezone.parse(self.default_time))
-        dagbag.bag_dag(dag=dag)
+        dag.sync_to_db()
+        SerializedDagModel.write_dag(dag, bundle_name="testing")
 
         self.app.dependency_overrides[dag_bag_from_app] = lambda: dagbag
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -103,7 +103,7 @@ class TestTaskInstanceEndpoint:
         with_ti_history=False,
     ):
         """Method to create task instances using kwargs and default arguments"""
-        dag = self.dagbag.get_dag(dag_id)
+        dag = self.dagbag.get_latest_version_of_dag(dag_id, session)
         tasks = dag.tasks
         counter = len(tasks)
         if task_instances is not None:
@@ -2223,7 +2223,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{request_dag}/clearTaskInstances",
             json=payload,
@@ -2249,7 +2248,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert response.status_code == 400
         assert (
@@ -2317,7 +2315,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{request_dag}/clearTaskInstances",
             json=payload,
@@ -2330,7 +2327,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
         dag_id = "example_python_operator"
         payload = {"reset_dag_runs": True, "dry_run": False}
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2349,7 +2345,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert dagrun.state == "running"
 
         payload = {"dry_run": False, "reset_dag_runs": True, "task_ids": [""]}
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2399,7 +2394,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=DagRunState.FAILED,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2484,7 +2478,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2570,7 +2563,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2654,7 +2646,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2804,7 +2795,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             "/dags/example_python_operator/clearTaskInstances",
             json=payload,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -1164,7 +1164,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
     def test_not_found(self, test_client):
         response = test_client.get("/dags/invalid/dagRuns/~/taskInstances")
         assert response.status_code == 404
-        assert response.json() == {"detail": "DAG with dag_id: `invalid` was not found"}
+        assert response.json() == {"detail": "Dag with dag_id: `invalid` was not found"}
 
         response = test_client.get("/dags/~/dagRuns/invalid/taskInstances")
         assert response.status_code == 404

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -16,14 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import os
 from datetime import datetime
 
 import pytest
 
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.models.dag import DAG
-from airflow.models.dagbag import DagBag
+from airflow.models.dagbag import SchedulerDagBag
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.definitions._internal.expandinput import EXPAND_INPUT_EMPTY
@@ -64,12 +63,14 @@ class TestTaskEndpoint:
 
         task1 >> task2
         task4 >> task5
-        dag_bag = DagBag(os.devnull, include_examples=False)
-        dag_bag.dags = {
-            dag.dag_id: dag,
-            mapped_dag.dag_id: mapped_dag,
-            unscheduled_dag.dag_id: unscheduled_dag,
-        }
+        dag.sync_to_db()
+        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        mapped_dag.sync_to_db()
+        SerializedDagModel.write_dag(mapped_dag, bundle_name="testing")
+        unscheduled_dag.sync_to_db()
+        SerializedDagModel.write_dag(unscheduled_dag, bundle_name="testing")
+        dag_bag = SchedulerDagBag()
+
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
     @staticmethod
@@ -239,7 +240,7 @@ class TestGetTask(TestTaskEndpoint):
         dag.sync_to_db()
         SerializedDagModel.write_dag(dag, bundle_name="test_bundle")
 
-        dag_bag = DagBag(os.devnull, include_examples=False, read_dags_from_db=True)
+        dag_bag = SchedulerDagBag()
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
         expected = {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -543,7 +543,7 @@ class TestCreateXComEntry(TestXComEndpoint):
                 "invalid-dag-run-id",
                 XComCreateBody(key=TEST_XCOM_KEY, value=TEST_XCOM_VALUE),
                 404,
-                f"DAG Run with ID: `invalid-dag-run-id` not found for DAG: `{TEST_DAG_ID}`",
+                f"Dag Run with ID: `invalid-dag-run-id` not found for DAG: `{TEST_DAG_ID}`",
                 id="dag-run-not-found",
             ),
             # Test case: XCom entry already exists

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -543,7 +543,7 @@ class TestCreateXComEntry(TestXComEndpoint):
                 "invalid-dag-run-id",
                 XComCreateBody(key=TEST_XCOM_KEY, value=TEST_XCOM_VALUE),
                 404,
-                f"Dag Run with ID: `invalid-dag-run-id` not found for DAG: `{TEST_DAG_ID}`",
+                f"Dag Run with ID: `invalid-dag-run-id` not found for dag: `{TEST_DAG_ID}`",
                 id="dag-run-not-found",
             ),
             # Test case: XCom entry already exists

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -533,7 +533,7 @@ class TestCreateXComEntry(TestXComEndpoint):
                 run_id,
                 XComCreateBody(key=TEST_XCOM_KEY, value=TEST_XCOM_VALUE),
                 404,
-                f"Task with ID: `invalid-task-id` not found in DAG: `{TEST_DAG_ID}`",
+                f"Task with ID: `invalid-task-id` not found in dag: `{TEST_DAG_ID}`",
                 id="task-not-found",
             ),
             # Test case: DAG Run not found

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
@@ -23,7 +23,7 @@ import pytest
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
-from airflow.jobs.scheduler_job_runner import SchedulerDagBag
+from airflow.models.dagbag import SchedulerDagBag
 from airflow.utils.state import State
 
 from tests_common.test_utils.db import clear_db_assets, clear_db_runs

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -460,7 +460,7 @@ class TestSchedulerJob:
         scheduler_job = Job(executor=executor)
         self.job_runner = SchedulerJobRunner(scheduler_job)
         self.job_runner.scheduler_dag_bag = mock.MagicMock()
-        self.job_runner.scheduler_dag_bag.get_dag.side_effect = Exception("failed")
+        self.job_runner.scheduler_dag_bag.get_dag_for_run.side_effect = Exception("failed")
 
         session = settings.Session()
 
@@ -976,7 +976,7 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
 
         self.job_runner.scheduler_dag_bag = mock.MagicMock()
-        self.job_runner.scheduler_dag_bag.get_dag.return_value = None
+        self.job_runner.scheduler_dag_bag.get_dag_for_run.return_value = None
 
         dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
 
@@ -3472,7 +3472,7 @@ class TestSchedulerJob:
         dr = drs[0]
 
         self.job_runner._schedule_dag_run(dag_run=dr, session=session)
-        len(self.job_runner.scheduler_dag_bag.get_dag(dr, session).tasks) == 1
+        len(self.job_runner.scheduler_dag_bag.get_dag_for_run(dr, session).tasks) == 1
         dag_version_1 = DagVersion.get_latest_version(dr.dag_id, session=session)
         assert dr.dag_versions[-1].id == dag_version_1.id
 
@@ -3490,7 +3490,7 @@ class TestSchedulerJob:
         assert len(drs) == 1
         dr = drs[0]
         assert dr.dag_versions[-1].id == dag_version_2.id
-        assert len(self.job_runner.scheduler_dag_bag.get_dag(dr, session).tasks) == 2
+        assert len(self.job_runner.scheduler_dag_bag.get_dag_for_run(dr, session).tasks) == 2
 
         if SQLALCHEMY_V_1_4:
             tis_count = (
@@ -4335,7 +4335,7 @@ class TestSchedulerJob:
         # assert len(self.job_runner.scheduler_dag_bag._dags) == 1  # sanity check
         # Get serialized dag
         dr = DagRun.find(dag_id=dag.dag_id)[0]
-        s_dag_2 = self.job_runner.scheduler_dag_bag.get_dag(dr, session=session)
+        s_dag_2 = self.job_runner.scheduler_dag_bag.get_dag_for_run(dr, session=session)
         custom_task = s_dag_2.task_dict["custom_task"]
         # Test that custom_task has no Operator Links (after de-serialization) in the Scheduling Loop
         assert not custom_task.operator_extra_links

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -204,7 +204,7 @@ class ClearTaskInstancesBody(BaseModel):
     run_on_latest_version: Annotated[
         bool | None,
         Field(
-            description="(Experimental) Run on the latest bundle version of the DAG after clearing the task instances.",
+            description="(Experimental) Run on the latest bundle version of the dag after clearing the task instances.",
             title="Run On Latest Version",
         ),
     ] = False
@@ -318,7 +318,7 @@ class DAGRunClearBody(BaseModel):
     run_on_latest_version: Annotated[
         bool | None,
         Field(
-            description="(Experimental) Run on the latest bundle version of the DAG after clearing the DAG Run.",
+            description="(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run.",
             title="Run On Latest Version",
         ),
     ] = False


### PR DESCRIPTION
This removes the use of DagBag in API server which parses files in some cases and
replaces it with refactored SchedulerDagBag.