### PR TITLE
Add Helm chart option to configure extra labels for pgbouncer deployment

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -41,8 +41,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+      {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- if .Values.pgbouncer.annotations }}
   annotations: {{- toYaml .Values.pgbouncer.annotations | nindent 4 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7372,6 +7372,14 @@
                         "type": "string"
                     }
                 },
+                "labels": {
+                    "description": "Labels to add to the PgBouncer objects and pods.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "replicas": {
                     "description": "Number of PgBouncer replicas to run in Deployment.",
                     "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1941,6 +1941,9 @@ triggerer:
   # annotations for the triggerer deployment
   annotations: {}
 
+  # Labels to add to PgBouncer objects and pods
+  labels: {}
+
   podAnnotations: {}
 
   # Labels specific to triggerer objects and pods
@@ -2418,6 +2421,9 @@ pgbouncer:
 
   # annotations to be added to the PgBouncer deployment
   annotations: {}
+  # labels to be added to the PgBouncer deployment
+  labels: {}
+
 
   podAnnotations: {}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1941,9 +1941,6 @@ triggerer:
   # annotations for the triggerer deployment
   annotations: {}
 
-  # Labels to add to PgBouncer objects and pods
-  labels: {}
-
   podAnnotations: {}
 
   # Labels specific to triggerer objects and pods
@@ -2421,9 +2418,6 @@ pgbouncer:
 
   # annotations to be added to the PgBouncer deployment
   annotations: {}
-  # labels to be added to the PgBouncer deployment
-  labels: {}
-
 
   podAnnotations: {}
 


### PR DESCRIPTION
* Adds a configurable helm chart option pgbouncer.labels - suitable for adding labels specifically to the pgbouncer deployment. The existing pgbouncer.annotations are also specific to the deployment resource.

closes: #53839
