### PR TITLE
Refactoring `from_json`

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -549,8 +549,11 @@ class Connection(Base, LoggingMixin):
         return conn
 
     @classmethod
-    def from_json(cls, value, conn_id=None) -> Connection:
-        kwargs = json.loads(value)
+    def from_json(cls, value, conn_id=None) -> Connection | None:
+        try:
+            kwargs = json.loads(value)
+        except json.JSONDecodeError:
+            return None
         extra = kwargs.pop("extra", None)
         if extra:
             kwargs["extra"] = extra if isinstance(extra, str) else json.dumps(extra)
@@ -561,8 +564,8 @@ class Connection(Base, LoggingMixin):
         if port:
             try:
                 kwargs["port"] = int(port)
-            except ValueError:
-                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+            except ValueError as e:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from e
         return Connection(conn_id=conn_id, **kwargs)
 
     def as_json(self) -> str:

--- a/airflow-core/src/airflow/secrets/base_secrets.py
+++ b/airflow-core/src/airflow/secrets/base_secrets.py
@@ -61,8 +61,9 @@ class BaseSecretsBackend(ABC):
         from airflow.models.connection import Connection
 
         value = value.strip()
-        if value[0] == "{":
-            return Connection.from_json(conn_id=conn_id, value=value)
+        conn = Connection.from_json(conn_id=conn_id, value=value)
+        if conn is not None:
+            return conn
         return Connection(conn_id=conn_id, uri=value)
 
     def get_connection(self, conn_id: str) -> Connection | None:

--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -854,7 +854,7 @@ class TestConnection:
         result = conn.as_json()
         assert result == expected_json
         restored_conn = Connection.from_json(result)
-
+        assert restored_conn is not None
         assert restored_conn.conn_type == conn.conn_type
         assert restored_conn.description == conn.description
         assert restored_conn.host == conn.host


### PR DESCRIPTION
The original condition:

```python
if value[0] == "{":
```
was refactored because it lacked clarity and maintainability.

This approach relied on the assumption that a JSON string would always start with {, which made the logic implicit and potentially fragile.

Instead, I refactored the logic using`JSONDecodeError`, and fall back to treating it as a URI if parsing fails. This makes the code more robust, readable, and easier to maintain.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
