### PR TITLE
Fix: enter SmtpHook before trying to read properties

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py
@@ -106,37 +106,37 @@ class SmtpNotifier(BaseNotifier):
 
     def notify(self, context):
         """Send a email via smtp server."""
-        fields_to_re_render = []
-        if self.from_email is None:
-            if self.hook.from_email is not None:
-                self.from_email = self.hook.from_email
-            else:
-                raise ValueError("You should provide `from_email` or define it in the connection")
-            fields_to_re_render.append("from_email")
-        if self.subject is None:
-            smtp_default_templated_subject_path: str
-            if self.hook.subject_template:
-                smtp_default_templated_subject_path = self.hook.subject_template
-            else:
-                smtp_default_templated_subject_path = (
-                    Path(__file__).parent / "templates" / "email_subject.jinja2"
-                ).as_posix()
-            self.subject = self._read_template(smtp_default_templated_subject_path)
-            fields_to_re_render.append("subject")
-        if self.html_content is None:
-            smtp_default_templated_html_content_path: str
-            if self.hook.html_content_template:
-                smtp_default_templated_html_content_path = self.hook.html_content_template
-            else:
-                smtp_default_templated_html_content_path = (
-                    Path(__file__).parent / "templates" / "email.html"
-                ).as_posix()
-            self.html_content = self._read_template(smtp_default_templated_html_content_path)
-            fields_to_re_render.append("html_content")
-        if fields_to_re_render:
-            jinja_env = self.get_template_env(dag=context["dag"])
-            self._do_render_template_fields(self, fields_to_re_render, context, jinja_env, set())
         with self.hook as smtp:
+            fields_to_re_render = []
+            if self.from_email is None:
+                if smtp.from_email is not None:
+                    self.from_email = smtp.from_email
+                else:
+                    raise ValueError("You should provide `from_email` or define it in the connection")
+                fields_to_re_render.append("from_email")
+            if self.subject is None:
+                smtp_default_templated_subject_path: str
+                if smtp.subject_template:
+                    smtp_default_templated_subject_path = smtp.subject_template
+                else:
+                    smtp_default_templated_subject_path = (
+                        Path(__file__).parent / "templates" / "email_subject.jinja2"
+                    ).as_posix()
+                self.subject = self._read_template(smtp_default_templated_subject_path)
+                fields_to_re_render.append("subject")
+            if self.html_content is None:
+                smtp_default_templated_html_content_path: str
+                if smtp.html_content_template:
+                    smtp_default_templated_html_content_path = smtp.html_content_template
+                else:
+                    smtp_default_templated_html_content_path = (
+                        Path(__file__).parent / "templates" / "email.html"
+                    ).as_posix()
+                self.html_content = self._read_template(smtp_default_templated_html_content_path)
+                fields_to_re_render.append("html_content")
+            if fields_to_re_render:
+                jinja_env = self.get_template_env(dag=context["dag"])
+                self._do_render_template_fields(self, fields_to_re_render, context, jinja_env, set())
             smtp.send_email_smtp(
                 smtp_conn_id=self.smtp_conn_id,
                 from_email=self.from_email,

--- a/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
@@ -124,8 +124,8 @@ class TestSmtpNotifier:
             from_email="any email",
             to="test_reciver@test.com",
         )
-        mock_smtphook_hook.return_value.subject_template = None
-        mock_smtphook_hook.return_value.html_content_template = None
+        mock_smtphook_hook.return_value.__enter__.return_value.subject_template = None
+        mock_smtphook_hook.return_value.__enter__.return_value.html_content_template = None
         notifier(context)
         mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
             from_email="any email",
@@ -157,10 +157,9 @@ class TestSmtpNotifier:
 
             f_content.write("Mock content goes here")
             f_content.flush()
-
-            mock_smtphook_hook.return_value.from_email = "{{ ti.task_id }}@test.com"
-            mock_smtphook_hook.return_value.subject_template = f_subject.name
-            mock_smtphook_hook.return_value.html_content_template = f_content.name
+            mock_smtphook_hook.return_value.__enter__.return_value.from_email = "{{ ti.task_id }}@test.com"
+            mock_smtphook_hook.return_value.__enter__.return_value.subject_template = f_subject.name
+            mock_smtphook_hook.return_value.__enter__.return_value.html_content_template = f_content.name
             notifier = SmtpNotifier(
                 to="test_reciver@test.com",
             )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #49920

This PR tries to fix the issue #49920, the `SmtpHook` is tried to be used and its properties are only available once the `.conn` attibute is available, which is only the case in the `with` statement.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

