### PR TITLE
Warn when DAG bundle path does not exist

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/base.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/base.py
@@ -280,8 +280,20 @@ class BaseDagBundle(ABC):
         This method must ultimately be safe to call concurrently from different threads or processes.
         If it isn't naturally safe, you'll need to make it so with some form of locking.
         There is a `lock` context manager on this class available for this purpose.
+
+        If you override this method, ensure you call `super().initialize()`
+        at the end of your method, after the bundle is initialized, not the beginning.
         """
         self.is_initialized = True
+
+        # Check if the bundle path exists after initialization
+        bundle_path = self.path
+        if not bundle_path.exists():
+            log.warning(
+                "Bundle '%s' path does not exist: %s. This may cause DAG loading issues.",
+                self.name,
+                bundle_path,
+            )
 
     @property
     @abstractmethod


### PR DESCRIPTION
Add path existence check to bundle initialization to help users identify configuration issues early. When a bundle is initialized but its path doesn't exist on disk, Airflow now logs a clear warning message indicating the missing path and potential DAG loading issues.

This improves the debugging experience for users setting up DAG bundles by providing immediate feedback when bundle paths are misconfigured.