### PR TITLE
Add customizable log prefix and formatter to KubernetesPodOperator

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/test_base.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_base.py
@@ -51,7 +51,7 @@ print()
 
 class StringContainingId(str):
     def __eq__(self, other):
-        return self in other
+        return self in other.strip() or self in other
 
 
 class BaseK8STest:

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -552,10 +552,11 @@ class TestKubernetesPodOperatorSystem:
                 task_id=str(uuid4()),
                 in_cluster=False,
                 do_xcom_push=False,
+                log_prefix=False,
             )
             context = create_context(k)
             k.execute(context=context)
-            mock_logger.info.assert_any_call("[%s] %s", "base", StringContainingId("retrieved from mount"))
+            mock_logger.info.assert_any_call("%s", StringContainingId("retrieved from mount"))
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
             self.expected_pod["spec"]["containers"][0]["args"] = args
             self.expected_pod["spec"]["containers"][0]["volumeMounts"] = [
@@ -1429,72 +1430,54 @@ class TestKubernetesPodOperatorSystem:
         )
 
     @pytest.mark.asyncio
-    def test_log_prefix_enabled(self, mock_get_connection, caplog):
-        """Test default behavior with log_prefix=True (container name prefix included)."""
+    @pytest.mark.parametrize(
+        "log_prefix_enabled, log_formatter, expected_log_message_check",
+        [
+            pytest.param(
+                True,
+                None,
+                lambda marker, record_message: f"[base] {marker}" in record_message,
+                id="log_prefix_enabled",
+            ),
+            pytest.param(
+                False,
+                None,
+                lambda marker, record_message: marker in record_message and "[base]" not in record_message,
+                id="log_prefix_disabled",
+            ),
+            pytest.param(
+                False,  # Ignored when log_formatter is provided
+                lambda container_name, message: f"CUSTOM[{container_name}]: {message}",
+                lambda marker, record_message: f"CUSTOM[base]: {marker}" in record_message,
+                id="custom_log_formatter",
+            ),
+        ],
+    )
+    def test_log_output_configurations(
+        self, mock_get_connection, caplog, log_prefix_enabled, log_formatter, expected_log_message_check
+    ):
+        """
+        Tests various log output configurations (log_prefix, log_formatter)
+        for KubernetesPodOperator.
+        """
         marker = f"test_log_{uuid4()}"
         k = KubernetesPodOperator(
             namespace="default",
             image="busybox",
             cmds=["sh", "-cx"],
             arguments=[f"echo {marker}"],
-            labels=self.labels,
+            labels={"test_label": "test"},
             task_id=str(uuid4()),
             in_cluster=False,
             do_xcom_push=False,
             get_logs=True,
-            log_prefix=True,  # Explicitly set default
+            log_prefix=log_prefix_enabled,
+            log_formatter=log_formatter,
         )
         context = create_context(k)
         with caplog.at_level(logging.INFO, logger="airflow.task.operators"):
             k.execute(context)
