### PR TITLE
Fix toaster messages

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useAddConnection.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useAddConnection.ts
@@ -35,10 +35,10 @@ export const useAddConnection = ({ onSuccessConfirm }: { onSuccessConfirm: () =>
     });
 
     toaster.create({
-      description: translate("toaster.success.description", {
+      description: translate("toaster.create.success.description", {
         resourceName: translate("admin:connections.connection_one"),
       }),
-      title: translate("toaster.success.title", {
+      title: translate("toaster.create.success.title", {
         action: translate("toaster.create"),
         resourceName: translate("admin:connections.connection_one"),
       }),

--- a/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
@@ -41,10 +41,10 @@ export const useEditConnection = (
     });
 
     toaster.create({
-      description: translate("toaster.edit.success.description", {
+      description: translate("toaster.update.success.description", {
         resourceName: translate("admin:connections.connection_one"),
       }),
-      title: translate("toaster.edit.success.title", {
+      title: translate("toaster.update.success.title", {
         resourceName: translate("admin:connections.connection_one"),
       }),
       type: "success",

--- a/airflow-core/src/airflow/ui/src/queries/useEditVariable.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useEditVariable.ts
@@ -42,10 +42,10 @@ export const useEditVariable = (
     });
 
     toaster.create({
-      description: translate("toaster.edit.success.description", {
+      description: translate("toaster.update.success.description", {
         resourceName: translate("admin:variables.variable_one"),
       }),
-      title: translate("toaster.edit.success.title", {
+      title: translate("toaster.update.success.title", {
         resourceName: translate("admin:variables.variable_one"),
       }),
       type: "success",


### PR DESCRIPTION
Fix toaster translation:

### Before
<img width="682" height="367" alt="Screenshot 2025-08-01 at 12 00 34" src="https://github.com/user-attachments/assets/ce1e3572-049e-4558-96bb-2d2950fb76aa" />
<img width="764" height="520" alt="Screenshot 2025-08-01 at 12 00 42" src="https://github.com/user-attachments/assets/8e95835b-bd2b-4455-8b4e-8007c6bde2f9" />
<img width="705" height="383" alt="Screenshot 2025-08-01 at 12 00 21" src="https://github.com/user-attachments/assets/1a6a133f-fa5e-4ba8-953c-8eaa013fe67f" />

### After
<img width="1685" height="927" alt="Screenshot 2025-08-01 at 11 59 16" src="https://github.com/user-attachments/assets/afa67560-2cb3-4f80-9e00-db73d03519f1" />
<img width="793" height="581" alt="Screenshot 2025-08-01 at 11 59 34" src="https://github.com/user-attachments/assets/03a57114-cb82-4fce-943d-bd0047b7bc18" />
<img width="649" height="362" alt="Screenshot 2025-08-01 at 12 00 00" src="https://github.com/user-attachments/assets/77af3cf5-59d7-42a5-ba66-1ad34e6a9d70" />
