### PR TITLE
Rename SchedulerDagBag and Refactor API server DAG handling

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -16,19 +16,20 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
 
-from airflow.models.dagbag import SchedulerDagBag
+from airflow.models.dagbag import DBDagBag
 
 
-def create_dag_bag() -> SchedulerDagBag:
+def create_dag_bag() -> DBDagBag:
     """Create DagBag to retrieve DAGs from the database."""
-    return SchedulerDagBag()
+    return DBDagBag()
 
 
-def dag_bag_from_app(request: Request) -> SchedulerDagBag:
+def dag_bag_from_app(request: Request) -> DBDagBag:
     """
     FastAPI dependency resolver that returns the shared DagBag instance from app.state.
 
@@ -38,4 +39,28 @@ def dag_bag_from_app(request: Request) -> SchedulerDagBag:
     return request.app.state.dag_bag
 
 
-DagBagDep = Annotated[SchedulerDagBag, Depends(dag_bag_from_app)]
+def get_latest_version_of_dag(dag_bag, dag_id: str, session: Session):
+    dag = dag_bag.get_latest_version_of_dag(dag_id, session=session)
+    if not dag:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Dag with ID: `{dag_id}` was not found")
+    return dag
+
+
+def get_dag_for_run(dag_bag, dag_run, session: Session):
+    dag = dag_bag.get_dag_for_run(dag_run, session=session)
+    if not dag:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Dag with ID: `{dag_run.dag_id}` was not found")
+    return dag
+
+
+def get_dag_for_run_or_latest_version(dag_bag, dag_run: Any | None, dag_id: str | None, session: Session):
+    if dag_run:
+        dag = dag_bag.get_dag_for_run(dag_run, session=session)
+    else:
+        dag = dag_bag.get_latest_version_of_dag(dag_id, session=session)
+    if not dag:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Dag with ID: `{dag_id}` was not found")
+    return dag
+
+
+DagBagDep = Annotated[DBDagBag, Depends(dag_bag_from_app)]

--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -43,9 +43,19 @@ def dag_bag_from_app(request: Request) -> DBDagBag:
     return request.app.state.dag_bag
 
 
-def get_latest_version_of_dag(dag_bag: DBDagBag, dag_id: str, session: Session) -> DAG:
+def get_latest_version_of_dag(
+    dag_bag: DBDagBag, dag_id: str, session: Session, include_reason: bool = False
+) -> DAG:
     dag = dag_bag.get_latest_version_of_dag(dag_id, session=session)
     if not dag:
+        if include_reason:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                detail={
+                    "reason": "not_found",
+                    "message": f"The Dag with ID: `{dag_id}` was not found",
+                },
+            )
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Dag with ID: `{dag_id}` was not found")
     return dag
 

--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
@@ -25,6 +25,7 @@ from airflow.models.dagbag import DBDagBag
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
+    from airflow.models.dagrun import DagRun
 
 
 def create_dag_bag() -> DBDagBag:
@@ -49,7 +50,7 @@ def get_latest_version_of_dag(dag_bag: DBDagBag, dag_id: str, session: Session) 
     return dag
 
 
-def get_dag_for_run(dag_bag: DBDagBag, dag_run, session: Session) -> DAG:
+def get_dag_for_run(dag_bag: DBDagBag, dag_run: DagRun, session: Session) -> DAG:
     dag = dag_bag.get_dag_for_run(dag_run, session=session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Dag with ID: `{dag_run.dag_id}` was not found")
@@ -57,7 +58,7 @@ def get_dag_for_run(dag_bag: DBDagBag, dag_run, session: Session) -> DAG:
 
 
 def get_dag_for_run_or_latest_version(
-    dag_bag: DBDagBag, dag_run: Any | None, dag_id: str | None, session: Session
+    dag_bag: DBDagBag, dag_run: DagRun | None, dag_id: str | None, session: Session
 ) -> DAG:
     dag: DAG | None = None
     if dag_run:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     FilterParam,
@@ -111,10 +111,7 @@ def get_dag_versions(
     query = select(DagVersion).options(joinedload(DagVersion.dag_model))
 
     if dag_id != "~":
-        dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-        if not dag:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"The DAG with dag_id: `{dag_id}` was not found")
-
+        get_latest_version_of_dag(dag_bag, dag_id, session)
         query = query.filter(DagVersion.dag_id == dag_id)
 
     dag_versions_select, total_entries = paginated_select(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -25,7 +25,7 @@ from pydantic import ValidationError
 from sqlalchemy import delete, insert, select, update
 
 from airflow.api.common import delete_dag as delete_dag_module
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
@@ -172,10 +172,7 @@ def get_dag(
     dag_bag: DagBagDep,
 ) -> DAGResponse:
     """Get basic information about a DAG."""
-    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
-
+    dag = get_latest_version_of_dag(dag_bag, dag_id, session)
     dag_model: DagModel = session.get(DagModel, dag_id)
     if not dag_model:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Unable to obtain dag with id {dag_id} from session")
@@ -199,9 +196,7 @@ def get_dag(
 )
 def get_dag_details(dag_id: str, session: SessionDep, dag_bag: DagBagDep) -> DAGDetailsResponse:
     """Get details of DAG."""
-    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
+    dag = get_latest_version_of_dag(dag_bag, dag_id, session)
 
     dag_model: DagModel = session.get(DagModel, dag_id)
     if not dag_model:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/extra_links.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/extra_links.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, cast
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.sql import select
 
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run_or_latest_version
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.extra_links import ExtraLinkCollectionResponse
@@ -59,12 +59,7 @@ def get_extra_links(
 
     dag_run = session.scalar(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id))
 
-    if dag_run:
-        dag = dag_bag.get_dag_for_run(dag_run, session=session)
-    else:
-        dag = dag_bag.get_latest_version_of_dag(dag_id, session=session)
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with ID = {dag_id} not found")
+    dag = get_dag_for_run_or_latest_version(dag_bag, dag_run, dag_id, session)
 
     try:
         # TODO (GH-52141): Make dag a db-backed object so it only returns db-backed tasks.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -24,7 +24,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run_or_latest_version
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import QueryLimit, QueryOffset
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -192,12 +192,7 @@ def create_xcom_entry(
 
     dag_run = session.scalar(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id))
     # Validate DAG ID
-    if dag_run:
-        dag = dag_bag.get_dag_for_run(dag_run, session)
-    else:
-        dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with ID: `{dag_id}` was not found")
+    dag = get_dag_for_run_or_latest_version(dag_bag, dag_run, dag_id, session)
 
     # Validate Task ID
     try:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -39,11 +39,6 @@ def next_run_assets(
     dag_bag: DagBagDep,
     session: SessionDep,
 ) -> dict:
-    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"can't find dag {dag_id}")
-
     dag_model = DagModel.get_dagmodel(dag_id, session=session)
     if dag_model is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"can't find associated dag_model {dag_id}")

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/calendar.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from fastapi import Depends, HTTPException
-from starlette import status
+from fastapi import Depends
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.parameters import RangeFilter, datetime_range_filter_factory
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -59,9 +58,8 @@ def get_calendar(
     granularity: Literal["hourly", "daily"] = "daily",
 ) -> CalendarTimeRangeCollectionResponse:
     """Get calendar data for a DAG including historical and planned DAG runs."""
-    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with dag_id: '{dag_id}' not found")
+    dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+
     calendar_service = CalendarService()
 
     return calendar_service.get_calendar_data(

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.datamodels.common import (
     BulkActionNotOnExistence,
@@ -56,9 +56,7 @@ def _patch_ti_validate_request(
     map_index: int | None = -1,
     update_mask: list[str] | None = Query(None),
 ) -> tuple[DAG, list[TI], dict]:
-    dag = dag_bag.get_latest_version_of_dag(dag_id, session)
-    if not dag:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG {dag_id} not found")
+    dag = get_latest_version_of_dag(dag_bag, dag_id, session)
 
     if not dag.has_task(task_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Task '{task_id}' not found in DAG '{dag_id}'")

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -224,6 +224,7 @@ class InProcessExecutionAPI:
     @cached_property
     def app(self):
         if not self._app:
+            from airflow.api_fastapi.common.dagbag import create_dag_bag
             from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
             from airflow.api_fastapi.execution_api.deps import (
                 JWTBearerDep,
@@ -235,6 +236,9 @@ class InProcessExecutionAPI:
             from airflow.api_fastapi.execution_api.routes.xcoms import has_xcom_access
 
             self._app = create_task_execution_api_app()
+
+            # Set up dag_bag in app state for dependency injection
+            self._app.state.dag_bag = create_dag_bag()
 
             async def always_allow(): ...
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -787,7 +787,6 @@ def get_task_instance_count(
             query = query.where(TI.state.in_(states))
 
     count = session.scalar(query)
-
     return count or 0
 
 
@@ -853,7 +852,7 @@ def _get_group_tasks(
     dag_id: str, task_group_id: str, session: SessionDep, dag_bag: DagBagDep, logical_dates=None, run_ids=None
 ):
     # Get all tasks in the task group
-    dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+    dag = get_latest_version_of_dag(dag_bag, dag_id, session, include_reason=True)
     task_group = dag.task_group_dict.get(task_group_id)
     if not task_group:
         raise HTTPException(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -38,7 +38,7 @@ from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
 from airflow._shared.timezones import timezone
-from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
@@ -59,7 +59,6 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
 from airflow.api_fastapi.execution_api.deps import JWTBearerTIPathDep
 from airflow.exceptions import TaskNotFound
 from airflow.models.asset import AssetActive
-from airflow.models.dagbag import SchedulerDagBag
 from airflow.models.dagrun import DagRun as DR
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
 from airflow.models.taskreschedule import TaskReschedule
@@ -736,6 +735,7 @@ def get_previous_successful_dagrun(
 def get_task_instance_count(
     dag_id: str,
     session: SessionDep,
+    dag_bag: DagBagDep,
     map_index: Annotated[int | None, Query()] = None,
     task_ids: Annotated[list[str] | None, Query()] = None,
     task_group_id: Annotated[str | None, Query()] = None,
@@ -759,7 +759,7 @@ def get_task_instance_count(
         query = query.where(TI.run_id.in_(run_ids))
 
     if task_group_id:
-        group_tasks = _get_group_tasks(dag_id, task_group_id, session, logical_dates, run_ids)
+        group_tasks = _get_group_tasks(dag_id, task_group_id, session, dag_bag, logical_dates, run_ids)
 
         # Get unique (task_id, map_index) pairs
 
@@ -795,6 +795,7 @@ def get_task_instance_count(
 def get_task_instance_states(
     dag_id: str,
     session: SessionDep,
+    dag_bag: DagBagDep,
     map_index: Annotated[int | None, Query()] = None,
     task_ids: Annotated[list[str] | None, Query()] = None,
     task_group_id: Annotated[str | None, Query()] = None,
@@ -818,7 +819,7 @@ def get_task_instance_states(
     results = session.scalars(query).all()
 
     if task_group_id:
-        group_tasks = _get_group_tasks(dag_id, task_group_id, session, logical_dates, run_ids)
+        group_tasks = _get_group_tasks(dag_id, task_group_id, session, dag_bag, logical_dates, run_ids)
 
         results = results + group_tasks if task_ids else group_tasks
 
@@ -848,18 +849,11 @@ def _is_eligible_to_retry(state: str, try_number: int, max_tries: int) -> bool:
     return max_tries != 0 and try_number <= max_tries
 
 
-def _get_group_tasks(dag_id: str, task_group_id: str, session: SessionDep, logical_dates=None, run_ids=None):
+def _get_group_tasks(
+    dag_id: str, task_group_id: str, session: SessionDep, dag_bag: DagBagDep, logical_dates=None, run_ids=None
+):
     # Get all tasks in the task group
-    dag = SchedulerDagBag().get_latest_version_of_dag(dag_id, session)
-    if not dag:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"DAG {dag_id} not found",
-            },
-        )
-
+    dag = get_latest_version_of_dag(dag_bag, dag_id, session)
     task_group = dag.task_group_dict.get(task_group_id)
     if not task_group:
         raise HTTPException(

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2465,3 +2465,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # ourselves here and the user should get some feedback about that.
         self.log.warning("Executor, %s, was not found but a Task was configured to use it", executor_name)
         return None
+
+
+# Backcompat for older versions of task sdk import SchedulerDagBag from here
+SchedulerDagBag = DBDagBag

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -60,7 +60,7 @@ from airflow.models.asset import (
 from airflow.models.backfill import Backfill
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
-from airflow.models.dagbag import SchedulerDagBag
+from airflow.models.dagbag import DBDagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.serialized_dag import SerializedDagModel
@@ -212,7 +212,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if log:
             self._log = log
 
-        self.scheduler_dag_bag = SchedulerDagBag(load_op_links=False)
+        self.scheduler_dag_bag = DBDagBag(load_op_links=False)
 
     @provide_session
     def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:
@@ -732,7 +732,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
     @classmethod
     def process_executor_events(
-        cls, executor: BaseExecutor, job_id: str | None, scheduler_dag_bag: SchedulerDagBag, session: Session
+        cls, executor: BaseExecutor, job_id: str | None, scheduler_dag_bag: DBDagBag, session: Session
     ) -> int:
         """
         Respond to executor events.

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -715,7 +715,7 @@ class DagBag(LoggingMixin):
         )
 
 
