### PR TITLE
Move DagBag to SDK and make it return SDK DAG objects

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -24,7 +24,8 @@ from typing import TYPE_CHECKING
 
 from airflow._shared.timezones import timezone
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
-from airflow.models import DagBag, DagModel, DagRun
+from airflow.models import DagModel, DagRun
+from airflow.models.dagbag import DBDagBag
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -34,11 +35,13 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm.session import Session
 
+    from airflow.timetables.base import DataInterval
+
 
 @provide_session
 def _trigger_dag(
     dag_id: str,
-    dag_bag: DagBag,
+    dag_bag: DBDagBag,
     *,
     triggered_by: DagRunTriggeredByType,
     triggering_user_name: str | None = None,
@@ -63,9 +66,7 @@ def _trigger_dag(
     :param replace_microseconds: whether microseconds should be zeroed
     :return: list of triggered dags
     """
-    dag = dag_bag.get_dag(dag_id, session=session)  # prefetch dag if it is stored serialized
-
-    if dag is None or dag_id not in dag_bag.dags:
+    if (dag := dag_bag.get_latest_version_of_dag(dag_id, session=session)) is None:
         raise DagNotFound(f"Dag id {dag_id} not found")
 
     run_after = run_after or timezone.coerce_datetime(timezone.utcnow())
@@ -85,7 +86,9 @@ def _trigger_dag(
                     f"[{min_dag_start_date.isoformat()}] from DAG's default_args"
                 )
         coerced_logical_date = timezone.coerce_datetime(logical_date)
-        data_interval = dag.timetable.infer_manual_data_interval(run_after=run_after)
+        data_interval: DataInterval | None = dag.timetable.infer_manual_data_interval(
+            run_after=timezone.coerce_datetime(run_after)
+        )
     else:
         data_interval = None
 
@@ -152,7 +155,7 @@ def trigger_dag(
     if dag_model is None:
         raise DagNotFound(f"Dag id {dag_id} not found in DagModel")
 
-    dagbag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
+    dagbag = DBDagBag()
     dr = _trigger_dag(
         dag_id=dag_id,
         dag_bag=dagbag,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -370,7 +370,6 @@ def materialize_asset(
         )
 
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-
     return dag.create_dagrun(
         run_id=dag.timetable.generate_run_id(
             run_type=DagRunType.MANUAL,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -357,8 +357,7 @@ def get_dag_runs(
     query = select(DagRun)
 
     if dag_id != "~":
-        # Check if the DAG exists
-        get_latest_version_of_dag(dag_bag, dag_id, session)
+        get_latest_version_of_dag(dag_bag, dag_id, session)  # Check if the DAG exists.
         query = query.filter(DagRun.dag_id == dag_id).options(joinedload(DagRun.dag_model))
 
     dag_run_select, total_entries = paginated_select(

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -57,7 +57,6 @@ def _patch_ti_validate_request(
     update_mask: list[str] | None = Query(None),
 ) -> tuple[DAG, list[TI], dict]:
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-
     if not dag.has_task(task_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Task '{task_id}' not found in DAG '{dag_id}'")
 

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -40,6 +40,7 @@ from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.jobs.job import Job
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.models.dagbag import sync_bag_to_db
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils import cli as cli_utils
@@ -668,4 +669,4 @@ def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
             continue
         bundle.initialize()
         dag_bag = DagBag(bundle.path, bundle_path=bundle.path, include_examples=False)
-        dag_bag.sync_to_db(bundle.name, bundle_version=bundle.get_current_version(), session=session)
+        sync_bag_to_db(dag_bag, bundle.name, bundle_version=bundle.get_current_version(), session=session)

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -52,7 +52,6 @@ from airflow.exceptions import (
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.base import Base, StringID
 from airflow.models.dag_version import DagVersion
-from airflow.stats import Stats
 from airflow.utils.docs import get_docs_url
 from airflow.utils.file import (
     correct_maybe_zipped,
@@ -611,17 +610,6 @@ class DagBag(LoggingMixin):
                 self.log.exception(e)
 
         self.dagbag_stats = sorted(stats, key=lambda x: x.duration, reverse=True)
-
-    def collect_dags_from_db(self):
-        """Collect DAGs from database."""
-        from airflow.models.serialized_dag import SerializedDagModel
-
-        with Stats.timer("collect_db_dags"):
-            self.log.info("Filling up the DagBag from database")
-
-            # The dagbag contains all rows in serialized_dag table. Deleted DAGs are deleted
-            # from the table by the scheduler job.
-            self.dags = SerializedDagModel.read_all_dags()
 
     def dagbag_report(self):
         """Print a report around DagBag loading stats."""

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -31,7 +31,7 @@ from collections.abc import Collection, Generator, Iterable, Iterator, Mapping, 
 from functools import cache, cached_property
 from inspect import signature
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeAlias, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeAlias, TypeVar, cast, overload
 
 import attrs
 import lazy_object_proxy
@@ -2281,7 +2281,7 @@ def _has_kubernetes() -> bool:
 
 
 AssetT = TypeVar("AssetT", bound=BaseAsset)
-MaybeSerializedDAG = Union[DAG, "LazyDeserializedDAG"]
+MaybeSerializedDAG: TypeAlias = "DAG | LazyDeserializedDAG"
 
 
 class LazyDeserializedDAG(pydantic.BaseModel):

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -272,12 +272,12 @@ def get_dag(
     dags folder.
     """
     from airflow.models.dagbag import DagBag
+    from airflow.models.serialized_dag import SerializedDagModel
 
     bundle_names = bundle_names or []
     dag: DAG | None = None
     if from_db:
-        dagbag = DagBag(read_dags_from_db=True)
-        dag = dagbag.get_dag(dag_id)  # get_dag loads from the DB as requested
+        dag = SerializedDagModel.get_dag(dag_id)
     elif bundle_names:
         manager = DagBundlesManager()
         for bundle_name in bundle_names:
@@ -286,8 +286,7 @@ def get_dag(
                 dagbag = DagBag(
                     dag_folder=dagfile_path or bundle.path, bundle_path=bundle.path, include_examples=False
                 )
-            dag = dagbag.dags.get(dag_id)
-            if dag:
+            if dag := dagbag.dags.get(dag_id):
                 break
     if not dag:
         if from_db:

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -271,7 +271,7 @@ def get_dag(
     find the correct path (assuming it's a file) and failing that, use the configured
     dags folder.
     """
-    from airflow.models.dagbag import DagBag
+    from airflow.models.dagbag import DagBag, sync_bag_to_db
     from airflow.models.serialized_dag import SerializedDagModel
 
     bundle_names = bundle_names or []
@@ -298,11 +298,11 @@ def get_dag(
             bundle.initialize()
 
             with _airflow_parsing_context_manager(dag_id=dag_id):
-                dag_bag = DagBag(
+                dagbag = DagBag(
                     dag_folder=dagfile_path or bundle.path, bundle_path=bundle.path, include_examples=False
                 )
-                dag_bag.sync_to_db(bundle.name, bundle.version)
-            dag = dag_bag.dags.get(dag_id)
+                sync_bag_to_db(dagbag, bundle.name, bundle.version)
+            dag = dagbag.dags.get(dag_id)
             if dag:
                 break
         if not dag:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_parsing.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_parsing.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import pytest
 from sqlalchemy import select
 
-from airflow.models import DagBag
-from airflow.models.dagbag import DagPriorityParsingRequest
+from airflow.models.dagbag import DagPriorityParsingRequest, DBDagBag
 
 from tests_common.test_utils.api_fastapi import _check_last_log
 from tests_common.test_utils.db import clear_db_dag_parsing_requests, clear_db_logs, parse_and_sync_to_db
@@ -46,8 +45,7 @@ class TestDagParsingEndpoint:
 
     def test_201_and_400_requests(self, url_safe_serializer, session, test_client):
         parse_and_sync_to_db(EXAMPLE_DAG_FILE)
-        dagbag = DagBag(read_dags_from_db=True)
-        test_dag = dagbag.get_dag(TEST_DAG_ID)
+        test_dag = DBDagBag(load_op_links=False).get_latest_version_of_dag(TEST_DAG_ID, session=session)
 
         # grab the token
         token = test_client.get(f"/dags/{TEST_DAG_ID}").json()["file_token"]

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -48,7 +48,7 @@ TEST_DAG_DISPLAY_NAME = "example_simplest_dag"
 @pytest.fixture
 def test_dag(session):
     parse_and_sync_to_db(EXAMPLE_DAG_FILE, include_examples=False)
-    return DBDagBag().get_latest_version_of_dag(TEST_DAG_ID, session)
+    return DBDagBag().get_latest_version_of_dag(TEST_DAG_ID, session=session)
 
 
 class TestGetDAGSource:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -36,7 +36,7 @@ from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag_version import DagVersion
-from airflow.models.dagbag import DagBag
+from airflow.models.dagbag import DagBag, sync_bag_to_db
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskmap import TaskMap
@@ -655,7 +655,7 @@ class TestGetMappedTaskInstances:
             DagBundlesManager().sync_bundles_to_db()
             dagbag = DagBag(os.devnull, include_examples=False)
             dagbag.dags = {dag_id: dag_maker.dag}
-            dagbag.sync_to_db("dags-folder", None)
+            sync_bag_to_db(dagbag, "dags-folder", None)
             session.flush()
 
             TaskMap.expand_mapped_task(sdag.task_dict[mapped.task_id], dr.run_id, session=session)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -103,7 +103,7 @@ class TestTaskInstanceEndpoint:
         with_ti_history=False,
     ):
         """Method to create task instances using kwargs and default arguments"""
-        dag = self.dagbag.get_latest_version_of_dag(dag_id, session)
+        dag = self.dagbag.get_latest_version_of_dag(dag_id, session=session)
         tasks = dag.tasks
         counter = len(tasks)
         if task_instances is not None:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dashboard.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dashboard.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 import pendulum
 import pytest
 
-from airflow.models import DagBag
+from airflow.models.dagbag import DBDagBag
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -34,9 +34,7 @@ pytestmark = pytest.mark.db_test
 
 @pytest.fixture(autouse=True, scope="module")
 def examples_dag_bag():
-    # Speed up: We don't want example dags for this module
-
-    return DagBag(include_examples=False, read_dags_from_db=True)
+    return DBDagBag()
 
 
 @pytest.fixture(autouse=True)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -25,8 +25,8 @@ import pytest
 from sqlalchemy import select
 
 from airflow._shared.timezones import timezone
-from airflow.models import DagBag
 from airflow.models.dag import DagModel
+from airflow.models.dagbag import DBDagBag
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import task_group
@@ -109,8 +109,7 @@ GRID_NODES = [
 
 @pytest.fixture(autouse=True, scope="module")
 def examples_dag_bag():
-    # Speed up: We don't want example dags for this module
-    return DagBag(include_examples=False, read_dags_from_db=True)
+    return DBDagBag()
 
 
 @pytest.fixture(autouse=True)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -25,8 +25,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from airflow._shared.timezones import timezone
-from airflow.models import DagBag
 from airflow.models.asset import AssetAliasModel, AssetEvent, AssetModel
+from airflow.models.dagbag import DBDagBag
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.providers.standard.sensors.external_task import ExternalTaskSensor
@@ -89,10 +89,8 @@ FIRST_VERSION_DAG_RESPONSE["nodes"] = [
 
 
 @pytest.fixture(autouse=True, scope="module")
-def examples_dag_bag() -> DagBag:
-    # Speed up: We don't want example dags for this module
-
-    return DagBag(include_examples=False, read_dags_from_db=True)
+def examples_dag_bag() -> DBDagBag:
+    return DBDagBag()
 
 
 @pytest.fixture(autouse=True)

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -36,7 +36,7 @@ from airflow.cli import cli_parser
 from airflow.cli.commands import dag_command
 from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagModel, DagRun
-from airflow.models.dagbag import DBDagBag
+from airflow.models.dagbag import DBDagBag, sync_bag_to_db
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import BaseOperator, task
@@ -867,7 +867,7 @@ class TestCliDags:
 
         with configure_testing_dag_bundle(path_to_parse):
             bag = DagBag(dag_folder=path_to_parse, include_examples=False)
-            bag.sync_to_db("testing", None)
+            sync_bag_to_db(bag, "testing", None)
             cli_args = self.parser.parse_args(
                 ["dags", "test", "test_dag_parsing_context", DEFAULT_DATE.isoformat()]
             )

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -444,7 +444,6 @@ class TestUpdateDagParsingResults:
     def test_serialized_dags_are_written_to_db_on_sync(self, testing_dag_bundle, session):
         """
         Test that when dagbag.sync_to_db is called the DAGs are Serialized and written to DB
-        even when dagbag.read_dags_from_db is False
         """
         serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
         assert serialized_dags_count == 0

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -350,10 +350,7 @@ class TestUpdateDagParsingResults:
     def test_sync_perms_syncs_dag_specific_perms_on_update(
         self, monkeypatch, spy_agency: SpyAgency, session, time_machine, testing_dag_bundle
     ):
-        """
-        Test that dagbag.sync_to_db will sync DAG specific permissions when a DAG is
-        new or updated
-        """
+        """Test DAG-specific permissions are synced when a DAG is new or updated"""
         from airflow import settings
 
         serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
@@ -442,9 +439,7 @@ class TestUpdateDagParsingResults:
         assert serialized_dags_count == 0
 
     def test_serialized_dags_are_written_to_db_on_sync(self, testing_dag_bundle, session):
-        """
-        Test that when dagbag.sync_to_db is called the DAGs are Serialized and written to DB
-        """
+        """Test DAGs are Serialized and written to DB when parsing result is updated"""
         serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
         assert serialized_dags_count == 0
 

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -53,6 +53,7 @@ from airflow.dag_processing.processor import DagFileProcessorProcess
 from airflow.models import DAG, DagBag, DagModel, DbCallbackRequest
 from airflow.models.asset import TaskOutletAssetReference
 from airflow.models.dag_version import DagVersion
+from airflow.models.dagbag import DBDagBag
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
@@ -717,7 +718,7 @@ class TestDagFileProcessorManager:
             dag = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id))
             assert dag.is_stale is True
 
-    def test_deactivate_deleted_dags(self, dag_maker):
+    def test_deactivate_deleted_dags(self, dag_maker, session):
         with dag_maker("test_dag1") as dag1:
             dag1.relative_fileloc = "test_dag1.py"
         with dag_maker("test_dag2") as dag2:
@@ -736,11 +737,11 @@ class TestDagFileProcessorManager:
         manager = DagFileProcessorManager(max_runs=1)
         manager.deactivate_deleted_dags("dag_maker", active_files)
 
-        dagbag = DagBag(read_dags_from_db=True)
+        dagbag = DBDagBag()
         # The DAG from test_dag1.py is still active
-        assert dagbag.get_dag("test_dag1").get_is_active() is True
+        assert dagbag.get_latest_version_of_dag("test_dag1", session=session).get_is_active() is True
         # and the DAG from test_dag2.py is deactivated
-        assert dagbag.get_dag("test_dag2").get_is_active() is False
+        assert dagbag.get_latest_version_of_dag("test_dag2", session=session).get_is_active() is False
 
     @conf_vars({("core", "load_examples"): "False"})
     def test_fetch_callbacks_from_database(self, configure_testing_dag_bundle):

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -462,7 +462,6 @@ class TestDagFileProcessorManager:
         )
         dagbag = DagBag(
             test_dag_path.absolute_path,
-            read_dags_from_db=False,
             include_examples=False,
             bundle_path=test_dag_path.bundle_path,
         )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -6197,7 +6197,7 @@ class TestSchedulerJob:
         dag_file = Path(__file__).parents[1] / "dags/test_only_empty_tasks.py"
 
         # Write DAGs to dag and serialized_dag table
-        dagbag = DagBag(dag_folder=dag_file, include_examples=False, read_dags_from_db=False)
+        dagbag = DagBag(dag_folder=dag_file, include_examples=False)
         dagbag.sync_to_db("testing", None)
 
         scheduler_job = Job()
@@ -6864,7 +6864,7 @@ class TestSchedulerJobQueriesCount:
             ),
         ):
             dagruns = []
-            dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False, read_dags_from_db=False)
+            dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False)
             dagbag.sync_to_db("testing", None)
 
             for i, dag in enumerate(dagbag.dags.values()):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -61,7 +61,7 @@ from airflow.models.asset import (
 from airflow.models.backfill import Backfill, _create_backfill
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
-from airflow.models.dagbag import DagBag
+from airflow.models.dagbag import DagBag, sync_bag_to_db
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
@@ -3012,7 +3012,7 @@ class TestSchedulerJob:
         Noted: the DagRun state could be still in running state during CI.
         """
         dagbag = DagBag(TEST_DAG_FOLDER, include_examples=False)
-        dagbag.sync_to_db("testing", None)
+        sync_bag_to_db(dagbag, "testing", None)
         dag_id = "test_dagrun_states_root_future"
         dag = dagbag.get_dag(dag_id)
         DAG.bulk_write_to_db("testing", None, [dag])
@@ -3101,7 +3101,7 @@ class TestSchedulerJob:
         other_dag.is_paused_upon_creation = True
         dagbag.bag_dag(dag=other_dag)
 
-        dagbag.sync_to_db("testing", None)
+        sync_bag_to_db(dagbag, "testing", None)
 
         scheduler_job = Job(executor=self.null_exec)
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=3)
@@ -3137,7 +3137,7 @@ class TestSchedulerJob:
         other_dag.is_paused_upon_creation = True
         dagbag.bag_dag(dag=other_dag)
 
-        dagbag.sync_to_db("testing", None)
+        sync_bag_to_db(dagbag, "testing", None)
 
         scheduler_job = Job(executor=self.null_exec)
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=3)
@@ -6165,7 +6165,7 @@ class TestSchedulerJob:
         from airflow.executors.local_executor import LocalExecutor
 
         dagbag = DagBag(dag_folder=TEST_DAGS_FOLDER, include_examples=False)
-        dagbag.sync_to_db("testing", None)
+        sync_bag_to_db(dagbag, "testing", None)
         dagbag.process_file(str(TEST_DAGS_FOLDER / f"{dag_id}.py"))
         dag = dagbag.get_dag(dag_id)
         assert dag
@@ -6198,7 +6198,7 @@ class TestSchedulerJob:
 
         # Write DAGs to dag and serialized_dag table
         dagbag = DagBag(dag_folder=dag_file, include_examples=False)
-        dagbag.sync_to_db("testing", None)
+        sync_bag_to_db(dagbag, "testing", None)
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
@@ -6865,7 +6865,7 @@ class TestSchedulerJobQueriesCount:
         ):
             dagruns = []
             dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False)
-            dagbag.sync_to_db("testing", None)
+            sync_bag_to_db(dagbag, "testing", None)
 
             for i, dag in enumerate(dagbag.dags.values()):
                 dr = dag.create_dagrun(
@@ -6956,7 +6956,7 @@ class TestSchedulerJobQueriesCount:
             ),
         ):
             dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False)
