### PR TITLE
Added Labels to dagprocessor in helm chart

### DIFF
--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -49,6 +49,9 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.dagProcessor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- if .Values.dagProcessor.annotations }}
   annotations: {{- toYaml .Values.dagProcessor.annotations | nindent 4 }}
   {{- end }}
@@ -72,6 +75,9 @@ spec:
         component: dag-processor
         release: {{ .Release.Name }}
         {{- with .Values.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.dagProcessor.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -46,9 +46,10 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
-      {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+      {{- $global := default (dict) .Values.labels -}}
+      {{- $component := default (dict) .Values.dagProcessor.labels -}}
+      {{- mustMerge $component $global | toYaml | nindent 4 }}
     {{- end }}
   {{- if .Values.dagProcessor.annotations }}
   annotations: {{- toYaml .Values.dagProcessor.annotations | nindent 4 }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -46,7 +46,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
       {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- if .Values.dagProcessor.annotations }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -49,7 +49,7 @@ metadata:
     {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
       {{- $global := default (dict) .Values.labels -}}
       {{- $component := default (dict) .Values.dagProcessor.labels -}}
-      {{- mustMerge $component $global | toYaml | nindent 4 }}
+      {{- mustMerge $global $component | toYaml | nindent 4 }}
     {{- end }}
   {{- if .Values.dagProcessor.annotations }}
   annotations: {{- toYaml .Values.dagProcessor.annotations | nindent 4 }}
@@ -74,7 +74,7 @@ spec:
         component: dag-processor
         release: {{ .Release.Name }}
         {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
-          {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 8 }}
+          {{- mustMerge .Values.labels .Values.dagProcessor.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -46,11 +46,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.dagProcessor.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+      {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- if .Values.dagProcessor.annotations }}
   annotations: {{- toYaml .Values.dagProcessor.annotations | nindent 4 }}
@@ -74,11 +71,8 @@ spec:
         tier: airflow
         component: dag-processor
         release: {{ .Release.Name }}
-        {{- with .Values.labels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.dagProcessor.labels }}
-          {{- toYaml . | nindent 8 }}
+        {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+          {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -37,8 +37,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+      {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.dagProcessor.serviceAccount.annotations}}
   annotations: {{- toYaml . | nindent 4 }}

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -38,7 +38,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
-      {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
+      {{- $global := default (dict) .Values.labels -}}
+      {{- $component := default (dict) .Values.dagProcessor.labels -}}
+      {{- mustMerge $component $global | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.dagProcessor.serviceAccount.annotations}}
   annotations: {{- toYaml . | nindent 4 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3711,6 +3711,21 @@
                     ],
                     "default": null
                 },
+                "labels": {
+                    "description": "Labels to add to the DagProcessor.",
+                    "type": "object",
+                    "propertyNames": {
+                        "type": "string",
+                        "pattern": "^([A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?)(/[A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?)?$",
+                        "description": "Valid Kubernetes label key (with optional DNS prefix)."
+                    },
+                    "additionalProperties": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$",
+                        "description": "Valid Kubernetes label value."
+                    },
+                    "default": {}
+                },
                 "livenessProbe": {
                     "description": "Liveness probe configuration for dag processor.",
                     "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3711,21 +3711,6 @@
                     ],
                     "default": null
                 },
-                "labels": {
-                    "description": "Labels to add to the DagProcessor.",
-                    "type": "object",
-                    "propertyNames": {
-                        "type": "string",
-                        "pattern": "^([A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?)(/[A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?)?$",
-                        "description": "Valid Kubernetes label key (with optional DNS prefix)."
-                    },
-                    "additionalProperties": {
-                        "type": "string",
-                        "pattern": "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$",
-                        "description": "Valid Kubernetes label value."
-                    },
-                    "default": {}
-                },
                 "livenessProbe": {
                     "description": "Liveness probe configuration for dag processor.",
                     "type": "object",
@@ -3962,6 +3947,14 @@
                 },
                 "podAnnotations": {
                     "description": "Annotations to add to the dag processor pods.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "labels": {
+                    "description": "Labels to add to the dagProcessor objects and pods.",
                     "type": "object",
                     "default": {},
                     "additionalProperties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2100,6 +2100,8 @@ dagProcessor:
 
   podAnnotations: {}
 
+  labels: {}
+
   logGroomerSidecar:
     # Whether to deploy the Airflow dag processor log groomer sidecar.
     enabled: true

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -381,6 +381,7 @@ DagFileProcessorManager
 dagfolder
 dagmodel
 DagParam
+dagProcessor
 Dagre
 dagre
 DagRun

--- a/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
@@ -732,6 +732,21 @@ class TestDagProcessor:
         assert "annotations" in jmespath.search("metadata", docs[0])
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "enabled": True,
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        assert "labels" in jmespath.search("metadata", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+        assert "labels" in jmespath.search("spec.template.metadata", docs[0])
+        assert jmespath.search("spec.template.metadata.labels", docs[0])["test_label"] == "test_label_value"
+
     @pytest.mark.parametrize(
         "webserver_config, should_add_volume",
         [


### PR DESCRIPTION
Closes: #53190 

* **New Features**
  * Added support for specifying custom labels for the DAG Processor component, applied to both deployment and pod resources.

* **Tests**
  * Introduced a test to verify custom DAG Processor labels are correctly applied in the deployment manifest.

<!-- Please keep an empty line above the dashes. -->