### PR TITLE
Fix incorrect `bash_command` example

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -279,7 +279,7 @@ Often, many Operators inside a DAG need the same set of default arguments (such 
         schedule="@daily",
         default_args={"retries": 2},
     ):
-        op = BashOperator(task_id="hello_world", bash_command="Hello World!")
+        op = BashOperator(task_id="hello_world", bash_command="echo Hello World!")
         print(op.retries)  # 2
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

# Summary
One-word fix in one of the core doc pages. The `echo` command is missing unlike the other examples so I'm just adding it in.

# Motivation

Copy-pasting the example blew up in my terminal.

<!-- Please keep an empty line above the dashes. -->