### PR TITLE
Use standard library ``typing`` imports for Python 3.10+

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from abc import ABCMeta, abstractmethod
 from functools import cache
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from jwt import InvalidTokenError
 from sqlalchemy import select
@@ -36,7 +36,6 @@ from airflow.api_fastapi.auth.tokens import (
 from airflow.api_fastapi.common.types import ExtraMenuItem, MenuItem
 from airflow.configuration import conf
 from airflow.models import DagModel
-from airflow.typing_compat import Literal
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 

--- a/airflow-core/src/airflow/cli/simple_table.py
+++ b/airflow-core/src/airflow/cli/simple_table.py
@@ -32,7 +32,7 @@ from airflow.utils import yaml
 from airflow.utils.platform import is_tty
 
 if TYPE_CHECKING:
-    from airflow.typing_compat import TypeGuard
+    from typing import TypeGuard
 
 
 def is_data_sequence(data: Sequence[dict | Any]) -> TypeGuard[Sequence[dict]]:

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -106,6 +106,8 @@ from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pydantic import NonNegativeInt
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
@@ -113,7 +115,6 @@ if TYPE_CHECKING:
     from airflow.models.dagbag import DagBag
     from airflow.models.operator import Operator
     from airflow.serialization.serialized_objects import MaybeSerializedDAG
-    from airflow.typing_compat import Literal
 
 log = logging.getLogger(__name__)
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -91,6 +91,7 @@ from airflow.utils.types import NOTSET, DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from datetime import datetime
+    from typing import Literal
 
     from opentelemetry.sdk.trace import Span
     from pydantic import NonNegativeInt
@@ -102,7 +103,6 @@ if TYPE_CHECKING:
     from airflow.models.dag_version import DagVersion
     from airflow.models.operator import Operator
     from airflow.sdk import DAG as SDKDAG, Context
-    from airflow.typing_compat import Literal
     from airflow.utils.types import ArgNotSet
 
     CreatedTasks = TypeVar("CreatedTasks", Iterator["dict[str, Any]"], Iterator[TI])

--- a/airflow-core/src/airflow/models/expandinput.py
+++ b/airflow-core/src/airflow/models/expandinput.py
@@ -25,10 +25,11 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import attrs
 
 if TYPE_CHECKING:
+    from typing import TypeGuard
+
     from sqlalchemy.orm import Session
 
     from airflow.models.xcom_arg import SchedulerXComArg
-    from airflow.typing_compat import TypeGuard
 
 from airflow.sdk.definitions._internal.expandinput import (
     DictOfListsExpandInput,

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -109,6 +109,7 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datetime import datetime
+    from typing import Literal
 
     import pendulum
     from sqlalchemy.engine import Connection as SAConnection, Engine
@@ -126,7 +127,6 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.taskgroup import MappedTaskGroup
     from airflow.sdk.types import RuntimeTaskInstanceProtocol
-    from airflow.typing_compat import Literal
     from airflow.utils.context import Context
     from airflow.utils.task_group import TaskGroup
 

--- a/airflow-core/src/airflow/models/taskmixin.py
+++ b/airflow-core/src/airflow/models/taskmixin.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from airflow.typing_compat import TypeAlias
+    from typing import TypeAlias
 
 import airflow.sdk.definitions._internal.mixins
 import airflow.sdk.definitions._internal.node

--- a/airflow-core/src/airflow/providers_manager.py
+++ b/airflow-core/src/airflow/providers_manager.py
@@ -31,12 +31,11 @@ from dataclasses import dataclass
 from functools import wraps
 from importlib.resources import files as resource_files
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, ParamSpec, TypeVar
 
 from packaging.utils import canonicalize_name
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
-from airflow.typing_compat import ParamSpec
 from airflow.utils.entry_points import entry_points_with_dist
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.module_loading import import_string

--- a/airflow-core/src/airflow/typing_compat.py
+++ b/airflow-core/src/airflow/typing_compat.py
@@ -29,17 +29,8 @@ __all__ = [
 
 import sys
 
-# Literal from typing module has various issues in different Python versions, see:
-# - https://typing-extensions.readthedocs.io/en/latest/#Literal
-# - bpo-45679: https://github.com/python/cpython/pull/29334
-# - bpo-42345: https://github.com/python/cpython/pull/23294
-# - bpo-42345: https://github.com/python/cpython/pull/23383
-if sys.version_info >= (3, 10, 1) or (3, 9, 8) <= sys.version_info < (3, 10):
-    from typing import Literal
-else:
-    from typing import Literal  # type: ignore[assignment]
-
-from typing import ParamSpec, TypeAlias, TypeGuard
+# Keeping this for backwards-compat with old providers
+from typing import Literal, ParamSpec, TypeAlias, TypeGuard
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -47,12 +47,13 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State, TaskInstanceState
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from requests import Response
 
     from airflow.executors.base_executor import BaseExecutor
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancehistory import TaskInstanceHistory
-    from airflow.typing_compat import TypeAlias
 
 CHUNK_SIZE = 1024 * 1024 * 5  # 5MB
 DEFAULT_SORT_DATETIME = pendulum.datetime(2000, 1, 1)

--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -29,11 +29,12 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from sqlalchemy.orm.session import Session
 
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancehistory import TaskInstanceHistory
-    from airflow.typing_compat import TypeAlias
     from airflow.utils.log.file_task_handler import LogHandlerOutputStream, LogMetadata
 
 LogReaderOutputStream: TypeAlias = Generator[str, None, None]

--- a/airflow-core/src/airflow/utils/providers_configuration_loader.py
+++ b/airflow-core/src/airflow/utils/providers_configuration_loader.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from typing import TypeVar
-
-from airflow.typing_compat import ParamSpec
+from typing import ParamSpec, TypeVar
 
 PS = ParamSpec("PS")
 RT = TypeVar("RT")

--- a/airflow-core/src/airflow/utils/session.py
+++ b/airflow-core/src/airflow/utils/session.py
@@ -20,10 +20,9 @@ import contextlib
 from collections.abc import Callable, Generator
 from functools import wraps
 from inspect import signature
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
 
 from airflow import settings
-from airflow.typing_compat import ParamSpec
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session as SASession

--- a/airflow-core/src/airflow/utils/task_group.py
+++ b/airflow-core/src/airflow/utils/task_group.py
@@ -28,7 +28,7 @@ import airflow.sdk.definitions.taskgroup
 from airflow.configuration import conf
 
 if TYPE_CHECKING:
-    from airflow.typing_compat import TypeAlias
+    from typing import TypeAlias
 
 TaskGroup: TypeAlias = airflow.sdk.definitions.taskgroup.TaskGroup
 MappedTaskGroup: TypeAlias = airflow.sdk.definitions.taskgroup.MappedTaskGroup

--- a/airflow-core/src/airflow/utils/types.py
+++ b/airflow-core/src/airflow/utils/types.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 import airflow.sdk.definitions._internal.types
 
 if TYPE_CHECKING:
-    from airflow.typing_compat import TypeAlias
+    from typing import TypeAlias
 
 ArgNotSet: TypeAlias = airflow.sdk.definitions._internal.types.ArgNotSet
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/ec2.py
@@ -20,11 +20,10 @@ from __future__ import annotations
 import functools
 import time
 from collections.abc import Callable
-from typing import TypeVar
+from typing import ParamSpec, TypeVar
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
-from airflow.typing_compat import ParamSpec
 
 PS = ParamSpec("PS")
 RT = TypeVar("RT")

--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/suppress.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/suppress.py
@@ -30,9 +30,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from functools import wraps
-from typing import TypeVar
-
-from airflow.typing_compat import ParamSpec
+from typing import ParamSpec, TypeVar
 
 PS = ParamSpec("PS")
 RT = TypeVar("RT")

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -60,12 +60,13 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from celery.result import AsyncResult
 
     from airflow.executors import workloads
     from airflow.executors.base_executor import EventBufferValueType
     from airflow.models.taskinstance import TaskInstanceKey
-    from airflow.typing_compat import TypeAlias
 
     # We can't use `if AIRFLOW_V_3_0_PLUS` conditions in type checks, so unfortunately we just have to define
     # the type as the union of both kinds

--- a/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
@@ -31,7 +31,7 @@ from contextlib import contextmanager
 from functools import partial
 from io import BytesIO
 from tempfile import NamedTemporaryFile
-from typing import IO, TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import IO, TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
 from urllib.parse import urlsplit
 
 from gcloud.aio.storage import Storage
@@ -51,7 +51,6 @@ from airflow.providers.google.common.hooks.base_google import (
     GoogleBaseAsyncHook,
     GoogleBaseHook,
 )
-from airflow.typing_compat import ParamSpec
 from airflow.utils import timezone
 from airflow.version import version
 

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -76,9 +76,9 @@ from airflow.utils.platform import getuser
 
 if TYPE_CHECKING:
     from datetime import datetime
+    from typing import ParamSpec
 
     from airflow.sdk.execution_time.comms import RescheduleTask
-    from airflow.typing_compat import ParamSpec
 
     P = ParamSpec("P")
     T = TypeVar("T")

--- a/task-sdk/src/airflow/sdk/bases/decorator.py
+++ b/task-sdk/src/airflow/sdk/bases/decorator.py
@@ -23,7 +23,7 @@ import textwrap
 import warnings
 from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
 from functools import cached_property, update_wrapper
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, ParamSpec, Protocol, TypeVar, cast, overload
 
 import attr
 import typing_extensions
@@ -46,7 +46,6 @@ from airflow.sdk.definitions._internal.types import NOTSET
 from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.definitions.mappedoperator import MappedOperator, ensure_xcomarg_return_value
 from airflow.sdk.definitions.xcom_arg import XComArg
-from airflow.typing_compat import ParamSpec
 from airflow.utils import timezone
 from airflow.utils.context import KNOWN_CONTEXT_KEYS
 from airflow.utils.decorators import remove_task_decorator

--- a/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
@@ -27,9 +27,10 @@ import attrs
 from airflow.sdk.definitions._internal.mixins import ResolveMixin
 
 if TYPE_CHECKING:
+    from typing import TypeGuard
+
     from airflow.sdk.definitions.xcom_arg import XComArg
     from airflow.sdk.types import Operator
-    from airflow.typing_compat import TypeGuard
 
 ExpandInput = Union["DictOfListsExpandInput", "ListOfDictsExpandInput"]
 

--- a/task-sdk/src/airflow/sdk/definitions/decorators/task_group.py
+++ b/task-sdk/src/airflow/sdk/definitions/decorators/task_group.py
@@ -29,7 +29,7 @@ import functools
 import inspect
 import warnings
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, ParamSpec, TypeVar, overload
 
 import attr
 
@@ -43,7 +43,6 @@ from airflow.sdk.definitions._internal.node import DAGNode
 from airflow.sdk.definitions.mappedoperator import ensure_xcomarg_return_value
 from airflow.sdk.definitions.taskgroup import MappedTaskGroup, TaskGroup
 from airflow.sdk.definitions.xcom_arg import XComArg
-from airflow.typing_compat import ParamSpec
 from airflow.utils.helpers import prevent_duplicates
 
 if TYPE_CHECKING:

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -21,7 +21,7 @@ import contextlib
 import copy
 import warnings
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias, TypeGuard
 
 import attrs
 import methodtools
@@ -52,7 +52,6 @@ from airflow.sdk.definitions._internal.expandinput import (
 from airflow.sdk.definitions._internal.types import NOTSET
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
-from airflow.typing_compat import Literal, TypeAlias, TypeGuard
 from airflow.utils.helpers import is_container, prevent_duplicates
 
 if TYPE_CHECKING:

--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, TextIO, TypeAlias, TypeVar
 from airflow import settings
 
 if TYPE_CHECKING:
-    from airflow.typing_compat import TypeGuard
+    from typing import TypeGuard
 
 V1EnvVar = TypeVar("V1EnvVar")
 Redactable: TypeAlias = str | V1EnvVar | dict[Any, Any] | tuple[Any, ...] | list[Any]


### PR DESCRIPTION
Replace imports of `TypeGuard`, `TypeAlias`, `Literal` and `ParamSpec` from `airflow.typing_compat ` with direct imports from the standard library typing module, as these are now available in Python 3.10+ which is Airflow's minimum supported version.

The main motivator was to remove imports used in both Task SDK & Core Airflow for 3.1 decoupling

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
