### PR TITLE
Restore proper DAG callback  execution context

### DIFF
--- a/airflow-core/src/airflow/callbacks/callback_requests.py
+++ b/airflow-core/src/airflow/callbacks/callback_requests.py
@@ -77,11 +77,19 @@ class TaskCallbackRequest(BaseCallbackRequest):
         }
 
 
+class DagRunContext(BaseModel):
+    """Class to pass context info from the server to build a Execution context object."""
+
+    dag_run: ti_datamodel.DagRun | None = None
+    last_ti: ti_datamodel.TaskInstance | None = None
+
+
 class DagCallbackRequest(BaseCallbackRequest):
     """A Class with information about the success/failure DAG callback to be executed."""
 
     dag_id: str
     run_id: str
+    context_from_server: DagRunContext | None = None
     is_failure_callback: bool | None = True
     """Flag to determine whether it is a Failure Callback or Success Callback"""
     type: Literal["DagCallbackRequest"] = "DagCallbackRequest"

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -40,8 +40,12 @@ from airflow.sdk.execution_time.comms import (
     DeleteVariable,
     ErrorResponse,
     GetConnection,
+    GetPreviousDagRun,
+    GetPrevSuccessfulDagRun,
     GetVariable,
     OKResponse,
+    PreviousDagRunResult,
+    PrevSuccessfulDagRunResult,
     PutVariable,
     VariableResult,
 )
@@ -94,12 +98,24 @@ class DagFileParsingResult(BaseModel):
 
 
 ToManager = Annotated[
-    DagFileParsingResult | GetConnection | GetVariable | PutVariable | DeleteVariable,
+    DagFileParsingResult
+    | GetConnection
+    | GetVariable
+    | PutVariable
+    | DeleteVariable
+    | GetPrevSuccessfulDagRun
+    | GetPreviousDagRun,
     Field(discriminator="type"),
 ]
 
 ToDagProcessor = Annotated[
-    DagFileParseRequest | ConnectionResult | VariableResult | ErrorResponse | OKResponse,
+    DagFileParseRequest
+    | ConnectionResult
+    | VariableResult
+    | PreviousDagRunResult
+    | PrevSuccessfulDagRunResult
+    | ErrorResponse
+    | OKResponse,
     Field(discriminator="type"),
 ]
 
@@ -209,6 +225,8 @@ def _execute_callbacks(
 
 
 def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: FilteringBoundLogger) -> None:
+    from airflow.sdk.api.datamodels._generated import TIRunContext
+
     dag = dagbag.dags[request.dag_id]
 
     callbacks = dag.on_failure_callback if request.is_failure_callback else dag.on_success_callback
@@ -217,12 +235,27 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
         return
 
     callbacks = callbacks if isinstance(callbacks, list) else [callbacks]
-    # TODO:We need a proper context object!
-    context: Context = {
-        "dag": dag,
-        "run_id": request.run_id,
-        "reason": request.msg,
-    }
+    ctx_from_server = request.context_from_server
+
+    if ctx_from_server is not None and ctx_from_server.last_ti is not None:
+        task = dag.get_task(ctx_from_server.last_ti.task_id)
+
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **ctx_from_server.last_ti.model_dump(exclude_unset=True),
+            task=task,
+            _ti_context_from_server=TIRunContext.model_construct(
+                dag_run=ctx_from_server.dag_run,
+                max_tries=task.retries,
+            ),
+        )
+        context = runtime_ti.get_template_context()
+        context["reason"] = request.msg
+    else:
+        context: Context = {  # type: ignore[no-redef]
+            "dag": dag,
+            "run_id": request.run_id,
+            "reason": request.msg,
+        }
 
     for callback in callbacks:
         log.info(
@@ -383,6 +416,17 @@ class DagFileProcessorProcess(WatchedSubprocess):
             self.client.variables.set(msg.key, msg.value, msg.description)
         elif isinstance(msg, DeleteVariable):
             resp = self.client.variables.delete(msg.key)
+        elif isinstance(msg, GetPreviousDagRun):
+            resp = self.client.dag_runs.get_previous(
+                dag_id=msg.dag_id,
+                logical_date=msg.logical_date,
+                state=msg.state,
+            )
+        elif isinstance(msg, GetPrevSuccessfulDagRun):
+            dagrun_resp = self.client.task_instances.get_previous_successful_dagrun(self.id)
+            dagrun_result = PrevSuccessfulDagRunResult.from_dagrun_response(dagrun_resp)
+            resp = dagrun_result
+            dump_opts = {"exclude_unset": True}
         else:
             log.error("Unhandled request", msg=msg)
             self.send_msg(

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -40,7 +40,7 @@ from sqlalchemy.sql import expression
 from airflow import settings
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
-from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallbackRequest
+from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext, TaskCallbackRequest
 from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
 from airflow.executors import workloads
@@ -1854,6 +1854,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     run_id=dag_run.run_id,
                     bundle_name=dag_model.bundle_name,
                     bundle_version=dag_run.bundle_version,
+                    context_from_server=DagRunContext(
+                        dag_run=dag_run,
+                        last_ti=dag_run.get_last_ti(dag=dag, session=session),
+                    ),
                     is_failure_callback=True,
                     msg="timed_out",
                 )

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -61,7 +61,7 @@ from sqlalchemy.sql.functions import coalesce
 from sqlalchemy_utils import UUIDType
 
 from airflow._shared.timezones import timezone
-from airflow.callbacks.callback_requests import DagCallbackRequest
+from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.listeners.listener import get_listener_manager
@@ -102,7 +102,7 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.dag_version import DagVersion
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.sdk import DAG as SDKDAG, Context
+    from airflow.sdk import DAG as SDKDAG
     from airflow.sdk.types import Operator
     from airflow.serialization.serialized_objects import SerializedBaseOperator as BaseOperator
     from airflow.utils.types import ArgNotSet
@@ -1186,6 +1186,10 @@ class DagRun(Base, LoggingMixin):
                     run_id=self.run_id,
                     bundle_name=self.dag_model.bundle_name,
                     bundle_version=self.bundle_version,
+                    context_from_server=DagRunContext(
+                        dag_run=self,
+                        last_ti=self.get_last_ti(dag=dag, session=session),
+                    ),
                     is_failure_callback=True,
                     msg="task_failure",
                 )
