### PR TITLE
Making some brittle tests related to log assertion more robust

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from kubernetes.client.rest import ApiException
@@ -841,9 +841,7 @@ class TestSparkKubernetesSensor:
         mock_log_call.assert_called_once_with(
             "spark-pi-2020-02-24-1-driver", namespace="default", container="spark-kubernetes-driver"
         )
-        log_info_call = info_log_call.mock_calls[2]
-        log_value = log_info_call[1][0]
-        assert log_value == TEST_POD_LOG_RESULT
+        assert call(TEST_POD_LOG_RESULT) in info_log_call.mock_calls
 
     @patch(
         "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
@@ -888,6 +886,4 @@ class TestSparkKubernetesSensor:
         mock_log_call.assert_called_once_with(
             "spark-pi-2020-02-24-1-driver", namespace="default", container="spark-kubernetes-driver"
         )
-        log_info_call = info_log_call.mock_calls[2]
-        log_value = log_info_call[1][0]
-        assert log_value == TEST_POD_LOG_RESULT
+        assert call(TEST_POD_LOG_RESULT) in info_log_call.mock_calls


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While working on https://github.com/apache/airflow/pull/53704, I realised that some tests were relying on index order to assert whether a certain log is present or not.

This is super brittle and https://github.com/apache/airflow/pull/53704 is a classic example. I changed the log order from info => debug and the order of assertion in these tests broke down. That shouldn't be the case, an update in a base layer shouldn't affect provider tests that badly.

Making the tests more robust by asserting presence vs absence.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
