### PR TITLE
[v3-0-test] Resolve OOM When Reading Large Logs in Webserver

### DIFF
--- a/airflow-core/src/airflow/utils/log/log_stream_accumulator.py
+++ b/airflow-core/src/airflow/utils/log/log_stream_accumulator.py
@@ -1,0 +1,155 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from itertools import islice
+from typing import IO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from airflow.typing_compat import Self
+    from airflow.utils.log.file_task_handler import (
+        LogHandlerOutputStream,
+        StructuredLogMessage,
+        StructuredLogStream,
+    )
+
+
+class LogStreamAccumulator:
+    """
+    Memory-efficient log stream accumulator that tracks the total number of lines while preserving the original stream.
+
+    This class captures logs from a stream and stores them in a buffer, flushing them to disk when the buffer
+    exceeds a specified threshold. This approach optimizes memory usage while handling large log streams.
+
+    Usage:
+
+    .. code-block:: python
+
+        with LogStreamAccumulator(stream, threshold) as log_accumulator:
+            # Get total number of lines captured
+            total_lines = log_accumulator.get_total_lines()
+
+            # Retrieve the original stream of logs
+            for log in log_accumulator.get_stream():
+                print(log)
+    """
+
+    def __init__(
+        self,
+        stream: LogHandlerOutputStream,
+        threshold: int,
+    ) -> None:
+        """
+        Initialize the LogStreamAccumulator.
+
+        Args:
+            stream: The input log stream to capture and count.
+            threshold: Maximum number of lines to keep in memory before flushing to disk.
+        """
+        self._stream = stream
+        self._threshold = threshold
+        self._buffer: list[StructuredLogMessage] = []
+        self._disk_lines: int = 0
+        self._tmpfile: IO[str] | None = None
+
+    def _flush_buffer_to_disk(self) -> None:
+        """Flush the buffer contents to a temporary file on disk."""
+        if self._tmpfile is None:
+            self._tmpfile = tempfile.NamedTemporaryFile(delete=False, mode="w+", encoding="utf-8")
+
+        self._disk_lines += len(self._buffer)
+        self._tmpfile.writelines(f"{log.model_dump_json()}\n" for log in self._buffer)
+        self._tmpfile.flush()
+        self._buffer.clear()
+
+    def _capture(self) -> None:
+        """Capture logs from the stream into the buffer, flushing to disk when threshold is reached."""
+        while True:
+            # `islice` will try to get up to `self._threshold` lines from the stream.
+            self._buffer.extend(islice(self._stream, self._threshold))
+            # If there are no more lines to capture, exit the loop.
+            if len(self._buffer) < self._threshold:
+                break
+            self._flush_buffer_to_disk()
+
+    def _cleanup(self) -> None:
+        """Clean up the temporary file if it exists."""
+        self._buffer.clear()
+        if self._tmpfile:
+            self._tmpfile.close()
+            os.remove(self._tmpfile.name)
+            self._tmpfile = None
+
+    @property
+    def total_lines(self) -> int:
+        """
+        Return the total number of lines captured from the stream.
+
+        Returns:
+            The sum of lines stored in the buffer and lines written to disk.
+        """
+        return self._disk_lines + len(self._buffer)
+
+    @property
+    def stream(self) -> StructuredLogStream:
+        """
+        Return the original stream of logs and clean up resources.
+
+        Important: This method automatically cleans up resources after all logs have been yielded.
+        Make sure to fully consume the returned generator to ensure proper cleanup.
+
+        Returns:
+            A stream of the captured log messages.
+        """
+        try:
+            if not self._tmpfile:
+                # if no temporary file was created, return from the buffer
+                yield from self._buffer
+            else:
+                # avoid circular import
+                from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+                with open(self._tmpfile.name, encoding="utf-8") as f:
+                    yield from (StructuredLogMessage.model_validate_json(line.strip()) for line in f)
+                # yield the remaining buffer
+                yield from self._buffer
+        finally:
+            # Ensure cleanup after yielding
+            self._cleanup()
+
+    def __enter__(self) -> Self:
+        """
+        Context manager entry point that initiates log capture.
+
+        Returns:
+            Self instance for use in context manager.
+        """
+        self._capture()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Context manager exit that doesn't perform resource cleanup.
+
+        Note: Resources are not cleaned up here. Cleanup is deferred until
+        get_stream() is called and fully consumed, ensuring all logs are properly
+        yielded before cleanup occurs.
+        """

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import logging.config
 import sys
 from unittest import mock
@@ -36,6 +37,7 @@ from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import clear_db_runs
+from tests_common.test_utils.file_task_handler import convert_list_to_stream
 
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 
@@ -233,6 +235,12 @@ class TestTaskInstancesLog:
         assert expected_filename in resp_content
         assert log_content in resp_content
 
+        # check content is in ndjson format
+        for line in resp_content.splitlines():
+            log = json.loads(line)
+            assert "event" in log
+            assert "timestamp" in log
+
     @pytest.mark.parametrize(
         "request_url, expected_filename, extra_query_string, try_number",
         [
@@ -304,11 +312,22 @@ class TestTaskInstancesLog:
 
     @pytest.mark.parametrize("try_number", [1, 2])
     def test_get_logs_with_metadata_as_download_large_file(self, try_number):
+        from airflow.utils.log.file_task_handler import StructuredLogMessage
+
         with mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read") as read_mock:
-            first_return = (["", "1st line"], {})
-            second_return = (["", "2nd line"], {"end_of_log": False})
-            third_return = (["", "3rd line"], {"end_of_log": True})
-            fourth_return = (["", "should never be read"], {"end_of_log": True})
+            first_return = (convert_list_to_stream([StructuredLogMessage(event="", message="1st line")]), {})
+            second_return = (
+                convert_list_to_stream([StructuredLogMessage(event="", message="2nd line")]),
+                {"end_of_log": False},
+            )
+            third_return = (
+                convert_list_to_stream([StructuredLogMessage(event="", message="3rd line")]),
+                {"end_of_log": True},
+            )
+            fourth_return = (
+                convert_list_to_stream([StructuredLogMessage(event="", message="should never be read")]),
+                {"end_of_log": True},
+            )
             read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
 
             response = self.client.get(

--- a/airflow-core/tests/unit/utils/log/test_stream_accumulator.py
+++ b/airflow-core/tests/unit/utils/log/test_stream_accumulator.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pendulum
+import pytest
+
+from airflow.utils.log.file_task_handler import StructuredLogMessage
+from airflow.utils.log.log_stream_accumulator import LogStreamAccumulator
+
+if TYPE_CHECKING:
+    from airflow.utils.log.file_task_handler import LogHandlerOutputStream
+
+LOG_START_DATETIME = pendulum.datetime(2023, 10, 1, 0, 0, 0)
+LOG_COUNT = 20
+
+
+class TestLogStreamAccumulator:
+    """Test cases for the LogStreamAccumulator class."""
+
+    @pytest.fixture
+    def structured_logs(self):
+        """Create a stream of mock structured log messages."""
+
+        def generate_logs():
+            yield from (
+                StructuredLogMessage(
+                    event=f"test_event_{i + 1}",
+                    timestamp=LOG_START_DATETIME.add(seconds=i),
+                    level="INFO",
+                    message=f"Test log message {i + 1}",
+                )
+                for i in range(LOG_COUNT)
+            )
+
+        return generate_logs()
+
+    def validate_log_stream(self, log_stream: LogHandlerOutputStream):
+        """Validate the log stream by checking the number of lines."""
+
+        count = 0
+        for i, log in enumerate(log_stream):
+            assert log.event == f"test_event_{i + 1}"
+            assert log.timestamp == LOG_START_DATETIME.add(seconds=i)
+            count += 1
+        assert count == 20
+
+    def test__capture(self, structured_logs):
+        """Test that temporary file is properly cleaned up during get_stream, not when exiting context."""
+
+        accumulator = LogStreamAccumulator(structured_logs, 5)
+        with (
+            mock.patch.object(accumulator, "_capture") as mock_setup,
+        ):
+            with accumulator:
+                mock_setup.assert_called_once()
+
+    def test__flush_buffer_to_disk(self, structured_logs):
+        """Test flush-to-disk behavior with a small threshold."""
+        threshold = 6
+
+        # Mock the temporary file to verify it's being written to
+        with (
+            mock.patch("tempfile.NamedTemporaryFile") as mock_tmpfile,
+        ):
+            mock_file = mock.MagicMock()
+            mock_tmpfile.return_value = mock_file
+
+            with LogStreamAccumulator(structured_logs, threshold) as accumulator:
+                mock_tmpfile.assert_called_once_with(
+                    delete=False,
+                    mode="w+",
+                    encoding="utf-8",
+                )
+                # Verify _flush_buffer_to_disk was called multiple times
+                # (20 logs / 6 threshold = 3 flushes + 2 remaining logs in buffer)
+                assert accumulator._disk_lines == 18
+                assert mock_file.writelines.call_count == 3
+                assert len(accumulator._buffer) == 2
+
+    @pytest.mark.parametrize(
+        "threshold",
+        [
+            pytest.param(30, id="buffer_only"),
+            pytest.param(5, id="flush_to_disk"),
+        ],
+    )
+    def test_get_stream(self, structured_logs, threshold):
+        """Test that stream property returns all logs regardless of whether they were flushed to disk."""
+
+        tmpfile_name = None
+        with LogStreamAccumulator(structured_logs, threshold) as accumulator:
+            out_stream = accumulator.stream
+
+            # Check if the temporary file was created
+            if threshold < LOG_COUNT:
+                tmpfile_name = accumulator._tmpfile.name
+                assert os.path.exists(tmpfile_name)
+            else:
+                assert accumulator._tmpfile is None
+
+            # Validate the log stream
+            self.validate_log_stream(out_stream)
+
+            # Verify temp file was created and cleaned up
+            if threshold < LOG_COUNT:
+                assert accumulator._tmpfile is None
+                assert not os.path.exists(tmpfile_name) if tmpfile_name else True
+
+    @pytest.mark.parametrize(
+        "threshold, expected_buffer_size, expected_disk_lines",
+        [
+            pytest.param(30, 20, 0, id="no_flush_needed"),
+            pytest.param(10, 0, 20, id="single_flush_needed"),
+            pytest.param(3, 2, 18, id="multiple_flushes_needed"),
+        ],
+    )
+    def test_total_lines(self, structured_logs, threshold, expected_buffer_size, expected_disk_lines):
+        """Test that LogStreamAccumulator correctly counts lines across buffer and disk."""
+
+        with LogStreamAccumulator(structured_logs, threshold) as accumulator:
+            # Check buffer and disk line counts
+            assert len(accumulator._buffer) == expected_buffer_size
+            assert accumulator._disk_lines == expected_disk_lines
+            # Validate the log stream and line counts
+            self.validate_log_stream(accumulator.stream)
+
+    def test__cleanup(self, structured_logs):
+        """Test that cleanup happens when stream property is fully consumed, not on context exit."""
+
+        accumulator = LogStreamAccumulator(structured_logs, 5)
+        with mock.patch.object(accumulator, "_cleanup") as mock_cleanup:
+            with accumulator:
+                # _cleanup should not be called yet
+                mock_cleanup.assert_not_called()
+
+                # Get the stream but don't iterate through it yet
+                stream = accumulator.stream
+                mock_cleanup.assert_not_called()
+
+                # Now iterate through the stream
+                for _ in stream:
+                    pass
+
+                # After fully consuming the stream, cleanup should be called
+                mock_cleanup.assert_called_once()

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -17,15 +17,17 @@
 # under the License.
 from __future__ import annotations
 
+import heapq
+import io
 import itertools
 import logging
 import logging.config
 import os
 import re
-from collections.abc import Iterable
 from http import HTTPStatus
 from importlib import reload
 from pathlib import Path
+from typing import cast
 from unittest import mock
 from unittest.mock import patch
 
@@ -46,41 +48,40 @@ from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.trigger import Trigger
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.log.file_task_handler import (
+    DEFAULT_SORT_DATETIME,
     FileTaskHandler,
     LogType,
+    ParsedLogStream,
     StructuredLogMessage,
+    _add_log_from_parsed_log_streams_to_heap,
+    _create_sort_key,
     _fetch_logs_from_service,
+    _flush_logs_out_of_heap,
     _interleave_logs,
-    _parse_log_lines,
+    _is_logs_stream_like,
+    _is_sort_key_with_default_timestamp,
+    _log_stream_to_parsed_log_stream,
+    _stream_lines_by_chunk,
 )
 from airflow.utils.log.logging_mixin import set_context
 from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session
 from airflow.utils.state import State, TaskInstanceState
-from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.file_task_handler import (
+    convert_list_to_stream,
+    extract_events,
+    mock_parsed_logs_factory,
+)
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
 pytestmark = pytest.mark.db_test
 
-DEFAULT_DATE = datetime(2016, 1, 1)
+DEFAULT_DATE = pendulum.datetime(2016, 1, 1)
 TASK_LOGGER = "airflow.task"
 FILE_TASK_HANDLER = "task"
-
-
-def events(logs: Iterable[StructuredLogMessage], skip_source_info=True) -> list[str]:
-    """Helper function to return just the event (a.k.a message) from a list of StructuredLogMessage"""
-    logs = iter(logs)
-    if skip_source_info:
-
-        def is_source_group(log: StructuredLogMessage):
-            return not hasattr(log, "timestamp") or log.event == "::endgroup"
-
-        logs = itertools.dropwhile(is_source_group, logs)
-
-    return [s.event for s in logs]
 
 
 class TestFileTaskLogHandler:
@@ -144,9 +145,11 @@ class TestFileTaskLogHandler:
         assert hasattr(file_handler, "read")
         # Return value of read must be a tuple of list and list.
         # passing invalid `try_number` to read function
-        log, metadata = file_handler.read(ti, 0)
+        log_handler_output_stream, metadata = file_handler.read(ti, 0)
         assert isinstance(metadata, dict)
-        assert log[0].event == "Error fetching the logs. Try number 0 is invalid."
+        assert extract_events(log_handler_output_stream) == [
+            "Error fetching the logs. Try number 0 is invalid."
+        ]
 
         # Remove the generated tmp log file.
         os.remove(log_filename)
@@ -182,7 +185,8 @@ class TestFileTaskLogHandler:
         assert log_filename.endswith("0.log"), log_filename
 
         # Return value of read must be a tuple of list and list.
-        logs, metadata = file_handler.read(ti)
+        log_handler_output_stream, metadata = file_handler.read(ti)
+        logs = list(log_handler_output_stream)
         assert logs[0].event == "Task was skipped, no logs available."
 
         # Remove the generated tmp log file.
@@ -225,14 +229,16 @@ class TestFileTaskLogHandler:
         file_handler.close()
 
         assert hasattr(file_handler, "read")
-        log, metadata = file_handler.read(ti, 1)
+        log_handler_output_stream, metadata = file_handler.read(ti, 1)
         assert isinstance(metadata, dict)
         target_re = re.compile(r"\A\[[^\]]+\] {test_log_handlers.py:\d+} INFO - test\Z")
 
         # We should expect our log line from the callable above to appear in
         # the logs we read back
 
-        assert any(re.search(target_re, e) for e in events(log)), "Logs were " + str(log)
+        assert any(re.search(target_re, e) for e in extract_events(log_handler_output_stream)), (
+            f"Logs were {log_handler_output_stream}"
+        )
 
         # Remove the generated tmp log file.
         os.remove(log_filename)
@@ -352,8 +358,8 @@ class TestFileTaskLogHandler:
         logger.info("Test")
 
         # Return value of read must be a tuple of list and list.
-        logs, metadata = file_handler.read(ti)
-        assert isinstance(logs, list)
+        log_handler_output_stream, metadata = file_handler.read(ti)
+        assert _is_logs_stream_like(log_handler_output_stream)
         # Logs for running tasks should show up too.
         assert isinstance(metadata, dict)
 
@@ -430,7 +436,7 @@ class TestFileTaskLogHandler:
         assert find_rotate_log_1 is True
 
         # Logs for running tasks should show up too.
-        assert isinstance(logs, list)
+        assert _is_logs_stream_like(logs)
 
         # Remove the two generated tmp log files.
         os.remove(log_filename)
@@ -445,7 +451,7 @@ class TestFileTaskLogHandler:
         path = Path(
             "dag_id=dag_for_testing_local_log_read/run_id=scheduled__2016-01-01T00:00:00+00:00/task_id=task_for_testing_local_log_read/attempt=1.log"
         )
-        mock_read_local.return_value = (["the messages"], ["the log"])
+        mock_read_local.return_value = (["the messages"], [convert_list_to_stream(["the log"])])
         local_log_file_read = create_task_instance(
             dag_id="dag_for_testing_local_log_read",
             task_id="task_for_testing_local_log_read",
@@ -453,24 +459,23 @@ class TestFileTaskLogHandler:
             logical_date=DEFAULT_DATE,
         )
         fth = FileTaskHandler("")
-        logs, metadata = fth._read(ti=local_log_file_read, try_number=1)
+        log_handler_output_stream, metadata = fth._read(ti=local_log_file_read, try_number=1)
         mock_read_local.assert_called_with(path)
-        as_text = events(logs)
-        assert logs[0].sources == ["the messages"]
-        assert as_text[-1] == "the log"
+        assert extract_events(log_handler_output_stream) == ["the log"]
         assert metadata == {"end_of_log": True, "log_pos": 1}
 
     def test__read_from_local(self, tmp_path):
         """Tests the behavior of method _read_from_local"""
         path1 = tmp_path / "hello1.log"
         path2 = tmp_path / "hello1.log.suffix.log"
-        path1.write_text("file1 content")
-        path2.write_text("file2 content")
+        path1.write_text("file1 content\nfile1 content2")
+        path2.write_text("file2 content\nfile2 content2")
         fth = FileTaskHandler("")
-        assert fth._read_from_local(path1) == (
-            [str(path1), str(path2)],
-            ["file1 content", "file2 content"],
-        )
+        log_source_info, log_streams = fth._read_from_local(path1)
+        assert log_source_info == [str(path1), str(path2)]
+        assert len(log_streams) == 2
+        assert list(log_streams[0]) == ["file1 content", "file1 content2"]
+        assert list(log_streams[1]) == ["file2 content", "file2 content2"]
 
     @pytest.mark.parametrize(
         "remote_logs, local_logs, served_logs_checked",
@@ -500,32 +505,57 @@ class TestFileTaskLogHandler:
             logical_date=DEFAULT_DATE,
         )
         ti.state = TaskInstanceState.SUCCESS  # we're testing scenario when task is done
+        expected_logs = ["::group::Log message source details", "::endgroup::"]
         with conf_vars({("core", "executor"): executor_name}):
             reload(executor_loader)
             fth = FileTaskHandler("")
             if remote_logs:
                 fth._read_remote_logs = mock.Mock()
                 fth._read_remote_logs.return_value = ["found remote logs"], ["remote\nlog\ncontent"]
+                expected_logs.extend(
+                    [
+                        "remote",
+                        "log",
+                        "content",
+                    ]
+                )
             if local_logs:
                 fth._read_from_local = mock.Mock()
-                fth._read_from_local.return_value = ["found local logs"], ["local\nlog\ncontent"]
+                fth._read_from_local.return_value = (
+                    ["found local logs"],
+                    [convert_list_to_stream("local\nlog\ncontent".splitlines())],
+                )
+                # only when not read from remote and TI is unfinished will read from local
+                if not remote_logs:
+                    expected_logs.extend(
+                        [
+                            "local",
+                            "log",
+                            "content",
+                        ]
+                    )
             fth._read_from_logs_server = mock.Mock()
-            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+            fth._read_from_logs_server.return_value = (
+                ["this message"],
+                [convert_list_to_stream("this\nlog\ncontent".splitlines())],
+            )
+            # only when not read from remote and not read from local will read from logs server
+            if served_logs_checked:
+                expected_logs.extend(
+                    [
+                        "this",
+                        "log",
+                        "content",
+                    ]
+                )
+
             logs, metadata = fth._read(ti=ti, try_number=1)
         if served_logs_checked:
             fth._read_from_logs_server.assert_called_once()
-            assert events(logs) == [
-                "::group::Log message source details",
-                "::endgroup::",
-                "this",
-                "log",
-                "content",
-            ]
-            assert metadata == {"end_of_log": True, "log_pos": 3}
         else:
             fth._read_from_logs_server.assert_not_called()
-            assert logs
-            assert metadata
+        assert extract_events(logs, False) == expected_logs
+        assert metadata == {"end_of_log": True, "log_pos": 3}
 
     def test_add_triggerer_suffix(self):
         sample = "any/path/to/thing.txt"
@@ -733,11 +763,119 @@ AIRFLOW_CTX_DAG_RUN_ID=manual__2022-11-16T08:05:52.324532+00:00
 """
 
 
