### PR TITLE
Remove dev dependencies from PyPI constraints.

### DIFF
--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -84,6 +84,11 @@ and both at the same time. We decided to keep our dependencies as open as possib
 from time to time plain ``pip install apache-airflow`` will not work or will produce an unusable
 Airflow installation.
 
+.. warning::
+
+    As of Airflow 3.1, constraint files do not contain developer dependencies such as pytest, moto and
+    other development dependencies that are only used in tests.
+
 Reproducible Airflow installation
 =================================
 

--- a/airflow-core/newsfragments/53631.misc.rst
+++ b/airflow-core/newsfragments/53631.misc.rst
@@ -1,0 +1,1 @@
+The constraint do not contain developer dependencies as of Airflow 3.1.0

--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -370,6 +370,8 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
             "pip",
             "install",
             "--no-sources",
+            "--exact",
+            "--strict",
             "apache-airflow[all]",
             "apache-airflow-core[all]",
             "apache-airflow-task-sdk",


### PR DESCRIPTION
Historically, `PyPI` constraints of airflow contained also the development dependencies of Airflow - because it was not very easy to separate and remove them from the "core" constraints.

This however might not be really needed and those dev tools could be removed from PyPI constraints.

There are however certain consequences:

a) currently when we generate PyPi constraints we generally *know* that the dependencies of ours have been tested at some point of time at least when we released the provider - because potentially some of our dev dependencies might limit some 3rd-party deps

b) if we remove devel deps when we generate the PyPI constraints this **might** change - i.e. removal of development dependencies might cause some of the transient dependencies to be upgraded to newer - potentially incompatible versions. It's not very likely but possible.

This means that if we remove devel deps, there is a higher risk that constraints published for users might contain dependency versions that has never been tested in our CI.

Another option considered is to use a) and b) and remove the dependencies missing in b) from a) - leaving the versions that were matching the versions used during CI. This however has limited impact on the users (just removes the "devel noise" from PyPI constraints
- and the noise that should not matter when installing airflow). And it has anothe risk that some edge cases might kick-in. For example there might be a case where our dependencies add or remove their transient dependencies, which might change status of those from devel to prod or the other way round. And it's quite a bit more complex.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
