### PR TITLE
Enhanced Pod Failure Logging in KubernetesExecutor 

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from unittest.mock import Mock, patch
+
 import pytest
 
 from kubernetes_tests.test_base import (
@@ -102,3 +104,125 @@ class TestKubernetesExecutor(BaseK8STest):
         )
 
         assert self._num_pods_in_namespace("test-namespace") == 0, "failed to delete pods in other namespace"
+
+    @pytest.mark.execution_timeout(300)
+    @patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.log")
+    def test_pod_failure_logging_with_container_terminated(self, mock_log):
+        """Test that pod failure information is logged when container is terminated."""
+
+        from airflow.models.taskinstancekey import TaskInstanceKey
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import KubernetesExecutor
+        from airflow.utils.state import TaskInstanceState
+
+        # Create a mock KubernetesExecutor instance
+        executor = KubernetesExecutor()
+        executor.kube_client = Mock()
+        executor.kube_scheduler = Mock()
+
+        # Create mock pod status with terminated container
+        mock_container_state = Mock()
+        mock_container_state.terminated = Mock()
+        mock_container_state.terminated.reason = "Error"
+        mock_container_state.terminated.message = "Container failed with exit code 1"
+        mock_container_state.waiting = None
+
+        mock_container_status = Mock()
+        mock_container_status.state = mock_container_state
+
+        mock_pod_status = Mock()
+        mock_pod_status.phase = "Failed"
+        mock_pod_status.reason = "PodFailed"
+        mock_pod_status.message = "Pod execution failed"
+        mock_pod_status.container_statuses = [mock_container_status]
+
+        mock_pod = Mock()
+        mock_pod.status = mock_pod_status
+
+        executor.kube_client.read_namespaced_pod.return_value = mock_pod
+
+        # Create a test task key
+        task_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
+
+        # Call _change_state with FAILED status
+        executor._change_state(
+            key=task_key, state=TaskInstanceState.FAILED, pod_name="test-pod", namespace="test-namespace"
+        )
+
+        # Verify that the error log was called with expected parameters
+        mock_log.error.assert_called_once_with(
+            "Pod %s in namespace %s failed. Pod phase: %s, reason: %s, message: %s, container_state: %s, container_reason: %s, container_message: %s",
+            "test-pod",
+            "test-namespace",
+            "Failed",
+            "PodFailed",
+            "Pod execution failed",
+            "terminated",
+            "Error",
+            "Container failed with exit code 1",
+        )
+
+    @pytest.mark.execution_timeout(300)
+    @patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.log")
+    def test_pod_failure_logging_exception_handling(self, mock_log):
+        """Test that exceptions during pod status retrieval are handled gracefully."""
+        from kubernetes.client.rest import ApiException
+
+        from airflow.models.taskinstancekey import TaskInstanceKey
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import KubernetesExecutor
+        from airflow.utils.state import TaskInstanceState
+
+        # Create a mock KubernetesExecutor instance
+        executor = KubernetesExecutor()
+        executor.kube_client = Mock()
+        executor.kube_scheduler = Mock()
+
+        # Make read_namespaced_pod raise an exception
+        executor.kube_client.read_namespaced_pod.side_effect = ApiException(status=404, reason="Not Found")
+
+        # Create a test task key
+        task_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
+
+        # Call _change_state with FAILED status
+        executor._change_state(
+            key=task_key, state=TaskInstanceState.FAILED, pod_name="test-pod", namespace="test-namespace"
+        )
+
+        # Verify that the warning log was called with the correct parameters
+        mock_log.warning.assert_called_once()
+        call_args = mock_log.warning.call_args[0]
+        assert call_args[0] == "Failed to fetch pod failure reason for %s/%s: %s"
+        assert call_args[1] == "test-namespace"
+        assert call_args[2] == "test-pod"
+        # The third argument should be the exception
+        assert isinstance(call_args[3], ApiException)
+
+        # Verify that error log was not called
+        mock_log.error.assert_not_called()
+
+    @pytest.mark.execution_timeout(300)
+    @patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.log")
+    def test_pod_failure_logging_non_failed_state(self, mock_log):
+        """Test that pod failure logging only occurs for FAILED state."""
+        from airflow.models.taskinstancekey import TaskInstanceKey
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import KubernetesExecutor
+        from airflow.utils.state import TaskInstanceState
+
+        # Create a mock KubernetesExecutor instance
+        executor = KubernetesExecutor()
+        executor.kube_client = Mock()
+        executor.kube_scheduler = Mock()
+
+        # Create a test task key
+        task_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
+
+        # Call _change_state with SUCCESS status
+        executor._change_state(
+            key=task_key, state=TaskInstanceState.SUCCESS, pod_name="test-pod", namespace="test-namespace"
+        )
+
+        # Verify that no failure logs were called
+        mock_log.error.assert_not_called()
+        mock_log.warning.assert_not_called()
+
+        # Verify that kube_client methods were not called
+        executor.kube_client.read_namespaced_pod.assert_not_called()

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -16,9 +16,25 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 ADOPTED = "adopted"
+
+
+class FailureDetails(TypedDict, total=False):
+    """Detailed information about pod/container failure."""
+
+    pod_status: str | None
+    pod_reason: str | None
+    pod_message: str | None
+    container_state: str | None
+    container_reason: str | None
+    container_message: str | None
+    exit_code: int | None
+    container_type: str | None  # "init" or "main"
+    container_name: str | None
+
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -33,12 +49,12 @@ if TYPE_CHECKING:
 
     # key, pod state, pod_name, namespace, resource_version, failure_details
     KubernetesResultsType = tuple[
-        TaskInstanceKey, TaskInstanceState | str | None, str, str, str, dict[str, Any] | None
+        TaskInstanceKey, TaskInstanceState | str | None, str, str, str, FailureDetails | None
     ]
 
     # pod_name, namespace, pod state, annotations, resource_version, failure_details
     KubernetesWatchType = tuple[
-        str, str, TaskInstanceState | str | None, dict[str, str], str, dict[str, Any] | None
+        str, str, TaskInstanceState | str | None, dict[str, str], str, FailureDetails | None
     ]
 
 ALL_NAMESPACES = "ALL_NAMESPACES"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -31,11 +31,15 @@ if TYPE_CHECKING:
     # TaskInstance key, command, configuration, pod_template_file
     KubernetesJobType = tuple[TaskInstanceKey, CommandType, Any, str | None]
 
