### PR TITLE
AIP-68 Add dashboard destination for ReactApp plugins

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -227,7 +227,8 @@ definitions in Airflow.
         "bundle_url": "https://example.com/static/js/my_react_app.js",
         # Destination of the react app. This is used to determine where the app will be loaded in the UI.
         # Supported locations are Literal["nav", "dag", "dag_run", "task", "task_instance"], default to "nav".
-        # It can also be put inside of an existing page, the supported views are ["dashboard", "dag_overview", "task_overview"]
+        # It can also be put inside of an existing page, the supported views are ["dashboard", "dag_overview", "task_overview"]. You can position
+        # element in the existing page via the css `order` rule which will determine the flex order.
         "destination": "dag_run",
         # Optional icon, url to an svg file.
         "icon": "https://example.com/icon.svg",

--- a/airflow-core/docs/howto/custom-view-plugin.rst
+++ b/airflow-core/docs/howto/custom-view-plugin.rst
@@ -143,7 +143,7 @@ Create an Airflow plugin that serves your React application:
             {
                 "name": "My Awesome React App",
                 "url_route": "my-awesome-app",
-                "bundle_url": "http://localhost:28080/my-plugin/my-react-app/main.umd.cjs",
+                "bundle_url": "https://airflow-domain/my-plugin/my-react-app/main.umd.cjs",
                 "destination": "nav",
             }
         ]

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/plugins.py
@@ -69,6 +69,9 @@ class AppBuilderMenuItemResponse(BaseModel):
     category: str | None = None
 
 
+BaseDestinationLiteral = Literal["nav", "dag", "dag_run", "task", "task_instance"]
+
+
 class BaseUIResponse(BaseModel):
     """Base serializer for UI Plugin responses."""
 
@@ -79,7 +82,6 @@ class BaseUIResponse(BaseModel):
     icon_dark_mode: str | None = None
     url_route: str | None = None
     category: str | None = None
-    destination: Literal["nav", "dag", "dag_run", "task", "task_instance"] = "nav"
 
 
 class ExternalViewResponse(BaseUIResponse):
@@ -88,6 +90,7 @@ class ExternalViewResponse(BaseUIResponse):
     model_config = ConfigDict(extra="allow")
 
     href: str
+    destination: BaseDestinationLiteral = "nav"
 
 
 class ReactAppResponse(BaseUIResponse):
@@ -96,6 +99,7 @@ class ReactAppResponse(BaseUIResponse):
     model_config = ConfigDict(extra="allow")
 
     bundle_url: str
+    destination: Literal[BaseDestinationLiteral, "dashboard"] = "nav"
 
 
 class PluginResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -10119,6 +10119,9 @@ components:
           - type: string
           - type: 'null'
           title: Category
+        href:
+          type: string
+          title: Href
         destination:
           type: string
           enum:
@@ -10129,9 +10132,6 @@ components:
           - task_instance
           title: Destination
           default: nav
-        href:
-          type: string
-          title: Href
       additionalProperties: true
       type: object
       required:
@@ -10869,6 +10869,9 @@ components:
           - type: string
           - type: 'null'
           title: Category
+        bundle_url:
+          type: string
+          title: Bundle Url
         destination:
           type: string
           enum:
@@ -10877,11 +10880,9 @@ components:
           - dag_run
           - task
           - task_instance
+          - dashboard
           title: Destination
           default: nav
-        bundle_url:
-          type: string
-          title: Bundle Url
       additionalProperties: true
       type: object
       required:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3273,15 +3273,15 @@ export const $ExternalViewResponse = {
             ],
             title: 'Category'
         },
+        href: {
+            type: 'string',
+            title: 'Href'
+        },
         destination: {
             type: 'string',
             enum: ['nav', 'dag', 'dag_run', 'task', 'task_instance'],
             title: 'Destination',
             default: 'nav'
-        },
-        href: {
-            type: 'string',
-            title: 'Href'
         }
     },
     additionalProperties: true,
@@ -4325,15 +4325,15 @@ export const $ReactAppResponse = {
             ],
             title: 'Category'
         },
-        destination: {
-            type: 'string',
-            enum: ['nav', 'dag', 'dag_run', 'task', 'task_instance'],
-            title: 'Destination',
-            default: 'nav'
-        },
         bundle_url: {
             type: 'string',
             title: 'Bundle Url'
+        },
+        destination: {
+            type: 'string',
+            enum: ['nav', 'dag', 'dag_run', 'task', 'task_instance', 'dashboard'],
+            title: 'Destination',
+            default: 'nav'
         }
     },
     additionalProperties: true,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -875,8 +875,8 @@ export type ExternalViewResponse = {
     icon_dark_mode?: string | null;
     url_route?: string | null;
     category?: string | null;
-    destination?: 'nav' | 'dag' | 'dag_run' | 'task' | 'task_instance';
     href: string;
+    destination?: 'nav' | 'dag' | 'dag_run' | 'task' | 'task_instance';
     [key: string]: unknown | string;
 };
 
