### PR TITLE
Fix variable name in EKS command for token expiration timestamp

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
@@ -100,7 +100,7 @@ COMMAND = """
 
             json_string=$(printf '{{"kind": "ExecCredential","apiVersion": \
                 "client.authentication.k8s.io/v1alpha1","spec": {{}},"status": \
-                {{"expirationTimestamp": "%s","token": "%s"}}}}' "$expiration_timestamp" "$token")
+                {{"expirationTimestamp": "%s","token": "%s"}}}}' "$timestamp" "$token")
             echo $json_string
             """
 


### PR DESCRIPTION
Closes: #53626

# Why

There is a typo in the variable.

https://github.com/apache/airflow/blob/70ff46b57991843760560a6258bbccc6bdca53d5/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py#L103

# How

Change it to `timestamp`.

# What

```bash
cat <<EOF > get_token.py
output=\$(cat output.txt)

status=\$?

if [ "\$status" -ne 0 ]; then
    printf '%s' "\$output" >&2
    exit "\$status"
fi

# Use pure bash below to parse so that it's posix compliant
last_line=\${output##*$'\n'}  # strip everything up to the last newline

timestamp=\${last_line#expirationTimestamp: }  # drop the label
timestamp=\${timestamp%%,*}  # keep up to the first comma

token=\${last_line##*, token: }  # text after ", token: "

json_string=\$(printf '{"kind": "ExecCredential","apiVersion":                 "client.authentication.k8s.io/v1alpha1","spec": {},"status":                 {"expirationTimestamp": "%s","token": "%s"}}' "\$expiration_timestamp" "\$token")
echo \$json_string
EOF
```

Then we can see the `expirationTimestamp` is back.

```console
root@c30540d9dba1:/opt/airflow# bash get_token.py 
{"kind": "ExecCredential","apiVersion": "client.authentication.k8s.io/v1alpha1","spec": {},"status": {"expirationTimestamp": "2025-07-22T08:47:47Z","token": "foo"}}
```