### PR TITLE
refactor(hitl): replace timezone usage with airflow.sdk.timezone

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -26,7 +26,6 @@ if not AIRFLOW_V_3_1_PLUS:
 
 
 from collections.abc import Collection, Mapping
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.standard.exceptions import HITLTimeoutError, HITLTriggerEventError
@@ -36,6 +35,7 @@ from airflow.providers.standard.utils.skipmixin import SkipMixin
 from airflow.providers.standard.version_compat import BaseOperator
 from airflow.sdk.definitions.param import ParamsDict
 from airflow.sdk.execution_time.hitl import upsert_hitl_detail
+from airflow.sdk.timezone import utcnow
 
 if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
@@ -109,7 +109,7 @@ class HITLOperator(BaseOperator):
             params=self.serialized_params,
         )
         if self.execution_timeout:
-            timeout_datetime = datetime.now(timezone.utc) + self.execution_timeout
+            timeout_datetime = utcnow() + self.execution_timeout
         else:
             timeout_datetime = None
         self.log.info("Waiting for response")

--- a/providers/standard/src/airflow/providers/standard/triggers/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/hitl.py
@@ -34,8 +34,8 @@ from airflow.sdk.execution_time.hitl import (
     get_hitl_detail_content_detail,
     update_htil_detail_response,
 )
+from airflow.sdk.timezone import utcnow
 from airflow.triggers.base import BaseTrigger, TriggerEvent
-from airflow.utils import timezone
 
 
 class HITLTriggerEventSuccessPayload(TypedDict, total=False):
@@ -97,7 +97,7 @@ class HITLTrigger(BaseTrigger):
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Loop until the Human-in-the-loop response received or timeout reached."""
         while True:
-            if self.timeout_datetime and self.timeout_datetime < timezone.utcnow():
+            if self.timeout_datetime and self.timeout_datetime < utcnow():
                 if self.defaults is None:
                     yield TriggerEvent(
                         HITLTriggerEventFailurePayload(


### PR DESCRIPTION
## Why
* `airflow.utils.timezone` is deprecated
* we have `utcnow` and should reuse it 

## What
* Replace `airflow.utils.timezone` with `airflow.sdk.timezone`
* Replace `datetime.now(timezone.utc)` with `airflow.sdk.timezone.utcnow`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
