### PR TITLE
Add backward compatibility layer for dag_cycle_tester

### DIFF
--- a/airflow-core/src/airflow/utils/dag_cycle_tester.py
+++ b/airflow-core/src/airflow/utils/dag_cycle_tester.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from airflow.sdk.definitions.dag import DAG
+
+warnings.warn(
+    "`airflow.utils.dag_cycle_tester` module is deprecated and "
+    "will be removed in Airflow 3.2. Please use `dag.check_cycle()` method instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+def check_cycle(dag: DAG) -> None:
+    """
+    Check to see if there are any cycles in the DAG.
+
+    .. deprecated:: 3.1.0
+        This function is deprecated. Use `dag.check_cycle()` method instead.
+
+    :param dag: The DAG to check for cycles
+    :raises AirflowDagCycleException: If cycle is found in the DAG.
+    """
+    # No warning here since we already warned on import
+    dag.check_cycle()
+
+
+__all__ = ["check_cycle"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Users could be using `check_cycle` in their dags / tests which would start to fail without compat. This is not a clean way of achieving compat but it's the only one possible at the moment. Once we decide to remove it, we should nuke off this file.

Working example:
```
root@6c2cb22000eb:/opt/airflow# python
Python 3.10.18 (tags/v3.10.18:88663ef, Jul 22 2025, 04:10:51) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.utils.dag_cycle_tester import check_cycle
<stdin>:1 DeprecationWarning: `airflow.utils.dag_cycle_tester` module is deprecated and will be removed in Airflow 3.2. Please use `dag.check_cycle()` method instead.
>>> from airflow.sdk import DAG
>>> dag = DAG(
...     dag_id="abcd",
...     schedule=None,
...     catchup=False,
...     tags=["demo"],
... )
/opt/airflow/task-sdk/src/airflow/sdk/definitions/taskgroup.py:36 DeprecationWarning: airflow.exceptions.AirflowDagCycleException is deprecated. Use airflow.sdk.exceptions.AirflowDagCycleException instead.
>>> check_cycle(dag)
>>> check_cycle(dag)
KeyboardInterrupt
>>> check_cycle(dag) is None
True
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
