### PR TITLE
Replace mock.patch("utcnow") with time_machine in Edge Executor

### DIFF
--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+import time_machine
 
 from airflow.configuration import conf
 from airflow.models.taskinstancekey import TaskInstanceKey
@@ -275,9 +276,7 @@ class TestEdgeExecutor:
                 )
                 session.commit()
 
-        with patch(
-            "airflow.utils.timezone.utcnow", return_value=datetime(2023, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
-        ):
+        with time_machine.travel(datetime(2023, 1, 1, 1, 0, 0, tzinfo=timezone.utc), tick=False):
             with conf_vars({("edge", "heartbeat_interval"): "10"}):
                 executor.sync()
 


### PR DESCRIPTION
This one was missed in #53642

As part of a future PR (https://github.com/apache/airflow/pull/53149) we are going to move the location of this function, and more generally we shouldn't be mocking a specific function, time_machine is better suited to this task.