### PR TITLE
Include the max_active_tasks limit in the query fetching TIs to be queued

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -121,11 +121,12 @@ core:
       default: "32"
     max_active_tasks_per_dag:
       description: |
-        The maximum number of task instances allowed to run concurrently in each dag run.
-        This is also configurable per-dag with ``max_active_tasks``,
+        The maximum number of task instances allowed to run concurrently in each DAG. To calculate
+        the number of tasks that is running concurrently for a DAG, add up the number of running
+        tasks for all DAG runs of the DAG. This is configurable at the DAG level with ``max_active_tasks``,
         which is defaulted as ``[core] max_active_tasks_per_dag``.
 
-        An example scenario when this would be useful is when you want to stop a new dag run with an early
+        An example scenario when this would be useful is when you want to stop a new dag with an early
         start date from stealing all the executor slots in a cluster.
       version_added: 2.2.0
       type: integer

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -121,12 +121,11 @@ core:
       default: "32"
     max_active_tasks_per_dag:
       description: |
-        The maximum number of task instances allowed to run concurrently in each DAG. To calculate
-        the number of tasks that is running concurrently for a DAG, add up the number of running
-        tasks for all DAG runs of the DAG. This is configurable at the DAG level with ``max_active_tasks``,
+        The maximum number of task instances allowed to run concurrently in each dag run.
+        This is also configurable per-dag with ``max_active_tasks``,
         which is defaulted as ``[core] max_active_tasks_per_dag``.
 
-        An example scenario when this would be useful is when you want to stop a new dag with an early
+        An example scenario when this would be useful is when you want to stop a new dag run with an early
         start date from stealing all the executor slots in a cluster.
       version_added: 2.2.0
       type: integer
@@ -2367,13 +2366,6 @@ scheduler:
         signal SIGUSR1.
         This is an expensive operation and generally should not be used except for debugging purposes.
       version_added: 3.0.0
-      type: boolean
-      example: ~
-      default: "False"
-    enable_fair_task_selection:
-      description: |
-        Whether to enable task fair selection in the scheduler.
-      version_added: 3.1.0
       type: boolean
       example: ~
       default: "False"

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2369,6 +2369,13 @@ scheduler:
       type: boolean
       example: ~
       default: "False"
+    enable_fair_task_selection:
+      description: |
+        Whether to enable task fair selection in the scheduler.
+      version_added: 3.1.0
+      type: boolean
+      example: ~
+      default: "False"
 triggerer:
   description: ~
   options:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -210,6 +210,16 @@ def _is_parent_process() -> bool:
     return multiprocessing.current_process().name == "MainProcess"
 
 
+def _get_current_dr_task_concurrency(states: Iterable[TaskInstanceState]) -> Query:
+    """Get the dag_run IDs and how many tasks are in the provided states for each one."""
+    return (
+        select(TI.run_id, func.count("*").label("dr_count"))
+        .where(TI.state.in_(states))
+        .group_by(TI.run_id)
+        .subquery()
+    )
+
+
 class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     """
     SchedulerJobRunner runs for a specific time interval and schedules jobs that are ready to run.
@@ -424,17 +434,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.info("\n\t".join(map(repr, callstack)))
             self.log.info("-" * 80)
 
-    def __print_tis_selection(self, tis: list[TI]) -> None:
-        self.log.info("TaskInstance selection is: %s", dict(Counter(ti.dag_id for ti in tis)))
-
-    def __get_current_dr_concurrency(self, states: Iterable[TaskInstanceState]) -> Query:
-        return (
-            select(TI.run_id, func.count("*").label("dr_count"))
-            .where(TI.state.in_(states))
-            .group_by(TI.run_id)
-            .subquery()
-        )
-
     def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
         """
         Find TIs that are ready for execution based on conditions.
@@ -508,7 +507,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             num_starved_tasks = len(starved_tasks)
             num_starved_tasks_task_dagrun_concurrency = len(starved_tasks_task_dagrun_concurrency)
 
-            dr_concurrency_subquery = self.__get_current_dr_concurrency(states=EXECUTION_STATES)
+            dr_task_concurrency_subquery = _get_current_dr_task_concurrency(states=EXECUTION_STATES)
 
             query = (
                 select(TI)
@@ -519,16 +518,20 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
                 .where(DM.bundle_name.is_not(None))
-                .join(dr_concurrency_subquery, TI.run_id == dr_concurrency_subquery.c.run_id, isouter=True)
-                .where(func.coalesce(dr_concurrency_subquery.c.dr_count, 0) < DM.max_active_tasks)
+                .join(
+                    dr_task_concurrency_subquery,
+                    TI.run_id == dr_task_concurrency_subquery.c.run_id,
+                    isouter=True,
+                )
+                .where(func.coalesce(dr_task_concurrency_subquery.c.dr_count, 0) < DM.max_active_tasks)
                 .options(selectinload(TI.dag_model))
                 .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
             )
 
             # Create a subquery with row numbers partitioned by run_id.
             #
-            # dag_id | task_id | priority_weight | rn
-            # -------|---------|-----------------|----
+            # dag_id | task_id | priority_weight | row_num
+            # -------|---------|-----------------|--------
             # dag1   | task1   | 100             | 1
             # dag1   | task22  | 90              | 2
             # dag1   | task5   | 80              | 3
@@ -543,12 +546,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         partition_by=TI.run_id,
                         order_by=[-TI.priority_weight, DR.logical_date, TI.map_index],
                     )
-                    .label("rn"),
+                    .label("row_num"),
                     DM.max_active_tasks.label("dr_max_active_tasks"),
                 )
             ).subquery()
 
-            # Select only rows where row_number <= per_dag_run_limit.
+            # Select only rows where row_number <= max_active_tasks.
             query = (
                 select(TI)
                 .select_from(ranked_query)
@@ -559,7 +562,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     & (TI.run_id == ranked_query.c.run_id)
                     & (TI.map_index == ranked_query.c.map_index),
                 )
-                .where(ranked_query.c.rn <= ranked_query.c.dr_max_active_tasks)
+                .where(ranked_query.c.row_num <= ranked_query.c.dr_max_active_tasks)
             )
 
             if starved_pools:
@@ -584,8 +587,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             try:
                 locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
                 task_instances_to_examine: list[TI] = list(session.scalars(locked_query).all())
