### PR TITLE
Remove note accordion from details header

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -24,7 +24,6 @@ import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
-import EditableMarkdownArea from "src/components/EditableMarkdownArea";
 import EditableMarkdownButton from "src/components/EditableMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
@@ -69,19 +68,17 @@ export const Header = ({
       <HeaderCard
         actions={
           <>
-            {!Boolean(dagRun.note) && (
-              <EditableMarkdownButton
-                header={translate("note.dagRun")}
-                icon={<FiMessageSquare />}
-                isPending={isPending}
-                mdContent={note}
-                onConfirm={onConfirm}
-                placeholder={translate("note.placeholder")}
-                setMdContent={setNote}
-                text={translate("note.add")}
-                withText={containerWidth > 700}
-              />
-            )}
+            <EditableMarkdownButton
+              header={translate("note.dagRun")}
+              icon={<FiMessageSquare />}
+              isPending={isPending}
+              mdContent={note}
+              onConfirm={onConfirm}
+              placeholder={translate("note.placeholder")}
+              setMdContent={setNote}
+              text={Boolean(dagRun.note) ? translate("note.label") : translate("note.add")}
+              withText={containerWidth > 700}
+            />
             <ClearRunButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />
             <MarkRunAsButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />
           </>
@@ -124,9 +121,6 @@ export const Header = ({
         ]}
         title={<Time datetime={dagRun.run_after} />}
       />
-      {Boolean(dagRun.note) && (
-        <EditableMarkdownArea mdContent={note} onBlur={onConfirm} setMdContent={setNote} />
-      )}
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -25,7 +25,6 @@ import { MdOutlineTask } from "react-icons/md";
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
-import EditableMarkdownArea from "src/components/EditableMarkdownArea";
 import EditableMarkdownButton from "src/components/EditableMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
@@ -94,19 +93,17 @@ export const Header = ({
       <HeaderCard
         actions={
           <>
-            {!Boolean(taskInstance.note) && (
-              <EditableMarkdownButton
-                header={translate("note.taskInstance")}
-                icon={<FiMessageSquare />}
-                isPending={isPending}
-                mdContent={note}
-                onConfirm={onConfirm}
-                placeholder={translate("note.placeholder")}
-                setMdContent={setNote}
-                text={translate("note.add")}
-                withText={containerWidth > 700}
-              />
-            )}
+            <EditableMarkdownButton
+              header={translate("note.taskInstance")}
+              icon={<FiMessageSquare />}
+              isPending={isPending}
+              mdContent={note}
+              onConfirm={onConfirm}
+              placeholder={translate("note.placeholder")}
+              setMdContent={setNote}
+              text={Boolean(taskInstance.note) ? translate("note.label") : translate("note.add")}
+              withText={containerWidth > 700}
+            />
             <ClearTaskInstanceButton
               isHotkeyEnabled
               taskInstance={taskInstance}
@@ -126,9 +123,6 @@ export const Header = ({
         subTitle={<Time datetime={taskInstance.start_date} />}
         title={`${taskInstance.task_display_name}${taskInstance.map_index > -1 ? ` [${taskInstance.rendered_map_index ?? taskInstance.map_index}]` : ""}`}
       />
-      {Boolean(taskInstance.note) && (
-        <EditableMarkdownArea mdContent={note} onBlur={onConfirm} setMdContent={setNote} />
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
Partial revert of https://github.com/apache/airflow/pull/51764.

The note in the header is shifting too much the UI, and preventing the resolution of other bugs (https://github.com/apache/airflow/issues/53085) without useEffect which is not ideal.

Reverting for now as we work on a different approach / design to better show notes to users.