### PR TITLE
Add --warn-unreachable flag to mypy as a optional flag

### DIFF
--- a/scripts/ci/pre_commit/mypy_folder.py
+++ b/scripts/ci/pre_commit/mypy_folder.py
@@ -54,6 +54,7 @@ if len(sys.argv) < 2:
 mypy_folders = sys.argv[1:]
 
 show_unused_warnings = os.environ.get("SHOW_UNUSED_MYPY_WARNINGS", "false")
+show_unreachable_warnings = os.environ.get("SHOW_UNREACHABLE_MYPY_WARNINGS", "false")
 
 for mypy_folder in mypy_folders:
     if mypy_folder not in ALLOWED_FOLDERS:
@@ -127,14 +128,21 @@ else:
 
 print(f"Running mypy with {FILE_ARGUMENT}")
 
+mypy_cmd_parts = [f"TERM=ansi mypy {shlex.quote(FILE_ARGUMENT)}"]
+
 if show_unused_warnings == "true":
     console.print(
         "[info]Running mypy with --warn-unused-ignores to display unused ignores, unset environment variable: SHOW_UNUSED_MYPY_WARNINGS to runoff this behaviour"
     )
+    mypy_cmd_parts.append("--warn-unused-ignores")
 
-    mypy_cmd = f"TERM=ansi mypy {shlex.quote(FILE_ARGUMENT)} --warn-unused-ignores"
-else:
-    mypy_cmd = f"TERM=ansi mypy {shlex.quote(FILE_ARGUMENT)}"
+if show_unreachable_warnings == "true":
+    console.print(
+        "[info]Running mypy with --warn-unreachable to display unreachable code, unset environment variable: SHOW_UNREACHABLE_MYPY_WARNINGS to runoff this behaviour"
+    )
+    mypy_cmd_parts.append("--warn-unreachable")
+
+mypy_cmd = " ".join(mypy_cmd_parts)
 
 cmd = ["bash", "-c", mypy_cmd]
 


### PR DESCRIPTION
We are planing another activity after mypy bump, to see if any unreachable code warns and fix them. This pr helps to this https://github.com/apache/airflow/issues/53395 to enable community unreachable argument and fix if any real issues

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