-                self.log.info("Length of the tis to examine is %d", len(task_instances_to_examine))
-                self.__print_tis_selection(task_instances_to_examine)
+
+                self.log.debug("Length of the tis to examine is %d", len(task_instances_to_examine))
+                self.log.debug(
+                    "TaskInstance selection is: %s",
+                    dict(Counter(ti.dag_id for ti in task_instances_to_examine)),
+                )
 
                 timer.stop(send=True)
             except OperationalError as e:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -32,7 +32,22 @@ from functools import lru_cache, partial
 from itertools import groupby
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import and_, delete, desc, exists, func, inspect, or_, select, text, tuple_, update
+from sqlalchemy import (
+    and_,
+    delete,
+    desc,
+    exists,
+    func,
+    inspect,
+    lateral,
+    literal_column,
+    not_,
+    or_,
+    select,
+    text,
+    tuple_,
+    update,
+)
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, selectinload
 from sqlalchemy.sql import expression
@@ -412,6 +427,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.info("\n\t".join(map(repr, callstack)))
             self.log.info("-" * 80)
 
+    def __print_tis_selection(self, tis: list[TI]) -> None:
+        self.log.info("TaskInstance selection is: %s", dict(Counter(ti.dag_id for ti in tis)))
+
+    def __get_current_dag_concurrency(self, states: Iterable[TaskInstanceState]) -> Query:
+        return (
+            select(TI.dag_id, func.count("*").label("dag_count"))
+            .where(TI.state.in_(states))
+            .group_by(TI.dag_id)
+            .subquery()
+        )
+
     def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
         """
         Find TIs that are ready for execution based on conditions.
@@ -479,24 +505,79 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         pool_num_starving_tasks: dict[str, int] = Counter()
 
+        fts_enabled = conf.getboolean("scheduler", "enable_fair_task_selection")
+
         for loop_count in itertools.count(start=1):
             num_starved_pools = len(starved_pools)
             num_starved_dags = len(starved_dags)
             num_starved_tasks = len(starved_tasks)
             num_starved_tasks_task_dagrun_concurrency = len(starved_tasks_task_dagrun_concurrency)
 
-            query = (
-                select(TI)
-                .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
-                .join(TI.dag_run)
-                .where(DR.state == DagRunState.RUNNING)
-                .join(TI.dag_model)
-                .where(~DM.is_paused)
-                .where(TI.state == TaskInstanceState.SCHEDULED)
-                .where(DM.bundle_name.is_not(None))
-                .options(selectinload(TI.dag_model))
-                .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
-            )
+            if fts_enabled:
+                dag_concurrency_subquery = self.__get_current_dag_concurrency(states=EXECUTION_STATES)
+
+                per_dag_limit = conf.getint("core", "max_active_tasks_total_per_dag")
+
+                query = (
+                    select(TI)
+                    .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
+                    .join(TI.dag_run)
+                    .where(DR.state == DagRunState.RUNNING)
+                    .join(TI.dag_model)
+                    .where(~DM.is_paused)
+                    .where(TI.state == TaskInstanceState.SCHEDULED)
+                    .where(DM.bundle_name.is_not(None))
+                    .join(
+                        dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True
+                    )
+                    .where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < per_dag_limit)
+                    .options(selectinload(TI.dag_model))
+                    .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
+                )
+            else:
+                query = (
+                    select(TI)
+                    .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
+                    .join(TI.dag_run)
+                    .where(DR.state == DagRunState.RUNNING)
+                    .join(TI.dag_model)
+                    .where(~DM.is_paused)
+                    .where(TI.state == TaskInstanceState.SCHEDULED)
+                    .where(DM.bundle_name.is_not(None))
+                    .options(selectinload(TI.dag_model))
+                    .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
+                )
+
+            # Fair selection will ensure task instances are selected across multiple running DAGs
+            if fts_enabled:
+                self.log.info("Scheduler fair selection is enabled")
+
+                # per_dag_limit = DM.max_active_tasks
+                per_dagrun_limit = conf.getint("core", "max_active_tasks_per_dag")
+
+                self.log.info("Scheduler fair selection per dag limit is %d", per_dagrun_limit)
+
+                _subquery_dm = select(DM.dag_id).where(not_(DM.is_paused)).distinct().subquery()
+
+                _subquery_lateral = lateral(
+                    query.where(TI.dag_id == _subquery_dm.c.dag_id).limit(per_dagrun_limit)
+                ).alias("limited")
+
+                _reduced = (
+                    select(_subquery_dm, _subquery_lateral)
+                    .select_from(_subquery_dm)
+                    .join(_subquery_lateral, literal_column("true"))
+                    .alias("reduced")
+                )
+
+                query = select(TI).join(
+                    _reduced,
+                    (TI.dag_id == _reduced.c.dag_id)
+                    & (TI.task_id == _reduced.c.task_id)
+                    & (TI.run_id == _reduced.c.run_id)
+                    & (TI.state == _reduced.c.state)
+                    & (TI.map_index == _reduced.c.map_index),
+                )
 
             if starved_pools:
                 query = query.where(TI.pool.not_in(starved_pools))
@@ -520,6 +601,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             try:
                 locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
                 task_instances_to_examine: list[TI] = list(session.scalars(locked_query).all())
+                self.log.info("Length of the tis to examine is %d", len(task_instances_to_examine))
+                self.__print_tis_selection(task_instances_to_examine)
 
                 timer.stop(send=True)
             except OperationalError as e:
@@ -707,9 +790,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         assert executor_obj.name
 
                     if executor_slots_available[executor_obj.name] <= 0:
-                        self.log.debug(
+                        self.log.info(
                             "Not scheduling %s since its executor %s does not currently have any more "
-                            "available slots"
+                            "available slots",
+                            task_instance.task_id,
+                            executor_obj.name,
                         )
                         starved_tasks.add((task_instance.dag_id, task_instance.task_id))
                         continue

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -120,7 +120,7 @@ if TYPE_CHECKING:
     from types import FrameType
 
     from pendulum.datetime import DateTime
-    from sqlalchemy.orm import Load, Query, Session
+    from sqlalchemy.orm import Session
     from sqlalchemy.orm.interfaces import LoaderOption
     from sqlalchemy.sql.selectable import Subquery
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -502,13 +502,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         pool_num_starving_tasks: dict[str, int] = Counter()
 
-        fts_enabled = conf.getboolean("scheduler", "enable_fair_task_selection")
-
         for loop_count in itertools.count(start=1):
             num_starved_pools = len(starved_pools)
             num_starved_dags = len(starved_dags)
             num_starved_tasks = len(starved_tasks)
             num_starved_tasks_task_dagrun_concurrency = len(starved_tasks_task_dagrun_concurrency)
+
+            dag_concurrency_subquery = self.__get_current_dag_concurrency(states=EXECUTION_STATES)
 
             query = (
                 select(TI)
@@ -519,60 +519,47 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
                 .where(DM.bundle_name.is_not(None))
+                .join(dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True)
+                .where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < DM.max_active_tasks)
+                .options(selectinload(TI.dag_model))
             )
 
-            if fts_enabled:
-                dag_concurrency_subquery = self.__get_current_dag_concurrency(states=EXECUTION_STATES)
-                per_dag_limit = conf.getint("scheduler", "fair_task_selection_limit_per_dag")
-
-                query = query.join(
-                    dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True
-                ).where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < per_dag_limit)
-
-            query = query.options(selectinload(TI.dag_model))
-
-            if fts_enabled:
-                self.log.info("Scheduler fair selection is enabled")
-                per_dag_limit = conf.getint("scheduler", "fair_task_selection_limit_per_dag")
-                self.log.info("Scheduler fair selection per dag limit is %d", per_dag_limit)
-
-                # Create a subquery with row numbers partitioned by dag_id.
-                #
-                # dag_id | task_id | priority_weight | rn
-                # -------|---------|-----------------|----
-                # dag1   | task1   | 100             | 1
-                # dag1   | task22  | 90              | 2
-                # dag1   | task5   | 80              | 3
-                # dag1   | task13  | 70              | 4
-                # dag2   | task3   | 95              | 1
-                # dag2   | task1   | 85              | 2
-                # dag2   | task5   | 75              | 3
-                ranked_query = (
-                    query.add_columns(
-                        func.row_number()
-                        .over(
-                            partition_by=TI.dag_id,
-                            order_by=[-TI.priority_weight, DR.logical_date, TI.map_index],
-                        )
-                        .label("rn")
+            # Create a subquery with row numbers partitioned by run_id.
+            #
+            # dag_id | task_id | priority_weight | rn
+            # -------|---------|-----------------|----
+            # dag1   | task1   | 100             | 1
+            # dag1   | task22  | 90              | 2
+            # dag1   | task5   | 80              | 3
+            # dag1   | task13  | 70              | 4
+            # dag2   | task3   | 95              | 1
+            # dag2   | task1   | 85              | 2
+            # dag2   | task5   | 75              | 3
+            ranked_query = (
+                query.add_columns(
+                    func.row_number()
+                    .over(
+                        partition_by=TI.run_id,
+                        order_by=[-TI.priority_weight, DR.logical_date, TI.map_index],
                     )
-                ).subquery()
-
-                # Select only rows where row_number <= per_dag_limit.
-                query = (
-                    select(TI)
-                    .select_from(ranked_query)
-                    .join(
-                        TI,
-                        (TI.dag_id == ranked_query.c.dag_id)
-                        & (TI.task_id == ranked_query.c.task_id)
-                        & (TI.run_id == ranked_query.c.run_id)
-                        & (TI.map_index == ranked_query.c.map_index),
-                    )
-                    .where(ranked_query.c.rn <= per_dag_limit)
+                    .label("rn"),
+                    DM.max_active_tasks.label("dr_max_active_tasks"),
                 )
-            else:
-                query = query.order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
+            ).subquery()
+
+            # Select only rows where row_number <= per_dag_run_limit.
+            query = (
+                select(TI)
+                .select_from(ranked_query)
+                .join(
+                    TI,
+                    (TI.dag_id == ranked_query.c.dag_id)
+                    & (TI.task_id == ranked_query.c.task_id)
+                    & (TI.run_id == ranked_query.c.run_id)
+                    & (TI.map_index == ranked_query.c.map_index),
+                )
+                .where(ranked_query.c.rn <= ranked_query.c.dr_max_active_tasks)
+            )
 
             if starved_pools:
                 query = query.where(TI.pool.not_in(starved_pools))
@@ -703,16 +690,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     current_active_tasks_per_dag_run,
                     dag_max_active_tasks,
                 )
-                if current_active_tasks_per_dag_run >= dag_max_active_tasks:
-                    self.log.info(
-                        "Not executing %s since the number of tasks running or queued "
-                        "from DAG %s is >= to the DAG's max_active_tasks limit of %s",
-                        task_instance,
-                        dag_id,
-                        dag_max_active_tasks,
-                    )
-                    starved_dags.add(dag_id)
-                    continue
 
                 if task_instance.dag_model.has_task_concurrency_limits:
                     # Many dags don't have a task_concurrency, so where we can avoid loading the full

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -427,11 +427,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     def __print_tis_selection(self, tis: list[TI]) -> None:
         self.log.info("TaskInstance selection is: %s", dict(Counter(ti.dag_id for ti in tis)))
 
-    def __get_current_dag_concurrency(self, states: Iterable[TaskInstanceState]) -> Query:
+    def __get_current_dr_concurrency(self, states: Iterable[TaskInstanceState]) -> Query:
         return (
-            select(TI.dag_id, func.count("*").label("dag_count"))
+            select(TI.run_id, func.count("*").label("dr_count"))
             .where(TI.state.in_(states))
-            .group_by(TI.dag_id)
+            .group_by(TI.run_id)
             .subquery()
         )
 
@@ -508,7 +508,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             num_starved_tasks = len(starved_tasks)
             num_starved_tasks_task_dagrun_concurrency = len(starved_tasks_task_dagrun_concurrency)
 
-            dag_concurrency_subquery = self.__get_current_dag_concurrency(states=EXECUTION_STATES)
+            dr_concurrency_subquery = self.__get_current_dr_concurrency(states=EXECUTION_STATES)
 
             query = (
                 select(TI)
@@ -519,8 +519,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
                 .where(DM.bundle_name.is_not(None))
-                .join(dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True)
-                .where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < DM.max_active_tasks)
+                .join(dr_concurrency_subquery, TI.run_id == dr_concurrency_subquery.c.run_id, isouter=True)
+                .where(func.coalesce(dr_concurrency_subquery.c.dr_count, 0) < DM.max_active_tasks)
                 .options(selectinload(TI.dag_model))
             )
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import itertools
+import logging
 import multiprocessing
 import operator
 import os
@@ -596,11 +597,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
                 task_instances_to_examine = session.scalars(locked_query).all()
 
-                self.log.debug("Length of the tis to examine is %d", len(task_instances_to_examine))
-                self.log.debug(
-                    "TaskInstance selection is: %s",
-                    dict(Counter(ti.dag_id for ti in task_instances_to_examine)),
-                )
+                if self.log.isEnabledFor(logging.DEBUG):
+                    self.log.debug("Length of the tis to examine is %d", len(task_instances_to_examine))
+                    self.log.debug(
+                        "TaskInstance selection is: %s",
+                        dict(Counter(ti.dag_id for ti in task_instances_to_examine)),
+                    )
 
                 timer.stop(send=True)
             except OperationalError as e:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -532,17 +532,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
             )
 
-            # Create a subquery with row numbers partitioned by run_id.
-            #
-            # run_id    | task_id | priority_weight | row_num
-            # ----------|---------|-----------------|--------
-            # dag1_dr1  | task1   | 100             | 1
-            # dag1_dr1  | task22  | 90              | 2
-            # dag1_dr1  | task5   | 80              | 3
-            # dag1_dr1  | task13  | 70              | 4
-            # dag2_dr1  | task3   | 95              | 1
-            # dag2_dr1  | task1   | 85              | 2
-            # dag2_dr1  | task5   | 75              | 3
+            # Create a subquery with row numbers partitioned by dag_id and run_id.
+            # Different dags can have the same run_id but
+            # the dag_id combined with the run_id uniquely identify a run.
             ranked_query = (
                 query.add_columns(
                     func.row_number()

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -548,6 +548,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     )
                     .label("row_num"),
                     DM.max_active_tasks.label("dr_max_active_tasks"),
+                    # Create columns for the order_by checks here for sqlite.
+                    TI.priority_weight.label("priority_weight_for_ordering"),
+                    DR.logical_date.label("logical_date_for_ordering"),
+                    TI.map_index.label("map_index_for_ordering"),
                 )
             ).subquery()
 
@@ -563,6 +567,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     & (TI.map_index == ranked_query.c.map_index),
                 )
                 .where(ranked_query.c.row_num <= ranked_query.c.dr_max_active_tasks)
+                # Add the order_by columns from the ranked query for sqlite.
+                .order_by(
+                    -ranked_query.c.priority_weight_for_ordering,
+                    ranked_query.c.logical_date_for_ordering,
+                    ranked_query.c.map_index_for_ordering,
+                )
             )
 
             if starved_pools:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -513,40 +513,28 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             num_starved_tasks = len(starved_tasks)
             num_starved_tasks_task_dagrun_concurrency = len(starved_tasks_task_dagrun_concurrency)
 
+            query = (
+                select(TI)
+                .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
+                .join(TI.dag_run)
+                .where(DR.state == DagRunState.RUNNING)
+                .join(TI.dag_model)
+                .where(~DM.is_paused)
+                .where(TI.state == TaskInstanceState.SCHEDULED)
+                .where(DM.bundle_name.is_not(None))
+            )
+
             if fts_enabled:
                 dag_concurrency_subquery = self.__get_current_dag_concurrency(states=EXECUTION_STATES)
+                per_dag_limit = conf.getint("core", "max_active_tasks_per_dag")
 
-                per_dag_limit = conf.getint("core", "max_active_tasks_total_per_dag")
+                query = query.join(
+                    dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True
+                ).where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < per_dag_limit)
 
-                query = (
-                    select(TI)
-                    .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
-                    .join(TI.dag_run)
-                    .where(DR.state == DagRunState.RUNNING)
-                    .join(TI.dag_model)
-                    .where(~DM.is_paused)
-                    .where(TI.state == TaskInstanceState.SCHEDULED)
-                    .where(DM.bundle_name.is_not(None))
-                    .join(
-                        dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True
-                    )
-                    .where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < per_dag_limit)
-                    .options(selectinload(TI.dag_model))
-                    .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
-                )
-            else:
-                query = (
-                    select(TI)
-                    .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
-                    .join(TI.dag_run)
-                    .where(DR.state == DagRunState.RUNNING)
-                    .join(TI.dag_model)
-                    .where(~DM.is_paused)
-                    .where(TI.state == TaskInstanceState.SCHEDULED)
-                    .where(DM.bundle_name.is_not(None))
-                    .options(selectinload(TI.dag_model))
-                    .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
-                )
+            query = query.options(selectinload(TI.dag_model)).order_by(
+                -TI.priority_weight, DR.logical_date, TI.map_index
+            )
 
             # Fair selection will ensure task instances are selected across multiple running DAGs
             if fts_enabled:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -120,8 +120,9 @@ if TYPE_CHECKING:
     from types import FrameType
 
     from pendulum.datetime import DateTime
-    from sqlalchemy.orm import Session
+    from sqlalchemy.orm import Load, Query, Session
     from sqlalchemy.orm.interfaces import LoaderOption
+    from sqlalchemy.sql.selectable import Subquery
 
     from airflow._shared.logging.types import Logger
     from airflow.executors.base_executor import BaseExecutor
@@ -210,7 +211,7 @@ def _is_parent_process() -> bool:
     return multiprocessing.current_process().name == "MainProcess"
 
 
-def _get_current_dr_task_concurrency(states: Iterable[TaskInstanceState]) -> Query:
+def _get_current_dr_task_concurrency(states: Iterable[TaskInstanceState]) -> Subquery:
     """Get the dag_run IDs and how many tasks are in the provided states for each one."""
     return (
         select(TI.run_id, func.count("*").label("dr_count"))

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -530,15 +530,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             # Create a subquery with row numbers partitioned by run_id.
             #
-            # dag_id | task_id | priority_weight | row_num
-            # -------|---------|-----------------|--------
-            # dag1   | task1   | 100             | 1
-            # dag1   | task22  | 90              | 2
-            # dag1   | task5   | 80              | 3
-            # dag1   | task13  | 70              | 4
-            # dag2   | task3   | 95              | 1
-            # dag2   | task1   | 85              | 2
-            # dag2   | task5   | 75              | 3
+            # run_id    | task_id | priority_weight | row_num
+            # ----------|---------|-----------------|--------
+            # dag1_dr1  | task1   | 100             | 1
+            # dag1_dr1  | task22  | 90              | 2
+            # dag1_dr1  | task5   | 80              | 3
+            # dag1_dr1  | task13  | 70              | 4
+            # dag2_dr1  | task3   | 95              | 1
+            # dag2_dr1  | task1   | 85              | 2
+            # dag2_dr1  | task5   | 75              | 3
             ranked_query = (
                 query.add_columns(
                     func.row_number()

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -522,6 +522,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .join(dr_concurrency_subquery, TI.run_id == dr_concurrency_subquery.c.run_id, isouter=True)
                 .where(func.coalesce(dr_concurrency_subquery.c.dr_count, 0) < DM.max_active_tasks)
                 .options(selectinload(TI.dag_model))
+                .order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
             )
 
             # Create a subquery with row numbers partitioned by run_id.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -509,6 +509,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             num_starved_tasks = len(starved_tasks)
             num_starved_tasks_task_dagrun_concurrency = len(starved_tasks_task_dagrun_concurrency)
 
+            # This behaves the same as 'concurrency_map.load()' with the difference that
+            # 'load()' executes immediately while '_get_current_dr_task_concurrency' creates a
+            # subquery object that is then executed along with main query.
+            # The results of 'load()' aren't used again here because by the time the main query
+            # executes, there could be a change that will be ignored.
             dr_task_concurrency_subquery = _get_current_dr_task_concurrency(states=EXECUTION_STATES)
 
             query = (

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -592,7 +592,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             try:
                 locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
-                task_instances_to_examine: list[TI] = list(session.scalars(locked_query).all())
+                task_instances_to_examine = session.scalars(locked_query).all()
 
                 self.log.debug("Length of the tis to examine is %d", len(task_instances_to_examine))
                 self.log.debug(

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -526,7 +526,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             if fts_enabled:
                 dag_concurrency_subquery = self.__get_current_dag_concurrency(states=EXECUTION_STATES)
-                per_dag_limit = conf.getint("core", "max_active_tasks_per_dag")
+                per_dag_limit = conf.getint("scheduler", "fair_task_selection_limit_per_dag")
 
                 query = query.join(
                     dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True
@@ -540,15 +540,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if fts_enabled:
                 self.log.info("Scheduler fair selection is enabled")
 
-                # per_dag_limit = DM.max_active_tasks
-                per_dagrun_limit = conf.getint("core", "max_active_tasks_per_dag")
+                per_dag_limit = conf.getint("scheduler", "fair_task_selection_limit_per_dag")
 
-                self.log.info("Scheduler fair selection per dag limit is %d", per_dagrun_limit)
+                self.log.info("Scheduler fair selection per dag limit is %d", per_dag_limit)
 
                 _subquery_dm = select(DM.dag_id).where(not_(DM.is_paused)).distinct().subquery()
 
                 _subquery_lateral = lateral(
-                    query.where(TI.dag_id == _subquery_dm.c.dag_id).limit(per_dagrun_limit)
+                    query.where(TI.dag_id == _subquery_dm.c.dag_id).limit(per_dag_limit)
                 ).alias("limited")
 
                 _reduced = (

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -39,9 +39,6 @@ from sqlalchemy import (
     exists,
     func,
     inspect,
-    lateral,
-    literal_column,
-    not_,
     or_,
     select,
     text,
@@ -532,39 +529,50 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     dag_concurrency_subquery, TI.dag_id == dag_concurrency_subquery.c.dag_id, isouter=True
                 ).where(func.coalesce(dag_concurrency_subquery.c.dag_count, 0) < per_dag_limit)
 
-            query = query.options(selectinload(TI.dag_model)).order_by(
-                -TI.priority_weight, DR.logical_date, TI.map_index
-            )
+            query = query.options(selectinload(TI.dag_model))
 
-            # Fair selection will ensure task instances are selected across multiple running DAGs
             if fts_enabled:
                 self.log.info("Scheduler fair selection is enabled")
-
                 per_dag_limit = conf.getint("scheduler", "fair_task_selection_limit_per_dag")
-
                 self.log.info("Scheduler fair selection per dag limit is %d", per_dag_limit)
 
-                _subquery_dm = select(DM.dag_id).where(not_(DM.is_paused)).distinct().subquery()
+                # Create a subquery with row numbers partitioned by dag_id.
+                #
+                # dag_id | task_id | priority_weight | rn
+                # -------|---------|-----------------|----
+                # dag1   | task1   | 100             | 1
+                # dag1   | task22  | 90              | 2
+                # dag1   | task5   | 80              | 3
+                # dag1   | task13  | 70              | 4
+                # dag2   | task3   | 95              | 1
+                # dag2   | task1   | 85              | 2
+                # dag2   | task5   | 75              | 3
+                ranked_query = (
+                    query.add_columns(
+                        func.row_number()
+                        .over(
+                            partition_by=TI.dag_id,
+                            order_by=[-TI.priority_weight, DR.logical_date, TI.map_index],
+                        )
+                        .label("rn")
+                    )
+                ).subquery()
 
-                _subquery_lateral = lateral(
-                    query.where(TI.dag_id == _subquery_dm.c.dag_id).limit(per_dag_limit)
-                ).alias("limited")
-
-                _reduced = (
-                    select(_subquery_dm, _subquery_lateral)
-                    .select_from(_subquery_dm)
-                    .join(_subquery_lateral, literal_column("true"))
-                    .alias("reduced")
+                # Select only rows where row_number <= per_dag_limit.
+                query = (
+                    select(TI)
+                    .select_from(ranked_query)
+                    .join(
+                        TI,
+                        (TI.dag_id == ranked_query.c.dag_id)
+                        & (TI.task_id == ranked_query.c.task_id)
+                        & (TI.run_id == ranked_query.c.run_id)
+                        & (TI.map_index == ranked_query.c.map_index),
+                    )
+                    .where(ranked_query.c.rn <= per_dag_limit)
                 )
-
-                query = select(TI).join(
-                    _reduced,
-                    (TI.dag_id == _reduced.c.dag_id)
-                    & (TI.task_id == _reduced.c.task_id)
-                    & (TI.run_id == _reduced.c.run_id)
-                    & (TI.state == _reduced.c.state)
-                    & (TI.map_index == _reduced.c.map_index),
-                )
+            else:
+                query = query.order_by(-TI.priority_weight, DR.logical_date, TI.map_index)
 
             if starved_pools:
                 query = query.where(TI.pool.not_in(starved_pools))

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -690,6 +690,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     current_active_tasks_per_dag_run,
                     dag_max_active_tasks,
                 )
+                if current_active_tasks_per_dag_run >= dag_max_active_tasks:
+                    self.log.info(
+                        "Not executing %s since the number of tasks running or queued "
+                        "from DAG %s is >= to the DAG's max_active_tasks limit of %s",
+                        task_instance,
+                        dag_id,
+                        dag_max_active_tasks,
+                    )
+                    starved_dags.add(dag_id)
+                    continue
 
                 if task_instance.dag_model.has_task_concurrency_limits:
                     # Many dags don't have a task_concurrency, so where we can avoid loading the full
@@ -762,7 +772,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         assert executor_obj.name
 
                     if executor_slots_available[executor_obj.name] <= 0:
-                        self.log.info(
+                        self.log.debug(
                             "Not scheduling %s since its executor %s does not currently have any more "
                             "available slots",
                             task_instance.task_id,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1330,18 +1330,25 @@ class TestSchedulerJob:
             self.job_runner = SchedulerJobRunner(job=scheduler_job)
             session = settings.Session()
 
-            self.task_helper(dag_maker, session, "dag_12000_tasks", 12000)
-            self.task_helper(dag_maker, session, "dag_800_tasks", 800)
+            self.task_helper(dag_maker, session, "dag_1300_tasks", 1300)
+            self.task_helper(dag_maker, session, "dag_1200_tasks", 1200)
             self.task_helper(dag_maker, session, "dag_1100_tasks", 1100)
-
-            import time
-
-            start_time = time.perf_counter()
+            self.task_helper(dag_maker, session, "dag_1000_tasks", 100)
+            self.task_helper(dag_maker, session, "dag_900_tasks", 90)
+            self.task_helper(dag_maker, session, "dag_800_tasks", 80)
 
             count = 0
             iterations = 0
 
-            while count < 12:
+            from airflow.configuration import conf
+
+            task_num = conf.getint("core", "max_active_tasks_per_dag") * 6
+
+            # 6 dags * 4 = 24.
+            assert task_num == 24
+
+            queued_tis = None
+            while count < task_num:
                 # Use `_executable_task_instances_to_queued` because it returns a list of TIs
                 # while `_critical_section_enqueue_task_instances` just returns the number of the TIs.
                 queued_tis = self.job_runner._executable_task_instances_to_queued(
@@ -1349,17 +1356,23 @@ class TestSchedulerJob:
                 )
                 count += len(queued_tis)
                 iterations += 1
-                print(f"test: count: {count}")
-
-            duration_s = time.perf_counter() - start_time
-            print(f"test: needed iterations: {iterations} | total time: {duration_s:.2f}")
 
             if fts_enabled:
                 assert iterations == 1
-                assert count == 12
+                assert count == task_num
+
+                assert queued_tis is not None
+
+                dag_counts = Counter(ti.dag_id for ti in queued_tis)
+
+                # Tasks from all 6 dags should have been queued.
+                assert len(dag_counts) == 6
+                assert all(count == 4 for count in dag_counts.values()), (
+                    "Count for each dag_id should be 4 but it isn't"
+                )
             else:
                 assert iterations >= 2
-                assert count >= 12
+                assert count >= task_num
 
     def test_find_executable_task_instances_order_priority_with_pools(self, dag_maker):
         """

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1425,9 +1425,14 @@ class TestSchedulerJob:
 
         # Tasks from all 6 dags should have been queued.
         assert len(dag_counts) == 6
