### PR TITLE
Flexible form use ReactMarkdown instead of default Markdown component

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
@@ -19,9 +19,8 @@
 import { Field, Stack } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
+import ReactMarkdown from "src/components/ReactMarkdown";
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
@@ -66,7 +65,7 @@ export const FieldRow = ({ name, onUpdate: rowOnUpdate }: FlexibleFormElementPro
         {param.description === null ? (
           param.schema.description_md === undefined ? undefined : (
             <Field.HelperText>
-              <Markdown remarkPlugins={[remarkGfm]}>{param.schema.description_md}</Markdown>
+              <ReactMarkdown>{param.schema.description_md}</ReactMarkdown>
             </Field.HelperText>
           )
         ) : (


### PR DESCRIPTION
`ReactMarkdown` is our own component for rendering markdown that wraps the default `Markdown` components from `"react-markdown"` and will allow broader support, chakra UI integration (css reset), component mapping and set the `remarkPlugins` and some security measures (skipHtml etc.).

We should always use this component over the default `Markdown` one.