### PR TITLE
Add cert used for apiserver to client (fix for self-signed)

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1408,6 +1408,8 @@ api:
       description: |
         Paths to the SSL certificate and key for the api server. When both are
         provided SSL will be enabled. This does not change the api server port.
+        The same SSL certificate will also be loaded into the worker to enable
+        it to be trusted when a self-signed certificate is used.
       version_added: ~
       type: string
       example: ~

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -18,14 +18,14 @@
 from __future__ import annotations
 
 import logging
+import ssl
 import sys
 import uuid
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeVar
 
-import httpx
 import certifi
-import ssl
+import httpx
 import msgspec
 import structlog
 from pydantic import BaseModel
@@ -767,7 +767,7 @@ class Client(httpx.Client):
             kwargs["base_url"] = base_url
             ctx = ssl.create_default_context(cafile=certifi.where())
             if API_SSL_CERT_PATH:
-              ctx.load_verify_locations(API_SSL_CERT_PATH)
+                ctx.load_verify_locations(API_SSL_CERT_PATH)
             kwargs["verify"] = ctx
         pyver = f"{'.'.join(map(str, sys.version_info[:3]))}"
         super().__init__(

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -24,6 +24,8 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import httpx
+import certifi
+import ssl
 import msgspec
 import structlog
 from pydantic import BaseModel
@@ -747,6 +749,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
 API_RETRIES = conf.getint("workers", "execution_api_retries")
 API_RETRY_WAIT_MIN = conf.getfloat("workers", "execution_api_retry_wait_min")
 API_RETRY_WAIT_MAX = conf.getfloat("workers", "execution_api_retry_wait_max")
+API_SSL_CERT_PATH = conf.get("api", "ssl_cert")
 
 
 class Client(httpx.Client):
@@ -762,6 +765,10 @@ class Client(httpx.Client):
             kwargs.setdefault("base_url", "dry-run://server")
         else:
             kwargs["base_url"] = base_url
+            ctx = ssl.create_default_context(cafile=certifi.where())
+            if API_SSL_CERT_PATH:
+              ctx.load_verify_locations(API_SSL_CERT_PATH)
+            kwargs["verify"] = ctx
         pyver = f"{'.'.join(map(str, sys.version_info[:3]))}"
         super().__init__(
             auth=auth,

--- a/task-sdk/tests/task_sdk/__init__.py
+++ b/task-sdk/tests/task_sdk/__init__.py
@@ -16,8 +16,12 @@
 # under the License.
 from __future__ import annotations
 
+import ssl
+
+import certifi
 import httpx
 
+from airflow.sdk.api import client
 from airflow.sdk.api.client import Client
 from airflow.sdk.execution_time.comms import BundleInfo
 
@@ -43,3 +47,29 @@ def make_client_w_responses(responses: list[httpx.Response]) -> Client:
     return Client(
         base_url=None, dry_run=True, token="", mounts={"'http://": httpx.MockTransport(handle_request)}
     )
+
+
+def make_client_w_capath(capath: str) -> str | None:
+    """Check client is created with custom capath."""
+
+    check_capath = None
+    client.API_SSL_CERT_PATH = capath
+    _load_verify_locations = ssl.SSLContext.load_verify_locations
+
+    def load_verify_locations(
+        self, cafile: str | bytes | None = None, capath: str | bytes | None = None, cadata: str | None = None
+    ) -> None:
+        if certifi.where() not in [cafile, capath, cadata]:
+            nonlocal check_capath
+            check_capath = cafile or capath or cadata
+        else:
+            _load_verify_locations(self, cafile, capath, cadata)
+
+    ssl.SSLContext.load_verify_locations = load_verify_locations
+    Client(base_url="test://server", token="")
+
+    del ssl.SSLContext.load_verify_locations
+    ssl.SSLContext.load_verify_locations = _load_verify_locations
+    client.API_SSL_CERT_PATH = None
+
+    return check_capath

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -26,7 +26,7 @@ from unittest import mock
 import httpx
 import pytest
 import uuid6
-from task_sdk import make_client, make_client_w_dry_run, make_client_w_responses
+from task_sdk import make_client, make_client_w_capath, make_client_w_dry_run, make_client_w_responses
 from uuid6 import uuid7
 
 from airflow.sdk import timezone
@@ -87,6 +87,10 @@ class TestClient:
 
         assert resp.status_code == 200
         assert resp.json() == json_response
+
+    def test_add_capath(self):
+        capath = make_client_w_capath("/capath/does/not/exist/")
+        assert capath == "/capath/does/not/exist/"
 
     def test_error_parsing(self):
         responses = [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #53493 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
An addition to the tasks sdk apt client to import the same certificate used for the apiserver by getting the path from the config options so that self-signed certificates get trusted. No additional config options and user wise nothing of note has changed other than a self-signed certificate working without workarounds.

Verification remains on so there is otherwise no security implications.
Closes: #53493