-    # key, pod state, pod_name, namespace, resource_version
-    KubernetesResultsType = tuple[TaskInstanceKey, TaskInstanceState | str | None, str, str, str]
+    # key, pod state, pod_name, namespace, resource_version, failure_details
+    KubernetesResultsType = tuple[
+        TaskInstanceKey, TaskInstanceState | str | None, str, str, str, dict[str, Any] | None
+    ]
 
-    # pod_name, namespace, pod state, annotations, resource_version
-    KubernetesWatchType = tuple[str, str, TaskInstanceState | str | None, dict[str, str], str]
+    # pod_name, namespace, pod state, annotations, resource_version, failure_details
+    KubernetesWatchType = tuple[
+        str, str, TaskInstanceState | str | None, dict[str, str], str, dict[str, Any] | None
+    ]
 
 ALL_NAMESPACES = "ALL_NAMESPACES"
 POD_EXECUTOR_DONE_KEY = "airflow_executor_done"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 ADOPTED = "adopted"
 
@@ -31,7 +31,7 @@ class FailureDetails(TypedDict, total=False):
     container_reason: str | None
     container_message: str | None
     exit_code: int | None
-    container_type: str | None  # "init" or "main"
+    container_type: Literal["init", "main"] | None
     container_name: str | None
 
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -21,7 +21,7 @@ import json
 import multiprocessing
 import time
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from kubernetes import client, watch
 from kubernetes.client.rest import ApiException
@@ -406,7 +406,9 @@ def collect_pod_failure_details(pod: k8s.V1Pod) -> FailureDetails | None:
         }
 
 
