### PR TITLE
Google provider RayHook to proto compatibility

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/ray.py
@@ -20,19 +20,10 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import MutableMapping
 from typing import Any
 
-from airflow.exceptions import AirflowOptionalProviderFeatureException
-
-try:
-    import vertex_ray
-    from google._upb._message import ScalarMapContainer  # type: ignore[attr-defined]
-except ImportError:
-    # Fallback for environments where the upb module is not available.
-    raise AirflowOptionalProviderFeatureException(
-        "google._upb._message.ScalarMapContainer is not available. "
-        "Please install the ray package to use this feature."
-    )
+import vertex_ray
 from google.cloud import aiplatform
 from google.cloud.aiplatform.vertex_ray.util import resources
 from google.cloud.aiplatform_v1 import (
@@ -59,7 +50,7 @@ class RayHook(GoogleBaseHook):
         def __encode_value(value: Any) -> Any:
             if isinstance(value, (list, Repeated)):
                 return [__encode_value(nested_value) for nested_value in value]
-            if isinstance(value, ScalarMapContainer):
+            if not isinstance(value, dict) and isinstance(value, MutableMapping):
                 return {key: __encode_value(nested_value) for key, nested_value in dict(value).items()}
             if dataclasses.is_dataclass(value):
                 return dataclasses.asdict(value)

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/ray.py
@@ -282,7 +282,7 @@ class GetRayClusterOperator(RayBaseOperator):
                 location=self.location,
                 cluster_id=self.cluster_id,
             )
-            self.log.info("Cluster was gotten.")
+            self.log.info("Cluster data has been retrieved.")
             ray_cluster_dict = self.hook.serialize_cluster_obj(ray_cluster)
             return ray_cluster_dict
         except NotFound as not_found_err:

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_ray.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_ray.py
@@ -19,9 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
-import pytest
-
-ScalarMapContainer = pytest.importorskip("google._upb._message.ScalarMapContainer")
+from google.cloud.aiplatform.vertex_ray.util.resources import Cluster, Resources
 
 from airflow.providers.google.cloud.hooks.vertex_ai.ray import RayHook
 
@@ -167,6 +165,55 @@ class TestRayWithDefaultProjectIdHook:
         )
         mock_aiplatform_init.assert_called_once()
         mock_list_ray_clusters.assert_called_once()
+
+    @mock.patch(RAY_STRING.format("aiplatform.init"))
+    def test_serialize_cluster_obj(self, mock_aiplatform_init) -> None:
+        RESOURCE_SAMPLE = {
+            "accelerator_count": 0,
+            "accelerator_type": None,
+            "autoscaling_spec": None,
+            "boot_disk_size_gb": 100,
+            "boot_disk_type": "pd-ssd",
+            "custom_image": None,
+            "machine_type": "n1-standard-16",
+            "node_count": 1,
+        }
+        SAMPLE_CLUSTER_SERIALIZED = {
+            "cluster_resource_name": TEST_CLUSTER_NAME,
+            "dashboard_address": "dashboard_addr",
+            "head_node_type": RESOURCE_SAMPLE,
+            "labels": {"label1": "val1"},
+            "network": "custom_network",
+            "psc_interface_config": None,
+            "python_version": TEST_PYTHON_VERSION,
+            "ray_logs_enabled": True,
+            "ray_metric_enabled": True,
+            "ray_version": TEST_RAY_VERSION,
+            "reserved_ip_ranges": [
+                "172.16.0.0/16",
+                "10.10.10.0/28",
+            ],
+            "service_account": None,
+            "state": "RUNNING",
+            "worker_node_types": [RESOURCE_SAMPLE, RESOURCE_SAMPLE],
+        }
+        cluster_obj = Cluster(
+            cluster_resource_name=TEST_CLUSTER_NAME,
+            state="RUNNING",  # type: ignore[arg-type]
+            network="custom_network",
+            reserved_ip_ranges=["172.16.0.0/16", "10.10.10.0/28"],
+            python_version=TEST_PYTHON_VERSION,
+            ray_version=TEST_RAY_VERSION,
+            head_node_type=Resources(**RESOURCE_SAMPLE),  # type: ignore[arg-type]
+            worker_node_types=[
+                Resources(**RESOURCE_SAMPLE),  # type: ignore[arg-type]
+                Resources(**RESOURCE_SAMPLE),  # type: ignore[arg-type]
+            ],
+            dashboard_address="dashboard_addr",
+            labels={"label1": "val1"},
+        )
+
+        assert self.hook.serialize_cluster_obj(cluster_obj) == SAMPLE_CLUSTER_SERIALIZED
 
 
 class TestRayWithoutDefaultProjectIdHook:


### PR DESCRIPTION
- The previously used google._upb._message.ScalarMapContainer is not
available in protobuf >= 5.*, which breaks Ray hook and operators.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
