### PR TITLE
Add type casting for mypy to understand expand_input types

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -60,7 +60,6 @@ from airflow.exceptions import TaskNotFound
 from airflow.models.asset import AssetActive
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun as DR
-from airflow.models.expandinput import SchedulerExpandInput
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
@@ -74,6 +73,7 @@ from airflow.utils.state import DagRunState, TaskInstanceState, TerminalTIState
 if TYPE_CHECKING:
     from sqlalchemy.sql.dml import Update
 
+    from airflow.models.expandinput import SchedulerExpandInput
     from airflow.sdk.types import Operator
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -23,7 +23,7 @@ import json
 from collections import defaultdict
 from collections.abc import Iterator
 from datetime import datetime
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import UUID
 
 import attrs
@@ -60,6 +60,7 @@ from airflow.exceptions import TaskNotFound
 from airflow.models.asset import AssetActive
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun as DR
+from airflow.models.expandinput import SchedulerExpandInput
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
@@ -308,9 +309,9 @@ def _get_upstream_map_indexes(
                 mapped_ti_count = upstream_mapped_group.get_parse_time_mapped_ti_count()
             except NotFullyPopulated:
                 # for cases that needs to resolve xcom to get the correct count
-                mapped_ti_count = upstream_mapped_group._expand_input.get_total_map_length(
-                    run_id, session=session
-                )
+                mapped_ti_count = cast(
+                    "SchedulerExpandInput", upstream_mapped_group._expand_input
+                ).get_total_map_length(run_id, session=session)
             map_indexes = list(range(mapped_ti_count)) if mapped_ti_count is not None else None
 
         yield upstream_task.task_id, map_indexes


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Mypy issue on main:
```
airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py:311: error: Item "DictOfListsExpandInput" of
"SchedulerDictOfListsExpandInput | SchedulerListOfDictsExpandInput | DictOfListsExpandInput | ListOfDictsExpandInput" has no attribute "get_total_map_length"  [union-attr]
                    mapped_ti_count = upstream_mapped_group._expand_input.get_total_map_length(
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py:311: error: Item "ListOfDictsExpandInput" of
"SchedulerDictOfListsExpandInput | SchedulerListOfDictsExpandInput | DictOfListsExpandInput | ListOfDictsExpandInput" has no attribute "get_total_map_length"  [union-attr]
                    mapped_ti_count = upstream_mapped_group._expand_input.get_total_map_length(

```



Adding a type cast to help mypy understand that `upstream_mapped_group._expand_input`is a SchedulerExpandInput at runtime which has `get_total_map_length` defined. 

Safe cast because at runtime the expand input will always be a `SchedulerExpandInput`, we just need to help mypy understand this.

Example failure: https://github.com/apache/airflow/actions/runs/16221450919/job/45803515859


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
