### PR TITLE
Make GITHUB_TOKEN variable mandatory when updating installers

### DIFF
--- a/scripts/ci/pre_commit/update_installers_and_pre_commit.py
+++ b/scripts/ci/pre_commit/update_installers_and_pre_commit.py
@@ -249,6 +249,16 @@ def replace_version(pattern: re.Pattern[str], version: str, text: str, keep_tota
 
 
 if __name__ == "__main__":
+    if not GITHUB_TOKEN:
+        console.print(
+            "[red]GITHUB_TOKEN environment variable is not set. This will lead to failures on rate limits.[/]\n"
+            "Please set it to a valid GitHub token with public_repo scope. You can create one by clicking "
+            "the URL:\n\n"
+            "https://github.com/settings/tokens/new?scopes=public_repo&description=airflow-update-installers-and-pre-commit\n\n"
+            "Once you have the token you can prepend pre-commit command with GITHUB_TOKEN='<your token>' or"
+            "set it in your environment with export GITHUB_TOKEN='<your token>'\n\n"
+        )
+        sys.exit(1)
     changed = False
     golang_version = get_latest_golang_version()
     pip_version = get_latest_pypi_version("pip")


### PR DESCRIPTION
When running "update-installers-and-pre-commit" pre-commit, the script is virtually guaranteed to fail with "rate limits" reached if you do not use GITHUB_TOKEN. This change makes GITHUB_TOKEN variable mandatory for the pre-commit, it prints the helpful information and prints URL that allows to create such GITHUB_TOKEN very easily.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