-def test_parse_timestamps():
-    actual = []
-    for timestamp, _, _ in _parse_log_lines(log_sample.splitlines()):
-        actual.append(timestamp)
-    assert actual == [
+@pytest.mark.parametrize(
+    "chunk_size, expected_read_calls",
+    [
+        (10, 4),
+        (20, 3),
+        # will read all logs in one call, but still need another call to get empty string at the end to escape the loop
+        (50, 2),
+        (100, 2),
+    ],
+)
+def test__stream_lines_by_chunk(chunk_size, expected_read_calls):
+    # Mock CHUNK_SIZE to a smaller value to test
+    with mock.patch("airflow.utils.log.file_task_handler.CHUNK_SIZE", chunk_size):
+        log_io = io.StringIO("line1\nline2\nline3\nline4\n")
+        log_io.read = mock.MagicMock(wraps=log_io.read)
+
+        # Stream lines using the function
+        streamed_lines = list(_stream_lines_by_chunk(log_io))
+
+        # Verify the output matches the input split by lines
+        expected_output = ["line1", "line2", "line3", "line4"]
+        assert log_io.read.call_count == expected_read_calls, (
+            f"Expected {expected_read_calls} calls to read, got {log_io.read.call_count}"
+        )
+        assert streamed_lines == expected_output, f"Expected {expected_output}, got {streamed_lines}"
+
+
+@pytest.mark.parametrize(
+    "seekable",
+    [
+        pytest.param(True, id="seekable_stream"),
+        pytest.param(False, id="non_seekable_stream"),
+    ],
+)
+@pytest.mark.parametrize(
+    "closed",
+    [
+        pytest.param(False, id="not_closed_stream"),
+        pytest.param(True, id="closed_stream"),
+    ],
+)
+@pytest.mark.parametrize(
+    "unexpected_exception",
+    [
+        pytest.param(None, id="no_exception"),
+        pytest.param(ValueError, id="value_error"),
+        pytest.param(IOError, id="io_error"),
+        pytest.param(Exception, id="generic_exception"),
+    ],
+)
+@mock.patch(
+    "airflow.utils.log.file_task_handler.CHUNK_SIZE", 10
+)  # Mock CHUNK_SIZE to a smaller value for testing
+def test__stream_lines_by_chunk_error_handling(seekable, closed, unexpected_exception):
+    """
+    Test that _stream_lines_by_chunk handles errors correctly.
+    """
+    log_io = io.StringIO("line1\nline2\nline3\nline4\n")
+    log_io.seekable = mock.MagicMock(return_value=seekable)
+    log_io.seek = mock.MagicMock(wraps=log_io.seek)
+    # Mock the read method to check the call count and handle exceptions
+    if unexpected_exception:
+        expected_error = unexpected_exception("An error occurred while reading the log stream.")
+        log_io.read = mock.MagicMock(side_effect=expected_error)
+    else:
+        log_io.read = mock.MagicMock(wraps=log_io.read)
+
+    # Setup closed state if needed - must be done before starting the test
+    if closed:
+        log_io.close()
+
+    # If an exception is expected, we mock the read method to raise it
+    if unexpected_exception and not closed:
+        # Only expect logger error if stream is not closed and there's an exception
+        with mock.patch("airflow.utils.log.file_task_handler.logger.error") as mock_logger_error:
+            result = list(_stream_lines_by_chunk(log_io))
+            mock_logger_error.assert_called_once_with("Error reading log stream: %s", expected_error)
+    else:
+        # For normal case or closed stream with exception, collect the output
+        result = list(_stream_lines_by_chunk(log_io))
+
+    # Check if seekable was called properly
+    if seekable and not closed:
+        log_io.seek.assert_called_once_with(0)
+    if not seekable:
+        log_io.seek.assert_not_called()
+
+    # Validate the results based on the conditions
+    if not closed and not unexpected_exception:  # Non-seekable streams without errors should still get lines
+        assert log_io.read.call_count > 1, "Expected read method to be called at least once."
+        assert result == ["line1", "line2", "line3", "line4"]
+    elif closed:
+        assert log_io.read.call_count == 0, "Read method should not be called on a closed stream."
+        assert result == [], "Expected no lines to be yield from a closed stream."
+    elif unexpected_exception:  # If an exception was raised
+        assert log_io.read.call_count == 1, "Read method should be called once."
+        assert result == [], "Expected no lines to be yield from a stream that raised an exception."
+
+
+def test__log_stream_to_parsed_log_stream():
+    parsed_log_stream = _log_stream_to_parsed_log_stream(io.StringIO(log_sample))
+
+    actual_timestamps = []
+    last_idx = -1
+    for parsed_log in parsed_log_stream:
+        timestamp, idx, structured_log = parsed_log
+        actual_timestamps.append(timestamp)
+        if last_idx != -1:
+            assert idx > last_idx
+        last_idx = idx
+        assert isinstance(structured_log, StructuredLogMessage)
+
+    assert actual_timestamps == [
         pendulum.parse("2022-11-16T00:05:54.278000-08:00"),
         pendulum.parse("2022-11-16T00:05:54.278000-08:00"),
         pendulum.parse("2022-11-16T00:05:54.278000-08:00"),
@@ -761,34 +899,249 @@ def test_parse_timestamps():
     ]
 
 
+def test__create_sort_key():
+    # assert _sort_key should return int
+    sort_key = _create_sort_key(pendulum.parse("2022-11-16T00:05:54.278000-08:00"), 10)
+    assert sort_key == 16685859542780000010
+
+
+@pytest.mark.parametrize(
+    "timestamp, line_num, expected",
+    [
+        pytest.param(
+            pendulum.parse("2022-11-16T00:05:54.278000-08:00"),
+            10,
+            False,
+            id="normal_timestamp_1",
+        ),
+        pytest.param(
+            pendulum.parse("2022-11-16T00:05:54.457000-08:00"),
+            2025,
+            False,
+            id="normal_timestamp_2",
+        ),
+        pytest.param(
+            DEFAULT_SORT_DATETIME,
+            200,
+            True,
+            id="default_timestamp",
+        ),
+    ],
+)
+def test__is_sort_key_with_default_timestamp(timestamp, line_num, expected):
+    assert _is_sort_key_with_default_timestamp(_create_sort_key(timestamp, line_num)) == expected
+
+
+@pytest.mark.parametrize(
+    "log_stream, expected",
+    [
+        pytest.param(
+            convert_list_to_stream(
+                [
+                    "2022-11-16T00:05:54.278000-08:00",
+                    "2022-11-16T00:05:54.457000-08:00",
+                ]
+            ),
+            True,
+            id="normal_log_stream",
+        ),
+        pytest.param(
+            itertools.chain(
+                [
+                    "2022-11-16T00:05:54.278000-08:00",
+                    "2022-11-16T00:05:54.457000-08:00",
+                ],
+                convert_list_to_stream(
+                    [
+                        "2022-11-16T00:05:54.278000-08:00",
+                        "2022-11-16T00:05:54.457000-08:00",
+                    ]
+                ),
+            ),
+            True,
+            id="chain_log_stream",
+        ),
+        pytest.param(
+            [
+                "2022-11-16T00:05:54.278000-08:00",
+                "2022-11-16T00:05:54.457000-08:00",
+            ],
+            False,
+            id="non_stream_log",
+        ),
+    ],
+)
+def test__is_logs_stream_like(log_stream, expected):
+    assert _is_logs_stream_like(log_stream) == expected
+
+
+def test__add_log_from_parsed_log_streams_to_heap():
+    """
+    Test cases:
+
+    Timestamp: 26 27 28 29 30 31
+    Source 1:     --
+    Source 2:           -- --
+    Source 3:        -- -- --
+    """
+    heap: list[tuple[int, StructuredLogMessage]] = []
+    input_parsed_log_streams: dict[int, ParsedLogStream] = {
+        0: convert_list_to_stream(
+            mock_parsed_logs_factory("Source 1", pendulum.parse("2022-11-16T00:05:54.270000-08:00"), 1)
+        ),
+        1: convert_list_to_stream(
+            mock_parsed_logs_factory("Source 2", pendulum.parse("2022-11-16T00:05:54.290000-08:00"), 2)
+        ),
+        2: convert_list_to_stream(
+            mock_parsed_logs_factory("Source 3", pendulum.parse("2022-11-16T00:05:54.380000-08:00"), 3)
+        ),
+    }
+
+    # Check that we correctly get the first line of each non-empty log stream
+
+    # First call: should add log records for all log streams
+    _add_log_from_parsed_log_streams_to_heap(heap, input_parsed_log_streams)
+    assert len(input_parsed_log_streams) == 3
+    assert len(heap) == 3
+    # Second call: source 1 is empty, should add log records for source 2 and source 3
+    _add_log_from_parsed_log_streams_to_heap(heap, input_parsed_log_streams)
+    assert len(input_parsed_log_streams) == 2  # Source 1 should be removed
+    assert len(heap) == 5
+    # Third call: source 1 and source 2 are empty, should add log records for source 3
+    _add_log_from_parsed_log_streams_to_heap(heap, input_parsed_log_streams)
+    assert len(input_parsed_log_streams) == 1  # Source 2 should be removed
+    assert len(heap) == 6
+    # Fourth call: source 1, source 2, and source 3 are empty, should not add any log records
+    _add_log_from_parsed_log_streams_to_heap(heap, input_parsed_log_streams)
+    assert len(input_parsed_log_streams) == 0  # Source 3 should be removed
+    assert len(heap) == 6
+    # Fifth call: all sources are empty, should not add any log records
+    assert len(input_parsed_log_streams) == 0  # remains empty
+    assert len(heap) == 6  # no change in heap size
+    # Check heap
+    expected_logs: list[str] = [
+        "Source 1 Event 0",
+        "Source 2 Event 0",
+        "Source 3 Event 0",
+        "Source 2 Event 1",
+        "Source 3 Event 1",
+        "Source 3 Event 2",
+    ]
+    actual_logs: list[str] = []
+    for _ in range(len(heap)):
+        _, log = heapq.heappop(heap)
+        actual_logs.append(log.event)
+    assert actual_logs == expected_logs
+
+
+@pytest.mark.parametrize(
+    "heap_setup, flush_size, last_log, expected_events",
+    [
+        pytest.param(
+            [("msg1", "2023-01-01"), ("msg2", "2023-01-02")],
+            2,
+            None,
+            ["msg1", "msg2"],
+            id="exact_size_flush",
+        ),
+        pytest.param(
+            [
+                ("msg1", "2023-01-01"),
+                ("msg2", "2023-01-02"),
+                ("msg3", "2023-01-03"),
+                ("msg3", "2023-01-03"),
+                ("msg5", "2023-01-05"),
+            ],
+            5,
+            None,
+            ["msg1", "msg2", "msg3", "msg5"],  # msg3 is deduplicated, msg5 has default timestamp
+            id="flush_with_duplicates",
+        ),
+        pytest.param(
+            [("msg1", "2023-01-01"), ("msg1", "2023-01-01"), ("msg2", "2023-01-02")],
+            3,
+            "msg1",
+            ["msg2"],  # The last_log is "msg1", so any duplicates of "msg1" should be skipped
+            id="flush_with_last_log",
+        ),
+        pytest.param(
+            [("msg1", "DEFAULT"), ("msg1", "DEFAULT"), ("msg2", "DEFAULT")],
+            3,
+            "msg1",
+            [
+                "msg1",
+                "msg1",
+                "msg2",
+            ],  # All messages have default timestamp, so they should be flushed even if last_log is "msg1"
+            id="flush_with_default_timestamp_and_last_log",
+        ),
+        pytest.param(
+            [("msg1", "2023-01-01"), ("msg2", "2023-01-02"), ("msg3", "2023-01-03")],
+            2,
+            None,
+            ["msg1", "msg2"],  # Only the first two messages should be flushed
+            id="flush_size_smaller_than_heap",
+        ),
+    ],
+)
+def test__flush_logs_out_of_heap(heap_setup, flush_size, last_log, expected_events):
+    """Test the _flush_logs_out_of_heap function with different scenarios."""
+
+    # Create structured log messages from the test setup
+    heap = []
+    messages = {}
+    for i, (event, timestamp_str) in enumerate(heap_setup):
+        if timestamp_str == "DEFAULT":
+            timestamp = DEFAULT_SORT_DATETIME
+        else:
+            timestamp = pendulum.parse(timestamp_str)
+
+        msg = StructuredLogMessage(event=event, timestamp=timestamp)
+        messages[event] = msg
+        heapq.heappush(heap, (_create_sort_key(msg.timestamp, i), msg))
+
+    # Set last_log if specified in the test case
+    last_log_obj = messages.get(last_log) if last_log is not None else None
+    last_log_container = [last_log_obj]
+
+    # Run the function under test
+    result = list(_flush_logs_out_of_heap(heap, flush_size, last_log_container))
+
+    # Verify the results
+    assert len(result) == len(expected_events)
+    assert len(heap) == (len(heap_setup) - flush_size)
+    for i, expected_event in enumerate(expected_events):
+        assert result[i].event == expected_event, f"result = {result}, expected_event = {expected_events}"
+
+    # verify that the last log is updated correctly
+    last_log_obj = last_log_container[0]
+    assert last_log_obj is not None
+    last_log_obj = cast("StructuredLogMessage", last_log_obj)
+    assert last_log_obj.event == expected_events[-1]
+
+
 def test_interleave_interleaves():
-    log_sample1 = "\n".join(
-        [
-            "[2022-11-16T00:05:54.278-0800] {taskinstance.py:1258} INFO - Starting attempt 1 of 1",
-        ]
-    )
-    log_sample2 = "\n".join(
-        [
-            "[2022-11-16T00:05:54.295-0800] {taskinstance.py:1278} INFO - Executing <Task(TimeDeltaSensorAsync): wait> on 2022-11-16 08:05:52.324532+00:00",
-            "[2022-11-16T00:05:54.300-0800] {standard_task_runner.py:55} INFO - Started process 52536 to run task",
-            "[2022-11-16T00:05:54.300-0800] {standard_task_runner.py:55} INFO - Started process 52536 to run task",
-            "[2022-11-16T00:05:54.300-0800] {standard_task_runner.py:55} INFO - Started process 52536 to run task",
-            "[2022-11-16T00:05:54.306-0800] {standard_task_runner.py:82} INFO - Running: ['airflow', 'tasks', 'run', 'simple_async_timedelta', 'wait', 'manual__2022-11-16T08:05:52.324532+00:00', '--job-id', '33648', '--raw', '--subdir', '/Users/dstandish/code/airflow/airflow/example_dags/example_time_delta_sensor_async.py', '--cfg-path', '/var/folders/7_/1xx0hqcs3txd7kqt0ngfdjth0000gn/T/tmp725r305n']",
-            "[2022-11-16T00:05:54.309-0800] {standard_task_runner.py:83} INFO - Job 33648: Subtask wait",
-        ]
-    )
-    log_sample3 = "\n".join(
-        [
-            "[2022-11-16T00:05:54.457-0800] {task_command.py:376} INFO - Running <TaskInstance: simple_async_timedelta.wait manual__2022-11-16T08:05:52.324532+00:00 [running]> on host daniels-mbp-2.lan",
-            "[2022-11-16T00:05:54.592-0800] {taskinstance.py:1485} INFO - Exporting env vars: AIRFLOW_CTX_DAG_OWNER=airflow",
-            "AIRFLOW_CTX_DAG_ID=simple_async_timedelta",
-            "AIRFLOW_CTX_TASK_ID=wait",
-            "AIRFLOW_CTX_LOGICAL_DATE=2022-11-16T08:05:52.324532+00:00",
-            "AIRFLOW_CTX_TRY_NUMBER=1",
-            "AIRFLOW_CTX_DAG_RUN_ID=manual__2022-11-16T08:05:52.324532+00:00",
-            "[2022-11-16T00:05:54.604-0800] {taskinstance.py:1360} INFO - Pausing task as DEFERRED. dag_id=simple_async_timedelta, task_id=wait, execution_date=20221116T080552, start_date=20221116T080554",
-        ]
-    )
+    log_sample1 = [
+        "[2022-11-16T00:05:54.278-0800] {taskinstance.py:1258} INFO - Starting attempt 1 of 1",
+    ]
+    log_sample2 = [
+        "[2022-11-16T00:05:54.295-0800] {taskinstance.py:1278} INFO - Executing <Task(TimeDeltaSensorAsync): wait> on 2022-11-16 08:05:52.324532+00:00",
+        "[2022-11-16T00:05:54.300-0800] {standard_task_runner.py:55} INFO - Started process 52536 to run task",
+        "[2022-11-16T00:05:54.300-0800] {standard_task_runner.py:55} INFO - Started process 52536 to run task",
+        "[2022-11-16T00:05:54.300-0800] {standard_task_runner.py:55} INFO - Started process 52536 to run task",
+        "[2022-11-16T00:05:54.306-0800] {standard_task_runner.py:82} INFO - Running: ['airflow', 'tasks', 'run', 'simple_async_timedelta', 'wait', 'manual__2022-11-16T08:05:52.324532+00:00', '--job-id', '33648', '--raw', '--subdir', '/Users/dstandish/code/airflow/airflow/example_dags/example_time_delta_sensor_async.py', '--cfg-path', '/var/folders/7_/1xx0hqcs3txd7kqt0ngfdjth0000gn/T/tmp725r305n']",
+        "[2022-11-16T00:05:54.309-0800] {standard_task_runner.py:83} INFO - Job 33648: Subtask wait",
+    ]
+    log_sample3 = [
+        "[2022-11-16T00:05:54.457-0800] {task_command.py:376} INFO - Running <TaskInstance: simple_async_timedelta.wait manual__2022-11-16T08:05:52.324532+00:00 [running]> on host daniels-mbp-2.lan",
+        "[2022-11-16T00:05:54.592-0800] {taskinstance.py:1485} INFO - Exporting env vars: AIRFLOW_CTX_DAG_OWNER=airflow",
+        "AIRFLOW_CTX_DAG_ID=simple_async_timedelta",
+        "AIRFLOW_CTX_TASK_ID=wait",
+        "AIRFLOW_CTX_LOGICAL_DATE=2022-11-16T08:05:52.324532+00:00",
+        "AIRFLOW_CTX_TRY_NUMBER=1",
+        "AIRFLOW_CTX_DAG_RUN_ID=manual__2022-11-16T08:05:52.324532+00:00",
+        "[2022-11-16T00:05:54.604-0800] {taskinstance.py:1360} INFO - Pausing task as DEFERRED. dag_id=simple_async_timedelta, task_id=wait, execution_date=20221116T080552, start_date=20221116T080554",
+    ]
 
     # -08:00
     tz = pendulum.tz.fixed_timezone(-28800)
@@ -865,11 +1218,14 @@ def test_interleave_interleaves():
         },
     ]
     # Use a type adapter to durn it in to dicts -- makes it easier to compare/test than a bunch of objects
