### PR TITLE
Handle task timeouts within task SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/timeout.py
+++ b/task-sdk/src/airflow/sdk/execution_time/timeout.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+
+import structlog
+
+from airflow.exceptions import AirflowTaskTimeout
+
+
+class TimeoutPosix:
+    """POSIX Timeout version: To be used in a ``with`` block and timeout its content."""
+
+    def __init__(self, seconds=1, error_message="Timeout"):
+        super().__init__()
+        self.seconds = seconds
+        self.error_message = error_message + ", PID: " + str(os.getpid())
+        self.log = structlog.get_logger(logger_name="task")
+
+    def handle_timeout(self, signum, frame):
+        """Log information and raises AirflowTaskTimeout."""
+        self.log.error("Process timed out", pid=os.getpid())
+        raise AirflowTaskTimeout(self.error_message)
+
+    def __enter__(self):
+        import signal
+
+        try:
+            signal.signal(signal.SIGALRM, self.handle_timeout)
+            signal.setitimer(signal.ITIMER_REAL, self.seconds)
+        except ValueError:
+            self.log.warning("timeout can't be used in the current context", exc_info=True)
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        import signal
+
+        try:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+        except ValueError:
+            self.log.warning("timeout can't be used in the current context", exc_info=True)
+
+
+timeout = TimeoutPosix


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/54087



## What?
 Move timeout implementation to task SDK because it is mostly used there to measure support `execution_timeout` for running tasks. It also cuts down a single link between utils.timeout and sdk, and sdk can have its own.

This PR moves the timeout implementation used in task execution to the task SDK and updates it to use structlog for consistent logging.

While I was at it, I also removed windows support there. It isn't really needed because afaik the only way to run Airflow on windows is using WSL which is Windows Subsystem for Linux, which end of the day operates under linux. I mean to say that applications will not care if the hardware is windows, but they see Linux and that makes it easier to wipe that portion out.

## Why?

The timeout functionality is specific to task execution and should live with other task execution code in the Task SDK. This:

1. Reduces dependencies between Core and task SDK
2. Keeps execution specific code together


Why new module?

I initially moved it in task_runner, but we could repurpose it across providers etc, so it would be easier if it stayed as a module instead to not overload task_runner too.


## Tested with a DAG too

DAG:
```
from time import sleep

from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator
from datetime import datetime, timedelta


def print_hello():
    print("Going to sleep 100 seconds")
    sleep(100)

with DAG(
    dag_id="tasktimeout",
    schedule=None,
    catchup=False,
) as dag:
    hello_task = PythonOperator(
        task_id="ttimemout",
        retries=2,
        execution_timeout=timedelta(seconds=10),
        python_callable=print_hello,
    )
```

<img width="1724" height="865" alt="image" src="https://github.com/user-attachments/assets/df4970f6-11f4-4092-b917-1ee6830d5e97" />



## Migration

No migration needed - this is an internal implementation detail that doesn't affect DAG authors or providers.

## What's next?

Migrate the providers to use timeout from SDK and nuke `airflow.utils.timeout`


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
