### PR TITLE
Fix unreachable code mypy warnings in common compat provider

### DIFF
--- a/providers/common/compat/src/airflow/providers/common/compat/openlineage/check.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/openlineage/check.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import functools
 import logging
 from importlib import metadata
+from typing import Any
 
 from packaging.version import Version
 
@@ -29,7 +30,7 @@ log = logging.getLogger(__name__)
 
 
 def require_openlineage_version(
-    provider_min_version: str | None = None, client_min_version: str | None = None
+    provider_min_version: str | None | Any = None, client_min_version: str | None = None
 ):
     """
     Enforce minimum version requirements for OpenLineage provider or client.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #53395 

warning:
```
providers/common/compat/src/airflow/providers/common/compat/openlineage/check.py:56: error:
Right operand of "and" is never evaluated  [unreachable]
        if callable(provider_min_version) and client_min_version is None:
```
problematic condition:
```py
if callable(provider_min_version) and client_min_version is None:
```
this is because in original function signature:
```py
def require_openlineage_version(
    provider_min_version: str | None = None, 
    client_min_version: str | None = None
):
```
this tells mypy that `provider_min_version` could only be a string or `None` (never a callable), which in the problematic condition, makes `callable(provider_min_version)` always false, which makes right side of the and operand, i.e. `client_min_version is None`, unreachable.

fix: update the type annotation to allow `provider_min_version` to be a string, None, or any other type (including callables).
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
