### PR TITLE
Remove query obj from providers fab

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -534,6 +534,7 @@ repos:
         files: >
             (?x)
             ^airflow-ctl.*\.py$|
+            ^providers/fab.*\.py$|
             ^task_sdk.*\.py$
         pass_filenames: true
       - id: update-supported-versions

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1209,12 +1209,14 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         """FAB leaves faulty permissions that need to be cleaned up."""
         self.log.debug("Cleaning faulty perms")
         sesh = self.appbuilder.get_session
-        perms = sesh.scalars(select(Permission).where(
-            or_(
-                Permission.action == None,  # noqa: E711
-                Permission.resource == None,  # noqa: E711
+        perms = sesh.scalars(
+            select(Permission).where(
+                or_(
+                    Permission.action == None,  # noqa: E711
+                    Permission.resource == None,  # noqa: E711
+                )
             )
-        )).all()
+        ).all()
         # Since FAB doesn't define ON DELETE CASCADE on these tables, we need
         # to delete the _object_ so that SQLA knows to delete the many-to-many
         # relationship object too. :(

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1209,12 +1209,12 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         """FAB leaves faulty permissions that need to be cleaned up."""
         self.log.debug("Cleaning faulty perms")
         sesh = self.appbuilder.get_session
-        perms = sesh.query(Permission).filter(
+        perms = sesh.scalars(select(Permission).where(
             or_(
                 Permission.action == None,  # noqa: E711
                 Permission.resource == None,  # noqa: E711
             )
-        )
+        )).all()
         # Since FAB doesn't define ON DELETE CASCADE on these tables, we need
         # to delete the _object_ so that SQLA knows to delete the many-to-many
         # relationship object too. :(

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -565,7 +565,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             interface = self.appbuilder.get_app.session_interface
             session = interface.db.session
             user_session_model = interface.sql_session_model
-            num_sessions = session.query(user_session_model).count()
+            # num_sessions = session.query(user_session_model).count()
+            num_sessions = session.scalars(select(func.count()).select_from(user_session_model)).one()
             if num_sessions > MAX_NUM_DATABASE_USER_SESSIONS:
                 safe_username = escape(user.username)
                 self._cli_safe_flash(
@@ -580,7 +581,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                     "warning",
                 )
             else:
-                for s in session.query(user_session_model):
+                # for s in session.query(user_session_model):
+                for s in session.scalars(user_session_model).all():
                     session_details = interface.serializer.loads(want_bytes(s.data))
                     if session_details.get("_user_id") == user.id:
                         session.delete(s)
@@ -1292,10 +1294,11 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         :param name: the role name
         """
-        return self.get_session.query(self.role_model).filter_by(name=name).one_or_none()
+        return self.get_session.execute(select(self.role_model).filter_by(name=name)).unique().one_or_none()
 
     def get_all_roles(self):
-        return self.get_session.query(self.role_model).all()
+        # return self.get_session.query(self.role_model).all()
+        return self.get_session.scalars(select(self.role_model)).all()
 
     def delete_role(self, role_name: str) -> None:
         """
@@ -1304,7 +1307,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         :param role_name: the name of a role in the ab_role table
         """
         session = self.get_session
-        role = session.query(Role).filter(Role.name == role_name).first()
+        # role = session.query(Role).filter(Role.name == role_name).first()
+        role = session.execute(select(Role).where(Role.name == role_name)).first()
         if role:
             log.info("Deleting role '%s'", role_name)
             session.delete(role)
@@ -1338,7 +1342,10 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         return _roles
 
     def get_public_role(self):
-        return self.get_session.query(self.role_model).filter_by(name=self.auth_role_public).one_or_none()
+        # return self.get_session.query(self.role_model).filter_by(name=self.auth_role_public).one_or_none()
+        return self.get_session.execute(
+            select(self.role_model).filter_by(name=self.auth_role_public)
+        ).one_or_none()
 
     """
     -----------
@@ -1395,7 +1402,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
     def count_users(self):
         """Return the number of users in the database."""
-        return self.get_session.query(func.count(self.user_model.id)).scalar()
+        # return self.get_session.query(func.count(self.user_model.id)).scalar()
+        return self.get_session.execute(select(func.count(self.user_model.id))).scalar()
 
     def add_register_user(self, username, first_name, last_name, email, password="", hashed_password=""):
         """
@@ -1427,22 +1435,32 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         if username:
             try:
                 if self.auth_username_ci:
-                    return (
+                    """ return (
                         self.get_session.query(self.user_model)
                         .filter(func.lower(self.user_model.username) == func.lower(username))
                         .one_or_none()
-                    )
-                return (
+                    ) """
+                    return self.get_session.execute(
+                        select(self.user_model).where(
+                            func.lower(self.user_model.username) == func.lower(username)
+                        )
+                    ).one_or_none()
+                """ return (
                     self.get_session.query(self.user_model)
                     .filter(func.lower(self.user_model.username) == func.lower(username))
                     .one_or_none()
-                )
+                ) """
+                return self.get_session.execute(
+                    select(self.user_model).where(
+                        func.lower(self.user_model.username) == func.lower(username)
+                    )
+                ).one_or_none()
             except MultipleResultsFound:
                 log.error("Multiple results found for user %s", username)
                 return None
         elif email:
             try:
-                return self.get_session.query(self.user_model).filter_by(email=email).one_or_none()
+                return self.get_session.execute(select(self.user_model).filter_by(email=email)).one_or_none()
             except MultipleResultsFound:
                 log.error("Multiple results found for user with email %s", email)
                 return None
@@ -1474,7 +1492,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             return False
 
     def get_all_users(self):
-        return self.get_session.query(self.user_model).all()
+        return self.get_session.scalars(select(self.user_model)).all()
 
     def update_user_auth_stat(self, user, success=True):
         """
