### PR TITLE
Fix a UI bug where "All" does not show all dags when `hide_paused_dags_by_default = True`

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -98,7 +98,7 @@ export const DagsFilters = () => {
     ({ value }: { value: Array<string> }) => {
       const [val] = value;
 
-      if (val === undefined || val === "all") {
+      if (val === undefined) {
         searchParams.delete(PAUSED_PARAM);
       } else {
         searchParams.set(PAUSED_PARAM, val);


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/53439

This PR fixes a UI bug where the “All” option in the DAGs list dropdown filter (`All / Enabled / Disabled`) does not work when the config option `hide_paused_dags_by_default = True`.

Problem: when `hide_paused_dags_by_default` is enabled:

* Visiting `/dags` shows only enabled DAGs by default (as intended).
* Selecting “All” from the dropdown does not update the URL with `?paused=all`, which causes the page to fall back to config-based filtering and still show only enabled DAGs.
* This creates a confusing UX where users can see and choose the "All" option from the dropdown but it shows only the enabled DAGs.

Fix: updated the `handlePausedChange` logic to preserve `?paused=all` instead of deleting the query para, which ensures that selecting "All" results in the URL containing `?paused=all`, which is correctly handled by the backend.


https://github.com/user-attachments/assets/fe55c66e-adb2-48c3-affe-362f0f118b97



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
