### PR TITLE
test(hitl): fix test_update_hitl_detail_without_ti and test_get_hitl_detail_without_ti failure

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_hitl.py
@@ -159,7 +159,7 @@ def test_update_hitl_detail(client: Client, sample_ti: TaskInstance) -> None:
 def test_update_hitl_detail_without_ti(client: Client) -> None:
     ti_id = str(uuid7())
     response = client.patch(
-        f"/execution/hitl-details/{ti_id}",
+        f"/execution/hitlDetails/{ti_id}",
         json={
             "ti_id": ti_id,
             "chosen_options": ["Reject"],
@@ -183,7 +183,7 @@ def test_get_hitl_detail(client: Client, sample_ti: TaskInstance) -> None:
 
 
 def test_get_hitl_detail_without_ti(client: Client) -> None:
-    response = client.get(f"/execution/hitl-details/{uuid7()}")
+    response = client.get(f"/execution/hitlDetails/{uuid7()}")
     assert response.status_code == 404
     assert response.json() == {
         "detail": {


### PR DESCRIPTION
## Why
endpoint `/hitl-endpoints/` has been changed to `/hitlDetails/` in another PR. It was not caught due to PR merge order.

## What
replace `/hitl-endpoints/` as `/hitlDetails/` in the test cases

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
