### PR TITLE
Updating K8's supported versions in `prerequisites.rst` to match `README.md`

### DIFF
--- a/airflow-core/docs/installation/prerequisites.rst
+++ b/airflow-core/docs/installation/prerequisites.rst
@@ -28,7 +28,7 @@ Airflow® is tested with:
   * MySQL: 8.0, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
   * SQLite: 3.15.0+
 
-* Kubernetes: 1.26, 1.27, 1.28, 1.29, 1.30
+* Kubernetes: 1.30, 1.31, 1.32, 1.33
 
 While we recommend a minimum of 4GB of memory for Airflow, the actual requirements heavily depend on your chosen deployment.
 

--- a/airflow-core/docs/installation/prerequisites.rst
+++ b/airflow-core/docs/installation/prerequisites.rst
@@ -24,7 +24,7 @@ Airflow® is tested with:
 
 * Databases:
 
-  * PostgreSQL: 12, 13, 14, 15, 16
+  * PostgreSQL: 13, 14, 15, 16, 17
   * MySQL: 8.0, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
   * SQLite: 3.15.0+
 


### PR DESCRIPTION
Previously, the `prerequisites.rst` doc listed the following versions of K8's as being supported (`1.26, 1.27, 1.28, 1.29, 1.30`). This has since changed, with the updated versions being `1.30, 1.31, 1.32, 1.33`. This PR updates the K8's supported versions in in `prerequisites.rst` to match `README.md`.

closes: #53415 