### PR TITLE
Increase zIndex for tooltip visibility in GridTI component

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -143,7 +143,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, runId, search, taskId }:
             position="absolute"
             right={0}
             visibility="hidden"
-            zIndex={1}
+            zIndex={1000}
           >
             {translate("taskId")}: {taskId}
             <br />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -143,7 +143,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, runId, search, taskId }:
             position="absolute"
             right={0}
             visibility="hidden"
-            zIndex={1000}
+            zIndex="tooltip"
           >
             {translate("taskId")}: {taskId}
             <br />


### PR DESCRIPTION
## Motivation
While there’s no issue at the moment, a z-index of 1 is too low for a tooltip and may cause visibility issues as more UI elements are added. For example, in PR #53216, new version indicators are introduced in the grid, which could potentially overlap with the tooltip.

## Change
Tooltips typically use a z-index in the 1000–2000 range to ensure proper visibility, so this value has been increased accordingly.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
