### PR TITLE
UI - Invalidate DAG list on DAG deletion

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useDeleteDag.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useDeleteDag.ts
@@ -19,7 +19,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
-import { useDagServiceDeleteDag } from "openapi/queries";
+import { useDagServiceDeleteDag, useDagServiceGetDagsUiKey } from "openapi/queries";
 import { useDagServiceGetDagKey } from "openapi/queries";
 import { toaster } from "src/components/ui";
 
@@ -44,7 +44,7 @@ export const useDeleteDag = ({
   };
 
   const onSuccess = async () => {
-    const queryKeys = [[useDagServiceGetDagKey, { dagId }]];
+    const queryKeys = [[useDagServiceGetDagKey, { dagId }], [useDagServiceGetDagsUiKey]];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 


### PR DESCRIPTION
Invalidate Dags list when deleting a DAG.

Previous behavior would keep the deleted dag in the list, creating confusion.


Now the list is properly refreshed, and the dag is removed:

https://github.com/user-attachments/assets/9641322f-f8c0-4a03-ae94-2dda833c2b1e

