### PR TITLE
Clean up circular imports in HITL datamodels

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/hitl.py
@@ -38,12 +38,6 @@ class HITLDetailRequest(BaseModel):
     params: dict[str, Any] = Field(default_factory=dict)
 
 
-class GetHITLDetailResponsePayload(BaseModel):
-    """Schema for getting the response part of a Human-in-the-loop detail for a specific task instance."""
-
-    ti_id: UUID
-
-
 class UpdateHITLDetailPayload(BaseModel):
     """Schema for writing the response part of a Human-in-the-loop detail for a specific task instance."""
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -27,9 +27,9 @@ from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.execution_api.datamodels.hitl import (
     HITLDetailRequest,
     HITLDetailResponse,
+    UpdateHITLDetailPayload,
 )
 from airflow.models.hitl import HITLDetail
-from airflow.sdk.execution_time.comms import CreateHITLDetailPayload, UpdateHITLDetail
 
 router = APIRouter()
 
@@ -42,7 +42,7 @@ log = structlog.get_logger(__name__)
 )
 def add_hitl_detail(
     task_instance_id: UUID,
-    payload: CreateHITLDetailPayload,
+    payload: HITLDetailRequest,
     session: SessionDep,
 ) -> HITLDetailRequest:
     """Get Human-in-the-loop detail for a specific Task Instance."""
@@ -71,7 +71,7 @@ def add_hitl_detail(
 @router.patch("/{task_instance_id}")
 def update_hitl_detail(
     task_instance_id: UUID,
-    payload: UpdateHITLDetail,
+    payload: UpdateHITLDetailPayload,
     session: SessionDep,
 ) -> HITLDetailResponse:
     """Update the response part of a Human-in-the-loop detail for a specific Task Instance."""

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -80,6 +80,9 @@ from airflow.exceptions import (
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.asset import AssetEvent, AssetModel
 from airflow.models.base import Base, StringID, TaskInstanceDependencies
+
+# Import HITLDetail at runtime so SQLAlchemy can resolve the relationship
+from airflow.models.hitl import HITLDetail  # noqa: F401
 from airflow.models.log import Log
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.taskmap import TaskMap

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -38,7 +38,6 @@ from airflow.sdk.api.datamodels._generated import (
     AssetEventsResponse,
     AssetResponse,
     ConnectionResponse,
-    CreateHITLDetailPayload,
     DagRunStateResponse,
     DagRunType,
     HITLDetailResponse,
@@ -57,7 +56,6 @@ from airflow.sdk.api.datamodels._generated import (
     TISuccessStatePayload,
     TITerminalStatePayload,
     TriggerDAGRunPayload,
-    UpdateHITLDetail,
     ValidationError as RemoteValidationError,
     VariablePostBody,
     VariableResponse,
@@ -67,6 +65,7 @@ from airflow.sdk.api.datamodels._generated import (
 )
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
+    CreateHITLDetailPayload,
     DRCount,
     ErrorResponse,
     HITLDetailRequestResult,
@@ -74,6 +73,7 @@ from airflow.sdk.execution_time.comms import (
     SkipDownstreamTasks,
     TaskRescheduleStartDate,
     TICount,
+    UpdateHITLDetail,
 )
 from airflow.utils.net import get_hostname
 from airflow.utils.platform import getuser

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -102,23 +102,6 @@ class ConnectionResponse(BaseModel):
     extra: Annotated[str | None, Field(title="Extra")] = None
 
 
-class CreateHITLDetailPayload(BaseModel):
-    """
-    Add the input request part of a Human-in-the-loop response.
-    """
-
-    ti_id: Annotated[UUID, Field(title="Ti Id")]
-    options: Annotated[list[str], Field(title="Options")]
-    subject: Annotated[str, Field(title="Subject")]
-    body: Annotated[str | None, Field(title="Body")] = None
-    defaults: Annotated[list[str] | None, Field(title="Defaults")] = None
-    multiple: Annotated[bool | None, Field(title="Multiple")] = False
-    params: Annotated[dict[str, Any] | None, Field(title="Params")] = None
-    type: Annotated[Literal["CreateHITLDetailPayload"] | None, Field(title="Type")] = (
-        "CreateHITLDetailPayload"
-    )
-
-
 class DagRunAssetReference(BaseModel):
     """
     DagRun serializer for asset responses.
@@ -368,15 +351,14 @@ class TriggerDAGRunPayload(BaseModel):
     reset_dag_run: Annotated[bool | None, Field(title="Reset Dag Run")] = False
 
 
-class UpdateHITLDetail(BaseModel):
+class UpdateHITLDetailPayload(BaseModel):
     """
-    Update the response content part of an existing Human-in-the-loop response.
+    Schema for writing the response part of a Human-in-the-loop detail for a specific task instance.
     """
 
     ti_id: Annotated[UUID, Field(title="Ti Id")]
     chosen_options: Annotated[list[str], Field(title="Chosen Options")]
     params_input: Annotated[dict[str, Any] | None, Field(title="Params Input")] = None
-    type: Annotated[Literal["UpdateHITLDetail"] | None, Field(title="Type")] = "UpdateHITLDetail"
 
 
 class ValidationError(BaseModel):

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -856,15 +856,10 @@ class GetDRCount(BaseModel):
     type: Literal["GetDRCount"] = "GetDRCount"
 
 
-class GetHITLDetailResponsePayload(BaseModel):
-    """Schema for getting the response part of a Human-in-the-loop detail for a specific task instance."""
-
-    ti_id: UUID
-
-
-class GetHITLDetailResponse(GetHITLDetailResponsePayload):
+class GetHITLDetailResponse(BaseModel):
     """Get the response content part of a Human-in-the-loop response."""
 
+    ti_id: UUID
     type: Literal["GetHITLDetailResponse"] = "GetHITLDetailResponse"
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -63,10 +63,6 @@ import structlog
 from fastapi import Body
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, field_serializer
 
-from airflow.api_fastapi.execution_api.datamodels.hitl import (
-    GetHITLDetailResponsePayload,
-    UpdateHITLDetailPayload,
-)
 from airflow.sdk.api.datamodels._generated import (
     AssetEventDagRunReference,
     AssetEventResponse,
@@ -88,6 +84,7 @@ from airflow.sdk.api.datamodels._generated import (
     TISkippedDownstreamTasksStatePayload,
     TISuccessStatePayload,
     TriggerDAGRunPayload,
+    UpdateHITLDetailPayload,
     VariableResponse,
     XComResponse,
     XComSequenceIndexResponse,
@@ -857,6 +854,12 @@ class GetDRCount(BaseModel):
     run_ids: list[str] | None = None
     states: list[str] | None = None
     type: Literal["GetDRCount"] = "GetDRCount"
+
+
+class GetHITLDetailResponsePayload(BaseModel):
+    """Schema for getting the response part of a Human-in-the-loop detail for a specific task instance."""
+
+    ti_id: UUID
 
 
 class GetHITLDetailResponse(GetHITLDetailResponsePayload):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/53587


Core execution API routes were importing from Task SDK, creating a circular dependency & violating architectural boundaries.

In core: 
- Updated route functions to use Core's own types (`HITLDetailRequest`, `UpdateHITLDetailPayload`)

SDK -> core imports:
- Kept `GetHITLDetailResponsePayload` as local SDK type (only used internally)

Generation now works:
- SDK uses generated type instead of direct Core import



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