-        assert any(f"[base] {marker}" in record.message for record in caplog.records)
-
-    @pytest.mark.asyncio
-    def test_log_prefix_disabled(self, mock_get_connection, caplog):
-        """Test log_prefix=False removes container name prefix."""
-        marker = f"test_log_{uuid4()}"
-        k = KubernetesPodOperator(
-            namespace="default",
-            image="busybox",
-            cmds=["sh", "-cx"],
-            arguments=[f"echo {marker}"],
-            labels=self.labels,
-            task_id=str(uuid4()),
-            in_cluster=False,
-            do_xcom_push=False,
-            get_logs=True,
-            log_prefix=False,
-        )
-        context = create_context(k)
-        with caplog.at_level(logging.INFO, logger="airflow.task.operators"):
-            k.execute(context)
-        assert any(marker in record.message and "[base]" not in record.message for record in caplog.records)
-
-    @pytest.mark.asyncio
-    def test_custom_log_formatter(self, mock_get_connection, caplog):
-        """Test custom log_formatter function."""
-        marker = f"test_log_{uuid4()}"
-
-        def custom_formatter(container_name: str, message: str) -> str:
-            return f"CUSTOM[{container_name}]: {message}"
-
-        k = KubernetesPodOperator(
-            namespace="default",
-            image="busybox",
-            cmds=["sh", "-cx"],
-            arguments=[f"echo {marker}"],
-            labels=self.labels,
-            task_id=str(uuid4()),
-            in_cluster=False,
-            do_xcom_push=False,
-            get_logs=True,
-            log_prefix=False,  # Ignored when log_formatter is provided
-            log_formatter=custom_formatter,
-        )
-        context = create_context(k)
-        with caplog.at_level(logging.INFO, logger="airflow.task.operators"):
-            k.execute(context)
-        assert any(f"CUSTOM[base]: {marker}" in record.message for record in caplog.records)
+        assert any(expected_log_message_check(marker, record.message) for record in caplog.records)
 
 
 # TODO: Task SDK: https://github.com/apache/airflow/issues/45438

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1453,7 +1453,7 @@ class TestKubernetesPodOperatorSystem:
         ],
     )
     def test_log_output_configurations(
-        self, mock_get_connection, caplog, log_prefix_enabled, log_formatter, expected_log_message_check
+        self, mock_get_connection, log_prefix_enabled, log_formatter, expected_log_message_check
     ):
         """
         Tests various log output configurations (log_prefix, log_formatter)
@@ -1474,9 +1474,11 @@ class TestKubernetesPodOperatorSystem:
             log_formatter=log_formatter,
         )
         context = create_context(k)
-        with caplog.at_level(logging.INFO, logger="airflow.task.operators"):
+        logger = logging.getLogger("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager")
+        with mock.patch.object(logger, "info") as mock_info:
             k.execute(context)
-        assert any(expected_log_message_check(marker, record.message) for record in caplog.records)
+            captured_messages = [call_args[0] for call_args in mock_info.call_args_list if call_args]
+            assert any(expected_log_message_check(marker, msg) for msg in captured_messages)
 
 
 # TODO: Task SDK: https://github.com/apache/airflow/issues/45438

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1429,7 +1429,6 @@ class TestKubernetesPodOperatorSystem:
             < calls_args.find(marker_from_main_container)
         )
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "log_prefix_enabled, log_formatter, expected_log_message_check",
         [

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -235,6 +235,11 @@ class KubernetesPodOperator(BaseOperator):
         resuming to fetch the latest logs. If ``None``, then the task will remain in deferred state until pod
         is done, and no logs will be visible until that time.
     :param trigger_kwargs: additional keyword parameters passed to the trigger
+    :param container_name_log_prefix_enabled: if True, will prefix container name to each log line.
+        Default to True.
+    :param log_formatter: custom log formatter function that takes two string arguments:
+        the first string is the container_name and the second string is the message_to_log.
+        The function should return a formatted string. If None, the default formatting will be used.
     """
 
     # !!! Changes in KubernetesPodOperator's arguments should be also reflected in !!!
@@ -343,7 +348,7 @@ class KubernetesPodOperator(BaseOperator):
         progress_callback: Callable[[str], None] | None = None,
         logging_interval: int | None = None,
         trigger_kwargs: dict | None = None,
-        log_prefix: bool = True,
+        container_name_log_prefix_enabled: bool = True,
         log_formatter: Callable[[str, str], str] | None = None,
         **kwargs,
     ) -> None:
@@ -440,7 +445,7 @@ class KubernetesPodOperator(BaseOperator):
         self._progress_callback = progress_callback
         self.callbacks = [] if not callbacks else callbacks if isinstance(callbacks, list) else [callbacks]
         self._killed: bool = False
-        self.log_prefix = log_prefix
+        self.container_name_log_prefix_enabled = container_name_log_prefix_enabled
         self.log_formatter = log_formatter
 
     @cached_property
@@ -754,7 +759,7 @@ class KubernetesPodOperator(BaseOperator):
                     pod=pod,
                     init_containers=self.init_container_logs,
                     follow_logs=True,
-                    log_prefix=self.log_prefix,
+                    container_name_log_prefix_enabled=self.container_name_log_prefix_enabled,
                     log_formatter=self.log_formatter,
                 )
         except kubernetes.client.exceptions.ApiException as exc:
@@ -772,7 +777,7 @@ class KubernetesPodOperator(BaseOperator):
                     pod=pod,
                     containers=self.container_logs,
                     follow_logs=True,
