### PR TITLE
Add ALL_DONE_MIN_ONE_SUCCESS trigger rule

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -435,6 +435,7 @@ However, this is just the default behaviour, and you can control it using the ``
 * ``all_success`` (default): All upstream tasks have succeeded
 * ``all_failed``: All upstream tasks are in a ``failed`` or ``upstream_failed`` state
 * ``all_done``: All upstream tasks are done with their execution
+* ``all_done_min_one_success``: All non-skipped upstream tasks are done with their execution and at least one upstream task has succeeded
 * ``all_skipped``: All upstream tasks are in a ``skipped`` state
 * ``one_failed``: At least one upstream task has failed (does not wait for all upstream tasks to be done)
 * ``one_success``: At least one upstream task has succeeded (does not wait for all upstream tasks to be done)

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -430,6 +430,17 @@ class TriggerRuleDep(BaseTIDep):
                 elif trigger_rule == TR.ALL_SKIPPED:
                     if success or failed or upstream_failed:
                         new_state = TaskInstanceState.SKIPPED
+                elif trigger_rule == TR.ALL_DONE_MIN_ONE_SUCCESS:
+                    # For this trigger rule, skipped tasks are not considered "done"
+                    non_skipped_done = success + failed + upstream_failed + removed
+                    non_skipped_upstream = upstream - skipped
+
+                    if skipped > 0:
+                        # There are skipped tasks, so not all tasks are "done" for this rule
+                        new_state = TaskInstanceState.SKIPPED
+                    elif non_skipped_done >= non_skipped_upstream and success == 0:
+                        # All non-skipped tasks are done but no successes
+                        new_state = TaskInstanceState.UPSTREAM_FAILED
                 elif trigger_rule == TR.ALL_DONE_SETUP_SUCCESS:
                     if upstream_done and upstream_setup and skipped_setup >= upstream_setup:
                         # when there is an upstream setup and they have all skipped, then skip
@@ -570,6 +581,41 @@ class TriggerRuleDep(BaseTIDep):
                             f"Task's trigger rule '{trigger_rule}' requires at least one upstream setup task "
                             f"be successful, but found {upstream_setup - success_setup} task(s) that were "
                             f"not. upstream_states={upstream_states}, "
