### PR TITLE
Unconditionally disable start_from_trigger

### DIFF
--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -72,13 +72,18 @@ class MappedOperator(TaskSDKMappedOperator):
 
         :meta private:
         """
-        if not self.partial_kwargs.get("start_from_trigger", self.start_from_trigger):
+        if self.partial_kwargs.get("start_from_trigger", self.start_from_trigger):
             log.warning(
                 "Starting a mapped task from triggerer is currently unsupported",
                 task_id=self.task_id,
                 dag_id=self.dag_id,
             )
-            return False
+
+        # This is intentional. start_from_trigger does not work correctly with
+        # sdk-db separation yet, so it is disabled unconditionally for now.
+        # TODO: TaskSDK: Implement this properly.
+        return False
+
         # start_from_trigger only makes sense when start_trigger_args exists.
         if not self.start_trigger_args:
             return False


### PR DESCRIPTION
This is a fixup to #52861. While the fix resolves the issue in RC, the simple flip of conditional creates a log message where it should not appear.

This flips the conditional back (so the log only shows when it should), and adds a separate return statement to unconditionally disable the feature. The start-from-trigger feature is known to not work in 3 (see #48009).