### PR TITLE
Add setter for blob_service_client in WasbHook to support async injection

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, TypeVar, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from asgiref.sync import sync_to_async
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
@@ -272,7 +272,7 @@ class WasbHook(BaseHook):
         blobs = self.get_blobs_list(container_name=container_name, prefix=prefix, **kwargs)
         return bool(blobs)
 
-    T = TypeVar("T", AsyncBlobServiceClient, ContainerClient, AsyncContainerClient)
+    T = TypeVar("T", BlobServiceClient, ContainerClient, AsyncContainerClient)
 
     def check_for_variable_type(self, variable_name: str, container: T, expected_type: type[T]) -> None:
         if not isinstance(container, expected_type):
@@ -301,6 +301,7 @@ class WasbHook(BaseHook):
         """
         container = self._get_container_client(container_name)
         self.check_for_variable_type("container", container, ContainerClient)
+        container = cast("ContainerClient", container)
 
         blob_list = []
         blobs = container.walk_blobs(name_starts_with=prefix, include=include, delimiter=delimiter, **kwargs)
@@ -329,6 +330,7 @@ class WasbHook(BaseHook):
         """
         container = self._get_container_client(container_name)
         self.check_for_variable_type("container", container, ContainerClient)
+        container = cast("ContainerClient", container)
 
         blob_list = []
         blobs = container.list_blobs(name_starts_with=prefix, include=include, **kwargs)
@@ -618,6 +620,7 @@ class WasbAsyncHook(WasbHook):
             self.check_for_variable_type(
                 "self._blob_service_client", self._blob_service_client, AsyncBlobServiceClient
             )
+            self._blob_service_client = cast("AsyncBlobServiceClient", self._blob_service_client)
             return self._blob_service_client
 
         conn = await sync_to_async(self.get_connection)(self.conn_id)
@@ -745,6 +748,7 @@ class WasbAsyncHook(WasbHook):
         :param delimiter: filters objects based on the delimiter (for e.g '.csv')
         """
         container = self._get_container_client(container_name)
+        container = cast("AsyncContainerClient", container)
         self.check_for_variable_type("container", container, AsyncContainerClient)
 
         blob_list: list[BlobProperties | BlobPrefix] = []

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import logging
 import os
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 from asgiref.sync import sync_to_async
@@ -602,8 +601,12 @@ class WasbAsyncHook(WasbHook):
 
     async def get_async_conn(self) -> AsyncBlobServiceClient:
         """Return the Async BlobServiceClient object."""
-        if isinstance(self._blob_service_client, AsyncBlobServiceClient):
-            return self.blob_service_client
+        if self._blob_service_client is not None:
+            if isinstance(self._blob_service_client, AsyncBlobServiceClient):
+                return self.blob_service_client
+            raise TypeError(
+                f"_blob_service_client must be AsyncBlobServiceClient, got {type(self._blob_service_client).__name__}"
+            )
 
         conn = await sync_to_async(self.get_connection)(self.conn_id)
         extra = conn.extra_dejson or {}

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -162,7 +162,7 @@ class WasbHook(BaseHook):
         return self._blob_service_client
 
     @blob_service_client.setter
-    def blob_service_client(self, client: AsyncBlobServiceClient):
+    def blob_service_client(self, client: AsyncBlobServiceClient) -> None:
         """Set the cached BlobServiceClient object."""
         self._blob_service_client = client
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -292,8 +292,10 @@ class WasbHook(BaseHook):
         :param delimiter: filters objects based on the delimiter (for e.g '.csv')
         """
         container = self._get_container_client(container_name)
-        if isinstance(container, AsyncContainerClient):
-            raise TypeError("WasbAsyncHook should call get_blobs_list_async function instead.")
+        if not isinstance(container, ContainerClient):
+            raise TypeError(
+                f"_get_container_client for WasbHook should return ContainerClient object, got {type(container).__name__}"
+            )
 
         blob_list = []
         blobs = container.walk_blobs(name_starts_with=prefix, include=include, delimiter=delimiter, **kwargs)
@@ -321,8 +323,10 @@ class WasbHook(BaseHook):
         :param delimiter: filters objects based on the delimiter (for e.g '.csv')
         """
         container = self._get_container_client(container_name)
-        if isinstance(container, AsyncContainerClient):
-            raise TypeError("WasbAsyncHook should call get_blobs_list_async function instead.")
+        if not isinstance(container, ContainerClient):
+            raise TypeError(
+                f"_get_container_client for WasbHook should return ContainerClient object, got {type(container).__name__}"
+            )
 
         blob_list = []
         blobs = container.list_blobs(name_starts_with=prefix, include=include, **kwargs)
@@ -740,6 +744,11 @@ class WasbAsyncHook(WasbHook):
         :param delimiter: filters objects based on the delimiter (for e.g '.csv')
         """
         container = self._get_container_client(container_name)
+        if not isinstance(container, AsyncContainerClient):
+            raise TypeError(
+                f"_get_container_client for AsyncContainerClient should return AsyncContainerClient object, got {type(container).__name__}"
+            )
+
         blob_list: list[BlobProperties | BlobPrefix] = []
         blobs = container.walk_blobs(name_starts_with=prefix, include=include, delimiter=delimiter, **kwargs)
         async for blob in blobs:

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from asgiref.sync import sync_to_async
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
@@ -272,9 +272,7 @@ class WasbHook(BaseHook):
         blobs = self.get_blobs_list(container_name=container_name, prefix=prefix, **kwargs)
         return bool(blobs)
 
