### PR TITLE
Limit paramiko to `< 4.0.0` till we remove DSS support

### DIFF
--- a/providers/sftp/pyproject.toml
+++ b/providers/sftp/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-ssh>=4.0.0",
-    "paramiko>=2.9.0",
+    "paramiko>=2.9.0,<4.0.0",
     "asyncssh>=2.12.0",
 ]
 

--- a/providers/sftp/pyproject.toml
+++ b/providers/sftp/pyproject.toml
@@ -59,6 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-ssh>=4.0.0",
+    # TODO: Bump to >= 4.0.0 once https://github.com/apache/airflow/issues/54079 is handled
     "paramiko>=2.9.0,<4.0.0",
     "asyncssh>=2.12.0",
 ]

--- a/providers/ssh/pyproject.toml
+++ b/providers/ssh/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "paramiko>=2.9.0",
+    "paramiko>=2.9.0,<4.0.0",
     "sshtunnel>=0.3.2",
 ]
 

--- a/providers/ssh/pyproject.toml
+++ b/providers/ssh/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    # TODO: Bump to >= 4.0.0 once https://github.com/apache/airflow/issues/54079 is handled
     "paramiko>=2.9.0,<4.0.0",
     "sshtunnel>=0.3.2",
 ]

--- a/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
@@ -74,19 +74,24 @@ class SSHHook(BaseHook):
     """
 
     # List of classes to try loading private keys as, ordered (roughly) by most common to least common
-    _pkey_loaders: Sequence[type[paramiko.PKey]] = (
+    _pkey_loader_list = [
         paramiko.RSAKey,
         paramiko.ECDSAKey,
         paramiko.Ed25519Key,
-        paramiko.DSSKey,
-    )
+    ]
 
     _host_key_mappings = {
         "rsa": paramiko.RSAKey,
-        "dss": paramiko.DSSKey,
         "ecdsa": paramiko.ECDSAKey,
         "ed25519": paramiko.Ed25519Key,
     }
+
+    # Add DSSKey if available in paramiko
+    if hasattr(paramiko, "DSSKey"):
+        _pkey_loader_list.append(paramiko.DSSKey)
+        _host_key_mappings["dss"] = paramiko.DSSKey
+
+    _pkey_loaders: Sequence[type[paramiko.PKey]] = tuple(_pkey_loader_list)
 
     conn_name_attr = "ssh_conn_id"
     default_conn_name = "ssh_default"

--- a/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
@@ -74,24 +74,19 @@ class SSHHook(BaseHook):
     """
 
     # List of classes to try loading private keys as, ordered (roughly) by most common to least common
-    _pkey_loader_list = [
+    _pkey_loaders: Sequence[type[paramiko.PKey]] = (
         paramiko.RSAKey,
         paramiko.ECDSAKey,
         paramiko.Ed25519Key,
-    ]
+        paramiko.DSSKey,
+    )
 
     _host_key_mappings = {
         "rsa": paramiko.RSAKey,
+        "dss": paramiko.DSSKey,
         "ecdsa": paramiko.ECDSAKey,
         "ed25519": paramiko.Ed25519Key,
     }
-
-    # Add DSSKey if available in paramiko
-    if hasattr(paramiko, "DSSKey"):
-        _pkey_loader_list.append(paramiko.DSSKey)
-        _host_key_mappings["dss"] = paramiko.DSSKey
-
-    _pkey_loaders: Sequence[type[paramiko.PKey]] = tuple(_pkey_loader_list)
 
     conn_name_attr = "ssh_conn_id"
     default_conn_name = "ssh_default"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

A new version of paramiko has been released:

```
< paramiko==3.5.1
---
> paramiko==4.0.0
```

Due to the paramiko bump, there is an compatibility issue with newer versions of paramiko (4.0+) where `DSSKey` has been removed for security reasons.

This was causing test failures in `test_should_be_importable` for providers that depend on the SSH provider.

Failure:
```
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/models/dagbag.py", line 432, in parse
    loader.exec_module(new_module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/airflow/providers/google/tests/system/google/cloud/transfers/example_gcs_to_sftp.py", line 30, in <module>
    from airflow.providers.google.cloud.transfers.gcs_to_sftp import GCSToSFTPOperator
  File "/opt/airflow/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_sftp.py", line 31, in <module>
    from airflow.providers.sftp.hooks.sftp import SFTPHook
  File "/opt/airflow/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py", line 39, in <module>
    from airflow.providers.ssh.hooks.ssh import SSHHook
  File "/opt/airflow/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py", line 43, in <module>
    class SSHHook(BaseHook):
  File "/opt/airflow/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py", line 81, in SSHHook
    paramiko.DSSKey,
```

Example: https://github.com/apache/airflow/actions/runs/16713668042/job/47303410955.

An ideal way forward would be to remove the DSS support from airflow & bump the paramiko version with that, for now, to fix CI, i think limiting paramiko to < 4.0.0 would be good enough.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
