### PR TITLE
Fix: Validate and handle invalid `extra` field in connections UI and API (#53963)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -141,20 +141,21 @@ class ConnectionBody(StrictBaseModel):
     @classmethod
     def validate_extra(cls, v: str | None) -> str | None:
         """
-        Validate that `extra` is a JSON-encoded Python dict.
+        Validate that `extra` field is a JSON-encoded Python dict.
 
-        If `extra` is not a valid JSON, it will be returned as is.
+        If `extra` field is not a valid JSON, it will be returned as is.
         """
         if v is None:
             return v
+        if v == "":
+            return "{}"  # Backward compatibility: treat "" as empty JSON object
         try:
             extra_dict = json.loads(v)
             if not isinstance(extra_dict, dict):
-                raise ValueError("Extra must be a valid JSON object (e.g., {'key': 'value'})")
+                raise ValueError("The `extra` field must be a valid JSON object (e.g., {'key': 'value'})")
         except json.JSONDecodeError:
-            # If it's not a valid JSON, we can't redact it, so return as is
             raise ValueError(
-                "Extra must be a valid JSON object (e.g., {'key': 'value'}), "
-                "but encountered non-JSON in extra field"
+                "The `extra` field must be a valid JSON object (e.g., {'key': 'value'}), "
+                "but encountered non-JSON in `extra` field"
             )
         return v

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -136,3 +136,25 @@ class ConnectionBody(StrictBaseModel):
     port: int | None = Field(default=None)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
+
+    @field_validator("extra")
+    @classmethod
+    def validate_extra(cls, v: str | None) -> str | None:
+        """
+        Validate that `extra` is a JSON-encoded Python dict.
+
+        If `extra` is not a valid JSON, it will be returned as is.
+        """
+        if v is None:
+            return v
+        try:
+            extra_dict = json.loads(v)
+            if not isinstance(extra_dict, dict):
+                raise ValueError("Extra must be a valid JSON object (e.g., {'key': 'value'})")
+        except json.JSONDecodeError:
+            # If it's not a valid JSON, we can't redact it, so return as is
+            raise ValueError(
+                "Extra must be a valid JSON object (e.g., {'key': 'value'}), "
+                "but encountered non-JSON in extra field"
+            )
+        return v

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -38,11 +38,14 @@ def _mask_connection_fields(extra_fields):
     for k, v in extra_fields.items():
         if k == "extra" and v:
             try:
-                extra = json.loads(v)
-                extra = {k: secrets_masker.redact(v, k) for k, v in extra.items()}
-                result[k] = dict(extra)
+                parsed_extra = json.loads(v)
+                if isinstance(parsed_extra, dict):
+                    masked_extra = {ek: secrets_masker.redact(ev, ek) for ek, ev in parsed_extra.items()}
+                    result[k] = masked_extra
+                else:
+                    result[k] = "Expected JSON object in extra field, got non-dict JSON"
             except json.JSONDecodeError:
-                result[k] = "Encountered non-JSON in `extra` field"
+                result[k] = "Encountered non-JSON in extra field"
         else:
             result[k] = secrets_masker.redact(v, k)
     return result

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -43,9 +43,9 @@ def _mask_connection_fields(extra_fields):
                     masked_extra = {ek: secrets_masker.redact(ev, ek) for ek, ev in parsed_extra.items()}
                     result[k] = masked_extra
                 else:
-                    result[k] = "Expected JSON object in extra field, got non-dict JSON"
+                    result[k] = "Expected JSON object in `extra` field, got non-dict JSON"
             except json.JSONDecodeError:
-                result[k] = "Encountered non-JSON in extra field"
+                result[k] = "Encountered non-JSON in `extra` field"
         else:
             result[k] = secrets_masker.redact(v, k)
     return result

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -98,7 +98,11 @@ const ConnectionForm = ({
 
   const validateAndPrettifyJson = (value: string) => {
     try {
-      const parsedJson = JSON.parse(value) as JSON;
+      const parsedJson = JSON.parse(value);
+
+      if (typeof parsedJson !== 'object' || parsedJson === null || Array.isArray(parsedJson)) {
+        throw new Error('extra fields must be a valid JSON object (e.g., {"key": "value"})');
+      }
 
       setErrors((prev) => ({ ...prev, conf: undefined }));
       const formattedJson = JSON.stringify(parsedJson, undefined, 2);

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -98,10 +98,15 @@ const ConnectionForm = ({
 
   const validateAndPrettifyJson = (value: string) => {
     try {
-      const parsedJson = JSON.parse(value);
+      if (value.trim() === "") {
+        setErrors((prev) => ({ ...prev, conf: undefined }));
 
-      if (typeof parsedJson !== 'object' || parsedJson === null || Array.isArray(parsedJson)) {
-        throw new Error('extra fields must be a valid JSON object (e.g., {"key": "value"})');
+        return value;
+      }
+      const parsedJson = JSON.parse(value) as Record<string, unknown>;
+
+      if (typeof parsedJson !== "object" || Array.isArray(parsedJson)) {
+        throw new TypeError('extra fields must be a valid JSON object (e.g., {"key": "value"})');
       }
 
       setErrors((prev) => ({ ...prev, conf: undefined }));

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -1246,3 +1246,15 @@ class TestBulkConnections(TestConnectionEndpoint):
     def test_should_respond_403(self, unauthorized_test_client):
         response = unauthorized_test_client.patch("/connections", json={})
         assert response.status_code == 403
+
+
+class TestPostConnectionExtraBackwardCompatibility(TestConnectionEndpoint):
+    def test_post_should_accept_empty_string_as_extra(self, test_client, session):
+        body = {"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "extra": ""}
+
+        response = test_client.post("/connections", json=body)
+        assert response.status_code == 201
+
+        connection = session.query(Connection).filter_by(conn_id=TEST_CONN_ID).first()
+        assert connection is not None
+        assert connection.extra == "{}"  # Backward compatibility: treat "" as empty JSON object


### PR DESCRIPTION
This PR addresses issue [#53963](https://github.com/apache/airflow/issues/53963) by ensuring the `extra` field in connections is always a valid JSON object, both in the UI and backend.

### Summary of Changes

- **Frontend (`ConnectionForm`)**:
  - Added validation to prevent submission of `extra` values that are not JSON objects (e.g., `"abc"`, `[]`, `123`).
  - Displays a helpful error message to the user if invalid input is detected.

- **Backend (`ConnectionBody` schema)**:
  - Added a Pydantic validator to enforce that `extra` is a JSON-encoded Python `dict`.
  - If `extra` is invalid or not a dict, the API now returns a 422 Unprocessable Entity with a descriptive error message instead of crashing with a 500.

- **Backend (`_mask_connection_fields`)**:
  - Updated masking logic to safely handle non-dict JSON or malformed input in `extra` field.
  - Prevents `.items()` call on string/array and returns a fallback message instead.

**Related Issue**

Closes https://github.com/apache/airflow/issues/53963
