### PR TITLE
Add deprecation warnings + doc for `airflow.security.permissions`

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -239,7 +239,7 @@ Additional Caveats
 ^^^^^^^^^^^^^^^^^^
 
 * Your auth manager should not reference anything from the ``airflow.security.permissions`` module, as that module is in the process of being deprecated.
-  Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``.
+  Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``. For more details on the ``airflow.security.permissions`` deprecation, see :doc:`security/auth-manager/deprecated_permissions`
 * The ``access_control`` attribute of a DAG instance is only compatible with the FAB auth manager. Custom auth manager implementations should leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
 * You may find it useful to define a private, generalized ``_is_authorized`` method which acts as the standardized authorization mechanism, and which each
   public ``is_authorized_*`` method calls with the appropriate parameters.
@@ -271,5 +271,3 @@ Once you have created a new auth manager class implementing the :class:`~airflow
 
 .. note::
     For more information on Airflow's configuration, see :doc:`/howto/set-config` and for more information on managing Python modules in Airflow see :doc:`/administration-and-deployment/modules_management`.
-
-Deprecation Notice for

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -239,7 +239,7 @@ Additional Caveats
 ^^^^^^^^^^^^^^^^^^
 
 * Your auth manager should not reference anything from the ``airflow.security.permissions`` module, as that module is in the process of being deprecated.
-  Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``. For more details on the ``airflow.security.permissions`` deprecation, see :doc:`security/auth-manager/deprecated_permissions`
+  Instead, your code should use the definitions in ``airflow.api_fastapi.auth.managers.models.resource_details``. For more details on the ``airflow.security.permissions`` deprecation, see :doc:`/security/deprecated_permissions`
 * The ``access_control`` attribute of a DAG instance is only compatible with the FAB auth manager. Custom auth manager implementations should leverage ``get_authorized_dag_ids`` for DAG instance attribute-based access controls in more customizable ways (e.g. authorization based on DAG tags, DAG bundles, etc.).
 * You may find it useful to define a private, generalized ``_is_authorized`` method which acts as the standardized authorization mechanism, and which each
   public ``is_authorized_*`` method calls with the appropriate parameters.

--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -271,3 +271,5 @@ Once you have created a new auth manager class implementing the :class:`~airflow
 
 .. note::
     For more information on Airflow's configuration, see :doc:`/howto/set-config` and for more information on managing Python modules in Airflow see :doc:`/administration-and-deployment/modules_management`.
+
+Deprecation Notice for

--- a/airflow-core/docs/security/deprecated_permissions.rst
+++ b/airflow-core/docs/security/deprecated_permissions.rst
@@ -23,7 +23,7 @@ Since the release of Airflow 3, the Flask AppBuilder (AKA "FAB") provider is
 However, some modules specifically designed for :doc:`apache-airflow-providers-fab:auth-manager/index` remain in the core Airflow distribution as a
 backwards-compatible convenience for Airflow users. One such module which remains in the core distribution for backwards compatibility purposes is ``airflow.security.permissions``
 
-If your on ``airflow.security.permissions`` for any custom role definitions, or for any custom Auth Manager logic --
+If your deployment depends on ``airflow.security.permissions`` for any custom role definitions, or for any custom Auth Manager logic --
 regardless of whether you use the FAB Auth Manager or some other Auth Manager -- you should transition
 to the new authorization standard definitions for resources and actions.
 The deprecated ``airflow.security.permissions`` will be removed in Airflow 4.
@@ -34,10 +34,10 @@ Does this Deprecation Affect My Airflow System?
 Generally speaking, this deprecation warning applies to any Airflow system in which **either** of the following is true:
 
 * The Airflow deployment relies on ``airflow.security.permissions`` to define custom RBAC roles.
-* The Airflow deployment has other custom logic which relies on ``airflow.security.permissions``, including any custom :doc:`core-concepts/auth-manager/index` dependencies.
+* The Airflow deployment has other custom logic which relies on ``airflow.security.permissions``, including any custom :doc:`/core-concepts/auth-manager/index` dependencies.
 
 However, if you rely on the **unmodified** :doc:`apache-airflow-providers-fab:auth-manager/index` and you **do not** use any custom role definitions, then the rest of this doc does not apply to you.
-Similarly, if you rely on the :doc:`simple/index` or any of the other provider Auth Managers, and have no custom code using ``airflow.security.permissions``, then the rest of this doc does not apply to you.
+Similarly, if you rely on the :doc:`/core-concepts/auth-manager/simple/index` or any of the other provider Auth Managers, and have no custom code using ``airflow.security.permissions``, then the rest of this doc does not apply to you.
 
 .. note::
     Each customized Airflow RBAC setup differs on a case-by-case basis. As such, this doc can only provide general
