### PR TITLE
Swap `connections_get` CLI command to use Connection instead of BaseHook from sdk

### DIFF
--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -66,9 +66,7 @@ def _connection_mapper(conn: Connection) -> dict[str, Any]:
 def connections_get(args):
     """Get a connection."""
     try:
-        from airflow.sdk import BaseHook
-
-        conn = BaseHook.get_connection(args.conn_id)
+        conn = Connection.get_connection_from_secrets(args.conn_id)
     except AirflowNotFoundException:
         raise SystemExit("Connection not found.")
     AirflowConsole().print_as(

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -30,7 +30,7 @@ import pytest
 
 from airflow.cli import cli_config, cli_parser
 from airflow.cli.commands import connection_command
-from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.utils.db import merge_conn
 from airflow.utils.session import create_session
@@ -61,8 +61,7 @@ class TestCliGetConnection:
             stdout = stdout.getvalue()
         assert "google-cloud-platform:///default" in stdout
 
-    def test_cli_connection_get_invalid(self, mock_supervisor_comms):
-        mock_supervisor_comms.send.side_effect = AirflowNotFoundException
+    def test_cli_connection_get_invalid(self):
         with pytest.raises(SystemExit, match=re.escape("Connection not found.")):
             connection_command.connections_get(self.parser.parse_args(["connections", "get", "INVALID"]))
 


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The `connections_get` CLI command imports and uses basehook from sdk when there is no need to do so. It can just use the models.Connection as the utility will most likely not be used on worker.

This cuts down a tie between task SDK & core and also removed an unwanted `mock_supervisor_comms` usage in tests. Core tests shouldn't need that.

If a worker backend is set up, when the connections module moved to using task sdk connection, that will be handled in bulk.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