@@ -1514,7 +1532,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         :param name: name
         """
-        return self.get_session.query(self.action_model).filter_by(name=name).one_or_none()
+        return self.get_session.execute(select(self.action_model).filter_by(name=name)).one_or_none()
 
     def create_action(self, name):
         """
@@ -1547,11 +1565,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             log.warning(const.LOGMSG_WAR_SEC_DEL_PERMISSION, name)
             return False
         try:
-            perms = (
-                self.get_session.query(self.permission_model)
-                .filter(self.permission_model.action == action)
-                .all()
-            )
+            perms = self.get_session.scalars(
+                select(self.permission_model).where(self.permission_model.action == action)
+            ).all()
             if perms:
                 log.warning(const.LOGMSG_WAR_SEC_DEL_PERM_PVM, action, perms)
                 return False
@@ -1575,7 +1591,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         :param name: Name of resource
         """
-        return self.get_session.query(self.resource_model).filter_by(name=name).one_or_none()
+        return self.get_session.execute(select(self.resource_model).filter_by(name=name)).one_or_none()
 
     def create_resource(self, name) -> Resource | None:
         """
@@ -1616,11 +1632,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         action = self.get_action(action_name)
         resource = self.get_resource(resource_name)
         if action and resource:
-            return (
-                self.get_session.query(self.permission_model)
-                .filter_by(action=action, resource=resource)
-                .one_or_none()
-            )
+            return self.get_session.execute(
+                select(self.permission_model).filter_by(action=action, resource=resource)
+            ).one_or_none()
         return None
 
     def get_resource_permissions(self, resource: Resource) -> Permission:
@@ -1629,7 +1643,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         :param resource: Object representing a single resource.
         """
-        return self.get_session.query(self.permission_model).filter_by(resource_id=resource.id).all()
+        return self.get_session.scalars(
+            select(self.permission_model).filter_by(resource_id=resource.id)
+        ).all()
 
     def create_permission(self, action_name, resource_name) -> Permission | None:
         """
@@ -1676,9 +1692,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         perm = self.get_permission(action_name, resource_name)
         if not perm:
             return
-        roles = (
-            self.get_session.query(self.role_model).filter(self.role_model.permissions.contains(perm)).first()
-        )
+        roles = self.get_session.execute(
+            select(self.role_model).where(self.role_model.permissions.contains(perm))
+        ).first()
         if roles:
             log.warning(const.LOGMSG_WAR_SEC_DEL_PERMVIEW, resource_name, action_name, roles)
             return