@@ -59,7 +59,7 @@ replacement component in Airflow core:
 | ``DAG.access_control``                      | Generally, DAG-level permissions should be handled via the chosen Auth Manager's ``filter_authorized_dag_ids`` method. |
 +---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
 
-If you maintain a custom :doc:`core-concepts/auth-manager/index` which relies on the deprecated module, it is
+If you maintain a custom :doc:`/core-concepts/auth-manager/index` which relies on the deprecated module, it is
 recommended you refer to the ``SimpleAuthManager``'s `source code <https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py>`_
 as an example for how you might use the ``ResourceMethod`` and ``resource_details`` components.
 

--- a/airflow-core/docs/security/deprecated_permissions.rst
+++ b/airflow-core/docs/security/deprecated_permissions.rst
@@ -1,0 +1,66 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Deprecation Notice for airflow.security.permissions
+===================================================
+
+Since the release of Airflow 3, the Flask AppBuilder (AKA "FAB") provider is
+`no longer a core Airflow dependency <https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-79%3A+Remove+Flask+AppBuilder+as+Core+dependency>`_.
+However, some modules specifically designed for :doc:`apache-airflow-providers-fab:auth-manager/index` remain in the core Airflow distribution as a
+backwards-compatible convenience for Airflow users. One such module which remains in the core distribution for backwards compatibility purposes is ``airflow.security.permissions``
+
+If your on ``airflow.security.permissions`` for any custom role definitions, or for any custom Auth Manager logic --
+regardless of whether you use the FAB Auth Manager or some other Auth Manager -- you should transition
+to the new authorization standard definitions for resources and actions.
+The deprecated ``airflow.security.permissions`` will be removed in Airflow 4.
+
+Does this Deprecation Affect My Airflow System?
+-----------------------------------------------
+
+Generally speaking, this deprecation warning applies to any Airflow system in which **either** of the following is true:
+
+* The Airflow deployment relies on ``airflow.security.permissions`` to define custom RBAC roles.
+* The Airflow deployment has other custom logic which relies on ``airflow.security.permissions``, including any custom :doc:`core-concepts/auth-manager/index` dependencies.
+
+However, if you rely on the **unmodified** :doc:`apache-airflow-providers-fab:auth-manager/index` and you **do not** use any custom role definitions, then the rest of this doc does not apply to you.
+Similarly, if you rely on the :doc:`simple/index` or any of the other provider Auth Managers, and have no custom code using ``airflow.security.permissions``, then the rest of this doc does not apply to you.
+
+.. note::
+    Each customized Airflow RBAC setup differs on a case-by-case basis. As such, this doc can only provide general
+    guidance for the transition to the new Airflow authorization standards, without being overly prescriptive.
+
+How to Migrate to the New Authorization Standard Definitions
+------------------------------------------------------------
+
+The table below lists the deprecated permissions module components, and the corresponding supported
+replacement component in Airflow core:
+
++---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| Deprecated                                  | Supported Standard                                                                                                     |
++=======================+==============================================================================================================================================+
+| ``airflow.security.permissions.ACTION_*``   | ``airflow.api_fastapi.auth.managers.base_auth_manager.ResourceMethod``                                                 |
++---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| ``airflow.security.permissions.RESOURCE_*`` | ``airflow.api_fastapi.auth.managers.models.resource_details``                                                          |
++---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| ``DAG.access_control``                      | Generally, DAG-level permissions should be handled via the chosen Auth Manager's ``filter_authorized_dag_ids`` method. |
++---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+
+If you maintain a custom :doc:`core-concepts/auth-manager/index` which relies on the deprecated module, it is
+recommended you refer to the ``SimpleAuthManager``'s `source code <https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py>`_
+as an example for how you might use the ``ResourceMethod`` and ``resource_details`` components.
+
+If you rely on custom role definitions based off the deprecated module, you should refer to the documentation of the auth manager your system uses.

--- a/airflow-core/docs/security/deprecated_permissions.rst
+++ b/airflow-core/docs/security/deprecated_permissions.rst
@@ -46,18 +46,12 @@ Similarly, if you rely on the :doc:`/core-concepts/auth-manager/simple/index` or
 How to Migrate to the New Authorization Standard Definitions
 ------------------------------------------------------------
 
-The table below lists the deprecated permissions module components, and the corresponding supported
-replacement component in Airflow core:
+Refer to the list below for the deprecated permissions module components, and the corresponding supported
+replacement available from Airflow core:
 
