### PR TITLE
Fix: ignore connection schema when schema is none in mongo hook

### DIFF
--- a/providers/mongo/src/airflow/providers/mongo/hooks/mongo.py
+++ b/providers/mongo/src/airflow/providers/mongo/hooks/mongo.py
@@ -212,7 +212,11 @@ class MongoHook(BaseHook):
             netloc = f"{quote_plus(login)}:{quote_plus(password)}@{netloc}"
         if self.connection.port:
             netloc = f"{netloc}:{self.connection.port}"
-        path = f"/{self.connection.schema}"
+
+        if self.connection.schema:
+            path = f"/{self.connection.schema}"
+        else:
+            path = ""
         return urlunsplit((scheme, netloc, path, "", ""))
 
     def get_collection(self, mongo_collection: str, mongo_db: str | None = None) -> MongoCollection:

--- a/providers/mongo/tests/unit/mongo/hooks/test_mongo.py
+++ b/providers/mongo/tests/unit/mongo/hooks/test_mongo.py
@@ -283,7 +283,7 @@ class TestMongoHook:
         self.hook.connection.login = None
         self.hook.connection.password = None
         self.hook.connection.port = None
-        assert self.hook._create_uri() == "mongodb://mongo/None"
+        assert self.hook._create_uri() == "mongodb://mongo"
 
     def test_create_uri_srv_true(self):
         self.hook.extras["srv"] = True


### PR DESCRIPTION
When removing mongomock, found the schema is consider even when its none.
https://github.com/apache/airflow/pull/53773

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
