### PR TITLE
Support encoding parameter in FTP/FTPS connection extra

### DIFF
--- a/providers/ftp/docs/connections/ftp.rst
+++ b/providers/ftp/docs/connections/ftp.rst
@@ -65,3 +65,19 @@ Example connection string:
 .. code-block:: bash
 
    export AIRFLOW_CONN_FTP_DEFAULT='ftp://user:pass@localhost?passive=false'
+
+
+Extra Parameters
+----------------
+
+You can specify additional parameters in the extra field of your connection:
+
+- ``passive``: Set passive mode for FTP transfers (default: true).
+- ``encoding``: Specify the encoding for the FTP connection (e.g., ``cp1251`` for legacy servers).
+
+Example::
+
+    {
+        "passive": true,
+        "encoding": "cp1251"
+    }

--- a/providers/ftp/src/airflow/providers/ftp/hooks/ftp.py
+++ b/providers/ftp/src/airflow/providers/ftp/hooks/ftp.py
@@ -35,6 +35,7 @@ class FTPHook(BaseHook):
     Errors that may occur throughout but should be handled downstream.
     You can specify mode for data transfers in the extra field of your
     connection as ``{"passive": "true"}``.
+    You can also specify encoding for the FTP connection as ``{"encoding": "cp1251"}``.
 
     :param ftp_conn_id: The :ref:`ftp connection id <howto/connection:ftp>`
         reference.
@@ -49,6 +50,7 @@ class FTPHook(BaseHook):
         super().__init__()
         self.ftp_conn_id = ftp_conn_id
         self.conn: ftplib.FTP | None = None
+        self.encoding: str | None = None
 
     def __enter__(self):
         return self
@@ -62,7 +64,12 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            self.conn = ftplib.FTP()  # nosec: B321
+            encoding = params.extra_dejson.get("encoding")
+            self.encoding = encoding
+            if encoding:
+                self.conn = ftplib.FTP(encoding=encoding)  # nosec: B321
+            else:
+                self.conn = ftplib.FTP()  # nosec: B321
             if params.host:
                 port: int = int(ftplib.FTP_PORT)
                 if params.port is not None:
@@ -288,6 +295,8 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
+            encoding = params.extra_dejson.get("encoding")
+            self.encoding = encoding
 
             if params.port:
                 ftplib.FTP_TLS.port = params.port
@@ -297,7 +306,12 @@ class FTPSHook(FTPHook):
             params.host = cast("str", params.host)
             params.password = cast("str", params.password)
             params.login = cast("str", params.login)
-            self.conn = ftplib.FTP_TLS(params.host, params.login, params.password, context=context)  # nosec: B321
+            if encoding:
+                self.conn = ftplib.FTP_TLS(
+                    params.host, params.login, params.password, context=context, encoding=encoding
+                )  # nosec: B321
+            else:
+                self.conn = ftplib.FTP_TLS(params.host, params.login, params.password, context=context)  # nosec: B321
             self.conn.set_pasv(pasv)
 
         return self.conn

--- a/providers/ftp/tests/unit/ftp/hooks/test_ftp.py
+++ b/providers/ftp/tests/unit/ftp/hooks/test_ftp.py
@@ -240,7 +240,7 @@ class TestIntegrationFTPHook:
 
         hook = FTPHook("ftp_encoding")
         hook.get_conn()
-        mock_ftp.assert_called_with(encoding="cp1251")
+        assert mock_ftp.mock_calls[0] == mock.call(encoding="cp1251")
 
     @mock.patch("ftplib.FTP_TLS")
     def test_ftps_encoding_extra(self, mock_ftp_tls):

--- a/providers/ftp/tests/unit/ftp/hooks/test_ftp.py
+++ b/providers/ftp/tests/unit/ftp/hooks/test_ftp.py
@@ -176,6 +176,15 @@ class TestIntegrationFTPHook:
             )
         )
 
+        create_connection_without_db(
+            Connection(
+                conn_id="ftp_encoding",
+                conn_type="ftp",
+                host="localhost",
+                extra='{"encoding": "cp1251"}',
+            )
+        )
+
     def _test_mode(self, hook_type, connection_id, expected_mode):
         hook = hook_type(connection_id)
         conn = hook.get_conn()
@@ -224,3 +233,19 @@ class TestIntegrationFTPHook:
         from airflow.providers.ftp.hooks.ftp import FTPSHook
 
         self._test_mode(FTPSHook, "ftp_active", False)
+
+    @mock.patch("ftplib.FTP")
+    def test_ftp_encoding_extra(self, mock_ftp):
+        from airflow.providers.ftp.hooks.ftp import FTPHook
+
+        hook = FTPHook("ftp_encoding")
+        hook.get_conn()
+        mock_ftp.assert_called_with(encoding="cp1251")
+
+    @mock.patch("ftplib.FTP_TLS")
+    def test_ftps_encoding_extra(self, mock_ftp_tls):
+        from airflow.providers.ftp.hooks.ftp import FTPSHook
+
+        hook = FTPSHook("ftp_encoding")
+        hook.get_conn()
+        assert any(call.kwargs.get("encoding") == "cp1251" for call in mock_ftp_tls.mock_calls)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Description
This PR adds support for specifying the `encoding` parameter in the extra field of Airflow FTP and FTPS connections. This allows users to connect to FTP servers that use non-UTF-8 encodings (e.g., cp1251).

## Changes
- FTPHook/FTPSHook:
  - Read `encoding` from connection extra and pass it to `ftplib.FTP` or `ftplib.FTP_TLS` if provided.

Closes: #54015 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
