### PR TITLE
Fix missing expand/collapse buttons in Grid view using shared group sync hook (#53919)

### DIFF
--- a/airflow-core/src/airflow/ui/src/hooks/useGraphStructureSync.tsx
+++ b/airflow-core/src/airflow/ui/src/hooks/useGraphStructureSync.tsx
@@ -1,0 +1,56 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useLocalStorage } from "usehooks-ts";
+
+import { useStructureServiceStructureData } from "openapi/queries";
+import { useOpenGroups } from "src/context/openGroups";
+import useSelectedVersion from "src/hooks/useSelectedVersion";
+import { flattenGraphNodes } from "src/layouts/Details/Grid/utils.ts";
+
+export const useGraphStructureSync = () => {
+  const { dagId = "" } = useParams();
+  const selectedVersion = useSelectedVersion();
+  const { allGroupIds, setAllGroupIds } = useOpenGroups();
+  const [dependencies] = useLocalStorage<"all" | "immediate" | "tasks">(`dependencies-${dagId}`, "tasks");
+
+  const { data: graphData = { edges: [], nodes: [] } } = useStructureServiceStructureData(
+    {
+      dagId,
+      externalDependencies: dependencies === "immediate",
+      versionNumber: selectedVersion,
+    },
+    undefined,
+    { enabled: selectedVersion !== undefined },
+  );
+
+  useEffect(() => {
+    const observedGroupIds = flattenGraphNodes(graphData.nodes).allGroupIds;
+
+    if (
+      observedGroupIds.length !== allGroupIds.length ||
+      observedGroupIds.some((element, index) => allGroupIds[index] !== element)
+    ) {
+      setAllGroupIds(observedGroupIds);
+    }
+  }, [allGroupIds, graphData.nodes, setAllGroupIds]);
+
+  return graphData;
+};

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -19,19 +19,17 @@
 import { useToken } from "@chakra-ui/react";
 import { ReactFlow, Controls, Background, MiniMap, type Node as ReactFlowNode } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
-import { useStructureServiceStructureData } from "openapi/queries";
 import { DownloadButton } from "src/components/Graph/DownloadButton";
 import { edgeTypes, nodeTypes } from "src/components/Graph/graphTypes";
 import type { CustomNodeProps } from "src/components/Graph/reactflowUtils";
 import { type Direction, useGraphLayout } from "src/components/Graph/useGraphLayout";
 import { useColorMode } from "src/context/colorMode";
 import { useOpenGroups } from "src/context/openGroups";
+import { useGraphStructureSync } from "src/hooks/useGraphStructureSync";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
-import { flattenGraphNodes } from "src/layouts/Details/Grid/utils.ts";
 import { useDependencyGraph } from "src/queries/useDependencyGraph";
 import { useGridTiSummaries } from "src/queries/useGridTISummaries.ts";
 
@@ -73,32 +71,13 @@ export const Graph = () => {
     "gray.800",
   ]);
 
-  const { allGroupIds, openGroupIds, setAllGroupIds } = useOpenGroups();
+  const { openGroupIds } = useOpenGroups();
 
   const [dependencies] = useLocalStorage<"all" | "immediate" | "tasks">(`dependencies-${dagId}`, "tasks");
   const [direction] = useLocalStorage<Direction>(`direction-${dagId}`, "RIGHT");
 
   const selectedColor = colorMode === "dark" ? selectedDarkColor : selectedLightColor;
-  const { data: graphData = { edges: [], nodes: [] } } = useStructureServiceStructureData(
-    {
-      dagId,
-      externalDependencies: dependencies === "immediate",
-      versionNumber: selectedVersion,
-    },
-    undefined,
-    { enabled: selectedVersion !== undefined },
-  );
-
-  useEffect(() => {
-    const observedGroupIds = flattenGraphNodes(graphData.nodes).allGroupIds;
-
-    if (
-      observedGroupIds.length !== allGroupIds.length ||
-      observedGroupIds.some((element, index) => allGroupIds[index] !== element)
-    ) {
-      setAllGroupIds(observedGroupIds);
-    }
-  }, [allGroupIds, graphData.nodes, setAllGroupIds]);
+  const graphData = useGraphStructureSync();
 
   const { data: dagDependencies = { edges: [], nodes: [] } } = useDependencyGraph(`dag:${dagId}`, {
     enabled: dependencies === "all",

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -26,6 +26,7 @@ import { Link, useParams } from "react-router-dom";
 
 import type { GridRunsResponse } from "openapi/requests";
 import { useOpenGroups } from "src/context/openGroups";
+import { useGraphStructureSync } from "src/hooks/useGraphStructureSync";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
 import { useGridStructure } from "src/queries/useGridStructure.ts";
 import { isStatePending } from "src/utils";
@@ -51,6 +52,8 @@ export const Grid = ({ limit }: Props) => {
   const { dagId = "", runId = "" } = useParams();
 
   const { data: gridRuns, isLoading } = useGridRuns({ limit });
+
+  useGraphStructureSync();
 
   // Check if the selected dag run is inside of the grid response, if not, we'll update the grid filters
   // Eventually we should redo the api endpoint to make this work better


### PR DESCRIPTION
#### Overview

This PR addresses #53919 ensures that the Expand/Collapse all groups buttons are consistently visible in both the Grid and Graph views.

#### Root Cause:

The Expand/Collapse all groups buttons are visible only when the DAG contains task groups. These task groups (`allGroupIds`) were being calculated only in `graph.tsx`, but not in `grid.tsx`. As a result, the buttons were not rendered in the Grid view unless the Graph view was opened first, which triggered the group ID calculation.

#### Solution:

Refactored the task group calculation logic into a shared hook so it can be reused in both `graph.tsx` and `grid.tsx`, ensuring consistent visibility of the buttons across both views.

#### Changes Made:

- Extracted task group calculation logic from `graph.tsx` into a new reusable hook: `useGraphStructureSync.tsx`.
- This hook syncs the DAG's task group data (`allGroupIds`) by fetching and flattening graph nodes.
- Imported and used the hook in both `graph.tsx` and `grid.tsx` to ensure task group data is consistently available.

#### Related issue:
#53919 