### PR TITLE
Fix AWS Lambda executor error handling for DLQ vs task failures

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -399,8 +399,8 @@ class AwsLambdaExecutor(BaseExecutor):
                 self.sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
                 continue
             ser_task_key = body.get("task_key")
-            return_code = body.get("return_code") 
-            command = body.get("command") 
+            return_code = body.get("return_code")
+            command = body.get("command")
             # Fetch the real task key from the running_tasks dict, using the serialized task key.
             try:
                 task_key = self.running_tasks[ser_task_key]
@@ -429,7 +429,7 @@ class AwsLambdaExecutor(BaseExecutor):
                     self.fail(task_key)
                     if queue_url == self.dlq_url and return_code == None:
                         # DLQ failure: AWS Lambda service could not complete the invocation after retries.
-                        # This indicates a Lambda-level failure (timeout, memory limit, crash, etc.) 
+                        # This indicates a Lambda-level failure (timeout, memory limit, crash, etc.)
                         # where the function was unable to successfully execute to return a result.
                         self.log.error(
                             "Lambda invocation for task: %s failed at the service level (from DLQ). Command: %s",

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -398,8 +398,8 @@ class AwsLambdaExecutor(BaseExecutor):
                 self.log.warning("Deleting the message to avoid processing it again.")
                 self.sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
                 continue
-            ser_task_key = body.get("task_key")
             return_code = body.get("return_code")
+            ser_task_key = body.get("task_key")
             # Fetch the real task key from the running_tasks dict, using the serialized task key.
             try:
                 task_key = self.running_tasks[ser_task_key]


### PR DESCRIPTION

Enhanced error handling in the AWS Lambda executor to better distinguish between Lambda service failures (DLQ) and task execution failures. 

Added check to properly identify DLQ failures and updated error messages to clearly indicate whether the failure was at the Lambda service level (timeout/crash/memory) or during task execution. 

Previously, logging failures from the DLQ contained the incorrect field `return_code` instead of `command` which is located in the DLQ message body. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
