### PR TITLE
Fix elements nesting warning in connections DataTable

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -145,7 +145,7 @@ export const DataTable = <TData,>({
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
       ) : undefined}
       {!hasRows && !Boolean(isLoading) && (
-        <Text pl={4} pt={1}>
+        <Text as="div" pl={4} pt={1}>
           {noRowsMessage ?? translate("noItemsFound", { modelName })}
         </Text>
       )}


### PR DESCRIPTION
Following https://github.com/apache/airflow/pull/52032, there is a warning of `<p>` elements and `<div>` elements inside `<p>` from 'no connection' table:

### Before
<img width="1919" height="866" alt="Screenshot 2025-07-31 at 16 48 03" src="https://github.com/user-attachments/assets/b900cf43-bf1a-4919-9b09-26a67e25b456" />


### After
<img width="1920" height="930" alt="Screenshot 2025-07-31 at 16 47 26" src="https://github.com/user-attachments/assets/9abb7ae6-c274-43a0-bd96-71f9631a938e" />



Other 'no items' messages are unchanged:
<img width="1392" height="689" alt="Screenshot 2025-07-31 at 16 47 46" src="https://github.com/user-attachments/assets/0ffb9ab4-e0e4-4333-9320-2562d315c6ac" />