-        assert all(count == 4 for count in dag_counts.values()), (
-            "Count for each dag_id should be 4 but it isn't"
-        )
+        assert dag_counts == {
+            "dag_1300_tasks": 4,
+            "dag_1200_tasks": 4,
+            "dag_1100_tasks": 4,
+            "dag_100_tasks": 4,
+            "dag_90_tasks": 4,
+            "dag_80_tasks": 4,
+        }, "Count for each dag_id should be 4 but it isn't"
 
     def test_find_executable_task_instances_order_priority_with_pools(self, dag_maker):
         """

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1308,8 +1308,9 @@ class TestSchedulerJob:
             ("scheduler", "max_tis_per_query"): "100",
             ("scheduler", "max_dagruns_to_create_per_loop"): "10",
             ("scheduler", "max_dagruns_per_loop_to_schedule"): "20",
+            ("scheduler", "fair_task_selection_limit_per_dag"): "4",
             ("core", "parallelism"): "100",
-            ("core", "max_active_tasks_per_dag"): "4",
+            ("core", "max_active_tasks_per_dag"): "2",
             ("core", "max_active_runs_per_dag"): "10",
             ("core", "default_pool_task_slot_count"): "64",
         }
@@ -1342,7 +1343,7 @@ class TestSchedulerJob:
 
             from airflow.configuration import conf
 
-            task_num = conf.getint("core", "max_active_tasks_per_dag") * 6
+            task_num = conf.getint("scheduler", "fair_task_selection_limit_per_dag") * 6
 
             # 6 dags * 4 = 24.
             assert task_num == 24

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -200,6 +200,39 @@ def create_dagrun(session):
     return _create_dagrun
 
 
+def task_maker(dag_maker, session, dag_id: str, task_num: int, max_active_tasks: int):
+    dag_tasks = {}
+
+    with dag_maker(dag_id=dag_id):
+        for i in range(task_num):
+            # Assign priority weight to certain tasks.
+            if (i % 10) == 0:  # 10, 20, 30, 40, 50, ...
+                weight = int(i / 2)
+                dag_tasks[f"op{i}"] = EmptyOperator(task_id=f"dummy{i}", priority_weight=weight)
+            else:
+                # No executor specified, runs on default executor
+                dag_tasks[f"op{i}"] = EmptyOperator(task_id=f"dummy{i}")
+
+    # 'logical_date' is used to create the 'run_id'. Set it to 'now', in order to get distinct run ids.
+    dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, logical_date=timezone.utcnow())
+
+    task_tis = {}
+
+    tis_list = []
+    for i in range(task_num):
+        task_tis[f"ti{i}"] = dag_run.get_task_instance(dag_tasks[f"op{i}"].task_id, session)
+        # add
+        tis_list.append(task_tis[f"ti{i}"])
+
+    for ti in tis_list:
+        ti.state = State.SCHEDULED
+        ti.dag_model.max_active_tasks = max_active_tasks
+
+    session.flush()
+
+    return tis_list
+
+
 def _clean_db():
     clear_db_dags()
     clear_db_runs()
@@ -211,6 +244,26 @@ def _clean_db():
     clear_db_deadline()
     clear_db_callbacks()
     clear_db_triggers()
+
+
+@patch.dict(
+    ExecutorLoader.executors, {MOCK_EXECUTOR: f"{MockExecutor.__module__}.{MockExecutor.__qualname__}"}
+)
+@pytest.mark.usefixtures("disable_load_example")
+@pytest.mark.need_serialized_dag
+class TestSchedulerJob:
+    @staticmethod
+    def clean_db():
+        clear_db_dags()
+        clear_db_runs()
+        clear_db_backfills()
+        clear_db_pools()
+        clear_db_import_errors()
+        clear_db_jobs()
+        clear_db_assets()
+        clear_db_deadline()
+        clear_db_callbacks()
+        clear_db_triggers()
 
 
 @patch.dict(
@@ -1308,72 +1361,59 @@ class TestSchedulerJob:
             ("scheduler", "max_tis_per_query"): "100",
             ("scheduler", "max_dagruns_to_create_per_loop"): "10",
             ("scheduler", "max_dagruns_per_loop_to_schedule"): "20",
-            ("scheduler", "fair_task_selection_limit_per_dag"): "4",
             ("core", "parallelism"): "100",
-            ("core", "max_active_tasks_per_dag"): "2",
+            ("core", "max_active_tasks_per_dag"): "4",
             ("core", "max_active_runs_per_dag"): "10",
             ("core", "default_pool_task_slot_count"): "64",
         }
     )
-    @pytest.mark.parametrize(
-        "fts_enabled",
-        [pytest.param(True, id="fts_enabled"), pytest.param(False, id="fts_disabled")],
-    )
-    def test_fair_task_selection(self, dag_maker, mock_executors, fts_enabled: bool):
-        """
-        Test with and without FairTaskSelection.
-        """
-        with conf_vars({("scheduler", "enable_fair_task_selection"): str(fts_enabled)}):
-            scheduler_job = Job()
-            scheduler_job.executor.parallelism = 100
-            scheduler_job.executor.slots_available = 70
-            scheduler_job.max_tis_per_query = 100
-            self.job_runner = SchedulerJobRunner(job=scheduler_job)
-            session = settings.Session()
+    def test_per_dr_limit_during_task_queueing(self, dag_maker, mock_executors):
+        scheduler_job = Job()
+        scheduler_job.executor.parallelism = 100
+        scheduler_job.executor.slots_available = 70
+        scheduler_job.max_tis_per_query = 100
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        session = settings.Session()
 
-            self.task_helper(dag_maker, session, "dag_1300_tasks", 1300)
-            self.task_helper(dag_maker, session, "dag_1200_tasks", 1200)
-            self.task_helper(dag_maker, session, "dag_1100_tasks", 1100)
-            self.task_helper(dag_maker, session, "dag_1000_tasks", 100)
-            self.task_helper(dag_maker, session, "dag_900_tasks", 90)
-            self.task_helper(dag_maker, session, "dag_800_tasks", 80)
+        task_maker(dag_maker, session, "dag_1300_tasks", 1300, 4)
+        task_maker(dag_maker, session, "dag_1200_tasks", 1200, 4)
+        task_maker(dag_maker, session, "dag_1100_tasks", 1100, 4)
+        task_maker(dag_maker, session, "dag_1000_tasks", 100, 4)
+        task_maker(dag_maker, session, "dag_900_tasks", 90, 4)
+        task_maker(dag_maker, session, "dag_800_tasks", 80, 4)
 
-            count = 0
-            iterations = 0
+        count = 0
+        iterations = 0
 
-            from airflow.configuration import conf
+        from airflow.configuration import conf
 
-            task_num = conf.getint("scheduler", "fair_task_selection_limit_per_dag") * 6
+        task_num = conf.getint("core", "max_active_tasks_per_dag") * 6
 
-            # 6 dags * 4 = 24.
-            assert task_num == 24
+        # 6 dags * 4 = 24.
+        assert task_num == 24
 
-            queued_tis = None
-            while count < task_num:
-                # Use `_executable_task_instances_to_queued` because it returns a list of TIs
-                # while `_critical_section_enqueue_task_instances` just returns the number of the TIs.
-                queued_tis = self.job_runner._executable_task_instances_to_queued(
-                    max_tis=scheduler_job.executor.slots_available, session=session
-                )
-                count += len(queued_tis)
-                iterations += 1
+        queued_tis = None
+        while count < task_num:
+            # Use `_executable_task_instances_to_queued` because it returns a list of TIs
+            # while `_critical_section_enqueue_task_instances` just returns the number of the TIs.
+            queued_tis = self.job_runner._executable_task_instances_to_queued(
+                max_tis=scheduler_job.executor.slots_available, session=session
+            )
+            count += len(queued_tis)
+            iterations += 1
 
-            if fts_enabled:
-                assert iterations == 1
-                assert count == task_num
+        assert iterations == 1
+        assert count == task_num
 
-                assert queued_tis is not None
+        assert queued_tis is not None
 
-                dag_counts = Counter(ti.dag_id for ti in queued_tis)
+        dag_counts = Counter(ti.dag_id for ti in queued_tis)
 
-                # Tasks from all 6 dags should have been queued.
-                assert len(dag_counts) == 6
-                assert all(count == 4 for count in dag_counts.values()), (
-                    "Count for each dag_id should be 4 but it isn't"
-                )
-            else:
-                assert iterations >= 2
-                assert count >= task_num
+        # Tasks from all 6 dags should have been queued.
+        assert len(dag_counts) == 6
+        assert all(count == 4 for count in dag_counts.values()), (
+            "Count for each dag_id should be 4 but it isn't"
+        )
 
     def test_find_executable_task_instances_order_priority_with_pools(self, dag_maker):
         """

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -208,7 +208,7 @@ def task_maker(
     with dag_maker(dag_id=dag_id):
         for i in range(task_num):
             # Assign priority weight to certain tasks.
-            if (i % 10) == 0:  # 10, 20, 30, 40, 50, ...
+            if (i % 10) == 0:  # 0, 10, 20, 30, 40, 50, ...
                 weight = int(i / 2)
                 dag_tasks[f"op{i}"] = EmptyOperator(task_id=f"dummy{i}", priority_weight=weight)
             else:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1272,6 +1272,95 @@ class TestSchedulerJob:
         ]
         assert len(b_tis_in_wrong_executor) == 0
 
