### PR TITLE
Fix: make samba hook open_file method return

### DIFF
--- a/providers/samba/src/airflow/providers/samba/hooks/samba.py
+++ b/providers/samba/src/airflow/providers/samba/hooks/samba.py
@@ -128,7 +128,7 @@ class SambaHook(BaseHook):
         file_attributes=None,
         file_type="file",
     ):
-        self._open_file(
+        return self._open_file(
             path,
             mode,
             buffering,

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -166,3 +166,21 @@ class TestSambaHook:
         get_conn_mock.return_value = CONNECTION
         hook = SambaHook("samba_default")
         assert hook._join_path(path) == full_path
+
+    @mock.patch("airflow.providers.samba.hooks.samba.smbclient.open_file", return_value=mock.Mock())
+    @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
+    def test_open_file(self, get_conn_mock, open_file_mock):
+        CONNECTION = Connection(
+            host="ip",
+            schema="share",
+            login="username",
+            password="password",
+        )
+
+        get_conn_mock.return_value = CONNECTION
+        samba_hook = SambaHook("samba_default")
+        path = "test_file.txt"
+        mode = "wb"
+        result = samba_hook.open_file(path, mode=mode)
+        assert result is not None, "open_file method returned None"
+        assert hasattr(result, "write"), f"Error: {result} does not have a 'write' method"


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/54104

This was return type missed part of update https://github.com/apache/airflow/pull/53113/files
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
