### PR TITLE
fix(http): Fix HttpHook.url_from_endpoint() lazy initialization

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -135,6 +135,7 @@ class HttpHook(BaseHook):
         self.http_conn_id = http_conn_id
         self.method = method.upper()
         self.base_url: str = ""
+        self._base_url_initialized: bool = False
         self._retry_obj: Callable[..., Any]
         self._auth_type: Any = auth_type
 
@@ -203,6 +204,7 @@ class HttpHook(BaseHook):
         parsed = urlparse(self.base_url)
         if not parsed.scheme:
             raise ValueError(f"Invalid base URL: Missing scheme in {self.base_url}")
+        self._base_url_initialized = True
 
     def _configure_session_from_auth(self, session: Session, connection: Connection) -> Session:
         session.auth = self._extract_auth(connection)
@@ -383,6 +385,10 @@ class HttpHook(BaseHook):
 
     def url_from_endpoint(self, endpoint: str | None) -> str:
         """Combine base url with endpoint."""
+        # Ensure base_url is set by initializing it if it hasn't been initialized yet
+        if not self._base_url_initialized:
+            connection = self.get_connection(self.http_conn_id)
+            self._set_base_url(connection)
         return _url_from_endpoint(base_url=self.base_url, endpoint=endpoint)
 
     def test_connection(self):

--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -386,7 +386,7 @@ class HttpHook(BaseHook):
     def url_from_endpoint(self, endpoint: str | None) -> str:
         """Combine base url with endpoint."""
         # Ensure base_url is set by initializing it if it hasn't been initialized yet
-        if not self._base_url_initialized:
+        if not self._base_url_initialized and not self.base_url:
             connection = self.get_connection(self.http_conn_id)
             self._set_base_url(connection)
         return _url_from_endpoint(base_url=self.base_url, endpoint=endpoint)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Issue
`url_from_endpoint()` returns incorrect relative path without calling get_conn() first, due to flawed lazy initialization

## Cause
Logic used if not `self.base_url` for initialization, but empty strings evaluate to False, triggering incorrect behavior

## Solution:
- Added `_base_url_initialized `boolean flag to track initialization
- Updated `_set_base_url()` to set the flag
- Modified `url_from_endpoint()` to use flag for lazy initialization check

Closes: #54112


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
