### PR TITLE
Fix EMR operator parameter documentation and naming

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
@@ -970,7 +970,7 @@ class EmrServerlessCreateApplicationOperator(AwsBaseOperator[EmrServerlessHook])
 
     :param release_label: The EMR release version associated with the application.
     :param job_type: The type of application you want to start, such as Spark or Hive.
-    :param wait_for_completion: If true, wait for the Application to start before returning. Default to True.
+    :param wait_for_completion: If true, wait for the Application to start before returning. Defaults to True.
         If set to False, ``waiter_max_attempts`` and ``waiter_delay`` will only be applied when
         waiting for the application to be in the ``CREATED`` state.
     :param client_request_token: The client idempotency token of the application to create.
@@ -985,8 +985,9 @@ class EmrServerlessCreateApplicationOperator(AwsBaseOperator[EmrServerlessHook])
     :param verify: Whether or not to verify SSL certificates. See:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param waiter_max_attempts: Number of times the waiter should poll the application to check the state.
-        If not set, the waiter will use its default value.
+        Defaults to 25 if not set.
     :param waiter_delay: Number of seconds between polling the state of the application.
+        Defaults to 60 seconds if not set.
     :param deferrable: If True, the operator will wait asynchronously for application to be created.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False, but can be overridden in config file by setting default_deferrable to True)
@@ -1117,8 +1118,8 @@ class EmrServerlessStartJobOperator(AwsBaseOperator[EmrServerlessHook]):
       Its value must be unique for each request.
     :param config: Optional dictionary for arbitrary parameters to the boto API start_job_run call.
     :param wait_for_completion: If true, waits for the job to start before returning. Defaults to True.
-        If set to False, ``waiter_countdown`` and ``waiter_check_interval_seconds`` will only be applied
-        when waiting for the application be to in the ``STARTED`` state.
+        If set to False, ``waiter_max_attempts`` and ``waiter_delay`` will only be applied
+        when waiting for the application to be in the ``STARTED`` state.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
@@ -1129,8 +1130,9 @@ class EmrServerlessStartJobOperator(AwsBaseOperator[EmrServerlessHook]):
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param name: Name for the EMR Serverless job. If not provided, a default name will be assigned.
     :param waiter_max_attempts: Number of times the waiter should poll the application to check the state.
-        If not set, the waiter will use its default value.
+        Defaults to 25 if not set.
     :param waiter_delay: Number of seconds between polling the state of the job run.
+        Defaults to 60 seconds if not set.
     :param deferrable: If True, the operator will wait asynchronously for the crawl to complete.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False, but can be overridden in config file by setting default_deferrable to True)
@@ -1439,9 +1441,9 @@ class EmrServerlessStopApplicationOperator(AwsBaseOperator[EmrServerlessHook]):
         If you want to wait for the jobs to finish gracefully, use
         :class:`airflow.providers.amazon.aws.sensors.emr.EmrServerlessJobSensor`
     :param waiter_max_attempts: Number of times the waiter should poll the application to check the state.
-        Default is 25.
+        Defaults to 25 if not set.
     :param waiter_delay: Number of seconds between polling the state of the application.
-        Default is 60 seconds.
+        Defaults to 60 seconds if not set.
     :param deferrable: If True, the operator will wait asynchronously for the application to stop.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False, but can be overridden in config file by setting default_deferrable to True)
@@ -1574,9 +1576,9 @@ class EmrServerlessDeleteApplicationOperator(EmrServerlessStopApplicationOperato
     :param verify: Whether or not to verify SSL certificates. See:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param waiter_max_attempts: Number of times the waiter should poll the application to check the state.
-        Defaults to 25.
+        Defaults to 25 if not set.
     :param waiter_delay: Number of seconds between polling the state of the application.
-        Defaults to 60 seconds.
+        Defaults to 60 seconds if not set.
     :param deferrable: If True, the operator will wait asynchronously for application to be deleted.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False, but can be overridden in config file by setting default_deferrable to True)

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
@@ -89,9 +89,9 @@ class EmrAddStepsOperator(AwsBaseOperator[EmrHook]):
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
     :param wait_for_completion: If True, the operator will wait for all the steps to be completed.
+        Defaults to False. Note: When deferrable=True, this parameter will not take effect.
     :param execution_role_arn: The ARN of the runtime role for a step on the cluster.
     :param do_xcom_push: if True, job_flow_id is pushed to XCom with key job_flow_id.
-    :param wait_for_completion: Whether to wait for job run completion. (default: True)
     :param deferrable: If True, the operator will wait asynchronously for the job to complete.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False)

--- a/providers/amazon/tests/system/amazon/aws/example_emr_serverless.py
+++ b/providers/amazon/tests/system/amazon/aws/example_emr_serverless.py
@@ -134,7 +134,7 @@ with DAG(
         force_stop=True,
     )
     # [END howto_operator_emr_serverless_stop_application]
-    stop_app.waiter_check_interval_seconds = 1
+    stop_app.waiter_delay = 1
 
     # [START howto_operator_emr_serverless_delete_application]
     delete_app = EmrServerlessDeleteApplicationOperator(
@@ -142,7 +142,7 @@ with DAG(
         application_id=emr_serverless_app_id,
     )
     # [END howto_operator_emr_serverless_delete_application]
-    delete_app.waiter_check_interval_seconds = 1
+    delete_app.waiter_delay = 1
     delete_app.trigger_rule = TriggerRule.ALL_DONE
 
     delete_s3_bucket = S3DeleteBucketOperator(


### PR DESCRIPTION
1. **Fix wait_for_completion parameter documentation** - Remove references to deleted parameters in docstring

2. **Fix example file parameter references** - Correct usage of removed parameters in example code

3. **Minor parameter documentation improvements** - Enhance default value descriptions for consistency

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
