### PR TITLE
Fix: Dag capitalization in en translation

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -101,8 +101,8 @@
   "toggleTableView": "Show table view",
   "triggerDag": {
     "button": "Trigger",
-    "loading": "Loading DAG information...",
-    "loadingFailed": "Failed to load DAG information. Please try again.",
+    "loading": "Loading Dag information...",
+    "loadingFailed": "Failed to load Dag information. Please try again.",
     "runIdHelp": "Optional - will be generated if not provided",
     "selectDescription": "Trigger a single run of this Dag",
     "selectLabel": "Single Run",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dashboard.json
@@ -1,9 +1,9 @@
 {
   "favorite": {
-    "favoriteDags_one":   "First {{count}} favorite DAG",
-    "favoriteDags_other": "First {{count}} favorite DAGs",
+    "favoriteDags_one":   "First {{count}} favorite Dag",
+    "favoriteDags_other": "First {{count}} favorite Dags",
     "noDagRuns": "There is no DagRun for this dag yet.",
-    "noFavoriteDags": "No favorites yet. Click the star icon next to a DAG in the list to add it to your favorites."
+    "noFavoriteDags": "No favorites yet. Click the star icon next to a Dag in the list to add it to your favorites."
   },
   "group": "Group",
   "health": {


### PR DESCRIPTION
## Why
Some translation in en use "DAG" instead of "Dag".
## What
For consistency, change all "DAG" into "Dag".

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
