### PR TITLE
Resolve serialization for numpy bool 1.x and 2.x compatibility

### DIFF
--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -84,8 +84,4 @@ def deserialize(cls: type, version: int, data: str) -> Any:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    name = qualname(cls)
-    if name not in deserializers:
-        raise TypeError(f"unsupported {name} found for numpy deserialization")
-
     return cls(data)

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from airflow.utils.module_loading import import_string, qualname
+from airflow.utils.module_loading import qualname
 
 # lazy loading for performance reasons
 serializers = [
@@ -31,11 +31,12 @@ serializers = [
     "numpy.uint16",
     "numpy.uint32",
     "numpy.uint64",
-    "numpy.bool_",
     "numpy.float64",
     "numpy.float16",
     "numpy.complex128",
     "numpy.complex64",
+    "numpy.bool",
+    "numpy.bool_",
 ]
 
 if TYPE_CHECKING:
@@ -70,7 +71,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     ):
         return int(o), *metadata
 
-    if isinstance(o, np.bool_):
+    if hasattr(np, "bool") and isinstance(o, np.bool) or isinstance(o, np.bool_):
         return bool(o), *metadata
 
     if isinstance(o, (np.float16, np.float32, np.float64, np.complex64, np.complex128)):
@@ -83,9 +84,8 @@ def deserialize(cls: type, version: int, data: str) -> Any:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    allowed_deserialize_classes = [import_string(classname) for classname in deserializers]
-
-    if cls not in allowed_deserialize_classes:
-        raise TypeError(f"unsupported {qualname(cls)} found for numpy deserialization")
+    name = qualname(cls)
+    if name not in deserializers:
+        raise TypeError(f"unsupported {name} found for numpy deserialization")
 
     return cls(data)

--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -32,6 +32,7 @@ serializers = [
     "numpy.uint32",
     "numpy.uint64",
     "numpy.float64",
+    "numpy.float32",
     "numpy.float16",
     "numpy.complex128",
     "numpy.complex64",

--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -261,7 +261,6 @@ class TestSerializers:
         ("klass", "ver", "value", "msg"),
         [
             (np.int32, 999, 123, r"serialized version is newer"),
-            (np.float32, 1, 123, r"unsupported numpy\.float32"),
         ],
     )
     def test_numpy_deserialize_errors(self, klass, ver, value, msg):

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import enum
+import textwrap
 from collections import namedtuple
 from dataclasses import dataclass
 from importlib import import_module, metadata
@@ -83,30 +84,23 @@ def generate_serializers_importable_and_str_test_cases():
         mod = import_module(name)
         for s in getattr(mod, "serializers", list()):
             if s == "numpy.bool" and NUMPY_VERSION.major < 2:
