### PR TITLE
AIP-68 Fix multiple react app plugins

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/ReactPlugin.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/ReactPlugin.tsx
@@ -24,6 +24,13 @@ import type { ReactAppResponse } from "openapi/requests/types.gen";
 
 import { ErrorPage } from "./Error";
 
+type PluginComponentType = FC<{
+  dagId?: string;
+  mapIndex?: string;
+  runId?: string;
+  taskId?: string;
+}>;
+
 export const ReactPlugin = ({ reactApp }: { readonly reactApp: ReactAppResponse }) => {
   const { dagId, mapIndex, runId, taskId } = useParams();
 
@@ -31,20 +38,23 @@ export const ReactPlugin = ({ reactApp }: { readonly reactApp: ReactAppResponse 
     // We are assuming the plugin manager is trusted and the bundle_url is safe
     import(/* @vite-ignore */ reactApp.bundle_url)
       .then(() => {
-        const component = (
-          globalThis as unknown as {
-            AirflowPlugin: FC<{
-              dagId?: string;
-              mapIndex?: string;
-              runId?: string;
-              taskId?: string;
-            }>;
-          }
-        ).AirflowPlugin;
+        // Store components in globalThis[reactApp.name] to avoid conflicts with the shared globalThis.AirflowPlugin
+        // global variable.
+        let pluginComponent = (globalThis as Record<string, unknown>)[reactApp.name] as
+          | PluginComponentType
+          | undefined;
 
-        return {
-          default: component,
-        };
+        if (pluginComponent === undefined) {
+          pluginComponent = (globalThis as Record<string, unknown>).AirflowPlugin as PluginComponentType;
+
+          (globalThis as Record<string, unknown>)[reactApp.name] = pluginComponent;
+        }
+
+        if (typeof pluginComponent !== "function") {
+          throw new TypeError(`Expected function, got ${typeof pluginComponent} for plugin ${reactApp.name}`);
+        }
+
+        return { default: pluginComponent };
       })
       .catch((error: unknown) => {
         console.error("Component Failed Loading:", error);


### PR DESCRIPTION
This allows multiple react app plugins to be loaded on the same dashboard page without conflicts. (A global `AirflowPlugin` variable was conflicting)
<img width="1797" height="772" alt="Screenshot 2025-08-05 at 18 24 50" src="https://github.com/user-attachments/assets/4d5f86ea-55e2-49e0-9631-f9a16d2485d6" />
<img width="1831" height="581" alt="Screenshot 2025-08-05 at 18 24 55" src="https://github.com/user-attachments/assets/0c3f080e-621b-4e05-bbae-9904f7b31275" />
