### PR TITLE
i18n(Ko): add missing translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -81,6 +81,7 @@
   "expand": {
     "collapse": "접기",
     "expand": "펼치기",
+    "hotkey": "e",
     "tooltip": "{{hotkey}}를 눌러 펼치기/접기합니다."
   },
   "expression": {
@@ -153,6 +154,11 @@
   },
   "selectLanguage": "언어 선택",
   "showDetailsPanel": "세부 정보 패널 펼치기",
+  "source": {
+    "hide": "소스 숨기기",
+    "hotkey": "s",
+    "show": "소스 보기"
+  },
   "sourceAssetEvent_one": "소스 에셋 이벤트",
   "sourceAssetEvent_other": "소스 에셋 이벤트",
   "startDate": "시작일",
@@ -232,6 +238,11 @@
     "lastHour": "지난 1시간",
     "pastWeek": "지난 주"
   },
+  "timestamp": {
+    "hide": "타임스탬프 숨기기",
+    "hotkey": "t",
+    "show": "타임스탬프 보기"
+  },
   "timezone": "시간대",
   "timezoneModal": {
     "current-timezone": "현재 시간:",
@@ -281,6 +292,7 @@
   "tryNumber": "시도 횟수",
   "user": "사용자",
   "wrap": {
+    "hotkey": "w",
     "tooltip": "{{hotkey}}를 눌러 텍스트 줄바꿈 토글",
     "unwrap": "줄바꿈 해제",
     "wrap": "줄바꿈"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -34,6 +34,7 @@
     },
     "info": "정보",
     "noTryNumber": "시도 횟수 없음",
+    "settings": "로그 설정",
     "viewInExternal": "{{name}}에서 로그 보기 (시도 {{attempt}})",
     "warning": "경고"
   },


### PR DESCRIPTION
Added Korean translations for newly added UI strings.
Replaced all TODO placeholders accordingly.

<img width="823" height="464" alt="image" src="https://github.com/user-attachments/assets/4d31fe04-198d-444b-9cf2-6f0199b8a8c4" />

Please review this translation.
/cc @kgw7401 @0ne-stone


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
