### PR TITLE
Revert "Restrict tokenizers 0.21.4 as source distributions missing"

### DIFF
--- a/providers/cohere/pyproject.toml
+++ b/providers/cohere/pyproject.toml
@@ -59,8 +59,6 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "cohere>=5.13.4",
-     # https://github.com/huggingface/tokenizers/issues/1836
-    "tokenizers>=0.15,!=0.21.4"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Reverts apache/airflow#53819

Issue has been fixed, tokenizers published source distributions :)