-def _analyze_containers(container_statuses: list | None, container_type: str) -> FailureDetails | None:
+def _analyze_containers(
+    container_statuses: list[k8s.V1ContainerStatus] | None, container_type: Literal["init", "main"]
+) -> FailureDetails | None:
     """Analyze container statuses for failure details."""
     if not container_statuses:
         return None

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -53,7 +53,7 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     get_logs_task_metadata,
 )
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.utils import timezone
+from airflow.utils import timezone  # type: ignore[attr-defined]
 from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
@@ -675,7 +675,7 @@ class TestKubernetesExecutor:
         executor = self.kubernetes_executor
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number1")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=1)
             executor.running = {key}
             executor._change_state(key, State.RUNNING, "pod_name", "default")
             assert executor.event_buffer[key][0] == State.RUNNING
@@ -693,7 +693,7 @@ class TestKubernetesExecutor:
         executor = self.kubernetes_executor
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number2")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
             executor._change_state(key, State.SUCCESS, "pod_name", "default")
             assert executor.event_buffer[key][0] == State.SUCCESS
@@ -718,7 +718,7 @@ class TestKubernetesExecutor:
         executor.kube_config.delete_worker_pods_on_failure = False
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number3")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=3)
             executor.running = {key}
             executor._change_state(key, State.FAILED, "pod_id", "test-namespace")
             assert executor.event_buffer[key][0] == State.FAILED
@@ -769,7 +769,7 @@ class TestKubernetesExecutor:
         executor = self.kubernetes_executor
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number2")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
             executor._change_state(key, ADOPTED, "pod_name", "default")
             assert len(executor.event_buffer) == 0
@@ -785,7 +785,7 @@ class TestKubernetesExecutor:
         executor = self.kubernetes_executor
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number1")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=1)
             executor.running = set()
             executor._change_state(key, State.SUCCESS, "pod_name", "default")
             assert executor.event_buffer.get(key) is None
@@ -833,7 +833,7 @@ class TestKubernetesExecutor:
 
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number2")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
             executor._change_state(key, State.SUCCESS, "pod_name", "test-namespace")
             assert executor.event_buffer[key][0] == State.SUCCESS
@@ -859,7 +859,7 @@ class TestKubernetesExecutor:
 
         executor.start()
         try:
-            key = ("dag_id", "task_id", "run_id", "try_number2")
+            key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
             executor._change_state(key, State.FAILED, "pod_name", "test-namespace")
             assert executor.event_buffer[key][0] == State.FAILED
@@ -1483,6 +1483,7 @@ class TestKubernetesJobWatcher:
                 state,
                 self.core_annotations,
                 self.pod.metadata.resource_version,
+                mock.ANY,  # failure_details can be any value including None
             )
         )
 
@@ -1719,6 +1720,7 @@ class TestKubernetesJobWatcher:
                 ADOPTED,
                 self.core_annotations,
                 self.pod.metadata.resource_version,
+                None,  # failure_details is None for ADOPTED state
             )
         )
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -53,7 +53,12 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     get_logs_task_metadata,
 )
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.utils import timezone  # type: ignore[attr-defined]
+
+try:
+    from airflow.sdk import timezone
+except ImportError:
+    # Fallback for older Airflow location where timezone is in utils
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

## Description
Add detailed logging of pod and container failure information when tasks fail, including pod phase, reasons, messages, and container states for better debugging.

## Problem Statement
When tasks fail in KubernetesExecutor, operators often lack sufficient information to quickly diagnose the root cause of failures. The current implementation provides minimal failure context, making troubleshooting time-consuming and inefficient.

## Solution
Introduced comprehensive logging for pod and container failure states, capturing detailed error information to streamline debugging.

## Changes Made
Core Implementation
- Enhanced `_change_state` method in `KubernetesExecutor`
- Added pod status extraction using `kube_client.read_namespaced_pod()`
- Implemented container state analysis for terminated and waiting states
- Added graceful exception handling for Kubernetes API failures

Closes: #37548 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
