### PR TITLE
fix: Add api-server support for k8s pod template

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -83,8 +83,14 @@ spec:
         {{- if .Values.workers.extraVolumeMounts }}
           {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 8 }}
         {{- end }}
-        {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-          {{- include "airflow_webserver_config_mount" . | nindent 8 }}
+        {{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+          {{- if or .Values.apiServer.apiServerConfig .Values.apiServer.apiServerConfigConfigMapName }}
+            {{- include "airflow_api_server_config_mount" . | nindent 8 }}
+          {{- end }}
+        {{- else }}
+          {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
+            {{- include "airflow_webserver_config_mount" . | nindent 8 }}
+          {{- end }}
         {{- end }}
       envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 6 }}
       env:
@@ -183,8 +189,14 @@ spec:
         {{- if .Values.workers.extraVolumeMounts }}
           {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 8 }}
         {{- end }}
-        {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-          {{- include "airflow_webserver_config_mount" . | nindent 8 }}
+        {{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+          {{- if or .Values.apiServer.apiServerConfig .Values.apiServer.apiServerConfigConfigMapName }}
+            {{- include "airflow_api_server_config_mount" . | nindent 8 }}
+          {{- end }}
+        {{- else }}
+          {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
+            {{- include "airflow_webserver_config_mount" . | nindent 8 }}
+          {{- end }}
         {{- end }}
       envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 6 }}
       env:
@@ -249,10 +261,18 @@ spec:
   - configMap:
       name: {{ include "airflow_config" . }}
     name: config
-  {{- if and (or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName) (or .Values.workers.kerberosInitContainer.enabled .Values.workers.kerberosSidecar.enabled)}}
+  {{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+    {{- if and (or .Values.apiServer.apiServerConfig .Values.apiServer.apiServerConfigConfigMapName) (or .Values.workers.kerberosInitContainer.enabled .Values.workers.kerberosSidecar.enabled)}}
+  - name: api-server-config
+    configMap:
+      name: {{ template "airflow_api_server_config_configmap_name" . }}
+    {{- end }}
+  {{- else }}
+    {{- if and (or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName) (or .Values.workers.kerberosInitContainer.enabled .Values.workers.kerberosSidecar.enabled)}}
   - name: webserver-config
     configMap:
       name: {{ template "airflow_webserver_config_configmap_name" . }}
+    {{- end }}
   {{- end }}
   {{- if .Values.volumes }}
     {{- toYaml .Values.volumes | nindent 2 }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -611,7 +611,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{- end }}
 
 {{- define "airflow_api_server_config_configmap_name" -}}
-  {{- default (printf "%s-api-server-config" .Release.Name) .Values.webserver.webserverConfigConfigMapName }}
+  {{- default (printf "%s-api-server-config" .Release.Name) .Values.apiServer.apiServerConfigConfigMapName }}
 {{- end }}
 
 {{- define "airflow_api_server_config_mount" -}}


### PR DESCRIPTION
The current k8s pod template in the Helm chart only uses webserver configs. It doesn't take into account the new api-server in 3.0.

This PR adds if-else checks. It uses the api-server configs in case of Airflow 3.0+, otherwise it falls back to webserver.