### PR TITLE
fix count of versions behind in constraints-version-check

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
@@ -88,10 +88,14 @@ def count_versions_between(releases: dict[str, Any], current_version: str, lates
     if current == latest:
         return 0
 
-    valid_versions = [
-        v for v in releases.keys() if releases[v] and is_valid_version(version_str=v, latest_version=latest)
+    versions_between = [
+        v
+        for v in releases.keys()
+        if releases[v]
+        and is_valid_version(version_str=v, latest_version=latest)
+        and current < version.parse(v) <= latest
     ]
-    return max(len(valid_versions), 1) if current < latest else 0
+    return len(versions_between)
 
 
 def get_status_emoji(constraint_date, latest_date, is_latest_version):


### PR DESCRIPTION
This fixes wrong output of Version Behind count.

Example https://pypi.org/project/flask-babel/#history
we have version 2.0.0
versions released since are 3.0.0 3.0.1 3.1.0 4.0.0
so the column should show 4 


Before:
<img width="1527" height="622" alt="Screenshot 2025-08-05 at 11 06 17" src="https://github.com/user-attachments/assets/e20a0c48-70a0-4273-ac24-c079b38dc22e" />


After:
<img width="1534" height="572" alt="Screenshot 2025-08-05 at 11 10 51" src="https://github.com/user-attachments/assets/28c8ff2a-e6e0-48ff-b3e0-967b6af8df09" />
