### PR TITLE
fix: strip trailing slash of base url in config (#44337)

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -616,10 +616,10 @@ class TaskInstance(Base, LoggingMixin):
     def log_url(self) -> str:
         """Log URL for TaskInstance."""
         run_id = quote(self.run_id)
-        base_url = conf.get("api", "base_url", fallback="http://localhost:8080/")
+        base_url = conf.get("api", "base_url", fallback="http://localhost:8080")
         map_index = f"/mapped/{self.map_index}" if self.map_index >= 0 else ""
         try_number = f"?try_number={self.try_number}" if self.try_number > 0 else ""
-        _log_uri = f"{base_url}dags/{self.dag_id}/runs/{run_id}/tasks/{self.task_id}{map_index}{try_number}"
+        _log_uri = f"{base_url}/dags/{self.dag_id}/runs/{run_id}/tasks/{self.task_id}{map_index}{try_number}"
 
         return _log_uri
 


### PR DESCRIPTION
related: #44337 
closes: https://github.com/apache/airflow/issues/54247

The log url generated assumed a trailing slash in the base_url config, all other places don't. I think it should be validated and updated to strip these away and append when needed in airflow.