### PR TITLE
docs(cli): update variables import help to include YAML and ENV support

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -540,7 +540,7 @@ ARG_VAR_DESCRIPTION = Arg(
 )
 ARG_DESERIALIZE_JSON = Arg(("-j", "--json"), help="Deserialize JSON variable", action="store_true")
 ARG_SERIALIZE_JSON = Arg(("-j", "--json"), help="Serialize JSON variable", action="store_true")
-ARG_VAR_IMPORT = Arg(("file",), help="Import variables from JSON file")
+ARG_VAR_IMPORT = Arg(("file",), help="Import variables from .env, .json, .yaml or .yml file")
 ARG_VAR_EXPORT = Arg(
     ("file",),
     help="Export all variables to JSON file",

--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -176,9 +176,9 @@ def _parse_secret_file(file_path: str) -> dict[str, Any]:
     ext = Path(file_path).suffix.lstrip(".").lower()
 
     if ext not in FILE_PARSERS:
+        extensions = " ".join([f".{ext}" for ext in sorted(FILE_PARSERS.keys())])
         raise AirflowUnsupportedFileTypeException(
-            "Unsupported file format. The file must have one of the following extensions: "
-            ".env .json .yaml .yml"
+            f"Unsupported file format. The file must have one of the following extensions: {extensions}"
         )
 
     secrets, parse_errors = FILE_PARSERS[ext](file_path)

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -343,6 +343,31 @@ class TestCli:
         with pytest.raises(argparse.ArgumentTypeError):
             cli_config.positive_int(allow_zero=True)("-1")
 
+    def test_variables_import_help_message_consistency(self):
+        """
+        Test that ARG_VAR_IMPORT help message accurately reflects supported file formats.
+
+        This test ensures that when new file formats are added to FILE_PARSERS,
+        developers remember to update the CLI help message accordingly.
+        """
+        from airflow.cli.cli_config import ARG_VAR_IMPORT
+        from airflow.secrets.local_filesystem import FILE_PARSERS
+
+        # Get actually supported formats
+        supported_formats = set(FILE_PARSERS.keys())
+
+        # Check each supported format is mentioned in help as .ext
+        help_text = ARG_VAR_IMPORT.kwargs["help"].lower()
+        missing_in_help = {fmt for fmt in supported_formats if f".{fmt}" not in help_text}
+
+        assert not missing_in_help, (
+            f"CLI help message for 'airflow variables import' is missing supported formats.\n"
+            f"Supported formats: {sorted(supported_formats)}\n"
+            f"Missing from help: {sorted(missing_in_help)}\n"
+            f"Help message: '{ARG_VAR_IMPORT.kwargs['help']}'\n"
+            f"Please update ARG_VAR_IMPORT help message in cli_config.py to include: {', '.join([f'.{fmt}' for fmt in sorted(missing_in_help)])}"
+        )
+
     @pytest.mark.parametrize(
         "command",
         [


### PR DESCRIPTION
New file types have been added to the `airflow variables import` command in this [PR](https://github.com/apache/airflow/pull/53726).

We need to update the CLI command's help message to reflect this change.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---