### PR TITLE
Handle unmodified sensitived fields when updating connections

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1636,6 +1636,7 @@ repos:
           ^airflow-core/src/airflow/api/common/mark_tasks\.py$|
           ^airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets\.py$|
           ^airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections\.py$|
+          ^airflow-core/src/airflow/api_fastapi/core_api/services/public/connections\.py$|
           ^airflow-core/src/airflow/api_fastapi/core_api/datamodels/hitl\.py$|
           ^airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables\.py$|
           ^airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid\.py$|

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
@@ -61,10 +61,9 @@ def update_orm_from_pydantic(
     ):
         if pydantic_conn.password is None:
             orm_conn.set_password(pydantic_conn.password)
-            return
-
-        merged_password = merge(pydantic_conn.password, orm_conn.password, "password")
-        orm_conn.set_password(merged_password)
+        else:
+            merged_password = merge(pydantic_conn.password, orm_conn.password, "password")
+            orm_conn.set_password(merged_password)
     if (not update_mask and "extra" in pydantic_conn.model_fields_set) or (
         update_mask and "extra" in update_mask
     ):

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import json
+
 from fastapi import HTTPException, status
 from pydantic import ValidationError
 from sqlalchemy import select
@@ -32,6 +34,7 @@ from airflow.api_fastapi.core_api.datamodels.common import (
 from airflow.api_fastapi.core_api.datamodels.connections import ConnectionBody
 from airflow.api_fastapi.core_api.services.public.common import BulkService
 from airflow.models.connection import Connection
+from airflow.sdk.execution_time.secrets_masker import merge
 
 
 def update_orm_from_pydantic(
@@ -56,11 +59,24 @@ def update_orm_from_pydantic(
     if (not update_mask and "password" in pydantic_conn.model_fields_set) or (
         update_mask and "password" in update_mask
     ):
-        orm_conn.set_password(pydantic_conn.password)
+        if pydantic_conn.password is None:
+            orm_conn.set_password(pydantic_conn.password)
+            return
+
+        merged_password = merge(pydantic_conn.password, orm_conn.password, "password")
+        orm_conn.set_password(merged_password)
     if (not update_mask and "extra" in pydantic_conn.model_fields_set) or (
         update_mask and "extra" in update_mask
     ):
-        orm_conn.set_extra(pydantic_conn.extra)
+        if pydantic_conn.extra is None or orm_conn.extra is None:
+            orm_conn.set_extra(pydantic_conn.extra)
+            return
+        try:
+            merged_extra = merge(json.loads(pydantic_conn.extra), json.loads(orm_conn.extra))
+            orm_conn.set_extra(json.dumps(merged_extra))
+        except json.JSONDecodeError:
+            # We can't merge fields in an unstructured `extra`
+            orm_conn.set_extra(pydantic_conn.extra)
 
 
 class BulkConnectionService(BulkService[ConnectionBody]):

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -36,6 +36,7 @@
       "extraFields": "Extra Fields",
       "extraFieldsJson": "Extra Fields JSON",
       "helperText": "Connection type missing? Make sure you have installed the corresponding Airflow Providers Package.",
+      "helperTextForRedactedFields": "Redacted fields ('***') will remain unchanged if not modified.",
       "selectConnectionType": "Select Connection Type",
       "standardFields": "Standard Fields"
     },

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -32,12 +32,14 @@ export type FlexibleFormProps = {
   initialParamsDict: { paramsDict: ParamsSpec };
   key?: string;
   setError: (error: boolean) => void;
+  subHeader?: string;
 };
 
 export const FlexibleForm = ({
   flexibleFormDefaultSection,
   initialParamsDict,
   setError,
+  subHeader,
 }: FlexibleFormProps) => {
   const { paramsDict: params, setInitialParamDict, setParamsDict } = useParamStore();
   const processedSections = new Map();
@@ -126,6 +128,11 @@ export const FlexibleForm = ({
 
               <Accordion.ItemContent pt={0}>
                 <Accordion.ItemBody>
+                  {Boolean(subHeader) ? (
+                    <Text color="fg.muted" fontSize="xs" mb={2}>
+                      {subHeader}
+                    </Text>
+                  ) : undefined}
                   <Stack separator={<StackSeparator />}>
                     {Object.entries(params)
                       .filter(

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -37,6 +37,7 @@ import type { ConnectionBody } from "./Connections";
 type AddConnectionFormProps = {
   readonly error: unknown;
   readonly initialConnection: ConnectionBody;
+  readonly isEditMode?: boolean;
   readonly isPending: boolean;
   readonly mutateConnection: (requestBody: ConnectionBody) => void;
 };
@@ -44,6 +45,7 @@ type AddConnectionFormProps = {
 const ConnectionForm = ({
   error,
   initialConnection,
+  isEditMode = false,
   isPending,
   mutateConnection,
 }: AddConnectionFormProps) => {
@@ -202,6 +204,7 @@ const ConnectionForm = ({
               initialParamsDict={paramsDic}
               key={selectedConnType}
               setError={setFormErrors}
+              subHeader={isEditMode ? translate("connections.form.helperTextForRedactedFields") : undefined}
             />
             <Accordion.Item key="extraJson" value="extraJson">
               <Accordion.ItemTrigger cursor="button">
@@ -220,6 +223,11 @@ const ConnectionForm = ({
                         }}
                       />
                       {Boolean(errors.conf) ? <Field.ErrorText>{errors.conf}</Field.ErrorText> : undefined}
+                      {isEditMode ? (
+                        <Field.HelperText>
+                          {translate("connections.form.helperTextForRedactedFields")}
+                        </Field.HelperText>
+                      ) : undefined}
                     </Field.Root>
                   )}
                 />

--- a/airflow-core/src/airflow/ui/src/pages/Connections/EditConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/EditConnectionButton.tsx
@@ -81,6 +81,7 @@ const EditConnectionButton = ({ connection, disabled }: Props) => {
             <ConnectionForm
               error={error}
               initialConnection={initialConnectionValue}
+              isEditMode
               isPending={isPending}
               mutateConnection={editConnection}
             />

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -469,6 +469,27 @@ class TestPatchConnection(TestConnectionEndpoint):
                 },
             ),
             (
+                # Sensitive "***" should be ignored.
+                {
+                    "connection_id": TEST_CONN_ID,
+                    "conn_type": TEST_CONN_TYPE,
+                    "port": 80,
+                    "login": "test_login_patch",
+                    "password": "***",
+                },
+                {
+                    "conn_type": TEST_CONN_TYPE,
+                    "connection_id": TEST_CONN_ID,
+                    "description": TEST_CONN_DESCRIPTION,
+                    "extra": None,
+                    "host": TEST_CONN_HOST,
+                    "login": "test_login_patch",
+                    "password": None,
+                    "port": 80,
+                    "schema": None,
+                },
+            ),
+            (
                 {
                     "connection_id": TEST_CONN_ID,
                     "conn_type": TEST_CONN_TYPE,

--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -27,7 +27,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator
 from enum import Enum
 from functools import cache, cached_property
 from re import Pattern
-from typing import Any, TextIO, TypeAlias, TypeVar
+from typing import Any, TextIO, TypeAlias, TypeVar, overload
 
 from airflow import settings
 
@@ -116,9 +116,17 @@ def redact(value: Redactable, name: str | None = None, max_depth: int | None = N
     return _secrets_masker().redact(value, name, max_depth)
 
 
+@overload
+def merge(new_value: str, old_value: str, name: str | None = None, max_depth: int | None = None) -> str: ...
+
+
+@overload
+def merge(new_value: dict, old_value: dict, name: str | None = None, max_depth: int | None = None) -> str: ...
+
+
 def merge(
     new_value: Redacted, old_value: Redactable, name: str | None = None, max_depth: int | None = None
-) -> Redactable:
+) -> Redacted:
     """
     Merge a redacted value with its original unredacted counterpart.
 
@@ -313,7 +321,7 @@ class SecretsMasker(logging.Filter):
         depth: int,
         max_depth: int,
         force_sensitive: bool = False,
-    ) -> Redactable:
+    ) -> Redacted:
         """Merge a redacted item with its original unredacted counterpart."""
         if depth > max_depth:
             if isinstance(new_item, str) and new_item == "***":
@@ -394,7 +402,7 @@ class SecretsMasker(logging.Filter):
 
     def merge(
         self, new_item: Redacted, old_item: Redactable, name: str | None = None, max_depth: int | None = None
-    ) -> Redactable:
+    ) -> Redacted:
         """
         Merge a redacted item with its original unredacted counterpart.
 

--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -350,7 +350,7 @@ class SecretsMasker(logging.Filter):
                         merged[key] = new_item[key]
                 return merged
 
-            if isinstance(new_item, (list, tuple)) and isinstance(old_item, (list, tuple)):
+            if isinstance(new_item, (list, tuple)) and type(old_item) is type(new_item):
                 merged_list = []
                 for i in range(len(new_item)):
                     if i < len(old_item):

--- a/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
+++ b/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
@@ -34,6 +34,7 @@ from airflow.sdk.execution_time.secrets_masker import (
     RedactedIO,
     SecretsMasker,
     mask_secret,
+    merge,
     redact,
     reset_secrets_masker,
     should_hide_value_for_key,
@@ -53,6 +54,7 @@ def lineno():
 
 class MyEnum(str, Enum):
     testname = "testvalue"
+    testname2 = "testvalue2"
 
 
 @pytest.fixture
@@ -729,3 +731,370 @@ class TestMixedDataScenarios:
             assert "***" in redacted_data["description"]
             assert redacted_data["nested"]["token"] == "***"
             assert redacted_data["nested"]["info"] == "No secrets here"
+
+
+class TestSecretsMaskerMerge:
+    """Test the merge functionality for restoring original values from redacted data."""
+
+    @pytest.mark.parametrize(
+        ("new_value", "old_value", "name", "expected"),
+        [
+            ("***", "original_secret", "password", "original_secret"),
+            ("new_secret", "original_secret", "password", "new_secret"),
+            ("***", "original_value", "normal_field", "***"),
+            ("new_value", "original_value", "normal_field", "new_value"),
+            ("***", "original_value", None, "***"),
+            ("new_value", "original_value", None, "new_value"),
+        ],
+    )
+    def test_merge_simple_strings(self, new_value, old_value, name, expected):
+        secrets_masker = SecretsMasker()
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_value, old_value, name)
+            assert result == expected
+
+    def test_merge_dictionaries(self):
+        """Test merging dictionaries with sensitive and non-sensitive keys."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {
+            "password": "original_password",
+            "api_key": "original_api_key",
+            "normal_field": "original_normal",
+            "token": "original_token",
+        }
+
+        new_data = {
+            "password": "***",
+            "api_key": "new_api_key",
+            "normal_field": "new_normal",
+            "token": "***",
+        }
+
+        expected = {
+            "password": "original_password",
+            "api_key": "new_api_key",
+            "normal_field": "new_normal",
+            "token": "original_token",
+        }
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            assert result == expected
+
+    def test_merge_nested_dictionaries(self):
+        """Test merging nested dictionary structures."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {
+            "config": {"password": "original_password", "host": "original_host"},
+            "credentials": {"api_key": "original_api_key", "username": "original_user"},
+        }
+
+        new_data = {
+            "config": {
+                "password": "***",
+                "host": "new_host",
+            },
+            "credentials": {
+                "api_key": "new_api_key",
+                "username": "new_user",
+            },
+        }
+
+        expected = {
+            "config": {
+                "password": "original_password",
+                "host": "new_host",
+            },
+            "credentials": {
+                "api_key": "new_api_key",
+                "username": "new_user",
+            },
+        }
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            assert result == expected
+
+    @pytest.mark.parametrize(
+        ("old_data", "new_data", "name", "expected"),
+        [
+            (
+                ["original_item1", "original_item2", "original_item3"],
+                ["new_item1", "new_item2"],
+                None,
+                ["new_item1", "new_item2"],
+            ),
+            (
+                ["original_item1", "original_item2"],
+                ["new_item1", "new_item2", "new_item3", "new_item4"],
+                None,
+                ["new_item1", "new_item2", "new_item3", "new_item4"],
+            ),
+            (
+                ["secret1", "secret2", "secret3"],
+                ["***", "new_secret2", "***"],
+                "password",  # sensitive field name
+                ["secret1", "new_secret2", "secret3"],
+            ),
+            (
+                ["value1", "value2", "value3"],
+                ["***", "new_value2", "***"],
+                "normal_list",  # non-sensitive field name
+                ["***", "new_value2", "***"],
+            ),
+        ],
+    )
+    def test_merge_lists(self, old_data, new_data, name, expected):
+        """Test merging list structures with various scenarios."""
+        secrets_masker = SecretsMasker()
+
+        # Call merge directly on the instance instead of using the global function
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = secrets_masker.merge(new_data, old_data, name)
+            assert result == expected
+
+    def test_merge_tuples_and_sets(self):
+        """Test merging tuple and set structures."""
+        secrets_masker = SecretsMasker()
+
+        # Test tuples
+        old_tuple = ("original_item1", "original_item2", "original_item3")
+        new_tuple = ("new_item1", "new_item2")
+        expected_tuple = (
+            "new_item1",
+            "new_item2",
+        )  # Only process items from new_tuple, ignore remaining old items
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = secrets_masker.merge(new_tuple, old_tuple)
+            assert result == expected_tuple
+            assert isinstance(result, tuple)
+
+        # Test sets (note: order is not guaranteed in sets)
+        old_set = {"original_item1", "original_item2", "original_item3"}
+        new_set = {"new_item1", "new_item2"}
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_set, old_set)
+            assert isinstance(result, set)
+            # For sets, we expect only the items from new_set since order is not preserved
+            assert result == new_set
+
+    def test_merge_mismatched_types(self):
+        """Test merging when types don't match between new and old."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {"key": "value"}
+        new_data = "some_string"  # Different type
+
+        # When types don't match, prefer the new item
+        expected = "some_string"
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            assert result == expected
+
+    def test_merge_with_missing_keys(self):
+        """Test merging dictionaries with different keys."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {"password": "original_password", "old_only_key": "old_value", "common_key": "old_common"}
+
+        new_data = {
+            "password": "***",  # Unchanged redacted
+            "new_only_key": "new_value",
+            "common_key": "new_common",
+        }
+
+        expected = {
+            "password": "original_password",  # Restored from original
+            "new_only_key": "new_value",  # Kept from new
+            "common_key": "new_common",  # User modification
+            # old_only_key is ignored since it's not in new_data
+        }
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            assert result == expected
+
+    def test_merge_complex_redacted_structures(self):
+        """Test merging when nested structures have redacted items."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {
+            "sensitive_config": {
+                "nested_password": "original_nested_password",
+                "nested_list": ["item1", "item2"],
+            },
+            "normal_field": "normal_value",
+        }
+
+        # Simulate what happens when sensitive fields are redacted individually
+        new_data = {
+            "sensitive_config": {"nested_password": "***", "nested_list": ["***", "***"]},
+            "normal_field": "new_normal_value",
+        }
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            # The nested_password should be restored because it's a sensitive field name
+            # The nested_list items remain "***" because individual list items don't have sensitive context
+            expected = {
+                "sensitive_config": {
+                    "nested_password": "original_nested_password",  # Restored because sensitive field name
+                    "nested_list": ["***", "***"],  # Individual items stay redacted without sensitive context
+                },
+                "normal_field": "new_normal_value",  # Kept because it's not sensitive
+            }
+            assert result == expected
+
+    def test_merge_partially_redacted_structures(self):
+        """Test merging when structures are partially redacted."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {
+            "config": {
+                "password": "original_password",
+                "host": "original_host",
+                "nested": {"api_key": "original_api_key", "timeout": 30},
+            }
+        }
+
+        new_data = {
+            "config": {
+                "password": "***",  # Unchanged redacted
+                "host": "new_host",  # Modified
+                "nested": {
+                    "api_key": "***",  # Unchanged redacted
+                    "timeout": 60,  # Modified
+                },
+            }
+        }
+
+        expected = {
+            "config": {
+                "password": "original_password",  # Restored
+                "host": "new_host",  # Kept modification
+                "nested": {
+                    "api_key": "original_api_key",  # Restored
+                    "timeout": 60,  # Kept modification
+                },
+            }
+        }
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            assert result == expected
+
+    def test_merge_max_depth(self):
+        """Test merge respects max_depth parameter."""
+        secrets_masker = SecretsMasker()
+
+        # Create deeply nested structure
+        old_data = {"level1": {"level2": {"level3": {"password": "original_password"}}}}
+        new_data = {"level1": {"level2": {"level3": {"password": "***"}}}}
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            # With max_depth=1, should stop early and return new_data
+            result = merge(new_data, old_data, max_depth=1)
+            assert result == new_data
+
+            # With sufficient depth, should merge properly
+            result = merge(new_data, old_data, max_depth=10)
+            assert result["level1"]["level2"]["level3"]["password"] == "original_password"
+
+    def test_merge_error_handling(self):
+        """Test merge handles errors gracefully."""
+        secrets_masker = SecretsMasker()
+
+        # Create a situation that might cause an error (e.g., incompatible structures)
+        old_data = "simple_string"
+        new_data = {"complex": "dict"}
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            # Should not raise an exception and should prefer new_data
+            result = merge(new_data, old_data)
+            assert result == new_data
+
+    def test_merge_enum_values(self):
+        """Test merging enum values."""
+        secrets_masker = SecretsMasker()
+
+        old_enum = MyEnum.testname
+        new_enum = MyEnum.testname2
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_enum, old_enum)
+            assert result == new_enum
+            assert isinstance(result, MyEnum)
+
+    def test_is_redacted_value_helper(self):
+        """Test the _is_redacted_value helper method."""
+        secrets_masker = SecretsMasker()
+
+        # Test basic redacted values
+        assert secrets_masker._is_redacted_value("***") is True
+        assert secrets_masker._is_redacted_value("not_redacted") is False
+        assert secrets_masker._is_redacted_value("") is False
+
+        # Test redacted collections
+        assert secrets_masker._is_redacted_value({"key": "***"}) is True
+        assert secrets_masker._is_redacted_value({"key": "value"}) is False
+        assert secrets_masker._is_redacted_value({"key1": "***", "key2": "***"}) is True
+        assert secrets_masker._is_redacted_value({"key1": "***", "key2": "value"}) is False
+
+        assert secrets_masker._is_redacted_value(["***", "***"]) is True
+        assert secrets_masker._is_redacted_value(["***", "value"]) is False
+        assert secrets_masker._is_redacted_value(("***", "***")) is True
+        assert secrets_masker._is_redacted_value(("***", "value")) is False
+
+    def test_public_merge_function(self):
+        """Test the public merge function works correctly."""
+        secrets_masker = SecretsMasker()
+
+        old_data = {"password": "original_password", "normal": "original_normal"}
+        new_data = {"password": "***", "normal": "new_normal"}
+        expected = {"password": "original_password", "normal": "new_normal"}
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            result = merge(new_data, old_data)
+            assert result == expected
+
+    def test_merge_real_world_scenario(self):
+        """Test a realistic scenario combining redact and merge."""
+        secrets_masker = SecretsMasker()
+
+        # Original data with sensitive information
+        original_config = {
+            "database": {"host": "db.example.com", "password": "super_secret_password", "username": "admin"},
+            "api": {"api_key": "secret_api_key_12345", "endpoint": "https://api.example.com", "timeout": 30},
+            "app_name": "my_application",
+        }
+
+        with patch("airflow.sdk.execution_time.secrets_masker._secrets_masker", return_value=secrets_masker):
+            # Step 1: Redact the original data
+            redacted_config = redact(original_config)
+
+            # Verify sensitive fields are redacted
+            assert redacted_config["database"]["password"] == "***"
+            assert redacted_config["api"]["api_key"] == "***"
+            assert redacted_config["database"]["host"] == "db.example.com"  # Not sensitive
+
+            # Step 2: User modifies some fields (simulating user editing redacted data)
+            user_modified_config = redacted_config.copy()
+            user_modified_config["database"]["host"] = "new-db.example.com"  # User changed host
+            user_modified_config["api"]["timeout"] = 60  # User changed timeout
+            user_modified_config["api"]["api_key"] = "new_api_key_67890"  # User changed API key
+            # User left password as "***" (unchanged)
+
+            # Step 3: Merge to restore unchanged sensitive values
+            final_config = merge(user_modified_config, original_config)
+
+            # Verify the results
+            assert final_config["database"]["password"] == "super_secret_password"  # Restored
+            assert final_config["database"]["host"] == "new-db.example.com"  # User modification kept
+            assert final_config["api"]["api_key"] == "new_api_key_67890"  # User modification kept
+            assert final_config["api"]["timeout"] == 60  # User modification kept
+            assert final_config["app_name"] == "my_application"  # Unchanged

--- a/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
+++ b/task-sdk/tests/task_sdk/definitions/test_secrets_masker.py
@@ -835,13 +835,13 @@ class TestSecretsMaskerMerge:
             (
                 ["secret1", "secret2", "secret3"],
                 ["***", "new_secret2", "***"],
-                "password",  # sensitive field name
+                "password",
                 ["secret1", "new_secret2", "secret3"],
             ),
             (
                 ["value1", "value2", "value3"],
                 ["***", "new_value2", "***"],
-                "normal_list",  # non-sensitive field name
+                "normal_list",
                 ["***", "new_value2", "***"],
             ),
         ],


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/52301
closes: https://github.com/apache/airflow/issues/53753

How it works: 
For connection, 'password' and 'extras' are merged with their original value when doing an update. The function works similarly to the `redact` function, it will recursively handle all sort of data types and detect sensitive values that were not modified in the 'new_value' and then restore the value from the unredacted previous value.


 See the warning note:
<img width="957" height="670" alt="Screenshot 2025-07-30 at 19 34 42" src="https://github.com/user-attachments/assets/47415058-7ec6-47c5-a57e-e8213433036c" />
<img width="933" height="801" alt="Screenshot 2025-07-30 at 19 34 48" src="https://github.com/user-attachments/assets/9e503490-b243-4cad-b888-71134e561532" />


After adding a key 'new_key' to the extra and saving this is what we get in the UI:
<img width="1055" height="845" alt="Screenshot 2025-07-30 at 19 35 44" src="https://github.com/user-attachments/assets/57a092e4-b154-46b2-9187-b599e80bfda1" />

And from the CLI we can see that both password, and extra redacted field were preserved:
<img width="1886" height="186" alt="Screenshot 2025-07-30 at 19 36 10" src="https://github.com/user-attachments/assets/70df3ba2-039f-4f5d-99ca-fa25cafe3ffb" />


The only downside is that we cannot 'insert' a real '\*\*\*' for redacted value because this is how we detect that the value didn't change. I think it's a fair limitation, '\*\*\*' shouldn't never be a valid value for a sensitive field anyway.  @ashb is working on a follow up PR to instead use unicode characters that looks like '\*\*\*' but are not, to make it even less likely that it will be blocking for users. (They would have to chose a very weird value for their secret).

Another example, it also handle well arrays:


<img width="1102" height="721" alt="Screenshot 2025-07-30 at 19 38 58" src="https://github.com/user-attachments/assets/becdd7e1-ef62-4ce1-8f3e-fc477bf17e7d" />
<img width="1077" height="914" alt="Screenshot 2025-07-30 at 19 39 14" src="https://github.com/user-attachments/assets/1717a557-bbd3-4b63-90bc-db8acd249777" />
password1 and password3 value in the array are retained.
<img width="1896" height="240" alt="Screenshot 2025-07-30 at 19 39 31" src="https://github.com/user-attachments/assets/ecb406ac-4af9-4f2c-97ca-27ca0f80c9a0" />



