### PR TITLE
Add sql extras to pandas in the providers where sqlalchemy is needed

### DIFF
--- a/providers/common/sql/pyproject.toml
+++ b/providers/common/sql/pyproject.toml
@@ -69,7 +69,9 @@ dependencies = [
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
 "pandas" = [
-    'pandas>=2.1.2; python_version <"3.13"',
+    'pandas[sql-other]>=2.1.2; python_version <"3.13"',
+    # Technically - we should add "sql-other" here as well, but this will only be possible when we move
+    # to sqlalchemy 2+ TODO(potiuk): do so.
     'pandas>=2.2.3; python_version >="3.13"',
 ]
 "openlineage" = [

--- a/providers/presto/pyproject.toml
+++ b/providers/presto/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
     "presto-python-client>=0.8.4",
-    'pandas>=2.1.2; python_version <"3.13"',
+    'pandas[postgres]>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
 ]
 


### PR DESCRIPTION
Without those extras pandas does not impose limitations on sqlalchemy version used - but it is really an implicit dependency of pandas, when it is used for sqlalchemy interactions.

This will drop constraint version of pandas for Airflow 3 to 2.1 and it is really a conflicting dependency for Python 3.13 where only pandas 2.2.3 can be used but it requires sqlalchemy 2. This extra should be added while migrating to sqlalchemy 2 is complete.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
