### PR TITLE
Enhancement: AWS Provider sql to s3 operator pd.read_sql kwargs

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -69,6 +69,7 @@ class SqlToS3Operator(BaseOperator):
     :param sql_hook_params: Extra config params to be passed to the underlying hook.
         Should match the desired hook constructor params.
     :param parameters: (optional) the parameters to render the SQL query with.
+    :param read_pd_kwargs: arguments to include in DataFrame when ``pd.read_sql()`` is called.
     :param aws_conn_id: reference to a specific S3 connection
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
@@ -97,6 +98,7 @@ class SqlToS3Operator(BaseOperator):
     template_fields_renderers = {
         "query": "sql",
         "pd_kwargs": "json",
+        "read_pd_kwargs": "json",
     }
 
     def __init__(
@@ -108,6 +110,7 @@ class SqlToS3Operator(BaseOperator):
         sql_conn_id: str,
         sql_hook_params: dict | None = None,
         parameters: None | Mapping[str, Any] | list | tuple = None,
+        read_pd_kwargs: dict | None = None,
         replace: bool = False,
         aws_conn_id: str | None = "aws_default",
         verify: bool | str | None = None,
@@ -127,6 +130,7 @@ class SqlToS3Operator(BaseOperator):
         self.replace = replace
         self.pd_kwargs = pd_kwargs or {}
         self.parameters = parameters
+        self.read_pd_kwargs = read_pd_kwargs or {}
         self.max_rows_per_file = max_rows_per_file
         self.groupby_kwargs = groupby_kwargs or {}
         self.sql_hook_params = sql_hook_params
@@ -185,9 +189,12 @@ class SqlToS3Operator(BaseOperator):
     def execute(self, context: Context) -> None:
         sql_hook = self._get_hook()
         s3_conn = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        data_df = sql_hook.get_df(sql=self.query, parameters=self.parameters, df_type="pandas")
+        data_df = sql_hook.get_df(
+            sql=self.query, parameters=self.parameters, df_type="pandas", **self.read_pd_kwargs
+        )
         self.log.info("Data from SQL obtained")
-        self._fix_dtypes(data_df, self.file_format)
+        if ("dtype_backend", "pyarrow") not in self.read_pd_kwargs.items():
+            self._fix_dtypes(data_df, self.file_format)
         file_options = FILE_OPTIONS_MAP[self.file_format]
 
         for group_name, df in self._partition_dataframe(df=data_df):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The AWS Provider Transfer operator, SqlToS3Operator allows for Pandas kwargs to be passed to the write function, but not to the get_df()/read_sql() function. This PR adds a new parameter to the operator called read_pd_kwargs that takes a dictionary and unpacks the dictionary in the get_df function. The get_df method in the DbApiHook allows for kwargs to be passed through and unpacks them in read_sql(). I enhanced the unit tests for csv/parquet with the read_pd_kwargs parameter and made sure it was unpacked successfully.

There is functionality in the operator to fix Numpy data types, which aren't necessary if the dtype_backend is set to 'pyarrow', so I created a conditional to only run the method if 'dtype_backend': 'pyarrow' is not found in the read_pd_kwargs. I added a unit test to ensure the _fix_dtype method is NOT called when the pyarrow backend kwarg is present.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
