### PR TITLE
clarify priority_weight behaviour

### DIFF
--- a/airflow-core/docs/administration-and-deployment/priority-weight.rst
+++ b/airflow-core/docs/administration-and-deployment/priority-weight.rst
@@ -21,7 +21,8 @@ Priority Weights
 ================
 
 ``priority_weight`` defines priorities in the executor queue. The default ``priority_weight`` is ``1``, and can be
-bumped to any integer. Moreover, each task has a true ``priority_weight`` that is calculated based on its
+bumped to any integer; larger numbers mean higher priority.
+Moreover, each task has a true ``priority_weight`` that is calculated based on its
 ``weight_rule`` which defines the weighting method used for the effective total priority weight of the task.
 
 Below are the weighting methods. By default, Airflow's weighting method is ``downstream``.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Maybe I am just dumb, but it's not clear to me just from reading the docs if a priority weight of `100` is higher or lower than a priority weight of `10`. It sounds like 100 is supposed to mean _more important_ than 10?

Compare e.g. your company may have an internal incident escalation framework, the most important issues might be called "P1" or "SEV0"/"SEV1", less critical issues a "P2"/"P3"/"SEV3" etc. Or for example the U.S. DEFCON levels, 5 being the lowest level, 1 being the highest.

To be clear, I am _not_ suggesting changing the semantics here; I just want the docs to be very explicit about what the priority weight means.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
