### PR TITLE
Make snowpark optional for snowflake provider and disable it for Pyth…

### DIFF
--- a/providers/snowflake/README.rst
+++ b/providers/snowflake/README.rst
@@ -23,7 +23,7 @@
 
 Package ``apache-airflow-providers-snowflake``
 
-Release: ``6.5.0``
+Release: ``6.5.1``
 
 
 `Snowflake <https://www.snowflake.com/>`__
@@ -36,7 +36,7 @@ This is a provider package for ``snowflake`` provider. All classes for this prov
 are in ``airflow.providers.snowflake`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.0/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.1/>`_.
 
 Installation
 ------------
@@ -50,9 +50,9 @@ The package supports the following python versions: 3.10,3.11,3.12,3.13
 Requirements
 ------------
 
-==========================================  ======================================
+==========================================  ========================================================================
 PIP package                                 Version required
-==========================================  ======================================
+==========================================  ========================================================================
 ``apache-airflow``                          ``>=2.10.0``
 ``apache-airflow-providers-common-compat``  ``>=1.6.0``
 ``apache-airflow-providers-common-sql``     ``>=1.21.0``
@@ -63,8 +63,8 @@ PIP package                                 Version required
 ``snowflake-connector-python``              ``>=3.7.1``
 ``snowflake-sqlalchemy``                    ``>=1.4.0``
 ``snowflake-snowpark-python``               ``>=1.17.0; python_version < "3.12"``
-``snowflake-snowpark-python``               ``>=1.27.0; python_version >= "3.12"``
-==========================================  ======================================
+``snowflake-snowpark-python``               ``>=1.27.0,<9999; python_version >= "3.12" and python_version < "3.13"``
+==========================================  ========================================================================
 
 Cross provider package dependencies
 -----------------------------------
@@ -88,4 +88,4 @@ Dependent package                                                               
 ==================================================================================================================  =================
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.0/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.1/changelog.html>`_.

--- a/providers/snowflake/docs/changelog.rst
+++ b/providers/snowflake/docs/changelog.rst
@@ -27,6 +27,24 @@
 Changelog
 ---------
 
+6.5.1
+.....
+
+Misc
+~~~~
+
+* ``Add Python 3.13 support for Airflow. (#46891)``
+* ``another magic pip resolver hint (#53329)``
+* ``fix: Improve logging and timeouts in OL helpers (#53139)``
+* ``Remove upper-binding for "python-requires" (#52980)``
+* ``Cleanup type ignores in snowflake provider where possible (#53258)``
+* ``Remove type ignore across codebase after mypy upgrade (#53243)``
+
+.. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
+   * ``Make dag_version_id in TI non-nullable (#50825)``
+   * ``Temporarily switch to use >=,< pattern instead of '~=' (#52967)``
+
 6.5.0
 .....
 

--- a/providers/snowflake/docs/index.rst
+++ b/providers/snowflake/docs/index.rst
@@ -78,7 +78,7 @@ apache-airflow-providers-snowflake package
 `Snowflake <https://www.snowflake.com/>`__
 
 
-Release: 6.5.0
+Release: 6.5.1
 
 Provider package
 ----------------
@@ -98,20 +98,21 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.10.0``.
 
-==========================================  ======================================
+==========================================  ========================================================================
 PIP package                                 Version required
-==========================================  ======================================
+==========================================  ========================================================================
 ``apache-airflow``                          ``>=2.10.0``
 ``apache-airflow-providers-common-compat``  ``>=1.6.0``
 ``apache-airflow-providers-common-sql``     ``>=1.21.0``
 ``pandas``                                  ``>=2.1.2; python_version < "3.13"``
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13"``
-``pyarrow``                                 ``>=16.1.0``
+``pyarrow``                                 ``>=16.1.0; python_version < "3.13"``
+``pyarrow``                                 ``>=18.0.0; python_version >= "3.13"``
 ``snowflake-connector-python``              ``>=3.7.1``
 ``snowflake-sqlalchemy``                    ``>=1.4.0``
 ``snowflake-snowpark-python``               ``>=1.17.0; python_version < "3.12"``
-``snowflake-snowpark-python``               ``>=1.27.0; python_version >= "3.12"``
-==========================================  ======================================
+``snowflake-snowpark-python``               ``>=1.27.0,<9999; python_version >= "3.12" and python_version < "3.13"``
+==========================================  ========================================================================
 
 Cross provider package dependencies
 -----------------------------------
@@ -140,5 +141,5 @@ Downloading official packages
 You can download officially released packages and verify their checksums and signatures from the
 `Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
 
-* `The apache-airflow-providers-snowflake 6.5.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-snowflake 6.5.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.0-py3-none-any.whl.sha512>`__)
+* `The apache-airflow-providers-snowflake 6.5.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.1.tar.gz.sha512>`__)
+* `The apache-airflow-providers-snowflake 6.5.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_snowflake-6.5.1-py3-none-any.whl.sha512>`__)

--- a/providers/snowflake/provider.yaml
+++ b/providers/snowflake/provider.yaml
@@ -28,6 +28,7 @@ source-date-epoch: 1751474253
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 6.5.1
   - 6.5.0
   - 6.4.0
   - 6.3.1

--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-snowflake"
-version = "6.5.0"
+version = "6.5.1"
 description = "Provider package apache-airflow-providers-snowflake for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -69,7 +69,7 @@ dependencies = [
     "snowflake-snowpark-python>=1.17.0;python_version<'3.12'",
     # The "<9999" is a hint to the pip resolver to resolve this requirement early,
     # can be removed when the pip resolver is improved
-    "snowflake-snowpark-python>=1.27.0,<9999;python_version>='3.12'",
+    "snowflake-snowpark-python>=1.27.0,<9999;python_version>='3.12' and python_version<'3.13'",
 ]
 
 # The optional dependencies should be modified in place in the generated file
@@ -117,8 +117,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.1"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-snowflake/6.5.1/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/snowflake/src/airflow/providers/snowflake/__init__.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "6.5.0"
+__version__ = "6.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/snowflake/tests/unit/snowflake/decorators/test_snowpark.py
+++ b/providers/snowflake/tests/unit/snowflake/decorators/test_snowpark.py
@@ -23,6 +23,8 @@ from unittest import mock
 
 import pytest
 
+pytest.importorskip("snowflake-snowpark-python")
+
 from airflow.decorators import task
 from airflow.utils import timezone
 

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowpark.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowpark.py
@@ -23,6 +23,8 @@ from unittest import mock
 
 import pytest
 
+pytest.importorskip("snowflake-snowpark-python")
+
 from airflow.providers.snowflake.operators.snowpark import SnowparkOperator
 from airflow.utils import timezone
 

--- a/providers/snowflake/tests/unit/snowflake/utils/test_snowpark.py
+++ b/providers/snowflake/tests/unit/snowflake/utils/test_snowpark.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("snowflake-snowpark-python")
+
 from airflow.providers.snowflake.utils.snowpark import inject_session_into_op_kwargs
 
 


### PR DESCRIPTION
…on 3.13

It seems that despite explicit "Requires-Python <3.13" in snowpark client library, uv installs it on Python 3.13.

This is tracked here https://github.com/astral-sh/uv/issues/14711

However, it also means that we have to exclude snowpark fro being installed on Python 3.13 explicitly in provider requirements and conditionally skip the tests for it.

We also need to bump version of the provider in package configuration and provider.yaml, because then snowflake provider used to be installed in CI will use the provider built locally rather than the one from PyPI that does not have such exclusion yet.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
