### PR TITLE
Add user facing docs for running a separate Task Execution API-server

### DIFF
--- a/airflow-core/docs/administration-and-deployment/web-stack.rst
+++ b/airflow-core/docs/administration-and-deployment/web-stack.rst
@@ -20,6 +20,10 @@
 Web Stack
 =========
 
+
+Configuration
+-------------
+
 Sometimes you want to deploy the backend and frontend behind a
 variable url path prefix. To do so, you can configure the url :ref:`config:api__base_url`
 for instance, set it to ``http://localhost:28080/d12345``. All the APIs routes will
@@ -30,3 +34,26 @@ and served successfully.
 You will also need to update the execution API server url
 :ref:`config:core__execution_api_server_url` for tasks to be able to reach the API
 with the new prefix.
+
+Separating API Servers
+-----------------------
+
+By default, both the Core API Server and the Execution API Server are served together:
+
+.. code-block:: bash
+
+   airflow api-server
+   # same as
+   airflow api-server --apps all
+   # or
+   airflow api-server --apps core,execution
+
+If you want to separate the Core API Server and the Execution API Server, you can run them
+separately. This might be useful for scaling them independently or for deploying them on different machines.
+
+.. code-block:: bash
+
+   # serve only the Core API Server
+   airflow api-server --apps core
+   # serve only the Execution API Server
+   airflow api-server --apps execution


### PR DESCRIPTION

closes: #43103

## What

After #52929 patch, the CLI command of API Server will respect `--apps` flag, so we need to add corresponding user facing docs for running a separate Task Execution API-server.
