### PR TITLE
Update authorization logic on list APIs in `FabAuthManager`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/common.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/common.py
@@ -112,11 +112,6 @@ async def paginated_select_async(
     if return_total_entries:
         total_entries = await get_query_count_async(statement, session=session)
 
-    # TODO: Re-enable when permissions are handled. Readable / writable entities,
-    # for instance:
-    # readable_dags = get_auth_manager().get_authorized_dag_ids(user=g.user)
-    # dags_select = dags_select.where(DagModel.dag_id.in_(readable_dags))
-
     statement = apply_filters_to_select(
         statement=statement,
         filters=[order_by, offset, limit],
@@ -170,11 +165,6 @@ def paginated_select(
     total_entries = None
     if return_total_entries:
         total_entries = get_query_count(statement, session=session)
-
-    # TODO: Re-enable when permissions are handled. Readable / writable entities,
-    # for instance:
-    # readable_dags = get_auth_manager().get_authorized_dag_ids(user=g.user)
-    # dags_select = dags_select.where(DagModel.dag_id.in_(readable_dags))
 
     statement = apply_filters_to_select(statement=statement, filters=[order_by, offset, limit])
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -558,7 +558,6 @@ def get_dag_asset_queued_event(
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
     dependencies=[
         Depends(requires_access_asset(method="DELETE")),
-        Depends(requires_access_dag(method="GET")),
         Depends(action_logging()),
     ],
 )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_report.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_report.py
@@ -21,7 +21,7 @@ import ast
 import os
 from typing import cast
 
-from fastapi import Depends, HTTPException, status
+from fastapi import HTTPException, status
 
 from airflow import settings
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -32,7 +32,6 @@ from airflow.api_fastapi.core_api.datamodels.dag_report import (
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import (
     ReadableDagsFilterDep,
-    requires_access_dag,
 )
 from airflow.models.dagbag import DagBag
 
@@ -46,7 +45,7 @@ dag_report_router = AirflowRouter(tags=["DagReport"], prefix="/dagReports")
             status.HTTP_400_BAD_REQUEST,
         ]
     ),
-    dependencies=[Depends(requires_access_dag(method="GET"))],
+    # No authorization access is performed on the API level because `ReadableDagsFilterDep` filters Dags accessible by the user only
 )
 def get_dag_reports(
     subdir: str,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -305,7 +305,7 @@ def clear_dag_run(
 @dag_run_router.get(
     "",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
-    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.RUN))],
+    # No authorization access is performed on the API level because `ReadableDagRunsFilterDep` filters Dags accessible by the user only
 )
 def get_dag_runs(
     dag_id: str,
@@ -502,7 +502,7 @@ def wait_dag_run_until_finished(
 @dag_run_router.post(
     "/list",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
-    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.RUN))],
+    # No authorization access is performed on the API level because `ReadableDagRunsFilterDep` filters Dags accessible by the user only
 )
 def get_list_dag_runs_batch(
     dag_id: Literal["~"],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_stats.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_stats.py
@@ -21,7 +21,6 @@ from typing import Annotated
 
 from fastapi import Depends, status
 
-from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
@@ -39,7 +38,7 @@ from airflow.api_fastapi.core_api.datamodels.dag_stats import (
     DagStatsStateResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import ReadableDagRunsFilterDep, requires_access_dag
+from airflow.api_fastapi.core_api.security import ReadableDagRunsFilterDep
 from airflow.models.dagrun import DagRun
 from airflow.utils.state import DagRunState
 
@@ -54,7 +53,7 @@ dag_stats_router = AirflowRouter(tags=["DagStats"], prefix="/dagStats")
             status.HTTP_404_NOT_FOUND,
         ]
     ),
-    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.RUN))],
+    # No authorization access is performed on the API level because `ReadableDagRunsFilterDep` filters Dags accessible by the user only
 )
 def get_dag_stats(
     readable_dag_runs_filter: ReadableDagRunsFilterDep,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py
@@ -34,13 +34,16 @@ from airflow.api_fastapi.common.parameters import (
 )
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.dag_tags import DAGTagCollectionResponse
-from airflow.api_fastapi.core_api.security import ReadableTagsFilterDep, requires_access_dag
+from airflow.api_fastapi.core_api.security import ReadableTagsFilterDep
 from airflow.models.dag import DagTag
 
 dag_tags_router = AirflowRouter(tags=["DAG"], prefix="/dagTags")
 
 
-@dag_tags_router.get("", dependencies=[Depends(requires_access_dag(method="GET"))])
+@dag_tags_router.get(
+    "",
+    # No authorization access is performed on the API level because `ReadableTagsFilterDep` filters Dags accessible by the user only
+)
 def get_dag_tags(
     limit: QueryLimit,
     offset: QueryOffset,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_warning.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_warning.py
@@ -22,7 +22,6 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy import select
 
-from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
@@ -38,7 +37,7 @@ from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.dag_warning import (
     DAGWarningCollectionResponse,
 )
-from airflow.api_fastapi.core_api.security import ReadableDagWarningsFilterDep, requires_access_dag
+from airflow.api_fastapi.core_api.security import ReadableDagWarningsFilterDep
 from airflow.models.dagwarning import DagWarning, DagWarningType
 
 dag_warning_router = AirflowRouter(tags=["DagWarning"])
@@ -46,7 +45,7 @@ dag_warning_router = AirflowRouter(tags=["DagWarning"])
 
 @dag_warning_router.get(
     "/dagWarnings",
-    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.WARNING))],
+    # No authorization access is performed on the API level because `ReadableDagWarningsFilterDep` filters Dags accessible by the user only
 )
 def list_dag_warnings(
     dag_id: Annotated[FilterParam[str | None], Depends(filter_param_factory(DagWarning.dag_id, str | None))],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -266,7 +266,8 @@ def patch_dag(
             status.HTTP_404_NOT_FOUND,
         ]
     ),
