### PR TITLE
[v3-0-test] Fix version for `parsing_pre_import_modules` config option move (#53995)

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -364,7 +364,7 @@ class AirflowConfigParser(ConfigParser):
         ("fab", "navbar_text_hover_color"): ("webserver", "navbar_text_hover_color", "3.0.2"),
         ("api", "secret_key"): ("webserver", "secret_key", "3.0.2"),
         ("api", "enable_swagger_ui"): ("webserver", "enable_swagger_ui", "3.0.2"),
-        ("dag_processor", "parsing_pre_import_modules"): ("scheduler", "parsing_pre_import_modules", "3.0.3"),
+        ("dag_processor", "parsing_pre_import_modules"): ("scheduler", "parsing_pre_import_modules", "3.0.4"),
     }
 
     # A mapping of new section -> (old section, since_version).


### PR DESCRIPTION
This will land in 3.0.4, not 3.1.0.

(cherry picked from commit https://github.com/apache/airflow/commit/bbca500d712025429cde6e4ad792b7a52bf5ef6d)