### PR TITLE
bump qdrant_client>=1.15.1

### DIFF
--- a/providers/qdrant/pyproject.toml
+++ b/providers/qdrant/pyproject.toml
@@ -58,8 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "qdrant_client>=1.10.1",
-    "portalocker>=2.8.1",
+    "qdrant_client>=1.15.1",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
this is needed to remove `portalocker` as direct dependency.
We previously added it becasue it was needed by `qdrant_client` yet they didn't list it as direct dependency.
In version 1.15 they fixed it.