### PR TITLE
Remove unused function from docker-test utils

### DIFF
--- a/docker-tests/tests/docker_tests/docker_utils.py
+++ b/docker-tests/tests/docker_tests/docker_utils.py
@@ -17,10 +17,8 @@
 from __future__ import annotations
 
 import os
-from time import monotonic, sleep
 
 from python_on_whales import docker
-from python_on_whales.exceptions import NoSuchContainer
 
 from docker_tests.constants import DEFAULT_DOCKER_IMAGE
 
@@ -96,40 +94,3 @@ Production image:
 ***** End of the instructions ****
 """
     )
-
-
-def wait_for_container(container_id: str, timeout: int = 300):
-    print(f"Waiting for container: [{container_id}] for {timeout} more seconds.")
-    start_time = monotonic()
-    while True:
-        if timeout != 0 and monotonic() - start_time > timeout:
-            err_msg = f"Timeout. The operation takes longer than the maximum waiting time ({timeout}s)"
-            raise TimeoutError(err_msg)
-
-        try:
-            container = docker.container.inspect(container_id)
-        except NoSuchContainer:
-            msg = f"Container ID {container_id!r} not found."
-            if timeout != 0:
-                msg += f"\nWaiting for {int(timeout - (monotonic() - start_time))} more seconds"
-            print(msg)
-            sleep(5)
-            continue
-
-        container_msg = f"Container {container.name}[{container_id}]"
-        if (state := container.state).status in ("running", "restarting"):
-            if state.health is None or state.health.status == "healthy":
-                print(
-                    f"{container_msg}. Status: {state.status!r}. "
-                    f"Healthcheck: {state.health.status if state.health else 'not set'!r}"
-                )
-                break
-        elif state.status == "exited":
-            print(f"{container_msg}. Status: {state.status!r}. Exit Code: {state.exit_code}")
-            break
-
-        msg = f"{container_msg} has state:\n {state}"
-        if timeout != 0:
-            msg += f"\nWaiting for {int(timeout - (monotonic() - start_time))} more seconds"
-        print(msg)
-        sleep(1)


### PR DESCRIPTION
Don't see anywhere its using this function.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
