### PR TITLE
Fix Helm Chart Linting Return Code Check

### DIFF
--- a/scripts/ci/pre_commit/lint_helm.py
+++ b/scripts/ci/pre_commit/lint_helm.py
@@ -39,6 +39,6 @@ result = subprocess.run(
     check=False,
     cwd=AIRFLOW_ROOT_PATH / "chart",
 )
-if res_setup.returncode != 0:
+if result.returncode != 0:
     console.print("[red]\nError while linting charts.")
-    sys.exit(res_setup.returncode)
+    sys.exit(result.returncode)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Description
Fixes incorrect return code check in `lint_helm.py` pre-commit script, ensuring Helm linting errors are properly detected.
- Addresses issue: Helm chart version upgrade test failure due to wrong return code (`res_setup.returncode`) checked.
- Corrects to check `result.returncode` for Helm lint command.

## Changes
- Updated `scripts/ci/pre_commit/lint_helm.py`:
-- Replaced `res_setup.returncode` with `result.returncode` in lint error check.

## Related PR
Replace break function in `pod-launcher-rolebinding.yaml` #49219 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