-+---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
-| Deprecated                                  | Supported Standard                                                                                                     |
-+=======================+==============================================================================================================================================+
-| ``airflow.security.permissions.ACTION_*``   | ``airflow.api_fastapi.auth.managers.base_auth_manager.ResourceMethod``                                                 |
-+---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
-| ``airflow.security.permissions.RESOURCE_*`` | ``airflow.api_fastapi.auth.managers.models.resource_details``                                                          |
-+---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
-| ``DAG.access_control``                      | Generally, DAG-level permissions should be handled via the chosen Auth Manager's ``filter_authorized_dag_ids`` method. |
-+---------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+* ``airflow.security.permissions.ACTION_*`` --> ``airflow.api_fastapi.auth.managers.base_auth_manager.ResourceMethod``
+* ``airflow.security.permissions.RESOURCE_*`` --> ``airflow.api_fastapi.auth.managers.models.resource_details``
+* ``DAG.access_control`` --> DAG-level permissions should be handled by the chosen Auth Manager's ``filter_authorized_dag_ids`` method.
 
 If you maintain a custom :doc:`/core-concepts/auth-manager/index` which relies on the deprecated module, it is
 recommended you refer to the ``SimpleAuthManager``'s `source code <https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py>`_

--- a/airflow-core/newsfragments/53796.misc.rst
+++ b/airflow-core/newsfragments/53796.misc.rst
@@ -1,0 +1,1 @@
+Add ``RemovedInAirflow4Warning`` warnings for ``airflow.security.permissions`` imports and ``access_control`` DAG attribute usage.

--- a/airflow-core/src/airflow/security/permissions.py
+++ b/airflow-core/src/airflow/security/permissions.py
@@ -16,7 +16,17 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from typing import TypedDict
+
+from airflow.exceptions import RemovedInAirflow4Warning
+
+warnings.warn(
+    "The airflow.security.permissions module is deprecated; please see https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html",
+    RemovedInAirflow4Warning,
+    stacklevel=2,
+)
+
 
 # Resource Constants
 RESOURCE_ACTION = "Permissions"

--- a/airflow-core/tests/unit/security/test_permissions_deprecation_warning.py
+++ b/airflow-core/tests/unit/security/test_permissions_deprecation_warning.py
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib
+import re
+
+import pytest
+
+from airflow.exceptions import RemovedInAirflow4Warning
+from airflow.security import permissions
+
+
+def test_permissions_import_warns() -> None:
+    """Ensures that imports of `airflow.security.permissions` trigger a `RemovedInAirflow4Warning`."""
+    with pytest.warns(
+        RemovedInAirflow4Warning, match=re.escape("The airflow.security.permissions module is deprecated")
+    ):
+        importlib.reload(permissions)

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -470,7 +470,7 @@ class DAG:
             self.default_args["start_date"] = timezone.convert_to_utc(start_date)
         if end_date := self.default_args.get("end_date", None):
             self.default_args["end_date"] = timezone.convert_to_utc(end_date)
