### PR TITLE
Rework Dashboard page to prepare plugins integration

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
@@ -36,9 +36,11 @@ export const Dashboard = () => {
 
   return (
     <Box overflow="auto" px={4}>
-      <VStack alignItems="start">
+      <VStack alignItems="stretch" gap={6}>
+        {/* All flex items within this VStack should specify an increasing order. This
+        will be used by third parties plugins to position themselves within the page via CSS */}
         {alerts.length > 0 ? (
-          <Accordion.Root collapsible defaultValue={["ui_alerts"]}>
+          <Accordion.Root collapsible defaultValue={["ui_alerts"]} order={1}>
             <Accordion.Item key="ui_alerts" value="ui_alerts">
               {alerts.map((alert: UIAlert, index) =>
                 index === 0 ? (
@@ -58,23 +60,23 @@ export const Dashboard = () => {
             </Accordion.Item>
           </Accordion.Root>
         ) : undefined}
-        <Heading mb={2} size="2xl">
+        <Heading order={2} size="2xl">
           {translate("welcome")}
         </Heading>
+        <Box order={3}>
+          <Stats />
+        </Box>
+        <Box order={4}>
+          <FavoriteDags />
+        </Box>
+        <Box display="flex" gap={8} order={5}>
+          <Health />
+          <PoolSummary />
+        </Box>
+        <Box order={6}>
+          <HistoricalMetrics />
+        </Box>
       </VStack>
-      <Box>
-        <Stats />
-      </Box>
-      <Box mt={5}>
-        <FavoriteDags />
-      </Box>
-      <Box display="flex" gap={8} mt={8}>
-        <Health />
-        <PoolSummary />
-      </Box>
-      <Box mt={8}>
-        <HistoricalMetrics />
-      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
Goal of this PR:

Update the Dashboard layout, visually it shouldn't bring much difference, but now the entire page is withing a flex container, with specified ordering of flex items. This will then be used by React plugins to be able to position themself within the page only via CSS properties.

### Before
<img width="1920" height="936" alt="Screenshot 2025-07-28 at 15 24 26" src="https://github.com/user-attachments/assets/85b2b514-7783-423b-a130-1d24272f8038" />


### After 
<img width="1920" height="933" alt="Screenshot 2025-07-28 at 15 23 47" src="https://github.com/user-attachments/assets/cb7056b6-ad32-4737-85ab-85333b0e0ebe" />