@@ -1687,7 +1703,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             self.get_session.delete(perm)
             self.get_session.commit()
             # if no more permission on permission view, delete permission
-            if not self.get_session.query(self.permission_model).filter_by(action=perm.action).all():
+            if not self.get_session.scalars(
+                select(self.permission_model).filter_by(action=perm.action)
+            ).all():
                 self.delete_action(perm.action.name)
             log.info(const.LOGMSG_INF_SEC_DEL_PERMVIEW, action_name, resource_name)
         except Exception as e:

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -680,9 +680,7 @@ class TestPatchUser(TestUserEndpoint):
 
         mock_generate_password_hash.assert_called_once_with("new-pass")
 
-        password_in_db = self.session.execute(
-            select(User.password).where(User.username == autoclean_username)
-        ).scalar()
+        password_in_db = self.session.scalar(select(User.password).where(User.username == autoclean_username))
         assert password_in_db == "fake-hashed-pass"
 
     @pytest.mark.usefixtures("autoclean_admin_user")
@@ -792,10 +790,7 @@ class TestDeleteUser(TestUserEndpoint):
         )
         assert response.status_code == 204, response.json  # NO CONTENT.
         assert (
-            self.session.execute(
-                select(func.count(User.id)).where(User.username == autoclean_username)
-            ).scalar()
-            == 0
+            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 0
         )
 
     @pytest.mark.usefixtures("autoclean_admin_user")
@@ -805,10 +800,7 @@ class TestDeleteUser(TestUserEndpoint):
         )
         assert response.status_code == 401, response.json
         assert (
-            self.session.execute(
-                select(func.count(User.id)).where(User.username == autoclean_username)
-            ).scalar()
-            == 1
+            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 1
         )
 
     @pytest.mark.usefixtures("autoclean_admin_user")
@@ -819,10 +811,7 @@ class TestDeleteUser(TestUserEndpoint):
         )
         assert response.status_code == 403, response.json
         assert (
-            self.session.execute(
-                select(func.count(User.id)).where(User.username == autoclean_username)
-            ).scalar()
-            == 1
+            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 1
         )
 
     def test_not_found(self, autoclean_username):

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import unittest.mock
 
 import pytest
-from sqlalchemy.sql.functions import count
+from sqlalchemy import delete, func, select
 
 from airflow.providers.fab.www.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.providers.fab.www.security import permissions
@@ -90,8 +90,7 @@ class TestUserEndpoint:
 
     def teardown_method(self) -> None:
         # Delete users that have our custom default time
-        users = self.session.query(User).filter(User.changed_on == timezone.parse(DEFAULT_TIME))
-        users.delete(synchronize_session=False)
+        self.session.execute(delete(User).where(User.changed_on == timezone.parse(DEFAULT_TIME)))
         self.session.commit()
 
     def _create_users(self, count, roles=None):
@@ -359,11 +358,11 @@ EXAMPLE_USER_EMAIL = "example_user@example.com"
 
 def _delete_user(**filters):
     with create_session() as session:
-        user = session.query(User).filter_by(**filters).first()
+        user = session.scalars(select(User).filter_by(**filters)).first()
         if user is None:
             return
         user.roles = []
-        session.delete(user)
+        session.execute(delete(User).filter_by(**filters))
 
 
 @pytest.fixture
@@ -681,10 +680,7 @@ class TestPatchUser(TestUserEndpoint):
         assert "password" not in response.json
 
         mock_generate_password_hash.assert_called_once_with("new-pass")
-
-        password_in_db = (
-            self.session.query(User.password).filter(User.username == autoclean_username).scalar()
-        )
+        password_in_db = self.session.scalar(select(User.password).where(User.username == autoclean_username))
         assert password_in_db == "fake-hashed-pass"
 
     @pytest.mark.usefixtures("autoclean_admin_user")
