### PR TITLE
Remove extra slash from endpoint URL

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/simple/token.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/simple/token.rst
@@ -30,7 +30,7 @@ Example
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X 'POST' \
         "${ENDPOINT_URL}/auth/token" \
         -H 'Content-Type: application/json' \
@@ -45,5 +45,5 @@ If ``[core] simple_auth_manager_all_admins`` is set to True, you can also genera
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X 'GET' "${ENDPOINT_URL}/auth/token"

--- a/airflow-core/docs/howto/docker-compose/index.rst
+++ b/airflow-core/docs/howto/docker-compose/index.rst
@@ -279,7 +279,7 @@ Here is a sample ``curl`` command, which sends a request to retrieve a pool list
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X GET  \
         --user "airflow:airflow" \
         "${ENDPOINT_URL}/api/v1/pools"

--- a/airflow-core/docs/security/api.rst
+++ b/airflow-core/docs/security/api.rst
@@ -43,7 +43,7 @@ Request
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X POST ${ENDPOINT_URL}/auth/token \
       -H "Content-Type: application/json" \
       -d '{
@@ -63,7 +63,7 @@ Use the JWT token to call Airflow public API
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X GET ${ENDPOINT_URL}/api/v2/dags \
       -H "Authorization: Bearer <JWT-TOKEN>"
 

--- a/providers/fab/docs/auth-manager/api-authentication.rst
+++ b/providers/fab/docs/auth-manager/api-authentication.rst
@@ -66,7 +66,7 @@ work. This means that your user name should be ``user_name@REALM``.
 .. code-block:: bash
 
     kinit user_name@REALM
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X GET  \
         --negotiate \  # enables Negotiate (SPNEGO) authentication
         --service airflow \  # matches the `airflow` service name in the `airflow/fully.qualified.domainname@REALM` principal
@@ -106,7 +106,7 @@ Here is a sample curl command you can use to validate the setup:
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X GET  \
         --user "username:password" \
         "${ENDPOINT_URL}/api/v1/pools"

--- a/providers/fab/docs/auth-manager/token.rst
+++ b/providers/fab/docs/auth-manager/token.rst
@@ -30,7 +30,7 @@ Example
 
 .. code-block:: bash
 
-    ENDPOINT_URL="http://localhost:8080/"
+    ENDPOINT_URL="http://localhost:8080"
     curl -X 'POST' \
         "${ENDPOINT_URL}/auth/token" \
         -H 'Content-Type: application/json' \

--- a/providers/google/docs/api-auth-backend/google-openid.rst
+++ b/providers/google/docs/api-auth-backend/google-openid.rst
@@ -59,7 +59,7 @@ look like the following.
 
   .. code-block:: bash
 
-      ENDPOINT_URL="http://localhost:8080/"
+      ENDPOINT_URL="http://localhost:8080"
 
       AUDIENCE="project-id-random-value.apps.googleusercontent.com"
       ID_TOKEN="$(gcloud auth print-identity-token "--audiences=${AUDIENCE}")"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adjusts the documentation in the API sections re. how to generate a token.

### Current behavior 
The extra slash causes `Method Not Allowed` error.

### Changes
- Remove the extra `/` in the definition of the endpoint URL

When removing the slash, the cURL request works as expected.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
