### PR TITLE
clear_task through cli, filtering by run_id

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -156,6 +156,7 @@ ARG_LOGICAL_DATE_OR_RUN_ID_OPTIONAL = Arg(
     help="The logical date of the DAG or run_id of the DAGRun (optional)",
 )
 ARG_TASK_REGEX = Arg(("-t", "--task-regex"), help="The regex to filter specific task_ids (optional)")
+ARG_DAG_RUN_ID = Arg(("-rid", "--dag-run-id"), help="The run_id of the DAGRun (optional)")
 ARG_BUNDLE_NAME = Arg(
     (
         "-B",
@@ -1221,6 +1222,7 @@ TASKS_COMMANDS = (
             ARG_ONLY_RUNNING,
             ARG_DAG_REGEX,
             ARG_VERBOSE,
+            ARG_DAG_RUN_ID,
         ),
     ),
     ActionCommand(

--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -456,6 +456,7 @@ def task_clear(args) -> None:
 
     SchedulerDAG.clear_dags(
         dags,
+        run_id=args.dag_run_id,
         start_date=args.start_date,
         end_date=args.end_date,
         only_failed=args.only_failed,

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -1451,6 +1451,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         confirm_prompt=False,
         dag_run_state=DagRunState.QUEUED,
         dry_run=False,
+        run_id=None,
     ):
         all_tis = []
         for dag in dags:
@@ -1464,6 +1465,7 @@ class DAG(TaskSDKDag, LoggingMixin):
                 confirm_prompt=False,
                 dag_run_state=dag_run_state,
                 dry_run=True,
+                run_id=run_id,
             )
             all_tis.extend(tis)
 
@@ -1492,6 +1494,7 @@ class DAG(TaskSDKDag, LoggingMixin):
                     confirm_prompt=False,
                     dag_run_state=dag_run_state,
                     dry_run=False,
+                    run_id=run_id,
                 )
         else:
             count = 0


### PR DESCRIPTION
added functionality that when user is clearing task through cli, he can also filter by run_id

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
