### PR TITLE
Conn docs extra fix

### DIFF
--- a/providers/airbyte/docs/connections.rst
+++ b/providers/airbyte/docs/connections.rst
@@ -41,7 +41,7 @@ Client Secret (required)
     The Client Secret to connect to the Airbyte server.
     You can find this information in the Settings / Applications page in Airbyte UI.
 
-Extras (optional)
+Extra (optional)
     Specify custom proxies in json format.
     Following default requests parameters are taken into account:
 

--- a/providers/apache/livy/docs/connections.rst
+++ b/providers/apache/livy/docs/connections.rst
@@ -44,7 +44,7 @@ Login (optional)
 Password (optional)
     Specify the password for the Apache Livy server you would like to connect too.
 
-Extras (optional)
+Extra (optional)
     Specify headers in json format.
 
 When specifying the connection in environment variable you should specify

--- a/providers/discord/docs/connections/discord-webhook.rst
+++ b/providers/discord/docs/connections/discord-webhook.rst
@@ -57,5 +57,5 @@ Schema (optional)
 Webhook Endpoint
     The endpoint that will be used to perform the HTTP request.
 
-Extras (optional)
+Extra (optional)
     Specify headers in json format.

--- a/providers/http/docs/connections/http.rst
+++ b/providers/http/docs/connections/http.rst
@@ -53,7 +53,7 @@ Port (optional)
 Schema (optional)
     Specify the service type etc: http/https.
 
-Extras (optional)
+Extra (optional)
     Specify headers and default requests parameters in json format.
     Following default requests parameters are taken into account:
 


### PR DESCRIPTION
The actual parameter is `connection.extra`. Having "extras" here is misleading and can cause users to try to use `extras` in their conn definition.