### PR TITLE
Enhance note button visibility with highlighting when notes exist

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -53,20 +53,33 @@ const EditableMarkdownButton = ({
 
   return (
     <Box>
-      <ActionButton
-        actionName={placeholder}
-        colorPalette={Boolean(mdContent?.trim()) ? "yellow" : undefined}
-        icon={icon}
-        onClick={() => {
-          if (!isOpen) {
-            onOpen();
-          }
-          setIsOpen(true);
-        }}
-        text={text}
-        variant={Boolean(mdContent?.trim()) ? "solid" : "outline"}
-        withText={withText}
-      />
+      <Box display="inline-block" position="relative">
+        <ActionButton
+          actionName={placeholder}
+          icon={icon}
+          onClick={() => {
+            if (!isOpen) {
+              onOpen();
+            }
+            setIsOpen(true);
+          }}
+          text={text}
+          variant="outline"
+          withText={withText}
+        />
+        {Boolean(mdContent?.trim()) && (
+          <Box
+            bg="blue.500"
+            borderRadius="full"
+            height="2.5"
+            position="absolute"
+            right="-0.5"
+            top="-0.5"
+            width="2.5"
+            zIndex={1}
+          />
+        )}
+      </Box>
       <Dialog.Root
         data-testid="markdown-modal"
         lazyMount

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -55,6 +55,7 @@ const EditableMarkdownButton = ({
     <Box>
       <ActionButton
         actionName={placeholder}
+        colorPalette={Boolean(mdContent?.trim()) ? "yellow" : undefined}
         icon={icon}
         onClick={() => {
           if (!isOpen) {
@@ -63,6 +64,7 @@ const EditableMarkdownButton = ({
           setIsOpen(true);
         }}
         text={text}
+        variant={Boolean(mdContent?.trim()) ? "solid" : "outline"}
         withText={withText}
       />
       <Dialog.Root

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -76,7 +76,6 @@ const EditableMarkdownButton = ({
             right={-0.5}
             top={-0.5}
             width={2.5}
-
           />
         )}
       </Box>

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -71,11 +71,12 @@ const EditableMarkdownButton = ({
           <Box
             bg="blue.500"
             borderRadius="full"
-            height="2.5"
+            height={2.5}
             position="absolute"
-            right="-0.5"
-            top="-0.5"
-            width="2.5"
+            right={-0.5}
+            top={-0.5}
+            width={2.5}
+
             zIndex={1}
           />
         )}

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -17,8 +17,9 @@
  * under the License.
  */
 import { Box, Heading, VStack, Flex } from "@chakra-ui/react";
-import { type ReactElement, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { PiNoteBlankLight, PiNoteLight } from "react-icons/pi";
 
 import { Button, Dialog } from "src/components/ui";
 
@@ -27,7 +28,6 @@ import ActionButton from "./ui/ActionButton";
 
 const EditableMarkdownButton = ({
   header,
-  icon,
   isPending,
   mdContent,
   onConfirm,
@@ -38,7 +38,6 @@ const EditableMarkdownButton = ({
   withText = true,
 }: {
   readonly header: string;
-  readonly icon: ReactElement;
   readonly isPending: boolean;
   readonly mdContent?: string | null;
   readonly onConfirm: () => void;
@@ -51,12 +50,14 @@ const EditableMarkdownButton = ({
   const { t: translate } = useTranslation("common");
   const [isOpen, setIsOpen] = useState(false);
 
+  const noteIcon = Boolean(mdContent?.trim()) ? <PiNoteLight /> : <PiNoteBlankLight />;
+
   return (
     <Box>
       <Box display="inline-block" position="relative">
         <ActionButton
           actionName={placeholder}
-          icon={icon}
+          icon={noteIcon}
           onClick={() => {
             if (!isOpen) {
               onOpen();
@@ -107,7 +108,7 @@ const EditableMarkdownButton = ({
                   setIsOpen(false);
                 }}
               >
-                {icon} {translate("modal.confirm")}
+                {noteIcon} {translate("modal.confirm")}
               </Button>
             </Flex>
           </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -77,7 +77,6 @@ const EditableMarkdownButton = ({
             top={-0.5}
             width={2.5}
 
-            zIndex={1}
           />
         )}
       </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { HStack, Text, Box } from "@chakra-ui/react";
-import { useCallback, useState, useRef } from "react";
+import { useCallback, useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 
@@ -42,6 +42,10 @@ export const Header = ({
 }) => {
   const { t: translate } = useTranslation();
   const [note, setNote] = useState<string | null>(dagRun.note);
+
+  useEffect(() => {
+    setNote(dagRun.note);
+  }, [dagRun.note]);
 
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -19,7 +19,7 @@
 import { HStack, Text, Box } from "@chakra-ui/react";
 import { useCallback, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { FiBarChart, FiMessageSquare } from "react-icons/fi";
+import { FiBarChart } from "react-icons/fi";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
@@ -77,7 +77,6 @@ export const Header = ({
           <>
             <EditableMarkdownButton
               header={translate("note.dagRun")}
-              icon={<FiMessageSquare />}
               isPending={isPending}
               mdContent={dagRun.note}
               onConfirm={onConfirm}

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { HStack, Text, Box } from "@chakra-ui/react";
-import { useCallback, useState, useRef, useEffect } from "react";
+import { useCallback, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 
@@ -43,9 +43,7 @@ export const Header = ({
   const { t: translate } = useTranslation();
   const [note, setNote] = useState<string | null>(dagRun.note);
 
-  useEffect(() => {
-    setNote(dagRun.note);
-  }, [dagRun.note]);
+  const hasContent = Boolean(dagRun.note?.trim());
 
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
@@ -81,12 +79,12 @@ export const Header = ({
               header={translate("note.dagRun")}
               icon={<FiMessageSquare />}
               isPending={isPending}
-              mdContent={note}
+              mdContent={dagRun.note}
               onConfirm={onConfirm}
               onOpen={onOpen}
               placeholder={translate("note.placeholder")}
               setMdContent={setNote}
-              text={Boolean(dagRun.note) ? translate("note.label") : translate("note.add")}
+              text={hasContent ? translate("note.label") : translate("note.add")}
               withText={containerWidth > 700}
             />
             <ClearRunButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Box } from "@chakra-ui/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FiMessageSquare } from "react-icons/fi";
 import { MdOutlineTask } from "react-icons/md";
@@ -63,6 +63,10 @@ export const Header = ({
   ];
 
   const [note, setNote] = useState<string | null>(taskInstance.note);
+
+  useEffect(() => {
+    setNote(taskInstance.note);
+  }, [taskInstance.note]);
 
   const dagId = taskInstance.dag_id;
   const dagRunId = taskInstance.dag_run_id;

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Box } from "@chakra-ui/react";
-import { useCallback, useRef, useState, useEffect } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiMessageSquare } from "react-icons/fi";
 import { MdOutlineTask } from "react-icons/md";
@@ -64,9 +64,7 @@ export const Header = ({
 
   const [note, setNote] = useState<string | null>(taskInstance.note);
 
-  useEffect(() => {
-    setNote(taskInstance.note);
-  }, [taskInstance.note]);
+  const hasContent = Boolean(taskInstance.note?.trim());
 
   const dagId = taskInstance.dag_id;
   const dagRunId = taskInstance.dag_run_id;
@@ -105,12 +103,12 @@ export const Header = ({
               header={translate("note.taskInstance")}
               icon={<FiMessageSquare />}
               isPending={isPending}
-              mdContent={note}
+              mdContent={taskInstance.note}
               onConfirm={onConfirm}
               onOpen={onOpen}
               placeholder={translate("note.placeholder")}
               setMdContent={setNote}
-              text={Boolean(taskInstance.note) ? translate("note.label") : translate("note.add")}
+              text={hasContent ? translate("note.label") : translate("note.add")}
               withText={containerWidth > 700}
             />
             <ClearTaskInstanceButton

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -19,7 +19,6 @@
 import { Box } from "@chakra-ui/react";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiMessageSquare } from "react-icons/fi";
 import { MdOutlineTask } from "react-icons/md";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
@@ -101,7 +100,6 @@ export const Header = ({
           <>
             <EditableMarkdownButton
               header={translate("note.taskInstance")}
-              icon={<FiMessageSquare />}
               isPending={isPending}
               mdContent={taskInstance.note}
               onConfirm={onConfirm}


### PR DESCRIPTION
- Add blue notification dot when DAG run or task instance has a note
- Fix state synchronization when switching between runs to maintain proper highlighting
- Improve user experience by making existing notes more discoverable in the UI

Without note: 
<img width="1917" height="615" alt="image" src="https://github.com/user-attachments/assets/0c1c2168-a6b3-4015-81fe-12667b6ae25e" />

With Note: 
<img width="1918" height="553" alt="image" src="https://github.com/user-attachments/assets/b69347d4-f87f-4bd9-b220-c13179e2cde7" />