-        if self.access_control is not None and len(self.access_control) > 0:
+        if self.access_control is not None:
             warnings.warn(
                 "The airflow.security.permissions module is deprecated; please see https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html",
                 RemovedInAirflow4Warning,

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -23,6 +23,7 @@ import itertools
 import logging
 import os
 import sys
+import warnings
 import weakref
 from collections import abc
 from collections.abc import Callable, Collection, Iterable, MutableSet
@@ -46,6 +47,7 @@ from airflow.exceptions import (
     DuplicateTaskIdFound,
     FailFastDagInvalidTriggerRule,
     ParamValidationError,
+    RemovedInAirflow4Warning,
     TaskNotFound,
 )
 from airflow.sdk.bases.operator import BaseOperator
@@ -468,6 +470,12 @@ class DAG:
             self.default_args["start_date"] = timezone.convert_to_utc(start_date)
         if end_date := self.default_args.get("end_date", None):
             self.default_args["end_date"] = timezone.convert_to_utc(end_date)
+        if self.access_control is not None and len(self.access_control) > 0:
+            warnings.warn(
+                "The airflow.security.permissions module is deprecated; please see https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html",
+                RemovedInAirflow4Warning,
+                stacklevel=2,
+            )
 
     @params.validator
     def _validate_params(self, _, params: ParamsDict):

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -16,13 +16,15 @@
 # under the License.
 from __future__ import annotations
 
+import re
+import warnings
 import weakref
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
 
-from airflow.exceptions import DuplicateTaskIdFound
+from airflow.exceptions import DuplicateTaskIdFound, RemovedInAirflow4Warning
 from airflow.sdk.bases.operator import BaseOperator
 from airflow.sdk.definitions.dag import DAG, dag as dag_decorator
 from airflow.sdk.definitions.param import DagParam, Param, ParamsDict
@@ -140,6 +142,36 @@ class TestDag:
         assert op7.dag == dag
         assert op8.dag == dag
         assert op9.dag == dag2
+
+    @pytest.mark.parametrize("access_control", [None, {}])
+    def test_none_or_empty_access_control_does_not_warn(self, access_control: dict[str, Any] | None) -> None:
+        """Ensure that `RemovedInAirflow4Warning` warnings do not arise when `access_control` is `None` or empty."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _ = DAG(
+                "test-no-warnings-dag", access_control=access_control, schedule=None, start_date=DEFAULT_DATE
+            )
+
+    @pytest.mark.parametrize(
+        "role_access_control_entry",
+        [
+            {"DAGs": {}},
+            {"DAG Runs": {}},
+            {"DAGs": {}, "DAG Runs": {}},
+            {"DAGs": {"can_read"}},
+            {"DAG Runs": {"can_read"}},
+            {"DAGs": {"can_read"}, "DAG Runs": {"can_read"}},
+        ],
+    )
+    def test_non_empty_access_control_warns(
+        self, role_access_control_entry: dict[str, set[str]] | None
+    ) -> None:
+        """Ensure that `RemovedInAirflow4Warning` warnings are triggered when `access_control` is non-empty."""
+        access_control = {"fake-role": role_access_control_entry}
+        with pytest.warns(
+            RemovedInAirflow4Warning, match=re.escape("The airflow.security.permissions module is deprecated")
+        ):
+            _ = DAG("should-warn-dag", access_control=access_control, schedule=None, start_date=DEFAULT_DATE)
 
     def test_params_not_passed_is_empty_dict(self):
         """

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -143,18 +143,16 @@ class TestDag:
         assert op8.dag == dag
         assert op9.dag == dag2
 
-    @pytest.mark.parametrize("access_control", [None, {}])
-    def test_none_or_empty_access_control_does_not_warn(self, access_control: dict[str, Any] | None) -> None:
-        """Ensure that `RemovedInAirflow4Warning` warnings do not arise when `access_control` is `None` or empty."""
+    def test_none_or_empty_access_control_does_not_warn(self) -> None:
+        """Ensure that `RemovedInAirflow4Warning` warnings do not arise when `access_control` is `None`."""
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            _ = DAG(
-                "test-no-warnings-dag", access_control=access_control, schedule=None, start_date=DEFAULT_DATE
-            )
+            _ = DAG("test-no-warnings-dag", access_control=None, schedule=None, start_date=DEFAULT_DATE)
 
     @pytest.mark.parametrize(
         "role_access_control_entry",
         [
+            {},
             {"DAGs": {}},
             {"DAG Runs": {}},
             {"DAGs": {}, "DAG Runs": {}},
@@ -163,11 +161,13 @@ class TestDag:
             {"DAGs": {"can_read"}, "DAG Runs": {"can_read"}},
         ],
     )
-    def test_non_empty_access_control_warns(
-        self, role_access_control_entry: dict[str, set[str]] | None
-    ) -> None:
+    def test_non_empty_access_control_warns(self, role_access_control_entry: dict[str, set[str]]) -> None:
         """Ensure that `RemovedInAirflow4Warning` warnings are triggered when `access_control` is non-empty."""
-        access_control = {"fake-role": role_access_control_entry}
+        access_control = (
+            {"fake-role": role_access_control_entry}
+            if len(role_access_control_entry) > 0
+            else role_access_control_entry
+        )
         with pytest.warns(
             RemovedInAirflow4Warning, match=re.escape("The airflow.security.permissions module is deprecated")
         ):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Related Issue: https://github.com/apache/airflow/issues/53716

## What?
* Adds `RemovedInAirflow4Warning` upon import of `airflow.security.permissions`, per the [deprecation policy](https://airflow.apache.org/docs/apache-airflow/stable/release-process.html#deprecation-policy)
* Adds `RemovedInAirflow4Warning` for DAG definitions which set the `access_control` attribute to a non-empty value.
* Adds a new doc detailing the deprecation of `airflow.security.permissions`, with general guidance on user migrations. The relevant warning messages surface the link to this doc.

## Testing
- Added relevant import warning test, and `access_control` warning tests.
- for airflow-core: ran`uv run pytest --skip-db-tests -n auto tests/unit`
- for task-sdk: ran `uv run pytest --skip-db-tests tests/task_sdk/definitions`
- for providers with Auth Manager implementations: ran 
    ```shell
    breeze testing providers-tests \
    --run-in-parallel --skip-db-tests \
    --parallel-test-types "Providers[amazon] Providers[keycloak] Providers[fab]"
    ```
- for doc builds: ran `breeze build-docs --docs-only --package-filter apache-airflow`