-    results = TypeAdapter(list[StructuredLogMessage]).dump_python(
-        _interleave_logs(log_sample2, log_sample1, log_sample3)
+    results: list[StructuredLogMessage] = list(
+        _interleave_logs(
+            convert_list_to_stream(log_sample2),
+            convert_list_to_stream(log_sample1),
+            convert_list_to_stream(log_sample3),
+        )
     )
-    # TypeAdapter gives us a generator out when it's generator is an input. Nice, but not useful for testing
-    results = list(results)
+    results: list[dict] = TypeAdapter(list[StructuredLogMessage]).dump_python(results)
     assert results == expected
 
 
@@ -886,7 +1242,13 @@ def test_interleave_logs_correct_ordering():
     [2023-01-17T12:47:11.883-0800] {triggerer_job.py:540} INFO - Trigger <airflow.triggers.temporal.DateTimeTrigger moment=2023-01-17T20:47:11.254388+00:00> (ID 1) fired: TriggerEvent<DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))>
     """
 
-    logs = events(_interleave_logs(sample_with_dupe, "", sample_with_dupe))
+    logs = extract_events(
+        _interleave_logs(
+            convert_list_to_stream(sample_with_dupe.splitlines()),
+            convert_list_to_stream([]),
+            convert_list_to_stream(sample_with_dupe.splitlines()),
+        )
+    )
     assert sample_with_dupe == "\n".join(logs)
 
 
@@ -902,7 +1264,12 @@ def test_interleave_logs_correct_dedupe():
     test,
     test"""
 