@@ -1180,10 +1180,12 @@ export type ReactAppResponse = {
     icon_dark_mode?: string | null;
     url_route?: string | null;
     category?: string | null;
-    destination?: 'nav' | 'dag' | 'dag_run' | 'task' | 'task_instance';
     bundle_url: string;
+    destination?: 'nav' | 'dag' | 'dag_run' | 'task' | 'task_instance' | 'dashboard';
     [key: string]: unknown | string;
 };
+
+export type destination2 = 'nav' | 'dag' | 'dag_run' | 'task' | 'task_instance' | 'dashboard';
 
 /**
  * Internal enum for setting reprocess behavior in a backfill.

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
@@ -19,11 +19,13 @@
 import { Box, Heading, VStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
-import type { UIAlert } from "openapi/requests/types.gen";
+import { usePluginServiceGetPlugins } from "openapi/queries";
+import type { ReactAppResponse, UIAlert } from "openapi/requests/types.gen";
 import ReactMarkdown from "src/components/ReactMarkdown";
 import { Accordion, Alert } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig";
 
+import { ReactPlugin } from "../ReactPlugin";
 import { FavoriteDags } from "./FavoriteDags";
 import { Health } from "./Health";
 import { HistoricalMetrics } from "./HistoricalMetrics";
@@ -33,6 +35,13 @@ import { Stats } from "./Stats";
 export const Dashboard = () => {
   const alerts = useConfig("dashboard_alert") as Array<UIAlert>;
   const { t: translate } = useTranslation("dashboard");
+
+  const { data: pluginData } = usePluginServiceGetPlugins();
+
+  const dashboardReactPlugins =
+    pluginData?.plugins
+      .flatMap((plugin) => plugin.react_apps)
+      .filter((reactAppPlugin: ReactAppResponse) => reactAppPlugin.destination === "dashboard") ?? [];
 
   return (
     <Box overflow="auto" px={4}>
@@ -76,6 +85,9 @@ export const Dashboard = () => {
         <Box order={6}>
           <HistoricalMetrics />
         </Box>
+        {dashboardReactPlugins.map((plugin) => (
+          <ReactPlugin key={plugin.name} reactApp={plugin} />
+        ))}
       </VStack>
     </Box>
   );

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -538,8 +538,8 @@ class ExternalViewResponse(BaseModel):
     icon_dark_mode: Annotated[str | None, Field(title="Icon Dark Mode")] = None
     url_route: Annotated[str | None, Field(title="Url Route")] = None
     category: Annotated[str | None, Field(title="Category")] = None
-    destination: Annotated[Destination | None, Field(title="Destination")] = "nav"
     href: Annotated[str, Field(title="Href")]
+    destination: Annotated[Destination | None, Field(title="Destination")] = "nav"
 
 
 class ExtraLinkCollectionResponse(BaseModel):
@@ -717,6 +717,15 @@ class QueuedEventResponse(BaseModel):
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
 
 
+class Destination1(str, Enum):
+    NAV = "nav"
+    DAG = "dag"
+    DAG_RUN = "dag_run"
+    TASK = "task"
+    TASK_INSTANCE = "task_instance"
+    DASHBOARD = "dashboard"
+
+
 class ReactAppResponse(BaseModel):
     """
     Serializer for React App Plugin responses.
@@ -730,8 +739,8 @@ class ReactAppResponse(BaseModel):
     icon_dark_mode: Annotated[str | None, Field(title="Icon Dark Mode")] = None
     url_route: Annotated[str | None, Field(title="Url Route")] = None
     category: Annotated[str | None, Field(title="Category")] = None
-    destination: Annotated[Destination | None, Field(title="Destination")] = "nav"
     bundle_url: Annotated[str, Field(title="Bundle Url")]
+    destination: Annotated[Destination1 | None, Field(title="Destination")] = "nav"
 
 
 class ReprocessBehavior(str, Enum):


### PR DESCRIPTION
Related to: https://github.com/apache/airflow/issues/53379

Add support for 'dashboard' destination for ReactApp plugins. 


This also adds some documentation on how to place the Plugin in the page. This is done through css and is fine grained, you can place it anywhere you'd like in the page vertically.

A few screenshot example:
### Top
<img width="1880" height="935" alt="Screenshot 2025-08-05 at 15 10 11" src="https://github.com/user-attachments/assets/4e6a2023-e66e-43fb-bc16-fa7d1a444084" />

### Bellow Favorite
<img width="1918" height="931" alt="Screenshot 2025-08-05 at 15 09 57" src="https://github.com/user-attachments/assets/0642c59a-3462-425b-8741-18febac78fb3" />

### Bottom
<img width="1916" height="941" alt="Screenshot 2025-08-05 at 15 10 51" src="https://github.com/user-attachments/assets/8771886a-61f4-4a7a-ad36-6a02602fa84f" />
