### PR TITLE
Fix poolbar counts

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, Link } from "@chakra-ui/react";
+import { Flex, Link, Box } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -54,13 +54,12 @@ export const PoolBar = ({
               alignItems="center"
               bg={`${color}.solid`}
               color="white"
-              flex={flexValue}
               gap={1}
               h="100%"
               justifyContent="center"
               px={1}
-              py={0.5}
               textAlign="center"
+              w="100%"
             >
               {icon}
               {slotValue}
@@ -69,11 +68,13 @@ export const PoolBar = ({
         );
 
         return color !== "success" && "name" in pool ? (
-          <Link asChild key={key}>
+          <Link asChild display="flex" flex={flexValue} key={key}>
             <RouterLink to={`/task_instances?state=${color}&pool=${pool.name}`}>{poolContent}</RouterLink>
           </Link>
         ) : (
-          poolContent
+          <Box display="flex" flex={flexValue} key={key}>
+            {poolContent}
+          </Box>
         );
       })}
     </>

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -37,7 +37,17 @@ export const PoolSummary = () => {
   const hasPoolsAccess = authLinks?.authorized_menu_items.includes("Pools");
 
   const pools = data?.pools;
-  const totalSlots = pools?.reduce((sum, pool) => sum + pool.slots, 0) ?? 0;
+  const totalSlots =
+    pools?.reduce(
+      (sum, pool) =>
+        sum +
+        pool.running_slots +
+        pool.queued_slots +
+        pool.deferred_slots +
+        pool.scheduled_slots +
+        pool.open_slots,
+      0,
+    ) ?? 0;
   const aggregatePool: Slots = {
     deferred_slots: 0,
     open_slots: 0,

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
@@ -64,7 +64,16 @@ const PoolBarCard = ({ pool }: PoolBarCardProps) => {
 
       <Box margin={4}>
         <Flex bg="gray.muted" borderRadius="md" h="20px" overflow="hidden" w="100%">
-          <PoolBar pool={pool} totalSlots={pool.slots} />
+          <PoolBar
+            pool={pool}
+            totalSlots={
+              pool.running_slots +
+              pool.queued_slots +
+              pool.deferred_slots +
+              pool.scheduled_slots +
+              pool.open_slots
+            }
+          />
         </Flex>
       </Box>
     </Box>


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/52272

This just fixes the bars. Indeed as mentioned in the related issue we might want to reconsider how we build this because the total number of slots displayed can grow beyond the total pool slots. This is caused by the fact that we display in the same way state that take up a pool slots and those that do not. (QUEUE, RUNNING, OPEN) should always be included, (DEFERRED) should only be included if configured, and SCHEDULED / DEFERRED (if not configured) should probably be displayed outside of that pool occupancy bar, to not confuse users.

This is a bigger effort to improve the UI to not have this confusion anymore and find a way to clearly display the difference between all kind of slots. (also because this component is shared with multiple pools summary) for the short term I just fixed the bar, and will create an issue for the follow up. 


### Before
<img width="1911" height="764" alt="Screenshot 2025-07-28 at 17 59 35" src="https://github.com/user-attachments/assets/0124a1bd-f7cc-4b1e-901b-311072762b3e" />
<img width="1909" height="647" alt="Screenshot 2025-07-28 at 17 59 42" src="https://github.com/user-attachments/assets/a90fd200-7db0-437a-9a64-69ef715a36f1" />


### After:
<img width="1881" height="556" alt="Screenshot 2025-07-28 at 17 59 08" src="https://github.com/user-attachments/assets/e875be04-b48c-48f7-8df1-86dd482fbe2c" />
<img width="1916" height="480" alt="Screenshot 2025-07-28 at 17 59 18" src="https://github.com/user-attachments/assets/59a84dcc-8d08-47ad-b770-7900dd0212b9" />
