### PR TITLE
fix(hitl): Fix HITLEntryOperator "options" and "defaults" handling

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -227,6 +227,8 @@ class HITLEntryOperator(HITLOperator):
     def __init__(self, **kwargs) -> None:
         if "options" not in kwargs:
             kwargs["options"] = ["OK"]
-            kwargs["defaults"] = ["OK"]
+
+            if "defaults" not in kwargs:
+                kwargs["defaults"] = ["OK"]
 
         super().__init__(**kwargs)

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -257,7 +257,7 @@ class TestApprovalOperator:
 
 
 class TestHITLEntryOperator:
-    def test_init(self) -> None:
+    def test_init_without_options_and_default(self) -> None:
         op = HITLEntryOperator(
             task_id="hitl_test",
             subject="This is subject",
@@ -267,3 +267,27 @@ class TestHITLEntryOperator:
 
         assert op.options == ["OK"]
         assert op.defaults == ["OK"]
+
+    def test_init_without_options(self) -> None:
+        op = HITLEntryOperator(
+            task_id="hitl_test",
+            subject="This is subject",
+            body="This is body",
+            params={"input": 1},
+            defaults=None,
+        )
+
+        assert op.options == ["OK"]
+        assert op.defaults is None
+
+    def test_init_without_default(self) -> None:
+        op = HITLEntryOperator(
+            task_id="hitl_test",
+            subject="This is subject",
+            body="This is body",
+            params={"input": 1},
+            options=["OK", "NOT OK"],
+        )
+
+        assert op.options == ["OK", "NOT OK"]
+        assert op.defaults is None


### PR DESCRIPTION
## Why
It's valid to set "defaults" to None while not providing `options`

## What
Only when both are not provided will they be set to ["OK"]

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