+                            f"upstream_task_ids={task.upstream_task_ids}"
+                        )
+                    )
+            elif trigger_rule == TR.ALL_DONE_MIN_ONE_SUCCESS:
+                # For this trigger rule, skipped tasks are not considered "done"
+                non_skipped_done = success + failed + upstream_failed + removed
+                non_skipped_upstream = upstream - skipped
+                if ti.map_index > -1:
+                    non_skipped_upstream -= removed
+                    non_skipped_done -= removed
+
+                if skipped > 0:
+                    yield self._failing_status(
+                        reason=(
+                            f"Task's trigger rule '{trigger_rule}' requires all non-skipped upstream tasks to have "
+                            f"completed, but found {skipped} skipped task(s). "
+                            f"upstream_states={upstream_states}, "
+                            f"upstream_task_ids={task.upstream_task_ids}"
+                        )
+                    )
+                elif non_skipped_done < non_skipped_upstream:
+                    yield self._failing_status(
+                        reason=(
+                            f"Task's trigger rule '{trigger_rule}' requires all non-skipped upstream tasks to have "
+                            f"completed, but found {non_skipped_upstream - non_skipped_done} task(s) that were not done. "
+                            f"upstream_states={upstream_states}, "
+                            f"upstream_task_ids={task.upstream_task_ids}"
+                        )
+                    )
+                elif success == 0:
+                    yield self._failing_status(
+                        reason=(
+                            f"Task's trigger rule '{trigger_rule}' requires all non-skipped upstream tasks to have "
+                            f"completed and at least one upstream task has succeeded, but found "
+                            f"{success} successful task(s). upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
                     )

--- a/airflow-core/src/airflow/utils/trigger_rule.py
+++ b/airflow-core/src/airflow/utils/trigger_rule.py
@@ -26,6 +26,7 @@ class TriggerRule(str, Enum):
     ALL_SUCCESS = "all_success"
     ALL_FAILED = "all_failed"
     ALL_DONE = "all_done"
+    ALL_DONE_MIN_ONE_SUCCESS = "all_done_min_one_success"
     ALL_DONE_SETUP_SUCCESS = "all_done_setup_success"
     ONE_SUCCESS = "one_success"
     ONE_FAILED = "one_failed"

--- a/airflow-core/tests/unit/utils/test_trigger_rule.py
+++ b/airflow-core/tests/unit/utils/test_trigger_rule.py
@@ -36,7 +36,8 @@ class TestTriggerRule:
         assert TriggerRule.is_valid(TriggerRule.ALWAYS)
         assert TriggerRule.is_valid(TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
         assert TriggerRule.is_valid(TriggerRule.ALL_DONE_SETUP_SUCCESS)
-        assert len(TriggerRule.all_triggers()) == 12
+        assert TriggerRule.is_valid(TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)
+        assert len(TriggerRule.all_triggers()) == 13
 
         with pytest.raises(ValueError):
             TriggerRule("NOT_EXIST_TRIGGER_RULE")


### PR DESCRIPTION
This trigger rule is useful for cases where we must verify all upstream is done with execution but we only need one of them to be successful.

Verified also with example dag:

```
from datetime import datetime
from airflow import DAG
from airflow.operators.bash import BashOperator
from airflow.operators.python import PythonOperator
from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.utils.trigger_rule import TriggerRule
from airflow.exceptions import AirflowSkipException
from airflow.sdk.definitions.edges import EdgeModifier

default_args = {
    'owner': 'airflow',
    'start_date': datetime(2023, 2, 1)
}

def always_skip_function():
    raise AirflowSkipException("This task is intentionally skipped.")

with DAG('1min_file', schedule=None, catchup=True, default_args=default_args):

    # Test case 1: One success, one failure -> Expected state: None
    a_success = EmptyOperator(task_id="a_success")
    a_fails = BashOperator(
        task_id='a_fails',
        bash_command='exit 1',  # A non-zero exit code indicates failure
    )
    rule_1 = EmptyOperator(task_id="rule_1", trigger_rule=TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)

    a_success >> EdgeModifier("expect rule_1 to be successful") >> rule_1
    a_fails >> EdgeModifier("expect rule_1 to be successful") >> rule_1

    # Test case 2: Two successes -> Expected state: None
    b_success = EmptyOperator(task_id="b_success")
    b_success2 = EmptyOperator(task_id="b_success2")
    rule_2 = EmptyOperator(task_id="rule_2", trigger_rule=TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)

    b_success >> EdgeModifier("expect rule_2 to be successful") >>  rule_2
    b_success2 >> EdgeModifier("expect rule_2 to be successful") >> rule_2

    # Test case 3: One success, one skip -> Expected state: SKIPPED
    c_success = EmptyOperator(task_id="c_success")
    c_skip = PythonOperator(
        task_id='c_skip',
        python_callable=always_skip_function,
    )
    rule_3 = EmptyOperator(task_id="rule_3", trigger_rule=TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)

    c_success  >> EdgeModifier("expect rule_3 to be skipped") >> rule_3
    c_skip >> EdgeModifier("expect rule_3 to be skipped") >>  rule_3

    # Test case 4: All failures -> Expected state: UPSTREAM_FAILED
    d_fails1 = BashOperator(
        task_id='d_fails1',
        bash_command='exit 1',
    )
    d_fails2 = BashOperator(
        task_id='d_fails2',
        bash_command='exit 1',
    )
    rule_4 = EmptyOperator(task_id="rule_4", trigger_rule=TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)

    d_fails1 >> EdgeModifier("expect rule_4 to be upstream failed") >> rule_4
    d_fails2 >> EdgeModifier("expect rule_4 to be upstream failed") >> rule_4


    # Test case 5: upstream failure cascade -> Expected state: UPSTREAM_FAILED
    e_fails3 = BashOperator(
        task_id='d_fails3',
        bash_command='exit 1',
    )
    e_upstream_failed = EmptyOperator(task_id="e_upstream")

    rule_5 = EmptyOperator(task_id="rule_5", trigger_rule=TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)

    e_fails3 >> e_upstream_failed >> EdgeModifier("expect rule_5 to be upstream failed") >> rule_5
```



<img width="1142" height="837" alt="Screenshot 2025-07-31 at 11 14 51" src="https://github.com/user-attachments/assets/33c2c547-71b2-4128-858d-1dd6b1621999" />