-    dependencies=[Depends(requires_access_dag(method="PUT")), Depends(action_logging())],
+    # No authorization access is performed on the API level because `EditableDagsFilterDep` filters Dags accessible by the user only
+    dependencies=[Depends(action_logging())],
 )
 def patch_dags(
     patch_body: DAGPatchBody,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -47,7 +47,11 @@ from airflow.api_fastapi.core_api.datamodels.hitl import (
     UpdateHITLDetailPayload,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import GetUserDep, ReadableTIFilterDep, requires_access_dag
+from airflow.api_fastapi.core_api.security import (
+    GetUserDep,
+    ReadableHITLFilterDep,
+    requires_access_dag,
+)
 from airflow.models.hitl import HITLDetail as HITLDetailModel
 from airflow.models.taskinstance import TaskInstance as TI
 
@@ -274,7 +278,7 @@ def get_mapped_ti_hitl_detail(
 @hitl_router.get(
     "/",
     status_code=status.HTTP_200_OK,
-    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.HITL_DETAIL))],
+    # No authorization access is performed on the API level because `ReadableHITLFilterDep` filters Dags accessible by the user only
 )
 def get_hitl_details(
     limit: QueryLimit,
@@ -300,7 +304,7 @@ def get_hitl_details(
     ],
     session: SessionDep,
     # ti related filter
-    readable_ti_filter: ReadableTIFilterDep,
+    readable_ti_filter: ReadableHITLFilterDep,
     dag_id_pattern: QueryHITLDetailDagIdPatternSearch,
     dag_run_id: QueryHITLDetailDagRunIdFilter,
     task_id: QueryHITLDetailTaskIdPatternSearch,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -497,7 +497,7 @@ def get_task_instances(
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
     dependencies=[
         Depends(action_logging()),
-        Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.TASK_INSTANCE)),
+        # No authorization access is performed on the API level because `ReadableTIFilterDep` filters Dags accessible by the user only
     ],
 )
 def get_task_instances_batch(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -68,10 +68,7 @@ dags_router = AirflowRouter(prefix="/dags", tags=["DAG"])
 @dags_router.get(
     "",
     response_model_exclude_none=True,
-    dependencies=[
-        Depends(requires_access_dag(method="GET")),
-        Depends(requires_access_dag("GET", DagAccessEntity.RUN)),
-    ],
+    # No authorization access is performed on the API level because `ReadableDagsFilterDep` filters Dags accessible by the user only
     operation_id="get_dags_ui",
 )
 def get_dags(

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -273,14 +273,25 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
         dag_ids: set[str],
         user: AwsAuthManagerUser,
         method: ResourceMethod = "GET",
+        access_entity: DagAccessEntity | None = None,
     ):
         requests: dict[str, dict[ResourceMethod, IsAuthorizedRequest]] = defaultdict(dict)
         requests_list: list[IsAuthorizedRequest] = []
         for dag_id in dag_ids:
+            context = (
+                None
+                if access_entity is None
+                else {
+                    "dag_entity": {
+                        "string": access_entity.value,
+                    },
+                }
+            )
             request: IsAuthorizedRequest = {
                 "method": method,
                 "entity_type": AvpEntities.DAG,
                 "entity_id": dag_id,
+                "context": context,
             }
             requests[dag_id][method] = request
             requests_list.append(request)


### PR DESCRIPTION
Resolves #53936.

Follow-up of [this comment](https://github.com/apache/airflow/issues/53936#issuecomment-3145637598).

## Description
For every list Dag or sub Dag entity (e.g. task instance, dag run, ...), the current authorization is a bit messy in `FabAuthManager`. Since a user can have access to specifics Dags (and not all of them), when the user lists Dags, Airflow uses `get_authorized_dag_ids` from auth manager to figure whether the user has access to at least one Dag. If the user has access to at least one Dag then the access is granted to the API, if not the access is denied. If the access is granted, then the implementation of the API itself uses again `get_authorized_dag_ids` to retrieve the list of Dags to return to the user. 

I do think we should not check whether the user is authorized to list dags because the API returns only the dags the user has access to anyway. The consequence would is, instead of having a 403, the user would get an empty list of DAGs. In a fined grained access context, it makes more sense. Let's say I am user who has access to the Dag `test` only but this Dag does not exist (or has been removed) in the Airflow environment. In the current implementation, if I list Dags, I'll get a 403, but does it make sense? I have permissions to access Dags, I just happen to not have access to Dags existing in the environment. @pierrejeambrun also brought it up in [his comment](https://github.com/apache/airflow/issues/53936#issuecomment-3150503079) that with the introduction of filters, having this logic on the API level does not make sense.

## Testing
I tried to test it as much as I could but please test it on your end as well since this PR is quite impactful.

## Future
Dags is the only resource type having fine grained access (authorizing a user having access to one specific Dag) in Airflow because it has been historically like this in `FabAuthManager`. But technically, nothing prevent us today, through `KeycloakAuthManager` for instance, to give permissions to users to say, one specific connection. Everything would work but the list API, you would get a 403. I am planning to add such capability across auth managers to other resources in the near future. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
