### PR TITLE
Typo change in hitl

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -105,7 +105,7 @@ class HITLOperator(BaseOperator):
             body=self.body,
             defaults=self.defaults,
             multiple=self.multiple,
-            params=self.serialzed_params,
+            params=self.serialized_params,
         )
         if self.execution_timeout:
             timeout_datetime = datetime.now(timezone.utc) + self.execution_timeout
@@ -118,7 +118,7 @@ class HITLOperator(BaseOperator):
                 ti_id=ti_id,
                 options=self.options,
                 defaults=self.defaults,
-                params=self.serialzed_params,
+                params=self.serialized_params,
                 multiple=self.multiple,
                 timeout_datetime=timeout_datetime,
             ),
@@ -126,7 +126,7 @@ class HITLOperator(BaseOperator):
         )
 
     @property
-    def serialzed_params(self) -> dict[str, Any]:
+    def serialized_params(self) -> dict[str, Any]:
         return self.params.dump() if isinstance(self.params, ParamsDict) else self.params
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
@@ -156,9 +156,9 @@ class HITLOperator(BaseOperator):
     def validate_params_input(self, params_input: Mapping) -> None:
         """Check whether user provide valid params input."""
         if (
-            self.serialzed_params is not None
+            self.serialized_params is not None
             and params_input is not None
-            and set(self.serialzed_params.keys()) ^ set(params_input)
+            and set(self.serialized_params.keys()) ^ set(params_input)
         ):
             raise ValueError(f"params_input {params_input} does not match params {self.params}")
 

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -145,7 +145,7 @@ class TestHITLOperator:
             options=["1", "2", "3", "4", "5"],
             params=input_params,
         )
-        assert hitl_op.serialzed_params == expected_params
+        assert hitl_op.serialized_params == expected_params
 
     def test_execute_complete(self) -> None:
         hitl_op = HITLOperator(


### PR DESCRIPTION
            serialzed_params  # before
            serialized_params  # after

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
