### PR TITLE
feat: persist Asset search query across navigation

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -21,6 +21,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams, Link as RouterLink } from "react-router-dom";
+import { useSessionStorage } from "usehooks-ts";
 
 import { useAssetServiceGetAssets } from "openapi/queries";
 import type { AssetResponse } from "openapi/requests/types.gen";
@@ -98,7 +99,8 @@ export const AssetsList = () => {
   const { t: translate } = useTranslation(["assets", "common"]);
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [namePattern, setNamePattern] = useState(searchParams.get(NAME_PATTERN_PARAM) ?? undefined);
+  const [savedSearchPattern, setSavedSearchPattern] = useSessionStorage("assets_search_temp", "");
+  const [namePattern, setNamePattern] = useState(searchParams.get(NAME_PATTERN_PARAM) ?? savedSearchPattern);
 
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
@@ -113,6 +115,7 @@ export const AssetsList = () => {
   });
 
   const handleSearchChange = (value: string) => {
+    setSavedSearchPattern(value);
     if (value) {
       searchParams.set(NAME_PATTERN_PARAM, value);
     } else {
@@ -131,7 +134,7 @@ export const AssetsList = () => {
       <VStack alignItems="none">
         <SearchBar
           buttonProps={{ disabled: true }}
-          defaultValue={namePattern ?? ""}
+          defaultValue={namePattern}
           onChange={handleSearchChange}
           placeHolder={translate("searchPlaceholder")}
         />


### PR DESCRIPTION
follow-up: #54059

Enhance Asset list search functionality to persist search queries when navigating between Asset details and back to the list view.

## Solution
The search query now persists until the browser session ends.


https://github.com/user-attachments/assets/88045870-cf76-42b8-8a04-6f682b5ba0ec


## Change
Add sessionStorage search state persistence in Asset list page.
Search query persists on navigation and refresh, clearing only when the session ends.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
