### PR TITLE
fix unreachable mypy warnings for microsoft/azure

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -437,7 +437,7 @@ class KiotaRequestAdapterHook(BaseHook):
         method: str = "GET",
         query_parameters: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
-        data: dict[str, Any] | str | BytesIO | None = None,
+        data: dict[str, Any] | str | bytes | BytesIO | None = None,
     ) -> RequestInformation:
         request_information = RequestInformation()
         request_information.path_parameters = path_parameters or {}

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -615,8 +615,9 @@ class WasbAsyncHook(WasbHook):
         tenant = self._get_field(extra, "tenant_id")
         if tenant:
             # use Active Directory auth
-            app_id = conn.login
-            app_secret = conn.password
+            app_id = conn.login or ""
+            app_secret = conn.password or ""
+
             token_credential = AsyncClientSecretCredential(
                 tenant, app_id, app_secret, **client_secret_auth_config
             )

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -591,7 +591,7 @@ class WasbAsyncHook(WasbHook):
         """Initialize the hook instance."""
         self.conn_id = wasb_conn_id
         self.public_read = public_read
-        self.blob_service_client: AsyncBlobServiceClient | None = None  # type: ignore
+        self.blob_service_client: AsyncBlobServiceClient = None  # type: ignore
 
     async def get_async_conn(self) -> AsyncBlobServiceClient:
         """Return the Async BlobServiceClient object."""

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -591,7 +591,7 @@ class WasbAsyncHook(WasbHook):
         """Initialize the hook instance."""
         self.conn_id = wasb_conn_id
         self.public_read = public_read
-        self.blob_service_client: AsyncBlobServiceClient = None  # type: ignore
+        self.blob_service_client: AsyncBlobServiceClient | None = None  # type: ignore
 
     async def get_async_conn(self) -> AsyncBlobServiceClient:
         """Return the Async BlobServiceClient object."""
@@ -615,9 +615,8 @@ class WasbAsyncHook(WasbHook):
         tenant = self._get_field(extra, "tenant_id")
         if tenant:
             # use Active Directory auth
-            app_id = conn.login or ""
-            app_secret = conn.password or ""
-
+            app_id = conn.login
+            app_secret = conn.password
             token_credential = AsyncClientSecretCredential(
                 tenant, app_id, app_secret, **client_secret_auth_config
             )

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/msgraph.py
@@ -247,7 +247,7 @@ class MSGraphAsyncOperator(BaseOperator):
     @classmethod
     def append_result(
         cls,
-        results: list[Any],
+        results: Any,
         result: Any,
         append_result_as_list_if_absent: bool = False,
     ) -> list[Any]:

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py
@@ -88,7 +88,7 @@ class AzureSynapseRunSparkBatchOperator(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self.job_id = None
+        self.job_id: Any = None
         self.azure_synapse_conn_id = azure_synapse_conn_id
         self.wait_for_termination = wait_for_termination
         self.spark_pool = spark_pool

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -100,15 +100,18 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
     ) -> None:
         super().__init__()
         self.vault_url = vault_url
-        if connections_prefix is not None:
+        self.connections_prefix: str | None
+        if connections_prefix:
             self.connections_prefix = connections_prefix.rstrip(sep)
         else:
             self.connections_prefix = connections_prefix
-        if variables_prefix is not None:
+        self.variables_prefix: str | None
+        if variables_prefix:
             self.variables_prefix = variables_prefix.rstrip(sep)
         else:
             self.variables_prefix = variables_prefix
-        if config_prefix is not None:
+        self.config_prefix: str | None
+        if config_prefix:
             self.config_prefix = config_prefix.rstrip(sep)
         else:
             self.config_prefix = config_prefix


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/53395

providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py:106: error: Statement is unreachable [unreachable]
self.connections_prefix = connections_prefix

providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py:110: error: Statement is unreachable [unreachable]
self.variables_prefix = variables_prefix

providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py:114: error: Statement is unreachable [unreachable]
self.config_prefix = config_prefix

providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py:151: error: Statement is unreachable [unreachable]
return None

providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py:163: error: Statement is unreachable [unreachable]
return None

providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py:175: error: Statement is unreachable [unreachable]
return None

---
All of the variables (connections_prefix, variables_prefix, config_prefix) are allowed to be None, as seen in existing test cases. However, the original code only implied string types, leading to unreachable MyPy errors.

We resolved this by:
	•	Explicitly annotating input arguments as str | None
	•	Using safe conditional initialization with

original:
```python
if connections_prefix:
    self.connections_prefix = connections_prefix.rstrip(sep)
else:
    self.connections_prefix = connections_prefix
```

```python
self.connections_prefix = connections_prefix
if isinstance(self.connections_prefix, str):
    self.connections_prefix.rstrip(sep)
```

---
providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py:599: error: Statement is unreachable [unreachable]
conn = await sync_to_async(self.get_connection)(self.conn_id)

The code was flagged as unreachable by MyPy because self.blob_service_client was not annotated to allow None.
As a result, the following condition is always True from the type checker’s perspective:
```python
if self.blob_service_client is not None:
    return self.blob_service_client
```
To fix this, we explicitly annotated the attribute to allow None:
```python
self.blob_service_client: AsyncBlobServiceClient | None = None  # type: ignore
```
This makes the conditional logic valid and resolves the MyPy warning.

---
providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py:463: error: Statement is unreachable [unreachable]
request_information.content = data

Added bytes to the input type annotation to fix a type mismatch.

---
providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py:129: error: Statement is unreachable [unreachable]
self.hook.cancel_job_run(

Annotated self.job_id as Any to match its default value None and resolve the type warning.

---
providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/msgraph.py:260: error: Statement is unreachable [unreachable]
if append_result_as_list_if_absent:

The is condition was unreachable due to the static type of results. Changing its annotation to Any resolves the issue.
