### PR TITLE
AIP-86 - Remove no-longer-needed deadlines when a dagrun succeeds

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1219,8 +1219,8 @@ class DagRun(Base, LoggingMixin):
                 )
 
             if (deadline := dag.deadline) and isinstance(deadline.reference, DeadlineReference.TYPES.DAGRUN):
-                # The dagrun has succeeded, so the deadline is no longer needed.
-                Deadline.remove_deadlines(session=session, conditions={DagRun.run_id: self.run_id})
+                # The dagrun has succeeded.  If there wre any Deadlines for it which were not breached, they are no longer needed.
+                Deadline.prune_deadlines(session=session, conditions={DagRun.run_id: self.run_id})
 
         # if *all tasks* are deadlocked, the run failed
         elif unfinished.should_schedule and not are_runnable_tasks:

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1256,13 +1256,14 @@ class TestDagRun:
         def on_success_callable(context):
             assert context["dag_run"].dag_id == "test_dagrun_success_callback"
 
+        future_date = datetime.datetime.now() + datetime.timedelta(days=365)
+
         with dag_maker(
             dag_id="test_dagrun_success_callback",
             schedule=datetime.timedelta(days=1),
-            start_date=datetime.datetime(2017, 1, 1),
             on_success_callback=on_success_callable,
             deadline=DeadlineAlert(
-                reference=DeadlineReference.FIXED_DATETIME(DEFAULT_DATE),
+                reference=DeadlineReference.FIXED_DATETIME(future_date),
                 interval=datetime.timedelta(hours=1),
                 callback=test_callback_for_deadline,
             ),
@@ -1277,7 +1278,7 @@ class TestDagRun:
             "test_state_succeeded2": TaskInstanceState.SUCCESS,
         }
 
-        # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
+        # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG.
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
         dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
         dag_run = session.merge(dag_run)

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -36,6 +36,8 @@ from unit.models import DEFAULT_DATE
 
 DAG_ID = "dag_id_1"
 RUN_ID = 1
+INVALID_DAG_ID = "invalid_dag_id"
+INVALID_RUN_ID = 2
 
 TEST_CALLBACK_PATH = f"{__name__}.test_callback_for_deadline"
 TEST_CALLBACK_KWARGS = {"arg1": "value1"}
@@ -102,6 +104,50 @@ class TestDeadline:
         assert result.deadline_time == deadline_orm.deadline_time
         assert result.callback == deadline_orm.callback
         assert result.callback_kwargs == deadline_orm.callback_kwargs
+
+    @pytest.mark.parametrize(
+        "conditions",
+        [
+            pytest.param({}, id="empty_conditions"),
+            pytest.param({Deadline.dagrun_id: INVALID_RUN_ID}, id="no_matches"),
+            pytest.param({Deadline.dagrun_id: RUN_ID}, id="single_condition"),
+            pytest.param({Deadline.dagrun_id: RUN_ID, Deadline.dag_id: DAG_ID}, id="multiple_conditions"),
+            pytest.param(
+                {Deadline.dagrun_id: RUN_ID, Deadline.dag_id: INVALID_DAG_ID}, id="mixed_conditions"
+            ),
+        ],
+    )
+    @mock.patch("sqlalchemy.orm.Session")
+    def test_resolve_deadlines(self, mock_session, conditions):
+        """Test deadline resolution with various conditions."""
+        expected_result = 1 if conditions else 0
+        # Set up the query chain to return a list of (Deadline, DagRun) pairs
+        mock_dagrun = mock.Mock(spec=DagRun, end_date=datetime.now())
+        mock_deadline = mock.Mock(spec=Deadline, deadline_time=mock_dagrun.end_date + timedelta(days=365))
+        mock_query = mock_session.query.return_value
+        mock_query.join.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [(mock_deadline, mock_dagrun)] if conditions else []
+
+        result = Deadline.remove_deadlines(conditions=conditions, session=mock_session)
+
+        assert result == expected_result
+        if conditions:
+            mock_session.query.assert_called_once_with(Deadline, DagRun)
+            mock_session.query.return_value.filter.assert_called_once()  # Assert that the conditions are applied.
+            mock_session.delete.assert_called_once_with(mock_deadline)
+        else:
+            mock_session.query.assert_not_called()
+
+    @mock.patch("sqlalchemy.orm.Session")
+    def test_resolve_deadlines_invalid_column(self, mock_session):
+        """Test that using an invalid column raises an error."""
+        invalid_column = DagRun.bundle_version  # A column that exists but not on the Deadline table.
+        error_msg = f"Invalid column '{invalid_column}' specified in conditions while resolving deadlines. Rolling back changes."
+        mock_session.query.side_effect = SQLAlchemyError("Invalid column")
+
+        with pytest.raises(SQLAlchemyError, match=error_msg):
+            Deadline.remove_deadlines(conditions={invalid_column: "value"}, session=mock_session)
 
     def test_orm(self):
         deadline_orm = Deadline(


### PR DESCRIPTION
When a DagRun finishes successfully, if that run has any Deadlines which have not expired, then we can safely remove them from the database.  If the Deadline has passed then it will be retained so we can still act on it in the next Scheduler pass.

This follows the previously-discussed policy that successful (not-needed) deadlines can be removed, and those which were missed will be retained in a separate table, which will allow UI integration and historical data on deadline miss statistics.  There will be a follow-up from @ramitkataria to handle missed deadlines while I start working on the next step to have the scheduler make the decision if there are deadlines which need to be acted on.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