-            dagbag.sync_to_db("testing", None)
+            sync_bag_to_db(dagbag, "testing", None)
 
             scheduler_job = Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
             scheduler_job.heartbeat = mock.MagicMock()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -154,11 +154,11 @@ def create_dagrun(session):
     def _create_dagrun(
         dag: DAG,
         *,
-        logical_date: datetime,
+        logical_date: datetime.datetime,
         data_interval: DataInterval,
         run_type: DagRunType,
         state: DagRunState = DagRunState.RUNNING,
-        start_date: datetime | None = None,
+        start_date: datetime.datetime | None = None,
     ) -> DagRun:
         run_after = logical_date or timezone.utcnow()
         run_id = DagRun.generate_run_id(
@@ -6867,10 +6867,7 @@ class TestSchedulerJobQueriesCount:
             dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False, read_dags_from_db=False)
             dagbag.sync_to_db("testing", None)
 
-            dag_ids = dagbag.dag_ids
-            dagbag = DagBag(read_dags_from_db=True)
-            for i, dag_id in enumerate(dag_ids):
-                dag = dagbag.get_dag(dag_id)
+            for i, dag in enumerate(dagbag.dags.values()):
                 dr = dag.create_dagrun(
                     state=State.RUNNING,
                     run_id=f"{DagRunType.MANUAL.value}__{i}",

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -31,21 +31,18 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-import time_machine
 from sqlalchemy import select
 
 from airflow import settings
-from airflow._shared.timezones import timezone as tz
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dagbag import DagBag, _capture_with_reraise
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.serialization.serialized_objects import SerializedDAG
+from airflow.sdk import BaseOperator
 from airflow.utils.session import create_session
 
 from tests_common.pytest_plugin import AIRFLOW_ROOT_PATH
 from tests_common.test_utils import db
-from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 from unit import cluster_policies
 from unit.models import TEST_DAGS_FOLDER
@@ -113,14 +110,12 @@ class TestDagBag:
         non_existing_dag_id = "non_existing_dag_id"
         assert dagbag.get_dag(non_existing_dag_id) is None
 
-    def test_serialized_dag_not_existing_doesnt_raise(self, tmp_path):
+    def test_serialized_dag_not_existing_doesnt_raise(self, tmp_path, session):
         """
         test that retrieving a non existing dag id returns None without crashing
         """
-        dagbag = DagBag(dag_folder=os.fspath(tmp_path), include_examples=False, read_dags_from_db=True)
-
         non_existing_dag_id = "non_existing_dag_id"
-        assert dagbag.get_dag(non_existing_dag_id) is None
+        assert session.scalar(select(True).where(SerializedDagModel.dag_id == non_existing_dag_id)) is None
 
     def test_dont_load_example(self, tmp_path):
         """
@@ -486,49 +481,6 @@ class TestDagBag:
         assert dag_id == dag.dag_id
         assert dagbag.process_file_calls == 2
 
-    def test_dag_removed_if_serialized_dag_is_removed(self, dag_maker, tmp_path, session):
-        """
-        Test that if a DAG does not exist in serialized_dag table (as the DAG file was removed),
-        remove dags from the DagBag
-        """
-        from airflow.providers.standard.operators.empty import EmptyOperator
-
-        with dag_maker(
-            dag_id="test_dag_removed_if_serialized_dag_is_removed",
-            schedule=None,
-            start_date=tz.datetime(2021, 10, 12),
-        ) as dag:
-            EmptyOperator(task_id="task_1")
-
-        dagbag = DagBag(dag_folder=os.fspath(tmp_path), include_examples=False, read_dags_from_db=True)
-        dagbag.dags = {dag.dag_id: SerializedDAG.from_dict(SerializedDAG.to_dict(dag))}
-        dagbag.dags_last_fetched = {dag.dag_id: (tz.utcnow() - timedelta(minutes=2))}
-        dagbag.dags_hash = {dag.dag_id: mock.ANY}
-
-        # observe we have serdag and dag is in dagbag
-        assert SerializedDagModel.has_dag(dag.dag_id) is True
-        assert dagbag.get_dag(dag.dag_id) is not None
-
-        # now delete serdags for this dag
-        SDM = SerializedDagModel
-        sdms = session.scalars(select(SDM).where(SDM.dag_id == dag.dag_id))
-        for sdm in sdms:
-            session.delete(sdm)
-        session.commit()
-
-        # first, confirm that serdags are gone for this dag
-        assert SerializedDagModel.has_dag(dag.dag_id) is False
-
-        # now see the dag is still in dagbag
-        assert dagbag.get_dag(dag.dag_id) is not None
-
-        # but, let's recreate the dagbag and see if the dag will be there
-        dagbag = DagBag(dag_folder=os.fspath(tmp_path), include_examples=False, read_dags_from_db=True)
-        assert dagbag.get_dag(dag.dag_id) is None
-        assert dag.dag_id not in dagbag.dags
-        assert dag.dag_id not in dagbag.dags_last_fetched
-        assert dag.dag_id not in dagbag.dags_hash
-
     def process_dag(self, create_dag, tmp_path):
         """
         Helper method to process a file generated from the input create_dag function.
@@ -714,147 +666,6 @@ with airflow.DAG(
         assert invalid_dag_filename in import_errors
         assert import_errors[invalid_dag_filename] == self._make_test_traceback(invalid_dag_filename, depth)
 
-    @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)
-    @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL", 5)
-    def test_get_dag_with_dag_serialization(self, testing_dag_bundle):
-        """
-        Test that Serialized DAG is updated in DagBag when it is updated in
-        Serialized DAG table after 'min_serialized_dag_fetch_interval' seconds are passed.
-        """
-        with time_machine.travel((tz.datetime(2020, 1, 5, 0, 0, 0)), tick=False):
-            example_bash_op_dag = DagBag(include_examples=True).dags.get("example_bash_operator")
-            session = settings.Session()
-            bundle_name = "testing"
-            dag_model = DagModel(
-                dag_id=example_bash_op_dag.dag_id,
-                bundle_name=bundle_name,
-            )
-
-            session.merge(dag_model)
-            session.flush()
-
-            DAG.from_sdk_dag(example_bash_op_dag).sync_to_db()
-            SerializedDagModel.write_dag(dag=example_bash_op_dag, bundle_name=bundle_name)
-
-            dag_bag = DagBag(read_dags_from_db=True)
-            ser_dag_1 = dag_bag.get_dag("example_bash_operator")
-            ser_dag_1_update_time = dag_bag.dags_last_fetched["example_bash_operator"]
-            assert example_bash_op_dag.tags == ser_dag_1.tags
-            assert ser_dag_1_update_time == tz.datetime(2020, 1, 5, 0, 0, 0)
-
-        # Check that if min_serialized_dag_fetch_interval has not passed we do not fetch the DAG
-        # from DB
-        with time_machine.travel((tz.datetime(2020, 1, 5, 0, 0, 4)), tick=False):
-            with assert_queries_count(0):
-                assert dag_bag.get_dag("example_bash_operator").tags == {"example", "example2"}
-
-        # Make a change in the DAG and write Serialized DAG to the DB
-        with time_machine.travel((tz.datetime(2020, 1, 5, 0, 0, 6)), tick=False):
-            example_bash_op_dag.tags.add("new_tag")
-            DAG.from_sdk_dag(example_bash_op_dag).sync_to_db()
-            SerializedDagModel.write_dag(dag=example_bash_op_dag, bundle_name=bundle_name)
-
-        # Since min_serialized_dag_fetch_interval is passed verify that calling 'dag_bag.get_dag'
-        # fetches the Serialized DAG from DB
-        with time_machine.travel((tz.datetime(2020, 1, 5, 0, 0, 8)), tick=False):
-            with assert_queries_count(2):
-                updated_ser_dag_1 = dag_bag.get_dag("example_bash_operator")
-                updated_ser_dag_1_update_time = dag_bag.dags_last_fetched["example_bash_operator"]
-
-        assert set(updated_ser_dag_1.tags) == {"example", "example2", "new_tag"}
-        assert updated_ser_dag_1_update_time > ser_dag_1_update_time
-
-    @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)
-    @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL", 5)
-    def test_get_dag_refresh_race_condition(self, session, testing_dag_bundle):
-        """
-        Test that DagBag.get_dag correctly refresh the Serialized DAG even if SerializedDagModel.last_updated
-        is before DagBag.dags_last_fetched.
-        """
-        db_clean_up()
-        # serialize the initial version of the DAG
-        with time_machine.travel((tz.datetime(2020, 1, 5, 0, 0, 0)), tick=False):
-            example_bash_op_dag = DagBag(include_examples=True).dags.get("example_bash_operator")
-            bundle_name = "testing"
-            dag_model = DagModel(
-                dag_id=example_bash_op_dag.dag_id,
-                bundle_name=bundle_name,
-            )
-            session.merge(dag_model)
-            session.flush()
-
-            DAG.from_sdk_dag(example_bash_op_dag).sync_to_db()
-            SerializedDagModel.write_dag(dag=example_bash_op_dag, bundle_name=bundle_name)
-
-        # deserialize the DAG
-        with time_machine.travel((tz.datetime(2020, 1, 5, 1, 0, 10)), tick=False):
-            dag_bag = DagBag(read_dags_from_db=True)
-
-            with assert_queries_count(2):
-                ser_dag = dag_bag.get_dag("example_bash_operator")
-
-            ser_dag_update_time = dag_bag.dags_last_fetched["example_bash_operator"]
-            assert ser_dag.tags == {"example", "example2"}
-            assert ser_dag_update_time == tz.datetime(2020, 1, 5, 1, 0, 10)
-
-            with create_session() as session:
-                assert SerializedDagModel.get_last_updated_datetime(
-                    dag_id="example_bash_operator",
-                    session=session,
-                ) == tz.datetime(2020, 1, 5, 0, 0, 0)
-
-        # Simulate a long-running serialization transaction
-        # Make a change in the DAG and write Serialized DAG to the DB
-        # Note the date *before* the deserialize step above, simulating a serialization happening
-        # long before the transaction is committed
-        with time_machine.travel((tz.datetime(2020, 1, 5, 1, 0, 0)), tick=False):
-            example_bash_op_dag.tags.add("new_tag")
-            DAG.from_sdk_dag(example_bash_op_dag).sync_to_db()
-            SerializedDagModel.write_dag(dag=example_bash_op_dag, bundle_name=bundle_name)
-
-        # Since min_serialized_dag_fetch_interval is passed verify that calling 'dag_bag.get_dag'
-        # fetches the Serialized DAG from DB
-        with time_machine.travel((tz.datetime(2020, 1, 5, 1, 0, 30)), tick=False):
-            with assert_queries_count(2):
-                updated_ser_dag = dag_bag.get_dag("example_bash_operator")
-                updated_ser_dag_update_time = dag_bag.dags_last_fetched["example_bash_operator"]
-
-        assert set(updated_ser_dag.tags) == {"example", "example2", "new_tag"}
-        assert updated_ser_dag_update_time > ser_dag_update_time
-
-    def test_collect_dags_from_db(self, testing_dag_bundle):
-        """DAGs are collected from Database"""
-        db.clear_db_dags()
-        dagbag = DagBag(str(example_dags_folder))
-
-        example_dags = dagbag.dags
-
-        session = settings.Session()
-        bundle_name = "testing"
-
-        for dag in example_dags.values():
-            # Create DagModel with bundle_name before syncing
-            dag_model = DagModel(
-                dag_id=dag.dag_id,
-                bundle_name=bundle_name,
-            )
-            session.merge(dag_model)
-            session.flush()
-
-            DAG.from_sdk_dag(dag).sync_to_db()
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
-
-        new_dagbag = DagBag(read_dags_from_db=True)
-        assert len(new_dagbag.dags) == 0
-        new_dagbag.collect_dags_from_db()
-        new_dags = new_dagbag.dags
-        assert len(example_dags) == len(new_dags)
-        for dag_id, dag in example_dags.items():
-            serialized_dag = new_dags[dag_id]
-
-            assert serialized_dag.dag_id == dag.dag_id
-            assert set(serialized_dag.task_dict) == set(dag.task_dict)
-
     @patch("airflow.settings.task_policy", cluster_policies.example_task_policy)
     def test_task_cluster_policy_violation(self):
         """
@@ -1001,8 +812,6 @@ with airflow.DAG(
         ),
     )
     def test_dag_warnings_invalid_pool(self, known_pools, expected):
-        from airflow.models.baseoperator import BaseOperator
-
         with DAG(dag_id="test") as dag:
             BaseOperator(task_id="1")
             BaseOperator(task_id="2", pool="pool1")

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -887,7 +887,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             from airflow.models import DagBag
 
             # Keep all the serialized dags we've created in this test
-            self.dagbag = DagBag(os.devnull, include_examples=False, read_dags_from_db=False)
+            self.dagbag = DagBag(os.devnull, include_examples=False)
 
         def __enter__(self):
             self.serialized_model = None

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -865,7 +865,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
     # This fixture is "called" early on in the pytest collection process, and
     # if we import airflow.* here the wrong (non-test) config will be loaded
     # and "baked" in to various constants
-    from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+    from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
     want_serialized = False
     want_activate_assets = True  # Only has effect if want_serialized=True on Airflow 3.
@@ -926,8 +926,6 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
 
             from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
             from airflow.models.asset import AssetModel, DagScheduleAssetReference, TaskOutletAssetReference
-
-            from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
 
             if AIRFLOW_V_3_1_PLUS:
                 from airflow.models.asset import TaskInletAssetReference
@@ -1123,8 +1121,6 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
 
             Returns the created TaskInstance.
             """
