### PR TITLE
To resolve issue dag_run timestamp incorrect due to setting time zone #54006

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -753,7 +753,8 @@ class DagRun(Base, LoggingMixin):
         """
         # _Ensure_ run_type is a DagRunType, not just a string from user code
         if logical_date:
-            return DagRunType(run_type).generate_run_id(suffix=run_after.isoformat())
+            #To ensure that the logicak_date aligns with the naming of run_id
+            return DagRunType(run_type).generate_run_id(suffix=logical_date.isoformat())
         return DagRunType(run_type).generate_run_id(suffix=f"{run_after.isoformat()}_{get_random_string()}")
 
     @staticmethod


### PR DESCRIPTION
Closes #54006 

While generating the run_id, the code should utilize the run type and the logical date if the logical dates exists. Currently it is derived from run type and run_after instead in all cases.

The run_after field is based on;
run_after = run_after or timezone.coerce_datetime(timezone.utcnow()).

If we don't provide a run_after field in the API call, it will take it as utcnow() and based on the same, we get to see the inconsistency even after providing a valid logical_date.

While running manually from UI, both logical date and run_after will be same based on the utcnow(), so we are getting the desired results.

To make this consistent, we can derive the run_id from logical_date (when it exists) instead of the run_after field to make things consistent.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
