### PR TITLE
Fix `importskip` statements in tests

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
@@ -20,7 +20,7 @@ import pytest
 
 from airflow.providers.amazon.aws.triggers.sqs import SqsSensorTrigger
 
-pytest.importorskip("airflow.providers.common.messaging.providers.base_provider.BaseMessageQueueProvider")
+pytest.importorskip("airflow.providers.common.messaging.providers.base_provider")
 
 
 def test_message_sqs_queue_create():

--- a/providers/apache/kafka/tests/unit/apache/kafka/queues/test_kafka.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/queues/test_kafka.py
@@ -20,7 +20,7 @@ import pytest
 
 from airflow.providers.apache.kafka.triggers.await_message import AwaitMessageTrigger
 
-pytest.importorskip("airflow.providers.common.messaging.providers.base_provider.BaseMessageQueueProvider")
+pytest.importorskip("airflow.providers.common.messaging.providers.base_provider")
 
 MOCK_KAFKA_TRIGGER_APPLY_FUNCTION = "mock_kafka_trigger_apply_function"
 


### PR DESCRIPTION
As called out by @Jasperora in https://github.com/apache/airflow/pull/53556#issuecomment-3154395050, `importskip` should be provided a module path and not a class path. When a class path is provided, the test is always skipped.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