-                serializer_collection.append(
-                    pytest.param(
-                        name,
-                        s,
-                        marks=pytest.mark.xfail(
-                            reason=f"""
-                        Current NumPy version: {NUMPY_VERSION}
+                reason = textwrap.dedent(f"""\
+                    Current NumPy version: {NUMPY_VERSION}
 
-                        In NumPy 1.20, `numpy.bool` was deprecated as an alias for the built-in `bool`.
-                        For NumPy versions <= 1.26, attempting to import `numpy.bool` raises an ImportError.
-                        Starting with NumPy 2.0, `numpy.bool` is reintroduced as the NumPy scalar type,
-                        and `numpy.bool_` becomes an alias for `numpy.bool`.
+                    In NumPy 1.20, `numpy.bool` was deprecated as an alias for the built-in `bool`.
+                    For NumPy versions <= 1.26, attempting to import `numpy.bool` raises an ImportError.
+                    Starting with NumPy 2.0, `numpy.bool` is reintroduced as the NumPy scalar type,
+                    and `numpy.bool_` becomes an alias for `numpy.bool`.
 
-                        The serializers are loaded lazily at runtime. As a result:
-                        - With NumPy <= 1.26, only `numpy.bool_` is loaded.
-                        - With NumPy >= 2.0, only `numpy.bool` is loaded.
+                    The serializers are loaded lazily at runtime. As a result:
+                    - With NumPy <= 1.26, only `numpy.bool_` is loaded.
+                    - With NumPy >= 2.0, only `numpy.bool` is loaded.
 
-                        This test case deliberately attempts to import both `numpy.bool` and `numpy.bool_`,
-                        regardless of the installed NumPy version. Therefore, when NumPy <= 1.26 is installed,
-                        importing `numpy.bool` will raise an ImportError.
-                        """
-                        ),
-                    )
-                )
+                    This test case deliberately attempts to import both `numpy.bool` and `numpy.bool_`,
+                    regardless of the installed NumPy version. Therefore, when NumPy <= 1.26 is installed,
+                    importing `numpy.bool` will raise an ImportError.
+                """)
+                serializer_collection.append(pytest.param(name, s, marks=pytest.mark.xfail(reason=reason)))
             else:
                 serializer_collection.append((name, s))
     return serializer_collection

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -394,6 +394,8 @@ class TestSerDe:
 
         import airflow.serialization.serializers
 
+        NUMPY_VERSION = version.parse(metadata.version("numpy"))
+
         for _, name, _ in iter_namespace(airflow.serialization.serializers):
             if name == "airflow.serialization.serializers.iceberg":
                 try:
@@ -412,20 +414,23 @@ class TestSerDe:
                 try:
                     import_string(s)
                 except ImportError:
-                    # In NumPy 1.20, `numpy.bool` was deprecated as an alias for the built-in `bool`.
-                    # For NumPy versions <= 1.26, attempting to import `numpy.bool` raises an ImportError.
-                    # Starting with NumPy 2.0, `numpy.bool` is reintroduced as the NumPy scalar type,
-                    # and `numpy.bool_` becomes an alias for `numpy.bool`.
-                    #
-                    # The serializers are loaded lazily at runtime. As a result:
-                    # - With NumPy <= 1.26, only `numpy.bool_` is loaded.
-                    # - With NumPy >= 2.0, only `numpy.bool` is loaded.
-                    #
-                    # This test case deliberately attempts to import both `numpy.bool` and `numpy.bool_`,
-                    # regardless of the installed NumPy version. Therefore, when NumPy <= 1.26 is installed,
-                    # importing `numpy.bool` will raise an ImportError.
-                    if version.parse(metadata.version("numpy")).major < 2 and s == "numpy.bool":
-                        continue
+                    if NUMPY_VERSION.major < 2 and s == "numpy.bool":
+                        pytest.xfail(f"""
+                        Current NumPy version: {NUMPY_VERSION}
+
+                        In NumPy 1.20, `numpy.bool` was deprecated as an alias for the built-in `bool`.
+                        For NumPy versions <= 1.26, attempting to import `numpy.bool` raises an ImportError.
+                        Starting with NumPy 2.0, `numpy.bool` is reintroduced as the NumPy scalar type,
+                        and `numpy.bool_` becomes an alias for `numpy.bool`.
+                        
+                        The serializers are loaded lazily at runtime. As a result:
+                        - With NumPy <= 1.26, only `numpy.bool_` is loaded.
+                        - With NumPy >= 2.0, only `numpy.bool` is loaded.
+                        
+                        This test case deliberately attempts to import both `numpy.bool` and `numpy.bool_`,
+                        regardless of the installed NumPy version. Therefore, when NumPy <= 1.26 is installed,
+                        importing `numpy.bool` will raise an ImportError.
+                        """)
                     raise AttributeError(f"{s} cannot be imported (located in {name})")
 
     def test_stringify(self):


### PR DESCRIPTION
Create this PR to help review the solution for #52753 
Closes: #52753 

### Unit Test
the testing ran in the breeze environment with numpy `1.26.4` installed. The following test case failed because it attempted to import `numpy.bool`. `np.bool` was a deprecated alias for the built-in Python `bool` type, introduced in NumPy version `1.20.0`. `np.bool_` is the Numpy scalar. If we keep both `"numpy.bool"` and `"numpy.bool_"` in the list of serializers and the list of deserializers, we might need to update this test case to run based on the installed numpy version. Or, update the code to check which numpy version we have and import and check the right bool (https://github.com/apache/airflow/issues/52753#issuecomment-3107668476).

```
breeze testing core-tests --test-type Serialization
```
<img width="1286" height="927" alt="Screenshot from 2025-07-23 21-36-12" src="https://github.com/user-attachments/assets/985eefab-d796-49ce-a86d-d9a2356844b7" />
<img width="1255" height="221" alt="Screenshot from 2025-07-23 21-36-38" src="https://github.com/user-attachments/assets/3b8d3e6f-dc4c-416e-ab8f-fb1e359c0f5b" />

then, I created a init file `files/airflow-breeze-config/init.sh` to run `uv pip install --upgrade pandas`. This upgrade both pandas and numpy to the following versions. We may not only update one package, because the pandas depends on the numpy package and can result in the error mentioned https://github.com/apache/airflow/issues/52753#issuecomment-3094732633. The test case that failed when numpy `1.26.4` is installed now pass because `numpy.bool` is the NumPy scalar in `2.3.1`.
```
Installed 2 packages in 116ms
- numpy==1.26.4
+ numpy==2.3.1
- pandas==2.1.4
+ pandas==2.3.1
```
<img width="1255" height="221" alt="Screenshot from 2025-07-23 22-03-51" src="https://github.com/user-attachments/assets/24650064-8595-4cce-8b35-689c8f05dcd0" />

If we only upgrade numpy to 2.x and didn't update pandas, the following error is raised. (`uv pip install --upgrade numpy`)
```
Installed 1 package in 188ms
- numpy==1.26.4
+ numpy==2.3.1
```
<img width="1255" height="331" alt="Screenshot from 2025-07-23 22-06-31" src="https://github.com/user-attachments/assets/d54fb4cb-8ec3-4d5b-a05f-55f9f490919d" />


### DAG Test (Run-time Behavior)
**Numpy version 1.26.4**
<img width="1285" height="801" alt="Screenshot from 2025-07-23 21-25-14" src="https://github.com/user-attachments/assets/ead88de2-4e01-4086-9c61-5d9e161b93e9" />

**Numpy version 2.3.1**
<img width="1285" height="801" alt="Screenshot from 2025-07-23 21-25-25" src="https://github.com/user-attachments/assets/6559eb17-d915-4d31-ab98-bf7c2e69e4d2" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
