### PR TITLE
Add caveat details in auth manager doc

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -123,7 +123,6 @@ Let's go over the different parameters used by most of these methods.
   * ``POST``: Can the user create a resource?
   * ``PUT``: Can the user modify the resource?
   * ``DELETE``: Can the user delete the resource?
-  * ``MENU``: Can the user see the resource in the menu? Note: this method is only applicable to a subset of auth manager Authorization methods.
 
 * ``details``: Optional details about the resource being accessed.
 * ``user``: The user trying to access the resource.
@@ -181,8 +180,8 @@ The following methods aren't required to override to have a functional Airflow a
 
 * ``batch_is_authorized_dag``: Batch version of ``is_authorized_dag``. If not overridden, it will call ``is_authorized_dag`` for every single item.
 * ``get_authorized_dag_ids``: Return the list of DAG IDs the user has access to.  If not overridden, it will call ``is_authorized_dag`` for every single DAG available in the environment.
-  * Note: The ``get_authorized_dag_ids`` may be of particular interest if you rely on per-DAG access controls derived from one or more fields on a given DAG (e.g. DAG tags).
-  * This method requires an active session with the Airflow metadata database. As such, it is recommended you refer to the :doc:`../../database-erd-ref`.
+  * Note: To filter the results of ``get_authorized_dag_ids``, it is recommended that you define the filtering logic in your ``filter_authorized_dag_ids`` method. For example, this may be usefule if you rely on per-DAG access controls derived from one or more fields on a given DAG (e.g. DAG tags).
+  * This method requires an active session with the Airflow metadata database. As such, overriding the ``get_authorized_dag_ids`` method is an advanced use case, which should be considered carefully -- it is recommended you refer to the :doc:`../../database-erd-ref`.
 
 CLI
 ^^^
@@ -241,6 +240,9 @@ Additional Caveats
 * Your auth manager should not reference anything from the ``airflow.security.permissions`` module, as that module is in the process of being deprecated.
   * Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``.
 * The ``access_control`` attribute of a DAG instance is only compatible with the FAB auth manager. Custom auth manager implementations should leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
+* You may find it useful to define a private, generalized ``_is_authorized`` method which acts as the standardized authorization mechanism, and which each
+  public ``is_authorized_*`` method calls with the appropriate parameters.
+  For concrete examples of this, refer to the ``SimpleAuthManager._is_authorized_method``. Further, it may be useful to optionally use the ``airflow.api_fastapi.auth.managers.base_auth_manager.ExtendedResourceMethod`` reference within your private method.
 
 DAG and DAG Sub-Component Authorization
 ---------------------------------------

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -146,8 +146,8 @@ These authorization methods are:
 * ``is_authorized_custom_view``: Return whether the user is authorized to access a specific view not defined in Airflow. This view can be provided by the auth manager itself or a plugin defined by the user.
 * ``filter_authorized_menu_items``: Given the list of menu items in the UI, return the list of menu items the user has access to.
 
-It should be noted that the API ``methods`` listed above may only have relevance for a specific subset of the auth manager's authorization methods.
-For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` API method is relevant in the context of ``is_authorized_configuration``.
+It should be noted that the parameter ``methods`` listed above may only have relevance for a specific subset of the auth manager's authorization methods.
+For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` parameter method is relevant in the context of ``is_authorized_configuration``.
 
 JWT token management by auth managers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -146,7 +146,7 @@ These authorization methods are:
 * ``filter_authorized_menu_items``: Given the list of menu items in the UI, return the list of menu items the user has access to.
 
 It should be noted that the parameter ``methods`` listed above may only have relevance for a specific subset of the auth manager's authorization methods.
-For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` parameter method is relevant in the context of ``is_authorized_configuration``.
+For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` parameter is relevant in the context of ``is_authorized_configuration``.
 
 JWT token management by auth managers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -240,7 +240,20 @@ Additional Caveats
 
 * Your auth manager should not reference anything from the ``airflow.security.permissions`` module, as that module is in the process of being deprecated.
   * Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``.
-* The DAG ``access_control`` attribute of a DAG is only compatible with the FAB auth manager. Custom auth manager implementations leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
+* The ``access_control`` attribute of a DAG instance is only compatible with the FAB auth manager. Custom auth manager implementations should leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
+
+DAG and DAG Sub-Component Authorization
+---------------------------------------
+
+Given the hierarchical structure of DAGs and their composite resources, the auth manager's ``is_authorized_dag`` method should also handle the authorization logic for DAG runs, tasks, and task instances.
+The ``access_entity`` parameter passed to ``is_authorized_dag`` indicates which (if any) DAG sub-component the user is attempting to access. This leads to a few important points:
+
+* If the ``access_entity`` parameter is ``None``, then the user is attempting to interact directly with the DAG, not any of its sub-components.
+* When the ``access_entity`` parameter is not ``None``, it means the user is attempting to access some sub-component of the DAG. This is noteworthy, as in some cases the ``method`` parameter may be valid
+  for the DAG's sub-entity, but not a valid action directly on the DAG itself. For example, the ``POST`` method is valid for DAG runs, but **not** for DAGs.
+* One potential way to model the example request mentioned above -- where the ``method`` only has meaning for the DAG sub-component -- is to authorize the user if **both** statements are true:
+  * The user has ``PUT`` ("edit") permissions for the given DAG.
+  * The user has ``POST`` ("create") permissions for DAG runs.
 
 Next Steps
 ----------

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -63,7 +63,7 @@ users does not need the same user management as an environment used by thousand 
 This is why the whole user management (user authentication and user authorization) is packaged in one component
 called auth manager. So that it is easy to plug-and-play an auth manager that suits your specific needs.
 
