### PR TITLE
Remove parameter from Edge example

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/example_dags/win_test.py
+++ b/providers/edge3/src/airflow/providers/edge3/example_dags/win_test.py
@@ -301,7 +301,7 @@ with DAG(
             except AirflowNotFoundException:
                 print("Connection 'integration_test' not found... but also OK.")
 
-        command = CmdOperator(task_id="command", command="echo Parameter is {{params.mapping_count}}")
+        command = CmdOperator(task_id="command", command="echo Hello World")
 
         def python_call():
             print("Hello world")


### PR DESCRIPTION
It might not be a good example to have a jinja tempalted parameter in a command line as this smells like the option of a remote injection backdoor. So the current example is not really a good example. Even if the parameter is validated to be only an integer it might lead users to copy&paste and drives a bad pactice of unchecked command code.

Therefore I propose to remove the parameter. Even if it is not a (current) problem but rather to be positive in examples