### PR TITLE
update git-sync to 4.4.2

### DIFF
--- a/chart/newsfragments/54085.significant.rst
+++ b/chart/newsfragments/54085.significant.rst
@@ -1,0 +1,3 @@
+Default git-sync image is updated to ``4.4.2``
+
+The default git-sync image that is used with the Chart is now ``4.4.2``, previously it was ``4.3.0``.

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -947,7 +947,7 @@
                         "tag": {
                             "description": "The gitSync image tag.",
                             "type": "string",
-                            "default": "v4.3.0"
+                            "default": "v4.4.2"
                         },
                         "pullPolicy": {
                             "description": "The gitSync image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,7 +123,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: registry.k8s.io/git-sync/git-sync
-    tag: v4.3.0
+    tag: v4.4.2
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.


### PR DESCRIPTION
Same as previous one https://github.com/apache/airflow/pull/41411
Update the default version of git-sync https://github.com/kubernetes/git-sync/releases used by the chart.