-    T = TypeVar("T", BlobServiceClient, ContainerClient, AsyncContainerClient)
-
-    def check_for_variable_type(self, variable_name: str, container: T, expected_type: type[T]) -> None:
+    def check_for_variable_type(self, variable_name: str, container: Any, expected_type: type[Any]) -> None:
         if not isinstance(container, expected_type):
             raise TypeError(
                 f"{variable_name} for {self.__class__.__name__} must be {expected_type.__name__}, got {type(container).__name__}"

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -598,6 +598,7 @@ class WasbAsyncHook(WasbHook):
         """Initialize the hook instance."""
         self.conn_id = wasb_conn_id
         self.public_read = public_read
+        self._blob_service_client: AsyncBlobServiceClient | BlobServiceClient | None = None
 
     async def get_async_conn(self) -> AsyncBlobServiceClient:
         """Return the Async BlobServiceClient object."""

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
@@ -199,6 +199,19 @@ class TestWasbHook:
             shared_access_key="token",
         )
 
+    def test_blob_service_client_setter_overrides_cache(self, monkeypatch):
+        hook = WasbHook(wasb_conn_id=self.azure_shared_key_test)
+        default_client = mock.MagicMock(name="default_client")
+        monkeypatch.setattr(hook, "get_conn", mock.MagicMock(return_value=default_client))
+        hook._blob_service_client = None
+        assert hook.blob_service_client is default_client
+        hook.get_conn.assert_called_once()
+        new_client = mock.MagicMock(name="new_client")
+        hook.blob_service_client = new_client
+        hook.get_conn.reset_mock()
+        assert hook.blob_service_client is new_client
+        hook.get_conn.assert_not_called()
+
     def test_managed_identity(self, mocked_default_azure_credential, mocked_blob_service_client):
         mocked_default_azure_credential.assert_not_called()
         mocked_default_azure_credential.return_value = "foo-bar"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 import os
 import re
 from unittest import mock
+from unittest.mock import create_autospec
 
 import pytest
 from azure.core.exceptions import ResourceNotFoundError
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobServiceClient, ContainerClient
 from azure.storage.blob._models import BlobProperties
 
 from airflow.exceptions import AirflowException
@@ -432,6 +433,8 @@ class TestWasbHook:
         get_blobs_list.assert_called_once_with(container_name="container", prefix="prefix", timeout=3)
 
     def test_get_blobs_list(self, mocked_blob_service_client):
+        mock_container = create_autospec(ContainerClient, instance=True)
+        mocked_blob_service_client.return_value.get_container_client.return_value = mock_container
         hook = WasbHook(wasb_conn_id=self.azure_shared_key_test)
         hook.get_blobs_list(container_name="mycontainer", prefix="my", include=None, delimiter="/")
         mock_container_client = mocked_blob_service_client.return_value.get_container_client
@@ -441,6 +444,8 @@ class TestWasbHook:
         )
 
     def test_get_blobs_list_recursive(self, mocked_blob_service_client):
+        mock_container = create_autospec(ContainerClient, instance=True)
+        mocked_blob_service_client.return_value.get_container_client.return_value = mock_container
         hook = WasbHook(wasb_conn_id=self.azure_shared_key_test)
         hook.get_blobs_list_recursive(
             container_name="mycontainer", prefix="test", include=None, endswith="file_extension"
@@ -452,6 +457,8 @@ class TestWasbHook:
         )
 
     def test_get_blobs_list_recursive_endswith(self, mocked_blob_service_client):
+        mock_container = create_autospec(ContainerClient, instance=True)
+        mocked_blob_service_client.return_value.get_container_client.return_value = mock_container
         hook = WasbHook(wasb_conn_id=self.azure_shared_key_test)
         mocked_blob_service_client.return_value.get_container_client.return_value.list_blobs.return_value = [
             BlobProperties(name="test/abc.py"),

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
@@ -244,6 +244,17 @@ class TestWasbHook:
             proxies=self.proxies,
         )
 
+    def test_variable_type_checking(self):
+        hook = WasbHook(wasb_conn_id=self.azure_shared_key_test)
+        ok_container = object.__new__(ContainerClient)
+        hook.check_for_variable_type("container", ok_container, ContainerClient)
+        wrong_container = object.__new__(BlobServiceClient)
+        with pytest.raises(TypeError) as ei:
+            hook.check_for_variable_type("container", wrong_container, ContainerClient)
+        msg = str(ei.value)
+        for s in ["container", "WasbHook", "ContainerClient", "BlobServiceClient"]:
+            assert s in msg
+
     def test_account_key_connection(self, mocked_blob_service_client):
         """Test that account_key from extra is used when no password is provided."""
         WasbHook(wasb_conn_id=self.account_key_conn_id).get_conn()

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_msgraph.py
@@ -38,7 +38,7 @@ from unit.microsoft.azure.test_utils import mock_json_response, mock_response
 try:
     from airflow.sdk import timezone
 except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
+    from airflow.utils import timezone  # type: ignore[no-redef]
 
 try:
     from airflow.sdk.definitions.context import Context


### PR DESCRIPTION
Resolve: https://github.com/apache/airflow/pull/53647#discussion_r2233971148

Originally, self.blob_service_client was set to None and later assigned via the `get_async_conn()` function, which does not follow the `@cached_property` pattern.
Therefore, we added a setter to allow direct injection into `WasbAsyncHook.`