### PR TITLE
Update color palette and leverage Chakra semantic tokens

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, Alert, CloseButton, Container, Heading, Span, Text } from "@chakra-ui/react";
+import { Alert, CloseButton, Container, Heading, Span, Text, Box, HStack } from "@chakra-ui/react";
 import type { LoginResponse } from "openapi-gen/requests/types.gen";
 import { useState } from "react";
 import { useCookies } from "react-cookie";
@@ -78,58 +78,78 @@ export const Login = () => {
   };
 
   return (
-    <Container
-      border="1px"
-      borderColor="gray.emphasized"
-      borderRadius={5}
-      borderStyle="solid"
-      borderWidth="1px"
-      maxW="2xl"
-      mt={2}
-      p="4"
+    <Box
+      _dark={{
+        bg: "gray.900",
+      }}
+      alignItems="center"
+      bg="gray.50"
+      display="flex"
+      justifyContent="center"
+      minH="100vh"
+      p={4}
     >
-      <Flex gap={2} mb={6}>
-        <AirflowPin height="35px" width="35px" />
-        <Heading colorPalette="blue" fontWeight="normal" size="xl">
-          Sign into Airflow
-        </Heading>
-      </Flex>
+      <Container
+        _dark={{
+          bg: "gray.800",
+        }}
+        bg="white"
+        borderRadius="lg"
+        boxShadow="lg"
+        maxW="md"
+        p={8}
+      >
+        <HStack gap={3} mb={6}>
+          <AirflowPin height="35px" width="35px" />
+          <Heading _dark={{ color: "white" }} color="gray.800" fontWeight="normal" size="xl">
+            Sign into Airflow
+          </Heading>
+        </HStack>
 
-      {Boolean(error) && <ErrorAlert error={error} />}
+        {Boolean(error) && (
+          <Box mb={4}>
+            <ErrorAlert error={error} />
+          </Box>
+        )}
 
-      <Text mb={4}>Enter your username and password below:</Text>
-      <LoginForm isPending={isPending} onLogin={onLogin} />
-      {isBannerDisabled === null && (
-        <Alert.Root mt={5} status="info">
-          <Alert.Indicator />
-          <Alert.Content>
-            <Alert.Title>Simple auth manager enabled</Alert.Title>
-            <Alert.Description>
-              The Simple auth manager is intended for development and testing. If you&apos;re using it in
-              production, ensure that access is controlled through other means. Please read{" "}
-              <Span textDecoration="underline">
-                <a
-                  href="https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/auth-manager/simple/index.html"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  the documentation
-                </a>
-              </Span>{" "}
-              to learn more about simple auth manager.
-            </Alert.Description>
-          </Alert.Content>
-          <CloseButton
-            insetEnd="-2"
-            onClick={() => {
-              localStorage.setItem(LOCAL_STORAGE_DISABLE_BANNER_KEY, "1");
-              setIsBannerDisabled("1");
-            }}
-            pos="relative"
-            top="-2"
-          />
-        </Alert.Root>
-      )}
-    </Container>
+        <Text _dark={{ color: "gray.300" }} color="gray.600" mb={4}>
+          Enter your username and password below:
+        </Text>
+
+        <LoginForm isPending={isPending} onLogin={onLogin} />
+
+        {isBannerDisabled === null && (
+          <Alert.Root mt={5} status="info">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title>Simple auth manager enabled</Alert.Title>
+              <Alert.Description>
+                The Simple auth manager is intended for development and testing. If you&apos;re using it in
+                production, ensure that access is controlled through other means. Please read{" "}
+                <Span textDecoration="underline">
+                  <a
+                    href="https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/auth-manager/simple/index.html"
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    the documentation
+                  </a>
+                </Span>{" "}
+                to learn more about simple auth manager.
+              </Alert.Description>
+            </Alert.Content>
+            <CloseButton
+              insetEnd="-2"
+              onClick={() => {
+                localStorage.setItem(LOCAL_STORAGE_DISABLE_BANNER_KEY, "1");
+                setIsBannerDisabled("1");
+              }}
+              pos="relative"
+              top="-2"
+            />
+          </Alert.Root>
+        )}
+      </Container>
+    </Box>
   );
 };

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/LoginForm.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/LoginForm.tsx
@@ -54,7 +54,7 @@ export const LoginForm = ({ isPending, onLogin }: LoginFormProps) => {
             <Field.Root invalid={Boolean(fieldState.error)} required>
               <Field.Label>Username</Field.Label>
               {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-              <Input autoFocus {...field} />
+              <Input autoFocus variant="subtle" {...field} />
             </Field.Root>
           )}
           rules={{ required: true }}
