### PR TITLE
Fix: Trigger form dropdown menus are truncated/not visible

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
@@ -84,6 +84,7 @@ const ConfigForm = <T extends FieldValues = FieldValues>({
       collapsible
       defaultValue={[flexibleFormDefaultSection]}
       mb={4}
+      overflow="visible"
       size="lg"
       variant="enclosed"
     >


### PR DESCRIPTION
This PR fixes the trigger form dropdown menu not being visible when there are more options. 
closes: #53366

Before:
<img width="1242" height="734" alt="image" src="https://github.com/user-attachments/assets/91b3d5f9-c007-4651-a238-20c9c8e39f3b" />

After:
<img width="936" height="543" alt="image" src="https://github.com/user-attachments/assets/b7c9f3fc-f451-48ba-b9f0-667072884d8b" />