@@ -793,7 +789,9 @@ class TestDeleteUser(TestUserEndpoint):
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 204, response.json  # NO CONTENT.
-        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 0
+        assert (
+            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 0
+        )
 
     @pytest.mark.usefixtures("autoclean_admin_user")
     def test_unauthenticated(self, autoclean_username):
@@ -801,7 +799,9 @@ class TestDeleteUser(TestUserEndpoint):
             f"/fab/v1/users/{autoclean_username}",
         )
         assert response.status_code == 401, response.json
-        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 1
+        assert (
+            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 1
+        )
 
     @pytest.mark.usefixtures("autoclean_admin_user")
     def test_forbidden(self, autoclean_username):
@@ -810,7 +810,9 @@ class TestDeleteUser(TestUserEndpoint):
             environ_overrides={"REMOTE_USER": "test_no_permissions"},
         )
         assert response.status_code == 403, response.json
-        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 1
+        assert (
+            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 1
+        )
 
     def test_not_found(self, autoclean_username):
         # This test does not populate autoclean_admin_user into the database.

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -19,11 +19,10 @@ from __future__ import annotations
 import unittest.mock
 
 import pytest
-from sqlalchemy import delete, func, select
+from sqlalchemy.sql.functions import count
 
 from airflow.providers.fab.www.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.providers.fab.www.security import permissions
-from airflow.sdk import timezone
 from airflow.utils.session import create_session
 
 from tests_common.test_utils.compat import ignore_provider_compatibility_error
@@ -34,6 +33,12 @@ from unit.fab.auth_manager.api_endpoints.api_connexion_utils import (
     delete_role,
     delete_user,
 )
+
+try:
+    from airflow.utils import timezone  # type: ignore[attr-defined]
+except AttributeError:
+    from airflow.sdk import timezone
+
 
 with ignore_provider_compatibility_error("2.9.0+", __file__):
     from airflow.providers.fab.auth_manager.models import User
@@ -85,11 +90,8 @@ class TestUserEndpoint:
 
     def teardown_method(self) -> None:
         # Delete users that have our custom default time
-        self.session.execute(
-            delete(User)
-            .where(User.changed_on == timezone.parse(DEFAULT_TIME))
-            .execution_options(synchronize_session="fetch")
-        )
+        users = self.session.query(User).filter(User.changed_on == timezone.parse(DEFAULT_TIME))
+        users.delete(synchronize_session=False)
         self.session.commit()
 
     def _create_users(self, count, roles=None):
@@ -357,11 +359,11 @@ EXAMPLE_USER_EMAIL = "example_user@example.com"
 
 def _delete_user(**filters):
     with create_session() as session:
-        user = session.scalars(select(User).filter_by(**filters)).first()
+        user = session.query(User).filter_by(**filters).first()
         if user is None:
             return
-        user.roles.clear()
-        session.execute(delete(User).filter_by(**filters))
+        user.roles = []
+        session.delete(user)
 
 
 @pytest.fixture
@@ -680,7 +682,9 @@ class TestPatchUser(TestUserEndpoint):
 
         mock_generate_password_hash.assert_called_once_with("new-pass")
 
-        password_in_db = self.session.scalar(select(User.password).where(User.username == autoclean_username))
+        password_in_db = (
+            self.session.query(User.password).filter(User.username == autoclean_username).scalar()
+        )
         assert password_in_db == "fake-hashed-pass"
 
     @pytest.mark.usefixtures("autoclean_admin_user")
@@ -789,9 +793,7 @@ class TestDeleteUser(TestUserEndpoint):
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 204, response.json  # NO CONTENT.
-        assert (
-            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 0
-        )
+        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 0
 
     @pytest.mark.usefixtures("autoclean_admin_user")
     def test_unauthenticated(self, autoclean_username):
@@ -799,9 +801,7 @@ class TestDeleteUser(TestUserEndpoint):
             f"/fab/v1/users/{autoclean_username}",
         )
         assert response.status_code == 401, response.json
-        assert (
-            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 1
-        )
+        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 1
 
     @pytest.mark.usefixtures("autoclean_admin_user")
     def test_forbidden(self, autoclean_username):
