### PR TITLE
Swap `send_mime_email` in core to use Connection instead of BaseHook

### DIFF
--- a/airflow-core/src/airflow/utils/email.py
+++ b/airflow-core/src/airflow/utils/email.py
@@ -246,9 +246,9 @@ def send_mime_email(
 
     if conn_id is not None:
         try:
-            from airflow.sdk import BaseHook
+            from airflow.models import Connection
 
-            airflow_conn = BaseHook.get_connection(conn_id)
+            airflow_conn = Connection.get_connection_from_secrets(conn_id)
             smtp_user = airflow_conn.login
             smtp_password = airflow_conn.password
         except AirflowException:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Extracted out of: https://github.com/apache/airflow/pull/54083, to fix:
```
______________________________________________________________________________ TestEmailSmtp.test_send_mime_airflow_config _______________________________________________________________________________
airflow-core/tests/unit/utils/test_email.py:218: in test_send_mime_airflow_config
    email.send_mime_email("from", "to", msg, dryrun=False)
airflow-core/src/airflow/utils/email.py:251: in send_mime_email
    airflow_conn = BaseHook.get_connection(conn_id)
task-sdk/src/airflow/sdk/bases/hook.py:63: in get_connection
    conn = Connection.get(conn_id)
task-sdk/src/airflow/sdk/definitions/connection.py:154: in get
    return _get_connection(conn_id)
task-sdk/src/airflow/sdk/execution_time/context.py:153: in _get_connection
    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
E   ImportError: cannot import name 'SUPERVISOR_COMMS' from 'airflow.sdk.execution_time.task_runner' (/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py)
```

The core email functionality has no reason to use BaseHook (from sdk). Swapping to use connection models. This will cut the link between sdk and core too.

Extracted out of https://github.com/apache/airflow/pull/54083

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
