### PR TITLE
Updating `apache-airflow-providers-openlineage` dependencies to use `1.36.0`

### DIFF
--- a/providers/openlineage/pyproject.toml
+++ b/providers/openlineage/pyproject.toml
@@ -60,8 +60,8 @@ dependencies = [
     "apache-airflow-providers-common-sql>=1.20.0",
     "apache-airflow-providers-common-compat>=1.4.0",
     "attrs>=22.2",
-    "openlineage-integration-common>=1.34.0",
-    "openlineage-python>=1.34.0",
+    "openlineage-integration-common>=1.36.0",
+    "openlineage-python>=1.36.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Version `1.36.0` was released for the `openlineage-integration-common` and `openlineage-python` packages. This PR bumps the dependency for the `apache-airflow-providers-openlineage`.

Release notes: https://openlineage.io/docs/releases/1_36_0