### PR TITLE
Improve SQL security in insert_rows and callproc methods

### DIFF
--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -341,8 +341,8 @@ class OracleHook(DbApiHook):
     def bulk_insert_rows(
         self,
         table: str,
-        rows: List[Tuple],
-        target_fields: List[str] | None = None,
+        rows: list[tuple],
+        target_fields: list[str] | None = None,
         commit_every: int = 5000,
         sequence_column: str | None = None,
         sequence_name: str | None = None,

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -252,8 +252,8 @@ class OracleHook(DbApiHook):
     def insert_rows(
         self,
         table: str,
-        rows: List[Tuple],
-        target_fields: List[str] | None = None,
+        rows: list[tuple],
+        target_fields: list[str] | None = None,
         commit_every: int = 1000,
         replace: bool | None = False,
         **kwargs,


### PR DESCRIPTION
… and callproc methods

- Modified insert_rows to use parameterized queries for VALUES clause, removing string concatenation
- Added validation for stored procedure name (identifiselect * from test_table;er) in callproc
- Added validation for table, target_fields, sequence_column, and sequence_name in bulk_insert_rows
- Introduced _is_valid_identifier function to restrict input to a-Z, 0-9, @, and ., preventing SQL injection
- Added error logging for invalid inputs
- Preserved original comments without adding new ones

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->




---