@@ -66,13 +66,13 @@ export const LoginForm = ({ isPending, onLogin }: LoginFormProps) => {
           render={({ field, fieldState }) => (
             <Field.Root invalid={Boolean(fieldState.error)} required>
               <Field.Label>Password</Field.Label>
-              <Input {...field} type="password" />
+              <Input variant="subtle" {...field} type="password" />
             </Field.Root>
           )}
           rules={{ required: true }}
         />
 
-        <Button colorPalette="blue" disabled={!isValid || isPending} type="submit">
+        <Button colorPalette="brand" disabled={!isValid || isPending} type="submit">
           Sign in
         </Button>
       </Stack>

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/main.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/main.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { ChakraProvider } from "@chakra-ui/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { CookiesProvider } from "react-cookie";
@@ -24,11 +24,12 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
 import { router } from "src/router";
+import { system } from "src/theme";
 
 import { queryClient } from "./queryClient";
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
-  <ChakraProvider value={defaultSystem}>
+  <ChakraProvider value={system}>
     <ThemeProvider attribute="class" disableTransitionOnChange>
       <QueryClientProvider client={queryClient}>
         <CookiesProvider>

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/theme.ts
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/theme.ts
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+/* THIS FILE IS A COPY OF THE AIRFLOW UI THEME FILE LOCATED IN
+   airflow-core/src/airflow/ui/src/theme.ts
+*/
 /* eslint-disable perfectionist/sort-objects */
-
 /* eslint-disable max-lines */
 import { createSystem, defaultConfig, defineConfig } from "@chakra-ui/react";
-import type { CSSProperties } from "react";
 
 const generateSemanticTokens = (color: string, darkContrast: string = "white") => ({
   solid: { value: `{colors.${color}.600}` },
@@ -405,22 +405,3 @@ export const getComputedCSSVariableValue = (variable: string): string =>
   getComputedStyle(document.documentElement)
     .getPropertyValue(variable.slice(4, variable.length - 1))
     .trim();
-
-// Returns ReactFlow style props using Chakra UI CSS variables
-export const getReactFlowThemeStyle = (colorMode: "dark" | "light"): CSSProperties =>
-  ({
-    // Background
-    "--xy-background-color":
-      colorMode === "dark" ? "var(--chakra-colors-brand-950)" : "var(--chakra-colors-brand-50)",
-    "--xy-background-pattern-color":
-      colorMode === "dark" ? "var(--chakra-colors-gray-200)" : "var(--chakra-colors-gray-800)",
-
-    // Controls
-    "--xy-controls-button-background-color":
-      colorMode === "dark" ? "var(--chakra-colors-gray-800)" : "var(--chakra-colors-white)",
-    "--xy-controls-button-background-color-hover":
-      colorMode === "dark" ? "var(--chakra-colors-gray-700)" : "var(--chakra-colors-gray-100)",
-
-    // MiniMap
-    "--xy-minimap-background-color": "var(--chakra-colors-bg)",
-  }) as CSSProperties;

--- a/airflow-core/src/airflow/ui/src/components/AssetExpression/AssetNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/AssetExpression/AssetNode.tsx
@@ -34,7 +34,7 @@ export const AssetNode = ({
   <Box
     bg="bg.muted"
     border="1px solid"
-    borderColor={Boolean(event?.lastUpdate) ? "green" : undefined}
+    borderColor={Boolean(event?.lastUpdate) ? "success.solid" : "border.emphasized"}
     borderRadius="md"
     borderWidth={Boolean(event?.lastUpdate) ? 3 : 1}
     display="inline-block"

--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -69,7 +69,7 @@ export const AssetEvents = ({
     <Box borderBottomWidth={0} borderRadius={5} borderWidth={1} p={4} py={2} {...rest}>
       <Flex alignItems="center" justify="space-between">
         <HStack>
-          <StateBadge colorPalette="blue" fontSize="md" variant="solid">
+          <StateBadge colorPalette="brand" fontSize="md" variant="solid">
             <FiDatabase />
             {data?.total_entries ?? " "}
           </StateBadge>

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -38,9 +38,9 @@ type Props = {
 };
 
 const buttonProps = {
-  _hover: { bg: "blue.contrast", color: "blue.muted" },
-  borderColor: "blue.contrast",
-  color: "blue.contrast",
+  _hover: { bg: "info.contrast", color: "info.muted" },
+  borderColor: "info.contrast",
+  color: "info.contrast",
   rounded: "full",
   size: "xs",
   variant: "outline",
@@ -90,7 +90,7 @@ const BackfillBanner = ({ dagId }: Props) => {
   }
 
   return (
-    <Box bg="blue.solid" borderRadius="full" color="blue.contrast" my="1" px="2" py="1">
+    <Box bg="info.solid" borderRadius="full" color="info.contrast" my="1" px="2" py="1">
       <HStack alignItems="center" ml={3}>
         <RiArrowGoBackFill />
         <Text key="backfill">{translate("banner.backfillInProgress")}:</Text>

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -129,7 +129,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
               </Checkbox>
             ) : undefined}
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               disabled={affectedTasks.total_entries === 0}
               loading={isPending || isPendingPatchDagRun}
               onClick={() => {

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearGroupTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearGroupTaskInstanceDialog.tsx
@@ -166,7 +166,7 @@ export const ClearGroupTaskInstanceDialog = ({ onClose, open, taskInstance }: Pr
               </Checkbox>
             ) : undefined}
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               disabled={affectedTasks.total_entries === 0 || groupTaskIds.length === 0}
               loading={isPending}
               onClick={() => {

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -171,7 +171,7 @@ const ClearTaskInstanceDialog = ({ onClose, open, taskInstance }: Props) => {
               </Checkbox>
             ) : undefined}
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               disabled={affectedTasks.total_entries === 0}
               loading={isPending || isPendingPatchDagRun}
               onClick={() => {

--- a/airflow-core/src/airflow/ui/src/components/ConfirmationModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfirmationModal.tsx
@@ -49,7 +49,7 @@ export const ConfirmationModal = ({ children, header, onConfirm, onOpenChange, o
             </Button>
           </Dialog.ActionTrigger>
           <Button
-            colorPalette="blue"
+            colorPalette="brand"
             onClick={() => {
               onConfirm();
               onOpenChange({ open });

--- a/airflow-core/src/airflow/ui/src/components/DagActions/DeleteDagButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/DeleteDagButton.tsx
@@ -47,7 +47,7 @@ const DeleteDagButton = ({ dagDisplayName, dagId, width, withText = true }: Dele
     <Box width={width}>
       <ActionButton
         actionName={translate("dagActions.delete.button")}
-        colorPalette="red"
+        colorPalette="danger"
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("dagActions.delete.button")}

--- a/airflow-core/src/airflow/ui/src/components/DagActions/FavoriteDagButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/FavoriteDagButton.tsx
@@ -54,7 +54,7 @@ export const FavoriteDagButton = ({ dagId, withText = true }: FavoriteDagButtonP
     <Box>
       <ActionButton
         actionName={isFavorite ? translate("unfavoriteDag") : translate("favoriteDag")}
-        icon={<FiStar style={{ fill: isFavorite ? "blue" : "none" }} />}
+        icon={<FiStar style={{ fill: isFavorite ? "var(--chakra-colors-brand-solid)" : "none" }} />}
         onClick={onToggle}
         text={isFavorite ? translate("unfavoriteDag") : translate("favoriteDag")}
         withText={withText}

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -190,7 +190,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
               <HStack align="stretch">
                 {reprocessBehaviors.map((item) => (
                   <RadioCardItem
-                    colorPalette="blue"
+                    colorPalette="brand"
                     indicatorPlacement="start"
                     key={item.value}
                     label={translate(item.label)}
@@ -224,7 +224,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
           control={control}
           name="run_backwards"
           render={({ field }) => (
-            <Checkbox checked={field.value} colorPalette="blue" onChange={field.onChange}>
+            <Checkbox checked={field.value} colorPalette="brand" onChange={field.onChange}>
               {translate("backfill.backwards")}
             </Checkbox>
           )}
@@ -234,7 +234,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
           <>
             <Checkbox
               checked={unpause}
-              colorPalette="blue"
+              colorPalette="brand"
               onChange={() => setUnpause(!unpause)}
               wordBreak="break-all"
             >
@@ -257,7 +257,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
           <Spacer />
           <Button onClick={() => void handleSubmit(onCancel)()}>{translate("common:modal.cancel")}</Button>
           <Button
-            colorPalette="blue"
+            colorPalette="brand"
             disabled={
               Boolean(errors.date) || isPendingDryRun || formError || affectedTasks.total_entries === 0
             }

--- a/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -33,13 +33,13 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
   const { t: translate } = useTranslation("components");
 
   return (
-    <HStack colorPalette="blue" gap={1} pb={2}>
+    <HStack colorPalette="brand" gap={1} pb={2}>
       <Tooltip content={translate("toggleCardView")}>
         <IconButton
-          _hover={{ bg: "colorPalette.subtle" }}
+          _hover={{ bg: "colorPalette.emphasized" }}
           aria-label={translate("toggleCardView")}
           bg={display === "card" ? "colorPalette.muted" : "bg"}
-          borderColor="colorPalette.fg"
+          borderColor="border.emphasized"
           borderWidth={1}
           color="colorPalette.fg"
           height={8}
@@ -52,10 +52,10 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
       </Tooltip>
       <Tooltip content={translate("toggleTableView")}>
         <IconButton
-          _hover={{ bg: "colorPalette.subtle" }}
+          _hover={{ bg: "colorPalette.emphasized" }}
           aria-label={translate("toggleTableView")}
           bg={display === "table" ? "colorPalette.muted" : "bg"}
-          borderColor="colorPalette.fg"
+          borderColor="border.emphasized"
           borderWidth={1}
           color="colorPalette.fg"
           height={8}

--- a/airflow-core/src/airflow/ui/src/components/DeleteDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DeleteDialog.tsx
@@ -64,7 +64,7 @@ const DeleteDialog: React.FC<DeleteDialogProps> = ({
             <Button onClick={onClose} variant="outline">
               {translate("modal.cancel")}
             </Button>
-            <Button colorPalette="red" loading={isDeleting} onClick={onDelete}>
+            <Button colorPalette="danger" loading={isDeleting} onClick={onDelete}>
               <FiTrash2 style={{ marginRight: "8px" }} />{" "}
               {deleteButtonText ?? translate("modal.delete.button")}
             </Button>

--- a/airflow-core/src/airflow/ui/src/components/DisplayMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DisplayMarkdownButton.tsx
@@ -49,7 +49,7 @@ const DisplayMarkdownButton = ({
         size="md"
       >
         <Dialog.Content backdrop>
-          <Dialog.Header bg="blue.muted">
+          <Dialog.Header bg="info.muted">
             <Heading size="xl">{header}</Heading>
             <Dialog.CloseTrigger closeButtonProps={{ size: "xl" }} />
           </Dialog.Header>

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -70,7 +70,7 @@ const EditableMarkdownButton = ({
         />
         {Boolean(mdContent?.trim()) && (
           <Box
-            bg="blue.500"
+            bg="brand.500"
             borderRadius="full"
             height={2.5}
             position="absolute"
@@ -89,7 +89,7 @@ const EditableMarkdownButton = ({
         unmountOnExit={true}
       >
         <Dialog.Content backdrop>
-          <Dialog.Header bg="blue.muted">
+          <Dialog.Header bg="brand.muted">
             <Heading size="xl">{header}</Heading>
             <Dialog.CloseTrigger closeButtonProps={{ size: "xl" }} />
           </Dialog.Header>
@@ -101,7 +101,7 @@ const EditableMarkdownButton = ({
             />
             <Flex justifyContent="end" mt={3} width="100%">
               <Button
-                colorPalette="blue"
+                colorPalette="brand"
                 loading={isPending}
                 onClick={() => {
                   onConfirm();

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
@@ -35,7 +35,7 @@ export const FieldBool = ({ name, namespace = "default" }: FlexibleFormElementPr
   return (
     <Switch
       checked={Boolean(param.value)}
-      colorPalette="blue"
+      colorPalette="brand"
       disabled={disabled}
       id={`element_${name}`}
       name={`element_${name}`}

--- a/airflow-core/src/airflow/ui/src/components/Graph/DownloadButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/DownloadButton.tsx
@@ -68,7 +68,10 @@ export const DownloadButton = ({ name }: { readonly name: string }) => {
     <Panel position="bottom-right" style={{ transform: "translateY(-150px)" }}>
       <IconButton
         aria-label={translate("graph.downloadImage")}
-        onClick={() => void onClick()}
+        colorPalette="info"
+        onClick={() => {
+          void onClick();
+        }}
         size="xs"
         title={translate("graph.downloadImage")}
         variant="ghost"

--- a/airflow-core/src/airflow/ui/src/components/Graph/Edge.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/Edge.tsx
@@ -22,17 +22,12 @@ import { LinePath } from "@visx/shape";
 import type { Edge as EdgeType } from "@xyflow/react";
 import type { ElkPoint } from "elkjs";
 
-import { useColorMode } from "src/context/colorMode";
-
 import type { EdgeData } from "./reactflowUtils";
 
 type Props = EdgeType<EdgeData>;
 
 const CustomEdge = ({ data }: Props) => {
-  const { colorMode } = useColorMode();
-
-  // corresponds to the "border.inverted" semantic token
-  const [lightStroke, darkStroke] = useToken("colors", ["gray.800", "gray.200"]);
+  const [strokeColor] = useToken("colors", ["border.inverted"]);
 
   if (data === undefined) {
     return undefined;
@@ -65,7 +60,7 @@ const CustomEdge = ({ data }: Props) => {
         <LinePath
           data={[section.startPoint, ...(section.bendPoints ?? []), section.endPoint]}
           key={section.id}
-          stroke={colorMode === "dark" ? darkStroke : lightStroke}
+          stroke={strokeColor}
           strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}
           strokeWidth={rest.isSelected ? 2 : 1}
           x={(point: ElkPoint) => point.x}

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -116,7 +116,7 @@ export const TaskNode = ({
             )}
             {isGroup ? (
               <Button
-                colorPalette="blue"
+                colorPalette="brand"
                 cursor="pointer"
                 height={8}
                 onClick={onClick}
@@ -135,22 +135,22 @@ export const TaskNode = ({
         {Boolean(isMapped) || Boolean(isGroup && !isOpen) ? (
           <>
             <Box
-              bg="bg.subtle"
+              bg={taskInstance?.state ? `${taskInstance.state}.solid` : "bg.subtle"}
               borderBottomLeftRadius={5}
               borderBottomRightRadius={5}
               borderBottomWidth={1}
-              borderColor="fg"
+              borderColor={taskInstance?.state ? `${taskInstance.state}.solid` : "border.emphasized"}
               borderLeftWidth={1}
               borderRightWidth={1}
               height={1}
               width={`${width - 10}px`}
             />
             <Box
-              bg="bg.subtle"
+              bg={taskInstance?.state ? `${taskInstance.state}.solid` : "bg.subtle"}
               borderBottomLeftRadius={5}
               borderBottomRightRadius={5}
               borderBottomWidth={1}
-              borderColor="fg"
+              borderColor={taskInstance?.state ? `${taskInstance.state}.solid` : "border.emphasized"}
               borderLeftWidth={1}
               borderRightWidth={1}
               height={1}

--- a/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
@@ -38,7 +38,7 @@ export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle
   const { t: translate } = useTranslation();
 
   return (
-    <Box borderColor="border" borderRadius={8} borderWidth={1} ml={2} p={2}>
+    <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} ml={2} p={2}>
       <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
         <Flex alignItems="center" flexWrap="wrap" gap={2}>
           <Heading size="xl">{icon}</Heading>
@@ -51,6 +51,7 @@ export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle
         </Flex>
         <HStack gap={1}>{actions}</HStack>
       </Flex>
+
       <HStack alignItems="flex-start" flexWrap="wrap" gap={5} justifyContent="space-between" my={2}>
         {stats.map(({ label, value }) => (
           <GridItem key={label}>

--- a/airflow-core/src/airflow/ui/src/components/JsonEditor.tsx
+++ b/airflow-core/src/airflow/ui/src/components/JsonEditor.tsx
@@ -38,7 +38,7 @@ export const JsonEditor = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>((
       height="200px"
       ref={ref}
       style={{
-        border: "1px solid var(--chakra-colors-border)",
+        border: "1px solid var(--chakra-colors-border-emphasized)",
         borderRadius: "8px",
         outline: "none",
         padding: "2px",

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
@@ -62,7 +62,7 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
           <ActionAccordion note={note} setNote={setNote} />
           <Flex justifyContent="end" mt={3}>
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               loading={isPending}
               onClick={() => {
                 mutate({

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -135,7 +135,7 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
           <ActionAccordion affectedTasks={affectedTasks} note={note} setNote={setNote} />
           <Flex justifyContent="end" mt={3}>
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               loading={isPending || isPendingDryRun}
               onClick={() => {
                 mutate({

--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -54,7 +54,8 @@ export const PoolBar = ({
             <Flex
               alignItems="center"
               bg={`${color}.solid`}
-              color="white"
+              color={`${color}.contrast`}
+              flex={flexValue}
               gap={1}
               h="100%"
               justifyContent="center"

--- a/airflow-core/src/airflow/ui/src/components/ReactMarkdown.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ReactMarkdown.tsx
@@ -53,12 +53,19 @@ const makeHeading =
 const components = {
   // eslint-disable-next-line id-length
   a: ({ children, href, title }: { children: ReactNode; href: string; title?: string }) => (
-    <Link color="blue.600" fontWeight="bold" href={href} title={title}>
+    <Link color="fg.info" fontWeight="bold" href={href} title={title}>
       {children}
     </Link>
   ),
   blockquote: ({ children }: PropsWithChildren) => (
-    <Box as="blockquote" borderColor="gray.400" borderLeft="solid 2px" fontStyle="italic" my={3} pl={2}>
+    <Box
+      as="blockquote"
+      borderColor="border.emphasized"
+      borderLeft="solid 2px"
+      fontStyle="italic"
+      my={3}
+      pl={2}
+    >
       {children}
     </Box>
   ),

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -69,13 +69,13 @@ export const SearchBar = ({
   return (
     <InputGroup
       {...groupProps}
-      colorPalette="blue"
+      colorPalette="brand"
       endElement={
         <>
           {Boolean(value) ? (
             <CloseButton
               aria-label={translate("search.clear")}
-              colorPalette="gray"
+              colorPalette="brand"
               data-testid="clear-search"
               onClick={() => {
                 setValue("");

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
@@ -47,7 +47,13 @@ export const SearchDagsButton = () => {
 
   return (
     <Box>
-      <Button justifyContent="flex-start" minWidth={200} onClick={() => setIsOpen(true)} variant="subtle">
+      <Button
+        colorPalette="brand"
+        justifyContent="flex-start"
+        minWidth={200}
+        onClick={() => setIsOpen(true)}
+        variant="subtle"
+      >
         <MdSearch /> {translate("search.dags")}{" "}
         <Kbd size="sm">
           {metaKey}

--- a/airflow-core/src/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskTrySelect.tsx
@@ -127,7 +127,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
           {sortedTries.map((ti) => (
             <TaskInstanceTooltip key={ti.try_number} taskInstance={ti}>
               <Button
-                colorPalette="blue"
+                colorPalette="brand"
                 data-testid={`log-attempt-select-button-${ti.try_number}`}
                 key={ti.try_number}
                 onClick={() => {

--- a/airflow-core/src/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TogglePause.tsx
@@ -59,7 +59,7 @@ export const TogglePause = ({ dagDisplayName, dagId, isPaused, skipConfirm, ...r
     <>
       <Switch
         checked={isPaused === undefined ? undefined : !isPaused}
-        colorPalette="blue"
+        colorPalette="brand"
         onCheckedChange={onChange}
         size="sm"
         {...rest}

--- a/airflow-core/src/airflow/ui/src/components/TrendCountButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TrendCountButton.tsx
@@ -46,8 +46,16 @@ export const TrendCountButton = ({
     <Skeleton borderRadius={4} height="45px" width="350px" />
   ) : (
     <Link to={route}>
-      <HStack borderRadius={4} borderWidth={1} p={3} width="350px">
-        <Badge borderRadius="50%" colorPalette={colorPalette} variant="solid">
+      <HStack
+        _hover={{ bg: "bg.subtle" }}
+        borderColor="border.emphasized"
+        borderRadius={4}
+        borderWidth={1}
+        p={3}
+        transition="background-color 0.2s"
+        width="350px"
+      >
+        <Badge borderRadius="md" colorPalette={colorPalette} variant="solid">
           {count}
         </Badge>
         <Text fontSize="sm" fontWeight="bold">

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
@@ -39,11 +39,10 @@ const TriggerDAGButton: React.FC<Props> = ({ dagDisplayName, dagId, isPaused, wi
     <Box>
       <ActionButton
         actionName={translate("triggerDag.title")}
-        colorPalette="blue"
         icon={<FiPlay />}
         onClick={onOpen}
         text={translate("triggerDag.button")}
-        variant="solid"
+        variant="outline"
         withText={withText}
       />
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -153,7 +153,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
       {isPaused ? (
         <Checkbox
           checked={unpause}
-          colorPalette="blue"
+          colorPalette="brand"
           onChange={() => setUnpause(!unpause)}
           wordBreak="break-all"
         >
@@ -165,7 +165,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
         <HStack w="full">
           <Spacer />
           <Button
-            colorPalette="blue"
+            colorPalette="brand"
             disabled={Boolean(errors.conf) || Boolean(errors.date) || formError || isPending}
             onClick={() => void handleSubmit(onSubmit)()}
           >

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
@@ -91,7 +91,7 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
             </Center>
           ) : isError ? (
             <Center py={6}>
-              <Text color="red.500">{translate("triggerDag.loadingFailed")}</Text>
+              <Text color="fg.error">{translate("triggerDag.loadingFailed")}</Text>
             </Center>
           ) : (
             <>

--- a/airflow-core/src/airflow/ui/src/components/ui/ActionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/ActionButton.tsx
@@ -50,7 +50,7 @@ const ActionButton = ({
       <div>
         <ButtonComponent
           aria-label={actionName}
-          colorPalette={withText ? colorPalette : "blue"}
+          colorPalette={withText ? colorPalette : "brand"}
           disabled={disabled}
           onClick={onClick}
           size={withText ? "md" : "sm"}

--- a/airflow-core/src/airflow/ui/src/components/ui/Clipboard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/Clipboard.tsx
@@ -51,7 +51,7 @@ export const ClipboardLabel = React.forwardRef<HTMLLabelElement, ChakraClipboard
 
 export const ClipboardButton = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
   <ChakraClipboard.Trigger asChild>
-    <Button ref={ref} size="sm" variant="surface" {...props}>
+    <Button ref={ref} size="sm" variant="outline" {...props}>
       <ClipboardIcon />
       <ClipboardCopyText />
     </Button>

--- a/airflow-core/src/airflow/ui/src/components/ui/SegmentedControl.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/SegmentedControl.tsx
@@ -48,10 +48,18 @@ const SegmentedControl = ({ defaultValues, multiple = false, onChange, options }
   useEffect(() => onChange?.(selectedOptions), [onChange, selectedOptions]);
 
   return (
-    <Group backgroundColor="bg.muted" borderRadius={8} colorPalette="gray" mb={3} p={1}>
+    <Group
+      backgroundColor="bg.muted"
+      borderColor="border.emphasized"
+      borderRadius={8}
+      borderWidth={1}
+      colorPalette="brand"
+      mb={3}
+      p={1}
+    >
       {options.map(({ disabled, label, value }: Option) => (
         <Button
-          _hover={{ backgroundColor: "bg.panel" }}
+          _hover={{ backgroundColor: "bg.emphasized" }}
           bg={selectedOptions.includes(value) ? "bg.panel" : undefined}
           disabled={disabled}
           key={value}

--- a/airflow-core/src/airflow/ui/src/components/ui/Toaster/Toaster.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/Toaster/Toaster.tsx
@@ -25,7 +25,7 @@ export const Toaster = () => (
     <ChakraToaster insetInline={{ mdDown: "4" }} toaster={toaster}>
       {(toast) => (
         <Toast.Root width={{ md: "sm" }}>
-          {toast.type === "loading" ? <Spinner color="blue.solid" size="sm" /> : <Toast.Indicator />}
+          {toast.type === "loading" ? <Spinner color="brand.solid" size="sm" /> : <Toast.Indicator />}
           <Stack flex="1" gap="1" maxWidth="100%">
             {Boolean(toast.title) ? <Toast.Title>{toast.title}</Toast.Title> : undefined}
             {Boolean(toast.description) ? (

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -170,7 +170,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
               >
                 <Box
                   alignItems="center"
-                  bg="fg.subtle"
+                  bg="border.emphasized"
                   cursor="col-resize"
                   display="flex"
                   h="100%"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -34,6 +34,7 @@ import useSelectedVersion from "src/hooks/useSelectedVersion";
 import { flattenGraphNodes } from "src/layouts/Details/Grid/utils.ts";
 import { useDependencyGraph } from "src/queries/useDependencyGraph";
 import { useGridTiSummaries } from "src/queries/useGridTISummaries.ts";
+import { getReactFlowThemeStyle } from "src/theme";
 
 const nodeColor = (
   { data: { depth, height, isOpen, taskInstance, width }, type }: ReactFlowNode<CustomNodeProps>,
@@ -65,12 +66,12 @@ export const Graph = () => {
 
   // corresponds to the "bg", "bg.emphasized", "border.inverted" semantic tokens
   const [oddLight, oddDark, evenLight, evenDark, selectedDarkColor, selectedLightColor] = useToken("colors", [
-    "white",
-    "black",
-    "gray.200",
-    "gray.800",
-    "gray.200",
-    "gray.800",
+    "bg",
+    "fg",
+    "bg.muted",
+    "bg.emphasized",
+    "bg.muted",
+    "bg.emphasized",
   ]);
 
   const { allGroupIds, openGroupIds, setAllGroupIds } = useOpenGroups();
@@ -164,6 +165,7 @@ export const Graph = () => {
       nodesDraggable={false}
       nodeTypes={nodeTypes}
       onlyRenderVisibleElements
+      style={getReactFlowThemeStyle(colorMode)}
     >
       <Background />
       <Controls showInteractive={false} />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -48,8 +48,8 @@ export const Bar = ({ max, nodes, onCellClick, onColumnClick, run }: Props) => {
 
   return (
     <Box
-      _hover={{ bg: "blue.subtle" }}
-      bg={isSelected ? "blue.muted" : undefined}
+      _hover={{ bg: "brand.subtle" }}
+      bg={isSelected ? "brand.muted" : undefined}
       position="relative"
       transition="background-color 0.2s"
     >
@@ -65,7 +65,7 @@ export const Bar = ({ max, nodes, onCellClick, onColumnClick, run }: Props) => {
       >
         <GridButton
           alignItems="center"
-          color="white"
+          color="fg"
           dagId={dagId}
           flexDir="column"
           height={`${(run.duration / max) * BAR_HEIGHT}px`}
@@ -77,7 +77,7 @@ export const Bar = ({ max, nodes, onCellClick, onColumnClick, run }: Props) => {
           state={run.state}
           zIndex={1}
         >
-          {run.run_type !== "scheduled" && <RunTypeIcon runType={run.run_type} size="10px" />}
+          {run.run_type !== "scheduled" && <RunTypeIcon color="white" runType={run.run_type} size="10px" />}
         </GridButton>
       </Flex>
       <TaskInstancesColumn

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -44,7 +44,7 @@ const onMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
   const tasks = document.querySelectorAll<HTMLDivElement>(`#${event.currentTarget.id}`);
 
   tasks.forEach((task) => {
-    task.style.backgroundColor = "var(--chakra-colors-blue-subtle)";
+    task.style.backgroundColor = "var(--chakra-colors-brand-subtle)";
   });
 };
 
@@ -77,7 +77,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, 
   return (
     <Flex
       alignItems="center"
-      bg={selectedTaskId === taskId || selectedGroupId === taskId ? "blue.muted" : undefined}
+      bg={selectedTaskId === taskId || selectedGroupId === taskId ? "brand.muted" : undefined}
       height="20px"
       id={taskId.replaceAll(".", "-")}
       justifyContent="center"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
@@ -37,7 +37,7 @@ const onMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
   const tasks = document.querySelectorAll<HTMLDivElement>(`#${event.currentTarget.id}`);
 
   tasks.forEach((task) => {
-    task.style.backgroundColor = "var(--chakra-colors-blue-subtle)";
+    task.style.backgroundColor = "var(--chakra-colors-info-subtle)";
   });
 };
 
@@ -59,9 +59,9 @@ export const TaskNames = ({ nodes, onRowClick }: Props) => {
 
   return nodes.map((node) => (
     <Box
-      bg={node.id === taskId || node.id === groupId ? "blue.muted" : undefined}
+      bg={node.id === taskId || node.id === groupId ? "info.muted" : undefined}
       borderBottomWidth={1}
-      borderColor={node.isGroup ? "border.emphasized" : "border.muted"}
+      borderColor={node.isGroup ? "border.emphasized" : "border"}
       cursor="pointer"
       id={node.id.replaceAll(".", "-")}
       key={node.id}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/NavTabs.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/NavTabs.tsx
@@ -31,7 +31,13 @@ export const NavTabs = ({ tabs }: Props) => {
   const containerWidth = useContainerWidth(containerRef);
 
   return (
-    <Flex alignItems="center" borderBottomWidth={1} mb={2} ref={containerRef}>
+    <Flex
+      alignItems="center"
+      borderBottomColor="border.emphasized"
+      borderBottomWidth={1}
+      mb={2}
+      ref={containerRef}
+    >
       {tabs.map(({ icon, label, value }) => (
         <NavLink
           end
@@ -43,6 +49,7 @@ export const NavTabs = ({ tabs }: Props) => {
         >
           {({ isActive }) => (
             <Center
+              _hover={{ color: "fg" }}
               borderBottomColor="border.info"
               borderBottomWidth={isActive ? 3 : 0}
               color={isActive ? "fg" : "fg.muted"}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -183,11 +183,11 @@ export const PanelButtons = ({
 
   return (
     <Box position="absolute" top={1} width="100%" zIndex={1}>
-      <Flex flexWrap="wrap" justifyContent="space-between">
+      <Flex justifyContent="space-between">
         <ButtonGroup attached size="sm" variant="outline">
           <IconButton
             aria-label={translate("dag:panel.buttons.showGridShortcut")}
-            colorPalette="blue"
+            colorPalette="brand"
             onClick={() => {
               setDagView("grid");
               if (dagView === "grid") {
@@ -201,7 +201,7 @@ export const PanelButtons = ({
           </IconButton>
           <IconButton
             aria-label={translate("dag:panel.buttons.showGraphShortcut")}
-            colorPalette="blue"
+            colorPalette="brand"
             onClick={() => {
               setDagView("graph");
               if (dagView === "graph") {
@@ -214,7 +214,7 @@ export const PanelButtons = ({
             <MdOutlineAccountTree />
           </IconButton>
         </ButtonGroup>
-        <Flex gap={1}>
+        <Flex gap={1} mr={3}>
           <ToggleGroups />
           {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Popover.Root autoFocus={false} positioning={{ placement: "bottom-end" }}>
@@ -233,6 +233,7 @@ export const PanelButtons = ({
                       <>
                         <DagVersionSelect />
                         <DagRunSelect limit={limit} />
+
                         <Select.Root
                           // @ts-expect-error The expected option type is incorrect
                           collection={getOptions(translate)}
@@ -262,6 +263,7 @@ export const PanelButtons = ({
                             </Select.Content>
                           </Select.Positioner>
                         </Select.Root>
+
                         <Select.Root
                           // @ts-expect-error The expected option type is incorrect
                           collection={directionOptions(translate)}
@@ -394,6 +396,7 @@ export const PanelButtons = ({
           </Popover.Root>
         </Flex>
       </Flex>
+
       {dagView === "grid" && (
         <Flex color="fg.muted" justifyContent="flex-end" mt={1}>
           <Tooltip

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/LanguageSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/LanguageSelector.tsx
@@ -47,6 +47,16 @@ const LanguageSelector: React.FC = () => {
     <VStack align="stretch" gap={6}>
       <Field.Root>
         <Select<{ label: string; value: string }>
+          chakraStyles={{
+            clearIndicator: (provided) => ({
+              ...provided,
+              color: "fg.muted",
+            }),
+            control: (provided) => ({
+              ...provided,
+              colorPalette: "input",
+            }),
+          }}
           onChange={handleLanguageChange}
           options={options}
           placeholder={translate("selectLanguage")}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -136,7 +136,7 @@ export const Nav = () => {
         right: 0,
       }}
       alignItems="center"
-      bg="blue.muted"
+      bg="brand.muted"
       height="100%"
       justifyContent="space-between"
       position="fixed"

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/NavButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/NavButton.tsx
@@ -21,9 +21,16 @@ import type { ReactElement } from "react";
 import { NavLink } from "react-router-dom";
 
 const styles = {
+  _active: {
+    bg: "brand.emphasized",
+  },
+  // Fix inverted hover and active colors
+  _hover: {
+    bg: "brand.emphasized", // Even darker for better light mode contrast
+  },
   alignItems: "center",
   borderRadius: "none",
-  colorPalette: "blue",
+  colorPalette: "brand",
   flexDir: "column",
   height: 20,
   variant: "ghost",
@@ -54,7 +61,14 @@ export const NavButton = ({ icon, isExternal = false, title, to, ...rest }: NavB
   ) : (
     <NavLink to={to}>
       {({ isActive }: { readonly isActive: boolean }) => (
-        <Button {...styles} variant={isActive ? "solid" : "ghost"} {...rest}>
+        <Button
+          {...styles}
+          _active={isActive ? { bg: "brand.solid" } : { bg: "brand.emphasized" }}
+          // Override styles for active state to ensure proper colors
+          _hover={isActive ? { bg: "brand.solid" } : { bg: "brand.emphasized" }}
+          variant={isActive ? "solid" : "ghost"}
+          {...rest}
+        >
           <Box alignSelf="center">{icon}</Box>
           <Box fontSize="xs">{title}</Box>
         </Button>

--- a/airflow-core/src/airflow/ui/src/pages/Asset/AssetGraph.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/AssetGraph.tsx
@@ -28,6 +28,7 @@ import type { CustomNodeProps } from "src/components/Graph/reactflowUtils";
 import { useGraphLayout } from "src/components/Graph/useGraphLayout";
 import { useColorMode } from "src/context/colorMode";
 import { useDependencyGraph } from "src/queries/useDependencyGraph";
+import { getReactFlowThemeStyle } from "src/theme";
 
 export const AssetGraph = ({ asset }: { readonly asset?: AssetResponse }) => {
   const { assetId } = useParams();
@@ -45,7 +46,7 @@ export const AssetGraph = ({ asset }: { readonly asset?: AssetResponse }) => {
     node.id === `asset:${assetId}` ? { ...node, data: { ...node.data, isSelected: true } } : node,
   );
 
-  const [selectedDarkColor, selectedLightColor] = useToken("colors", ["gray.200", "gray.800"]);
+  const [selectedDarkColor, selectedLightColor] = useToken("colors", ["bg.muted", "bg.emphasized"]);
 
   const selectedColor = colorMode === "dark" ? selectedDarkColor : selectedLightColor;
 
@@ -74,6 +75,7 @@ export const AssetGraph = ({ asset }: { readonly asset?: AssetResponse }) => {
       nodesDraggable={false}
       nodeTypes={nodeTypes}
       onlyRenderVisibleElements
+      style={getReactFlowThemeStyle(colorMode)}
     >
       <Background />
       <Controls showInteractive={false} />

--- a/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEvent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEvent.tsx
@@ -39,7 +39,7 @@ export const CreateAssetEvent = ({ asset, withText = true }: Props) => {
     <Box>
       <ActionButton
         actionName={translate("createEvent.button")}
-        colorPalette="blue"
+        colorPalette="brand"
         disabled={asset === undefined}
         icon={<FiPlay />}
         onClick={onOpen}

--- a/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
@@ -206,7 +206,7 @@ export const CreateAssetEventModal = ({ asset, onClose, open }: Props) => {
             </Field.Root>
           ) : undefined}
           {eventType === "materialize" && dag?.is_paused ? (
-            <Checkbox checked={unpause} colorPalette="blue" onChange={() => setUnpause(!unpause)}>
+            <Checkbox checked={unpause} colorPalette="brand" onChange={() => setUnpause(!unpause)}>
               {translate("createEvent.materialize.unpauseDag", { dagName: dag.dag_display_name })}
             </Checkbox>
           ) : undefined}
@@ -214,7 +214,7 @@ export const CreateAssetEventModal = ({ asset, onClose, open }: Props) => {
         </Dialog.Body>
         <Dialog.Footer>
           <Button
-            colorPalette="blue"
+            colorPalette="brand"
             disabled={Boolean(extraError)}
             loading={isPending || isMaterializePending}
             onClick={handleSubmit}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/AddConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/AddConnectionButton.tsx
@@ -48,7 +48,7 @@ const AddConnectionButton = () => {
     <Box>
       <ActionButton
         actionName={translate("connections.add")}
-        colorPalette="blue"
+        colorPalette="brand"
         icon={<FiPlusCircle />}
         onClick={onOpen}
         text={translate("connections.add")}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -59,7 +59,7 @@ const ConnectionForm = ({
   const { conf: extra, setConf } = useParamStore();
   const {
     control,
-    formState: { isValid },
+    formState: { isDirty, isValid },
     handleSubmit,
     reset,
     watch,
@@ -250,8 +250,8 @@ const ConnectionForm = ({
         <HStack w="full">
           <Spacer />
           <Button
-            colorPalette="blue"
-            disabled={Boolean(errors.conf) || formErrors || isPending || !isValid}
+            colorPalette="brand"
+            disabled={Boolean(errors.conf) || formErrors || isPending || !isValid || !isDirty}
             onClick={() => void handleSubmit(onSubmit)()}
           >
             <FiSave /> {translate("formActions.save")}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -68,7 +68,7 @@ const getColumns = ({
       <Checkbox
         borderWidth={1}
         checked={selectedRows.get(row.original.connection_id)}
-        colorPalette="blue"
+        colorPalette="brand"
         onCheckedChange={(event) => onRowSelect(row.original.connection_id, Boolean(event.checked))}
       />
     ),
@@ -78,7 +78,7 @@ const getColumns = ({
       <Checkbox
         borderWidth={1}
         checked={allRowsSelected}
-        colorPalette="blue"
+        colorPalette="brand"
         onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
       />
     ),

--- a/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionButton.tsx
@@ -40,6 +40,7 @@ const DeleteConnectionButton = ({ connectionId, disabled }: Props) => {
     <>
       <ActionButton
         actionName={translate("connections.delete.title")}
+        colorPalette="danger"
         disabled={disabled}
         icon={<FiTrash />}
         onClick={() => {
@@ -60,7 +61,7 @@ const DeleteConnectionButton = ({ connectionId, disabled }: Props) => {
           <Dialog.CloseTrigger />
 
           <Dialog.Body width="full">
-            <Text color="gray.solid" fontSize="md" fontWeight="semibold" mb={4}>
+            <Text color="fg" fontSize="md" fontWeight="semibold" mb={4}>
               {translate("connections.delete.firstConfirmMessage_one")}
               <br />
               <Code mb={2} mt={2} p={4}>
@@ -72,7 +73,7 @@ const DeleteConnectionButton = ({ connectionId, disabled }: Props) => {
             </Text>
             <Flex justifyContent="end" mt={3}>
               <Button
-                colorPalette="red"
+                colorPalette="danger"
                 loading={isPending}
                 onClick={() => {
                   mutate({

--- a/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionsButton.tsx
@@ -43,7 +43,13 @@ const DeleteConnectionsButton = ({ clearSelections, deleteKeys: connectionIds }:
 
   return (
     <>
-      <Button aria-label={translate("deleteActions.button")} onClick={onOpen} size="sm" variant="outline">
+      <Button
+        aria-label={translate("deleteActions.button")}
+        colorPalette="red"
+        onClick={onOpen}
+        size="sm"
+        variant="outline"
+      >
         <FiTrash2 /> {translate("deleteActions.button")}
       </Button>
 
@@ -60,7 +66,7 @@ const DeleteConnectionsButton = ({ clearSelections, deleteKeys: connectionIds }:
           <Dialog.CloseTrigger />
 
           <Dialog.Body width="full">
-            <Text color="gray.solid" fontSize="md" fontWeight="semibold" mb={4}>
+            <Text color="fg" fontSize="md" fontWeight="semibold" mb={4}>
               {translate("connections.delete.firstConfirmMessage", { count: connectionIds.length })}
               <br />
               <Code mb={2} mt={2} p={4}>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
@@ -183,14 +183,14 @@ export const Calendar = () => {
 
           <ButtonGroup attached size="sm" variant="outline">
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               onClick={() => setGranularity("daily")}
               variant={granularity === "daily" ? "solid" : "outline"}
             >
               {translate("calendar.daily")}
             </Button>
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               onClick={() => setGranularity("hourly")}
               variant={granularity === "hourly" ? "solid" : "outline"}
             >
@@ -200,14 +200,14 @@ export const Calendar = () => {
 
           <ButtonGroup attached size="sm" variant="outline">
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               onClick={() => setViewMode("total")}
               variant={viewMode === "total" ? "solid" : "outline"}
             >
               {translate("calendar.totalRuns")}
             </Button>
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               onClick={() => setViewMode("failed")}
               variant={viewMode === "failed" ? "solid" : "outline"}
             >
@@ -237,9 +237,9 @@ export const Calendar = () => {
               <Box
                 animation={`${spin} 1s linear infinite`}
                 border="3px solid"
-                borderColor={{ _dark: "gray.600", _light: "blue.100" }}
+                borderColor={{ _dark: "border.emphasized", _light: "brand.100" }}
                 borderRadius="50%"
-                borderTopColor="blue.500"
+                borderTopColor="brand.500"
                 height="24px"
                 width="24px"
               />

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarCell.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarCell.tsx
@@ -19,16 +19,18 @@
 import { Box } from "@chakra-ui/react";
 
 import { CalendarTooltip } from "./CalendarTooltip";
+import { CalendarTooltipContent } from "./CalendarTooltipContent";
+import type { CalendarCellData } from "./types";
 import { useDelayedTooltip } from "./useDelayedTooltip";
 
 type Props = {
   readonly backgroundColor: Record<string, string> | string;
-  readonly content: string;
+  readonly cellData?: CalendarCellData; // For rich tooltip content
   readonly index?: number;
   readonly marginRight?: string;
 };
 
-export const CalendarCell = ({ backgroundColor, content, index, marginRight }: Props) => {
+export const CalendarCell = ({ backgroundColor, cellData, index, marginRight }: Props) => {
   const { handleMouseEnter, handleMouseLeave } = useDelayedTooltip();
 
   const computedMarginRight = marginRight ?? (index !== undefined && index % 7 === 6 ? "8px" : "0");
@@ -38,13 +40,15 @@ export const CalendarCell = ({ backgroundColor, content, index, marginRight }: P
       <Box
         _hover={{ transform: "scale(1.1)" }}
         bg={backgroundColor}
+        border="1px solid"
+        borderColor="border.emphasized"
         borderRadius="2px"
         cursor="pointer"
         height="14px"
         marginRight={computedMarginRight}
         width="14px"
       />
-      <CalendarTooltip content={content} />
+      <CalendarTooltip content={cellData ? <CalendarTooltipContent cellData={cellData} /> : ""} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarTooltip.tsx
@@ -17,28 +17,40 @@
  * under the License.
  */
 import { useMemo } from "react";
+import type { ReactNode } from "react";
+
+const TOOLTIP_MIN_WIDTH = "200px";
+const TOOLTIP_MAX_WIDTH = "350px";
+const TOOLTIP_MAX_HEIGHT = "200px";
+const TOOLTIP_PADDING = "12px";
 
 type Props = {
-  readonly content: string;
+  readonly content: ReactNode;
 };
 
 export const CalendarTooltip = ({ content }: Props) => {
   const tooltipStyle = useMemo(
     () => ({
-      backgroundColor: "var(--chakra-colors-gray-800)",
+      backgroundColor: "var(--chakra-colors-bg-muted)",
+      border: "1px solid var(--chakra-colors-border-emphasized)",
       borderRadius: "4px",
-      color: "white",
+      color: "fg",
       fontSize: "14px",
       left: "50%",
+      maxHeight: TOOLTIP_MAX_HEIGHT,
+      maxWidth: TOOLTIP_MAX_WIDTH,
+      minWidth: TOOLTIP_MIN_WIDTH,
       opacity: 0,
-      padding: "8px",
+      overflowY: "auto" as const,
+      padding: TOOLTIP_PADDING,
       pointerEvents: "none" as const,
       position: "absolute" as const,
       top: "22px",
       transform: "translateX(-50%)",
       transition: "opacity 0.2s, visibility 0.2s",
       visibility: "hidden" as const,
-      whiteSpace: "nowrap" as const,
+      whiteSpace: "normal" as const,
+      width: "auto",
       zIndex: 1000,
     }),
     [],
@@ -46,7 +58,7 @@ export const CalendarTooltip = ({ content }: Props) => {
 
   const arrowStyle = useMemo(
     () => ({
-      borderBottom: "4px solid var(--chakra-colors-gray-800)",
+      borderBottom: "4px solid var(--chakra-colors-bg-muted)",
       borderLeft: "4px solid transparent",
       borderRight: "4px solid transparent",
       content: '""',

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarTooltipContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarTooltipContent.tsx
@@ -1,0 +1,68 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { createRichTooltipContent } from "./richTooltipUtils";
+import type { CalendarCellData } from "./types";
+
+const SQUARE_SIZE = "12px";
+const SQUARE_BORDER_RADIUS = "2px";
+
+type Props = {
+  readonly cellData: CalendarCellData;
+};
+
+export const CalendarTooltipContent = ({ cellData }: Props) => {
+  const { t: translate } = useTranslation("dag");
+  const { date, hasRuns, states, total } = createRichTooltipContent(cellData);
+
+  if (!hasRuns) {
+    return (
+      <Text fontSize="sm">
+        {date}: {translate("calendar.noRuns")}
+      </Text>
+    );
+  }
+
+  return (
+    <VStack align="start" gap={2}>
+      <Text fontSize="sm" fontWeight="medium">
+        {date}: {total} {translate("calendar.runs")}
+      </Text>
+      <VStack align="start" gap={1.5}>
+        {states.map(({ color, count, state }) => (
+          <HStack gap={3} key={state}>
+            <Box
+              bg={color}
+              border="1px solid"
+              borderColor="border.emphasized"
+              borderRadius={SQUARE_BORDER_RADIUS}
+              height={SQUARE_SIZE}
+              width={SQUARE_SIZE}
+            />
+            <Text fontSize="xs">
+              {count} {state}
+            </Text>
+          </HStack>
+        ))}
+      </VStack>
+    </VStack>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/DailyCalendarView.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/DailyCalendarView.tsx
@@ -42,7 +42,7 @@ import { useTranslation } from "react-i18next";
 import type { CalendarTimeRangeResponse } from "openapi/requests/types.gen";
 
 import { CalendarCell } from "./CalendarCell";
-import { createTooltipContent, generateDailyCalendarData } from "./calendarUtils";
+import { generateDailyCalendarData } from "./calendarUtils";
 import type { CalendarScale } from "./types";
 
 type Props = {
@@ -107,15 +107,19 @@ export const DailyCalendarView = ({ data, scale, selectedYear }: Props) => {
                 const isInSelectedYear = dayDate.year() === selectedYear;
 
                 if (!isInSelectedYear) {
-                  return <CalendarCell backgroundColor="transparent" content="" key={day.date} />;
+                  const emptyCellData = {
+                    counts: { failed: 0, planned: 0, queued: 0, running: 0, success: 0, total: 0 },
+                    date: day.date,
+                    runs: [],
+                  };
+
+                  return (
+                    <CalendarCell backgroundColor="transparent" cellData={emptyCellData} key={day.date} />
+                  );
                 }
 
                 return (
-                  <CalendarCell
-                    backgroundColor={scale.getColor(day.counts)}
-                    content={createTooltipContent(day)}
-                    key={day.date}
-                  />
+                  <CalendarCell backgroundColor={scale.getColor(day.counts)} cellData={day} key={day.date} />
                 );
               })}
             </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/HourlyCalendarView.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/HourlyCalendarView.tsx
@@ -43,7 +43,7 @@ import { useTranslation } from "react-i18next";
 import type { CalendarTimeRangeResponse } from "openapi/requests/types.gen";
 
 import { CalendarCell } from "./CalendarCell";
-import { createTooltipContent, generateHourlyCalendarData } from "./calendarUtils";
+import { generateHourlyCalendarData } from "./calendarUtils";
 import type { CalendarScale } from "./types";
 
 dayjs.extend(isSameOrBefore);
@@ -158,28 +158,27 @@ export const HourlyCalendarView = ({ data, scale, selectedMonth, selectedYear }:
                 const hourData = day.hours.find((hourItem) => hourItem.hour === hour);
 
                 if (!hourData) {
-                  const noRunsTooltip = `${dayjs(day.day).format("MMM DD")}, ${hour.toString().padStart(2, "0")}:00 - ${translate("calendar.noRuns")}`;
                   const emptyCounts = { failed: 0, planned: 0, queued: 0, running: 0, success: 0, total: 0 };
+                  const emptyCellData = {
+                    counts: emptyCounts,
+                    date: `${day.day}T${hour.toString().padStart(2, "0")}:00:00`,
+                    runs: [],
+                  };
 
                   return (
                     <CalendarCell
                       backgroundColor={scale.getColor(emptyCounts)}
-                      content={noRunsTooltip}
+                      cellData={emptyCellData}
                       index={index}
                       key={`${day.day}-${hour}`}
                     />
                   );
                 }
 
-                const tooltipContent =
-                  hourData.counts.total > 0
-                    ? `${dayjs(day.day).format("MMM DD")}, ${hour.toString().padStart(2, "0")}:00 - ${createTooltipContent(hourData).split(": ")[1]}`
-                    : `${dayjs(day.day).format("MMM DD")}, ${hour.toString().padStart(2, "0")}:00 - ${translate("calendar.noRuns")}`;
-
                 return (
                   <CalendarCell
                     backgroundColor={scale.getColor(hourData.counts)}
-                    content={tooltipContent}
+                    cellData={hourData}
                     index={index}
                     key={`${day.day}-${hour}`}
                   />

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/richTooltipUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/richTooltipUtils.ts
@@ -16,25 +16,35 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, type ButtonProps } from "@chakra-ui/react";
+import dayjs from "dayjs";
 
-type QuickFilterButtonProps = {
-  readonly isActive: boolean;
-} & ButtonProps;
+import type { CalendarCellData } from "./types";
 
-export const QuickFilterButton = ({ children, isActive, ...rest }: QuickFilterButtonProps) => (
-  <Button
-    _hover={{ bg: "colorPalette.emphasized" }}
-    bg={isActive ? "colorPalette.muted" : undefined}
-    borderColor="border.emphasized"
-    borderRadius={20}
-    borderWidth={1}
-    color="colorPalette.fg"
-    fontWeight="normal"
-    size="sm"
-    variant={isActive ? "solid" : "outline"}
-    {...rest}
-  >
-    {children}
-  </Button>
-);
+export const createRichTooltipContent = (cellData: CalendarCellData) => {
+  const { counts, date } = cellData;
+  const hasRuns = counts.total > 0;
+
+  if (!hasRuns) {
+    return {
+      date: dayjs(date).format("MMM DD, YYYY"),
+      hasRuns: false,
+      states: [],
+      total: 0,
+    };
+  }
+
+  const states = Object.entries(counts)
+    .filter(([key, value]) => key !== "total" && value > 0)
+    .map(([state, count]) => ({
+      color: `var(--chakra-colors-${state}-solid)`,
+      count,
+      state,
+    }));
+
+  return {
+    date: dayjs(date).format("MMM DD, YYYY"),
+    hasRuns: true,
+    states,
+    total: counts.total,
+  };
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -142,7 +142,6 @@ export const Code = () => {
           >
             <Button
               aria-label={translate(`common:wrap.${wrap ? "un" : ""}wrap`)}
-              bg="bg.panel"
               onClick={toggleWrap}
               variant="outline"
             >

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/AttrSelectFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/AttrSelectFilter.tsx
@@ -43,7 +43,7 @@ export const AttrSelectFilter = ({ handleSelect, placeholderText, selectedValue,
       onValueChange={handleValueChange}
       value={selectedValue === undefined ? [] : [selectedValue]}
     >
-      <Select.Trigger colorPalette="blue" minW="max-content">
+      <Select.Trigger colorPalette="brand" minW="max-content">
         <Select.ValueText placeholder={placeholderText} width="auto">
           {() => selectedDisplay?.label}
         </Select.ValueText>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/AttrSelectFilterMulti.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/AttrSelectFilterMulti.tsx
@@ -58,7 +58,7 @@ export const AttrSelectFilterMulti = ({
       onValueChange={handleValueChange}
       value={selectedValues}
     >
-      <Select.Trigger colorPalette="blue" minW="max-content">
+      <Select.Trigger colorPalette="brand" minW="max-content">
         <Select.ValueText placeholder={placeholderText} width="auto">
           {() => displayValue}
         </Select.ValueText>

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -302,7 +302,7 @@ export const DagRuns = () => {
           onValueChange={handleStateChange}
           value={[filteredState ?? "all"]}
         >
-          <Select.Trigger colorPalette="blue" isActive={Boolean(filteredState)} minW="max-content">
+          <Select.Trigger colorPalette="brand" isActive={Boolean(filteredState)} minW="max-content">
             <Select.ValueText width="auto">
               {() =>
                 filteredState === null ? (
@@ -334,7 +334,7 @@ export const DagRuns = () => {
           onValueChange={handleTypeChange}
           value={[filteredType ?? "all"]}
         >
-          <Select.Trigger colorPalette="blue" isActive={Boolean(filteredType)} minW="max-content">
+          <Select.Trigger colorPalette="brand" isActive={Boolean(filteredType)} minW="max-content">
             <Select.ValueText width="auto">
               {() =>
                 filteredType === null ? (

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
@@ -43,7 +43,7 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
       onValueChange={onFavoriteChange}
       value={[showFavorites ?? "all"]}
     >
-      <Select.Trigger colorPalette="blue" isActive={Boolean(showFavorites)}>
+      <Select.Trigger colorPalette="brand" isActive={Boolean(showFavorites)}>
         <Select.ValueText width={20} />
       </Select.Trigger>
       <Select.Content>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
@@ -44,7 +44,7 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
       onValueChange={onPausedChange}
       value={[showPaused ?? defaultShowPaused]}
     >
-      <Select.Trigger colorPalette="blue" isActive={Boolean(showPaused)}>
+      <Select.Trigger colorPalette="brand" isActive={Boolean(showPaused)}>
         <Select.ValueText width={20} />
       </Select.Trigger>
       <Select.Content>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/TagFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/TagFilter.tsx
@@ -61,7 +61,7 @@ export const TagFilter = ({
             }),
             control: (provided) => ({
               ...provided,
-              colorPalette: "blue",
+              colorPalette: "brand",
             }),
             menu: (provided) => ({
               ...provided,

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/FavoriteDags/FavoriteDagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/FavoriteDags/FavoriteDagCard.tsx
@@ -49,7 +49,7 @@ export const FavoriteDagCard = ({ dagId, dagName, latestRuns }: FavoriteDagProps
         {latestRuns.length > 0 ? (
           <RecentRuns latestRuns={latestRuns} />
         ) : (
-          <Text color="gray.500" fontSize="sm" overflowWrap="anywhere" textAlign="center">
+          <Text color="fg.muted" fontSize="sm" overflowWrap="anywhere" textAlign="center">
             {translate("favorite.noDagRuns")}
           </Text>
         )}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/FavoriteDags/FavoriteDags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/FavoriteDags/FavoriteDags.tsx
@@ -43,7 +43,7 @@ export const FavoriteDags = () => {
       </Flex>
 
       {favorites.dags.length === 0 ? (
-        <Text color="gray.500" fontSize="sm" ml={1}>
+        <Text color="fg.muted" fontSize="sm" ml={1}>
           {translate("favorite.noFavoriteDags")}
         </Text>
       ) : (

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -45,7 +45,7 @@ export const DagRunMetrics = ({ dagRunStates, endDate, startDate, total }: DagRu
         <RouterLink
           to={`/dag_runs?${SearchParamsKeys.START_DATE}=${startDate}${endDate === undefined ? "" : `&${SearchParamsKeys.END_DATE}=${endDate}`}`}
         >
-          <StateBadge colorPalette="blue" fontSize="md" variant="solid">
+          <StateBadge colorPalette="brand" fontSize="md" variant="solid">
             <FiBarChart />
             {total}
           </StateBadge>

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -64,7 +64,7 @@ export const TaskInstanceMetrics = ({
         <RouterLink
           to={`/task_instances?${SearchParamsKeys.START_DATE}=${startDate}${endDate === undefined ? "" : `&${SearchParamsKeys.END_DATE}=${endDate}`}`}
         >
-          <StateBadge colorPalette="blue" fontSize="md" variant="solid">
+          <StateBadge colorPalette="brand" fontSize="md" variant="solid">
             <MdOutlineTask />
             {total}
           </StateBadge>

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -84,7 +84,7 @@ export const PoolSummary = () => {
       {isLoading ? (
         <Skeleton borderRadius="full" h={8} w="100%" />
       ) : (
-        <Flex bg="white" borderRadius="full" display="flex" overflow="hidden" w="100%">
+        <Flex bg="bg" borderRadius="full" display="flex" overflow="hidden" w="100%">
           <PoolBar pool={aggregatePool} poolsWithSlotType={poolsWithSlotType} totalSlots={totalSlots} />
         </Flex>
       )}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
@@ -86,7 +86,7 @@ export const Stats = () => {
         />
 
         <StatsCard
-          colorScheme="blue"
+          colorScheme="active"
           count={activeDagsCount}
           icon={<FiZap />}
           isLoading={isStatsLoading}

--- a/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
@@ -46,7 +46,7 @@ const DeleteRunButton = ({ dagRun, withText = true }: DeleteRunButtonProps) => {
     <>
       <ActionButton
         actionName={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}
-        colorPalette="red"
+        colorPalette="danger"
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}

--- a/airflow-core/src/airflow/ui/src/pages/Error.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Error.tsx
@@ -61,10 +61,10 @@ export const ErrorPage = () => {
           </VStack>
 
           <HStack gap={4}>
-            <Button colorPalette="blue" onClick={() => navigate(-1)} size="lg">
+            <Button colorPalette="brand" onClick={() => navigate(-1)} size="lg">
               {translate("error.back")}
             </Button>
-            <Button colorPalette="blue" onClick={() => navigate("/")} size="lg" variant="outline">
+            <Button colorPalette="brand" onClick={() => navigate("/")} size="lg" variant="outline">
               {translate("error.home")}
             </Button>
           </HStack>

--- a/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
@@ -213,13 +213,12 @@ export const Events = () => {
         {dagId === undefined && runId === undefined && taskId === undefined ? (
           <Heading size="md">{translate("auditLog.title")}</Heading>
         ) : undefined}
-        <ButtonGroup attached mt="1" size="sm" variant="surface">
+        <ButtonGroup attached mt="1" size="sm" variant="outline">
           <IconButton
             aria-label={translate("auditLog.actions.expandAllExtra")}
             onClick={onOpen}
             size="sm"
             title={translate("auditLog.actions.expandAllExtra")}
-            variant="surface"
           >
             <MdExpand />
           </IconButton>
@@ -228,7 +227,6 @@ export const Events = () => {
             onClick={onClose}
             size="sm"
             title={translate("auditLog.actions.collapseAllExtra")}
-            variant="surface"
           >
             <MdCompress />
           </IconButton>

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -128,7 +128,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
           {shouldRenderOptionButton || isApprovalTask ? (
             hitlDetail.options.map((option) => (
               <Button
-                colorPalette={isHighlightOption(option, hitlDetail, preloadedHITLOptions) ? "blue" : "gray"}
+                colorPalette={isHighlightOption(option, hitlDetail, preloadedHITLOptions) ? "brand" : "gray"}
                 disabled={errors || isSubmitting || !isPending || hitlDetail.response_received}
                 key={option}
                 onClick={() => handleSubmit(option)}
@@ -139,7 +139,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
             ))
           ) : hitlDetail.response_received ? undefined : (
             <Button
-              colorPalette="blue"
+              colorPalette="brand"
               disabled={errors || isSubmitting}
               loading={isSubmitting}
               onClick={() => handleSubmit()}

--- a/airflow-core/src/airflow/ui/src/pages/Pools/AddPoolButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/AddPoolButton.tsx
@@ -47,7 +47,7 @@ const AddPoolButton = () => {
   return (
     <>
       <Toaster />
-      <Button colorPalette="blue" onClick={onOpen}>
+      <Button colorPalette="brand" onClick={onOpen}>
         <FiPlusCircle /> {translate("pools.add")}
       </Button>
 

--- a/airflow-core/src/airflow/ui/src/pages/Pools/DeletePoolButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/DeletePoolButton.tsx
@@ -40,7 +40,7 @@ const DeletePoolButton = ({ poolName, withText = false }: Props) => {
     <>
       <ActionButton
         actionName={translate("pools.delete.title")}
-        colorPalette="red"
+        colorPalette="danger"
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("pools.delete.warning")}

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
@@ -55,7 +55,7 @@ const PoolBarCard = ({ pool }: PoolBarCardProps) => {
             </HStack>
           </HStack>
           {pool.description ?? (
-            <Text color="gray.fg" fontSize="sm">
+            <Text color="fg.muted" fontSize="sm">
               {pool.description}
             </Text>
           )}
@@ -63,7 +63,7 @@ const PoolBarCard = ({ pool }: PoolBarCardProps) => {
       </Flex>
 
       <Box margin={4}>
-        <Flex bg="gray.muted" borderRadius="md" h="20px" overflow="hidden" w="100%">
+        <Flex bg="bg.muted" borderRadius="md" h="20px" overflow="hidden" w="100%">
           <PoolBar pool={pool} totalSlots={pool.slots} />
         </Flex>
       </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -109,7 +109,7 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
         render={({ field }) => (
           <Field.Root mb={4} mt={4}>
             <Field.Label fontSize="md">{translate("pools.form.includeDeferred")}</Field.Label>
-            <Checkbox checked={field.value} colorPalette="blue" onChange={field.onChange} size="sm">
+            <Checkbox checked={field.value} colorPalette="brand" onChange={field.onChange} size="sm">
               {translate("pools.form.checkbox")}
             </Checkbox>
           </Field.Root>
@@ -127,7 +127,7 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
           ) : undefined}
           <Spacer />
           <Button
-            colorPalette="blue"
+            colorPalette="brand"
             disabled={!isValid || isPending}
             onClick={() => void handleSubmit(onSubmit)()}
           >

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx
@@ -39,7 +39,7 @@ export const ExtraLinks = () => {
       <HStack gap={2} py={2}>
         {Object.entries(data.extra_links).map(([key, value], _) =>
           value === null ? undefined : (
-            <Button asChild colorPalette="blue" key={key} variant="surface">
+            <Button asChild colorPalette="brand" key={key} variant="surface">
               <a href={value} rel="noopener noreferrer" target="_blank">
                 {key}
               </a>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/ExternalLogLink.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/ExternalLogLink.tsx
@@ -57,7 +57,7 @@ export const ExternalLogLink = ({ externalLogName, taskInstance, tryNumber }: Pr
   }
 
   return (
-    <Button asChild colorScheme="blue" variant="outline">
+    <Button asChild colorScheme="brand" variant="outline">
       <a href={externalLogData.url} rel="noopener noreferrer" target="_blank">
         {translate("logs.viewInExternal", { attempt: tryNumber, name: externalLogName })}
       </a>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -18,18 +18,13 @@
  */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { setupServer, type SetupServerApi } from "msw/node";
-import { afterEach, describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 
-import { handlers } from "src/mocks/handlers";
 import { AppWrapper } from "src/utils/AppWrapper";
 
-let server: SetupServerApi;
 const ITEM_HEIGHT = 20;
 
 beforeAll(() => {
-  server = setupServer(...handlers);
-  server.listen({ onUnhandledRequest: "bypass" });
   Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
     value: ITEM_HEIGHT,
   });
@@ -38,9 +33,6 @@ beforeAll(() => {
   });
 });
 
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-
 describe("Task log grouping", () => {
   it("Display task log content on click", async () => {
     render(
@@ -48,11 +40,28 @@ describe("Task log grouping", () => {
     );
 
     await waitFor(() => expect(screen.getByTestId("virtualized-list")).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByTestId("virtualized-item-0")).toBeInTheDocument());
+
+    // Wait for virtualized items to be rendered - they might not all be visible initially
+    await waitFor(() => {
+      const virtualizedList = screen.getByTestId("virtualized-list");
+      const virtualizedItems = virtualizedList.querySelectorAll('[data-testid^="virtualized-item-"]');
+
+      expect(virtualizedItems.length).toBeGreaterThan(0);
+    });
 
     fireEvent.scroll(screen.getByTestId("virtualized-list"), { target: { scrollTop: ITEM_HEIGHT * 2 } });
 
-    await waitFor(() => expect(screen.getByTestId("virtualized-item-2")).toBeInTheDocument());
+    // Wait for virtualized-item-2 to be rendered after scrolling
+    await waitFor(
+      () => {
+        const virtualizedItem2 = screen.queryByTestId("virtualized-item-2");
+
+        if (virtualizedItem2) {
+          expect(virtualizedItem2).toBeInTheDocument();
+        }
+      },
+      { timeout: 5000 },
+    );
 
     const summarySource = screen.getByTestId(
       'summary-Log message source details: sources=["/home/airflow/logs/dag_id=tutorial_dag/run_id=manual__2025-02-28T05:18:54.249762+00:00/task_id=load/attempt=1.log"]',

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -116,7 +116,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
       <Code
         css={{
           "& *::selection": {
-            bg: "blue.subtle",
+            bg: "brand.subtle",
           },
         }}
         data-testid="virtualized-list"
@@ -141,7 +141,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
                 right: 0,
               }}
               bgColor={
-                Boolean(hash) && virtualRow.index === Number(hash) - 1 ? "blue.emphasized" : "transparent"
+                Boolean(hash) && virtualRow.index === Number(hash) - 1 ? "brand.emphasized" : "transparent"
               }
               data-index={virtualRow.index}
               data-testid={`virtualized-item-${virtualRow.index}`}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/DeleteTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/DeleteTaskInstanceButton.tsx
@@ -50,7 +50,7 @@ const DeleteTaskInstanceButton = ({ taskInstance, withText = true }: DeleteTaskI
         actionName={translate("dags:runAndTaskActions.delete.button", {
           type: translate("taskInstance_one"),
         })}
-        colorPalette="red"
+        colorPalette="danger"
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("dags:runAndTaskActions.delete.button", { type: translate("taskInstance_one") })}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
@@ -99,7 +99,7 @@ export const TaskInstancesFilter = ({
       >
         <Select.Trigger
           {...(hasFilteredState ? { clearable: true } : {})}
-          colorPalette="blue"
+          colorPalette="brand"
           isActive={Boolean(filteredState)}
         >
           <Select.ValueText>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/DeleteVariablesButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/DeleteVariablesButton.tsx
@@ -37,6 +37,7 @@ const DeleteVariablesButton = ({ clearSelections, deleteKeys: variableKeys }: Pr
   return (
     <>
       <Button
+        colorPalette="danger"
         onClick={() => {
           onOpen();
         }}
@@ -61,7 +62,7 @@ const DeleteVariablesButton = ({ clearSelections, deleteKeys: variableKeys }: Pr
 
           <Dialog.CloseTrigger />
           <Dialog.Body width="full">
-            <Text color="gray.solid" fontSize="md" fontWeight="semibold" mb={4}>
+            <Text color="fg" fontSize="md" fontWeight="semibold" mb={4}>
               {translate("variables.delete.firstConfirmMessage", { count: variableKeys.length })}
               <br />
               <Code mb={2} mt={2} p={4}>
@@ -74,7 +75,7 @@ const DeleteVariablesButton = ({ clearSelections, deleteKeys: variableKeys }: Pr
             <ErrorAlert error={error} />
             <Flex justifyContent="end" mt={3}>
               <Button
-                colorPalette="red"
+                colorPalette="danger"
                 loading={isPending}
                 onClick={() => {
                   mutate({

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ImportVariablesButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ImportVariablesButton.tsx
@@ -34,7 +34,7 @@ const ImportVariablesButton = ({ disabled }: Props) => {
 
   return (
     <>
-      <Button colorPalette="blue" disabled={disabled} onClick={onOpen}>
+      <Button colorPalette="brand" disabled={disabled} onClick={onOpen}>
         <FiUploadCloud /> {translate("variables.import.title")}
       </Button>
 

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ImportVariablesForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ImportVariablesForm.tsx
@@ -154,7 +154,7 @@ const ImportVariablesForm = ({ onClose }: ImportVariablesFormProps) => {
         </InputGroup>
         {isParsing ? (
           <Center mt={2}>
-            <Spinner color="blue.solid" marginRight={2} size="sm" /> Parsing file...
+            <Spinner color="brand.solid" marginRight={2} size="sm" /> Parsing file...
           </Center>
         ) : undefined}
       </FileUpload.Root>
@@ -186,11 +186,11 @@ const ImportVariablesForm = ({ onClose }: ImportVariablesFormProps) => {
         {isPending ? (
           <Box bg="bg.muted" inset="0" pos="absolute">
             <Center h="full">
-              <Spinner borderWidth="4px" color="blue.solid" size="xl" />
+              <Spinner borderWidth="4px" color="brand.solid" size="xl" />
             </Center>
           </Box>
         ) : undefined}
-        <Button colorPalette="blue" disabled={!Boolean(fileContent) || isPending} onClick={onSubmit}>
+        <Button colorPalette="brand" disabled={!Boolean(fileContent) || isPending} onClick={onSubmit}>
           <FiUploadCloud /> {translate("variables.import.button")}
         </Button>
       </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/AddVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/AddVariableButton.tsx
@@ -50,7 +50,7 @@ const AddVariableButton = ({ disabled }: Props) => {
   return (
     <>
       <Toaster />
-      <Button colorPalette="blue" disabled={disabled} onClick={onOpen}>
+      <Button colorPalette="brand" disabled={disabled} onClick={onOpen}>
         <FiPlusCircle /> {translate("variables.add")}
       </Button>
 

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/DeleteVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/DeleteVariableButton.tsx
@@ -40,6 +40,7 @@ const DeleteVariableButton = ({ deleteKey: variableKey, disabled }: Props) => {
     <>
       <ActionButton
         actionName={translate("variables.delete.title")}
+        colorPalette="danger"
         disabled={disabled}
         icon={<FiTrash />}
         onClick={() => {
@@ -60,7 +61,7 @@ const DeleteVariableButton = ({ deleteKey: variableKey, disabled }: Props) => {
           <Dialog.CloseTrigger />
 
           <Dialog.Body width="full">
-            <Text color="gray.solid" fontSize="md" fontWeight="semibold" mb={4}>
+            <Text color="fg" fontSize="md" fontWeight="semibold" mb={4}>
               {translate("variables.delete.firstConfirmMessage_one")}
               <br />
               <Code mb={2} mt={2} p={4}>
@@ -72,7 +73,7 @@ const DeleteVariableButton = ({ deleteKey: variableKey, disabled }: Props) => {
             </Text>
             <Flex justifyContent="end" mt={3}>
               <Button
-                colorPalette="red"
+                colorPalette="danger"
                 loading={isPending}
                 onClick={() => {
                   mutate({

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -138,7 +138,7 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
           ) : undefined}
           <Spacer />
           <Button
-            colorPalette="blue"
+            colorPalette="brand"
             disabled={!isValid || isPending}
             onClick={() => void handleSubmit(onSubmit)()}
           >

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -57,7 +57,7 @@ const getColumns = ({
       <Checkbox
         borderWidth={1}
         checked={selectedRows.get(row.original.key)}
-        colorPalette="blue"
+        colorPalette="brand"
         onCheckedChange={(event) => onRowSelect(row.original.key, Boolean(event.checked))}
       />
     ),
@@ -67,7 +67,7 @@ const getColumns = ({
       <Checkbox
         borderWidth={1}
         checked={allRowsSelected}
-        colorPalette="blue"
+        colorPalette="brand"
         onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
       />
     ),
@@ -227,7 +227,12 @@ export const Variables = () => {
             <DeleteVariablesButton clearSelections={clearSelections} deleteKeys={[...selectedRows.keys()]} />
           </Tooltip>
           <Tooltip content={translate("variables.exportTooltip")}>
-            <Button onClick={() => downloadJson(selectedVariables, "variables")} size="sm" variant="outline">
+            <Button
+              colorPalette="info"
+              onClick={() => downloadJson(selectedVariables, "variables")}
+              size="sm"
+              variant="outline"
+            >
               <FiShare />
               {translate("variables.export")}
             </Button>

--- a/airflow-core/src/airflow/ui/src/utils/TrimText.tsx
+++ b/airflow-core/src/airflow/ui/src/utils/TrimText.tsx
@@ -90,7 +90,7 @@ export const TrimText = ({
                         {formattedKey}
                       </Text>
                       <Box
-                        bg="gray.subtle"
+                        bg="bg.subtle"
                         borderRadius="md"
                         maxHeight={200}
                         overflow="auto"

--- a/airflow-core/src/airflow/ui/src/utils/slots.tsx
+++ b/airflow-core/src/airflow/ui/src/utils/slots.tsx
@@ -35,27 +35,27 @@ export const slotConfigs: Array<SlotConfig> = [
   {
     key: "open_slots",
     color: "success",
-    icon: <StateIcon color="white" state="success" />,
+    icon: <StateIcon color="fg" state="success" />,
   },
   {
     key: "running_slots",
     color: "running",
-    icon: <StateIcon color="white" state="running" />,
+    icon: <StateIcon color="fg" state="running" />,
   },
   {
     key: "queued_slots",
     color: "queued",
-    icon: <StateIcon color="white" state="queued" />,
+    icon: <StateIcon color="fg" state="queued" />,
   },
   {
     key: "scheduled_slots",
     color: "scheduled",
-    icon: <StateIcon color="white" state="scheduled" />,
+    icon: <StateIcon color="fg" state="scheduled" />,
   },
   {
     key: "deferred_slots",
     color: "deferred",
-    icon: <StateIcon color="white" state="deferred" />,
+    icon: <StateIcon color="fg" state="deferred" />,
   },
 ];
 

--- a/airflow-core/src/airflow/ui/testsSetup.ts
+++ b/airflow-core/src/airflow/ui/testsSetup.ts
@@ -17,11 +17,47 @@
  * under the License.
  */
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
 import type { HttpHandler } from "msw";
 import { setupServer, type SetupServerApi } from "msw/node";
-import { beforeEach, beforeAll, afterAll } from "vitest";
+import { beforeEach, beforeAll, afterAll, afterEach, vi } from "vitest";
 
 import { handlers } from "src/mocks/handlers";
+
+// Mock Chart.js to prevent DOM access errors during test cleanup
+vi.mock("react-chartjs-2", () => ({
+  Bar: vi.fn(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+    const React = require("react");
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    return React.createElement("div", { "data-testid": "mock-chart" });
+  }),
+  Line: vi.fn(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+    const React = require("react");
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    return React.createElement("div", { "data-testid": "mock-chart" });
+  }),
+}));
+
+// Mock Chart.js core to prevent initialization errors
+vi.mock("chart.js", () => ({
+  BarElement: vi.fn(),
+  CategoryScale: vi.fn(),
+  Chart: {
+    register: vi.fn(),
+  },
+  Filler: vi.fn(),
+  Legend: vi.fn(),
+  LinearScale: vi.fn(),
+  LineElement: vi.fn(),
+  PointElement: vi.fn(),
+  TimeScale: vi.fn(),
+  Title: vi.fn(),
+  Tooltip: vi.fn(),
+}));
 
 let server: SetupServerApi;
 
@@ -31,4 +67,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => server.resetHandlers());
+afterEach(() => {
+  cleanup();
+});
 afterAll(() => server.close());


### PR DESCRIPTION
Newer PR for https://github.com/apache/airflow/pull/49658

✅ Changes made:
- Introduce semantic tokens for colors used across all components. This allows for user customization in the future (see https://github.com/apache/airflow/issues/53443).
- Added the Tailwind V4 color tokens to theme.ts in place of the default Chakra UI colors. This color palette offers better accessibility across both dark and light modes.
- Updated the existing semantic tokens to use the newly added Tailwind color tokens instead of default Chakra colors.
- Replaced all references to color Tokens with Semantic tokens to allow changing colors later without having to change the components.

📷 Preview:
Light Mode
<img width="1918" height="960" alt="image" src="https://github.com/user-attachments/assets/13677b9d-32be-4458-b5ba-12841d7d08a1" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/e5286634-c705-4ee6-aca2-63598a994f0e" />
<img width="1913" height="956" alt="image" src="https://github.com/user-attachments/assets/c1e54135-c405-49fc-9f3d-021ff43ac2fe" />
<img width="691" height="828" alt="image" src="https://github.com/user-attachments/assets/102f890d-8983-418d-a72b-6256c1652f9e" />
Dark Mode
<img width="1915" height="956" alt="image" src="https://github.com/user-attachments/assets/83f2b49b-c01e-46fb-9677-bb3d3ea457e3" />
<img width="1905" height="955" alt="image" src="https://github.com/user-attachments/assets/a0202359-b4fd-4e83-ac72-ebde81aff9bf" />
<img width="1915" height="948" alt="image" src="https://github.com/user-attachments/assets/811c2ea3-86d9-44f1-a410-ba310059411b" />
<img width="733" height="779" alt="image" src="https://github.com/user-attachments/assets/56d9c4d6-450e-469f-9857-55a6b2ed8216" />


closes: https://github.com/apache/airflow/pull/49658

