### PR TITLE
fix: corrects issues with edge rendering on the graph view

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/useGraphLayout.ts
+++ b/airflow-core/src/airflow/ui/src/components/Graph/useGraphLayout.ts
@@ -210,7 +210,20 @@ const generateElkGraph = ({
 
   const children = nodes.map(formatChildNode);
 
-  const edges = filteredEdges.map((fe) => formatElkEdge(fe, font));
+  // Deduplicate edges that point to the same source/target
+  const edgeMap = new Map<string, EdgeResponse>();
+
+  filteredEdges.forEach((edge) => {
+    const edgeKey = `${edge.source_id}-${edge.target_id}`;
+
+    if (!edgeMap.has(edgeKey)) {
+      edgeMap.set(edgeKey, edge);
+    }
+  });
+
+  // Convert back to array and create formatted edges
+  const deduplicatedEdges = [...edgeMap.values()];
+  const edges = deduplicatedEdges.map((fe) => formatElkEdge(fe, font));
 
   return {
     children: children as Array<ElkNode>,


### PR DESCRIPTION
closes: #35301 

The graph UI has issues rendering edges between dependent tasks nested in task groups.  Edges render with excessive bends in various directions instead of directly between tasks and their parents task groups as they are collapsed and expanded.  They also tend to render vertically off center at node borders.  This PR addresses this edge rendering issue.

Example code that reproduces the issue:
```
from typing import Dict, List
import pendulum
from airflow.sdk import BaseOperator, dag, task, task_group
@dag(
    schedule=None,
    start_date=pendulum.datetime(2023, 1, 1),
)
def test_dag():
    _all_tasks: Dict[str, List[BaseOperator]] = {}
    def _generate_task_group_callable(group_id, tasks):
        @task_group(group_id=group_id)
        def _task_group():
            [t() for t in tasks]
        return _task_group
    def _generate_task_callable(task_id, task_set):
        def _generate():
            @task(task_id=task_id)
            def _task():
                pass
            if _all_tasks.get(task_set) is None:
                _all_tasks[task_set] = []
            _all_tasks[task_set].append(_task())
        return _generate
    _set_callables = []
    for _set in range(0, 2):
        _set_id = f"set_{_set}"
        _group_callables_a = []
        for _nga in range(0, 1):
            _nga_id = f"group_{_nga}"
            _group_callables_b = []
            for _ngb in range(0, 3):
                _ngb_id = f"group_{_ngb}"
                _task_callables = []
                for _task in range(0, 10):
                    _task_id = f"task_{_task}"
                    _callable = _generate_task_callable(_task_id, _set_id)
                    _task_callables.append(_callable)
                _group_callable_inner = _generate_task_group_callable(_ngb_id, _task_callables)
                _group_callables_b.append(_group_callable_inner)
            _group_callable_outer = _generate_task_group_callable(_nga_id, _group_callables_b)
            _group_callables_a.append(_group_callable_outer)
        _set_callable = _generate_task_group_callable(_set_id, _group_callables_a)
        _set_callables.append(_set_callable)
    [_s() for _s in _set_callables]
    for i in range(0, len(_all_tasks["set_0"])):
        _all_tasks["set_0"][i] >> _all_tasks["set_1"][i]
test_dag()
```
**Rendering issue examples:**
<img width="353" alt="image" src="https://github.com/user-attachments/assets/b522f940-4cc7-4389-9ae1-52219c565836" />
<img width="527" alt="image" src="https://github.com/user-attachments/assets/c242c69b-63e0-458b-b373-da9ac12e3cf2" />
<img width="478" alt="image" src="https://github.com/user-attachments/assets/63939743-1d3c-4bdd-8241-5f760703c552" />
<img width="438" alt="image" src="https://github.com/user-attachments/assets/cdee8743-2d91-437c-a33c-b63270426a75" />
<img width="471" alt="image" src="https://github.com/user-attachments/assets/5f496e0c-2b9e-4af4-9655-bb7696dedd70" />


**With this fix:**
<img width="363" alt="image" src="https://github.com/user-attachments/assets/73e1d440-a0ea-48f4-af19-06c43ac88fbc" />
<img width="363" alt="image" src="https://github.com/user-attachments/assets/acd3c724-44ed-445f-96ec-a979b75e31bc" />
<img width="405" alt="image" src="https://github.com/user-attachments/assets/92eee5db-dc90-4752-aecf-ae2db701426b" />
<img width="418" alt="image" src="https://github.com/user-attachments/assets/72fb0439-8044-4435-9686-30abd426a76d" />
<img width="435" alt="image" src="https://github.com/user-attachments/assets/3ed9f9c1-4504-4670-a406-99cee5f160f8" />
<img width="353" alt="image" src="https://github.com/user-attachments/assets/227c7ef2-e2fe-4adc-8e94-06c990a3e72b" />

<!-- Please keep an empty line above the dashes. -->
---