-    logs = events(_interleave_logs(",\n    ".join(["test"] * 10)))
+    input_logs = ",\n    ".join(["test"] * 10)
+    logs = extract_events(
+        _interleave_logs(
+            convert_list_to_stream(input_logs.splitlines()),
+        )
+    )
     assert sample_without_dupe == "\n".join(logs)
 
 

--- a/devel-common/src/tests_common/test_utils/file_task_handler.py
+++ b/devel-common/src/tests_common/test_utils/file_task_handler.py
@@ -1,0 +1,76 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import itertools
+from collections.abc import Generator, Iterable
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pendulum
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if TYPE_CHECKING:
+    from airflow.utils.log.file_task_handler import ParsedLog, StructuredLogMessage
+
+
+def extract_events(logs: Iterable[StructuredLogMessage], skip_source_info=True) -> list[str]:
+    """Helper function to return just the event (a.k.a message) from a list of StructuredLogMessage"""
+    logs = iter(logs)
+    if skip_source_info:
+
+        def is_source_group(log: StructuredLogMessage) -> bool:
+            return not hasattr(log, "timestamp") or log.event == "::endgroup::" or hasattr(log, "sources")
+
+        logs = itertools.dropwhile(is_source_group, logs)
+
+    return [s.event for s in logs]
+
+
+def convert_list_to_stream(input_list: list[str]) -> Generator[str, None, None]:
+    """
+    Convert a list of strings to a stream-like object.
+    This function yields each string in the list one by one.
+    """
+    yield from input_list
+
+
+def mock_parsed_logs_factory(
+    event_prefix: str,
+    start_datetime: datetime,
+    count: int,
+) -> list[ParsedLog]:
+    """
+    Create a list of ParsedLog objects with the specified start datetime and count.
+    Each ParsedLog object contains a timestamp and a list of StructuredLogMessage objects.
+    """
+    if AIRFLOW_V_3_0_PLUS:
+        from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    return [
+        (
+            pendulum.instance(start_datetime + pendulum.duration(seconds=i)),
+            i,
+            StructuredLogMessage(
+                timestamp=pendulum.instance(start_datetime + pendulum.duration(seconds=i)),
+                event=f"{event_prefix} Event {i}",
+            ),
+        )
+        for i in range(count)
+    ]

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1699,6 +1699,7 @@ StrictUndefined
 Stringified
 stringified
 Struct
