### PR TITLE
Add dag run id to dag run tables

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -60,6 +60,7 @@
   },
   "dagRun_one": "Dag Run",
   "dagRun_other": "Dag Runs",
+  "dagRunId": "Dag Run ID",
   "dagWarnings": "Dag warnings/errors",
   "defaultToGraphView": "Default to graph view",
   "defaultToGridView": "Default to grid view",

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -39,6 +39,7 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { SearchBar } from "src/components/SearchBar";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
+import { TruncatedText } from "src/components/TruncatedText";
 import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { dagRunTypeOptions, dagRunStateOptions as stateOptions } from "src/constants/stateOptions";
@@ -64,6 +65,17 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
           header: translate("dagId"),
         },
       ]),
+  {
+    accessorKey: "dag_run_id",
+    cell: ({ row: { original } }: DagRunRow) => (
+      <Link asChild color="fg.info" fontWeight="bold">
+        <RouterLink to={`/dags/${original.dag_id}/runs/${original.dag_run_id}`}>
+          <TruncatedText text={original.dag_run_id} />
+        </RouterLink>
+      </Link>
+    ),
+    header: translate("dagRunId"),
+  },
   {
     accessorKey: "run_after",
     cell: ({ row: { original } }: DagRunRow) => (


### PR DESCRIPTION
This adds the dag_run_id column to the table. Mostly because it is confusing to not have that, since we can now search by dag_run_id pattern.

Sometimes run_id are arbitrary and we do not have enough information to understand and search a particular dag_run_id, sometimes leaving the impression that the searchbox for dag_run was not working. (People would start typing dag ids there)

### Now
<img width="1858" height="603" alt="Screenshot 2025-07-29 at 17 18 03" src="https://github.com/user-attachments/assets/0ecf832c-a397-4cc9-b9f2-ebe57b173ff8" />
<img width="1829" height="707" alt="Screenshot 2025-07-29 at 17 18 16" src="https://github.com/user-attachments/assets/5359c999-c295-448c-8630-ea340be5f628"
<img width="1916" height="926" alt="Screenshot 2025-07-29 at 17 19 18" src="https://github.com/user-attachments/assets/2f50c2fd-f961-4b01-82a7-e581aa53fefc" />
 />
