### PR TITLE
sphinx: avoid repeated isinstance checks

### DIFF
--- a/devel-common/src/sphinx_exts/substitution_extensions.py
+++ b/devel-common/src/sphinx_exts/substitution_extensions.py
@@ -61,7 +61,8 @@ class SubstitutionCodeBlockTransform(SphinxTransform):
             return isinstance(node, (nodes.literal_block, nodes.literal))
 
         for node in self.document.traverse(condition):
-            if not node.get(_SUBSTITUTION_OPTION_NAME):
+            # Guard: Only process Element nodes with a truthy substitution option
+            if not (isinstance(node, nodes.Element) and node.attributes.get(_SUBSTITUTION_OPTION_NAME)):
                 continue
 
             # Some nodes don't have a direct document property, so walk up until we find it
@@ -74,15 +75,20 @@ class SubstitutionCodeBlockTransform(SphinxTransform):
             substitution_defs = document.substitution_defs
             for child in node.children:
                 old_child = child
-                for name, value in substitution_defs.items():
-                    replacement = value.astext()
-                    if isinstance(child, nodes.Text):
-                        child = nodes.Text(child.replace(f"|{name}|", replacement))
-                if isinstance(node, nodes.Element):
-                    node.replace(old_child, child)
+                # Only substitute for Text nodes
+                if isinstance(child, nodes.Text):
+                    new_text = str(child)
+                    for name, value in substitution_defs.items():
+                        replacement = value.astext()
+                        new_text = new_text.replace(f"|{name}|", replacement)
+                    # Only replace if the text actually changed
+                    if new_text != str(child):
+                        child = nodes.Text(new_text)
+                        node.replace(old_child, child)
+                # For non-Text nodes, do not replace
 
             # The highlighter checks this -- without this, it will refuse to apply highlighting
-            node.rawsource = node.astext()  # type: ignore[attr-defined]
+            node.rawsource = node.astext()
 
 
 def substitution_code_role(*args, **kwargs) -> tuple[list, list[Any]]:


### PR DESCRIPTION
This is a different fix for the same issue addressed in #53364, which was developed in parallel.

The main improvement are:
- Eliminate `# type: ignore[attr-defined]`
- `isinstance` branching happens at an earlier scope (so fewer times overall).

Also (according to copilot):

1. Type Safety:
- The suggested approach only processes nodes that are `isinstance(node, nodes.Element)`, which is correct because only `Element` nodes have `.attributes`, `.children`, and `.rawsource`.
- The existing approach uses `node.get(...)` and then checks `isinstance(node, nodes.Element)` later, which is less clear and could allow non-`Element` nodes to be processed incorrectly.
2. Clarity and Correctness:
- The suggested approach makes it explicit that only `Element` nodes with the substitution option are processed, matching the `docutils` node model.
- The existing approach could process nodes that are not `Element`, leading to possible attribute errors or incorrect behavior.
3. Efficiency:
- The suggested approach avoids unnecessary checks and only runs the substitution logic where it is valid.