### PR TITLE
GitHub API to fetch Github artefacts

### DIFF
--- a/providers/slack/tests/unit/slack/notifications/test_slack.py
+++ b/providers/slack/tests/unit/slack/notifications/test_slack.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
-import requests
-import os
 
 from airflow.providers.slack.notifications.slack import SlackNotifier, send_slack_notification
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -30,32 +28,7 @@ pytestmark = pytest.mark.db_test
 
 DEFAULT_HOOKS_PARAMETERS = {"base_url": None, "timeout": None, "proxy": None, "retry_handlers": None}
 
-RAW_GITHUB_ICON_URL = "https://raw.githubusercontent.com/apache/airflow/main/airflow-core/src/airflow/ui/public/pin_100.png"
-GITHUB_API_ICON_URL = "https://api.github.com/repos/apache/airflow/contents/airflow-core/src/airflow/ui/public/pin_100.png"
-
-def fetch_raw_url(link: str, fallback_link: str) -> str:
-    """
-    Fetch the image url from GitHub
-    """
-    token = os.environ.get("GITHUB_TOKEN")
-    headers = {}
-    if token:
-        headers["Authorization"] = f"token {token}"
-    else:
-        print("Warning: GITHUB_TOKEN not found, making unauthenticated request")
-    
-    response = requests.get(link, headers=headers)
-    if response.status_code == 200:
-        content = response.json()
-        if "download_url" in content:
-            return content["download_url"]
-        else:
-            return fallback_link
-    else:
-        print(f"Failed to fetch URL: {link} {response.status_code} - {response.text}")
-        return fallback_link
-
-ICON_URL = fetch_raw_url(GITHUB_API_ICON_URL, RAW_GITHUB_ICON_URL)
+ICON_URL = "https://raw.githubusercontent.com/apache/airflow/main/airflow-core/src/airflow/ui/public/pin_100.png"
 
 class TestSlackNotifier:
     @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")


### PR DESCRIPTION
Implemented changes in scripts mentioned in #50737 to use GitHub API instead of fetching files via raw.githubusercontent.com.



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
