### PR TITLE
Remove unneeded target-version fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -562,11 +562,9 @@ bypass-selection = true
 # Needed until https://github.com/astral-sh/ruff/issues/8237 is available.
 [tool.black]
 line-length = 110
-target-version = ['py310', 'py311', 'py312']
 
 ## ruff settings ##
 [tool.ruff]
-target-version = "py310"
 line-length = 110
 extend-exclude = [
     ".eggs",


### PR DESCRIPTION
[Both ruff][1] [and black][2] will infer the correct value(s) for `target-version` from the `[project.requires-python]` field in `pyproject.toml`.

[1]: https://docs.astral.sh/ruff/settings/#target-version
[2]: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version

This will probably help with keeping these up-to-date.