### PR TITLE
Fix pandas FutureWarning

### DIFF
--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -572,8 +572,8 @@ def test_get_df(df_type, df_class, description):
         if df_type == "pandas":
             mock_cursor.fetchall.assert_called_once_with()
             assert df.columns[0] == column
-            assert df.iloc[0][0] == "row1"
-            assert df.iloc[1][0] == "row2"
+            assert df.iloc[0, 0] == "row1"
+            assert df.iloc[1, 0] == "row2"
         else:
             mock_execute.fetchall.assert_called_once_with()
             assert df.columns[0] == column


### PR DESCRIPTION
Handels:
```
{"category": "FutureWarning", "message": "Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`", "filename": "providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py", "lineno": 575, "when": "runtest", "node_id": "providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py::test_get_df", "param_id": "pandas-dataframe", "group": "tests", "count": 1}
{"category": "FutureWarning", "message": "Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`", "filename": "providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py", "lineno": 576, "when": "runtest", "node_id": "providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py::test_get_df", "param_id": "pandas-dataframe", "group": "tests", "count": 1}
```