### PR TITLE
Remove deprecated method check send_file usage from slack operators

### DIFF
--- a/providers/slack/pyproject.toml
+++ b/providers/slack/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.6.1",
     "apache-airflow-providers-common-sql>=1.27.0",
-    "slack_sdk>=3.36.0",
+    "slack_sdk>=3.19.0",
 ]
 
 [dependency-groups]

--- a/providers/slack/pyproject.toml
+++ b/providers/slack/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.6.1",
     "apache-airflow-providers-common-sql>=1.27.0",
-    "slack_sdk>=3.19.0",
+    "slack_sdk>=3.36.0",
 ]
 
 [dependency-groups]

--- a/providers/slack/src/airflow/providers/slack/hooks/slack.py
+++ b/providers/slack/src/airflow/providers/slack/hooks/slack.py
@@ -237,7 +237,6 @@ class SlackHook(BaseHook):
         initial_comment: str | None = None,
         title: str | None = None,
         snippet_type: str | None = None,
-        **kwargs,
     ) -> list[SlackResponse]:
         """
         Smooth transition between ``send_file`` and ``send_file_v2`` methods.

--- a/providers/slack/src/airflow/providers/slack/operators/slack.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack.py
@@ -18,10 +18,12 @@
 from __future__ import annotations
 
 import json
+import warnings
 from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.slack.hooks.slack import SlackHook
 from airflow.providers.slack.version_compat import BaseOperator
 
@@ -225,7 +227,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         filetype: str | None = None,
         content: str | None = None,
         title: str | None = None,
-        method_version: Literal["v1", "v2"] = "v2",
+        method_version: Literal["v1", "v2"] | None = None,
         snippet_type: str | None = None,
         **kwargs,
     ) -> None:
@@ -239,18 +241,25 @@ class SlackAPIFileOperator(SlackAPIOperator):
         self.method_version = method_version
         self.snippet_type = snippet_type
 
-    @property
-    def _method_resolver(self):
-        if self.method_version == "v1":
-            return self.hook.send_file
-        return self.hook.send_file_v1_to_v2
+        if self.filetype:
+            warnings.warn(
+                "The property `filetype` is no longer supported in slack_sdk and will be removed in a future release.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+
+        if self.method_version:
+            warnings.warn(
+                "The property `method_version` is no longer required for `SlackAPIFileOperator`, as slack_sdk is using the files_upload_v2 method by default.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
 
     def execute(self, context: Context):
-        self._method_resolver(
+        self.hook.send_file_v1_to_v2(
             channels=self.channels,
             # For historical reason SlackAPIFileOperator use filename as reference to file
             file=self.filename,
-            filetype=self.filetype,
             content=self.content,
             initial_comment=self.initial_comment,
             title=self.title,

--- a/providers/slack/src/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/providers/slack/src/airflow/providers/slack/transfers/sql_to_slack.py
@@ -122,12 +122,6 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
             retry_handlers=self.slack_retry_handlers,
         )
 
-    @property
-    def _method_resolver(self):
-        if self.slack_method_version == "v1":
-            return self.slack_hook.send_file
-        return self.slack_hook.send_file_v1_to_v2
-
     def execute(self, context: Context) -> None:
         # Parse file format from filename
         output_file_format, _ = parse_filename(
@@ -162,7 +156,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
                 # if SUPPORTED_FILE_FORMATS extended and no actual implementation for specific format.
                 raise AirflowException(f"Unexpected output file format: {output_file_format}")
 
-            self._method_resolver(
+            self.slack_hook.send_file_v1_to_v2(
                 channels=self.slack_channels,
                 file=output_file_name,
                 filename=self.slack_filename,

--- a/providers/slack/src/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/providers/slack/src/airflow/providers/slack/transfers/sql_to_slack.py
@@ -16,12 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping, Sequence
 from functools import cached_property
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Literal
 
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.slack.hooks.slack import SlackHook
 from airflow.providers.slack.transfers.base_sql_to_slack import BaseSqlToSlackOperator
 from airflow.providers.slack.utils import parse_filename
@@ -91,7 +92,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         slack_initial_comment: str | None = None,
         slack_title: str | None = None,
         slack_base_url: str | None = None,
-        slack_method_version: Literal["v1", "v2"] = "v2",
+        slack_method_version: Literal["v1", "v2"] | None = None,
         df_kwargs: dict | None = None,
         action_on_empty_df: Literal["send", "skip", "error"] = "send",
         **kwargs,
@@ -110,6 +111,13 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         if not action_on_empty_df or action_on_empty_df not in ("send", "skip", "error"):
             raise ValueError(f"Invalid `action_on_empty_df` value {action_on_empty_df!r}")
         self.action_on_empty_df = action_on_empty_df
+
+        if self.slack_method_version:
+            warnings.warn(
+                "The property `slack_method_version` is no longer required for `SqlToSlackApiFileOperator`, as slack_sdk is using the files_upload_v2 method by default.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
 
     @cached_property
     def slack_hook(self):

--- a/providers/slack/tests/system/slack/example_slack.py
+++ b/providers/slack/tests/system/slack/example_slack.py
@@ -76,7 +76,6 @@ with DAG(
         task_id="slack_file_upload_1",
         channels=SLACK_CHANNEL,
         filename="/files/dags/test.txt",
-        filetype="txt",
     )
     # [END slack_api_file_operator_howto_guide]
 

--- a/providers/slack/tests/unit/slack/hooks/test_slack.py
+++ b/providers/slack/tests/unit/slack/hooks/test_slack.py
@@ -463,11 +463,8 @@ class TestSlackHook:
     @pytest.mark.parametrize("title", [None, "test title"])
     @pytest.mark.parametrize("filename", [None, "foo.bar"])
     @pytest.mark.parametrize("channel", [None, "#random"])
-    @pytest.mark.parametrize("filetype", [None, "auto"])
     @pytest.mark.parametrize("snippet_type", [None, "text"])
-    def test_send_file_v1_to_v2_content(
-        self, initial_comment, title, filename, channel, filetype, snippet_type
-    ):
+    def test_send_file_v1_to_v2_content(self, initial_comment, title, filename, channel, snippet_type):
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
         with mock.patch.object(SlackHook, "send_file_v2") as mocked_send_file_v2:
             hook.send_file_v1_to_v2(
@@ -476,7 +473,6 @@ class TestSlackHook:
                 filename=filename,
                 initial_comment=initial_comment,
                 title=title,
-                filetype=filetype,
                 snippet_type=snippet_type,
             )
             mocked_send_file_v2.assert_called_once_with(
@@ -494,9 +490,8 @@ class TestSlackHook:
     @pytest.mark.parametrize("title", [None, "test title"])
     @pytest.mark.parametrize("filename", [None, "foo.bar"])
     @pytest.mark.parametrize("channel", [None, "#random"])
-    @pytest.mark.parametrize("filetype", [None, "auto"])
     @pytest.mark.parametrize("snippet_type", [None, "text"])
-    def test_send_file_v1_to_v2_file(self, initial_comment, title, filename, channel, filetype, snippet_type):
+    def test_send_file_v1_to_v2_file(self, initial_comment, title, filename, channel, snippet_type):
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
         with mock.patch.object(SlackHook, "send_file_v2") as mocked_send_file_v2:
             hook.send_file_v1_to_v2(
@@ -505,7 +500,6 @@ class TestSlackHook:
                 filename=filename,
                 initial_comment=initial_comment,
                 title=title,
-                filetype=filetype,
                 snippet_type=snippet_type,
             )
             mocked_send_file_v2.assert_called_once_with(

--- a/providers/slack/tests/unit/slack/operators/test_slack.py
+++ b/providers/slack/tests/unit/slack/operators/test_slack.py
@@ -181,7 +181,6 @@ class TestSlackAPIFileOperator:
         self.test_channel = "#test_slack_channel"
         self.test_initial_comment = "test text file test_filename.txt"
         self.filename = "test_filename.txt"
-        self.test_filetype = "text"
         self.test_content = "This is a test text file!"
         self.test_api_params = {"key": "value"}
         self.expected_method = "files.upload"
@@ -194,7 +193,6 @@ class TestSlackAPIFileOperator:
             channels=self.test_channel,
             initial_comment=self.test_initial_comment,
             filename=self.filename,
-            filetype=self.test_filetype,
             content=self.test_content,
             api_params=test_api_params,
             snippet_type=self.test_snippet_type,
@@ -210,23 +208,15 @@ class TestSlackAPIFileOperator:
         assert slack_api_post_operator.channels == self.test_channel
         assert slack_api_post_operator.api_params == self.test_api_params
         assert slack_api_post_operator.filename == self.filename
-        assert slack_api_post_operator.filetype == self.test_filetype
+        assert slack_api_post_operator.filetype is None
         assert slack_api_post_operator.content == self.test_content
         assert slack_api_post_operator.snippet_type == self.test_snippet_type
         assert not hasattr(slack_api_post_operator, "token")
 
     @pytest.mark.parametrize("initial_comment", [None, "foo-bar"])
     @pytest.mark.parametrize("title", [None, "Spam Egg"])
-    @pytest.mark.parametrize(
-        "method_version, method_name",
-        [
-            pytest.param("v2", "send_file_v1_to_v2", id="v2"),
-        ],
-    )
     @pytest.mark.parametrize("snippet_type", [None, "text"])
-    def test_api_call_params_with_content_args(
-        self, initial_comment, title, method_version, method_name, snippet_type
-    ):
+    def test_api_call_params_with_content_args(self, initial_comment, title, snippet_type):
         op = SlackAPIFileOperator(
             task_id="slack",
             slack_conn_id=SLACK_API_TEST_CONNECTION_ID,
@@ -234,16 +224,16 @@ class TestSlackAPIFileOperator:
             channels="#test-channel",
             initial_comment=initial_comment,
             title=title,
-            method_version=method_version,
             snippet_type=snippet_type,
         )
-        with mock.patch(f"airflow.providers.slack.operators.slack.SlackHook.{method_name}") as mock_send_file:
+        with mock.patch(
+            "airflow.providers.slack.operators.slack.SlackHook.send_file_v1_to_v2"
+        ) as mock_send_file:
             op.execute({})
             mock_send_file.assert_called_once_with(
                 channels="#test-channel",
                 content="test-content",
                 file=None,
-                filetype=None,
                 initial_comment=initial_comment,
                 title=title,
                 snippet_type=snippet_type,
@@ -251,16 +241,8 @@ class TestSlackAPIFileOperator:
 
     @pytest.mark.parametrize("initial_comment", [None, "foo-bar"])
     @pytest.mark.parametrize("title", [None, "Spam Egg"])
-    @pytest.mark.parametrize(
-        "method_version, method_name",
-        [
-            pytest.param("v2", "send_file_v1_to_v2", id="v2"),
-        ],
-    )
     @pytest.mark.parametrize("snippet_type", [None, "text"])
-    def test_api_call_params_with_file_args(
-        self, initial_comment, title, method_version, method_name, snippet_type
-    ):
+    def test_api_call_params_with_file_args(self, initial_comment, title, snippet_type):
         op = SlackAPIFileOperator(
             task_id="slack",
             slack_conn_id=SLACK_API_TEST_CONNECTION_ID,
@@ -268,16 +250,16 @@ class TestSlackAPIFileOperator:
             filename="/dev/null",
             initial_comment=initial_comment,
             title=title,
-            method_version=method_version,
             snippet_type=snippet_type,
         )
-        with mock.patch(f"airflow.providers.slack.operators.slack.SlackHook.{method_name}") as mock_send_file:
+        with mock.patch(
+            "airflow.providers.slack.operators.slack.SlackHook.send_file_v1_to_v2"
+        ) as mock_send_file:
             op.execute({})
             mock_send_file.assert_called_once_with(
                 channels="C1234567890",
                 content=None,
                 file="/dev/null",
-                filetype=None,
                 initial_comment=initial_comment,
                 title=title,
                 snippet_type=snippet_type,

--- a/providers/slack/tests/unit/slack/transfers/test_sql_to_slack.py
+++ b/providers/slack/tests/unit/slack/transfers/test_sql_to_slack.py
@@ -22,7 +22,11 @@ import pytest
 
 from airflow.exceptions import AirflowSkipException
 from airflow.providers.slack.transfers.sql_to_slack import SqlToSlackApiFileOperator
-from airflow.utils import timezone
+
+try:
+    from airflow.sdk import timezone
+except ImportError:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 TEST_DAG_ID = "sql_to_slack_unit_test"
 TEST_TASK_ID = "sql_to_slack_unit_test_task"
@@ -83,7 +87,6 @@ class TestSqlToSlackApiFileOperator:
     @pytest.mark.parametrize(
         "method_version, method_name",
         [
-            pytest.param("v1", "send_file", id="v1"),
             pytest.param("v2", "send_file_v1_to_v2", id="v2"),
         ],
     )

--- a/providers/slack/tests/unit/slack/transfers/test_sql_to_slack.py
+++ b/providers/slack/tests/unit/slack/transfers/test_sql_to_slack.py
@@ -84,12 +84,6 @@ class TestSqlToSlackApiFileOperator:
             ),
         ],
     )
-    @pytest.mark.parametrize(
-        "method_version, method_name",
-        [
-            pytest.param("v2", "send_file_v1_to_v2", id="v2"),
-        ],
-    )
     def test_send_file(
         self,
         mock_slack_hook_cls,
@@ -102,12 +96,10 @@ class TestSqlToSlackApiFileOperator:
         title,
         slack_op_kwargs: dict,
         hook_extra_kwargs: dict,
-        method_version,
-        method_name: str,
     ):
         # Mock Hook
         mock_send_file = mock.MagicMock()
-        setattr(mock_slack_hook_cls.return_value, method_name, mock_send_file)
+        setattr(mock_slack_hook_cls.return_value, "send_file_v1_to_v2", mock_send_file)
 
         # Mock returns pandas.DataFrame and expected method
         mock_df = mock.MagicMock()
@@ -122,7 +114,6 @@ class TestSqlToSlackApiFileOperator:
             "slack_channels": channels,
             "slack_initial_comment": initial_comment,
             "slack_title": title,
-            "slack_method_version": method_version,
             "df_kwargs": df_kwargs,
             **slack_op_kwargs,
         }


### PR DESCRIPTION
We have removed send_file deprecation method part of this https://github.com/apache/airflow/pull/44693.

There were some leftovers of usage of `send_file ` eg: https://github.com/apache/airflow/blob/main/providers/slack/src/airflow/providers/slack/operators/slack.py#L245, this would fail if anyone sends v1 as there is no send_file method in hooks.

We should remove now usages.

1. Bumped version to 3.36.0 latest
2. Updated tests
3. Removed deprecated usage.

As we removed method_resolver function, we dont need of the method_version argument at all, for now added deprecation warning if anyone uses this would notify the default is slack_sdk file_upload_v2.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
