### PR TITLE
Fix flaky test_get_last_ti_with_multiple_tis by ensuring natural task_id sorting using natsort

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -30,6 +30,7 @@ from typing import (
     overload,
 )
 
+from natsort import natsorted
 from sqlalchemy import (
     JSON,
     Column,
@@ -1373,7 +1374,10 @@ class DagRun(Base, LoggingMixin):
         if dag.partial:
             tis = [ti for ti in tis if not ti.state == State.NONE]
         # filter out removed tasks
-        tis = [ti for ti in tis if ti.state != TaskInstanceState.REMOVED]
+        tis = natsorted(
+            (ti for ti in tis if ti.state != TaskInstanceState.REMOVED),
+            key=lambda ti: ti.task_id,
+        )
         if not tis:
             return None
         ti = tis[-1]  # get last TaskInstance of DagRun

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ version = "3.1.0"
 dependencies = [
     "apache-airflow-task-sdk<1.2.0,>=1.0.0",
     "apache-airflow-core==3.1.0",
+    "natsort>=8.4.0",
 ]
 
 packages = []


### PR DESCRIPTION
### Description

<img width="2048" height="675" alt="image" src="https://github.com/user-attachments/assets/a035d725-79a5-4da5-962e-79cf4bfee447" />
https://github.com/apache/airflow/actions/runs/16537752338/job/46774859176?pr=53597


See failure example: https://github.com/apache/airflow/actions/runs/16537752338/job/46774859176?pr=53597

This happened because `DagRun.get_task_instances()` returns TaskInstances in a non-deterministic order (usually depending on the database), and the test incorrectly assumed that the last TI in the returned list would be the one with the lexicographically largest `task_id`.

### Solution

To ensure consistent behavior, we now explicitly sort TaskInstances by `task_id` in natural (human-friendly) order using `natsort`, so that:

- `"task2"` comes before `"task10"`
- `tis[-1]` now reliably refers to the correct "last" task when sorted by `task_id`

This ensures `DagRun.get_last_ti()` behaves deterministically and the associated test is no longer flaky.

### Changes

- Use `natsorted` in `get_last_ti()` to sort TIs by `task_id` in a stable natural order
- Document rationale in the code




<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
