### PR TITLE
Remove type ignore across codebase after mypy upgrade

### DIFF
--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -23,7 +23,7 @@
 # Make `airflow` a namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user
 # lib.)  This is required by some IDEs to resolve the import paths.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 __version__ = "3.1.0"
 

--- a/airflow-core/tests/system/__init__.py
+++ b/airflow-core/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/airflow-core/tests/system/__init__.py
+++ b/airflow-core/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/airflow-core/tests/unit/__init__.py
+++ b/airflow-core/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/airflow-core/tests/unit/__init__.py
+++ b/airflow-core/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/airflow-ctl/src/airflowctl/__init__.py
+++ b/airflow-ctl/src/airflowctl/__init__.py
@@ -17,4 +17,6 @@
 # under the License.
 from __future__ import annotations
 
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
 __version__ = "1.0.0"

--- a/airflow-ctl/src/airflowctl/__init__.py
+++ b/airflow-ctl/src/airflowctl/__init__.py
@@ -17,6 +17,4 @@
 # under the License.
 from __future__ import annotations
 
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
-
 __version__ = "1.0.0"

--- a/airflow-ctl/src/airflowctl/ctl/__init__.py
+++ b/airflow-ctl/src/airflowctl/ctl/__init__.py
@@ -18,3 +18,5 @@
 # Pycharm needs to see this line. VSCode/pyright doesn't care about it, but this file needs to exist
 # https://github.com/microsoft/pyright/issues/9439#issuecomment-2468990559
 from __future__ import annotations
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/airflow-ctl/src/airflowctl/ctl/__init__.py
+++ b/airflow-ctl/src/airflowctl/ctl/__init__.py
@@ -18,5 +18,3 @@
 # Pycharm needs to see this line. VSCode/pyright doesn't care about it, but this file needs to exist
 # https://github.com/microsoft/pyright/issues/9439#issuecomment-2468990559
 from __future__ import annotations
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/airbyte/src/airflow/__init__.py
+++ b/providers/airbyte/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/airbyte/src/airflow/providers/__init__.py
+++ b/providers/airbyte/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/airbyte/tests/system/__init__.py
+++ b/providers/airbyte/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/airbyte/tests/system/__init__.py
+++ b/providers/airbyte/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/airbyte/tests/unit/__init__.py
+++ b/providers/airbyte/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/airbyte/tests/unit/__init__.py
+++ b/providers/airbyte/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/alibaba/src/airflow/__init__.py
+++ b/providers/alibaba/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/alibaba/src/airflow/providers/__init__.py
+++ b/providers/alibaba/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/alibaba/tests/system/__init__.py
+++ b/providers/alibaba/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/alibaba/tests/system/__init__.py
+++ b/providers/alibaba/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/alibaba/tests/unit/__init__.py
+++ b/providers/alibaba/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/alibaba/tests/unit/__init__.py
+++ b/providers/alibaba/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/amazon/src/airflow/__init__.py
+++ b/providers/amazon/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/amazon/src/airflow/providers/__init__.py
+++ b/providers/amazon/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/amazon/tests/system/__init__.py
+++ b/providers/amazon/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/amazon/tests/system/__init__.py
+++ b/providers/amazon/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/amazon/tests/unit/__init__.py
+++ b/providers/amazon/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/amazon/tests/unit/__init__.py
+++ b/providers/amazon/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/beam/src/airflow/__init__.py
+++ b/providers/apache/beam/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/beam/src/airflow/providers/__init__.py
+++ b/providers/apache/beam/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/beam/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/beam/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/beam/tests/system/__init__.py
+++ b/providers/apache/beam/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/beam/tests/system/__init__.py
+++ b/providers/apache/beam/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/beam/tests/system/apache/__init__.py
+++ b/providers/apache/beam/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/beam/tests/unit/__init__.py
+++ b/providers/apache/beam/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/beam/tests/unit/__init__.py
+++ b/providers/apache/beam/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/beam/tests/unit/apache/__init__.py
+++ b/providers/apache/beam/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/src/airflow/__init__.py
+++ b/providers/apache/cassandra/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/src/airflow/providers/__init__.py
+++ b/providers/apache/cassandra/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/cassandra/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/tests/integration/__init__.py
+++ b/providers/apache/cassandra/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/tests/integration/__init__.py
+++ b/providers/apache/cassandra/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/cassandra/tests/integration/apache/__init__.py
+++ b/providers/apache/cassandra/tests/integration/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/tests/system/__init__.py
+++ b/providers/apache/cassandra/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/tests/system/__init__.py
+++ b/providers/apache/cassandra/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/cassandra/tests/system/apache/__init__.py
+++ b/providers/apache/cassandra/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/tests/unit/__init__.py
+++ b/providers/apache/cassandra/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/cassandra/tests/unit/__init__.py
+++ b/providers/apache/cassandra/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/cassandra/tests/unit/apache/__init__.py
+++ b/providers/apache/cassandra/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/src/airflow/__init__.py
+++ b/providers/apache/drill/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/src/airflow/providers/__init__.py
+++ b/providers/apache/drill/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/drill/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/tests/integration/__init__.py
+++ b/providers/apache/drill/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/tests/integration/__init__.py
+++ b/providers/apache/drill/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/drill/tests/integration/apache/__init__.py
+++ b/providers/apache/drill/tests/integration/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/tests/system/__init__.py
+++ b/providers/apache/drill/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/tests/system/__init__.py
+++ b/providers/apache/drill/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/drill/tests/system/apache/__init__.py
+++ b/providers/apache/drill/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/tests/unit/__init__.py
+++ b/providers/apache/drill/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/drill/tests/unit/__init__.py
+++ b/providers/apache/drill/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/drill/tests/unit/apache/__init__.py
+++ b/providers/apache/drill/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/src/airflow/__init__.py
+++ b/providers/apache/druid/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/src/airflow/providers/__init__.py
+++ b/providers/apache/druid/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/druid/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/tests/system/__init__.py
+++ b/providers/apache/druid/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/tests/system/__init__.py
+++ b/providers/apache/druid/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/druid/tests/system/apache/__init__.py
+++ b/providers/apache/druid/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/tests/unit/__init__.py
+++ b/providers/apache/druid/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/druid/tests/unit/__init__.py
+++ b/providers/apache/druid/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/druid/tests/unit/apache/__init__.py
+++ b/providers/apache/druid/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/flink/src/airflow/__init__.py
+++ b/providers/apache/flink/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/flink/src/airflow/providers/__init__.py
+++ b/providers/apache/flink/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/flink/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/flink/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/flink/tests/unit/__init__.py
+++ b/providers/apache/flink/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/flink/tests/unit/__init__.py
+++ b/providers/apache/flink/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/flink/tests/unit/apache/__init__.py
+++ b/providers/apache/flink/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hdfs/src/airflow/__init__.py
+++ b/providers/apache/hdfs/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hdfs/src/airflow/providers/__init__.py
+++ b/providers/apache/hdfs/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hdfs/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/hdfs/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hdfs/tests/unit/__init__.py
+++ b/providers/apache/hdfs/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hdfs/tests/unit/__init__.py
+++ b/providers/apache/hdfs/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/hdfs/tests/unit/apache/__init__.py
+++ b/providers/apache/hdfs/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/src/airflow/__init__.py
+++ b/providers/apache/hive/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/src/airflow/providers/__init__.py
+++ b/providers/apache/hive/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/hive/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/tests/integration/__init__.py
+++ b/providers/apache/hive/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/tests/integration/__init__.py
+++ b/providers/apache/hive/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/hive/tests/integration/apache/__init__.py
+++ b/providers/apache/hive/tests/integration/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/tests/system/__init__.py
+++ b/providers/apache/hive/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/tests/system/__init__.py
+++ b/providers/apache/hive/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/hive/tests/system/apache/__init__.py
+++ b/providers/apache/hive/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/tests/unit/__init__.py
+++ b/providers/apache/hive/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/hive/tests/unit/__init__.py
+++ b/providers/apache/hive/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/hive/tests/unit/apache/__init__.py
+++ b/providers/apache/hive/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/src/airflow/__init__.py
+++ b/providers/apache/iceberg/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/src/airflow/providers/__init__.py
+++ b/providers/apache/iceberg/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/iceberg/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/tests/system/__init__.py
+++ b/providers/apache/iceberg/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/tests/system/__init__.py
+++ b/providers/apache/iceberg/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/iceberg/tests/system/apache/__init__.py
+++ b/providers/apache/iceberg/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/tests/unit/__init__.py
+++ b/providers/apache/iceberg/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/iceberg/tests/unit/__init__.py
+++ b/providers/apache/iceberg/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/iceberg/tests/unit/apache/__init__.py
+++ b/providers/apache/iceberg/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/impala/src/airflow/__init__.py
+++ b/providers/apache/impala/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/impala/src/airflow/providers/__init__.py
+++ b/providers/apache/impala/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/impala/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/impala/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/impala/tests/system/apache/__init__.py
+++ b/providers/apache/impala/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/impala/tests/unit/__init__.py
+++ b/providers/apache/impala/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/impala/tests/unit/__init__.py
+++ b/providers/apache/impala/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/impala/tests/unit/apache/__init__.py
+++ b/providers/apache/impala/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/src/airflow/__init__.py
+++ b/providers/apache/kafka/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/src/airflow/providers/__init__.py
+++ b/providers/apache/kafka/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/tests/integration/__init__.py
+++ b/providers/apache/kafka/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/tests/integration/__init__.py
+++ b/providers/apache/kafka/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/kafka/tests/integration/apache/__init__.py
+++ b/providers/apache/kafka/tests/integration/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/tests/system/__init__.py
+++ b/providers/apache/kafka/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/tests/system/__init__.py
+++ b/providers/apache/kafka/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/kafka/tests/system/apache/__init__.py
+++ b/providers/apache/kafka/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/tests/unit/__init__.py
+++ b/providers/apache/kafka/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kafka/tests/unit/__init__.py
+++ b/providers/apache/kafka/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/kafka/tests/unit/apache/__init__.py
+++ b/providers/apache/kafka/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/src/airflow/__init__.py
+++ b/providers/apache/kylin/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/src/airflow/providers/__init__.py
+++ b/providers/apache/kylin/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/kylin/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/tests/system/__init__.py
+++ b/providers/apache/kylin/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/tests/system/__init__.py
+++ b/providers/apache/kylin/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/kylin/tests/system/apache/__init__.py
+++ b/providers/apache/kylin/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/tests/unit/__init__.py
+++ b/providers/apache/kylin/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/kylin/tests/unit/__init__.py
+++ b/providers/apache/kylin/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/kylin/tests/unit/apache/__init__.py
+++ b/providers/apache/kylin/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/src/airflow/__init__.py
+++ b/providers/apache/livy/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/src/airflow/providers/__init__.py
+++ b/providers/apache/livy/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/livy/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/tests/system/__init__.py
+++ b/providers/apache/livy/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/tests/system/__init__.py
+++ b/providers/apache/livy/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/livy/tests/system/apache/__init__.py
+++ b/providers/apache/livy/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/tests/unit/__init__.py
+++ b/providers/apache/livy/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/livy/tests/unit/__init__.py
+++ b/providers/apache/livy/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/livy/tests/unit/apache/__init__.py
+++ b/providers/apache/livy/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/src/airflow/__init__.py
+++ b/providers/apache/pig/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/src/airflow/providers/__init__.py
+++ b/providers/apache/pig/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/pig/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/tests/system/__init__.py
+++ b/providers/apache/pig/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/tests/system/__init__.py
+++ b/providers/apache/pig/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/pig/tests/system/apache/__init__.py
+++ b/providers/apache/pig/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/tests/unit/__init__.py
+++ b/providers/apache/pig/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pig/tests/unit/__init__.py
+++ b/providers/apache/pig/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/pig/tests/unit/apache/__init__.py
+++ b/providers/apache/pig/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/src/airflow/__init__.py
+++ b/providers/apache/pinot/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/src/airflow/providers/__init__.py
+++ b/providers/apache/pinot/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/pinot/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/integration/__init__.py
+++ b/providers/apache/pinot/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/integration/__init__.py
+++ b/providers/apache/pinot/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/pinot/tests/integration/apache/__init__.py
+++ b/providers/apache/pinot/tests/integration/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/integration/apache/pinot/__init__.py
+++ b/providers/apache/pinot/tests/integration/apache/pinot/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/integration/apache/pinot/__init__.py
+++ b/providers/apache/pinot/tests/integration/apache/pinot/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/pinot/tests/system/__init__.py
+++ b/providers/apache/pinot/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/system/__init__.py
+++ b/providers/apache/pinot/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/pinot/tests/system/apache/__init__.py
+++ b/providers/apache/pinot/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/unit/__init__.py
+++ b/providers/apache/pinot/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/pinot/tests/unit/__init__.py
+++ b/providers/apache/pinot/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/pinot/tests/unit/apache/__init__.py
+++ b/providers/apache/pinot/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/src/airflow/__init__.py
+++ b/providers/apache/spark/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/src/airflow/providers/__init__.py
+++ b/providers/apache/spark/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/spark/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/tests/system/__init__.py
+++ b/providers/apache/spark/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/tests/system/__init__.py
+++ b/providers/apache/spark/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/spark/tests/system/apache/__init__.py
+++ b/providers/apache/spark/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/tests/unit/__init__.py
+++ b/providers/apache/spark/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/spark/tests/unit/__init__.py
+++ b/providers/apache/spark/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/spark/tests/unit/apache/__init__.py
+++ b/providers/apache/spark/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/src/airflow/__init__.py
+++ b/providers/apache/tinkerpop/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/src/airflow/providers/__init__.py
+++ b/providers/apache/tinkerpop/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/src/airflow/providers/apache/__init__.py
+++ b/providers/apache/tinkerpop/src/airflow/providers/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/tests/integration/apache/__init__.py
+++ b/providers/apache/tinkerpop/tests/integration/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/tests/system/apache/__init__.py
+++ b/providers/apache/tinkerpop/tests/system/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/tests/unit/__init__.py
+++ b/providers/apache/tinkerpop/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apache/tinkerpop/tests/unit/__init__.py
+++ b/providers/apache/tinkerpop/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/apache/tinkerpop/tests/unit/apache/__init__.py
+++ b/providers/apache/tinkerpop/tests/unit/apache/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apprise/src/airflow/__init__.py
+++ b/providers/apprise/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apprise/src/airflow/providers/__init__.py
+++ b/providers/apprise/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apprise/tests/unit/__init__.py
+++ b/providers/apprise/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/apprise/tests/unit/__init__.py
+++ b/providers/apprise/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/arangodb/src/airflow/__init__.py
+++ b/providers/arangodb/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/arangodb/src/airflow/providers/__init__.py
+++ b/providers/arangodb/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/arangodb/tests/unit/__init__.py
+++ b/providers/arangodb/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/arangodb/tests/unit/__init__.py
+++ b/providers/arangodb/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/asana/src/airflow/__init__.py
+++ b/providers/asana/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/asana/src/airflow/providers/__init__.py
+++ b/providers/asana/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/asana/tests/system/__init__.py
+++ b/providers/asana/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/asana/tests/system/__init__.py
+++ b/providers/asana/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/asana/tests/unit/__init__.py
+++ b/providers/asana/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/asana/tests/unit/__init__.py
+++ b/providers/asana/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/atlassian/jira/src/airflow/__init__.py
+++ b/providers/atlassian/jira/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/atlassian/jira/src/airflow/providers/__init__.py
+++ b/providers/atlassian/jira/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/atlassian/jira/src/airflow/providers/atlassian/__init__.py
+++ b/providers/atlassian/jira/src/airflow/providers/atlassian/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/atlassian/jira/tests/unit/__init__.py
+++ b/providers/atlassian/jira/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/atlassian/jira/tests/unit/__init__.py
+++ b/providers/atlassian/jira/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/atlassian/jira/tests/unit/atlassian/__init__.py
+++ b/providers/atlassian/jira/tests/unit/atlassian/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/celery/src/airflow/__init__.py
+++ b/providers/celery/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/celery/src/airflow/providers/__init__.py
+++ b/providers/celery/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/celery/tests/integration/__init__.py
+++ b/providers/celery/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/celery/tests/integration/__init__.py
+++ b/providers/celery/tests/integration/__init__.py
@@ -14,5 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/celery/tests/unit/__init__.py
+++ b/providers/celery/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/celery/tests/unit/__init__.py
+++ b/providers/celery/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/cloudant/src/airflow/__init__.py
+++ b/providers/cloudant/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cloudant/src/airflow/providers/__init__.py
+++ b/providers/cloudant/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cloudant/tests/unit/__init__.py
+++ b/providers/cloudant/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cloudant/tests/unit/__init__.py
+++ b/providers/cloudant/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/cncf/kubernetes/src/airflow/__init__.py
+++ b/providers/cncf/kubernetes/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cncf/kubernetes/src/airflow/providers/__init__.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/__init__.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cncf/kubernetes/tests/system/__init__.py
+++ b/providers/cncf/kubernetes/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cncf/kubernetes/tests/system/__init__.py
+++ b/providers/cncf/kubernetes/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/cncf/kubernetes/tests/system/cncf/__init__.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cncf/kubernetes/tests/unit/__init__.py
+++ b/providers/cncf/kubernetes/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cncf/kubernetes/tests/unit/__init__.py
+++ b/providers/cncf/kubernetes/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/cncf/kubernetes/tests/unit/cncf/__init__.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cohere/src/airflow/__init__.py
+++ b/providers/cohere/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cohere/src/airflow/providers/__init__.py
+++ b/providers/cohere/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cohere/tests/system/__init__.py
+++ b/providers/cohere/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cohere/tests/system/__init__.py
+++ b/providers/cohere/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/cohere/tests/unit/__init__.py
+++ b/providers/cohere/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/cohere/tests/unit/__init__.py
+++ b/providers/cohere/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/compat/src/airflow/__init__.py
+++ b/providers/common/compat/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/compat/src/airflow/providers/__init__.py
+++ b/providers/common/compat/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/compat/src/airflow/providers/common/__init__.py
+++ b/providers/common/compat/src/airflow/providers/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/compat/tests/unit/__init__.py
+++ b/providers/common/compat/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/compat/tests/unit/__init__.py
+++ b/providers/common/compat/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/compat/tests/unit/common/__init__.py
+++ b/providers/common/compat/tests/unit/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/src/airflow/__init__.py
+++ b/providers/common/io/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/src/airflow/providers/__init__.py
+++ b/providers/common/io/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/src/airflow/providers/common/__init__.py
+++ b/providers/common/io/src/airflow/providers/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/tests/system/__init__.py
+++ b/providers/common/io/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/tests/system/__init__.py
+++ b/providers/common/io/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/io/tests/system/common/__init__.py
+++ b/providers/common/io/tests/system/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/tests/unit/__init__.py
+++ b/providers/common/io/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/io/tests/unit/__init__.py
+++ b/providers/common/io/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/io/tests/unit/common/__init__.py
+++ b/providers/common/io/tests/unit/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/src/airflow/__init__.py
+++ b/providers/common/messaging/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/src/airflow/providers/__init__.py
+++ b/providers/common/messaging/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/src/airflow/providers/common/__init__.py
+++ b/providers/common/messaging/src/airflow/providers/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/tests/system/__init__.py
+++ b/providers/common/messaging/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/tests/system/__init__.py
+++ b/providers/common/messaging/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/messaging/tests/system/common/__init__.py
+++ b/providers/common/messaging/tests/system/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/tests/unit/__init__.py
+++ b/providers/common/messaging/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/messaging/tests/unit/__init__.py
+++ b/providers/common/messaging/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/messaging/tests/unit/common/__init__.py
+++ b/providers/common/messaging/tests/unit/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/src/airflow/__init__.py
+++ b/providers/common/sql/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/src/airflow/providers/__init__.py
+++ b/providers/common/sql/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/src/airflow/providers/common/__init__.py
+++ b/providers/common/sql/src/airflow/providers/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/tests/system/__init__.py
+++ b/providers/common/sql/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/tests/system/__init__.py
+++ b/providers/common/sql/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/sql/tests/system/common/__init__.py
+++ b/providers/common/sql/tests/system/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/tests/unit/__init__.py
+++ b/providers/common/sql/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/common/sql/tests/unit/__init__.py
+++ b/providers/common/sql/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/common/sql/tests/unit/common/__init__.py
+++ b/providers/common/sql/tests/unit/common/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/databricks/src/airflow/__init__.py
+++ b/providers/databricks/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/databricks/src/airflow/providers/__init__.py
+++ b/providers/databricks/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/databricks/tests/system/__init__.py
+++ b/providers/databricks/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/databricks/tests/system/__init__.py
+++ b/providers/databricks/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/databricks/tests/unit/__init__.py
+++ b/providers/databricks/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/databricks/tests/unit/__init__.py
+++ b/providers/databricks/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/datadog/src/airflow/__init__.py
+++ b/providers/datadog/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/datadog/src/airflow/providers/__init__.py
+++ b/providers/datadog/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/datadog/tests/unit/__init__.py
+++ b/providers/datadog/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/datadog/tests/unit/__init__.py
+++ b/providers/datadog/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/dbt/cloud/src/airflow/__init__.py
+++ b/providers/dbt/cloud/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dbt/cloud/src/airflow/providers/__init__.py
+++ b/providers/dbt/cloud/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dbt/cloud/src/airflow/providers/dbt/__init__.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dbt/cloud/tests/system/__init__.py
+++ b/providers/dbt/cloud/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dbt/cloud/tests/system/__init__.py
+++ b/providers/dbt/cloud/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/dbt/cloud/tests/system/dbt/__init__.py
+++ b/providers/dbt/cloud/tests/system/dbt/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dbt/cloud/tests/unit/__init__.py
+++ b/providers/dbt/cloud/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dbt/cloud/tests/unit/__init__.py
+++ b/providers/dbt/cloud/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/dbt/cloud/tests/unit/dbt/__init__.py
+++ b/providers/dbt/cloud/tests/unit/dbt/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dingding/src/airflow/__init__.py
+++ b/providers/dingding/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dingding/src/airflow/providers/__init__.py
+++ b/providers/dingding/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dingding/tests/system/__init__.py
+++ b/providers/dingding/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dingding/tests/system/__init__.py
+++ b/providers/dingding/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/dingding/tests/unit/__init__.py
+++ b/providers/dingding/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/dingding/tests/unit/__init__.py
+++ b/providers/dingding/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/discord/src/airflow/__init__.py
+++ b/providers/discord/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/discord/src/airflow/providers/__init__.py
+++ b/providers/discord/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/discord/tests/unit/__init__.py
+++ b/providers/discord/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/discord/tests/unit/__init__.py
+++ b/providers/discord/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/docker/src/airflow/__init__.py
+++ b/providers/docker/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/docker/src/airflow/providers/__init__.py
+++ b/providers/docker/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/docker/tests/system/__init__.py
+++ b/providers/docker/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/docker/tests/system/__init__.py
+++ b/providers/docker/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/docker/tests/unit/__init__.py
+++ b/providers/docker/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/docker/tests/unit/__init__.py
+++ b/providers/docker/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/edge3/src/airflow/__init__.py
+++ b/providers/edge3/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/edge3/src/airflow/providers/__init__.py
+++ b/providers/edge3/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/edge3/tests/unit/__init__.py
+++ b/providers/edge3/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/edge3/tests/unit/__init__.py
+++ b/providers/edge3/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/elasticsearch/src/airflow/__init__.py
+++ b/providers/elasticsearch/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/elasticsearch/src/airflow/providers/__init__.py
+++ b/providers/elasticsearch/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/elasticsearch/tests/system/__init__.py
+++ b/providers/elasticsearch/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/elasticsearch/tests/system/__init__.py
+++ b/providers/elasticsearch/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/elasticsearch/tests/unit/__init__.py
+++ b/providers/elasticsearch/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/elasticsearch/tests/unit/__init__.py
+++ b/providers/elasticsearch/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/exasol/src/airflow/__init__.py
+++ b/providers/exasol/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/exasol/src/airflow/providers/__init__.py
+++ b/providers/exasol/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/exasol/tests/unit/__init__.py
+++ b/providers/exasol/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/exasol/tests/unit/__init__.py
+++ b/providers/exasol/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/fab/src/airflow/__init__.py
+++ b/providers/fab/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/fab/src/airflow/providers/__init__.py
+++ b/providers/fab/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/fab/tests/unit/__init__.py
+++ b/providers/fab/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/fab/tests/unit/__init__.py
+++ b/providers/fab/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/facebook/src/airflow/__init__.py
+++ b/providers/facebook/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/facebook/src/airflow/providers/__init__.py
+++ b/providers/facebook/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/facebook/tests/unit/__init__.py
+++ b/providers/facebook/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/facebook/tests/unit/__init__.py
+++ b/providers/facebook/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/ftp/src/airflow/__init__.py
+++ b/providers/ftp/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ftp/src/airflow/providers/__init__.py
+++ b/providers/ftp/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ftp/tests/system/__init__.py
+++ b/providers/ftp/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ftp/tests/system/__init__.py
+++ b/providers/ftp/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/ftp/tests/unit/__init__.py
+++ b/providers/ftp/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ftp/tests/unit/__init__.py
+++ b/providers/ftp/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/git/src/airflow/__init__.py
+++ b/providers/git/src/airflow/__init__.py
@@ -14,5 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/git/src/airflow/providers/__init__.py
+++ b/providers/git/src/airflow/providers/__init__.py
@@ -14,5 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/github/src/airflow/__init__.py
+++ b/providers/github/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/github/src/airflow/providers/__init__.py
+++ b/providers/github/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/github/tests/system/__init__.py
+++ b/providers/github/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/github/tests/system/__init__.py
+++ b/providers/github/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/github/tests/unit/__init__.py
+++ b/providers/github/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/github/tests/unit/__init__.py
+++ b/providers/github/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/google/src/airflow/__init__.py
+++ b/providers/google/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/google/src/airflow/providers/__init__.py
+++ b/providers/google/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/google/tests/integration/__init__.py
+++ b/providers/google/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/google/tests/integration/__init__.py
+++ b/providers/google/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/google/tests/system/__init__.py
+++ b/providers/google/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/google/tests/system/__init__.py
+++ b/providers/google/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/google/tests/unit/__init__.py
+++ b/providers/google/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/google/tests/unit/__init__.py
+++ b/providers/google/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/grpc/src/airflow/__init__.py
+++ b/providers/grpc/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/grpc/src/airflow/providers/__init__.py
+++ b/providers/grpc/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/grpc/tests/unit/__init__.py
+++ b/providers/grpc/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/grpc/tests/unit/__init__.py
+++ b/providers/grpc/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/hashicorp/src/airflow/__init__.py
+++ b/providers/hashicorp/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/hashicorp/src/airflow/providers/__init__.py
+++ b/providers/hashicorp/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/hashicorp/tests/unit/__init__.py
+++ b/providers/hashicorp/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/hashicorp/tests/unit/__init__.py
+++ b/providers/hashicorp/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/http/src/airflow/__init__.py
+++ b/providers/http/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/http/src/airflow/providers/__init__.py
+++ b/providers/http/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/http/tests/system/__init__.py
+++ b/providers/http/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/http/tests/system/__init__.py
+++ b/providers/http/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/http/tests/unit/__init__.py
+++ b/providers/http/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/http/tests/unit/__init__.py
+++ b/providers/http/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/imap/src/airflow/__init__.py
+++ b/providers/imap/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/imap/src/airflow/providers/__init__.py
+++ b/providers/imap/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/imap/tests/unit/__init__.py
+++ b/providers/imap/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/imap/tests/unit/__init__.py
+++ b/providers/imap/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/influxdb/src/airflow/__init__.py
+++ b/providers/influxdb/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/influxdb/src/airflow/providers/__init__.py
+++ b/providers/influxdb/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/influxdb/tests/system/__init__.py
+++ b/providers/influxdb/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/influxdb/tests/system/__init__.py
+++ b/providers/influxdb/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/influxdb/tests/unit/__init__.py
+++ b/providers/influxdb/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/influxdb/tests/unit/__init__.py
+++ b/providers/influxdb/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/jdbc/src/airflow/__init__.py
+++ b/providers/jdbc/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jdbc/src/airflow/providers/__init__.py
+++ b/providers/jdbc/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jdbc/tests/system/__init__.py
+++ b/providers/jdbc/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jdbc/tests/system/__init__.py
+++ b/providers/jdbc/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/jdbc/tests/unit/__init__.py
+++ b/providers/jdbc/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jdbc/tests/unit/__init__.py
+++ b/providers/jdbc/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/jenkins/src/airflow/__init__.py
+++ b/providers/jenkins/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jenkins/src/airflow/providers/__init__.py
+++ b/providers/jenkins/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jenkins/tests/system/__init__.py
+++ b/providers/jenkins/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jenkins/tests/system/__init__.py
+++ b/providers/jenkins/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/jenkins/tests/unit/__init__.py
+++ b/providers/jenkins/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/jenkins/tests/unit/__init__.py
+++ b/providers/jenkins/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/keycloak/src/airflow/__init__.py
+++ b/providers/keycloak/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/keycloak/src/airflow/providers/__init__.py
+++ b/providers/keycloak/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/keycloak/tests/system/__init__.py
+++ b/providers/keycloak/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/keycloak/tests/system/__init__.py
+++ b/providers/keycloak/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/keycloak/tests/system/keycloak/__init__.py
+++ b/providers/keycloak/tests/system/keycloak/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/keycloak/tests/system/keycloak/__init__.py
+++ b/providers/keycloak/tests/system/keycloak/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/keycloak/tests/unit/__init__.py
+++ b/providers/keycloak/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/keycloak/tests/unit/__init__.py
+++ b/providers/keycloak/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/keycloak/tests/unit/keycloak/__init__.py
+++ b/providers/keycloak/tests/unit/keycloak/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/keycloak/tests/unit/keycloak/__init__.py
+++ b/providers/keycloak/tests/unit/keycloak/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/azure/src/airflow/__init__.py
+++ b/providers/microsoft/azure/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/azure/src/airflow/providers/__init__.py
+++ b/providers/microsoft/azure/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/__init__.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/azure/tests/system/__init__.py
+++ b/providers/microsoft/azure/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/azure/tests/system/__init__.py
+++ b/providers/microsoft/azure/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/azure/tests/system/microsoft/__init__.py
+++ b/providers/microsoft/azure/tests/system/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/azure/tests/unit/__init__.py
+++ b/providers/microsoft/azure/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/azure/tests/unit/__init__.py
+++ b/providers/microsoft/azure/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/azure/tests/unit/microsoft/__init__.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/src/airflow/__init__.py
+++ b/providers/microsoft/mssql/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/src/airflow/providers/__init__.py
+++ b/providers/microsoft/mssql/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/src/airflow/providers/microsoft/__init__.py
+++ b/providers/microsoft/mssql/src/airflow/providers/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/tests/integration/__init__.py
+++ b/providers/microsoft/mssql/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/tests/integration/__init__.py
+++ b/providers/microsoft/mssql/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/mssql/tests/integration/microsoft/__init__.py
+++ b/providers/microsoft/mssql/tests/integration/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/tests/system/__init__.py
+++ b/providers/microsoft/mssql/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/tests/system/__init__.py
+++ b/providers/microsoft/mssql/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/mssql/tests/system/microsoft/__init__.py
+++ b/providers/microsoft/mssql/tests/system/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/tests/unit/__init__.py
+++ b/providers/microsoft/mssql/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/mssql/tests/unit/__init__.py
+++ b/providers/microsoft/mssql/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/mssql/tests/unit/microsoft/__init__.py
+++ b/providers/microsoft/mssql/tests/unit/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/psrp/src/airflow/__init__.py
+++ b/providers/microsoft/psrp/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/psrp/src/airflow/providers/__init__.py
+++ b/providers/microsoft/psrp/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/__init__.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/psrp/tests/unit/__init__.py
+++ b/providers/microsoft/psrp/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/psrp/tests/unit/__init__.py
+++ b/providers/microsoft/psrp/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/psrp/tests/unit/microsoft/__init__.py
+++ b/providers/microsoft/psrp/tests/unit/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/src/airflow/__init__.py
+++ b/providers/microsoft/winrm/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/src/airflow/providers/__init__.py
+++ b/providers/microsoft/winrm/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/__init__.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/tests/system/__init__.py
+++ b/providers/microsoft/winrm/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/tests/system/__init__.py
+++ b/providers/microsoft/winrm/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/winrm/tests/system/microsoft/__init__.py
+++ b/providers/microsoft/winrm/tests/system/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/tests/unit/__init__.py
+++ b/providers/microsoft/winrm/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/microsoft/winrm/tests/unit/__init__.py
+++ b/providers/microsoft/winrm/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/microsoft/winrm/tests/unit/microsoft/__init__.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mongo/src/airflow/__init__.py
+++ b/providers/mongo/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mongo/src/airflow/providers/__init__.py
+++ b/providers/mongo/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mongo/tests/integration/__init__.py
+++ b/providers/mongo/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mongo/tests/integration/__init__.py
+++ b/providers/mongo/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/mongo/tests/unit/__init__.py
+++ b/providers/mongo/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mongo/tests/unit/__init__.py
+++ b/providers/mongo/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/mysql/src/airflow/__init__.py
+++ b/providers/mysql/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mysql/src/airflow/providers/__init__.py
+++ b/providers/mysql/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mysql/tests/system/__init__.py
+++ b/providers/mysql/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mysql/tests/system/__init__.py
+++ b/providers/mysql/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/mysql/tests/unit/__init__.py
+++ b/providers/mysql/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/mysql/tests/unit/__init__.py
+++ b/providers/mysql/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/neo4j/src/airflow/__init__.py
+++ b/providers/neo4j/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/neo4j/src/airflow/providers/__init__.py
+++ b/providers/neo4j/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/neo4j/tests/system/__init__.py
+++ b/providers/neo4j/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/neo4j/tests/system/__init__.py
+++ b/providers/neo4j/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/neo4j/tests/unit/__init__.py
+++ b/providers/neo4j/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/neo4j/tests/unit/__init__.py
+++ b/providers/neo4j/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/odbc/src/airflow/__init__.py
+++ b/providers/odbc/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/odbc/src/airflow/providers/__init__.py
+++ b/providers/odbc/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/odbc/tests/system/__init__.py
+++ b/providers/odbc/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/odbc/tests/system/__init__.py
+++ b/providers/odbc/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/odbc/tests/unit/__init__.py
+++ b/providers/odbc/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/odbc/tests/unit/__init__.py
+++ b/providers/odbc/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/openai/src/airflow/__init__.py
+++ b/providers/openai/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openai/src/airflow/providers/__init__.py
+++ b/providers/openai/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openai/tests/system/__init__.py
+++ b/providers/openai/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openai/tests/system/__init__.py
+++ b/providers/openai/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/openai/tests/unit/__init__.py
+++ b/providers/openai/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openai/tests/unit/__init__.py
+++ b/providers/openai/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/openfaas/src/airflow/__init__.py
+++ b/providers/openfaas/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openfaas/src/airflow/providers/__init__.py
+++ b/providers/openfaas/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openfaas/tests/unit/__init__.py
+++ b/providers/openfaas/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openfaas/tests/unit/__init__.py
+++ b/providers/openfaas/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/openlineage/src/airflow/__init__.py
+++ b/providers/openlineage/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openlineage/src/airflow/providers/__init__.py
+++ b/providers/openlineage/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openlineage/tests/integration/__init__.py
+++ b/providers/openlineage/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openlineage/tests/integration/__init__.py
+++ b/providers/openlineage/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/openlineage/tests/system/__init__.py
+++ b/providers/openlineage/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openlineage/tests/system/__init__.py
+++ b/providers/openlineage/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/openlineage/tests/unit/__init__.py
+++ b/providers/openlineage/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/openlineage/tests/unit/__init__.py
+++ b/providers/openlineage/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/opensearch/src/airflow/__init__.py
+++ b/providers/opensearch/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opensearch/src/airflow/providers/__init__.py
+++ b/providers/opensearch/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opensearch/tests/system/__init__.py
+++ b/providers/opensearch/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opensearch/tests/system/__init__.py
+++ b/providers/opensearch/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/opensearch/tests/unit/__init__.py
+++ b/providers/opensearch/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opensearch/tests/unit/__init__.py
+++ b/providers/opensearch/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/opsgenie/src/airflow/__init__.py
+++ b/providers/opsgenie/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opsgenie/src/airflow/providers/__init__.py
+++ b/providers/opsgenie/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opsgenie/tests/system/__init__.py
+++ b/providers/opsgenie/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opsgenie/tests/system/__init__.py
+++ b/providers/opsgenie/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/opsgenie/tests/unit/__init__.py
+++ b/providers/opsgenie/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/opsgenie/tests/unit/__init__.py
+++ b/providers/opsgenie/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/oracle/src/airflow/__init__.py
+++ b/providers/oracle/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/oracle/src/airflow/providers/__init__.py
+++ b/providers/oracle/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/oracle/tests/system/__init__.py
+++ b/providers/oracle/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/oracle/tests/system/__init__.py
+++ b/providers/oracle/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/oracle/tests/unit/__init__.py
+++ b/providers/oracle/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/oracle/tests/unit/__init__.py
+++ b/providers/oracle/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/pagerduty/src/airflow/__init__.py
+++ b/providers/pagerduty/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pagerduty/src/airflow/providers/__init__.py
+++ b/providers/pagerduty/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pagerduty/tests/unit/__init__.py
+++ b/providers/pagerduty/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pagerduty/tests/unit/__init__.py
+++ b/providers/pagerduty/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/papermill/src/airflow/__init__.py
+++ b/providers/papermill/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/papermill/src/airflow/providers/__init__.py
+++ b/providers/papermill/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/papermill/tests/system/__init__.py
+++ b/providers/papermill/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/papermill/tests/system/__init__.py
+++ b/providers/papermill/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/papermill/tests/unit/__init__.py
+++ b/providers/papermill/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/papermill/tests/unit/__init__.py
+++ b/providers/papermill/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/pgvector/src/airflow/__init__.py
+++ b/providers/pgvector/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pgvector/src/airflow/providers/__init__.py
+++ b/providers/pgvector/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pgvector/tests/system/__init__.py
+++ b/providers/pgvector/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pgvector/tests/system/__init__.py
+++ b/providers/pgvector/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/pgvector/tests/unit/__init__.py
+++ b/providers/pgvector/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pgvector/tests/unit/__init__.py
+++ b/providers/pgvector/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/pinecone/src/airflow/__init__.py
+++ b/providers/pinecone/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pinecone/src/airflow/providers/__init__.py
+++ b/providers/pinecone/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pinecone/tests/system/__init__.py
+++ b/providers/pinecone/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pinecone/tests/system/__init__.py
+++ b/providers/pinecone/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/pinecone/tests/unit/__init__.py
+++ b/providers/pinecone/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/pinecone/tests/unit/__init__.py
+++ b/providers/pinecone/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/postgres/src/airflow/__init__.py
+++ b/providers/postgres/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/postgres/src/airflow/providers/__init__.py
+++ b/providers/postgres/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/postgres/tests/system/__init__.py
+++ b/providers/postgres/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/postgres/tests/system/__init__.py
+++ b/providers/postgres/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/postgres/tests/unit/__init__.py
+++ b/providers/postgres/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/postgres/tests/unit/__init__.py
+++ b/providers/postgres/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/presto/src/airflow/__init__.py
+++ b/providers/presto/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/presto/src/airflow/providers/__init__.py
+++ b/providers/presto/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/presto/tests/system/__init__.py
+++ b/providers/presto/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/presto/tests/system/__init__.py
+++ b/providers/presto/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/presto/tests/unit/__init__.py
+++ b/providers/presto/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/presto/tests/unit/__init__.py
+++ b/providers/presto/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/qdrant/src/airflow/__init__.py
+++ b/providers/qdrant/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/qdrant/src/airflow/providers/__init__.py
+++ b/providers/qdrant/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/qdrant/tests/integration/__init__.py
+++ b/providers/qdrant/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/qdrant/tests/integration/__init__.py
+++ b/providers/qdrant/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/qdrant/tests/system/__init__.py
+++ b/providers/qdrant/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/qdrant/tests/system/__init__.py
+++ b/providers/qdrant/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/qdrant/tests/unit/__init__.py
+++ b/providers/qdrant/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/qdrant/tests/unit/__init__.py
+++ b/providers/qdrant/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/redis/src/airflow/__init__.py
+++ b/providers/redis/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/redis/src/airflow/providers/__init__.py
+++ b/providers/redis/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/redis/tests/integration/__init__.py
+++ b/providers/redis/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/redis/tests/integration/__init__.py
+++ b/providers/redis/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/redis/tests/system/__init__.py
+++ b/providers/redis/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/redis/tests/system/__init__.py
+++ b/providers/redis/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/redis/tests/unit/__init__.py
+++ b/providers/redis/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/redis/tests/unit/__init__.py
+++ b/providers/redis/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/salesforce/src/airflow/__init__.py
+++ b/providers/salesforce/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/salesforce/src/airflow/providers/__init__.py
+++ b/providers/salesforce/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/salesforce/tests/system/__init__.py
+++ b/providers/salesforce/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/salesforce/tests/system/__init__.py
+++ b/providers/salesforce/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/salesforce/tests/unit/__init__.py
+++ b/providers/salesforce/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/salesforce/tests/unit/__init__.py
+++ b/providers/salesforce/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/samba/src/airflow/__init__.py
+++ b/providers/samba/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/samba/src/airflow/providers/__init__.py
+++ b/providers/samba/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/samba/tests/system/__init__.py
+++ b/providers/samba/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/samba/tests/system/__init__.py
+++ b/providers/samba/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/samba/tests/unit/__init__.py
+++ b/providers/samba/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/samba/tests/unit/__init__.py
+++ b/providers/samba/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/segment/src/airflow/__init__.py
+++ b/providers/segment/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/segment/src/airflow/providers/__init__.py
+++ b/providers/segment/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/segment/tests/unit/__init__.py
+++ b/providers/segment/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/segment/tests/unit/__init__.py
+++ b/providers/segment/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/sendgrid/src/airflow/__init__.py
+++ b/providers/sendgrid/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sendgrid/src/airflow/providers/__init__.py
+++ b/providers/sendgrid/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sendgrid/tests/unit/__init__.py
+++ b/providers/sendgrid/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sendgrid/tests/unit/__init__.py
+++ b/providers/sendgrid/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/sftp/src/airflow/__init__.py
+++ b/providers/sftp/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sftp/src/airflow/providers/__init__.py
+++ b/providers/sftp/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sftp/tests/system/__init__.py
+++ b/providers/sftp/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sftp/tests/system/__init__.py
+++ b/providers/sftp/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/sftp/tests/unit/__init__.py
+++ b/providers/sftp/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sftp/tests/unit/__init__.py
+++ b/providers/sftp/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/singularity/src/airflow/__init__.py
+++ b/providers/singularity/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/singularity/src/airflow/providers/__init__.py
+++ b/providers/singularity/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/singularity/tests/system/__init__.py
+++ b/providers/singularity/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/singularity/tests/system/__init__.py
+++ b/providers/singularity/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/singularity/tests/unit/__init__.py
+++ b/providers/singularity/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/singularity/tests/unit/__init__.py
+++ b/providers/singularity/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/slack/src/airflow/__init__.py
+++ b/providers/slack/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/slack/src/airflow/providers/__init__.py
+++ b/providers/slack/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/slack/tests/system/__init__.py
+++ b/providers/slack/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/slack/tests/system/__init__.py
+++ b/providers/slack/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/slack/tests/unit/__init__.py
+++ b/providers/slack/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/slack/tests/unit/__init__.py
+++ b/providers/slack/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/smtp/src/airflow/__init__.py
+++ b/providers/smtp/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/smtp/src/airflow/providers/__init__.py
+++ b/providers/smtp/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/smtp/tests/unit/__init__.py
+++ b/providers/smtp/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/smtp/tests/unit/__init__.py
+++ b/providers/smtp/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/snowflake/src/airflow/__init__.py
+++ b/providers/snowflake/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/snowflake/src/airflow/providers/__init__.py
+++ b/providers/snowflake/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/snowflake/tests/system/__init__.py
+++ b/providers/snowflake/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/snowflake/tests/system/__init__.py
+++ b/providers/snowflake/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/snowflake/tests/unit/__init__.py
+++ b/providers/snowflake/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/snowflake/tests/unit/__init__.py
+++ b/providers/snowflake/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/sqlite/src/airflow/__init__.py
+++ b/providers/sqlite/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sqlite/src/airflow/providers/__init__.py
+++ b/providers/sqlite/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sqlite/tests/system/__init__.py
+++ b/providers/sqlite/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sqlite/tests/system/__init__.py
+++ b/providers/sqlite/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/sqlite/tests/unit/__init__.py
+++ b/providers/sqlite/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/sqlite/tests/unit/__init__.py
+++ b/providers/sqlite/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/ssh/src/airflow/__init__.py
+++ b/providers/ssh/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ssh/src/airflow/providers/__init__.py
+++ b/providers/ssh/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ssh/tests/unit/__init__.py
+++ b/providers/ssh/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ssh/tests/unit/__init__.py
+++ b/providers/ssh/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/standard/src/airflow/__init__.py
+++ b/providers/standard/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/standard/src/airflow/providers/__init__.py
+++ b/providers/standard/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/standard/tests/unit/__init__.py
+++ b/providers/standard/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/standard/tests/unit/__init__.py
+++ b/providers/standard/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/tableau/src/airflow/__init__.py
+++ b/providers/tableau/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/tableau/src/airflow/providers/__init__.py
+++ b/providers/tableau/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/tableau/tests/system/__init__.py
+++ b/providers/tableau/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/tableau/tests/system/__init__.py
+++ b/providers/tableau/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/tableau/tests/unit/__init__.py
+++ b/providers/tableau/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/tableau/tests/unit/__init__.py
+++ b/providers/tableau/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/telegram/src/airflow/__init__.py
+++ b/providers/telegram/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/telegram/src/airflow/providers/__init__.py
+++ b/providers/telegram/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/telegram/tests/system/__init__.py
+++ b/providers/telegram/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/telegram/tests/system/__init__.py
+++ b/providers/telegram/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/telegram/tests/unit/__init__.py
+++ b/providers/telegram/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/telegram/tests/unit/__init__.py
+++ b/providers/telegram/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/teradata/src/airflow/__init__.py
+++ b/providers/teradata/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/teradata/src/airflow/providers/__init__.py
+++ b/providers/teradata/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/teradata/tests/system/__init__.py
+++ b/providers/teradata/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/teradata/tests/system/__init__.py
+++ b/providers/teradata/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/teradata/tests/unit/__init__.py
+++ b/providers/teradata/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/teradata/tests/unit/__init__.py
+++ b/providers/teradata/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/trino/src/airflow/__init__.py
+++ b/providers/trino/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/trino/src/airflow/providers/__init__.py
+++ b/providers/trino/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/trino/tests/integration/__init__.py
+++ b/providers/trino/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/trino/tests/integration/__init__.py
+++ b/providers/trino/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/trino/tests/system/__init__.py
+++ b/providers/trino/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/trino/tests/system/__init__.py
+++ b/providers/trino/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/trino/tests/unit/__init__.py
+++ b/providers/trino/tests/unit/__init__.py
@@ -1,3 +1,4 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,3 +15,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/trino/tests/unit/__init__.py
+++ b/providers/trino/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/vertica/src/airflow/__init__.py
+++ b/providers/vertica/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/vertica/src/airflow/providers/__init__.py
+++ b/providers/vertica/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/vertica/tests/system/__init__.py
+++ b/providers/vertica/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/vertica/tests/system/__init__.py
+++ b/providers/vertica/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/vertica/tests/unit/__init__.py
+++ b/providers/vertica/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/vertica/tests/unit/__init__.py
+++ b/providers/vertica/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/weaviate/src/airflow/__init__.py
+++ b/providers/weaviate/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/weaviate/src/airflow/providers/__init__.py
+++ b/providers/weaviate/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/weaviate/tests/system/__init__.py
+++ b/providers/weaviate/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/weaviate/tests/system/__init__.py
+++ b/providers/weaviate/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/weaviate/tests/unit/__init__.py
+++ b/providers/weaviate/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/weaviate/tests/unit/__init__.py
+++ b/providers/weaviate/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/yandex/src/airflow/__init__.py
+++ b/providers/yandex/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/yandex/src/airflow/providers/__init__.py
+++ b/providers/yandex/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/yandex/tests/system/__init__.py
+++ b/providers/yandex/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/yandex/tests/system/__init__.py
+++ b/providers/yandex/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/yandex/tests/unit/__init__.py
+++ b/providers/yandex/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/yandex/tests/unit/__init__.py
+++ b/providers/yandex/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/ydb/src/airflow/__init__.py
+++ b/providers/ydb/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ydb/src/airflow/providers/__init__.py
+++ b/providers/ydb/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ydb/tests/integration/__init__.py
+++ b/providers/ydb/tests/integration/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ydb/tests/integration/__init__.py
+++ b/providers/ydb/tests/integration/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/ydb/tests/system/__init__.py
+++ b/providers/ydb/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ydb/tests/system/__init__.py
+++ b/providers/ydb/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/ydb/tests/unit/__init__.py
+++ b/providers/ydb/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/ydb/tests/unit/__init__.py
+++ b/providers/ydb/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/zendesk/src/airflow/__init__.py
+++ b/providers/zendesk/src/airflow/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/zendesk/src/airflow/providers/__init__.py
+++ b/providers/zendesk/src/airflow/providers/__init__.py
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/zendesk/tests/system/__init__.py
+++ b/providers/zendesk/tests/system/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/zendesk/tests/system/__init__.py
+++ b/providers/zendesk/tests/system/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/providers/zendesk/tests/unit/__init__.py
+++ b/providers/zendesk/tests/unit/__init__.py
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/zendesk/tests/unit/__init__.py
+++ b/providers/zendesk/tests/unit/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -689,7 +689,7 @@ testing = ["dev", "providers.tests", "tests_common", "tests", "system", "unit", 
 
 # Those are needed so that __init__.py chaining of packages properly works for IDEs
 # the first non-comment line of such empty __init__.py files should be:
-# __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+#
 "airflow-core/tests/unit/__init__.py" = ["I002"]
 "airflow-core/tests/system/__init__.py" = ["I002"]
 "airflow-core/tests/integration/__init__.py" = ["I002"]

--- a/scripts/ci/pre_commit/check_providers_subpackages_all_have_init.py
+++ b/scripts/ci/pre_commit/check_providers_subpackages_all_have_init.py
@@ -41,7 +41,7 @@ ACCEPTED_NON_INIT_DIRS = [
     "non_python_src",
 ]
 
-PATH_EXTENSION_STRING = '__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore'
+PATH_EXTENSION_STRING = '__path__ = __import__("pkgutil").extend_path(__path__, __name__)'
 
 ALLOWED_SUB_FOLDERS_OF_TESTS = ["unit", "system", "integration"]
 

--- a/task-sdk/src/airflow/__init__.py
+++ b/task-sdk/src/airflow/__init__.py
@@ -15,4 +15,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/task-sdk/src/airflow/__init__.py
+++ b/task-sdk/src/airflow/__init__.py
@@ -15,3 +15,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
Relates to #53241

I realized that a generated `type: ignore` is produced by pre-commit which is not needed after mypy upgrade - this PR updates all with the update of pre-commit.