+StructuredLogMessage
 STS
 subchart
 subclassed

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -25,11 +25,11 @@ from unittest import mock
 from unittest.mock import ANY, call
 
 import boto3
+import pendulum
 import pytest
 import time_machine
 from moto import mock_aws
 from pydantic import TypeAdapter
-from pydantic_core import TzInfo
 from watchtower import CloudWatchLogHandler
 
 from airflow.models import DAG, DagRun, TaskInstance
@@ -49,7 +49,7 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_
 
 def get_time_str(time_in_milliseconds):
     dt_time = dt.fromtimestamp(time_in_milliseconds / 1000.0, tz=timezone.utc)
-    return dt_time.strftime("%Y-%m-%d %H:%M:%S,000")
+    return dt_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @pytest.fixture(autouse=True)
@@ -144,23 +144,12 @@ class TestCloudRemoteLogIO:
             stream_name = self.task_log_path.replace(":", "_")
             logs = self.subject.read(stream_name, self.ti)
 
-            if AIRFLOW_V_3_0_PLUS:
-                from airflow.utils.log.file_task_handler import StructuredLogMessage
+            metadata, logs = logs
 
-                metadata, logs = logs
-
-                results = TypeAdapter(list[StructuredLogMessage]).dump_python(logs)
-                assert metadata == [
-                    f"Reading remote log from Cloudwatch log_group: log_group_name log_stream: {stream_name}"
-                ]
-                assert results == [
-                    {
-                        "event": "Hi",
-                        "foo": "bar",
-                        "level": "info",
-                        "timestamp": datetime(2025, 3, 27, 21, 58, 1, 2000, tzinfo=TzInfo(0)),
-                    },
-                ]
+            assert metadata == [
+                f"Reading remote log from Cloudwatch log_group: log_group_name log_stream: {stream_name}"
+            ]
+            assert logs == ['[2025-03-27T21:58:01Z] {"foo": "bar", "event": "Hi", "level": "info"}']
 
     def test_event_to_str(self):
         handler = self.subject