-                    log_prefix=self.log_prefix,
+                    container_name_log_prefix_enabled=self.container_name_log_prefix_enabled,
                     log_formatter=self.log_formatter,
                 )
             if not self.get_logs or (
@@ -922,7 +927,7 @@ class KubernetesPodOperator(BaseOperator):
                         container_name=self.base_container_name,
                         follow=follow,
                         since_time=last_log_time,
-                        log_prefix=self.log_prefix,
+                        container_name_log_prefix_enabled=self.container_name_log_prefix_enabled,
                         log_formatter=self.log_formatter,
                     )
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -456,6 +456,26 @@ class PodManager(LoggingMixin):
 
             await asyncio.sleep(check_interval)
 
+    def _log_message(
+        self,
+        message: str,
+        container_name: str,
+        container_name_log_prefix_enabled: bool,
+        log_formatter: Callable[[str, str], str] | None,
+    ) -> None:
+        """Log a message with appropriate formatting."""
+        if is_log_group_marker(message):
+            print(message)
+        else:
+            if log_formatter:
+                formatted_message = log_formatter(container_name, message)
+                self.log.info("%s", formatted_message)
+            else:
+                log_message = (
+                    f"[{container_name}] {message}" if container_name_log_prefix_enabled else message
+                )
+                self.log.info("%s", log_message)
+
     def fetch_container_logs(
         self,
         pod: V1Pod,
@@ -464,7 +484,7 @@ class PodManager(LoggingMixin):
         follow=False,
         since_time: DateTime | None = None,
         post_termination_timeout: int = 120,
-        log_prefix: bool = True,
+        container_name_log_prefix_enabled: bool = True,
         log_formatter: Callable[[str, str], str] | None = None,
     ) -> PodLoggingStatus:
         """
@@ -531,20 +551,12 @@ class PodManager(LoggingMixin):
                                             line=line, client=self._client, mode=ExecutionMode.SYNC
                                         )
                                 if message_to_log is not None:
-                                    if is_log_group_marker(message_to_log):
-                                        print(message_to_log)
-                                    else:
-                                        # Apply custom formatter or prefix logic
-                                        if log_formatter:
-                                            formatted_message = log_formatter(container_name, message_to_log)
-                                            self.log.info("%s", formatted_message)
-                                        else:
-                                            log_message = (
-                                                f"[{container_name}] {message_to_log}"
-                                                if log_prefix
-                                                else message_to_log
-                                            )
-                                            self.log.info("%s", log_message)
+                                    self._log_message(
+                                        message_to_log,
+                                        container_name,
+                                        container_name_log_prefix_enabled,
+                                        log_formatter,
+                                    )
                                 last_captured_timestamp = message_timestamp
                                 message_to_log = message
                                 message_timestamp = line_timestamp
@@ -560,17 +572,9 @@ class PodManager(LoggingMixin):
                                 line=line, client=self._client, mode=ExecutionMode.SYNC
                             )
                     if message_to_log is not None:
-                        if is_log_group_marker(message_to_log):
-                            print(message_to_log)
-                        else:
-                            if log_formatter:
-                                formatted_message = log_formatter(container_name, message_to_log)
-                                self.log.info("%s", formatted_message)
-                            else:
-                                log_message = (
-                                    f"[{container_name}] {message_to_log}" if log_prefix else message_to_log
-                                )
-                                self.log.info("%s", log_message)
+                        self._log_message(
+                            message_to_log, container_name, container_name_log_prefix_enabled, log_formatter
+                        )
                     last_captured_timestamp = message_timestamp
             except TimeoutError as e:
                 # in case of timeout, increment return time by 2 seconds to avoid
@@ -653,7 +657,7 @@ class PodManager(LoggingMixin):
         pod: V1Pod,
         init_containers: Iterable[str] | str | Literal[True] | None,
         follow_logs=False,
-        log_prefix: bool = True,
+        container_name_log_prefix_enabled: bool = True,
         log_formatter: Callable[[str, str], str] | None = None,
     ) -> list[PodLoggingStatus]:
         """
@@ -678,7 +682,7 @@ class PodManager(LoggingMixin):
                 pod=pod,
                 container_name=c,
                 follow=follow_logs,
-                log_prefix=log_prefix,
+                container_name_log_prefix_enabled=container_name_log_prefix_enabled,
                 log_formatter=log_formatter,
             )
             pod_logging_statuses.append(status)
@@ -689,7 +693,7 @@ class PodManager(LoggingMixin):
         pod: V1Pod,
         containers: Iterable[str] | str | Literal[True],
         follow_logs=False,
