### PR TITLE
Fix set data_interval to logical_date when triggering DAG run

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -69,7 +69,6 @@ def _trigger_dag(
     if (dag := dag_bag.get_latest_version_of_dag(dag_id, session=session)) is None:
         raise DagNotFound(f"Dag id {dag_id} not found")
 
-    run_after = run_after or timezone.coerce_datetime(timezone.utcnow())
     coerced_logical_date: datetime | None = None
     if logical_date:
         if not timezone.is_localized(logical_date):
@@ -87,11 +86,12 @@ def _trigger_dag(
                 )
         coerced_logical_date = timezone.coerce_datetime(logical_date)
         data_interval: DataInterval | None = dag.timetable.infer_manual_data_interval(
-            run_after=timezone.coerce_datetime(run_after)
+            run_after=coerced_logical_date
         )
     else:
         data_interval = None
 
+    run_after = run_after or timezone.coerce_datetime(timezone.utcnow())
     run_id = run_id or DagRun.generate_run_id(
         run_type=DagRunType.MANUAL,
         logical_date=coerced_logical_date,


### PR DESCRIPTION
In Airflow 2, the data_interval was set to logical_date (execution_date) when triggering a DAG run.
In Airflow 3, the current data_interval is set to run_after, which causes issues when using data_interval_end.
This commit addresses this problem.

For reference, the code in Airflow 2 looked like this: 
<img width="747" height="70" alt="스크린샷 2025-08-05 오후 4 51 12" src="https://github.com/user-attachments/assets/65ed958e-2e03-4448-a4c4-fb79dda0b3ef" />
