### PR TITLE
Fixed Task group names duplication in Task's task_id for MappedOperator

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -1022,7 +1022,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     ):
         # Note: Metaclass handles passing in the DAG/TaskGroup from active context manager, if any
 
-        self.task_id = task_group.child_id(task_id) if task_group else task_id
+        # Only apply task_group prefix if this operator was not created from a mapped operator
+        # Mapped operators already have the prefix applied during their creation
+        self.task_id = task_group.child_id(task_id) if task_group and not self.__from_mapped else task_id
         if not self.__from_mapped and task_group:
             task_group.add(self)
 

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -1024,9 +1024,11 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
         # Only apply task_group prefix if this operator was not created from a mapped operator
         # Mapped operators already have the prefix applied during their creation
-        self.task_id = task_group.child_id(task_id) if task_group and not self.__from_mapped else task_id
-        if not self.__from_mapped and task_group:
+        if task_group and not self.__from_mapped:
+            self.task_id = task_group.child_id(task_id)
             task_group.add(self)
+        else:
+            self.task_id = task_id
 
         super().__init__()
         self.task_group = task_group

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -736,19 +736,7 @@ class MappedOperator(AbstractOperator):
             is_setup = kwargs.pop("is_setup", False)
             is_teardown = kwargs.pop("is_teardown", False)
             on_failure_fail_dagrun = kwargs.pop("on_failure_fail_dagrun", False)
-
-            # Fix task_id duplication issue: if task_group is present and has prefix enabled,
-            # strip the prefix from task_id to avoid double prefixing when BaseOperator.__init__ is called
-            if self.task_group and self.task_group.prefix_group_id:
-                # Strip the task group prefix to avoid double prefixing
-                prefix = f"{self.task_group.group_id}."
-                if self.task_id.startswith(prefix):
-                    kwargs["task_id"] = self.task_id[len(prefix) :]
-                else:
-                    kwargs["task_id"] = self.task_id
-            else:
-                kwargs["task_id"] = self.task_id
-
+            kwargs["task_id"] = self.task_id
             op = self.operator_class(**kwargs, _airflow_from_mapped=True)
             op.is_setup = is_setup
             op.is_teardown = is_teardown

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -732,3 +732,25 @@ def test_setters(setter_name: str, old_value: object, new_value: object) -> None
     assert getattr(op, setter_name) == old_value
     setattr(op, setter_name, new_value)
     assert getattr(op, setter_name) == new_value
+
+
+def test_mapped_operator_in_task_group_no_duplicate_prefix():
+    """Test that task_id doesn't get duplicated prefix when unmapping a mapped operator in a task group."""
+    from airflow.sdk.definitions.taskgroup import TaskGroup
+
+    with DAG("test-dag") as dag:
+        with TaskGroup(group_id="tg1") as tg1:
+            # Create a mapped task within the task group
+            mapped_task = MockOperator.partial(task_id="mapped_task", arg1="a").expand(arg2=["a", "b", "c"])
+
+    # Check the mapped operator has correct task_id
+    assert mapped_task.task_id == "tg1.mapped_task"
+    assert mapped_task.task_group == tg1
+    assert mapped_task.task_group.group_id == "tg1"
+
+    # Simulate what happens during execution - unmap the operator
+    # unmap expects resolved kwargs
+    unmapped = mapped_task.unmap({"arg2": "a"})
+
+    # The unmapped operator should have the same task_id, not a duplicate prefix
+    assert unmapped.task_id == "tg1.mapped_task", f"Expected 'tg1.mapped_task' but got '{unmapped.task_id}'"

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -738,7 +738,7 @@ def test_mapped_operator_in_task_group_no_duplicate_prefix():
     """Test that task_id doesn't get duplicated prefix when unmapping a mapped operator in a task group."""
     from airflow.sdk.definitions.taskgroup import TaskGroup
 
-    with DAG("test-dag") as dag:
+    with DAG("test-dag"):
         with TaskGroup(group_id="tg1") as tg1:
             # Create a mapped task within the task group
             mapped_task = MockOperator.partial(task_id="mapped_task", arg1="a").expand(arg2=["a", "b", "c"])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Summary
Fixes task_id duplication when unmapping a MappedOperator within a TaskGroup. Previously, task IDs would get double-prefixed (e.g., `tg1.tg1.mapped_task` instead of `tg1.mapped_task`).

## Problem
When `MappedOperator.unmap()` is called, it passes the already-prefixed task_id to `BaseOperator.__init__`, which applies the prefix again via `task_group.child_id()`.

closes: #52334

## Solution
Check if task_id already contains the task group prefix before passing to BaseOperator, preventing double prefixing.

## Testing
Added test `test_mapped_operator_in_task_group_no_duplicate_prefix` to verify the fix. All existing tests pass.

---