-        log_prefix: bool = True,
+        container_name_log_prefix_enabled: bool = True,
         log_formatter: Callable[[str, str], str] | None = None,
     ) -> list[PodLoggingStatus]:
         """
@@ -711,7 +715,7 @@ class PodManager(LoggingMixin):
                 pod=pod,
                 container_name=c,
                 follow=follow_logs,
-                log_prefix=log_prefix,
+                container_name_log_prefix_enabled=container_name_log_prefix_enabled,
                 log_formatter=log_formatter,
             )
             pod_logging_statuses.append(status)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -23,7 +23,7 @@ import enum
 import json
 import math
 import time
-from collections.abc import Generator, Iterable
+from collections.abc import Callable, Generator, Iterable
 from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import timedelta
@@ -464,6 +464,8 @@ class PodManager(LoggingMixin):
         follow=False,
         since_time: DateTime | None = None,
         post_termination_timeout: int = 120,
+        log_prefix: bool = True,
+        log_formatter: Callable[[str, str], str] | None = None,
     ) -> PodLoggingStatus:
         """
         Follow the logs of container and stream to airflow logging.
@@ -532,7 +534,17 @@ class PodManager(LoggingMixin):
                                     if is_log_group_marker(message_to_log):
                                         print(message_to_log)
                                     else:
-                                        self.log.info("[%s] %s", container_name, message_to_log)
+                                        # Apply custom formatter or prefix logic
+                                        if log_formatter:
+                                            formatted_message = log_formatter(container_name, message_to_log)
+                                            self.log.info("%s", formatted_message)
+                                        else:
+                                            log_message = (
+                                                f"[{container_name}] {message_to_log}"
+                                                if log_prefix
+                                                else message_to_log
+                                            )
+                                            self.log.info("%s", log_message)
                                 last_captured_timestamp = message_timestamp
                                 message_to_log = message
                                 message_timestamp = line_timestamp
@@ -551,7 +563,14 @@ class PodManager(LoggingMixin):
                         if is_log_group_marker(message_to_log):
                             print(message_to_log)
                         else:
-                            self.log.info("[%s] %s", container_name, message_to_log)
+                            if log_formatter:
+                                formatted_message = log_formatter(container_name, message_to_log)
+                                self.log.info("%s", formatted_message)
+                            else:
+                                log_message = (
+                                    f"[{container_name}] {message_to_log}" if log_prefix else message_to_log
+                                )
+                                self.log.info("%s", log_message)
                     last_captured_timestamp = message_timestamp
             except TimeoutError as e:
                 # in case of timeout, increment return time by 2 seconds to avoid
@@ -630,7 +649,12 @@ class PodManager(LoggingMixin):
         return containers_to_log
 
     def fetch_requested_init_container_logs(
-        self, pod: V1Pod, init_containers: Iterable[str] | str | Literal[True] | None, follow_logs=False
+        self,
+        pod: V1Pod,
+        init_containers: Iterable[str] | str | Literal[True] | None,
+        follow_logs=False,
+        log_prefix: bool = True,
+        log_formatter: Callable[[str, str], str] | None = None,
     ) -> list[PodLoggingStatus]:
         """
         Follow the logs of containers in the specified pod and publish it to airflow logging.
@@ -650,12 +674,23 @@ class PodManager(LoggingMixin):
         containers_to_log = sorted(containers_to_log, key=lambda cn: all_containers.index(cn))
         for c in containers_to_log:
             self._await_init_container_start(pod=pod, container_name=c)
-            status = self.fetch_container_logs(pod=pod, container_name=c, follow=follow_logs)
+            status = self.fetch_container_logs(
+                pod=pod,
+                container_name=c,
+                follow=follow_logs,
+                log_prefix=log_prefix,
+                log_formatter=log_formatter,
+            )
             pod_logging_statuses.append(status)
         return pod_logging_statuses
 
     def fetch_requested_container_logs(
-        self, pod: V1Pod, containers: Iterable[str] | str | Literal[True], follow_logs=False
+        self,
+        pod: V1Pod,
+        containers: Iterable[str] | str | Literal[True],
+        follow_logs=False,
+        log_prefix: bool = True,
+        log_formatter: Callable[[str, str], str] | None = None,
     ) -> list[PodLoggingStatus]:
         """
         Follow the logs of containers in the specified pod and publish it to airflow logging.