@@ -1215,6 +1219,10 @@ class DagRun(Base, LoggingMixin):
                     run_id=self.run_id,
                     bundle_name=self.dag_model.bundle_name,
                     bundle_version=self.bundle_version,
+                    context_from_server=DagRunContext(
+                        dag_run=self,
+                        last_ti=self.get_last_ti(dag=dag, session=session),
+                    ),
                     is_failure_callback=False,
                     msg="success",
                 )
@@ -1238,6 +1246,10 @@ class DagRun(Base, LoggingMixin):
                     run_id=self.run_id,
                     bundle_name=self.dag_model.bundle_name,
                     bundle_version=self.bundle_version,
+                    context_from_server=DagRunContext(
+                        dag_run=self,
+                        last_ti=self.get_last_ti(dag=dag, session=session),
+                    ),
                     is_failure_callback=True,
                     msg="all_tasks_deadlocked",
                 )
@@ -1350,13 +1362,63 @@ class DagRun(Base, LoggingMixin):
         # we can't get all the state changes on SchedulerJob,
         # or LocalTaskJob, so we don't want to "falsely advertise" we notify about that
 
+    @provide_session
+    def get_last_ti(self, dag: DAG, session: Session = NEW_SESSION) -> TI:
+        """Get Last TI from the dagrun to build and pass Execution context object from server to then run callbacks."""
+        tis = self.get_task_instances(session=session)
+        # tis from a dagrun may not be a part of dag.partial_subset,
+        # since dag.partial_subset is a subset of the dag.
+        # This ensures that we will only use the accessible TI
+        # context for the callback.
+        if dag.partial:
+            tis = [ti for ti in tis if not ti.state == State.NONE]
+        # filter out removed tasks
+        tis = [ti for ti in tis if ti.state != TaskInstanceState.REMOVED]
+        ti = tis[-1]  # get last TaskInstance of DagRun
+        return ti
+
     def handle_dag_callback(self, dag: SDKDAG, success: bool = True, reason: str = "success"):
         """Only needed for `dag.test` where `execute_callbacks=True` is passed to `update_state`."""
