### PR TITLE
[v3-0-test] Bump min task sdk version in core to 1.0.4 (#54171)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ classifiers = [
 version = "3.0.4"
 
 dependencies = [
-    "apache-airflow-task-sdk<1.1.0,>=1.0.0",
+    "apache-airflow-task-sdk<1.1.0,>=1.0.4",
     "apache-airflow-core==3.0.4",
 ]
 


### PR DESCRIPTION
(cherry picked from commit 6ecc0e9a7e30af64f3d03e395f0645c2f84799c7)