### PR TITLE
Update mypy script with --warn-unused-ignores

### DIFF
--- a/contributing-docs/08_static_code_checks.rst
+++ b/contributing-docs/08_static_code_checks.rst
@@ -579,6 +579,12 @@ For example:
 
   pre-commit run --hook-stage manual mypy-airflow --all-files
 
+To show unused mypy ignores for any providers/airflow etc, eg: run below command:
+
+.. code-block:: bash
+  export SHOW_UNUSED_MYPY_WARNINGS=true
+  pre-commit run --hook-stage manual mypy-airflow --all-files
+
 MyPy uses a separate docker-volume (called ``mypy-cache-volume``) that keeps the cache of last MyPy
 execution in order to speed MyPy checks up (sometimes by order of magnitude). While in most cases MyPy
 will handle refreshing the cache when and if needed, there are some cases when it won't (cache invalidation

--- a/scripts/ci/pre_commit/mypy_folder.py
+++ b/scripts/ci/pre_commit/mypy_folder.py
@@ -53,6 +53,8 @@ if len(sys.argv) < 2:
 
 mypy_folders = sys.argv[1:]
 
+show_unused_warnings = os.environ.get("SHOW_UNUSED_MYPY_WARNINGS", "false")
+
 for mypy_folder in mypy_folders:
     if mypy_folder not in ALLOWED_FOLDERS:
         console.print(
@@ -124,6 +126,15 @@ else:
     console.print(f"[info]You cand check the list of files in:[/] {MYPY_FILE_LIST}")
 
 print(f"Running mypy with {FILE_ARGUMENT}")
+
+if show_unused_warnings == "true":
+    console.print(
+        "[info]Running mypy with --warn-unused-ignores to display unused ignores, unset environment variable: SHOW_UNUSED_MYPY_WARNINGS to runoff this behaviour"
+    )
+
+    mypy_cmd = f"TERM=ansi mypy {shlex.quote(FILE_ARGUMENT)} --warn-unused-ignores"
+else:
+    mypy_cmd = f"TERM=ansi mypy {shlex.quote(FILE_ARGUMENT)}"
 
 cmd = ["bash", "-c", f"TERM=ansi mypy {shlex.quote(FILE_ARGUMENT)}"]
 


### PR DESCRIPTION
Adding this config helps to show what are un used type ignores. this will help to get help from community to cleanup providers.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