@@ -672,7 +707,13 @@ class PodManager(LoggingMixin):
             pod_name=pod.metadata.name,
         )
         for c in containers_to_log:
-            status = self.fetch_container_logs(pod=pod, container_name=c, follow=follow_logs)
+            status = self.fetch_container_logs(
+                pod=pod,
+                container_name=c,
+                follow=follow_logs,
+                log_prefix=log_prefix,
+                log_formatter=log_formatter,
+            )
             pod_logging_statuses.append(status)
         return pod_logging_statuses
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1734,7 +1734,11 @@ class TestKubernetesPodOperator:
 
         # check that the base container is not included in the logs
         mock_fetch_log.assert_called_once_with(
-            pod=pod, containers=["some_init_container"], follow_logs=True, log_prefix=True, log_formatter=None
+            pod=pod,
+            containers=["some_init_container"],
+            follow_logs=True,
+            container_name_log_prefix_enabled=True,
+            log_formatter=None,
         )
         # check that KPO waits for the base container to complete before proceeding to extract XCom
         mock_await_container_completion.assert_called_once_with(
@@ -2006,7 +2010,7 @@ class TestKubernetesPodOperator:
                         pod=pod,
                         containers=k.container_logs,
                         follow_logs=True,
-                        log_prefix=True,
+                        container_name_log_prefix_enabled=True,
                         log_formatter=None,
                     )
                 ]

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1733,7 +1733,9 @@ class TestKubernetesPodOperator:
         pod, _ = self.run_pod(k)
 
         # check that the base container is not included in the logs
-        mock_fetch_log.assert_called_once_with(pod=pod, containers=["some_init_container"], follow_logs=True)
+        mock_fetch_log.assert_called_once_with(
+            pod=pod, containers=["some_init_container"], follow_logs=True, log_prefix=True, log_formatter=None
+        )
         # check that KPO waits for the base container to complete before proceeding to extract XCom
         mock_await_container_completion.assert_called_once_with(
             pod=pod, container_name="base", polling_time=1
@@ -1999,7 +2001,16 @@ class TestKubernetesPodOperator:
 
         if get_logs:
             fetch_requested_container_logs.assert_has_calls(
-                [mock.call(pod=pod, containers=k.container_logs, follow_logs=True)] * 3
+                [
+                    mock.call(
+                        pod=pod,
+                        containers=k.container_logs,
+                        follow_logs=True,
+                        log_prefix=True,
+                        log_formatter=None,
+                    )
+                ]
+                * 3
             )
         else:
             mock_await_container_completion.assert_has_calls(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -729,7 +729,7 @@ class TestSparkKubernetesOperator:
             pod=op.pod,
             containers="spark-kubernetes-driver",
             follow_logs=True,
-            log_prefix=True,
+            container_name_log_prefix_enabled=True,
             log_formatter=None,
         )
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -729,6 +729,8 @@ class TestSparkKubernetesOperator:
             pod=op.pod,
             containers="spark-kubernetes-driver",
             follow_logs=True,
+            log_prefix=True,
+            log_formatter=None,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->




<!-- Please keep an empty line above the dashes. -->
## Description
Addresses the issue where KubernetesPodOperator (KPO) logs always include a container name prefix, which can consume unnecessary horizontal space and feel redundant. This PR introduces two new optional parameters to `KubernetesPodOperator`:
- `log_prefix`: A boolean to enable/disable the container name prefix in logs (default: True).
- `log_formatter`: A callable to fully customize log output format, overriding log_prefix if provided.

This allows users to either disable the prefix or define a custom log format, improving log readability and flexibility.

## Changes
- Added `log_prefix: bool = True` and `log_formatter: Callable[[str, str], str] | None = None` to `KubernetesPodOperator` constructor.
- Updated `PodManager` methods (`fetch_container_logs`, `fetch_requested_init_container_logs`, `fetch_requested_container_logs`) to accept and use these new parameters.
- Modified log handling in `PodManager.fetch_container_logs` to:
  - Apply `log_formatter` if provided.
  - Use `log_prefix` to include/exclude container name prefix when `log_formatter` is not set.
- Added pytest unit tests to verify:
  - Default behavior with `log_prefix=True`.
  - Behavior with `log_prefix=False` (no container name prefix).
  - Custom log formatting with `log_formatter`.

## Related Issue
#53054 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
