### PR TITLE
Fix typo in mock ``spec`` parameter

### DIFF
--- a/airflow-core/tests/unit/core/test_stats.py
+++ b/airflow-core/tests/unit/core/test_stats.py
@@ -215,7 +215,7 @@ class TestDogStats:
         )
 
     def test_does_send_stats_using_dogstatsd_when_statsd_and_dogstatsd_both_on(self):
-        # ToDo: Figure out why it identical to test_does_send_stats_using_dogstatsd_when_dogstatsd_on
+        """Test that dogstatsd works when both statsd and dogstatsd are enabled (dogstatsd takes precedence)."""
         self.dogstatsd.incr("empty_key")
         self.dogstatsd_client.increment.assert_called_once_with(
             metric="empty_key", sample_rate=1, tags=[], value=1
@@ -389,7 +389,7 @@ class TestDogStatsWithAllowList:
         pytest.importorskip("datadog")
         from datadog import DogStatsd
 
-        self.dogstatsd_client = Mock(speck=DogStatsd)
+        self.dogstatsd_client = Mock(spec=DogStatsd)
         self.dogstats = SafeDogStatsdLogger(
             self.dogstatsd_client, PatternAllowListValidator("stats_one, stats_two")
         )
@@ -416,7 +416,7 @@ class TestDogStatsWithMetricsTags:
         pytest.importorskip("datadog")
         from datadog import DogStatsd
 
-        self.dogstatsd_client = Mock(speck=DogStatsd)
+        self.dogstatsd_client = Mock(spec=DogStatsd)
         self.dogstatsd = SafeDogStatsdLogger(self.dogstatsd_client, metrics_tags=True)
 
     def test_does_send_stats_using_dogstatsd_with_tags(self):
@@ -431,7 +431,7 @@ class TestDogStatsWithDisabledMetricsTags:
         pytest.importorskip("datadog")
         from datadog import DogStatsd
 
-        self.dogstatsd_client = Mock(speck=DogStatsd)
+        self.dogstatsd_client = Mock(spec=DogStatsd)
         self.dogstatsd = SafeDogStatsdLogger(
             self.dogstatsd_client,
             metrics_tags=True,


### PR DESCRIPTION
Changed `'speck='` to `'spec='` in `Mock()` calls for `DogStatsd` objects in `test_stats.py`. This typo prevented proper mock specification and could lead to less effective tests.

Also improved test documentation by replacing TODO comment with proper docstring.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
