### PR TITLE
Fix nth-child warning

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -108,7 +108,7 @@ export const FlexibleForm = ({
             <Accordion.Item
               // We need to make the item content overflow visible for dropdowns to work, but directly applying the style does not work
               css={{
-                "& > :nth-child(2)": {
+                "& > div:nth-of-type(1)": {
                   overflow: "visible",
                 },
               }}


### PR DESCRIPTION
Fix warning console complaining about the use of `nth-child` css selector.


### Before
<img width="1912" height="719" alt="Screenshot 2025-07-31 at 17 27 44" src="https://github.com/user-attachments/assets/c0649633-7963-464b-9f5d-094a459da757" />


### After
<img width="1911" height="732" alt="Screenshot 2025-07-31 at 17 26 22" src="https://github.com/user-attachments/assets/f1ce6e2f-1a34-40d6-817c-ad3e203a4105" />

There is still one unrelated forward warning to fix tough.

Functionally visibility is still unchanged:
<img width="896" height="642" alt="Screenshot 2025-07-31 at 17 26 50" src="https://github.com/user-attachments/assets/79398535-9b30-40c4-a539-56816f1154a8" />
