### PR TITLE
Add proper spec parameters to ``MagicMock`` usage in dag processing tests

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -24,12 +24,13 @@ import textwrap
 import uuid
 from collections.abc import Callable
 from socket import socketpair
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO
 from unittest.mock import MagicMock, patch
 
 import pytest
 import structlog
 from pydantic import TypeAdapter
+from structlog.typing import FilteringBoundLogger
 
 from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
@@ -116,8 +117,8 @@ class TestDagFileProcessor:
         monkeypatch: pytest.MonkeyPatch,
         inprocess_client,
     ):
-        logger = MagicMock()
-        logger_filehandle = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, Variable
@@ -153,8 +154,8 @@ class TestDagFileProcessor:
         monkeypatch: pytest.MonkeyPatch,
         inprocess_client,
     ):
-        logger = MagicMock()
-        logger_filehandle = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, Variable
@@ -185,8 +186,8 @@ class TestDagFileProcessor:
     def test_top_level_variable_set(self, tmp_path: pathlib.Path, inprocess_client):
         from airflow.models.variable import Variable as VariableORM
 
-        logger = MagicMock()
-        logger_filehandle = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, Variable
@@ -222,8 +223,8 @@ class TestDagFileProcessor:
     def test_top_level_variable_delete(self, tmp_path: pathlib.Path, inprocess_client):
         from airflow.models.variable import Variable as VariableORM
 
-        logger = MagicMock()
-        logger_filehandle = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, Variable
@@ -264,8 +265,8 @@ class TestDagFileProcessor:
     def test_top_level_connection_access(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, inprocess_client
     ):
-        logger = MagicMock()
-        logger_filehandle = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, BaseHook
@@ -295,8 +296,8 @@ class TestDagFileProcessor:
         assert result.serialized_dags[0].dag_id == "test_my_conn"
 
     def test_top_level_connection_access_not_found(self, tmp_path: pathlib.Path, inprocess_client):
-        logger = MagicMock()
-        logger_filehandle = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
 
         def dag_in_a_fn():
             from airflow.sdk import DAG, BaseHook
@@ -343,8 +344,8 @@ class TestDagFileProcessor:
             path=dag1_path,
             bundle_path=tmp_path,
             callbacks=[],
-            logger=MagicMock(),
-            logger_filehandle=MagicMock(),
+            logger=MagicMock(spec=FilteringBoundLogger),
+            logger_filehandle=MagicMock(spec=BinaryIO),
             client=inprocess_client,
         )
         while not proc.is_ready:
@@ -356,7 +357,7 @@ class TestDagFileProcessor:
         assert result.serialized_dags[0].dag_id == "dag_name"
 
     def test__pre_import_airflow_modules_when_disabled(self):
-        logger = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
         with (
             env_vars({"AIRFLOW__DAG_PROCESSOR__PARSING_PRE_IMPORT_MODULES": "false"}),
             patch("airflow.dag_processing.processor.iter_airflow_imports") as mock_iter,
@@ -367,7 +368,7 @@ class TestDagFileProcessor:
         logger.warning.assert_not_called()
 
     def test__pre_import_airflow_modules_when_enabled(self):
-        logger = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
         with (
             env_vars({"AIRFLOW__DAG_PROCESSOR__PARSING_PRE_IMPORT_MODULES": "true"}),
             patch("airflow.dag_processing.processor.iter_airflow_imports", return_value=["airflow.models"]),
@@ -379,7 +380,7 @@ class TestDagFileProcessor:
         logger.warning.assert_not_called()
 
     def test__pre_import_airflow_modules_warns_on_missing_module(self):
-        logger = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
         with (
             env_vars({"AIRFLOW__DAG_PROCESSOR__PARSING_PRE_IMPORT_MODULES": "true"}),
             patch(
@@ -398,7 +399,7 @@ class TestDagFileProcessor:
         assert "test.py" in warning_args[2]
 
     def test__pre_import_airflow_modules_partial_success_and_warning(self):
-        logger = MagicMock()
+        logger = MagicMock(spec=FilteringBoundLogger)
         with (
             env_vars({"AIRFLOW__DAG_PROCESSOR__PARSING_PRE_IMPORT_MODULES": "true"}),
             patch(


### PR DESCRIPTION
Fixed MagicMock instances without spec parameters in dag processing tests. Added proper spec parameters using `FilteringBoundLogger` for logger objects and BinaryIO for `logger_filehandle` objects to improve test effectiveness.

This follows testing best practices by ensuring mocks properly simulate the expected interface of the objects they replace.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