-        context: Context = {
-            "dag": dag,
-            "run_id": str(self.run_id),
-            "reason": reason,
-        }
+        from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+            DagRun as DRDataModel,
+            TaskInstance as TIDataModel,
+            TIRunContext,
+        )
+        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+
+        last_ti = self.get_last_ti(dag)  # type: ignore[arg-type]
+        last_ti_model = TIDataModel.model_validate(last_ti, from_attributes=True)
+        task = dag.get_task(last_ti.task_id)
+
+        dag_run_data = DRDataModel(
+            dag_id=self.dag_id,
+            run_id=self.run_id,
+            logical_date=self.logical_date,
+            data_interval_start=self.data_interval_start,
+            data_interval_end=self.data_interval_end,
+            run_after=self.run_after,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            run_type=self.run_type,
+            state=self.state,
+            conf=self.conf,
+            consumed_asset_events=[],
+        )
+
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **last_ti_model.model_dump(exclude_unset=True),
+            task=task,
+            _ti_context_from_server=TIRunContext(
+                dag_run=dag_run_data,
+                max_tries=last_ti.max_tries,
+                variables=[],
+                connections=[],
+                xcom_keys_to_clear=[],
+            ),
+            max_tries=last_ti.max_tries,
+        )
+        context = runtime_ti.get_template_context()
+        context["reason"] = reason
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback
         if not callbacks:

--- a/airflow-core/tests/unit/callbacks/test_callback_requests.py
+++ b/airflow-core/tests/unit/callbacks/test_callback_requests.py
@@ -22,8 +22,13 @@ from datetime import datetime
 import pytest
 
 from airflow._shared.timezones import timezone
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+    DagRun as DRDataModel,
+    TaskInstance as TIDataModel,
+)
 from airflow.callbacks.callback_requests import (
     DagCallbackRequest,
+    DagRunContext,
     TaskCallbackRequest,
 )
 from airflow.models.dag import DAG
@@ -114,3 +119,192 @@ class TestCallbackRequest:
         )
 
         assert request.is_failure_callback == expected_is_failure
+
+
+class TestDagRunContext:
+    def test_dagrun_context_creation(self):
+        """Test DagRunContext can be created with dag_run and first_ti"""
+        current_time = timezone.utcnow()
+        dag_run_data = DRDataModel(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=current_time,
+            data_interval_start=current_time,
+            data_interval_end=current_time,
+            run_after=current_time,
+            start_date=current_time,
+            end_date=None,
+            run_type="manual",
+            state="running",
+            consumed_asset_events=[],
+        )
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context = DagRunContext(dag_run=dag_run_data, last_ti=ti_data)
+
+        assert context.dag_run == dag_run_data
+        assert context.last_ti == ti_data
+
+    def test_dagrun_context_none_values(self):
+        """Test DagRunContext can be created with None values"""
+        context = DagRunContext()
+        assert context.dag_run is None
+        assert context.last_ti is None
+
+    def test_dagrun_context_serialization(self):
+        """Test DagRunContext can be serialized and deserialized"""
+        current_time = timezone.utcnow()
+        dag_run_data = DRDataModel(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=current_time,
+            data_interval_start=current_time,
+            data_interval_end=current_time,
+            run_after=current_time,
+            start_date=current_time,
+            end_date=None,
+            run_type="manual",
+            state="running",
+            consumed_asset_events=[],
+        )
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context = DagRunContext(dag_run=dag_run_data, last_ti=ti_data)
+
+        # Test serialization
+        serialized = context.model_dump_json()
+
+        # Test deserialization
+        deserialized = DagRunContext.model_validate_json(serialized)
+
+        assert deserialized.dag_run.dag_id == context.dag_run.dag_id
+        assert deserialized.last_ti.task_id == context.last_ti.task_id
+
+
+class TestDagCallbackRequestWithContext:
+    def test_dag_callback_request_with_context_from_server(self):
+        """Test DagCallbackRequest with context_from_server field"""
+        current_time = timezone.utcnow()
+        dag_run_data = DRDataModel(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=current_time,
+            data_interval_start=current_time,
+            data_interval_end=current_time,
+            run_after=current_time,
+            start_date=current_time,
+            end_date=None,
+            run_type="manual",
+            state="running",
+            consumed_asset_events=[],
+        )
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context_from_server = DagRunContext(dag_run=dag_run_data, last_ti=ti_data)
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            context_from_server=context_from_server,
+            is_failure_callback=True,
+            msg="test_failure",
+        )
+
+        assert request.context_from_server is not None
+        assert request.context_from_server.dag_run.dag_id == "test_dag"
+        assert request.context_from_server.last_ti.task_id == "test_task"
+
+    def test_dag_callback_request_without_context_from_server(self):
+        """Test DagCallbackRequest without context_from_server field"""
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            is_failure_callback=True,
+            msg="test_failure",
+        )
+
+        assert request.context_from_server is None
+
+    def test_dag_callback_request_serialization_with_context(self):
+        """Test DagCallbackRequest can be serialized and deserialized with context_from_server"""
+        current_time = timezone.utcnow()
+        dag_run_data = DRDataModel(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=current_time,
+            data_interval_start=current_time,
+            data_interval_end=current_time,
+            run_after=current_time,
+            start_date=current_time,
+            end_date=None,
+            run_type="manual",
+            state="running",
+            consumed_asset_events=[],
+        )
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context_from_server = DagRunContext(dag_run=dag_run_data, last_ti=ti_data)
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            context_from_server=context_from_server,
+            is_failure_callback=True,
+            msg="test_failure",
+        )
+
+        # Test serialization
+        json_str = request.to_json()
+
+        # Test deserialization
+        result = DagCallbackRequest.from_json(json_str)
+
+        assert result == request
+        assert result.context_from_server is not None
+        assert result.context_from_server.dag_run.dag_id == "test_dag"
+        assert result.context_from_server.last_ti.task_id == "test_task"

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -571,6 +571,7 @@ class TestDagFileProcessorManager:
                         run_id="run_id",
                         bundle_name="testing",
                         bundle_version=None,