@@ -279,23 +268,40 @@ class TestCloudwatchTaskHandler:
                 {}
             """)[1:][:-1]  # Strip off leading and trailing new lines, but not spaces
         else:
+            monkeypatch.setattr(
+                self.cloudwatch_task_handler,
+                "_read_from_logs_server",
+                lambda ti, worker_log_rel_path: ([], []),
+            )
             msg_template = textwrap.dedent("""
+                INFO - ::group::Log message source details
                 *** Reading remote log from Cloudwatch log_group: {} log_stream: {}
+                INFO - ::endgroup::
                 {}
-            """).strip()
+            """)[1:][:-1]  # Strip off leading and trailing new lines, but not spaces
 
         logs, metadata = self.cloudwatch_task_handler.read(self.ti)
         if AIRFLOW_V_3_0_PLUS:
             from airflow.utils.log.file_task_handler import StructuredLogMessage
 
+            logs = list(logs)
             results = TypeAdapter(list[StructuredLogMessage]).dump_python(logs)
             assert results[-4:] == [
                 {"event": "::endgroup::", "timestamp": None},
-                {"event": "First", "timestamp": datetime(2025, 3, 27, 21, 57, 59)},
-                {"event": "Second", "timestamp": datetime(2025, 3, 27, 21, 58, 0)},
-                {"event": "Third", "timestamp": datetime(2025, 3, 27, 21, 58, 1)},
+                {
+                    "event": "[2025-03-27T21:57:59Z] First",
+                    "timestamp": pendulum.datetime(2025, 3, 27, 21, 57, 59),
+                },
+                {
+                    "event": "[2025-03-27T21:58:00Z] Second",
+                    "timestamp": pendulum.datetime(2025, 3, 27, 21, 58, 0),
+                },
+                {
+                    "event": "[2025-03-27T21:58:01Z] Third",
+                    "timestamp": pendulum.datetime(2025, 3, 27, 21, 58, 1),
+                },
             ]
