### PR TITLE
Handle get_queue_info todo in JenkinsJobTriggerOperator

### DIFF
--- a/providers/jenkins/src/airflow/providers/jenkins/operators/jenkins_job_trigger.py
+++ b/providers/jenkins/src/airflow/providers/jenkins/operators/jenkins_job_trigger.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import ast
-import json
+import re
 import time
 from collections.abc import Iterable, Mapping, Sequence
 from functools import cached_property
@@ -143,47 +143,46 @@ class JenkinsJobTriggerOperator(BaseOperator):
         queue without having a build number assigned. We have to wait until the
         job exits the queue to know its build number.
 
-        To do so, we add ``/api/json`` (or ``/api/xml``) to the location
-        returned by the ``build_job`` call, and poll this file. When an
-        ``executable`` block appears in the response, the job execution would
-        have started, and the field ``number`` would contains the build number.
+        To do so, we use get_queue_item to get information about a queued item
+        https://python-jenkins.readthedocs.io/en/latest/api.html#jenkins.Jenkins.get_queue_item
 
         :param location: Location to poll, returned in the header of the build_job call
         :param jenkins_server: The jenkins server to poll
         :return: The build_number corresponding to the triggered job
         """
-        location += "/api/json"
-        # TODO Use get_queue_info instead
-        # once it will be available in python-jenkins (v > 0.4.15)
         self.log.info("Polling jenkins queue at the url %s", location)
+
+        match = re.search(r"/queue/item/(\d+)/?", location)
+        if not match:
+            raise ValueError(f"Invalid queue location format: {location}")
+
+        queue_id = int(match.group(1))
+
+        self.log.info("Polling Jenkins queue item with ID %s", queue_id)
         for attempt in range(self.max_try_before_job_appears):
             if attempt:
                 time.sleep(self.sleep_time)
-
             try:
-                location_answer = jenkins_request_with_headers(
-                    jenkins_server, Request(method="POST", url=location)
-                )
-            # we don't want to fail the operator, this will continue to poll
-            # until max_try_before_job_appears reached
+                json_response: dict = jenkins_server.get_queue_item(queue_id)
             except (HTTPError, JenkinsException):
                 self.log.warning("polling failed, retrying", exc_info=True)
-            else:
-                if location_answer is not None:
-                    json_response = json.loads(location_answer["body"])
-                    if (
-                        "executable" in json_response
-                        and json_response["executable"] is not None
-                        and "number" in json_response["executable"]
-                    ):
-                        build_number = json_response["executable"]["number"]
-                        self.log.info("Job executed on Jenkins side with the build number %s", build_number)
-                        return build_number
-        else:
-            raise AirflowException(
-                f"The job hasn't been executed after polling the queue "
-                f"{self.max_try_before_job_appears} times"
-            )
+
+            if json_response:
+                # The returned dict will have an "executable" key if the queued item is running on an executor,
+                # or has completed running.
+                if (
+                    "executable" in json_response
+                    and json_response["executable"] is not None
+                    and "number" in json_response["executable"]
+                ):
+                    build_number = json_response["executable"]["number"]
+                    self.log.info("Job executed on Jenkins side with the build number %s", build_number)
+                    return build_number
+                self.log.debug("Job not yet started. Queue item: %s", json_response)
+
+        raise AirflowException(
+            f"The job hasn't been executed after polling the queue {self.max_try_before_job_appears} times"
+        )
 
     @cached_property
     def hook(self) -> JenkinsHook:

--- a/providers/jenkins/tests/unit/jenkins/operators/test_jenkins_job_trigger.py
+++ b/providers/jenkins/tests/unit/jenkins/operators/test_jenkins_job_trigger.py
@@ -42,6 +42,10 @@ class TestJenkinsOperator:
             "url": "http://aaa.fake-url.com/congratulation/its-a-job",
         }
         jenkins_mock.build_job_url.return_value = "http://www.jenkins.url/somewhere/in/the/universe"
+        jenkins_mock.get_queue_item.side_effect = [
+            {},
+            {"executable": {"number": "1"}},
+        ]
 
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
@@ -56,11 +60,12 @@ class TestJenkinsOperator:
                 "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
             ) as mock_make_request,
         ):
-            mock_make_request.side_effect = [
-                {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
-                {"body": '{"executable":{"number":"1"}}', "headers": {}},
-            ]
+            mock_make_request.return_value = {
+                "body": "",
+                "headers": {"Location": "http://what-a-strange.url/queue/item/18/"},
+            }
             hook_mocked.return_value = hook_mock
+
             operator = JenkinsJobTriggerOperator(
                 dag=None,
                 jenkins_connection_id="fake_jenkins_connection",
@@ -85,6 +90,10 @@ class TestJenkinsOperator:
             {"result": "SUCCESS", "url": "http://aaa.fake-url.com/congratulation/its-a-job"},
         ]
         jenkins_mock.build_job_url.return_value = "http://www.jenkins.url/somewhere/in/the/universe"
+        jenkins_mock.get_queue_item.side_effect = [
+            {},
+            {"executable": {"number": "1"}},
+        ]
 
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
@@ -99,10 +108,10 @@ class TestJenkinsOperator:
                 "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
             ) as mock_make_request,
         ):
-            mock_make_request.side_effect = [
-                {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
-                {"body": '{"executable":{"number":"1"}}', "headers": {}},
-            ]
+            mock_make_request.return_value = {
+                "body": "",
+                "headers": {"Location": "http://what-a-strange.url/queue/item/18/"},
+            }
             hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
@@ -126,6 +135,10 @@ class TestJenkinsOperator:
             "url": "http://aaa.fake-url.com/congratulation/its-a-job",
         }
         jenkins_mock.build_job_url.return_value = "http://www.jenkins.url/somewhere/in/the/universe"
+        jenkins_mock.get_queue_item.side_effect = [
+            {},
+            {"executable": {"number": "1"}},
+        ]
 
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
@@ -140,10 +153,10 @@ class TestJenkinsOperator:
                 "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
             ) as mock_make_request,
         ):
-            mock_make_request.side_effect = [
-                {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
-                {"body": '{"executable":{"number":"1"}}', "headers": {}},
-            ]
+            mock_make_request.return_value = {
+                "body": "",
+                "headers": {"Location": "http://what-a-strange.url/queue/item/18/"},
+            }
             hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
@@ -187,6 +200,10 @@ class TestJenkinsOperator:
             "url": "http://aaa.fake-url.com/congratulation/its-a-job",
         }
         jenkins_mock.build_job_url.return_value = "http://www.jenkins.url/somewhere/in/the/universe"
+        jenkins_mock.get_queue_item.side_effect = [
+            {},
+            {"executable": {"number": "1"}},
+        ]
 
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
@@ -201,10 +218,10 @@ class TestJenkinsOperator:
                 "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers",
             ) as mock_make_request,
         ):
-            mock_make_request.side_effect = [
-                {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
-                {"body": '{"executable":{"number":"1"}}', "headers": {}},
-            ]
+            mock_make_request.return_value = {
+                "body": "",
+                "headers": {"Location": "http://what-a-strange.url/queue/item/18/"},
+            }
             hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
@@ -254,6 +271,10 @@ class TestJenkinsOperator:
             "url": "http://aaa.fake-url.com/congratulation/its-a-job",
         }
         jenkins_mock.build_job_url.return_value = "http://www.jenkins.url/somewhere/in/the/universe"
+        jenkins_mock.get_queue_item.side_effect = [
+            {},
+            {"executable": {"number": "1"}},
+        ]
 
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
@@ -268,10 +289,10 @@ class TestJenkinsOperator:
                 "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
             ) as mock_make_request,
         ):
-            mock_make_request.side_effect = [
-                {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
-                {"body": '{"executable":{"number":"1"}}', "headers": {}},
-            ]
+            mock_make_request.return_value = {
+                "body": "",
+                "headers": {"Location": "http://what-a-strange.url/queue/item/18/"},
+            }
             hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,

--- a/providers/jenkins/tests/unit/jenkins/operators/test_jenkins_job_trigger.py
+++ b/providers/jenkins/tests/unit/jenkins/operators/test_jenkins_job_trigger.py
@@ -134,9 +134,11 @@ class TestJenkinsOperator:
             operator.execute(None)
             assert jenkins_mock.get_build_info.call_count == 2
             assert jenkins_mock.get_queue_item.call_count == 4
-
-            assert mock_log.warning.call_count == 2
-            assert mock_log.warning.call_args == mock.call("polling failed, retrying", exc_info=True)
+            # on HTTPError and JenkinsException
+            assert mock_log.warning.mock_calls == [
+                mock.call("polling failed, retrying", exc_info=True),
+                mock.call("polling failed, retrying", exc_info=True),
+            ]
 
     @pytest.mark.parametrize("parameters", TEST_PARAMETERS)
     def test_execute_job_failure(self, parameters, mocker):


### PR DESCRIPTION
Close: https://github.com/apache/airflow/issues/54067

### Change Summary

The task is to resolve a TODO comment in the code to refactor the poll job method with [`get_queue_info`](https://python-jenkins.readthedocs.io/en/latest/api.html#jenkins.Jenkins.get_queue_info) which is available in python-jenkins (v > 0.4.15). After reviewing the document, `get_queue_info` will return a list of job dictionaries, for the jobs in the queue. Using this method, we might need to traverse the list to identify which job is triggered and poll the status for that job.   

In python-jenkins, there is another method called [`get_queue_item`](https://python-jenkins.readthedocs.io/en/latest/api.html#jenkins.Jenkins.get_queue_item). This method can get information about a queued item. The returned dict will have a “why” key if the queued item is still waiting for an executor. The returned dict will have an “executable” key if the queued item is running on an executor, or has completed running. Use this to determine the job number / URL. We can use the regex pattern `/queue/item/(\d+)/?` to extract the item number, which will be used as the parameter to the `get_queue_item`, from the returned header of the `build_job` call. This offers the following benefits.

1. When there are multiple jobs in the queue, we can explicitly poll the status of the job triggered by the operator, without the needs to traverse the list of job dictionaries.
2. Even the job exits the queue, we can still extract the status (i.e., the returned dictionary will contain a "executable" key). The `get_queue_info` method will return an empty list when the queue is empty. Therefore, the extraction of build number will be easier.

The job is triggered and in the queue.
<img width="1644" height="306" alt="Screenshot from 2025-08-07 01-09-06" src="https://github.com/user-attachments/assets/bba19af0-1621-425d-9b26-82717e7785f5" />

The operator can fetch the item number to poll the job status.
<img width="1558" height="675" alt="Screenshot from 2025-08-07 01-09-41" src="https://github.com/user-attachments/assets/8b73107e-0633-4a65-8e2c-669ec0b95742" />

The return value of the operator which is the build number / URL.
<img width="1576" height="389" alt="Screenshot from 2025-08-07 01-12-15" src="https://github.com/user-attachments/assets/411566b4-80f2-4feb-af5c-6588a9180193" />

However, I would like to gather feedback regarding the use of regex matching. It looks like the URL will align with the pattern `/queue/item/(\d+)/?` for all Jenkins version when attempting to access job in the queue. I also updated the URLs in the test cases to align with this pattern.

### Issue with Jenkins connection

During the development, I found that the `schema` is required to set up a connection. This results in the URL to be resolved as `http://jenkins-blueocean:8080/None`. Because of this, I cannot successfully connect to Jenkins. After removing this `schema`, I am able to connect to Jenkins through `http://jenkins-blueocean:8080`. Also, this parameter is not configurable through the UI as shown below. Not sure if we need to create an issue for adding the `schema` field in connection to the UI.

> I deployed Jenkins using Docker and set the network to `breeze_default`, which is the same network as Airflow services running in the breeze environment.

https://github.com/apache/airflow/blob/dc952f0cf44691b67c51d5de34973886d8025209/providers/jenkins/src/airflow/providers/jenkins/hooks/jenkins.py#L70

<img width="1576" height="389" alt="Screenshot from 2025-08-07 01-29-36" src="https://github.com/user-attachments/assets/64f371d4-7733-4be9-88c9-1be29039c676" />

<img width="1047" height="835" alt="Screenshot from 2025-08-07 01-33-25" src="https://github.com/user-attachments/assets/347b5024-764f-4dd1-8628-c9c021faf7a8" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