+                        context_from_server=None,
                         is_failure_callback=False,
                     )
                 ],
@@ -586,6 +587,7 @@ class TestDagFileProcessorManager:
                             "msg": None,
                             "dag_id": "dag_id",
                             "run_id": "run_id",
+                            "context_from_server": None,
                             "is_failure_callback": False,
                             "type": "DagCallbackRequest",
                         }

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -35,14 +35,21 @@ from structlog.typing import FilteringBoundLogger
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+    DagRun as DRDataModel,
     TaskInstance as TIDataModel,
     TIRunContext,
 )
-from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest, TaskCallbackRequest
+from airflow.callbacks.callback_requests import (
+    CallbackRequest,
+    DagCallbackRequest,
+    DagRunContext,
+    TaskCallbackRequest,
+)
 from airflow.dag_processing.processor import (
     DagFileParseRequest,
     DagFileParsingResult,
     DagFileProcessorProcess,
+    _execute_dag_callbacks,
     _execute_task_callbacks,
     _parse_file,
     _pre_import_airflow_modules,
@@ -564,6 +571,263 @@ def test_parse_file_with_task_callbacks(spy_agency):
     )
 
     assert called is True
+
+
+class TestExecuteDagCallbacks:
+    """Test the _execute_dag_callbacks function with context_from_server"""
+
+    def test_execute_dag_callbacks_with_context_from_server(self, spy_agency):
+        """Test _execute_dag_callbacks uses RuntimeTaskInstance context when context_from_server is provided"""
+        called = False
+        context_received = None
+
+        def on_failure(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with DAG(dag_id="test_dag", on_failure_callback=on_failure) as dag:
+            BaseOperator(task_id="test_task")
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        current_time = timezone.utcnow()
+        dag_run_data = DRDataModel(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=current_time,
+            data_interval_start=current_time,
+            data_interval_end=current_time,
+            run_after=current_time,
+            start_date=current_time,
+            end_date=None,
+            run_type="manual",
+            state="running",
+            consumed_asset_events=[],
+        )
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context_from_server = DagRunContext(dag_run=dag_run_data, last_ti=ti_data)
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            context_from_server=context_from_server,
+            is_failure_callback=True,
+            msg="Test failure message",
+        )
+
+        log = structlog.get_logger()
+        _execute_dag_callbacks(dagbag, request, log)
+
+        assert called is True
+        assert context_received is not None
+        # When context_from_server is provided, we get a full RuntimeTaskInstance context
+        assert "dag_run" in context_received
+        assert "logical_date" in context_received
+        assert "reason" in context_received
+        assert context_received["reason"] == "Test failure message"
+        # Check that we have template context variables from RuntimeTaskInstance
+        assert "ts" in context_received
+        assert "params" in context_received
+
+    def test_execute_dag_callbacks_without_context_from_server(self, spy_agency):
+        """Test _execute_dag_callbacks falls back to simple context when context_from_server is None"""
+        called = False
+        context_received = None
+
+        def on_failure(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with DAG(dag_id="test_dag", on_failure_callback=on_failure) as dag:
+            BaseOperator(task_id="test_task")
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            context_from_server=None,  # No context from server
+            is_failure_callback=True,
+            msg="Test failure message",
+        )
+
+        log = structlog.get_logger()
+        _execute_dag_callbacks(dagbag, request, log)
+
+        assert called is True
+        assert context_received is not None
+        # When context_from_server is None, we get simple context
+        assert context_received["dag"] == dag
+        assert context_received["run_id"] == "test_run"
+        assert context_received["reason"] == "Test failure message"
+        # Should not have template context variables
+        assert "ts" not in context_received
+        assert "params" not in context_received
+
+    def test_execute_dag_callbacks_success_callback(self, spy_agency):
+        """Test _execute_dag_callbacks executes success callback with context_from_server"""
+        called = False
+        context_received = None
+
+        def on_success(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with DAG(dag_id="test_dag", on_success_callback=on_success) as dag:
+            BaseOperator(task_id="test_task")
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        # Create test data
+        current_time = timezone.utcnow()
+        dag_run_data = DRDataModel(
+            dag_id="test_dag",
+            run_id="test_run",
+            logical_date=current_time,
+            data_interval_start=current_time,
+            data_interval_end=current_time,
+            run_after=current_time,
+            start_date=current_time,
+            end_date=None,
+            run_type="manual",
+            state="success",
+            consumed_asset_events=[],
+        )
+
+        ti_data = TIDataModel(
+            id=uuid.uuid4(),
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+            map_index=-1,
+            try_number=1,
+            dag_version_id=uuid.uuid4(),
+        )
+
+        context_from_server = DagRunContext(dag_run=dag_run_data, last_ti=ti_data)
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            context_from_server=context_from_server,
+            is_failure_callback=False,  # Success callback
+            msg="Test success message",
+        )
+
+        log = structlog.get_logger()
+        _execute_dag_callbacks(dagbag, request, log)
+
+        assert called is True
+        assert context_received is not None
+        assert "dag_run" in context_received
+        assert context_received["reason"] == "Test success message"
+
+    def test_execute_dag_callbacks_multiple_callbacks(self, spy_agency):
+        """Test _execute_dag_callbacks executes multiple callbacks"""
+        call_count = 0
+
+        def on_failure_1(context):
+            nonlocal call_count
+            call_count += 1
+
+        def on_failure_2(context):
+            nonlocal call_count
+            call_count += 1
+
+        with DAG(dag_id="test_dag", on_failure_callback=[on_failure_1, on_failure_2]) as dag:
+            BaseOperator(task_id="test_task")
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            is_failure_callback=True,
+            msg="Test failure message",
+        )
+
+        log = structlog.get_logger()
+        _execute_dag_callbacks(dagbag, request, log)
+
+        assert call_count == 2
+
+    def test_execute_dag_callbacks_no_callback_defined(self, spy_agency):
+        """Test _execute_dag_callbacks when no callback is defined"""
+        with DAG(dag_id="test_dag") as dag:  # No callbacks defined
+            BaseOperator(task_id="test_task")
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            is_failure_callback=True,
+            msg="Test failure message",
+        )
+
+        log = MagicMock(spec=FilteringBoundLogger)
+        _execute_dag_callbacks(dagbag, request, log)
+
+        # Should log warning about no callback found
+        log.warning.assert_called_once_with("Callback requested, but dag didn't have any", dag_id="test_dag")
 
 
 class TestExecuteTaskCallbacks:

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import joinedload
 
 from airflow import settings
 from airflow._shared.timezones import timezone
