### PR TITLE
fix: Check dynamic transport env vars in is_disabled()

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/conf.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/conf.py
@@ -136,9 +136,17 @@ def is_disabled() -> bool:
     if _is_true(os.getenv("OPENLINEAGE_DISABLED", "")):  # Check legacy variable
         return True
 
-    # Check if both 'transport' and 'config_path' are not present and also
-    # if legacy 'OPENLINEAGE_URL' environment variables is not set
-    return transport() == {} and config_path(True) == "" and os.getenv("OPENLINEAGE_URL", "") == ""
+    if transport():  # Check if transport is present
+        return False
+    if config_path(True):  # Check if config file is present
+        return False
+    if os.getenv("OPENLINEAGE_URL"):  # Check if url simple env var is present
+        return False
+    # Check if any transport configuration env var is present
+    if any(k.startswith("OPENLINEAGE__TRANSPORT") and v for k, v in os.environ.items()):
+        return False
+
+    return True  # No transport configuration is present, we can disable OpenLineage
 
 
 @cache

--- a/providers/openlineage/tests/unit/openlineage/test_conf.py
+++ b/providers/openlineage/tests/unit/openlineage/test_conf.py
@@ -476,6 +476,39 @@ def test_is_disabled_empty_conf_option():
     assert is_disabled() is True
 
 
+@mock.patch.dict(os.environ, {_VAR_URL: "", "OPENLINEAGE__TRANSPORT": '{"type": "console"}'}, clear=True)
+@conf_vars(
+    {
+        (_CONFIG_SECTION, _CONFIG_OPTION_CONFIG_PATH): "",
+        (_CONFIG_SECTION, _CONFIG_OPTION_TRANSPORT): "",
+    }
+)
+def test_is_disabled_env_variables_present():
+    assert is_disabled() is False
+
+
+@mock.patch.dict(os.environ, {_VAR_URL: "", "OPENLINEAGE__TRANSPORT": ""}, clear=True)
+@conf_vars(
+    {
+        (_CONFIG_SECTION, _CONFIG_OPTION_CONFIG_PATH): "",
+        (_CONFIG_SECTION, _CONFIG_OPTION_TRANSPORT): "",
+    }
+)
+def test_is_disabled_env_variables_not_present():
+    assert is_disabled() is True
+
+
+@mock.patch.dict(os.environ, {_VAR_URL: "", "OPENLINEAGE__TRANSPOR": '{"type": "console"}'}, clear=True)
+@conf_vars(
+    {
+        (_CONFIG_SECTION, _CONFIG_OPTION_CONFIG_PATH): "",
+        (_CONFIG_SECTION, _CONFIG_OPTION_TRANSPORT): "",
+    }
+)
+def test_is_disabled_env_variables_not_present_typo():
+    assert is_disabled() is True
+
+
 @mock.patch.dict(os.environ, {_VAR_URL: ""}, clear=True)
 @conf_vars(
     {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Since client version 1.23 users can also configure openlineage transport with OPENLINEAGE__TRANSPORT env vars. We should check for them when checking if any OL config is present.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
