### PR TITLE
feat(hitl): initialize notifier hooking logic to HITLOperators

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -25,7 +25,7 @@ if not AIRFLOW_V_3_1_PLUS:
     raise AirflowOptionalProviderFeatureException("Human in the loop functionality needs Airflow 3.1+.")
 
 
-from collections.abc import Collection, Mapping
+from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.standard.exceptions import HITLTimeoutError, HITLTriggerEventError
@@ -38,6 +38,7 @@ from airflow.sdk.execution_time.hitl import upsert_hitl_detail
 from airflow.sdk.timezone import utcnow
 
 if TYPE_CHECKING:
+    from airflow.sdk import BaseNotifier
     from airflow.sdk.definitions.context import Context
 
 
@@ -66,6 +67,7 @@ class HITLOperator(BaseOperator):
         defaults: str | list[str] | None = None,
         multiple: bool = False,
         params: ParamsDict | dict[str, Any] | None = None,
+        notifiers: Sequence[BaseNotifier] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -78,6 +80,8 @@ class HITLOperator(BaseOperator):
         self.multiple = multiple
 
         self.params: ParamsDict = params if isinstance(params, ParamsDict) else ParamsDict(params or {})
+
+        self.notifiers = notifiers or []
 
         self.validate_defaults()
 
@@ -108,11 +112,16 @@ class HITLOperator(BaseOperator):
             multiple=self.multiple,
             params=self.serialized_params,
         )
+
+        for notifier in self.notifiers:
+            notifier(context)
+
         if self.execution_timeout:
             timeout_datetime = utcnow() + self.execution_timeout
         else:
             timeout_datetime = None
-        self.log.info("Waiting for response")
+
+        self.log.info("[HITL] Waiting for response")
         # Defer the Human-in-the-loop response checking process to HITLTrigger
         self.defer(
             trigger=HITLTrigger(


### PR DESCRIPTION
## Why
Add a better way to notify the users that they should respond

close: #54017 

## What
WIP

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
