### PR TITLE
Add Triggering User Name to the DagRun UI page

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -36,6 +36,7 @@ export enum SearchParamsKeys {
   STATE = "state",
   TAGS = "tags",
   TAGS_MATCH_MODE = "tags_match_mode",
+  TRIGGERING_USER_NAME = "triggering_user_name",
   TRY_NUMBER = "try_number",
   VERSION_NUMBER = "version_number",
 }

--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -36,7 +36,6 @@ export enum SearchParamsKeys {
   STATE = "state",
   TAGS = "tags",
   TAGS_MATCH_MODE = "tags_match_mode",
-  TRIGGERING_USER_NAME = "triggering_user_name",
   TRY_NUMBER = "try_number",
   VERSION_NUMBER = "version_number",
 }

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -96,6 +96,12 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
     header: translate("dagRun.runType"),
   },
   {
+    accessorKey: "triggering_user_name",
+    cell: ({ row: { original } }) => <Text>{original.triggering_user_name ?? ""}</Text>,
+    enableSorting: false,
+    header: translate("dagRun.triggeringUser"),
+  },
+  {
     accessorKey: "start_date",
     cell: ({ row: { original } }) => <Time datetime={original.start_date} />,
     header: translate("startDate"),

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -52,7 +52,6 @@ const {
   RUN_TYPE: RUN_TYPE_PARAM,
   START_DATE: START_DATE_PARAM,
   STATE: STATE_PARAM,
-  TRIGGERING_USER_NAME: TRIGGERING_USER_NAME_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
 const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRunResponse>> => [
@@ -169,7 +168,6 @@ export const DagRuns = () => {
   const filteredState = searchParams.get(STATE_PARAM);
   const filteredType = searchParams.get(RUN_TYPE_PARAM);
   const filteredRunIdPattern = searchParams.get(RUN_ID_PATTERN_PARAM);
-  const filteredTriggeringUserName = searchParams.get(TRIGGERING_USER_NAME_PARAM);
   const startDate = searchParams.get(START_DATE_PARAM);
   const endDate = searchParams.get(END_DATE_PARAM);
 
@@ -194,16 +192,6 @@ export const DagRuns = () => {
         query.state.data?.dag_runs.some((run) => isStatePending(run.state)) ? refetchInterval : false,
     },
   );
-
-  // Client-side filtering for triggering_user_name (backend doesn't support this filter yet)
-  const filteredDagRuns =
-    data?.dag_runs.filter((run) => {
-      if (filteredTriggeringUserName === null || filteredTriggeringUserName === "") {
-        return true;
-      }
-
-      return run.triggering_user_name?.toLowerCase().includes(filteredTriggeringUserName.toLowerCase());
-    }) ?? [];
 
   const handleStateChange = useCallback(
     ({ value }: SelectValueChangeDetails<string>) => {
@@ -257,22 +245,6 @@ export const DagRuns = () => {
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );
 
-  const handleTriggeringUserNameChange = useCallback(
-    (value: string) => {
-      if (value === "") {
-        searchParams.delete(TRIGGERING_USER_NAME_PARAM);
-      } else {
-        searchParams.set(TRIGGERING_USER_NAME_PARAM, value);
-      }
-      setTableURLState({
-        pagination: { ...pagination, pageIndex: 0 },
-        sorting,
-      });
-      setSearchParams(searchParams);
-    },
-    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
-  );
-
   return (
     <>
       <HStack paddingY="4px">
@@ -283,15 +255,6 @@ export const DagRuns = () => {
             hotkeyDisabled={false}
             onChange={handleRunIdPatternChange}
             placeHolder={translate("dags:filters.runIdPatternFilter")}
-          />
-        </Box>
-        <Box>
-          <SearchBar
-            defaultValue={filteredTriggeringUserName ?? ""}
-            hideAdvanced
-            hotkeyDisabled={true}
-            onChange={handleTriggeringUserNameChange}
-            placeHolder="Filter by triggering user..."
           />
         </Box>
         <Select.Root
@@ -364,13 +327,13 @@ export const DagRuns = () => {
       </HStack>
       <DataTable
         columns={runColumns(translate, dagId)}
-        data={filteredDagRuns}
+        data={data?.dag_runs ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
         isLoading={isLoading}
         modelName={translate("common:dagRun_other")}
         onStateChange={setTableURLState}
-        total={filteredDagRuns.length}
+        total={data?.total_entries}
       />
     </>
   );


### PR DESCRIPTION
For DAGs with frequent manual triggers from multiple users, it can be difficult to determine which DagRun corresponds to which user. With the addition of the triggering_user_name field to the DagRun model in #51738, this PR enhances the DagRun UI by displaying the triggering user's name, making it easier to trace manual runs.

<img width="1689" height="599" alt="image" src="https://github.com/user-attachments/assets/895dd7a1-df9b-44ed-a3e1-f8e968b63d17" />
