### PR TITLE
Standardize key sorting to match jsonc natural sort rule

### DIFF
--- a/dev/i18n/check_translations_completeness.py
+++ b/dev/i18n/check_translations_completeness.py
@@ -518,23 +518,12 @@ def add_missing_translations(language: str, summary: dict[str, LocaleSummary], c
 
         add_keys(en_data, lang_data)
 
-        # Write back to file, preserving order and using eslint-style key sorting
-        def eslint_key_sort(obj):
+        def natural_key_sort(obj):
             if isinstance(obj, dict):
-                # Sort keys: numbers first, then uppercase, then lowercase, then others (eslint default)
-                def sort_key(k):
-                    if k.isdigit():
-                        return (0, int(k))
-                    if k and k[0].isupper():
-                        return (1, k)
-                    if k and k[0].islower():
-                        return (2, k)
-                    return (3, k)
-
-                return {k: eslint_key_sort(obj[k]) for k in sorted(obj, key=sort_key)}
+                return {k: natural_key_sort(obj[k]) for k in sorted(obj, key=lambda x: (x.lower(), x))}
             return obj
 
-        lang_data = eslint_key_sort(lang_data)
+        lang_data = natural_key_sort(lang_data)
         lang_path.parent.mkdir(parents=True, exist_ok=True)
         with open(lang_path, "w", encoding="utf-8") as f:
             json.dump(lang_data, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## problem
This PR resolves an inconsistency between the ESLint jsonc/sort-keys rule and the key sorting logic used in check_translations_completeness.py. 
https://github.com/apache/airflow/blob/0c178848bf42dcb1a48435ddb09056ba9625daf9/airflow-core/src/airflow/ui/rules/jsonc.js#L37-L45

https://github.com/apache/airflow/blob/0c178848bf42dcb1a48435ddb09056ba9625daf9/dev/i18n/check_translations_completeness.py#L522-L534
The mismatch caused unstable key ordering in translation files, leading to unnecessary diffs and confusion.

### JSONC (natural: true) sorting behavior
* Sorting is based on x.lower(), so it's case-insensitive
* Special characters (like _) generally come before alphabetical characters

### eslint_key_sort() sorting behavior
* Keys starting with special characters like _ fall into the last category return (3, k)

To address this, the key sorting logic is updated to follow the same behavior as ESLint JSONC(natural: true).

## Changes
* Replace custom ESLint-style sorting with natural sort (case-insensitive, human-friendly order)
* Rename eslint_key_sort → natural_key_sort for clarity

closes: #53663

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
