### PR TITLE
Make log redaction safer in edge case when redaction has an error

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -306,12 +306,13 @@ class SecretsMasker(logging.Filter):
             log.warning(
                 "Unable to redact value of type %s, please report this via "
                 "<https://github.com/apache/airflow/issues>. Error was: %s: %s",
-                item,
+                type(item),
                 type(exc).__name__,
                 exc,
                 extra={self.ALREADY_FILTERED_FLAG: True},
             )
-            return item
+            # Rather than expose sensitive info, lets play it safe
+            return "<redaction-failed>"
 
     def _merge(
         self,


### PR DESCRIPTION
Previously this both logged the item, and returned the unable-to-be-redacted item unchanged.

Lets play it safe, only log the type that failed and return a known-to-be-safe string in cases like this.