-            from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
-
             if dag_run is None:
                 if dag_run_kwargs is None:
                     dag_run_kwargs = {}
@@ -1155,14 +1151,14 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             return ti
 
         def sync_dagbag_to_db(self):
-            if not AIRFLOW_V_3_0_PLUS:
-                self.dagbag.sync_to_db()
-                return
+            if AIRFLOW_V_3_1_PLUS:
+                from airflow.models.dagbag import sync_bag_to_db
 
-            self.dagbag.sync_to_db(
-                self.bundle_name,
-                None,
-            )
+                sync_bag_to_db(self.dagbag, self.bundle_name, None)
+            elif AIRFLOW_V_3_0_PLUS:
+                self.dagbag.sync_to_db(self.bundle_name, None)
+            else:
+                self.dagbag.sync_to_db()
 
         def __call__(
             self,

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -156,6 +156,8 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
             dagbag.sync_to_db(session=session)  # type: ignore[call-arg]
         session.commit()
 
+    return dagbag
+
 
 def clear_db_runs():
     with create_session() as session:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -86,10 +86,18 @@ def _bootstrap_dagbag():
 
         dagbag = DagBag()
         # Save DAGs in the ORM
-        if AIRFLOW_V_3_0_PLUS:
-            dagbag.sync_to_db(bundle_name="dags-folder", bundle_version=None, session=session)
+        if AIRFLOW_V_3_1_PLUS:
+            from airflow.models.dagbag import sync_bag_to_db
+
+            sync_bag_to_db(dagbag, bundle_name="dags-folder", bundle_version=None, session=session)
+        elif AIRFLOW_V_3_0_PLUS:
+            dagbag.sync_to_db(  # type: ignore[attr-defined]
+                bundle_name="dags-folder",
+                bundle_version=None,
+                session=session,
+            )
         else:
-            dagbag.sync_to_db(session=session)
+            dagbag.sync_to_db(session=session)  # type: ignore[attr-defined]
 
         # Deactivate the unknown ones
         DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
@@ -150,10 +158,14 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
             session.commit()
 
         dagbag = DagBag(dag_folder=folder, include_examples=include_examples)
-        if AIRFLOW_V_3_0_PLUS:
-            dagbag.sync_to_db("dags-folder", None, session)
+        if AIRFLOW_V_3_1_PLUS:
+            from airflow.models.dagbag import sync_bag_to_db
+
+            sync_bag_to_db(dagbag, "dags-folder", None, session=session)
+        elif AIRFLOW_V_3_0_PLUS:
+            dagbag.sync_to_db("dags-folder", None, session)  # type: ignore[attr-defined]
         else:
-            dagbag.sync_to_db(session=session)  # type: ignore[call-arg]
+            dagbag.sync_to_db(session=session)  # type: ignore[attr-defined]
         session.commit()
 
     return dagbag

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -27,7 +27,6 @@ from flask_appbuilder import BaseView
 from flask_appbuilder.api import expose
 
 from airflow.exceptions import AirflowException, TaskInstanceNotFound
-from airflow.models import DagBag
 from airflow.models.dag import DAG, clear_task_instances
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
@@ -90,8 +89,15 @@ def get_databricks_task_ids(
 if not AIRFLOW_V_3_0_PLUS:
     from airflow.utils.session import NEW_SESSION, provide_session
 
-    @provide_session
-    def _get_dagrun(dag: DAG, run_id: str, session: Session | None = None) -> DagRun:
+    def _get_dag(dag_id: str, session: Session) -> DAG:
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        dag = SerializedDagModel.get_dag(dag_id, session=session)
+        if not dag:
+            raise AirflowException("Dag not found.")
+        return dag
+
+    def _get_dagrun(dag: DAG, run_id: str, session: Session) -> DagRun:
         """
         Retrieve the DagRun object associated with the specified DAG and run_id.
 
@@ -107,10 +113,9 @@ if not AIRFLOW_V_3_0_PLUS:
 
     @provide_session
     def _clear_task_instances(
-        dag_id: str, run_id: str, task_ids: list[str], log: logging.Logger, session: Session | None = None
+        dag_id: str, run_id: str, task_ids: list[str], log: logging.Logger, session: Session = NEW_SESSION
     ) -> None:
-        dag_bag = DagBag(read_dags_from_db=True)
-        dag = dag_bag.get_dag(dag_id)
+        dag = _get_dag(dag_id, session=session)
         log.debug("task_ids %s to clear", str(task_ids))
         dr: DagRun = _get_dagrun(dag, run_id, session=session)
         tis_to_clear = [ti for ti in dr.get_task_instances() if ti.databricks_task_key in task_ids]
@@ -274,13 +279,8 @@ class WorkflowJobRunLink(BaseOperatorLink, LoggingMixin):
             ti = get_task_instance(operator, dttm)
             ti_key = ti.key
         task_group = operator.task_group
-
         if not task_group:
             raise AirflowException("Task group is required for generating Databricks Workflow Job Run Link.")
-
-        dag_bag = DagBag(read_dags_from_db=True)
-        dag = dag_bag.get_dag(ti_key.dag_id)
-        dag.get_task(ti_key.task_id)
         self.log.info("Getting link for task %s", ti_key.task_id)
         if ".launch" not in ti_key.task_id:
             self.log.debug("Finding the launch task for job run metadata %s", ti_key.task_id)
@@ -375,9 +375,12 @@ class WorkflowJobRepairAllFailedLink(BaseOperatorLink, LoggingMixin):
             raise AirflowException("Task group is required for generating repair link.")
         if not task_group.group_id:
             raise AirflowException("Task group ID is required for generating repair link.")
-        dag_bag = DagBag(read_dags_from_db=True)
-        dag = dag_bag.get_dag(ti_key.dag_id)
-        dr = _get_dagrun(dag, ti_key.run_id)
+
+        from airflow.utils.session import create_session
+
+        with create_session() as session:
+            dag = _get_dag(ti_key.dag_id, session=session)
+            dr = _get_dagrun(dag, ti_key.run_id, session=session)
         log.debug("Getting failed and skipped tasks for dag run %s", dr.run_id)
         task_group_sub_tasks = self.get_task_group_children(task_group).items()
         failed_and_skipped_tasks = self._get_failed_and_skipped_tasks(dr)
@@ -435,9 +438,14 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
             task_group.group_id,
             ti_key.task_id,
         )
-        dag_bag = DagBag(read_dags_from_db=True)
-        dag = dag_bag.get_dag(ti_key.dag_id)
+
+        from airflow.utils.session import create_session
+
+        with create_session() as session:
+            dag = _get_dag(ti_key.dag_id, session=session)
         task = dag.get_task(ti_key.task_id)
+        if TYPE_CHECKING:
+            assert isinstance(task, DatabricksTaskBaseOperator)
 
         if ".launch" not in ti_key.task_id:
             launch_task_id = get_launch_task_id(task_group)

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -217,7 +217,7 @@ def test_workflow_job_run_link_airflow2():
                 "airflow.providers.databricks.plugins.databricks_workflow.get_xcom_result"
             ) as mock_get_xcom_result:
                 with patch(
-                    "airflow.providers.databricks.plugins.databricks_workflow.DagBag.get_dag"
+                    "airflow.providers.databricks.plugins.databricks_workflow._get_dag"
                 ) as mock_get_dag:
                     mock_connection = Mock()
                     mock_connection.extra_dejson = {"host": "mockhost"}
@@ -448,15 +448,15 @@ class TestDatabricksWorkflowPluginAirflow2:
             with patch(
                 "airflow.providers.databricks.plugins.databricks_workflow.get_xcom_result"
             ) as mock_get_xcom:
-                with patch("airflow.providers.databricks.plugins.databricks_workflow.DagBag") as mock_dag_bag:
+                with patch(
+                    "airflow.providers.databricks.plugins.databricks_workflow._get_dag"
+                ) as mock_get_dag:
                     with patch(
                         "airflow.providers.databricks.plugins.databricks_workflow.DatabricksHook"
                     ) as mock_hook:
                         mock_get_ti.return_value = Mock(key=ti_key)
                         mock_get_xcom.return_value = Mock(conn_id="conn_id", run_id=1, job_id=1)
-                        mock_dag_bag.return_value.get_dag.return_value.get_task.return_value = Mock(
-                            task_id="test_task"
-                        )
+                        mock_get_dag.return_value.get_task.return_value = Mock(task_id="test_task")
 
                         mock_hook_instance = Mock()
                         mock_hook_instance.host = "test-host"

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -70,7 +70,6 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag
 from airflow.providers.fab.auth_manager.models import (
     Action,
     Group,
@@ -101,6 +100,7 @@ from airflow.providers.fab.auth_manager.views.user_edit import (
     CustomUserInfoEditView,
 )
 from airflow.providers.fab.auth_manager.views.user_stats import CustomUserStatsChartView
+from airflow.providers.fab.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.providers.fab.www.security import permissions
 from airflow.providers.fab.www.security_manager import AirflowSecurityManagerV2
 from airflow.providers.fab.www.session import AirflowDatabaseSessionInterface
@@ -111,11 +111,28 @@ if TYPE_CHECKING:
         RESOURCE_ASSET,
         RESOURCE_ASSET_ALIAS,
     )
+    from airflow.sdk import DAG
 else:
     from airflow.providers.common.compat.security.permissions import (
         RESOURCE_ASSET,
         RESOURCE_ASSET_ALIAS,
     )
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.models.dagbag import DBDagBag
+    from airflow.utils.session import create_session
+
+    def _iter_dags() -> Iterable[DAG]:
+        with create_session() as session:
+            yield from DBDagBag().iter_all_latest_version_dags(session=session)
+else:
+    from airflow.models.dagbag import DagBag
+
+    def _iter_dags() -> Iterable[DAG]:
+        dagbag = DagBag(read_dags_from_db=True)
+        dagbag.collect_dags_from_db()
+        return dagbag.dags.values()
+
 
 log = logging.getLogger(__name__)
 
@@ -938,11 +955,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         if you only need to sync a single DAG.
         """
         perms = self.get_all_permissions()
-        dagbag = DagBag(read_dags_from_db=True)
-        dagbag.collect_dags_from_db()
-        dags = dagbag.dags.values()
 
-        for dag in dags:
+        for dag in _iter_dags():
+            print(dag)
             for resource_name, resource_values in self.RESOURCE_DETAILS_MAP.items():
                 dag_resource_name = permissions.resource_name(dag.dag_id, resource_name)
                 for action_name in resource_values["actions"]:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -129,7 +129,7 @@ else:
     from airflow.models.dagbag import DagBag
 
     def _iter_dags() -> Iterable[DAG]:
-        dagbag = DagBag(read_dags_from_db=True)
+        dagbag = DagBag(read_dags_from_db=True)  # type: ignore[call-arg]
         dagbag.collect_dags_from_db()
         return dagbag.dags.values()
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -130,7 +130,7 @@ else:
 
     def _iter_dags() -> Iterable[DAG]:
         dagbag = DagBag(read_dags_from_db=True)  # type: ignore[call-arg]
-        dagbag.collect_dags_from_db()
+        dagbag.collect_dags_from_db()  # type: ignore[attr-defined]
         return dagbag.dags.values()
 
 

--- a/providers/fab/tests/unit/fab/auth_manager/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/conftest.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import os
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -26,7 +25,6 @@ import pytest
 from airflow.providers.fab.www import app
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.db import parse_and_sync_to_db
 from unit.fab.decorators import dont_initialize_flask_app_submodules
 
 
@@ -72,14 +70,6 @@ def set_auth_role_public(request):
     yield
 
     app.config["AUTH_ROLE_PUBLIC"] = auto_role_public
-
-
-@pytest.fixture(scope="module")
-def dagbag():
-    from airflow.models import DagBag
-
-    parse_and_sync_to_db(os.devnull, include_examples=True)
-    return DagBag(read_dags_from_db=True)
 
 
 @pytest.fixture

--- a/providers/fab/tests/unit/fab/www/views/conftest.py
+++ b/providers/fab/tests/unit/fab/www/views/conftest.py
@@ -23,7 +23,6 @@ import jinja2
 import pytest
 
 from airflow import settings
-from airflow.models import DagBag
 from airflow.providers.fab.www.app import create_app
 
 from tests_common.test_utils.config import conf_vars
@@ -41,8 +40,7 @@ def session():
 
 @pytest.fixture(autouse=True, scope="module")
 def examples_dag_bag(session):
-    parse_and_sync_to_db(os.devnull, include_examples=True)
-    dag_bag = DagBag(read_dags_from_db=True)
+    dag_bag = parse_and_sync_to_db(os.devnull, include_examples=True)
     session.commit()
     return dag_bag
 

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -35,11 +35,15 @@ from airflow.exceptions import (
     DagRunAlreadyExists,
 )
 from airflow.models.dag import DagModel
-from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.external_task import DagStateTrigger
-from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS, BaseOperator, BaseOperatorLink
-from airflow.utils import timezone
+from airflow.providers.standard.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    BaseOperator,
+    BaseOperatorLink,
+    timezone,
+)
 from airflow.utils.state import DagRunState
 from airflow.utils.types import NOTSET, ArgNotSet, DagRunType
 
@@ -275,8 +279,7 @@ class TriggerDagRunOperator(BaseOperator):
                     raise DagNotFound(f"Dag id {self.trigger_dag_id} not found in DagModel")
 
                 # Note: here execution fails on database isolation mode. Needs structural changes for AIP-72
-                dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
-                dag = dag_bag.get_dag(self.trigger_dag_id)
+                dag = SerializedDagModel.get_dag(self.trigger_dag_id)
                 dag.clear(start_date=dag_run.logical_date, end_date=dag_run.logical_date)
             else:
                 if self.skip_when_already_exists:

--- a/providers/standard/src/airflow/providers/standard/utils/sensor_helper.py
+++ b/providers/standard/src/airflow/providers/standard/utils/sensor_helper.py
@@ -20,7 +20,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import func, select, tuple_
 
-from airflow.models import DagBag, DagRun, TaskInstance
+from airflow.models import DagRun, TaskInstance
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -105,7 +106,7 @@ def _get_external_task_group_task_ids(dttm_filter, external_task_group_id, exter
     :param external_dag_id: The ID of the external DAG.
     :param session: airflow session object
     """
-    refreshed_dag_info = DagBag(read_dags_from_db=True).get_dag(external_dag_id, session)
+    refreshed_dag_info = SerializedDagModel.get_dag(external_dag_id, session=session)
     task_group = refreshed_dag_info.task_group_dict.get(external_task_group_id)
 
     if task_group:

--- a/providers/standard/src/airflow/providers/standard/version_compat.py
+++ b/providers/standard/src/airflow/providers/standard/version_compat.py
@@ -39,11 +39,12 @@ AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 # DecoratedOperator -- where `DecoratedOperator._handle_output` needed `xcom_push` to exist on `BaseOperator`
 # even though it wasn't used.
 if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook, BaseOperator
+    from airflow.sdk import BaseHook, BaseOperator, timezone
     from airflow.sdk.definitions.context import context_merge
 else:
     from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
     from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
     from airflow.utils.context import context_merge  # type: ignore[no-redef, attr-defined]
 
 if AIRFLOW_V_3_0_PLUS:
@@ -62,4 +63,5 @@ __all__ = [
     "BaseSensorOperator",
     "PokeReturnValue",
     "context_merge",
+    "timezone",
 ]

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -26,20 +26,8 @@ from unittest import mock
 import pytest
 
 from airflow import settings
-from airflow.exceptions import (
-    AirflowException,
-    AirflowSensorTimeout,
-    AirflowSkipException,
-    TaskDeferred,
-)
+from airflow.exceptions import AirflowException, AirflowSensorTimeout, AirflowSkipException, TaskDeferred
 from airflow.models import DagBag, DagRun, TaskInstance
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
 from airflow.models.dag import DAG
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.xcom_arg import XComArg
@@ -56,38 +44,37 @@ from airflow.providers.standard.exceptions import (
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
-from airflow.providers.standard.sensors.external_task import (
-    ExternalTaskMarker,
-    ExternalTaskSensor,
-)
+from airflow.providers.standard.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
 from airflow.providers.standard.sensors.time import TimeSensor
 from airflow.providers.standard.triggers.external_task import WorkflowTrigger
 from airflow.serialization.serialized_objects import SerializedBaseOperator
 from airflow.timetables.base import DataInterval
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
-from airflow.utils.timezone import coerce_datetime, datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.mock_operators import MockOperator
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.models.dag_version import DagVersion
-    from airflow.sdk import task as task_deco
+    from airflow.sdk import BaseOperator, task as task_deco
     from airflow.utils.types import DagRunTriggeredByType
 else:
     from airflow.decorators import task as task_deco  # type: ignore[attr-defined,no-redef]
+    from airflow.models import BaseOperator  # type: ignore[assignment,no-redef]
 
-try:
-    from airflow.sdk.definitions.taskgroup import TaskGroup
-except ImportError:
-    # Fallback for Airflow < 3.1
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import TaskGroup
+    from airflow.sdk.timezone import coerce_datetime, datetime
+else:
     from airflow.utils.task_group import TaskGroup  # type: ignore[no-redef]
+    from airflow.utils.timezone import coerce_datetime, datetime  # type: ignore[attr-defined,no-redef]
 
 pytestmark = pytest.mark.db_test
 
+TI = TaskInstance
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = "unit_test_dag"
@@ -372,7 +359,6 @@ class TestExternalTaskSensorV2:
 
         # then
         session = settings.Session()
-        TI = TaskInstance
         task_instances: list[TI] = session.query(TI).filter(TI.task_id == op.task_id).all()
         assert len(task_instances) == 1, "Unexpected number of task instances"
         assert task_instances[0].state == State.SKIPPED, "Unexpected external task state"
@@ -392,7 +378,6 @@ class TestExternalTaskSensorV2:
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         # then
-        TI = TaskInstance
         task_instances: list[TI] = session.query(TI).filter(TI.task_id == op.task_id).all()
         assert len(task_instances) == 1, "Unexpected number of task instances"
         assert task_instances[0].state == State.SKIPPED, "Unexpected external task state"
@@ -500,7 +485,6 @@ class TestExternalTaskSensorV2:
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         # then
-        TI = TaskInstance
         task_instances: list[TI] = session.query(TI).filter(TI.task_id == op.task_id).all()
         assert len(task_instances) == 1, "Unexpected number of task instances"
         assert task_instances[0].state == State.SKIPPED, "Unexpected external task state"
@@ -529,7 +513,6 @@ exit 0
         )
 
         session = settings.Session()
-        TI = TaskInstance
         try:
             task_external_with_failure.run(
                 start_date=DEFAULT_DATE, end_date=DEFAULT_DATE + timedelta(seconds=1), ignore_ti_state=True


### PR DESCRIPTION
* [x] Remove DagBag usages where `read_dags_from_db=True`
* [ ] Remove db access from DagBag
    * [x] Everything except auto expiring check in `get_dag`
* [ ] ~~Move DagBag to SDK (for use in dag parser and task runner)~~ I give up