-By default, Airflow comes with the :doc:`apache-airflow-providers-fab:auth-manager/index`.
+By default, Airflow comes with the :doc:`simple/index`.
 
 .. note::
     Switching to a different auth manager is a heavy operation and should be considered as such. It will
@@ -123,10 +123,11 @@ Let's go over the different parameters used by most of these methods.
   * ``POST``: Can the user create a resource?
   * ``PUT``: Can the user modify the resource?
   * ``DELETE``: Can the user delete the resource?
-  * ``MENU``: Can the user see the resource in the menu?
+  * ``MENU``: Can the user see the resource in the menu? Note: this method is only applicable to a subset of auth manager Authorization methods.
 
 * ``details``: Optional details about the resource being accessed.
 * ``user``: The user trying to access the resource.
+
 
 These authorization methods are:
 
@@ -145,6 +146,9 @@ These authorization methods are:
 * ``is_authorized_custom_view``: Return whether the user is authorized to access a specific view not defined in Airflow. This view can be provided by the auth manager itself or a plugin defined by the user.
 * ``filter_authorized_menu_items``: Given the list of menu items in the UI, return the list of menu items the user has access to.
 
+It should be noted that the API ``methods`` listed above may only have relevance for a specific subset of the auth manager's authorization methods.
+For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` API method is relevant in the context of ``is_authorized_configuration``.
+
 JWT token management by auth managers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The auth manager is responsible for creating the JWT token needed to interact with Airflow public API.
@@ -152,10 +156,9 @@ To achieve this, the auth manager **must** provide an endpoint to create this JW
 available at ``POST /auth/token``.
 Please double check the auth manager documentation to find the accurate token generation endpoint.
 
-The auth manager is also responsible of passing the JWT token to Airflow UI. The protocol to exchange the JWT
+The auth manager is also responsible for passing the JWT token to Airflow UI. The protocol to exchange the JWT
 token between the auth manager and Airflow UI is using cookies. The auth manager needs to save the JWT token in a
-cookie named ``_token`` before redirecting to the Airflow UI. The Airflow UI will then read the cookie, save it and
-delete the cookie.
+cookie named ``_token`` before redirecting to the Airflow UI. The Airflow UI will then read the cookie, save it, and delete it.
 
 .. code-block:: python
 
@@ -163,7 +166,7 @@ delete the cookie.
 
     response = RedirectResponse(url="/")
 
-    secure = bool(conf.get("api", "ssl_cert", fallback=""))
+    secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
     response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
     return response
 
@@ -178,6 +181,8 @@ The following methods aren't required to override to have a functional Airflow a
 
 * ``batch_is_authorized_dag``: Batch version of ``is_authorized_dag``. If not overridden, it will call ``is_authorized_dag`` for every single item.
 * ``get_authorized_dag_ids``: Return the list of DAG IDs the user has access to.  If not overridden, it will call ``is_authorized_dag`` for every single DAG available in the environment.
+  * Note: The ``get_authorized_dag_ids`` may be of particular interest if you rely on per-DAG access controls derived from one or more fields on a given DAG (e.g. DAG tags).
+  * This method requires an active session with the Airflow metadata database. As such, it is recommended you refer to the :doc:`apache-airflow:database-erd-ref`.
 
 CLI
 ^^^
@@ -228,6 +233,14 @@ Other optional methods
 * ``get_db_manager``: If your auth manager requires one or several database managers (see :class:`~airflow.utils.db_manager.BaseDBManager`),
   their class paths need to be returned as part of this method. By doing so, they will be automatically added to the
   config ``[database] external_db_managers``.
+
+
+Additional Caveats
+^^^^^^^^^^^^^^^^^^
+
+* Your auth manager should not reference anything from the ``airflow.security.permissions`` module, as that module is in the process of being deprecated.
+  * Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``.
+* The DAG ``access_control`` attribute of a DAG is only compatible with the FAB auth manager. Custom auth manager implementations leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
 
 Next Steps
 ----------

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -182,7 +182,7 @@ The following methods aren't required to override to have a functional Airflow a
 * ``batch_is_authorized_dag``: Batch version of ``is_authorized_dag``. If not overridden, it will call ``is_authorized_dag`` for every single item.
 * ``get_authorized_dag_ids``: Return the list of DAG IDs the user has access to.  If not overridden, it will call ``is_authorized_dag`` for every single DAG available in the environment.
   * Note: The ``get_authorized_dag_ids`` may be of particular interest if you rely on per-DAG access controls derived from one or more fields on a given DAG (e.g. DAG tags).
-  * This method requires an active session with the Airflow metadata database. As such, it is recommended you refer to the :doc:`apache-airflow:database-erd-ref`.
+  * This method requires an active session with the Airflow metadata database. As such, it is recommended you refer to the :doc:`../../database-erd-ref`.
 
 CLI
 ^^^

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -145,7 +145,7 @@ These authorization methods are:
 * ``is_authorized_custom_view``: Return whether the user is authorized to access a specific view not defined in Airflow. This view can be provided by the auth manager itself or a plugin defined by the user.
 * ``filter_authorized_menu_items``: Given the list of menu items in the UI, return the list of menu items the user has access to.
 
-It should be noted that the parameter ``methods`` listed above may only have relevance for a specific subset of the auth manager's authorization methods.
+It should be noted that the ``method`` parameter listed above may only have relevance for a specific subset of the auth manager's authorization methods.
 For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` parameter is relevant in the context of ``is_authorized_configuration``.
 
 JWT token management by auth managers
