### PR TITLE
Bump apache-airflow-providers-common-sql>=1.27.5 for Snowflake

### DIFF
--- a/providers/common/sql/provider.yaml
+++ b/providers/common/sql/provider.yaml
@@ -28,6 +28,7 @@ source-date-epoch: 1753690201
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 1.27.5
   - 1.27.4
   - 1.27.3
   - 1.27.2

--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-compat>=1.6.0",
-    "apache-airflow-providers-common-sql>=1.21.0",
+    "apache-airflow-providers-common-sql>=1.27.5",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
     "pyarrow>=16.1.0; python_version < '3.13'",


### PR DESCRIPTION
For the fix in https://github.com/apache/airflow/pull/53837 to work properly we need to make sure it uses apache-airflow-providers-common-sql version with the fix as the combination of fix in the two providers is what resolving the problem