### PR TITLE
Handling auto classification of providers with longer paths

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -196,18 +196,17 @@ TYPE_OF_CHANGE_DESCRIPTION = {
 
 
 def classification_result(provider_id, changed_files):
-    provider_path = f"providers/{provider_id}/"
-    changed_files = list(filter(lambda f: f.startswith(provider_path), changed_files))
+    changed_files = list(filter(lambda f: provider_id in f, changed_files))
 
     if not changed_files:
         return "other"
 
     def is_doc(f):
-        return re.match(r"^providers/[^/]+/docs/", f) and f.endswith(".rst")
+        return re.match(r"^providers/.+/docs/", f) and f.endswith(".rst")
 
     def is_test_or_example(f):
-        return re.match(r"^providers/[^/]+/tests/", f) or re.match(
-            r"^providers/[^/]+/src/airflow/providers/[^/]+/example_dags/", f
+        return re.match(r"^providers/.+/tests/", f) or re.match(
+            r"^providers/.+/src/airflow/providers/.+/example_dags/", f
         )
 
     all_docs = all(is_doc(f) for f in changed_files)

--- a/dev/breeze/tests/test_provider_documentation.py
+++ b/dev/breeze/tests/test_provider_documentation.py
@@ -399,7 +399,16 @@ def test_get_most_impactful_change(changes, expected):
     [
         pytest.param("slack", ["providers/slack/docs/slack.rst"], "documentation", id="only_docs"),
         pytest.param(
+            "flink", ["providers/apache/flink/docs/slack.rst"], "documentation", id="only_docs_longer_path"
+        ),
+        pytest.param(
             "slack", ["providers/slack/tests/test_slack.py"], "test_or_example_only", id="only_tests"
+        ),
+        pytest.param(
+            "flink",
+            ["providers/apache/flink/tests/unit/apache/flink/sensors/test_flink_kubernetes.py"],
+            "test_or_example_only",
+            id="only_tests_longer_path",
         ),
         pytest.param(
             "slack",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

@eladkal caught a case where autoclassification was not done for https://github.com/apache/airflow/pull/53747/files. The reason for that was the regex was not matching the providers with longer names like the apache ones.

Updated it and added some tests too.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
