### PR TITLE
Another magic pip resolver hint

### DIFF
--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -65,7 +65,9 @@ dependencies = [
     "snowflake-connector-python>=3.7.1",
     "snowflake-sqlalchemy>=1.4.0",
     "snowflake-snowpark-python>=1.17.0;python_version<'3.12'",
-    "snowflake-snowpark-python>=1.27.0;python_version>='3.12'",
+    # The "<9999" is a hint to the pip resolver to resolve this requirement early,
+    # can be removed when the pip resolver is improved
+    "snowflake-snowpark-python>=1.27.0,<9999;python_version>='3.12'",
 ]
 
 # The optional dependencies should be modified in place in the generated file


### PR DESCRIPTION
See https://github.com/apache/airflow/pull/53306 and CC: @potiuk 

The issue is many versions (e.g. 1.33.0)  of `snowflake-snowpark-python` require `protobuf<6,>=3.20` but this conflicts largely with `grpcio-status` where many versions (e.g. 1.73.1) require `protobuf<7.0.0,>=6.30.0`.

This takes advantage of the fact that pip uses an upper bound as an indicator that that requirement must be resolved first, without adding any actual restrictions on upper bounds: https://pip.pypa.io/en/stable/topics/more-dependency-resolution/#the-resolver-algorithm

Unfortunately this particular one trips up even the optimistic back tracker optimization coming in pip 25.2, so either I need to figure out some more optimizations for pip's resolver to handle this, or pip needs a whole new resolver.