### PR TITLE
Allow downgrading to 2.11 from 3.x

### DIFF
--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -66,7 +66,11 @@ def _get_version_revision(version: str, revision_heads_map: dict[str, str] | Non
     if version in revision_heads_map:
         return revision_heads_map[version]
 
-    wanted = tuple(map(int, version.split(".")))
+    try:
+        wanted = tuple(map(int, version.split(".")))
+    except ValueError:
+        return None
+
     # Else, we walk backwards in the revision map until we find a version that is < the target
     for revision, head in reversed(revision_heads_map.items()):
         try:

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -1189,21 +1189,21 @@ def downgrade(*, to_revision, from_revision=None, show_sql_only=False, session: 
     config = _get_alembic_config()
     # Check if downgrade is less than 3.0.0 and requires that `ab_user` fab table is present
     if _revision_greater(config, _REVISION_HEADS_MAP["2.10.3"], to_revision):
-        unitest_mode = conf.getboolean("core", "unit_test_mode")
-        if unitest_mode:
-            try:
-                from airflow.providers.fab.auth_manager.models.db import FABDBManager
-
-                dbm = FABDBManager(session)
-                dbm.initdb()
-            except ImportError:
-                log.warning("Import error occurred while importing FABDBManager. Skipping the check.")
-                return
-        if not inspect(settings.engine).has_table("ab_user") and not unitest_mode:
-            raise AirflowException(
-                "Downgrade to revision less than 3.0.0 requires that `ab_user` table is present. "
-                "Please add FabDBManager to [core] external_db_managers and run fab migrations before proceeding"
+        try:
+            from airflow.providers.fab.auth_manager.models.db import FABDBManager
+        except ImportError:
+            # Raise the error with a new message
+            raise RuntimeError(
+                "Import error occurred while importing FABDBManager. We need that to exist before we can "
+                "downgrade to <3.0.0"
             )
+        dbm = FABDBManager(session)
+        if hasattr(dbm, "reset_to_2_x"):
+            dbm.reset_to_2_x()
+        else:
+            # Older version before we added that function, it only has a single migration so we can just
+            # created
+            dbm.create_db_from_orm()
     with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
         if show_sql_only:
             log.warning("Generating sql scripts for manual migration.")

--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -216,12 +216,6 @@ class RunDBManager(LoggingMixin):
             m = manager(session)
             m.upgradedb()
 
-    def downgrade(self, session):
-        """Downgrade the external database managers."""
-        for manager in self._managers:
-            m = manager(session)
-            m.downgrade()
-
     def drop_tables(self, session, connection):
         """Drop the external database managers."""
         for manager in self._managers:

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -658,3 +658,19 @@ class TestCLIDBClean:
         )
         db_command.drop_archived(args)
         mock_drop_archived_records.assert_called_once_with(table_names=None, needs_confirm=expected)
+
+
+def test_get_version_revision():
+    heads: dict[str, str] = {
+        "2.10.0": "22ed7efa9da2",
+        "2.10.3": "5f2621c13b39",
+        "3.0.0": "29ce7909c52b",
+        "3.0.3": "fe199e1abd77",
+        "3.1.0": "808787349f22",
+    }
+
+    assert db_command._get_version_revision("3.1.0", heads) == "808787349f22"
+    assert db_command._get_version_revision("3.1.1", heads) == "808787349f22"
+    assert db_command._get_version_revision("2.11.1", heads) == "5f2621c13b39"
+    assert db_command._get_version_revision("2.10.1", heads) == "22ed7efa9da2"
+    assert db_command._get_version_revision("2.0.0", heads) is None

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -33,10 +33,8 @@ from alembic.script import ScriptDirectory
 from sqlalchemy import Column, Integer, MetaData, Table, select
 
 from airflow import settings
-from airflow.exceptions import AirflowException
 from airflow.models import Base as airflow_base
 from airflow.utils.db import (
-    _REVISION_HEADS_MAP,
     AutocommitEngineForMySQL,
     LazySelectSequence,
     _get_alembic_config,
@@ -379,18 +377,6 @@ class TestDb:
         lss = LazySelectSequence.from_select(select(t.c.id), order_by=[], session=MockSession())
 
         assert bool(lss) is False
-
-    @conf_vars({("core", "unit_test_mode"): "False"})
-    def test_downgrade_raises_if_lower_than_v3_0_0_and_no_ab_user(self, mocker):
-        mock_inspect = mocker.patch("airflow.utils.db.inspect")
-        mock_inspect.return_value.has_table.return_value = False
-        msg = (
-            "Downgrade to revision less than 3.0.0 requires that `ab_user` table is present. "
-            "Please add FabDBManager to [core] external_db_managers and run fab migrations before "
-            "proceeding"
-        )
-        with pytest.raises(AirflowException, match=re.escape(msg)):
-            downgrade(to_revision=_REVISION_HEADS_MAP["2.7.0"])
 
 
 class TestAutocommitEngineForMySQL:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import json
+import os
 from tempfile import gettempdir
 from typing import TYPE_CHECKING
 
@@ -101,9 +102,23 @@ def initial_db_init():
     from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
     db.resetdb()
+    # If we are testing core we want to downgrand and upgrade to ensure things migraitons are set correctly,
+    # but we can skip that for providers
+
     if AIRFLOW_V_3_0_PLUS:
-        db.downgrade(to_revision="5f2621c13b39")
-        db.upgradedb(to_revision="head")
+        if os.getenv("TEST_GROUP") != "providers":
+            db.downgrade(to_revision="5f2621c13b39")
+            db.upgradedb(to_revision="head")
+        else:
+            try:
+                from airflow.providers.fab.auth_manager.models.db import FABDBManager
+            except ModuleNotFoundError:
+                pass
+            else:
+                # If we loaded it (i.e. the provider exists) create the DB
+                with create_session() as session:
+                    FABDBManager(session).create_db_from_orm()
+                    session.commit()
     else:
         from flask import Flask
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/models/db.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/models/db.py
@@ -59,6 +59,11 @@ class FABDBManager(BaseDBManager):
         super().create_db_from_orm()
         _get_flask_db(settings.SQL_ALCHEMY_CONN).create_all()
 
+    def reset_to_2_x(self):
+        self.create_db_from_orm()
+        # And ensure it's at the oldest version
+        self.downgrade(_REVISION_HEADS_MAP["1.4.0"])
+
     def upgradedb(self, to_revision=None, from_revision=None, show_sql_only=False):
         """Upgrade the database."""
         if from_revision and not show_sql_only:

--- a/providers/fab/tests/unit/fab/db_manager/test_fab_db_manager.py
+++ b/providers/fab/tests/unit/fab/db_manager/test_fab_db_manager.py
@@ -22,7 +22,7 @@ import pytest
 from sqlalchemy import Table
 
 from airflow.exceptions import AirflowException
-from airflow.utils.db import downgrade, initdb
+from airflow.utils.db import initdb
 from airflow.utils.db_manager import RunDBManager
 
 from tests_common.test_utils.config import conf_vars
@@ -57,27 +57,12 @@ class TestRunDBManagerWithFab:
             run_db_manager.validate()
         metadata._remove_table("dag_run", None)
 
-    @mock.patch.object(RunDBManager, "downgrade")
     @mock.patch.object(RunDBManager, "upgradedb")
     @mock.patch.object(RunDBManager, "initdb")
-    def test_init_db_calls_rundbmanager(self, mock_initdb, mock_upgrade_db, mock_downgrade_db, session):
+    def test_init_db_calls_rundbmanager(self, mock_initdb, mock_upgrade_db, session):
         initdb(session=session)
         mock_initdb.assert_called()
         mock_initdb.assert_called_once_with(session)
-        mock_downgrade_db.assert_not_called()
-
-    @mock.patch.object(RunDBManager, "downgrade")
-    @mock.patch.object(RunDBManager, "upgradedb")
-    @mock.patch.object(RunDBManager, "initdb")
-    @mock.patch("alembic.command")
-    def test_downgrade_dont_call_rundbmanager(
-        self, mock_alembic_command, mock_initdb, mock_upgrade_db, mock_downgrade_db, session
-    ):
-        downgrade(to_revision="base")
-        mock_alembic_command.downgrade.assert_called_once_with(mock.ANY, revision="base", sql=False)
-        mock_upgrade_db.assert_not_called()
-        mock_initdb.assert_not_called()
-        mock_downgrade_db.assert_not_called()
 
     @conf_vars(
         {("database", "external_db_managers"): "airflow.providers.fab.auth_manager.models.db.FABDBManager"}
@@ -93,9 +78,7 @@ class TestRunDBManagerWithFab:
         # upgradedb
         ext_db.upgradedb(session=session)
         fabdb_manager.upgradedb.assert_called_once()
-        # downgrade
-        ext_db.downgrade(session=session)
-        mock_fabdb_manager.return_value.downgrade.assert_called_once()
+        # drop_tables
         connection = mock.MagicMock()
         ext_db.drop_tables(session, connection)
         mock_fabdb_manager.return_value.drop_tables.assert_called_once_with(connection)


### PR DESCRIPTION
There were two things blocking this:

1) The revision heads map didn't have any 2.11.x versions in it, so the
   previous implementation of `_get_version_revision` was only looking within
   the same `<major>.<minor>` patch version.

   We change it to rely on the fact that our pre-commit checks ensure this map
   is ordered, and iterate over the dictionary reversed, and when we find the
   first thing less than the target revision we use that (direct equal is
   handled already above)

2) The `ab_*` tables not existing were blocking the migration. Part of this is
   now fixable manually with #54227, but I have decided that since FAB was
   required and the only option in 2.x, so I have decided to just create the
   tables if they are missing

   In order to try and cope with possible future changes I create the tables
   at the latest version and then downgrade to the oldest known revision.

   This is all handled in a `reset_to_2_x()` method on the FABDBManager, with
   a fallback to just blindly create the tables from the ORM for versions of
   the provider that don't yet have that function.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
