### PR TITLE
#53957-Deterministic order for template fields

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -61,9 +61,9 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes"
 
     # `cmds` and `arguments` are used internally by the operator
-    template_fields: Sequence[str] = tuple(sorted(
-        {"op_args", "op_kwargs", *KubernetesPodOperator.template_fields} - {"cmds", "arguments"}
-    ))
+    template_fields: Sequence[str] = tuple(
+        sorted({"op_args", "op_kwargs", *KubernetesPodOperator.template_fields} - {"cmds", "arguments"})
+    )
 
     # Since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -61,9 +61,9 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes"
 
     # `cmds` and `arguments` are used internally by the operator
-    template_fields: Sequence[str] = tuple(
+    template_fields: Sequence[str] = tuple(sorted(
         {"op_args", "op_kwargs", *KubernetesPodOperator.template_fields} - {"cmds", "arguments"}
-    )
+    ))
 
     # Since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -95,7 +95,9 @@ class KubernetesJobOperator(KubernetesPodOperator):
         compatibility.
     """
 
-    template_fields: Sequence[str] = tuple(sorted({"job_template_file"} | set(KubernetesPodOperator.template_fields)))
+    template_fields: Sequence[str] = tuple(
+        sorted({"job_template_file"} | set(KubernetesPodOperator.template_fields))
+    )
 
     def __init__(
         self,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -95,7 +95,7 @@ class KubernetesJobOperator(KubernetesPodOperator):
         compatibility.
     """
 
-    template_fields: Sequence[str] = tuple({"job_template_file"} | set(KubernetesPodOperator.template_fields))
+    template_fields: Sequence[str] = tuple(sorted({"job_template_file"} | set(KubernetesPodOperator.template_fields)))
 
     def __init__(
         self,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -47,6 +47,7 @@ POLL_INTERVAL = 100
 JOB_NAME = "test-job"
 JOB_NAMESPACE = "test-namespace"
 JOB_POLL_INTERVAL = 20.0
+JOB_TEMPLATE_FILE = "job_template.yaml"
 KUBERNETES_CONN_ID = "test-conn_id"
 POD_NAME = "test-pod"
 POD_NAMESPACE = "test-namespace"
@@ -106,6 +107,16 @@ def create_context(task, persist_to_db=False, map_index=None):
 @pytest.mark.db_test
 @pytest.mark.execution_timeout(300)
 class TestKubernetesJobOperator:
+    def test_template_fields_order(self):
+        """Test that template_fields includes deterministic order."""
+        job = KubernetesJobOperator(job_template_file=JOB_TEMPLATE_FILE, task_id="task")
+
+        # Verify that job_template_file is in template_fields
+        assert "job_template_file" in job.template_fields
+
+        # Verify that all fields are ordered
+        assert list(job.template_fields) == sorted(job.template_fields)
+
     @pytest.fixture(autouse=True)
     def setup_tests(self):
         self._default_client_patch = patch(f"{HOOK_CLASS}._get_default_client")


### PR DESCRIPTION
closes: #53957 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #53957 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---
Changes to resolve non-deterministic order for template fields in kubernetes decorator and k8 job operator during serialized update
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
