### PR TITLE
Fix unreachable code mypy warnings in singularity provider

### DIFF
--- a/providers/singularity/src/airflow/providers/singularity/operators/singularity.py
+++ b/providers/singularity/src/airflow/providers/singularity/operators/singularity.py
@@ -93,8 +93,8 @@ class SingularityOperator(BaseOperator):
         self.pull_folder = pull_folder
         self.volumes = volumes or []
         self.working_dir = working_dir
-        self.cli: Any = None
-        self.container: Any = None
+        self.cli: None
+        self.container: None
 
     def execute(self, context: Context) -> None:
         self.log.info("Preparing Singularity container %s", self.image)
@@ -140,8 +140,8 @@ class SingularityOperator(BaseOperator):
             self.image, options=self.options, args=self.start_command, start=False
         )
 
-        self.instance.start()  # type: ignore[attr-defined]
-        self.log.info(self.instance.cmd)  # type: ignore[attr-defined]
+        self.instance.start()
+        self.log.info(self.instance.cmd)
         self.log.info("Created instance %s from %s", self.instance, self.image)
 
         self.log.info("Running command %s", self._get_command())
@@ -152,7 +152,7 @@ class SingularityOperator(BaseOperator):
 
         # Stop the instance
         self.log.info("Stopping instance %s", self.instance)
-        self.instance.stop()  # type: ignore[attr-defined]
+        self.instance.stop()
 
         if self.auto_remove and os.path.exists(self.image):
             shutil.rmtree(self.image)

--- a/providers/singularity/src/airflow/providers/singularity/operators/singularity.py
+++ b/providers/singularity/src/airflow/providers/singularity/operators/singularity.py
@@ -93,8 +93,8 @@ class SingularityOperator(BaseOperator):
         self.pull_folder = pull_folder
         self.volumes = volumes or []
         self.working_dir = working_dir
-        self.cli: None
-        self.container: None
+        self.cli = None
+        self.container = None
 
     def execute(self, context: Context) -> None:
         self.log.info("Preparing Singularity container %s", self.image)

--- a/providers/singularity/src/airflow/providers/singularity/operators/singularity.py
+++ b/providers/singularity/src/airflow/providers/singularity/operators/singularity.py
@@ -88,13 +88,13 @@ class SingularityOperator(BaseOperator):
         self.environment = environment or {}
         self.force_pull = force_pull
         self.image = image
-        self.instance = None
+        self.instance: Any = None
         self.options = options or []
         self.pull_folder = pull_folder
         self.volumes = volumes or []
         self.working_dir = working_dir
-        self.cli = None
-        self.container = None
+        self.cli: Any = None
+        self.container: Any = None
 
     def execute(self, context: Context) -> None:
         self.log.info("Preparing Singularity container %s", self.image)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #53395

original warning:
```shell
providers/singularity/src/airflow/providers/singularity/operators/singularity.py:176: error:
Statement is unreachable  [unreachable]
[self.log.info](http://self.log.info/)("Stopping Singularity instance")
```

this is caused by:
```py
def on_kill(self) -> None:
    if self.instance is not None:
        self.log.info("Stopping Singularity instance")
        self.instance.stop()
```
when mypy infers the type of `self.instance` as `None`, it makes the `if self.instance is not None` condition always false, which makes `self.log.info("Stopping Singularity instance")` unreachable.

fix: use `self.instance: Any = None` to tell mypy that self.instance can be None or any other type
note: affected `# type: ignore[attr-defined]` comments are removed to fix all warnings

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
