### PR TITLE
Handle no_status in TaskInstance translation. Add translation to state in header component.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
@@ -34,7 +34,11 @@ export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceR
       row: {
         original: { state },
       },
-    }) => <StateBadge state={state}>{translate(`common:states.${state}`)}</StateBadge>,
+    }) => (
+      <StateBadge state={state}>
+        {state ? translate(`common:states.${state}`) : translate("common:states.no_status")}
+      </StateBadge>
+    ),
     header: translate("state"),
   },
   {

--- a/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, Flex, GridItem, Heading, HStack, Spinner } from "@chakra-ui/react";
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { Stat } from "src/components/Stat";
@@ -33,24 +34,30 @@ type Props = {
   readonly title: ReactNode | string;
 };
 
-export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle, title }: Props) => (
-  <Box borderColor="border" borderRadius={8} borderWidth={1} ml={2} p={2}>
-    <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
-      <Flex alignItems="center" flexWrap="wrap" gap={2}>
-        <Heading size="xl">{icon}</Heading>
-        <Heading size="lg">{title}</Heading>
-        <Heading size="lg">{subTitle}</Heading>
-        {state === undefined ? undefined : <StateBadge state={state}>{state}</StateBadge>}
-        {isRefreshing ? <Spinner /> : <div />}
+export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle, title }: Props) => {
+  const { t: translate } = useTranslation();
+
+  return (
+    <Box borderColor="border" borderRadius={8} borderWidth={1} ml={2} p={2}>
+      <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
+        <Flex alignItems="center" flexWrap="wrap" gap={2}>
+          <Heading size="xl">{icon}</Heading>
+          <Heading size="lg">{title}</Heading>
+          <Heading size="lg">{subTitle}</Heading>
+          {state === undefined ? undefined : (
+            <StateBadge state={state}>{state ? translate(`common:states.${state}`) : undefined}</StateBadge>
+          )}
+          {isRefreshing ? <Spinner /> : <div />}
+        </Flex>
+        <HStack gap={1}>{actions}</HStack>
       </Flex>
-      <HStack gap={1}>{actions}</HStack>
-    </Flex>
-    <HStack alignItems="flex-start" flexWrap="wrap" gap={5} justifyContent="space-between" my={2}>
-      {stats.map(({ label, value }) => (
-        <GridItem key={label}>
-          <Stat label={label}>{value}</Stat>
-        </GridItem>
-      ))}
-    </HStack>
-  </Box>
-);
+      <HStack alignItems="flex-start" flexWrap="wrap" gap={5} justifyContent="space-between" my={2}>
+        {stats.map(({ label, value }) => (
+          <GridItem key={label}>
+            <Stat label={label}>{value}</Stat>
+          </GridItem>
+        ))}
+      </HStack>
+    </Box>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -56,7 +56,7 @@ export const Details = () => {
           <Table.Cell>
             <Flex gap={1}>
               <StateBadge state={dagRun.state} />
-              {dagRun.state}
+              {translate(`common:states.${dagRun.state}`)}
             </Flex>
           </Table.Cell>
         </Table.Row>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -116,7 +116,11 @@ const taskInstanceColumns = ({
       row: {
         original: { state },
       },
-    }) => <StateBadge state={state}>{translate(`common:states.${state}`)}</StateBadge>,
+    }) => (
+      <StateBadge state={state}>
+        {state ? translate(`common:states.${state}`) : translate("common:states.no_status")}
+      </StateBadge>
+    ),
     header: () => translate("state"),
   },
   {


### PR DESCRIPTION
`state` being null is not handled for TaskInstance leading to `states.null` in clear task instance dialog and list task instances. Translation is also missing for the state in header card and dag run detail.