### PR TITLE
Fix serialization order of ops

### DIFF
--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -53,6 +53,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         return "", "", 0, False
 
     name = qualname(o)
+    metadata = (name, __version__, True)
     if isinstance(
         o,
         np.int_
@@ -67,13 +68,13 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         | np.uint32
         | np.uint64,
     ):
-        return int(o), name, __version__, True
+        return int(o), *metadata
 
     if isinstance(o, np.bool_):
-        return bool(o), name, __version__, True
+        return bool(o), *metadata
 
     if isinstance(o, (np.float16, np.float32, np.float64, np.complex64, np.complex128)):
-        return float(o), name, __version__, True
+        return float(o), *metadata
 
     return "", "", 0, False
 

--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -256,7 +256,6 @@ class TestSerializers:
         else:
             assert serialize(np.float32(3.14)) == (float(np.float32(3.14)), "numpy.float32", 1, True)
         assert serialize(np.array([1, 2, 3])) == ("", "", 0, False)
-        assert serialize(np.complex128(3 + 2j)) == (complex(3 + 2j), "numpy.complex128", 1, True)
 
     @pytest.mark.parametrize(
         ("klass", "ver", "value", "msg"),

--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -227,11 +227,22 @@ class TestSerializers:
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, version, payload)
 
-    def test_numpy(self):
-        i = np.int16(10)
-        e = serialize(i)
+    @pytest.mark.parametrize(
+        "value",
+        [
+            np.int8(1),
+            np.int16(2),
+            np.int64(4),
+            np.float16(4.5),
+            np.float64(123.11241231351),
+        ],
+    )
+    def test_numpy(self, value):
+        e = serialize(value)
+        assert isinstance(e, dict)
         d = deserialize(e)
-        assert i == d
+        assert value == d
+        assert type(value) is type(d)
 
     def test_numpy_serializers(self):
         from airflow.serialization.serializers.numpy import serialize
@@ -245,6 +256,7 @@ class TestSerializers:
         else:
             assert serialize(np.float32(3.14)) == (float(np.float32(3.14)), "numpy.float32", 1, True)
         assert serialize(np.array([1, 2, 3])) == ("", "", 0, False)
+        assert serialize(np.complex128(3 + 2j)) == (complex(3 + 2j), "numpy.complex128", 1, True)
 
     @pytest.mark.parametrize(
         ("klass", "ver", "value", "msg"),


### PR DESCRIPTION
Adjusted order of operations to run custom serialization first before checking if subclass of base object

closes: #54097






<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