-class SchedulerDagBag:
+class DBDagBag:
     """
     Internal class for retrieving and caching dags in the scheduler.
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -223,9 +223,9 @@ def clear_task_instances(
     :meta private:
     """
     task_instance_ids: list[str] = []
-    from airflow.models.dagbag import SchedulerDagBag
+    from airflow.models.dagbag import DBDagBag
 
-    scheduler_dagbag = SchedulerDagBag(load_op_links=False)
+    scheduler_dagbag = DBDagBag(load_op_links=False)
 
     for ti in tis:
         task_instance_ids.append(ti.id)

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -48,13 +48,13 @@ class TestDagBagSingleton:
         """Patch DagBag once before app is created, and reset counter."""
         self.dagbag_call_counter["count"] = 0
 
-        from airflow.models.dagbag import SchedulerDagBag as RealDagBag
+        from airflow.models.dagbag import DBDagBag as RealDagBag
 
         def factory(*args, **kwargs):
             self.dagbag_call_counter["count"] += 1
             return RealDagBag(*args, **kwargs)
 
-        with mock.patch("airflow.api_fastapi.common.dagbag.SchedulerDagBag", side_effect=factory):
+        with mock.patch("airflow.api_fastapi.common.dagbag.DBDagBag", side_effect=factory):
             purge_cached_app()
             yield
 

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -176,10 +176,10 @@ def make_dag_with_multiple_versions(dag_maker, configure_git_connection_for_dag_
 
 @pytest.fixture(scope="module")
 def dagbag():
-    from airflow.models.dagbag import SchedulerDagBag
+    from airflow.models.dagbag import DBDagBag
 
     parse_and_sync_to_db(os.devnull, include_examples=True)
-    return SchedulerDagBag()
+    return DBDagBag()
 
 
 @pytest.fixture

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -281,7 +281,7 @@ class TestGetDagRuns:
         response = test_client.get("/dags/invalid/dagRuns")
         assert response.status_code == 404
         body = response.json()
-        assert body["detail"] == "The DAG with dag_id: `invalid` was not found"
+        assert body["detail"] == "The Dag with ID: `invalid` was not found"
 
     def test_invalid_order_by_raises_400(self, test_client):
         response = test_client.get("/dags/test_dag1/dagRuns?order_by=invalid")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -24,7 +24,7 @@ import pytest
 from httpx import Response
 from sqlalchemy import select
 
-from airflow.models.dagbag import SchedulerDagBag
+from airflow.models.dagbag import DBDagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.state import DagRunState
@@ -48,7 +48,7 @@ TEST_DAG_DISPLAY_NAME = "example_simplest_dag"
 @pytest.fixture
 def test_dag(session):
     parse_and_sync_to_db(EXAMPLE_DAG_FILE, include_examples=False)
-    return SchedulerDagBag().get_latest_version_of_dag(TEST_DAG_ID, session)
+    return DBDagBag().get_latest_version_of_dag(TEST_DAG_ID, session)
 
 
 class TestGetDAGSource:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -496,7 +496,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
         response = test_client.get("/dags/MISSING_ID/dagVersions")
         assert response.status_code == 404
         assert response.json() == {
-            "detail": "The DAG with dag_id: `MISSING_ID` was not found",
+            "detail": "The Dag with ID: `MISSING_ID` was not found",
         }
 
     def test_should_respond_401(self, unauthenticated_test_client):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -21,7 +21,7 @@ import pytest
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.api_fastapi.core_api.datamodels.extra_links import ExtraLinkCollectionResponse
-from airflow.models.dagbag import SchedulerDagBag
+from airflow.models.dagbag import DBDagBag
 from airflow.models.xcom import XComModel as XCom
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.state import DagRunState
@@ -85,7 +85,7 @@ class TestGetExtraLinks:
 
         self.dag = self._create_dag(dag_maker)
 
-        dag_bag = SchedulerDagBag()
+        dag_bag = DBDagBag()
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
         dag_maker.create_dagrun(
@@ -120,7 +120,7 @@ class TestGetExtraLinks:
             pytest.param(
                 "/dags/INVALID/dagRuns/TEST_DAG_RUN_ID/taskInstances/TEST_SINGLE_LINK/links",
                 404,
-                {"detail": "DAG with ID = INVALID not found"},
+                {"detail": "The Dag with ID: `INVALID` was not found"},
                 id="missing_dag",
             ),
             pytest.param(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -731,7 +731,7 @@ class TestGetMappedTaskInstances:
             "/dags/mapped_tis/dagRuns/run_mapped_tis/taskInstances/task_2/listMapped",
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "DAG mapped_tis not found"}
+        assert response.json() == {"detail": "The Dag with ID: `mapped_tis` was not found"}
 
     def test_should_respond_200(self, one_task_with_many_mapped_tis, test_client):
         response = test_client.get(
@@ -1168,7 +1168,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
     def test_not_found(self, test_client):
         response = test_client.get("/dags/invalid/dagRuns/~/taskInstances")
         assert response.status_code == 404
-        assert response.json() == {"detail": "Dag with dag_id: `invalid` was not found"}
+        assert response.json() == {"detail": "The Dag with ID: `invalid` was not found"}
 
         response = test_client.get("/dags/~/dagRuns/invalid/taskInstances")
         assert response.status_code == 404
@@ -2874,7 +2874,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert "DAG non-existent-dag not found" in response.text
+        assert "The Dag with ID: `non-existent-dag` was not found" in response.text
 
 
 class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
@@ -3466,7 +3466,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "DAG non-existent-dag not found"}
+        assert response.json() == {"detail": "The Dag with ID: `non-existent-dag` was not found"}
 
     def test_should_raise_404_for_non_existent_task_in_dag(self, test_client):
         response = test_client.patch(
@@ -4156,7 +4156,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "DAG non-existent-dag not found"}
+        assert response.json() == {"detail": "The Dag with ID: `non-existent-dag` was not found"}
 
     def test_should_raise_404_for_non_existent_task_in_dag(self, test_client):
         response = test_client.patch(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -22,7 +22,7 @@ import pytest
 
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
 from airflow.models.dag import DAG
-from airflow.models.dagbag import SchedulerDagBag
+from airflow.models.dagbag import DBDagBag
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.definitions._internal.expandinput import EXPAND_INPUT_EMPTY
@@ -69,7 +69,7 @@ class TestTaskEndpoint:
         SerializedDagModel.write_dag(mapped_dag, bundle_name="testing")
         unscheduled_dag.sync_to_db()
         SerializedDagModel.write_dag(unscheduled_dag, bundle_name="testing")
-        dag_bag = SchedulerDagBag()
+        dag_bag = DBDagBag()
 
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
@@ -240,7 +240,7 @@ class TestGetTask(TestTaskEndpoint):
         dag.sync_to_db()
         SerializedDagModel.write_dag(dag, bundle_name="test_bundle")
 
-        dag_bag = SchedulerDagBag()
+        dag_bag = DBDagBag()
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 
         expected = {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -523,7 +523,7 @@ class TestCreateXComEntry(TestXComEndpoint):
                 run_id,
                 XComCreateBody(key=TEST_XCOM_KEY, value=TEST_XCOM_VALUE),
                 404,
-                "Dag with ID: `invalid-dag-id` was not found",
+                "The Dag with ID: `invalid-dag-id` was not found",
                 id="dag-not-found",
             ),
             # Test case: Task not found in DAG

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2001,7 +2001,7 @@ class TestGetTaskStates:
         assert response.status_code == 404
         assert response.json()["detail"] == {
             "reason": "not_found",
-            "message": "DAG non_existent_dag not found",
+            "message": "The Dag with ID: `non_existent_dag` was not found",
         }
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1631,7 +1631,7 @@ class TestGetCount:
         assert response.status_code == 404
         assert response.json()["detail"] == {
             "reason": "not_found",
-            "message": "DAG non_existent_dag not found",
+            "message": "The Dag with ID: `non_existent_dag` was not found",
         }
 
     def test_get_count_with_none_state(self, client, session, create_task_instance):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
@@ -23,7 +23,7 @@ import pytest
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
-from airflow.models.dagbag import SchedulerDagBag
+from airflow.models.dagbag import DBDagBag
 from airflow.utils.state import State
 
 from tests_common.test_utils.db import clear_db_assets, clear_db_runs
@@ -107,7 +107,7 @@ class TestTIUpdateState:
             start_date=instant,
         )
 
-        dagbag = SchedulerDagBag()
+        dagbag = DBDagBag()
         execution_app = get_execution_app(ver_client)
         execution_app.dependency_overrides[dag_bag_from_app] = lambda: dagbag
         session.commit()

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1217,10 +1217,11 @@ class DAG:
                             log.exception("Task failed; ti=%s", ti)
                 if use_executor:
                     executor.heartbeat()
-                    from airflow.jobs.scheduler_job_runner import SchedulerDagBag, SchedulerJobRunner
+                    from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+                    from airflow.models.dagbag import DBDagBag
 
                     SchedulerJobRunner.process_executor_events(
-                        executor=executor, job_id=None, scheduler_dag_bag=SchedulerDagBag(), session=session
+                        executor=executor, job_id=None, scheduler_dag_bag=DBDagBag(), session=session
                     )
             if use_executor:
                 executor.end()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1423,11 +1423,11 @@ class InProcessTestSupervisor(ActivitySubprocess):
         api = in_process_api_server()
         if dag is not None:
             from airflow.api_fastapi.common.dagbag import dag_bag_from_app
-            from airflow.jobs.scheduler_job_runner import SchedulerDagBag
+            from airflow.models.dagbag import DBDagBag
 
-            # This is needed since the Execution API server uses the SchedulerDagBag in its "state".
+            # This is needed since the Execution API server uses the DBDagBag in its "state".
             # This `app.state.dag_bag` is used to get some DAG properties like `fail_fast`.
-            dag_bag = SchedulerDagBag()
+            dag_bag = DBDagBag()
 
             api.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
 


### PR DESCRIPTION
Major Changes:
- Rename `SchedulerDagBag` to `DBDagBag` for better clarity
- Add centralized DAG validation functions in API server at `dagbag.py`:
  - `get_latest_version_of_dag()` - validates DAG exists and returns latest version
  - `get_dag_for_run()` - validates DAG exists for specific run
  - `get_dag_for_run_or_latest_version()` - flexible DAG retrieval
- Replace scattered DAG existence checks across all API routes with centralized functions
- Standardize error messages across all DAG-related endpoints

