### PR TITLE
Update doc string for BaseOperator

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -788,8 +788,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     :param task_display_name: The display name of the task which appears on the UI.
     :param logger_name: Name of the logger used by the Operator to emit logs.
         If set to `None` (default), the logger name will fall back to
-        `airflow.task.operators.{class.__module__}.{class.__name__}` (e.g. SimpleHttpOperator will have
-        *airflow.task.operators.airflow.providers.http.operators.http.SimpleHttpOperator* as logger).
+        `airflow.task.operators.{class.__module__}.{class.__name__}` (e.g. HttpOperator will have
+        *airflow.task.operators.airflow.providers.http.operators.http.HttpOperator* as logger).
     :param allow_nested_operators: if True, when an operator is executed within another one a warning message
         will be logged. If False, then an exception will be raised if the operator is badly used (e.g. nested
         within another one). In future releases of Airflow this parameter will be removed and an exception


### PR DESCRIPTION
We no longer have `SimpleHttpOperator`
https://github.com/apache/airflow/blob/1d9075ef1cb7cc236a59a3285698018901c88e7b/providers/http/src/airflow/providers/http/operators/http.py#L46