### PR TITLE
Fix broken link in advanced logging config docs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
@@ -34,7 +34,7 @@ Some configuration options require that the logging config class be overwritten.
 configuration of Airflow and modifying it to suit your needs.
 
 The default configuration can be seen in the
-`airflow_local_settings.py template <https://github.com/apache/airflow/blob/|airflow-version|/airflow/config_templates/airflow_local_settings.py>`_
+`airflow_local_settings.py template <https://github.com/apache/airflow/blob/|airflow-version|/airflow-core/src/airflow/config_templates/airflow_local_settings.py>`_
 and you can see the loggers and handlers used there.
 
 See :ref:`Configuring local settings <set-config:configuring-local-settings>` for details on how to


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Fixes a broken link in the advanced logging docs.

Old link: https://github.com/apache/airflow/blob/3.0.3/airflow/config_templates/airflow_local_settings.py
New link: https://github.com/apache/airflow/blob/3.0.3/airflow-core/src/airflow/config_templates/airflow_local_settings.py