### PR TITLE
Add util for auth manager cookie secure value

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -162,11 +162,12 @@ cookie named ``_token`` before redirecting to the Airflow UI. The Airflow UI wil
 .. code-block:: python
 
     from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
+    from airflow.api_fastapi.auth.tokens import is_cookie_secure
 
     response = RedirectResponse(url="/")
-
-    secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
-    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
+    response.set_cookie(
+        COOKIE_NAME_JWT_TOKEN, token, secure=is_cookie_secure(request_scheme=request.base_url.scheme)
+    )
     return response
 
 .. note::

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -23,6 +23,7 @@ from starlette.responses import RedirectResponse
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody, LoginResponse
 from airflow.api_fastapi.auth.managers.simple.services.login import SimpleAuthManagerLogin
+from airflow.api_fastapi.auth.tokens import is_cookie_secure
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.configuration import conf
@@ -60,15 +61,10 @@ def create_token_all_admins() -> LoginResponse:
 def login_all_admins(request: Request) -> RedirectResponse:
     """Login the user with no credentials."""
     response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"))
-
-    # The default config has this as an empty string, so we can't use `has_option`.
-    # And look at the request info (needs `--proxy-headers` flag to api-server)
-    secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
-
     response.set_cookie(
         COOKIE_NAME_JWT_TOKEN,
         SimpleAuthManagerLogin.create_token_all_admins(),
-        secure=secure,
+        secure=is_cookie_secure(request.base_url.scheme),
     )
     return response
 

--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -34,6 +34,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
+from airflow.configuration import conf
 from airflow.utils import timezone
 
 if TYPE_CHECKING:
@@ -579,3 +580,10 @@ def get_sig_validation_args(make_secret_key_if_needed: bool = True) -> dict[str,
         }
 
     return {"secret_key": get_signing_key("api_auth", "jwt_secret", make_secret_key_if_needed)}
+
+
+def is_cookie_secure(request_scheme: str) -> bool:
+    """Return `True` if the cookie in the auth response should be set as `secure`. Otherwise return `False`."""
+    # The default config has this as an empty string, so we can't use `has_option`.
+    # And look at the request info (needs `--proxy-headers` flag to api-server)
+    return request_scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))

--- a/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
@@ -243,7 +243,7 @@ async def test_jwt_generate_validate_roundtrip_with_jwks(private_key, algorithm,
 def test_is_cookie_secure(request_scheme: str, api_ssl_cert_setting: str, expected: bool) -> None:
     from tests_common.test_utils.config import conf_vars
 
-    with conf_vars({("api", "ssl_cert"): str(api_ssl_cert_setting)}):
+    with conf_vars({("api", "ssl_cert"): api_ssl_cert_setting}):
         actual = is_cookie_secure(request_scheme=request_scheme)
         assert actual == expected
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
@@ -30,6 +30,7 @@ from airflow.api_fastapi.app import (
     get_auth_manager,
 )
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
+from airflow.api_fastapi.auth.tokens import is_cookie_secure
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.configuration import conf
 from airflow.providers.amazon.aws.auth_manager.constants import CONF_SAML_METADATA_URL_KEY, CONF_SECTION_NAME
@@ -100,8 +101,9 @@ def login_callback(request: Request):
 
     if relay_state == "login-redirect":
         response = RedirectResponse(url=url, status_code=303)
-        secure = bool(conf.get("api", "ssl_cert", fallback=""))
-        response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
+        response.set_cookie(
+            COOKIE_NAME_JWT_TOKEN, token, secure=is_cookie_secure(request_scheme=request.base_url.scheme)
+        )
         return response
     if relay_state == "login-token":
         return LoginResponse(access_token=token)

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -24,6 +24,7 @@ from starlette.responses import HTMLResponse, RedirectResponse
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
+from airflow.api_fastapi.auth.tokens import is_cookie_secure
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.configuration import conf
 from airflow.providers.keycloak.auth_manager.keycloak_auth_manager import KeycloakAuthManager
@@ -67,6 +68,7 @@ def login_callback(request: Request):
     token = get_auth_manager().generate_jwt(user)
 
     response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"), status_code=303)
-    secure = bool(conf.get("api", "ssl_cert", fallback=""))
-    response.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure)
+    response.set_cookie(
+        COOKIE_NAME_JWT_TOKEN, token, secure=is_cookie_secure(request_scheme=request.base_url.scheme)
+    )
     return response


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Related issue: https://github.com/apache/airflow/issues/51971
Related comment from a recent auth manager doc update PR: https://github.com/apache/airflow/pull/53397/files#r2208921571

## What?
* Consolidates the repeated code into a utility function for determining the `secure` field of the JWT cookie in the auth manager's response
* Ensures the Simple auth manager, Amazon auth manager, and Keycloak auth manager code all use the new util.
* Updates the code block in the auth manager doc to reference the new util.

## Why?
* Reduces repetitive code, while offering a "standard" util for user auth manager implementations.

## Testing
* `uv run pytest --skip-db-tests -n auto tests/unit/api_fastapi/auth/test_tokens.py::test_is_cookie_secure`
* `breeze testing providers-tests --run-in-parallel --skip-db-tests --parallel-test-types "Providers[amazon] Providers[keycloak] Providers[fab]"`
* `pre-commit run` 

