### PR TITLE
Update HiveToDynamoDBOperator to support Polars

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 from airflow.providers.amazon.version_compat import BaseOperator
@@ -53,6 +53,7 @@ class HiveToDynamoDBOperator(BaseOperator):
     :param hiveserver2_conn_id: Reference to the
         :ref: `Hive Server2 thrift service connection id <howto/connection:hiveserver2>`.
     :param aws_conn_id: aws connection
+    :param df_type: DataFrame type to use ("pandas" or "polars").
     """
 
     template_fields: Sequence[str] = ("sql",)
@@ -73,6 +74,7 @@ class HiveToDynamoDBOperator(BaseOperator):
         schema: str = "default",
         hiveserver2_conn_id: str = "hiveserver2_default",
         aws_conn_id: str | None = "aws_default",
+        df_type: Literal["pandas", "polars"] = "pandas",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -86,6 +88,7 @@ class HiveToDynamoDBOperator(BaseOperator):
         self.schema = schema
         self.hiveserver2_conn_id = hiveserver2_conn_id
         self.aws_conn_id = aws_conn_id
+        self.df_type = df_type
 
     def execute(self, context: Context):
         hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
@@ -93,7 +96,7 @@ class HiveToDynamoDBOperator(BaseOperator):
         self.log.info("Extracting data from Hive")
         self.log.info(self.sql)
 
-        data = hive.get_df(self.sql, schema=self.schema, df_type="pandas")
+        data = hive.get_df(self.sql, schema=self.schema, df_type=self.df_type)
         dynamodb = DynamoDBHook(
             aws_conn_id=self.aws_conn_id,
             table_name=self.table_name,
@@ -104,7 +107,10 @@ class HiveToDynamoDBOperator(BaseOperator):
         self.log.info("Inserting rows into dynamodb")
 
         if self.pre_process is None:
-            dynamodb.write_batch_data(json.loads(data.to_json(orient="records")))
+            if self.df_type == "polars":
+                dynamodb.write_batch_data(data.to_dicts())  # type:ignore[operator]
+            elif self.df_type == "pandas":
+                dynamodb.write_batch_data(json.loads(data.to_json(orient="records")))  # type:ignore[union-attr]
         else:
             dynamodb.write_batch_data(
                 self.pre_process(data=data, args=self.pre_process_args, kwargs=self.pre_process_kwargs)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
 
## Why

Current HiveToDynamoDBOperator only supports Pandas DataFrames, limiting extensibility to Polars
cc: @eladkal

 ## How

- Added `df_type` parameter supporting "pandas" (default) and "polars"
- Enhanced data serialization to handle both DataFrame types with appropriate methods
- Added tests for both DataFrame types
- Removed unused type overload

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