-from airflow.callbacks.callback_requests import DagCallbackRequest
+from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun, DagRunNote
@@ -676,6 +676,10 @@ class TestDagRun:
             is_failure_callback=False,
             bundle_name="testing",
             bundle_version=None,
+            context_from_server=DagRunContext(
+                dag_run=dag_run,
+                last_ti=dag_run.get_last_ti(dag, session),
+            ),
             msg="success",
         )
 
@@ -727,6 +731,10 @@ class TestDagRun:
             msg="task_failure",
             bundle_name="testing",
             bundle_version=None,
+            context_from_server=DagRunContext(
+                dag_run=dag_run,
+                last_ti=dag_run.get_last_ti(dag, session),
+            ),
         )
 
     def test_dagrun_set_state_end_date(self, dag_maker, session):
@@ -2813,3 +2821,204 @@ def test_teardown_and_fail_fast(dag_maker):
         "tg_2.my_teardown": "skipped",
         "tg_2.my_work": "skipped",
     }
+
+
+class TestDagRunGetLastTi:
+    def test_get_last_ti_with_multiple_tis(self, dag_maker, session):
+        """Test get_last_ti returns the last TI (first created) when multiple TIs exist"""
+        with dag_maker("test_dag", session=session) as dag:
+            BashOperator(task_id="task1", bash_command="echo 1")
+            BashOperator(task_id="task2", bash_command="echo 2")
+            BashOperator(task_id="task3", bash_command="echo 3")
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances(session=session)
+        assert len(tis) == 3
+
+        # Mark some TIs with different states
+        tis[0].state = TaskInstanceState.SUCCESS
+        tis[1].state = TaskInstanceState.FAILED
+        tis[2].state = TaskInstanceState.RUNNING
+        session.commit()
+
+        last_ti = dr.get_last_ti(dag, session=session)
+
+        # Should return the last TI in the list (index -1)
+        assert last_ti is not None
+        assert last_ti == tis[-1]
+        assert last_ti.task_id == "task3"
+
+    def test_get_last_ti_filters_none_state_in_partial_dag(self, dag_maker, session):
+        """Test get_last_ti filters out NONE state TIs when dag is partial"""
+        with dag_maker("test_dag", session=session) as dag:
+            BashOperator(task_id="task1", bash_command="echo 1")
+            BashOperator(task_id="task2", bash_command="echo 2")
+
+        dr = dag_maker.create_dagrun()
+
+        dag.partial = True
+
+        # Create task instances with different states
+        tis = dr.get_task_instances(session=session)
+        tis[0].state = State.NONE  # Should be filtered out in partial DAG
+        tis[1].state = TaskInstanceState.RUNNING
+        session.commit()
+
+        last_ti = dr.get_last_ti(dag, session=session)
+
+        assert last_ti is not None
+        assert last_ti.state != State.NONE
+        assert last_ti.task_id == "task2"
+
+    def test_get_last_ti_filters_removed_tasks(self, dag_maker, session):
+        """Test get_last_ti filters out REMOVED task instances"""
+        with dag_maker("test_dag", session=session) as dag:
+            BashOperator(task_id="task1", bash_command="echo 1")
+            BashOperator(task_id="task2", bash_command="echo 2")
+            BashOperator(task_id="task3", bash_command="echo 3")
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances(session=session)
+
+        # Mark some TIs as removed
+        tis[0].state = TaskInstanceState.REMOVED
+        tis[1].state = TaskInstanceState.REMOVED
+        tis[2].state = TaskInstanceState.SUCCESS
+        session.commit()
+
+        last_ti = dr.get_last_ti(dag, session=session)
+
+        # Should return the TI that is not REMOVED
+        assert last_ti is not None
+        assert last_ti.state != TaskInstanceState.REMOVED
+        assert last_ti.task_id == "task3"
+
+    def test_get_last_ti_with_single_ti(self, dag_maker, session):
+        """Test get_last_ti works with single task instance"""
+        with dag_maker("test_dag", session=session) as dag:
+            BashOperator(task_id="single_task", bash_command="echo 1")
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances(session=session)
+        assert len(tis) == 1
+
+        last_ti = dr.get_last_ti(dag, session=session)
+
+        assert last_ti is not None
+        assert last_ti == tis[0]
+        assert last_ti.task_id == "single_task"
+
+
+class TestDagRunHandleDagCallback:
+    """Test the handle_dag_callback method (only uses in dag.test)."""
+
+    def test_handle_dag_callback_success(self, dag_maker, session):
+        """Test handle_dag_callback executes success callback with RuntimeTaskInstance context"""
+        called = False
+        context_received = None
+
+        def on_success(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with dag_maker("test_dag", session=session, on_success_callback=on_success) as dag:
+            BashOperator(task_id="test_task", bash_command="echo 1")
+
+        dr = dag_maker.create_dagrun()
+
+        dag.on_success_callback = on_success
+        dag.has_on_success_callback = True
+
+        dr.handle_dag_callback(dag, success=True, reason="test_success")
+
+        assert called is True
+        assert context_received is not None
+        # Should have RuntimeTaskInstance context with template variables
+        assert "dag_run" in context_received
+        assert "logical_date" in context_received
+        assert "reason" in context_received
+        assert context_received["reason"] == "test_success"
+        assert "ts" in context_received
+        assert "params" in context_received
+
+    def test_handle_dag_callback_failure(self, dag_maker, session):
+        """Test handle_dag_callback executes failure callback with RuntimeTaskInstance context"""
+        called = False
+        context_received = None
+
+        def on_failure(context):
+            nonlocal called, context_received
+            called = True
+            context_received = context
+
+        with dag_maker("test_dag", session=session, on_failure_callback=on_failure) as dag:
+            BashOperator(task_id="test_task", bash_command="echo 1")
+
+        dr = dag_maker.create_dagrun()
+
+        dag.on_failure_callback = on_failure
+        dag.has_on_failure_callback = True
+
+        dr.handle_dag_callback(dag, success=False, reason="test_failure")
+
+        assert called is True
+        assert context_received is not None
+        # Should have RuntimeTaskInstance context with template variables
+        assert "dag_run" in context_received
+        assert "logical_date" in context_received
+        assert "reason" in context_received
+        assert context_received["reason"] == "test_failure"
+        assert "ts" in context_received
+        assert "params" in context_received
+
+    def test_handle_dag_callback_multiple_callbacks(self, dag_maker, session):
+        """Test handle_dag_callback executes multiple callbacks"""
+        call_count = 0
+
+        def on_failure_1(context):
+            nonlocal call_count
+            call_count += 1
+
+        def on_failure_2(context):
+            nonlocal call_count
+            call_count += 1
+
+        with dag_maker("test_dag", session=session, on_failure_callback=[on_failure_1, on_failure_2]) as dag:
+            BashOperator(task_id="test_task", bash_command="echo 1")
+
+        dr = dag_maker.create_dagrun()
+
+        dag.on_failure_callback = [on_failure_1, on_failure_2]
+        dag.has_on_failure_callback = True
+
+        dr.handle_dag_callback(dag, success=False, reason="test_failure")
+
+        assert call_count == 2
+
+    def test_handle_dag_callback_context_has_correct_ti_info(self, dag_maker, session):
+        """Test handle_dag_callback context contains correct task instance information"""
+        context_received = None
+
+        def on_failure(context):
+            nonlocal context_received
+            context_received = context
+
+        with dag_maker("test_dag", session=session, on_failure_callback=on_failure) as dag:
+            BashOperator(task_id="test_task", bash_command="echo 1", retries=2)
+
+        dr = dag_maker.create_dagrun()
+
+        dag.on_failure_callback = on_failure
+        dag.has_on_failure_callback = True
+
+        dr.handle_dag_callback(dag, success=False, reason="test_failure")
+
+        assert context_received is not None
+        # Check that context contains correct task info
+        assert context_received["ti"].task_id == "test_task"
+        assert context_received["ti"].dag_id == "test_dag"
+        assert context_received["ti"].run_id == dr.run_id

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -613,14 +613,14 @@ class TriggeringAssetEventsAccessor(
 
 @cache  # Prevent multiple API access.
 def get_previous_dagrun_success(ti_id: UUID) -> PrevSuccessfulDagRunResponse:
+    from airflow.sdk.execution_time import task_runner
     from airflow.sdk.execution_time.comms import (
         GetPrevSuccessfulDagRun,
         PrevSuccessfulDagRunResponse,
         PrevSuccessfulDagRunResult,
     )
-    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    msg = SUPERVISOR_COMMS.send(GetPrevSuccessfulDagRun(ti_id=ti_id))
+    msg = task_runner.SUPERVISOR_COMMS.send(GetPrevSuccessfulDagRun(ti_id=ti_id))
 
     if TYPE_CHECKING:
         assert isinstance(msg, PrevSuccessfulDagRunResult)


### PR DESCRIPTION
This ensures DAG callbacks receive the same rich context as task callbacks, improving consistency and providing access to template variables and macros similar to Airflow 2.

This has been a blocker for few users similar to https://github.com/apache/airflow/pull/53058

Closes #52824
Closes #51402
Closes #51949
Closes #53654
Related to https://github.com/apache/airflow/discussions/53618


Logs from an example run:

```
{"timestamp":"2025-07-23T21:07:02.487673","level":"info","event":"Filling up the DagBag from /files/dags/daga.py","logger":"airflow.models.dagbag.DagBag"}
{"timestamp":"2025-07-23T21:07:02.514790","level":"info","event":"Executing on_success dag callback","dag_id":"a_dag","logger":"task"}
{"timestamp":"2025-07-23T21:07:02.520721Z","level":"info","event":"{'conn': <ConnectionAccessor (dynamic access)>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.520836Z","level":"info","event":" 'dag': <DAG: a_dag>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.520874Z","level":"info","event":" 'dag_run': DagRun(dag_id='a_dag', run_id='manual__2025-07-23T21:06:58.041559+00:00', logical_date=datetime.datetime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')), data_interval_start=datetime.datetime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')), data_interval_end=datetime.datetime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')), run_after=datetime.datetime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')), start_date=datetime.datetime(2025, 7, 23, 21, 6, 58, 575761, tzinfo=Timezone('UTC')), end_date=datetime.datetime(2025, 7, 23, 21, 7, 1, 507739, tzinfo=Timezone('UTC')), clear_number=0, run_type=<DagRunType.MANUAL: 'manual'>, state=<DagRunState.SUCCESS: 'success'>, conf={}, consumed_asset_events=[]),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.520925Z","level":"info","event":" 'data_interval_end': DateTime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.520964Z","level":"info","event":" 'data_interval_start': DateTime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.520993Z","level":"info","event":" 'ds': '2025-07-23',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521024Z","level":"info","event":" 'ds_nodash': '20250723',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521058Z","level":"info","event":" 'inlet_events': InletEventsAccessors(_inlets=[], _assets={}, _asset_aliases={}),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521087Z","level":"info","event":" 'inlets': [],","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521115Z","level":"info","event":" 'logical_date': DateTime(2025, 7, 23, 21, 6, 56, 583000, tzinfo=Timezone('UTC')),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521142Z","level":"info","event":" 'macros': <MacrosAccessor (dynamic access to macros)>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521170Z","level":"info","event":" 'map_index_template': None,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521197Z","level":"info","event":" 'outlet_events': <airflow.sdk.execution_time.context.OutletEventAccessors object at 0xffffa86d8520>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521225Z","level":"info","event":" 'outlets': [],","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.521256Z","level":"info","event":" 'params': {},","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.540978Z","level":"info","event":" 'prev_data_interval_end_success': <Proxy at 0xffffa86d9510 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffffa86b9900>>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541156Z","level":"info","event":" 'prev_data_interval_start_success': <Proxy at 0xffffa86d94e0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffffa86b9870>>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541273Z","level":"info","event":" 'prev_end_date_success': <Proxy at 0xffffa86d8ee0 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffffa86bad40>>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541346Z","level":"info","event":" 'prev_start_date_success': <Proxy at 0xffffa86d8a30 with factory <function RuntimeTaskInstance.get_template_context.<locals>.<lambda> at 0xffffab843400>>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541404Z","level":"info","event":" 'reason': 'success',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541512Z","level":"info","event":" 'run_id': 'manual__2025-07-23T21:06:58.041559+00:00',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541622Z","level":"info","event":" 'task': <Task(_PythonDecoratedOperator): print_the_context>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541730Z","level":"info","event":" 'task_instance': RuntimeTaskInstance(id=UUID('0198391c-619c-77b9-b26b-a41462239ff8'), task_id='print_the_context', dag_id='a_dag', run_id='manual__2025-07-23T21:06:58.041559+00:00', try_number=1, dag_version_id=UUID('01983904-64e0-7aa9-bda6-592268defae2'), map_index=-1, hostname='aa8528989b89', context_carrier=None, task=<Task(_PythonDecoratedOperator): print_the_context>, max_tries=0, end_date=None, state=None, is_mapped=None, rendered_map_index=None, log_url=None),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541849Z","level":"info","event":" 'task_instance_key_str': 'a_dag__print_the_context__20250723',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.541985Z","level":"info","event":" 'task_reschedule_count': 0,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542045Z","level":"info","event":" 'ti': RuntimeTaskInstance(id=UUID('0198391c-619c-77b9-b26b-a41462239ff8'), task_id='print_the_context', dag_id='a_dag', run_id='manual__2025-07-23T21:06:58.041559+00:00', try_number=1, dag_version_id=UUID('01983904-64e0-7aa9-bda6-592268defae2'), map_index=-1, hostname='aa8528989b89', context_carrier=None, task=<Task(_PythonDecoratedOperator): print_the_context>, max_tries=0, end_date=None, state=None, is_mapped=None, rendered_map_index=None, log_url=None),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542088Z","level":"info","event":" 'triggering_asset_events': TriggeringAssetEventsAccessor(_events=defaultdict(<class 'list'>, {})),","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542118Z","level":"info","event":" 'ts': '2025-07-23T21:06:56.583000+00:00',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542148Z","level":"info","event":" 'ts_nodash': '20250723T210656',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542176Z","level":"info","event":" 'ts_nodash_with_tz': '20250723T210656.583000+0000',","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542204Z","level":"info","event":" 'var': {'json': <VariableAccessor (dynamic access)>,","chan":"stdout","logger":"processor"}
{"timestamp":"2025-07-23T21:07:02.542232Z","level":"info","event":"         'value': <VariableAccessor (dynamic access)>}}","chan":"stdout","logger":"processor"}

```

Dag used:

```py
from pprint import pprint
import pendulum
from airflow.sdk import dag, task, Context


def test_cb(context: Context):
    pprint(context)


@dag(
    on_success_callback=test_cb,
)
def a_dag():
    @task(task_id="print_the_context")
    def print_context(**kwargs):
        pass

    print_context()

example_dag = a_dag()
```

<img width="1728" height="782" alt="image" src="https://github.com/user-attachments/assets/dd338af0-9d56-4463-ada3-720e0052419c" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
