### PR TITLE
refactor(HITL): make default options class variables to avoid typo

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -170,6 +170,9 @@ class ApprovalOperator(HITLOperator, SkipMixin):
 
     FIXED_ARGS = ["options", "multiple"]
 
+    APPROVE = "Approve"
+    REJECT = "Reject"
+
     def __init__(self, ignore_downstream_trigger_rules: bool = False, **kwargs) -> None:
         for arg in self.FIXED_ARGS:
             if arg in kwargs:
@@ -177,13 +180,17 @@ class ApprovalOperator(HITLOperator, SkipMixin):
 
         self.ignore_downstream_trigger_rules = ignore_downstream_trigger_rules
 
-        super().__init__(options=["Approve", "Reject"], multiple=False, **kwargs)
+        super().__init__(
+            options=[ApprovalOperator.APPROVE, ApprovalOperator.REJECT],
+            multiple=False,
+            **kwargs,
+        )
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
         ret = super().execute_complete(context=context, event=event)
 
         chosen_option = ret["chosen_options"][0]
-        if chosen_option == "Approve":
+        if chosen_option == ApprovalOperator.APPROVE:
             self.log.info("Approved. Proceeding with downstream tasks...")
             return ret
 
@@ -224,11 +231,13 @@ class HITLBranchOperator(HITLOperator):
 class HITLEntryOperator(HITLOperator):
     """Human-in-the-loop Operator that is used to accept user input through TriggerForm."""
 
+    OK = "OK"
+
     def __init__(self, **kwargs) -> None:
         if "options" not in kwargs:
-            kwargs["options"] = ["OK"]
+            kwargs["options"] = [HITLEntryOperator.OK]
 
             if "defaults" not in kwargs:
-                kwargs["defaults"] = ["OK"]
+                kwargs["defaults"] = [HITLEntryOperator.OK]
 
         super().__init__(**kwargs)

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -181,7 +181,7 @@ class ApprovalOperator(HITLOperator, SkipMixin):
         self.ignore_downstream_trigger_rules = ignore_downstream_trigger_rules
 
         super().__init__(
-            options=[ApprovalOperator.APPROVE, ApprovalOperator.REJECT],
+            options=[self.APPROVE, self.REJECT],
             multiple=False,
             **kwargs,
         )
@@ -190,7 +190,7 @@ class ApprovalOperator(HITLOperator, SkipMixin):
         ret = super().execute_complete(context=context, event=event)
 
         chosen_option = ret["chosen_options"][0]
-        if chosen_option == ApprovalOperator.APPROVE:
+        if chosen_option == self.APPROVE:
             self.log.info("Approved. Proceeding with downstream tasks...")
             return ret
 
@@ -235,9 +235,9 @@ class HITLEntryOperator(HITLOperator):
 
     def __init__(self, **kwargs) -> None:
         if "options" not in kwargs:
-            kwargs["options"] = [HITLEntryOperator.OK]
+            kwargs["options"] = [self.OK]
 
             if "defaults" not in kwargs:
-                kwargs["defaults"] = [HITLEntryOperator.OK]
+                kwargs["defaults"] = [self.OK]
 
         super().__init__(**kwargs)


### PR DESCRIPTION
## Why
Some options appear more than once in HITLOperator subclasses. Make them class variable instead magic string reduce the chance of typo

## What
Making these magic string class variables

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
