### PR TITLE
Initialize DAG bundles and sync dags in CLI `get_dag` function

### DIFF
--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -295,10 +295,13 @@ def get_dag(
         manager = DagBundlesManager()
         all_bundles = list(manager.get_all_dag_bundles())
         for bundle in all_bundles:
+            bundle.initialize()
+            manager.sync_bundles_to_db()
             with _airflow_parsing_context_manager(dag_id=dag_id):
                 dag_bag = DagBag(
                     dag_folder=dagfile_path or bundle.path, bundle_path=bundle.path, include_examples=False
                 )
+                dag_bag.sync_to_db(bundle.name, bundle.version)
             dag = dag_bag.dags.get(dag_id)
             if dag:
                 break

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -293,10 +293,11 @@ def get_dag(
         if from_db:
             raise AirflowException(f"Dag {dag_id!r} could not be found in DagBag read from database.")
         manager = DagBundlesManager()
+        manager.sync_bundles_to_db()
         all_bundles = list(manager.get_all_dag_bundles())
         for bundle in all_bundles:
             bundle.initialize()
-            manager.sync_bundles_to_db()
+
             with _airflow_parsing_context_manager(dag_id=dag_id):
                 dag_bag = DagBag(
                     dag_folder=dagfile_path or bundle.path, bundle_path=bundle.path, include_examples=False

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -843,7 +843,7 @@ class TestCliDags:
         )
         from airflow.example_dags.plugins.workday import AfterWorkdayTimetable
 
-        with mock.patch.object(AfterWorkdayTimetable, "get_next_workday", side_effect=[DEFAULT_DATE]):
+        with mock.patch.object(AfterWorkdayTimetable, "get_next_workday", return_value=DEFAULT_DATE):
             dag_command.dag_test(cli_args)
         assert "data_interval" in mock__get_or_create_dagrun.call_args.kwargs
 

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -276,9 +276,6 @@ class TestCliTasks:
         """
         tasks render should render and displays templated fields for a given mapping task
         """
-        dag = DagBag().get_dag("test_mapped_classic")
-        dag.sync_to_db()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_render(
                 self.parser.parse_args(


### PR DESCRIPTION
Add bundle.initialize() call before parsing DAGs in CLI commands to ensure
bundles are properly initialized. This fixes an issue where CLI commands
could not parse DAGs because serialized DAGs were required but bundles
were not initialized, preventing DAG runs from being created.

Closes:#53682

