### PR TITLE
Add get_secret function to the common/utils in google provider

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
@@ -350,6 +350,9 @@ class GenerativeModelHook(GoogleBaseHook):
         :param generation_config: Optional. Generation configuration settings.
         :param safety_settings: Optional. Per request settings for blocking unsafe content.
         """
+        # During run of the system test it was found out that names from xcom, e.g. 3402922389 can be
+        # treated as int and throw an error TypeError: expected string or bytes-like object, got 'int'
+        cached_content_name = str(cached_content_name)
         vertexai.init(project=project_id, location=location, credentials=self.get_credentials())
 
         cached_context_model = self.get_cached_context_model(cached_content_name=cached_content_name)

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py
@@ -58,7 +58,7 @@ class TextEmbeddingModelGetEmbeddingsOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("location", "project_id", "impersonation_chain", "prompt")
+    template_fields = ("location", "project_id", "impersonation_chain", "prompt", "pretrained_model")
 
     def __init__(
         self,
@@ -211,7 +211,14 @@ class SupervisedFineTuningTrainOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("location", "project_id", "impersonation_chain", "train_dataset", "validation_dataset")
+    template_fields = (
+        "location",
+        "project_id",
+        "impersonation_chain",
+        "train_dataset",
+        "validation_dataset",
+        "source_model",
+    )
 
     def __init__(
         self,

--- a/providers/google/src/airflow/providers/google/common/utils/get_secret.py
+++ b/providers/google/src/airflow/providers/google/common/utils/get_secret.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from google.cloud.exceptions import NotFound
+
+from airflow.providers.google.cloud.hooks.secret_manager import (
+    GoogleCloudSecretManagerHook,
+)
+
+
+def get_secret(secret_id: str) -> str:
+    hook = GoogleCloudSecretManagerHook()
+    if hook.secret_exists(secret_id=secret_id):
+        return hook.access_secret(secret_id=secret_id).payload.data.decode()
+    raise NotFound("The secret '%s' not found", secret_id)

--- a/providers/google/tests/system/google/marketing_platform/example_analytics_admin.py
+++ b/providers/google/tests/system/google/marketing_platform/example_analytics_admin.py
@@ -43,7 +43,6 @@ from datetime import datetime
 from typing import Any
 
 from google.analytics import admin_v1beta as google_analytics
-from google.cloud.exceptions import NotFound
 
 try:
     from airflow.sdk import task
@@ -51,7 +50,7 @@ except ImportError:
     # Airflow 2 path
     from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
 from airflow.models.dag import DAG
-from airflow.providers.google.cloud.hooks.secret_manager import GoogleCloudSecretManagerHook
+from airflow.providers.google.common.utils.get_secret import get_secret
 from airflow.providers.google.marketing_platform.operators.analytics_admin import (
     GoogleAnalyticsAdminCreateDataStreamOperator,
     GoogleAnalyticsAdminCreatePropertyOperator,
@@ -76,13 +75,6 @@ DATA_STREAM_ID = "{{ task_instance.xcom_pull('create_data_stream')['name'].split
 GA_ADS_LINK_ID = "{{ task_instance.xcom_pull('list_google_ads_links')[0]['name'].split('/')[-1] }}"
 
 log = logging.getLogger(__name__)
-
-
-def get_secret(secret_id: str) -> str:
-    hook = GoogleCloudSecretManagerHook()
-    if hook.secret_exists(secret_id=secret_id):
-        return hook.access_secret(secret_id=secret_id).payload.data.decode()
-    raise NotFound("The secret '%s' not found", secret_id)
 
 
 with DAG(

--- a/providers/google/tests/system/google/marketing_platform/example_campaign_manager.py
+++ b/providers/google/tests/system/google/marketing_platform/example_campaign_manager.py
@@ -34,8 +34,6 @@ import uuid
 from datetime import datetime
 from typing import Any, cast
 
-from google.api_core.exceptions import NotFound
-
 try:
     from airflow.sdk import task
 except ImportError:
@@ -43,8 +41,8 @@ except ImportError:
     from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
 from airflow.models.dag import DAG
 from airflow.models.xcom_arg import XComArg
-from airflow.providers.google.cloud.hooks.secret_manager import GoogleCloudSecretManagerHook
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
+from airflow.providers.google.common.utils.get_secret import get_secret
 from airflow.providers.google.marketing_platform.operators.campaign_manager import (
     GoogleCampaignManagerBatchInsertConversionsOperator,
     GoogleCampaignManagerBatchUpdateConversionsOperator,
@@ -139,13 +137,6 @@ CONVERSION_UPDATE = {
 
 
 log = logging.getLogger(__name__)
-
-
-def get_secret(secret_id: str) -> str:
-    hook = GoogleCloudSecretManagerHook()
-    if hook.secret_exists(secret_id=secret_id):
-        return hook.access_secret(secret_id=secret_id).payload.data.decode().strip()
-    raise NotFound("The secret '%s' not found", secret_id)
 
 
 with DAG(

--- a/providers/google/tests/system/google/marketing_platform/example_display_video.py
+++ b/providers/google/tests/system/google/marketing_platform/example_display_video.py
@@ -37,20 +37,16 @@ import json
 import os
 from datetime import datetime
 
-from google.cloud.exceptions import NotFound
-
 try:
     from airflow.sdk import task
 except ImportError:
     # Airflow 2 path
     from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
 from airflow.models.dag import DAG
-from airflow.providers.google.cloud.hooks.secret_manager import (
-    GoogleCloudSecretManagerHook,
-)
 from airflow.providers.google.cloud.operators.bigquery import BigQueryCreateEmptyDatasetOperator
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+from airflow.providers.google.common.utils.get_secret import get_secret
 from airflow.providers.google.marketing_platform.hooks.display_video import GoogleDisplayVideo360Hook
 from airflow.providers.google.marketing_platform.operators.display_video import (
     GoogleDisplayVideo360CreateSDFDownloadTaskOperator,
@@ -93,13 +89,6 @@ CREATE_SDF_DOWNLOAD_TASK_BODY_REQUEST: dict = {
 }
 
 # [END howto_display_video_env_variables]
-
-
-def get_secret(secret_id: str) -> str:
-    hook = GoogleCloudSecretManagerHook()
-    if hook.secret_exists(secret_id=secret_id):
-        return hook.access_secret(secret_id=secret_id).payload.data.decode()
-    raise NotFound("The secret '%s' not found", secret_id)
 
 
 with DAG(

--- a/providers/google/tests/unit/google/common/utils/test_get_secret.py
+++ b/providers/google/tests/unit/google/common/utils/test_get_secret.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from google.cloud.exceptions import NotFound
+
+from airflow.providers.google.common.utils.get_secret import get_secret
+
+
+class TestGetSecret:
+    @mock.patch("airflow.providers.google.common.utils.get_secret.GoogleCloudSecretManagerHook")
+    def test_get_secret_success(self, mock_hook_class):
+        mock_hook_instance = mock.Mock()
+        mock_hook_class.return_value = mock_hook_instance
+
+        mock_hook_instance.secret_exists.return_value = True
+
+        mock_payload = mock.Mock()
+        mock_payload.data.decode.return_value = "test_secret_value"
+        mock_access_secret_return = mock.Mock()
+        mock_access_secret_return.payload = mock_payload
+        mock_hook_instance.access_secret.return_value = mock_access_secret_return
+
+        secret_id = "test-secret-id"
+        expected_secret_value = "test_secret_value"
+
+        result = get_secret(secret_id=secret_id)
+
+        mock_hook_class.assert_called_once()
+        mock_hook_instance.secret_exists.assert_called_once_with(secret_id=secret_id)
+        mock_hook_instance.access_secret.assert_called_once_with(secret_id=secret_id)
+        assert result == expected_secret_value
+
+    @mock.patch("airflow.providers.google.common.utils.get_secret.GoogleCloudSecretManagerHook")
+    def test_get_secret_not_found(self, mock_hook_class):
+        mock_hook_instance = mock.Mock()
+        mock_hook_class.return_value = mock_hook_instance
+
+        mock_hook_instance.secret_exists.return_value = False
+
+        secret_id = "non-existent-secret"
+
+        with pytest.raises(NotFound):
+            get_secret(secret_id=secret_id)
+
+        mock_hook_class.assert_called_once()
+        mock_hook_instance.secret_exists.assert_called_once_with(secret_id=secret_id)
+        mock_hook_instance.access_secret.assert_not_called()


### PR DESCRIPTION
Add get_secret function to the common/utils in google provider to reuse it in system tests. Rework example_vertex_ai_generative_model.py, example_vertex_ai_generative_model_tuning.py system tests to accept api-key from secret manager. Add model field to the rendered template in generative_model operators. Add small fix for the generate from cached content operator.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