-            assert metadata["log_pos"] == 3
+            assert metadata == {"end_of_log": False, "log_pos": 3}
         else:
             events = "\n".join(
                 [

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -248,6 +248,7 @@ class TestS3TaskHandler:
         expected_s3_uri = f"s3://bucket/{self.remote_log_key}"
 
         if AIRFLOW_V_3_0_PLUS:
+            log = list(log)
             assert log[0].event == "::group::Log message source details"
             assert expected_s3_uri in log[0].sources
             assert log[1].event == "::endgroup::"
@@ -268,6 +269,7 @@ class TestS3TaskHandler:
         self.s3_task_handler._read_from_logs_server = mock.Mock(return_value=([], []))
         log, metadata = self.s3_task_handler.read(ti)
         if AIRFLOW_V_3_0_PLUS:
+            log = list(log)
             assert len(log) == 2
             assert metadata == {"end_of_log": True, "log_pos": 0}
         else:

--- a/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
+++ b/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
@@ -37,6 +37,9 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.file_task_handler import (
+    convert_list_to_stream,
+)
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 pytestmark = pytest.mark.db_test
@@ -78,14 +81,24 @@ class TestFileTaskLogHandler:
             fth = FileTaskHandler("")
 
             fth._read_from_logs_server = mock.Mock()
-            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+
+            # compat with 2.x and 3.x
+            if AIRFLOW_V_3_0_PLUS:
+                fth._read_from_logs_server.return_value = (
+                    ["this message"],
+                    [convert_list_to_stream(["this", "log", "content"])],
+                )
+            else:
+                fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+
             logs, metadata = fth._read(ti=ti, try_number=1)
             fth._read_from_logs_server.assert_called_once()
 
         if AIRFLOW_V_3_0_PLUS:
-            assert metadata == {"end_of_log": False, "log_pos": 3}
+            logs = list(logs)
             assert logs[0].sources == ["this message"]
             assert [x.event for x in logs[-3:]] == ["this", "log", "content"]
+            assert metadata == {"end_of_log": False, "log_pos": 3}
         else:
             assert "*** this message\n" in logs
             assert logs.endswith("this\nlog\ncontent")

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -209,6 +209,7 @@ class TestElasticsearchTaskHandler:
         )
 
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -235,6 +236,7 @@ class TestElasticsearchTaskHandler:
             )
 
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -301,10 +303,11 @@ class TestElasticsearchTaskHandler:
         ts = pendulum.now().add(seconds=-seconds)
         logs, metadatas = self.es_task_handler.read(ti, 1, {"offset": 0, "last_log_timestamp": str(ts)})
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             if seconds > 5:
                 # we expect a log not found message when checking began more than 5 seconds ago
                 expected_pattern = r"^\*\*\* Log .* not found in Elasticsearch.*"
