### PR TITLE
Add triggering user name to DagRun header stats

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -113,6 +113,14 @@ export const Header = ({
           { label: translate("startDate"), value: <Time datetime={dagRun.start_date} /> },
           { label: translate("endDate"), value: <Time datetime={dagRun.end_date} /> },
           { label: translate("duration"), value: getDuration(dagRun.start_date, dagRun.end_date) },
+          ...(dagRun.triggering_user_name === null
+            ? []
+            : [
+                {
+                  label: translate("dagRun.triggeringUser"),
+                  value: <Text>{dagRun.triggering_user_name}</Text>,
+                },
+              ]),
           {
             label: translate("dagRun.dagVersions"),
             value: (


### PR DESCRIPTION
Display the triggering user name in the DagRun page header pane alongside other stats like logical date, start date, and dag version. The field is conditionally shown only when triggering_user_name is available.

<img width="1917" height="602" alt="image" src="https://github.com/user-attachments/assets/35429f13-48d0-407d-8713-c4812331ca56" />
