### PR TITLE
Fix duplicate test IDs in parametrized tests

### DIFF
--- a/airflow-core/tests/unit/ti_deps/deps/test_prev_dagrun_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_prev_dagrun_dep.py
@@ -130,7 +130,7 @@ class TestPrevDagrunDep:
                 expected_dep_met=True,
                 past_depends_met_xcom_sent=True,
             ),
-            id="not_depends_on_past",
+            id="not_depends_on_past_with_wait",
         ),
         # If the context overrides depends_on_past, the dep should be met even
         # though there is no previous_ti which would normally fail the dep.
@@ -164,7 +164,7 @@ class TestPrevDagrunDep:
                 expected_dep_met=True,
                 past_depends_met_xcom_sent=True,
             ),
-            id="context_ignore_depends_on_past",
+            id="context_ignore_depends_on_past_with_wait",
         ),
         # The first task run should pass since it has no previous dagrun.
         # wait_for_past_depends_before_skipping is False, past_depends_met xcom should not be sent
@@ -241,7 +241,7 @@ class TestPrevDagrunDep:
             id="all_met",
         ),
         # All the conditions for the dep are met
-        # wait_for_past_depends_before_skipping is False, past_depends_met xcom should not be sent
+        # wait_for_past_depends_before_skipping is True, past_depends_met xcom should be sent
         pytest.param(
             dict(
                 depends_on_past=True,
@@ -254,7 +254,7 @@ class TestPrevDagrunDep:
                 expected_dep_met=True,
                 past_depends_met_xcom_sent=True,
             ),
-            id="all_met",
+            id="all_met_with_wait",
         ),
     ],
 )


### PR DESCRIPTION
Updated parametrized test IDs to be unique to prevent pytest conflicts:
- 'not_depends_on_past' -> 'not_depends_on_past_with_wait'
- 'context_ignore_depends_on_past' -> 'context_ignore_depends_on_past_with_wait'
- 'all_met' -> 'all_met_with_wait'

Also improved test comment clarity by specifying when xcom should be sent. Duplicate test IDs can cause pytest issues and make test debugging difficult.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