-                assert re.match(expected_pattern, logs) is not None
+                assert re.match(expected_pattern, logs[0].event) is not None
                 assert metadatas["end_of_log"] is True
             else:
                 # we've "waited" less than 5 seconds so it should not be "end of log" and should be no log message
@@ -356,6 +359,7 @@ class TestElasticsearchTaskHandler:
             },
         )
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -377,6 +381,7 @@ class TestElasticsearchTaskHandler:
     def test_read_with_none_metadata(self, ti):
         logs, metadatas = self.es_task_handler.read(ti, 1)
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -424,6 +429,7 @@ class TestElasticsearchTaskHandler:
         ts = pendulum.now()
         logs, metadatas = self.es_task_handler.read(ti, 1, {})
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -511,6 +517,7 @@ class TestElasticsearchTaskHandler:
             },
         )
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -588,6 +595,7 @@ class TestElasticsearchTaskHandler:
         )
         expected_message = "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - "
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[2].event == expected_message
         else:
             assert logs[0][0][1] == expected_message
@@ -620,6 +628,7 @@ class TestElasticsearchTaskHandler:
         )
         expected_message = "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - "
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[2].event == expected_message
         else:
             assert logs[0][0][1] == expected_message

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -114,6 +114,7 @@ class TestGCSTaskHandler:
         mock_blob.from_string.assert_called_once_with(expected_gs_uri, mock_client.return_value)
 
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == [expected_gs_uri]
             assert logs[1].event == "::endgroup::"
@@ -143,6 +144,7 @@ class TestGCSTaskHandler:
         expected_gs_uri = f"gs://bucket/{mock_obj.name}"
 
         if AIRFLOW_V_3_0_PLUS:
+            log = list(log)
             assert log[0].event == "::group::Log message source details"
             assert log[0].sources == [
                 expected_gs_uri,

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -117,14 +117,12 @@ class TestWasbTaskHandler:
         logs, metadata = self.wasb_task_handler.read(ti)
 
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["https://wasb-container.blob.core.windows.net/abc/hello.log"]
             assert logs[1].event == "::endgroup::"
             assert logs[2].event == "Log line"
-            assert metadata == {
-                "end_of_log": True,
-                "log_pos": 1,
-            }
+            assert metadata == {"end_of_log": True, "log_pos": 1}
         else:
             assert logs[0][0][0] == "localhost"
             assert (

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -24,7 +24,7 @@ import time
 from collections import defaultdict
 from datetime import datetime
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 import pendulum
 from opensearchpy import OpenSearch
@@ -44,6 +44,7 @@ from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
+    from airflow.utils.log.file_task_handler import LogMetadata
 
 
 if AIRFLOW_V_3_0_PLUS:
@@ -334,8 +335,8 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
         )
 
     def _read(
-        self, ti: TaskInstance, try_number: int, metadata: dict | None = None
-    ) -> tuple[OsLogMsgType, dict]:
+        self, ti: TaskInstance, try_number: int, metadata: LogMetadata | None = None
+    ) -> tuple[OsLogMsgType, LogMetadata]:
         """
         Endpoint for streaming log.
 
@@ -346,7 +347,10 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
         :return: a list of tuple with host and log documents, metadata.
         """
         if not metadata:
-            metadata = {"offset": 0}
+            # LogMetadata(TypedDict) is used as type annotation for log_reader; added ignore to suppress mypy error
+            metadata = {"offset": 0}  # type: ignore[assignment]
+        metadata = cast("LogMetadata", metadata)
+
         if "offset" not in metadata:
             metadata["offset"] = 0
 
@@ -385,6 +389,12 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
                     "If your task started recently, please wait a moment and reload this page. "
                     "Otherwise, the logs for this task instance may have been removed."
                 )
+                if AIRFLOW_V_3_0_PLUS:
+                    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+                    # return list of StructuredLogMessage for Airflow 3.0+
+                    return [StructuredLogMessage(event=missing_log_message)], metadata
+
                 return [("", missing_log_message)], metadata  # type: ignore[list-item]
             if (
                 # Assume end of log after not receiving new log for N min,

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -204,6 +204,7 @@ class TestOpensearchTaskHandler:
             "on 2023-07-09 07:47:32+00:00"
         )
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -234,6 +235,7 @@ class TestOpensearchTaskHandler:
             "on 2023-07-09 07:47:32+00:00"
         )
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"
@@ -328,10 +330,11 @@ class TestOpensearchTaskHandler:
         ):
             logs, metadatas = self.os_task_handler.read(ti, 1, {"offset": 0, "last_log_timestamp": str(ts)})
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             if seconds > 5:
                 # we expect a log not found message when checking began more than 5 seconds ago
-                assert len(logs[0]) == 2
-                actual_message = logs[0][1]
+                assert len(logs) == 1
+                actual_message = logs[0].event
                 expected_pattern = r"^\*\*\* Log .* not found in Opensearch.*"
                 assert re.match(expected_pattern, actual_message) is not None
                 assert metadatas["end_of_log"] is True
@@ -369,6 +372,7 @@ class TestOpensearchTaskHandler:
             "on 2023-07-09 07:47:32+00:00"
         )
         if AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[0].sources == ["default_host"]
             assert logs[1].event == "::endgroup::"

--- a/providers/redis/src/airflow/providers/redis/log/redis_task_handler.py
+++ b/providers/redis/src/airflow/providers/redis/log/redis_task_handler.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
 from airflow.providers.redis.hooks.redis import RedisHook
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from redis import Redis
 
     from airflow.models import TaskInstance
+    from airflow.utils.log.file_task_handler import LogMetadata
 
 
 class RedisTaskHandler(FileTaskHandler, LoggingMixin):
@@ -75,8 +76,8 @@ class RedisTaskHandler(FileTaskHandler, LoggingMixin):
         self,
         ti: TaskInstance,
         try_number: int,
-        metadata: dict[str, Any] | None = None,
-    ):
+        metadata: LogMetadata | None = None,
+    ) -> tuple[str | list[str], LogMetadata]:
         log_str = b"\n".join(
             self.conn.lrange(self._render_filename(ti, try_number), start=0, end=-1)
         ).decode()


### PR DESCRIPTION

related: #49470

## What

Backport [Resolve OOM When Reading Large Logs in Webserver #49470](#49470) to `v3-0-test` branch.

The only conflict when cherry-pick:
```
Merge Changes
└── airflow-core/src/airflow
    ├── api_fastapi/core_api/routes/public
    │   └── log.py                   [9+, !]
    ├── utils/log
    │   ├── file_task_handler.py     [4, !]
    │   └── log_reader.py            [!]
└── providers
    ├── amazon/tests/unit/amazon/aws/log
    │   └── test_cloudwatch_task_handler.py [!]
    ├── elasticsearch/src/airflow/providers/elasticsearch/log
    │   └── es_task_handler.py       [!]
    └── opensearch/src/airflow/providers/opensearch/log
        └── os_task_handler.py      [!]
```
