### PR TITLE
Making another brittle test related to log assertion more robust

### DIFF
--- a/providers/apache/flink/tests/unit/apache/flink/sensors/test_flink_kubernetes.py
+++ b/providers/apache/flink/tests/unit/apache/flink/sensors/test_flink_kubernetes.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from kubernetes.client import V1ObjectMeta, V1Pod, V1PodList
@@ -1130,10 +1130,7 @@ class TestFlinkKubernetesSensor:
             namespace="default", watch=False, label_selector="component=taskmanager,app=flink-stream-example"
         )
         mock_pod_logs.assert_called_once_with("basic-example-taskmanager-1-1", namespace="default")
-        log_info_call = info_log_call.mock_calls[4]
-        log_value = log_info_call[1][0]
-
-        assert log_value == TEST_POD_LOG_RESULT
+        assert call(TEST_POD_LOG_RESULT) in info_log_call.mock_calls
 
         mock_namespaced_crd.assert_called_once_with(
             group="flink.apache.org",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

```
======================================================================================== short test summary info =========================================================================================
FAILED providers/apache/flink/tests/unit/apache/flink/sensors/test_flink_kubernetes.py::TestFlinkKubernetesSensor::test_driver_logging_completed - assert equals failed
  'Flink application ended successfully'                                                        "2022-09-25 19:01:47,027 INFO  KubernetesTaskExecutorRunner [] - ---------\nSuccessful regis 
                                                                                                tration at resource manager akka.tcp://flink@basic-example.default:6\nReceive slot request 8 
                                                                                                0a7ef3e8cc1a2c09b4e3b2fbd70b28d for job 363eed78e59\nCheckpoint storage is set to 'jobmanage 
                                                                                                r'\nFlat Map -> Sink: Print to Std. Out (2/2)#0 (e7492dc4a) switched to RUNNING."
============================================================ 1 failed, 13193 passed, 3707 skipped, 1 xfailed, 5 warnings in 630.90s (0:10:30) ============================================================
```

related to https://github.com/apache/airflow/pull/53743


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
