### PR TITLE
Update SqlToS3Operator to support Polars and deprecate read_pd_kwargs

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import enum
 import gzip
 import io
+import warnings
 from collections import namedtuple
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -139,38 +140,23 @@ class SqlToS3Operator(BaseOperator):
         self.groupby_kwargs = groupby_kwargs or {}
         self.sql_hook_params = sql_hook_params
         self.df_type = df_type
-        if read_pd_kwargs is not None and read_kwargs is not None:
-            raise AirflowException(
-                "Cannot specify both 'read_kwargs' and 'read_pd_kwargs'. Use 'read_kwargs' instead."
-            )
-        if read_pd_kwargs is not None:
-            import warnings
 
+        if read_pd_kwargs is not None:
             warnings.warn(
                 "The 'read_pd_kwargs' parameter is deprecated. Use 'read_kwargs' instead.",
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
-            self.read_kwargs = read_pd_kwargs or {}
-        else:
-            self.read_kwargs = read_kwargs or {}
+        self.read_kwargs = read_kwargs if read_kwargs is not None else read_pd_kwargs or {}
 
-        # Handle df_kwargs and pd_kwargs backward compatibility
-        if pd_kwargs is not None and df_kwargs is not None:
-            raise AirflowException(
-                "Cannot specify both 'df_kwargs' and 'pd_kwargs'. Use 'df_kwargs' instead."
-            )
         if pd_kwargs is not None:
-            import warnings
-
             warnings.warn(
                 "The 'pd_kwargs' parameter is deprecated. Use 'df_kwargs' instead.",
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
-            self.df_kwargs = pd_kwargs or {}
-        else:
-            self.df_kwargs = df_kwargs or {}
+
+        self.df_kwargs = df_kwargs if df_kwargs is not None else pd_kwargs or {}
 
         if "path_or_buf" in self.df_kwargs:
             raise AirflowException("The argument path_or_buf is not allowed, please remove it")

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_sql_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_sql_to_s3.py
@@ -51,7 +51,7 @@ class TestSqlToS3Operator:
             task_id="task_id",
             replace=True,
             read_kwargs={"dtype_backend": dtype_backend},
-            pd_kwargs={"index": False, "header": False},
+            df_kwargs={"index": False, "header": False},
             dag=None,
         )
         op._get_hook = mock_dbapi_hook
@@ -126,7 +126,7 @@ class TestSqlToS3Operator:
             task_id="task_id",
             file_format="json",
             replace=True,
-            pd_kwargs={"date_format": "iso", "lines": True, "orient": "records"},
+            df_kwargs={"date_format": "iso", "lines": True, "orient": "records"},
             dag=None,
         )
         op._get_hook = mock_dbapi_hook
@@ -159,7 +159,7 @@ class TestSqlToS3Operator:
             aws_conn_id="aws_conn_id",
             task_id="task_id",
             replace=True,
-            pd_kwargs={"index": False, "compression": "gzip"},
+            df_kwargs={"index": False, "compression": "gzip"},
             dag=None,
         )
         op._get_hook = mock_dbapi_hook
@@ -261,7 +261,7 @@ class TestSqlToS3Operator:
             aws_conn_id="aws_conn_id",
             task_id="task_id",
             replace=True,
-            pd_kwargs={"index": False, "header": False},
+            df_kwargs={"index": False, "header": False},
             groupby_kwargs={"by": "Team"},
             dag=None,
         )
@@ -313,7 +313,7 @@ class TestSqlToS3Operator:
             aws_conn_id="aws_conn_id",
             task_id="task_id",
             replace=True,
-            pd_kwargs={"index": False, "header": False},
+            df_kwargs={"index": False, "header": False},
             dag=None,
         )
         example = {
@@ -355,7 +355,7 @@ class TestSqlToS3Operator:
             aws_conn_id="aws_conn_id",
             task_id="task_id",
             replace=True,
-            pd_kwargs={"index": False, "header": False},
+            df_kwargs={"index": False, "header": False},
             max_rows_per_file=3,
             dag=None,
         )
@@ -515,6 +515,20 @@ class TestSqlToS3Operator:
                 "can not be both specified",
                 None,
                 id="max-rows-groupby-conflict-error",
+            ),
+            pytest.param(
+                {"pd_kwargs": {"index": False}},
+                "The 'pd_kwargs' parameter is deprecated",
+                None,
+                None,
+                id="deprecated-pd-kwargs-warning",
+            ),
+            pytest.param(
+                {"df_kwargs": {"index": False}, "pd_kwargs": {"header": False}},
+                None,
+                "Cannot specify both 'df_kwargs' and 'pd_kwargs'",
+                None,
+                id="df-kwargs-conflict-error",
             ),
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related PR

#53399
cc @eladkal 

## Why

- Current read_pd_kwargs parameter is Pandas-specific, limiting extensibility
- Need library-agnostic support for both Pandas and Polars DataFrames

## How

- Renamed `read_pd_kwargs` → `read_kwargs` for library-agnostic naming
- Added `df_type` parameter supporting "pandas" (default) and "polars"
- Enhanced `_partition_dataframe()` to handle both DataFrame types
- Maintained backward compatibility with deprecation warning

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
