### PR TITLE
Simplify poolbar total slots

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -37,17 +37,7 @@ export const PoolSummary = () => {
   const hasPoolsAccess = authLinks?.authorized_menu_items.includes("Pools");
 
   const pools = data?.pools;
-  const totalSlots =
-    pools?.reduce(
-      (sum, pool) =>
-        sum +
-        pool.running_slots +
-        pool.queued_slots +
-        pool.deferred_slots +
-        pool.scheduled_slots +
-        pool.open_slots,
-      0,
-    ) ?? 0;
+  const totalSlots = pools?.reduce((sum, pool) => sum + pool.slots, 0) ?? 0;
   const aggregatePool: Slots = {
     deferred_slots: 0,
     open_slots: 0,

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
@@ -64,16 +64,7 @@ const PoolBarCard = ({ pool }: PoolBarCardProps) => {
 
       <Box margin={4}>
         <Flex bg="gray.muted" borderRadius="md" h="20px" overflow="hidden" w="100%">
-          <PoolBar
-            pool={pool}
-            totalSlots={
-              pool.running_slots +
-              pool.queued_slots +
-              pool.deferred_slots +
-              pool.scheduled_slots +
-              pool.open_slots
-            }
-          />
+          <PoolBar pool={pool} totalSlots={pool.slots} />
         </Flex>
       </Box>
     </Box>


### PR DESCRIPTION
Follow up of: https://github.com/apache/airflow/pull/53825

I just realized that we can go further and completely get rid of the `totalSlots` property. `flexValue` is directly the `slotValue`. flex property is not bound to [0,1] interval.


<img width="1918" height="725" alt="Screenshot 2025-07-29 at 12 00 40" src="https://github.com/user-attachments/assets/66fd3aa0-c5aa-4308-8f62-b3f719958a54" />

<img width="1917" height="586" alt="Screenshot 2025-07-29 at 12 00 16" src="https://github.com/user-attachments/assets/12ea8ebf-3c88-41bc-bcd4-626c5c6b87fc" />
