### PR TITLE
Fix `HITLResponseForm` display issue

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -90,6 +90,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
         defaultValue={[hitlDetail.subject]}
         mb={4}
         mt={4}
+        overflow="visible"
         size="lg"
         variant="enclosed"
       >
@@ -113,7 +114,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
             hitlDetail.options.map((option) => (
               <Button
                 colorPalette={isHighlightOption(option, hitlDetail) ? "blue" : "gray"}
-                disabled={(hitlDetail.response_received ?? errors) || isSubmitting}
+                disabled={errors || isSubmitting || hitlDetail.response_received}
                 key={option}
                 onClick={() => handleSubmit(option)}
                 variant={isHighlightOption(option, hitlDetail) ? "solid" : "subtle"}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Before

- select is truncated
<img width="827" height="286" alt="image" src="https://github.com/user-attachments/assets/2df6cff7-a958-49c6-a562-571c2435bb6c" />

- not disable option buttons when error occur
<img width="831" height="223" alt="image" src="https://github.com/user-attachments/assets/d9a92a7c-9278-4426-9ef4-fb8913124da0" />


## After
<img width="846" height="291" alt="image" src="https://github.com/user-attachments/assets/a54ad0e5-6f3e-4922-90b3-fccea05921ec" />

<img width="830" height="200" alt="image" src="https://github.com/user-attachments/assets/9ba7001f-aecb-472e-ad35-248aba799c88" />

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