@@ -810,9 +810,7 @@ class TestDeleteUser(TestUserEndpoint):
             environ_overrides={"REMOTE_USER": "test_no_permissions"},
         )
         assert response.status_code == 403, response.json
-        assert (
-            self.session.scalar(select(func.count(User.id)).where(User.username == autoclean_username)) == 1
-        )
+        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 1
 
     def test_not_found(self, autoclean_username):
         # This test does not populate autoclean_admin_user into the database.

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -23,7 +23,7 @@ from sqlalchemy import delete, func, select
 
 from airflow.providers.fab.www.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.providers.fab.www.security import permissions
-from airflow.utils import timezone
+from airflow.sdk import timezone
 from airflow.utils.session import create_session
 
 from tests_common.test_utils.compat import ignore_provider_compatibility_error

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import unittest.mock
 
 import pytest
-from sqlalchemy.sql.functions import count
+from sqlalchemy import delete, func, select
 
 from airflow.providers.fab.www.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.providers.fab.www.security import permissions
@@ -85,8 +85,11 @@ class TestUserEndpoint:
 
     def teardown_method(self) -> None:
         # Delete users that have our custom default time
-        users = self.session.query(User).filter(User.changed_on == timezone.parse(DEFAULT_TIME))
-        users.delete(synchronize_session=False)
+        self.session.execute(
+            delete(User)
+            .where(User.changed_on == timezone.parse(DEFAULT_TIME))
+            .execution_options(synchronize_session="fetch")
+        )
         self.session.commit()
 
     def _create_users(self, count, roles=None):
@@ -354,11 +357,11 @@ EXAMPLE_USER_EMAIL = "example_user@example.com"
 
 def _delete_user(**filters):
     with create_session() as session:
-        user = session.query(User).filter_by(**filters).first()
+        user = session.scalars(select(User).filter_by(**filters)).first()
         if user is None:
             return
-        user.roles = []
-        session.delete(user)
+        user.roles.clear()
+        session.execute(delete(User).filter_by(**filters))
 
 
 @pytest.fixture
@@ -677,9 +680,9 @@ class TestPatchUser(TestUserEndpoint):
 
         mock_generate_password_hash.assert_called_once_with("new-pass")
 
-        password_in_db = (
-            self.session.query(User.password).filter(User.username == autoclean_username).scalar()
-        )
+        password_in_db = self.session.execute(
+            select(User.password).where(User.username == autoclean_username)
+        ).scalar()
         assert password_in_db == "fake-hashed-pass"
 
     @pytest.mark.usefixtures("autoclean_admin_user")
@@ -788,7 +791,12 @@ class TestDeleteUser(TestUserEndpoint):
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 204, response.json  # NO CONTENT.
-        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 0
+        assert (
+            self.session.execute(
+                select(func.count(User.id)).where(User.username == autoclean_username)
+            ).scalar()
+            == 0
+        )
 
     @pytest.mark.usefixtures("autoclean_admin_user")
     def test_unauthenticated(self, autoclean_username):
@@ -796,7 +804,12 @@ class TestDeleteUser(TestUserEndpoint):
             f"/fab/v1/users/{autoclean_username}",
         )
         assert response.status_code == 401, response.json
-        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 1
+        assert (
+            self.session.execute(
+                select(func.count(User.id)).where(User.username == autoclean_username)
+            ).scalar()
+            == 1
+        )
 
     @pytest.mark.usefixtures("autoclean_admin_user")
     def test_forbidden(self, autoclean_username):
@@ -805,7 +818,12 @@ class TestDeleteUser(TestUserEndpoint):
             environ_overrides={"REMOTE_USER": "test_no_permissions"},
         )
         assert response.status_code == 403, response.json
-        assert self.session.query(count(User.id)).filter(User.username == autoclean_username).scalar() == 1
+        assert (
+            self.session.execute(
+                select(func.count(User.id)).where(User.username == autoclean_username)
+            ).scalar()
+            == 1
+        )
 
     def test_not_found(self, autoclean_username):
         # This test does not populate autoclean_admin_user into the database.

