### PR TITLE
fix: Trim non-alphanumeric characters from the executor label

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -57,7 +57,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    executor: {{ .Values.executor | replace "," "-" | trunc 63 | trimSuffix "-" | quote }}
+    executor: {{ .Values.executor | replace "," "-" | trunc 63 | trimSuffix "-" | trimSuffix ":" | trimSuffix "_" | trimSuffix "." | quote }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Kubernetes label doesn't allow non-alphanumeric characters at the end of the values. With hybrid and custom executors, it's possible to have a long executor value. The last character can be non-alphanumeric after the 63-character trimming.