### PR TITLE
Fix i18n requests ignoring base_url path configuration

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -46,13 +46,16 @@ export const namespaces = [
   "hitl",
 ] as const;
 
+const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
+const basePath = new URL(baseUrl).pathname.replace(/\/$/u, "");
+
 void i18n
   .use(Backend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     backend: {
-      loadPath: "/static/i18n/locales/{{lng}}/{{ns}}.json",
+      loadPath: `${basePath}/static/i18n/locales/{{lng}}/{{ns}}.json`,
     },
     defaultNS: "common",
     detection: {

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -46,7 +46,8 @@ export const namespaces = [
   "hitl",
 ] as const;
 
-const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
+const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? "";
+const baseUrl = new URL(baseHref, globalThis.location.origin);
 const basePath = new URL(baseUrl).pathname.replace(/\/$/u, "");
 
 void i18n

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -48,6 +48,7 @@ export const namespaces = [
 
 const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? "";
 const baseUrl = new URL(baseHref, globalThis.location.origin);
+const basePath = new URL(baseUrl).pathname.replace(/\/$/u, "");
 
 void i18n
   .use(Backend)
@@ -55,7 +56,7 @@ void i18n
   .use(initReactI18next)
   .init({
     backend: {
-      loadPath: new URL("/static/i18n/locales/{{lng}}/{{ns}}.json", baseUrl).href,
+      loadPath: `${basePath}/static/i18n/locales/{{lng}}/{{ns}}.json`,
     },
     defaultNS: "common",
     detection: {

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -48,7 +48,6 @@ export const namespaces = [
 
 const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? "";
 const baseUrl = new URL(baseHref, globalThis.location.origin);
-const basePath = new URL(baseUrl).pathname.replace(/\/$/u, "");
 
 void i18n
   .use(Backend)
@@ -56,7 +55,7 @@ void i18n
   .use(initReactI18next)
   .init({
     backend: {
-      loadPath: `${basePath}/static/i18n/locales/{{lng}}/{{ns}}.json`,
+      loadPath: new URL("/static/i18n/locales/{{lng}}/{{ns}}.json", baseUrl).href,
     },
     defaultNS: "common",
     detection: {


### PR DESCRIPTION
When Airflow is deployed under a subpath (e.g., http://localhost:8080/foo), i18n locale files were incorrectly requested from the root path instead of respecting the configured base_url path. This caused translation files to fail loading, resulting in untranslated UI text.

The fix ensures i18n requests properly honor the base_url path by dynamically constructing the locale file paths based on the HTML base tag, similar to how API requests are handled.

Fixes requests like:
- Before: `http://localhost:8080/static/i18n/locales/en/assets.json`
- After: `http://localhost:8080/foo/static/i18n/locales/en/assets.json`