### PR TITLE
Add missing PR number in amazon changelog

### DIFF
--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -68,7 +68,7 @@ Misc
    * ``Handle ruff PT028 changes (#53235)``
    * ``Create connection with API instead of directly through Session (#53161)``
    * ``Make dag_version_id in TI non-nullable (#50825)``
-   * ``Changing import path to 'airflow.sdk' in Amazon provider package``
+   * ``Changing import path to 'airflow.sdk' in Amazon provider package (#50659)``
 
 9.10.0
 ......


### PR DESCRIPTION
commit https://github.com/apache/airflow/commit/709353f98cdda906a2f4d87dd7ac5aba2fc1555e was merged without the PR number so it was not included in the changelog cc @vincbeck 