### PR TITLE
bugfix(airflowctl): handle version command exception and make tests unified

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -62,14 +62,19 @@ def lazy_load_command(import_path: str) -> Callable:
 
 
 def safe_call_command(function: Callable, args: Iterable[Arg]) -> None:
+    import sys
+
     try:
         function(args)
     except AirflowCtlCredentialNotFoundException as e:
         rich.print(f"command failed due to {e}")
+        sys.exit(1)
     except AirflowCtlConnectionException as e:
         rich.print(f"command failed due to {e}")
+        sys.exit(1)
     except AirflowCtlNotFoundException as e:
         rich.print(f"command failed due to {e}")
+        sys.exit(1)
 
 
 class DefaultHelpParser(argparse.ArgumentParser):

--- a/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
@@ -25,11 +25,10 @@ from airflowctl.api.client import NEW_API_CLIENT, ClientKind, provide_api_client
 @provide_api_client(kind=ClientKind.CLI)
 def version_info(arg, api_client=NEW_API_CLIENT):
     """Get version information."""
+    version_dict = {"airflowctl_version": airflowctl_version}
     try:
         version_response = api_client.version.get()
-        version_dict = version_response.model_dump()
-        version_dict["airflowctl_version"] = airflowctl_version
-        rich.print(version_dict)
+        version_dict.update(version_response.model_dump())
     except Exception as e:
         rich.print(f"[red]Error fetching version information: {e}[/red]")
-        rich.print({"airflowctl_version": airflowctl_version})
+    rich.print(version_dict)

--- a/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
@@ -25,7 +25,11 @@ from airflowctl.api.client import NEW_API_CLIENT, ClientKind, provide_api_client
 @provide_api_client(kind=ClientKind.CLI)
 def version_info(arg, api_client=NEW_API_CLIENT):
     """Get version information."""
-    version_response = api_client.version.get()
-    version_dict = version_response.model_dump()
-    version_dict["airflowctl_version"] = airflowctl_version
-    rich.print(version_dict)
+    try:
+        version_response = api_client.version.get()
+        version_dict = version_response.model_dump()
+        version_dict["airflowctl_version"] = airflowctl_version
+        rich.print(version_dict)
+    except Exception as e:
+        rich.print(f"[red]Error fetching version information: {e}[/red]")
+        rich.print({"airflowctl_version": airflowctl_version})

--- a/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import sys
+
 import rich
 
 from airflowctl import __version__ as airflowctl_version
@@ -29,6 +31,8 @@ def version_info(arg, api_client=NEW_API_CLIENT):
     try:
         version_response = api_client.version.get()
         version_dict.update(version_response.model_dump())
+        rich.print(version_dict)
     except Exception as e:
         rich.print(f"[red]Error fetching version information: {e}[/red]")
-    rich.print(version_dict)
+        rich.print(version_dict)
+        sys.exit(1)

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_version_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_version_command.py
@@ -43,12 +43,23 @@ def mock_client():
     return client
 
 
-parser = cli_parser.get_parser()
+class TestVersionCommand:
+    """Test the version command."""
 
+    parser = cli_parser.get_parser()
 
-def test_ctl_version(mock_client):
-    with redirect_stdout(StringIO()) as stdout:
-        version_info(parser.parse_args(["version"]), api_client=mock_client)
-        assert "version" in stdout.getvalue()
-        assert "git_version" in stdout.getvalue()
-        assert "airflowctl_version" in stdout.getvalue()
+    def test_ctl_version(self, mock_client):
+        with redirect_stdout(StringIO()) as stdout:
+            version_info(self.parser.parse_args(["version"]), api_client=mock_client)
+            assert "version" in stdout.getvalue()
+            assert "git_version" in stdout.getvalue()
+            assert "airflowctl_version" in stdout.getvalue()
+
+    def test_ctl_version_exception(self, mock_client):
+        """Test the version command with an exception."""
+        mock_client.version.get.side_effect = Exception("Test exception")
+        with redirect_stdout(StringIO()) as stdout:
+            version_info(self.parser.parse_args(["version"]), api_client=mock_client)
+            output = stdout.getvalue()
+            assert "Error fetching version information: Test exception" in output
+            assert "airflowctl_version" in output

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_version_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_version_command.py
@@ -59,7 +59,8 @@ class TestVersionCommand:
         """Test the version command with an exception."""
         mock_client.version.get.side_effect = Exception("Test exception")
         with redirect_stdout(StringIO()) as stdout:
-            version_info(self.parser.parse_args(["version"]), api_client=mock_client)
+            with pytest.raises(SystemExit):
+                version_info(self.parser.parse_args(["version"]), api_client=mock_client)
             output = stdout.getvalue()
-            assert "Error fetching version information: Test exception" in output
-            assert "airflowctl_version" in output
+        assert "Error fetching version information: Test exception" in output
+        assert "airflowctl_version" in output


### PR DESCRIPTION
Exception handling for ctl version, while if the API is not reachable, it will fall back to only show `ctl` version along with the error returned from the client, which will make debugging easier for all.

```shell
Error fetching version information: [Errno 104] Connection reset by peer
{'airflowctl_version': '1.0.0'}
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
