### PR TITLE
Free the limit for sqlalchemy 2

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -92,6 +92,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "false"
         type: string
+      upgrade-sqlalchemy:
+        description: "Whether to upgrade SQLAlchemy or not (true/false)"
+        required: false
+        default: "false"
+        type: string
       upgrade-boto:
         description: "Whether to upgrade boto or not (true/false)"
         required: false
@@ -162,6 +167,7 @@ jobs:
       PARALLEL_TEST_TYPES: ${{ matrix.test-types.test_types }}
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
       UPGRADE_BOTO: "${{ inputs.upgrade-boto }}"
+      UPGRADE_SQLALCHEMY: "${{ inputs.upgrade-sqlalchemy }}"
       AIRFLOW_MONITOR_DELAY_TIME_IN_SECONDS: "${{inputs.monitor-delay-time-in-seconds}}"
       VERBOSE: "true"
     if: inputs.test-group == 'core' || inputs.skip-providers-tests != 'true'

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -236,6 +236,54 @@ jobs:
       skip-providers-tests: ${{ inputs.skip-providers-tests }}
       use-uv: ${{ inputs.use-uv }}
 
+  tests-latest-sqlalchemy:
+    name: "Latest SQLAlchemy test: core"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runners: ${{ inputs.runners }}
+      platform: ${{ inputs.platform }}
+      upgrade-sqlalchemy: "true"
+      test-name: "LatestSQLAlchemy-Postgres"
+      test-scope: "DB"
+      test-group: "core"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.core-test-types-list-as-strings-in-json }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+
+  tests-latest-sqlalchemy-providers:
+    name: "Latest SQLAlchemy test: providers"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      runners: ${{ inputs.runners }}
+      platform: ${{ inputs.platform }}
+      upgrade-sqlalchemy: "true"
+      test-name: "LatestSQLAlchemy-Postgres"
+      test-scope: "DB"
+      test-group: "providers"
+      backend: "postgres"
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excluded-providers-as-string: ${{ inputs.excluded-providers-as-string }}
+      excludes: "[]"
+      test-types-as-strings-in-json: ${{ inputs.providers-test-types-list-as-strings-in-json }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+      skip-providers-tests: ${{ inputs.skip-providers-tests }}
+      use-uv: ${{ inputs.use-uv }}
+
   tests-quarantined-core:
     name: "Quarantined test: core"
     uses: ./.github/workflows/run-unit-tests.yml

--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -127,11 +127,8 @@ dependencies = [
     "rich-argparse>=1.0.0",
     "rich>=13.6.0",
     "setproctitle>=1.3.3",
-    # We use some deprecated features of sqlalchemy 2.0 and we should replace them before we can upgrade
-    # See https://sqlalche.me/e/b8d9 for details of deprecated features
-    # you can set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.
-    # The issue tracking it is https://github.com/apache/airflow/issues/28723
-    "sqlalchemy[asyncio]>=1.4.49,<2.0",
+    # The issue tracking deprecations for sqlalchemy 2 is https://github.com/apache/airflow/issues/28723
+    "sqlalchemy[asyncio]>=1.4.49",
     "sqlalchemy-jsonfield>=1.0",
     "sqlalchemy-utils>=0.41.2",
     "svcs>=25.1.0",


### PR DESCRIPTION
We are no longer bound with connexion and other dependencies are not blocking us from upgrading to SqlAlchemy 2 and we can remove the limit of airflow - because it does not really depend on FAB any more.

This also allows us to add special tests to run complete suite of tests when sqlalchemy is upgraded to latest version.

Separated out from https://github.com/apache/airflow/pull/52233

Co-authored-by: Dev-iL <Gid.CTO+github@gmail.com>

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
