### PR TITLE
404 Not Found for EmptyOperator docs for version 2.7+ #52643

### DIFF
--- a/airflow-core/docs/redirects.txt
+++ b/airflow-core/docs/redirects.txt
@@ -183,3 +183,6 @@ howto/operator/file.rst ../../apache-airflow-providers-standard/stable/sensors/f
 howto/operator/python.rst ../../apache-airflow-providers-standard/stable/operators/python.rst
 howto/operator/time.rst ../../apache-airflow-providers-standard/stable/sensors/datetime.rst
 howto/operator/weekday.rst ../../apache-airflow-providers-standard/stable/operators/datetime.rst#branchdayofweekoperator
+
+airflow/operators/datetime/index.html ../../apache-airflow-providers-standard/stable/operators/datetime.html
+airflow/operators/empty/index.html ../../apache-airflow-providers-standard/stable/operators/empty.html

--- a/airflow-core/docs/redirects.txt
+++ b/airflow-core/docs/redirects.txt
@@ -184,5 +184,5 @@ howto/operator/python.rst ../../apache-airflow-providers-standard/stable/operato
 howto/operator/time.rst ../../apache-airflow-providers-standard/stable/sensors/datetime.rst
 howto/operator/weekday.rst ../../apache-airflow-providers-standard/stable/operators/datetime.rst#branchdayofweekoperator
 
-airflow/operators/datetime/index.html ../../apache-airflow-providers-standard/stable/operators/datetime.html
-airflow/operators/empty/index.html ../../apache-airflow-providers-standard/stable/operators/empty.html
+_api/airflow/operators/datetime/index.html ../../apache-airflow-providers-standard/stable/operators/datetime.html
+_api/airflow/operators/empty/index.html ../../apache-airflow-providers-standard/stable/operators/empty.html

--- a/airflow-core/docs/redirects.txt
+++ b/airflow-core/docs/redirects.txt
@@ -184,5 +184,5 @@ howto/operator/python.rst ../../apache-airflow-providers-standard/stable/operato
 howto/operator/time.rst ../../apache-airflow-providers-standard/stable/sensors/datetime.rst
 howto/operator/weekday.rst ../../apache-airflow-providers-standard/stable/operators/datetime.rst#branchdayofweekoperator
 
-_api/airflow/operators/datetime/index.html ../../apache-airflow-providers-standard/stable/operators/datetime.html
-_api/airflow/operators/empty/index.html ../../apache-airflow-providers-standard/stable/operators/empty.html
+_api/airflow/operators/datetime/index.html ../apache-airflow-providers-standard/stable/_api/airflow/providers/standard/operators/datetime/index.html
+_api/airflow/operators/empty/index.html ../apache-airflow-providers-standard/stable/_api/airflow/providers/standard/operators/empty/index.html


### PR DESCRIPTION
Added redirects for empty and datetime operators documentation

closes #52643 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