--- a/providers/fab/tests/unit/fab/auth_manager/schemas/test_user_schema.py
+++ b/providers/fab/tests/unit/fab/auth_manager/schemas/test_user_schema.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 
 from airflow.utils import timezone
 
@@ -60,7 +61,7 @@ class TestUserBase:
         self.session = self.app.appbuilder.get_session
 
     def teardown_method(self):
-        user = self.session.query(User).filter(User.email == TEST_EMAIL).first()
+        user = self.session.scalars(select(User).where(User.email == TEST_EMAIL)).first()
         if user:
             self.session.delete(user)
             self.session.commit()
@@ -80,7 +81,7 @@ class TestUserCollectionItemSchema(TestUserBase):
         self.session.add(user_model)
         user_model.roles = [self.role]
         self.session.commit()
-        user = self.session.query(User).filter(User.email == TEST_EMAIL).first()
+        user = self.session.scalars(select(User).where(User.email == TEST_EMAIL)).first()
         deserialized_user = user_collection_item_schema.dump(user)
         # No user_id and password in dump
         assert deserialized_user == {
@@ -111,7 +112,7 @@ class TestUserSchema(TestUserBase):
         )
         self.session.add(user_model)
         self.session.commit()
-        user = self.session.query(User).filter(User.email == TEST_EMAIL).first()
+        user = self.session.scalars(select(User).where(User.email == TEST_EMAIL)).first()
         deserialized_user = user_schema.dump(user)
         # No user_id and password in dump
         assert deserialized_user == {

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -28,7 +28,7 @@ import pytest
 import time_machine
 from flask_appbuilder import SQLA, Model, expose, has_access
 from flask_appbuilder.views import BaseView, ModelView
-from sqlalchemy import Column, Date, Float, Integer, String, delete
+from sqlalchemy import Column, Date, Float, Integer, String, delete, select, func
 
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
@@ -138,7 +138,7 @@ def _create_dag_bundle(bundle_name, session):
 
 
 def _delete_dag_bundle(bundle_name, session):
-    session.query(DagBundleModel).filter(DagBundleModel.name == bundle_name).delete()
+    session.execute(delete(DagBundleModel).where(DagBundleModel.name == bundle_name))
     session.commit()
 
 
@@ -941,9 +941,10 @@ def test_no_additional_dag_permission_views_created(db, security_manager):
     ab_perm_role = assoc_permission_role
 
     security_manager.sync_roles()
-    num_pv_before = db.session().query(ab_perm_role).count()
+    num_pv_before = db.session().scalars(select(func.count()).select_from(ab_perm_role)).one()
+
     security_manager.sync_roles()
-    num_pv_after = db.session().query(ab_perm_role).count()
+    num_pv_after = db.session().scalars(select(func.count()).select_from(ab_perm_role)).one()
     assert num_pv_before == num_pv_after
 
 

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -28,7 +28,7 @@ import pytest
 import time_machine
 from flask_appbuilder import SQLA, Model, expose, has_access
 from flask_appbuilder.views import BaseView, ModelView
-from sqlalchemy import Column, Date, Float, Integer, String
+from sqlalchemy import Column, Date, Float, Integer, String, delete
 
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
@@ -1119,8 +1119,10 @@ def test_permissions_work_for_dags_with_dot_in_dagname(
             assert_user_has_dag_perms(perms=["GET", "PUT"], dag_id=dag_id, user=user)
             assert_user_does_not_have_dag_perms(perms=["GET", "PUT"], dag_id=dag_id_2, user=user)
             # Clean up DAG models and bundle
-            session.query(DagModel).delete()
-            session.query(DagBundleModel).filter(DagBundleModel.name == bundle_name).delete()
+            #session.query(DagModel).delete()
+            session.delete(DagModel)
+            session.delete(DagBundleModel).where(DagBundleModel.name == bundle_name)
+            #session.query(DagBundleModel).filter(DagBundleModel.name == bundle_name).delete()
             session.commit()
 
 

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -1119,10 +1119,8 @@ def test_permissions_work_for_dags_with_dot_in_dagname(
             assert_user_has_dag_perms(perms=["GET", "PUT"], dag_id=dag_id, user=user)
             assert_user_does_not_have_dag_perms(perms=["GET", "PUT"], dag_id=dag_id_2, user=user)
             # Clean up DAG models and bundle
-            #session.query(DagModel).delete()
-            session.delete(DagModel)
-            session.delete(DagBundleModel).where(DagBundleModel.name == bundle_name)
-            #session.query(DagBundleModel).filter(DagBundleModel.name == bundle_name).delete()
+            session.execute(delete(DagModel))
+            session.execute(delete(DagBundleModel).where(DagBundleModel.name == bundle_name))
             session.commit()
 
 

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -28,7 +28,7 @@ import pytest
 import time_machine
 from flask_appbuilder import SQLA, Model, expose, has_access
 from flask_appbuilder.views import BaseView, ModelView
-from sqlalchemy import Column, Date, Float, Integer, String, delete, select, func
+from sqlalchemy import Column, Date, Float, Integer, String, delete, func, select
 
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel

--- a/providers/fab/tests/unit/fab/utils.py
+++ b/providers/fab/tests/unit/fab/utils.py
@@ -25,6 +25,7 @@ from unittest import mock
 
 import flask
 import pytest
+from sqlalchemy import delete, select
 
 from airflow.models import Log
 
@@ -102,8 +103,8 @@ def _masked_value_check(data, sensitive_fields):
 
 
 def _check_last_log(session, dag_id, event, logical_date, expected_extra=None, check_masked=False):
-    logs = (
-        session.query(
+    logs = session.execute(
+        select(
             Log.dag_id,
             Log.task_id,
             Log.event,
@@ -118,8 +119,7 @@ def _check_last_log(session, dag_id, event, logical_date, expected_extra=None, c
         )
         .order_by(Log.dttm.desc())
         .limit(5)
-        .all()
-    )
+    ).all()
     assert len(logs) >= 1
     assert logs[0].extra
     if expected_extra:
@@ -128,28 +128,17 @@ def _check_last_log(session, dag_id, event, logical_date, expected_extra=None, c
         extra_json = json.loads(logs[0].extra)
         _masked_value_check(extra_json, sensitive_fields)
 
-    session.query(Log).delete()
+    session.execute(delete(Log))
 
 
 def _check_last_log_masked_connection(session, dag_id, event, logical_date):
-    logs = (
-        session.query(
-            Log.dag_id,
-            Log.task_id,
-            Log.event,
-            Log.logical_date,
-            Log.owner,
-            Log.extra,
-        )
-        .filter(
-            Log.dag_id == dag_id,
-            Log.event == event,
-            Log.logical_date == logical_date,
-        )
+    logs = session.execute(
+        select(Log.dag_id, Log.task_id, Log.event, Log.logical_date, Log.owner, Log.extra)
+        .where(Log.dag_id == dag_id, Log.event == event, Log.logical_date == logical_date)
         .order_by(Log.dttm.desc())
         .limit(5)
-        .all()
-    )
+    ).all()
+
     assert len(logs) >= 1
     extra = ast.literal_eval(logs[0].extra)
     assert extra == {
@@ -170,8 +159,8 @@ def _check_last_log_masked_variable(
     event,
     logical_date,
 ):
-    logs = (
-        session.query(
+    logs = session.execute(
+        select(
             Log.dag_id,
             Log.task_id,
             Log.event,
@@ -179,15 +168,14 @@ def _check_last_log_masked_variable(
             Log.owner,
             Log.extra,
         )
-        .filter(
+        .where(
             Log.dag_id == dag_id,
             Log.event == event,
             Log.logical_date == logical_date,
         )
         .order_by(Log.dttm.desc())
         .limit(5)
-        .all()
-    )
+    ).all()
     assert len(logs) >= 1
     extra_dict = ast.literal_eval(logs[0].extra)
     assert extra_dict == {"key": "x_secret", "val": "***"}


### PR DESCRIPTION
Related discussion : [here](https://github.com/apache/airflow/pull/47275#issuecomment-2997115034)

This PR is part of the migration to SQLAlchemy 2.0

Removed session.query() from src and tests

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
