### PR TITLE
Fix incorrect reference to SimpleHttpOperator in 3.0.0 release notes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -939,7 +939,6 @@ Airflow 3.0 completes the migration of several core operators, sensors, and hook
 - ``PythonOperator``
 - ``BashOperator``
 - ``EmailOperator``
-- ``SimpleHttpOperator``
 - ``ShortCircuitOperator``
 
 These operators were previously bundled inside ``airflow-core`` but are now treated as provider-managed components to
@@ -958,6 +957,8 @@ replaced with:
 .. code-block:: python
 
     from airflow.providers.standard.operators.python import PythonOperator
+
+The SimpleHttpOperator has been migrated to apache-airflow-providers-http and renamed to HttpOperator
 
 UI & Usability Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 6f266812d7639b6204f98b6450b4518e
-source-date-epoch: 1752254243
+release-notes-hash: 0c440473e3360412ce1ade38a7956f84
+source-date-epoch: 1753280864


### PR DESCRIPTION
manual backport of https://github.com/apache/airflow/pull/50740