@@ -155,7 +155,7 @@ To achieve this, the auth manager **must** provide an endpoint to create this JW
 available at ``POST /auth/token``.
 Please double check the auth manager documentation to find the accurate token generation endpoint.
 
-The auth manager is also responsible for passing the JWT token to Airflow UI. The protocol to exchange the JWT
+The auth manager is also responsible for passing the JWT token to the Airflow UI. The protocol to exchange the JWT
 token between the auth manager and Airflow UI is using cookies. The auth manager needs to save the JWT token in a
 cookie named ``_token`` before redirecting to the Airflow UI. The Airflow UI will then read the cookie, save it, and delete it.
 
@@ -180,7 +180,8 @@ The following methods aren't required to override to have a functional Airflow a
 
 * ``batch_is_authorized_dag``: Batch version of ``is_authorized_dag``. If not overridden, it will call ``is_authorized_dag`` for every single item.
 * ``get_authorized_dag_ids``: Return the list of DAG IDs the user has access to.  If not overridden, it will call ``is_authorized_dag`` for every single DAG available in the environment.
-  * Note: To filter the results of ``get_authorized_dag_ids``, it is recommended that you define the filtering logic in your ``filter_authorized_dag_ids`` method. For example, this may be usefule if you rely on per-DAG access controls derived from one or more fields on a given DAG (e.g. DAG tags).
+
+  * Note: To filter the results of ``get_authorized_dag_ids``, it is recommended that you define the filtering logic in your ``filter_authorized_dag_ids`` method. For example, this may be useful if you rely on per-DAG access controls derived from one or more fields on a given DAG (e.g. DAG tags).
   * This method requires an active session with the Airflow metadata database. As such, overriding the ``get_authorized_dag_ids`` method is an advanced use case, which should be considered carefully -- it is recommended you refer to the :doc:`../../database-erd-ref`.
 
 CLI
@@ -238,7 +239,7 @@ Additional Caveats
 ^^^^^^^^^^^^^^^^^^
 
 * Your auth manager should not reference anything from the ``airflow.security.permissions`` module, as that module is in the process of being deprecated.
-  * Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``.
+  Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``.
 * The ``access_control`` attribute of a DAG instance is only compatible with the FAB auth manager. Custom auth manager implementations should leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
 * You may find it useful to define a private, generalized ``_is_authorized`` method which acts as the standardized authorization mechanism, and which each
   public ``is_authorized_*`` method calls with the appropriate parameters.
@@ -254,6 +255,7 @@ The ``access_entity`` parameter passed to ``is_authorized_dag`` indicates which 
 * When the ``access_entity`` parameter is not ``None``, it means the user is attempting to access some sub-component of the DAG. This is noteworthy, as in some cases the ``method`` parameter may be valid
   for the DAG's sub-entity, but not a valid action directly on the DAG itself. For example, the ``POST`` method is valid for DAG runs, but **not** for DAGs.
 * One potential way to model the example request mentioned above -- where the ``method`` only has meaning for the DAG sub-component -- is to authorize the user if **both** statements are true:
+
   * The user has ``PUT`` ("edit") permissions for the given DAG.
   * The user has ``POST`` ("create") permissions for DAG runs.
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Related issue: https://github.com/apache/airflow/issues/51971

## What?
* Adds some clarifications and noteworthy caveats to the [main Auth Manager doc](https://airflow.apache.org/docs/apache-airflow/3.0.3/core-concepts/auth-manager/index.html) page.
    * Some of these details arose from the very helpful thread comments from @vincbeck (see linked issue above).
    * Additional caveats and notes added from my own recent endeavors into setting up a custom auth manager.
    * Fixes the outdated information about the default auth manager being FAB.
    * Add clarity to situations where the `method` parameter passed to `is_authorized_dag` may be applicable to a DAGAccessEntity, but not necessarily a DAG itself.

## Testing
* `pre-commit run`
* `breeze build-docs --docs-only apache-airflow` 
    * Visual formatting inspection of the rendered output from `./docs/start_doc_server.sh`

