### PR TITLE
auto-sync change of TaskInstance note without manual refresh

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -31,6 +31,7 @@ const EditableMarkdownButton = ({
   isPending,
   mdContent,
   onConfirm,
+  onOpen,
   placeholder,
   setMdContent,
   text,
@@ -41,6 +42,7 @@ const EditableMarkdownButton = ({
   readonly isPending: boolean;
   readonly mdContent?: string | null;
   readonly onConfirm: () => void;
+  readonly onOpen: () => void;
   readonly placeholder: string;
   readonly setMdContent: (value: string) => void;
   readonly text: string;
@@ -54,7 +56,12 @@ const EditableMarkdownButton = ({
       <ActionButton
         actionName={placeholder}
         icon={icon}
-        onClick={() => setIsOpen(true)}
+        onClick={() => {
+          if (!isOpen) {
+            onOpen();
+          }
+          setIsOpen(true);
+        }}
         text={text}
         withText={withText}
       />
@@ -64,6 +71,7 @@ const EditableMarkdownButton = ({
         onOpenChange={() => setIsOpen(false)}
         open={isOpen}
         size="md"
+        unmountOnExit={true}
       >
         <Dialog.Content backdrop>
           <Dialog.Header bg="blue.muted">

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -60,6 +60,11 @@ export const Header = ({
       });
     }
   }, [dagId, dagRun.note, dagRunId, mutate, note]);
+
+  const onOpen = () => {
+    setNote(dagRun.note ?? "");
+  };
+
   const containerRef = useRef<HTMLDivElement>();
   const containerWidth = useContainerWidth(containerRef);
 
@@ -74,6 +79,7 @@ export const Header = ({
               isPending={isPending}
               mdContent={note}
               onConfirm={onConfirm}
+              onOpen={onOpen}
               placeholder={translate("note.placeholder")}
               setMdContent={setNote}
               text={Boolean(dagRun.note) ? translate("note.label") : translate("note.add")}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -88,6 +88,10 @@ export const Header = ({
     }
   }, [dagId, dagRunId, mapIndex, mutate, note, taskId, taskInstance.note]);
 
+  const onOpen = () => {
+    setNote(taskInstance.note ?? "");
+  };
+
   return (
     <Box ref={containerRef}>
       <HeaderCard
@@ -99,6 +103,7 @@ export const Header = ({
               isPending={isPending}
               mdContent={note}
               onConfirm={onConfirm}
+              onOpen={onOpen}
               placeholder={translate("note.placeholder")}
               setMdContent={setNote}
               text={Boolean(taskInstance.note) ? translate("note.label") : translate("note.add")}


### PR DESCRIPTION
## Why
closes: [#53085](https://github.com/apache/airflow/issues/53085)
In `TaskInstance/Header.tsx`, the note state is not refreshed when the TI is refreshed from new cache value.
It needs manual refresh to solve this mismatch.
## What
Added a `useEffect` that listens for changes to `taskInstance.note `and updates the local note state accordingly.
No manual refresh is needed.
## Demo

https://github.com/user-attachments/assets/a86b0410-aa02-43b2-b498-c47633051d80


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
