### PR TITLE
Better type handling to account for types-docutils bump

### DIFF
--- a/devel-common/src/sphinx_exts/substitution_extensions.py
+++ b/devel-common/src/sphinx_exts/substitution_extensions.py
@@ -61,7 +61,7 @@ class SubstitutionCodeBlockTransform(SphinxTransform):
             return isinstance(node, (nodes.literal_block, nodes.literal))
 
         for node in self.document.traverse(condition):
-            if _SUBSTITUTION_OPTION_NAME not in node:
+            if not node.get(_SUBSTITUTION_OPTION_NAME):
                 continue
 
             # Some nodes don't have a direct document property, so walk up until we find it
@@ -76,11 +76,13 @@ class SubstitutionCodeBlockTransform(SphinxTransform):
                 old_child = child
                 for name, value in substitution_defs.items():
                     replacement = value.astext()
-                    child = nodes.Text(child.replace(f"|{name}|", replacement))
-                node.replace(old_child, child)
+                    if isinstance(child, nodes.Text):
+                        child = nodes.Text(child.replace(f"|{name}|", replacement))
+                if isinstance(node, nodes.Element):
+                    node.replace(old_child, child)
 
             # The highlighter checks this -- without this, it will refuse to apply highlighting
-            node.rawsource = node.astext()
+            node.rawsource = node.astext()  # type: ignore[attr-defined]
 
 
 def substitution_code_role(*args, **kwargs) -> tuple[list, list[Any]]:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

types-docutils released `types-docutils 0.21.0.20250715` with more stricter checks for types under nodes.


Adding some reactive type checks in our devel common modules to account / address that.

Example failure: https://github.com/apache/airflow/actions/runs/16287041685/job/45988572938

Error:
```
devel-common/src/sphinx_exts/substitution_extensions.py:64: error: Unsupported right operand type for in ("Node")  [operator]
                if _SUBSTITUTION_OPTION_NAME not in node:
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
devel-common/src/sphinx_exts/substitution_extensions.py:79: error: "Node" has no attribute "replace"  [attr-defined]
                        child = nodes.Text(child.replace(f"|{name}|", replacement))
                                           ^~~~~~~~~~~~~
devel-common/src/sphinx_exts/substitution_extensions.py:80: error: "Node" has no attribute "replace"  [attr-defined]
                    node.replace(old_child, child)
                    ^~~~~~~~~~~~
devel-common/src/sphinx_exts/substitution_extensions.py:83: error: "Node" has no attribute "rawsource"; maybe "source"?  [attr-defined]
                node.rawsource = node.astext()
                ^~~~~~~~~~~~~~
Found 4 errors in 1 file (checked 84 source files)
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