+    def task_helper(self, dag_maker, session, dag_id: str, task_num: int):
+        dag_tasks = {}
+
+        with dag_maker(dag_id=dag_id):
+            for i in range(task_num):
+                # Assign priority weight to certain tasks.
+                if (i % 10) == 0:  # 10, 20, 30, 40, 50, ...
+                    weight = int(i / 2)
+                    dag_tasks[f"op{i}"] = EmptyOperator(task_id=f"dummy{i}", priority_weight=weight)
+                else:
+                    # No executor specified, runs on default executor
+                    dag_tasks[f"op{i}"] = EmptyOperator(task_id=f"dummy{i}")
+
+        dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
+
+        task_tis = {}
+
+        tis_list = []
+        for i in range(task_num):
+            task_tis[f"ti{i}"] = dag_run.get_task_instance(dag_tasks[f"op{i}"].task_id, session)
+            # add
+            tis_list.append(task_tis[f"ti{i}"])
+
+        for ti in tis_list:
+            ti.state = State.SCHEDULED
+            ti.dag_model.max_active_tasks = 4
+
+        session.flush()
+
+        return tis_list
+
+    @conf_vars(
+        {
+            ("scheduler", "max_tis_per_query"): "100",
+            ("scheduler", "max_dagruns_to_create_per_loop"): "10",
+            ("scheduler", "max_dagruns_per_loop_to_schedule"): "20",
+            ("core", "parallelism"): "100",
+            ("core", "max_active_tasks_per_dag"): "4",
+            ("core", "max_active_runs_per_dag"): "10",
+            ("core", "default_pool_task_slot_count"): "64",
+        }
+    )
+    @pytest.mark.parametrize(
+        "fts_enabled",
+        [pytest.param(True, id="fts_enabled"), pytest.param(False, id="fts_disabled")],
+    )
+    def test_fair_task_selection(self, dag_maker, mock_executors, fts_enabled: bool):
+        """
+        Test with and without FairTaskSelection.
+        """
+        with conf_vars({("scheduler", "enable_fair_task_selection"): str(fts_enabled)}):
+            scheduler_job = Job()
+            scheduler_job.executor.parallelism = 100
+            scheduler_job.executor.slots_available = 70
+            scheduler_job.max_tis_per_query = 100
+            self.job_runner = SchedulerJobRunner(job=scheduler_job)
+            session = settings.Session()
+
+            self.task_helper(dag_maker, session, "dag_12000_tasks", 12000)
+            self.task_helper(dag_maker, session, "dag_800_tasks", 800)
+            self.task_helper(dag_maker, session, "dag_1100_tasks", 1100)
+
+            import time
+
+            start_time = time.perf_counter()
+
+            count = 0
+            iterations = 0
+
+            while count < 12:
+                # Use `_executable_task_instances_to_queued` because it returns a list of TIs
+                # while `_critical_section_enqueue_task_instances` just returns the number of the TIs.
+                queued_tis = self.job_runner._executable_task_instances_to_queued(
+                    max_tis=scheduler_job.executor.slots_available, session=session
+                )
+                count += len(queued_tis)
+                iterations += 1
+                print(f"test: count: {count}")
+
+            duration_s = time.perf_counter() - start_time
+            print(f"test: needed iterations: {iterations} | total time: {duration_s:.2f}")
+
+            if fts_enabled:
+                assert iterations == 1
+                assert count == 12
+            else:
+                assert iterations >= 2
+                assert count >= 12
+
     def test_find_executable_task_instances_order_priority_with_pools(self, dag_maker):
         """
         The scheduler job should pick tasks with higher priority for execution

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1378,9 +1378,9 @@ class TestSchedulerJob:
         task_maker(dag_maker, session, "dag_1300_tasks", 1300, 4)
         task_maker(dag_maker, session, "dag_1200_tasks", 1200, 4)
         task_maker(dag_maker, session, "dag_1100_tasks", 1100, 4)
-        task_maker(dag_maker, session, "dag_1000_tasks", 100, 4)
-        task_maker(dag_maker, session, "dag_900_tasks", 90, 4)
-        task_maker(dag_maker, session, "dag_800_tasks", 80, 4)
+        task_maker(dag_maker, session, "dag_100_tasks", 100, 4)
+        task_maker(dag_maker, session, "dag_90_tasks", 90, 4)
+        task_maker(dag_maker, session, "dag_80_tasks", 80, 4)
 
         count = 0
         iterations = 0

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -221,7 +221,7 @@ def task_maker(dag_maker, session, dag_id: str, task_num: int, max_active_tasks:
     tis_list = []
     for i in range(task_num):
         task_tis[f"ti{i}"] = dag_run.get_task_instance(dag_tasks[f"op{i}"].task_id, session)
-        # add
+        # Add to the list.
         tis_list.append(task_tis[f"ti{i}"])
 
     for ti in tis_list:
@@ -1367,7 +1367,7 @@ class TestSchedulerJob:
             ("core", "default_pool_task_slot_count"): "64",
         }
     )
-    def test_per_dr_limit_during_task_queueing(self, dag_maker, mock_executors):
+    def test_per_dr_limit_applied_in_task_query(self, dag_maker, mock_executors):
         scheduler_job = Job()
         scheduler_job.executor.parallelism = 100
         scheduler_job.executor.slots_available = 70

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1719,7 +1719,7 @@ class TestSchedulerJob:
         session.merge(t1)
         session.merge(t2)
         session.merge(t3)
-        # set 1 ti from dr1 to running
+        # set 1 ti from dr2 to running
         # one can be queued
         t1, t2, t3 = dr2.get_task_instances(session=session)
         t1.state = active_state
@@ -1728,7 +1728,7 @@ class TestSchedulerJob:
         session.merge(t1)
         session.merge(t2)
         session.merge(t3)
-        # set 0 tis from dr1 to running
+        # set 0 tis from dr3 to running
         # two can be queued
         t1, t2, t3 = dr3.get_task_instances(session=session)
         t1.state = State.SCHEDULED


### PR DESCRIPTION
Related discussion: https://lists.apache.org/thread/62nd3jkbk8znosx2yrcqzrw9ycj0ddwo

The goal of this PR is to increase scheduler throughput.

During queueing tasks, the steps are
1. the scheduler picks a number of SCHEDULED tasks to examine from the db (`max_tis_per_query`)
2. it applies checks on the retrieved tasks, to see if it can queue them
3. it checks if there are available pool slots
4. it checks if the dag run concurrency limits have been reached or crossed (`max_active_tasks_per_dag`)

If the dag_runs on top of the line, have already reached the number of `max_active_tasks_per_dag`, the scheduler won't be able to queue any more tasks. In that case, it will have to execute another db query to retrieve tasks from the next dag_run.

This inefficiency might not make any noticeable difference when there isn't load on the system, but when you have many large dags, or even a few very large ones, the performance drop in the scheduler and workers throughput is significant.

We already know in advance the `max_active_tasks` limit. By including it in the initial query, we don't retrieve more tasks than we can actually queue for a dag run. That way the query will only pick tasks that can be queued and if we are on the limit for a dag_run, it will move to the next one (by priority order). This multiplies throughput by 5-6 times more than before.

I've adjusted the changes so that the patch maintains the way that the scheduler has behaved up until now. All the existing scheduler tests are passing without modifications.

To make the changes more clear, let me provide an example with numbers
* `max_tis_per_query` is 50
* we have 6 dag runs with 100 tasks each
* `max_active_tasks_per_dag` is 10
* we have enough pool slots, e.g. 100

The initial approach
* it would concentrate on the first 3 dag runs
* the query will pick 50 tasks
* task selection would be something like 25 from dag1, 15 from dag2, 10 from dag3
* it can queue 10 tasks from each dag run
* total tasks queued for the iteration are 30

The new approach
* the query will pick 50 tasks
* it can queue 10 tasks from each dag and so it will pick only 10 tasks from every dag until it reaches 50
* task selection will be 10 from dag1, 10 from dag2, 10 from dag3, 10 from dag4, 10 from dag5
* total tasks queued for the iteration are 50


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
