### PR TITLE
Fix: Prevent duplicate edge_job insertions for deferrable tasks in EdgeExecutor (#53610)

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -140,19 +140,41 @@ class EdgeExecutor(BaseExecutor):
         del self.edge_queued_tasks[key]
 
         self.validate_airflow_tasks_run_command(command)  # type: ignore[attr-defined]
-        session.add(
-            EdgeJobModel(
+
+        # Check if job already exists with same dag_id, task_id, run_id, map_index, try_number
+        existing_job = (
+            session.query(EdgeJobModel)
+            .filter_by(
                 dag_id=key.dag_id,
                 task_id=key.task_id,
                 run_id=key.run_id,
                 map_index=key.map_index,
                 try_number=key.try_number,
-                state=TaskInstanceState.QUEUED,
-                queue=queue or DEFAULT_QUEUE,
-                concurrency_slots=task_instance.pool_slots,
-                command=str(command),
             )
+            .first()
         )
+
+        if existing_job:
+            # self.log.info(f"EdgeExecutor: Job already exists for {key}, updating it.")
+            existing_job.state = TaskInstanceState.QUEUED
+            existing_job.queue = queue or DEFAULT_QUEUE
+            existing_job.concurrency_slots = task_instance.pool_slots
+            existing_job.command = str(command)
+        else:
+            session.add(
+                EdgeJobModel(
+                    dag_id=key.dag_id,
+                    task_id=key.task_id,
+                    run_id=key.run_id,
+                    map_index=key.map_index,
+                    try_number=key.try_number,
+                    state=TaskInstanceState.QUEUED,
+                    queue=queue or DEFAULT_QUEUE,
+                    concurrency_slots=task_instance.pool_slots,
+                    command=str(command),
+                )
+            )
+            # self.log.info(f"EdgeExecutor: Inserted new job for {key}")
 
     @provide_session
     def queue_workload(
@@ -168,19 +190,41 @@ class EdgeExecutor(BaseExecutor):
 
         task_instance = workload.ti
         key = task_instance.key
-        session.add(
-            EdgeJobModel(
+
+        # Check if job already exists with same dag_id, task_id, run_id, map_index, try_number
+        existing_job = (
+            session.query(EdgeJobModel)
+            .filter_by(
                 dag_id=key.dag_id,
                 task_id=key.task_id,
                 run_id=key.run_id,
                 map_index=key.map_index,
                 try_number=key.try_number,
-                state=TaskInstanceState.QUEUED,
-                queue=task_instance.queue,
-                concurrency_slots=task_instance.pool_slots,
-                command=workload.model_dump_json(),
             )
+            .first()
         )
+
+        if existing_job:
+            # self.log.info(f"EdgeExecutor: Workload already exists for {key}, updating it.")
+            existing_job.state = TaskInstanceState.QUEUED
+            existing_job.queue = task_instance.queue
+            existing_job.concurrency_slots = task_instance.pool_slots
+            existing_job.command = workload.model_dump_json()
+        else:
+            session.add(
+                EdgeJobModel(
+                    dag_id=key.dag_id,
+                    task_id=key.task_id,
+                    run_id=key.run_id,
+                    map_index=key.map_index,
+                    try_number=key.try_number,
+                    state=TaskInstanceState.QUEUED,
+                    queue=task_instance.queue,
+                    concurrency_slots=task_instance.pool_slots,
+                    command=workload.model_dump_json(),
+                )
+            )
+            # self.log.info(f"EdgeExecutor: Inserted new workload for {key}")
 
     def _check_worker_liveness(self, session: Session) -> bool:
         """Reset worker state if heartbeat timed out."""

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -155,7 +155,6 @@ class EdgeExecutor(BaseExecutor):
         )
 
         if existing_job:
-            # self.log.info(f"EdgeExecutor: Job already exists for {key}, updating it.")
             existing_job.state = TaskInstanceState.QUEUED
             existing_job.queue = queue or DEFAULT_QUEUE
             existing_job.concurrency_slots = task_instance.pool_slots
@@ -174,7 +173,6 @@ class EdgeExecutor(BaseExecutor):
                     command=str(command),
                 )
             )
-            # self.log.info(f"EdgeExecutor: Inserted new job for {key}")
 
     @provide_session
     def queue_workload(
@@ -205,7 +203,6 @@ class EdgeExecutor(BaseExecutor):
         )
 
         if existing_job:
-            # self.log.info(f"EdgeExecutor: Workload already exists for {key}, updating it.")
             existing_job.state = TaskInstanceState.QUEUED
             existing_job.queue = task_instance.queue
             existing_job.concurrency_slots = task_instance.pool_slots
@@ -224,7 +221,6 @@ class EdgeExecutor(BaseExecutor):
                     command=workload.model_dump_json(),
                 )
             )
-            # self.log.info(f"EdgeExecutor: Inserted new workload for {key}")
 
     def _check_worker_liveness(self, session: Session) -> bool:
         """Reset worker state if heartbeat timed out."""

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -139,7 +139,10 @@ class EdgeExecutor(BaseExecutor):
         task_instance = self.edge_queued_tasks[key][3]  # type: ignore[index]
         del self.edge_queued_tasks[key]
 
-        self.validate_airflow_tasks_run_command(command)  # type: ignore[attr-defined]
+        # Run validation only if supported (available in Airflow 2.12+)
+        # This makes it compatible with older versions like 2.10 and 2.11
+        if hasattr(self, "validate_airflow_tasks_run_command"):
+            self.validate_airflow_tasks_run_command(command)  # type: ignore[attr-defined]
 
         # Check if job already exists with same dag_id, task_id, run_id, map_index, try_number
         existing_job = (

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -139,10 +139,7 @@ class EdgeExecutor(BaseExecutor):
         task_instance = self.edge_queued_tasks[key][3]  # type: ignore[index]
         del self.edge_queued_tasks[key]
 
-        # Run validation only if supported (available in Airflow 2.12+)
-        # This makes it compatible with older versions like 2.10 and 2.11
-        if hasattr(self, "validate_airflow_tasks_run_command"):
-            self.validate_airflow_tasks_run_command(command)  # type: ignore[attr-defined]
+        self.validate_airflow_tasks_run_command(command)  # type: ignore[attr-defined]
 
         # Check if job already exists with same dag_id, task_id, run_id, map_index, try_number
         existing_job = (

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -247,6 +247,11 @@ class TestEdgeExecutor:
 
         # Prepare some data
         with create_session() as session:
+            # Clear existing workers to avoid unique constraint violation
+            session.query(EdgeWorkerModel).delete()
+            session.commit()
+
+            # Add workers with different states
             for worker_name, state, last_heartbeat in [
                 (
                     "inactive_timed_out_worker",
@@ -338,3 +343,95 @@ class TestEdgeExecutor:
         with create_session() as session:
             jobs = session.query(EdgeJobModel).all()
             assert len(jobs) == 1
+
+    @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="API only available in Airflow <3.0")
+    def test_execute_async_updates_existing_job(self):
+        executor, key = self.get_test_executor()
+
+        # First insert a job with the same key
+        with create_session() as session:
+            session.add(
+                EdgeJobModel(
+                    dag_id=key.dag_id,
+                    run_id=key.run_id,
+                    task_id=key.task_id,
+                    map_index=key.map_index,
+                    try_number=key.try_number,
+                    state=TaskInstanceState.SCHEDULED,
+                    queue="default",
+                    concurrency_slots=1,
+                    command="old-command",
+                    last_update=timezone.utcnow(),
+                )
+            )
+            session.commit()
+
+        # Trigger execute_async which should update the existing job
+        executor.edge_queued_tasks = deepcopy(executor.queued_tasks)
+        executor.execute_async(key=key, command=["new", "command"])
+
+        with create_session() as session:
+            jobs = session.query(EdgeJobModel).all()
+            assert len(jobs) == 1
+            job = jobs[0]
+            assert job.state == TaskInstanceState.QUEUED
+            assert job.command != "old-command"
+            assert "new" in job.command
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="API only available in Airflow 3.0+")
+    def test_queue_workload_updates_existing_job(self):
+        from uuid import uuid4
+
+        from airflow.executors.workloads import ExecuteTask, TaskInstance
+
+        executor = self.get_test_executor()[0]
+
+        key = TaskInstanceKey(dag_id="mock", run_id="mock", task_id="mock", map_index=-1, try_number=1)
+
+        # Insert an existing job
+        with create_session() as session:
+            session.add(
+                EdgeJobModel(
+                    dag_id=key.dag_id,
+                    task_id=key.task_id,
+                    run_id=key.run_id,
+                    map_index=key.map_index,
+                    try_number=key.try_number,
+                    state=TaskInstanceState.SCHEDULED,
+                    queue="default",
+                    command="old-command",
+                    concurrency_slots=1,
+                    last_update=timezone.utcnow(),
+                )
+            )
+            session.commit()
+
+        # Queue a workload with same key
+        workload = ExecuteTask(
+            token="mock",
+            ti=TaskInstance(
+                id=uuid4(),
+                task_id=key.task_id,
+                dag_id=key.dag_id,
+                run_id=key.run_id,
+                try_number=key.try_number,
+                map_index=key.map_index,
+                pool_slots=1,
+                queue="updated-queue",
+                priority_weight=1,
+                start_date=timezone.utcnow(),
+                dag_version_id=uuid4(),
+            ),
+            dag_rel_path="mock.py",
+            log_path="mock.log",
+            bundle_info={"name": "n/a", "version": "no matter"},
+        )
+
+        executor.queue_workload(workload=workload)
+
+        with create_session() as session:
+            jobs = session.query(EdgeJobModel).all()
+            assert len(jobs) == 1
+            job = jobs[0]
+            assert job.queue == "updated-queue"
+            assert job.command != "old-command"

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -368,7 +368,7 @@ class TestEdgeExecutor:
 
         # Trigger execute_async which should update the existing job
         executor.edge_queued_tasks = deepcopy(executor.queued_tasks)
-        executor.execute_async(key=key, command=["new", "command"])
+        executor.execute_async(key=key, command=["airflow", "tasks", "run", "new", "command"])
 
         with create_session() as session:
             jobs = session.query(EdgeJobModel).all()


### PR DESCRIPTION
## Overview

This PR fixes a crash in the Apache Airflow `EdgeExecutor` caused by duplicate entries in the `edge_job` table when handling deferrable tasks like `ExternalTaskSensor(mode="reschedule")`.

---

## Root Cause

When a deferrable task times out and retries, both `execute_async()` and `queue_workload()` attempt to insert the same job into the `edge_job` table again, violating uniqueness constraints and causing the scheduler to crash.

---

## Solution

Instead of blindly inserting, both methods now:

- Check if a matching job exists (`dag_id`, `task_id`, `run_id`, `map_index`, `try_number`)
- If it exists → **Update** the job to reflect the latest state
- If not → Insert a new record

This preserves job queue integrity and ensures tasks are picked up correctly by the edge worker.

---

## Changes Made

- Patched `execute_async()` and `queue_workload()` in:
  `airflow/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py`

---

## Related Issue

Closes [#53610](https://github.com/apache/airflow/issues/53610)
