### PR TITLE
[v3-0-test] Fix: Validate and handle invalid `extra` field in connections UI and …

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -136,3 +136,26 @@ class ConnectionBody(StrictBaseModel):
     port: int | None = Field(default=None)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
+
+    @field_validator("extra")
+    @classmethod
+    def validate_extra(cls, v: str | None) -> str | None:
+        """
+        Validate that `extra` field is a JSON-encoded Python dict.
+
+        If `extra` field is not a valid JSON, it will be returned as is.
+        """
+        if v is None:
+            return v
+        if v == "":
+            return "{}"  # Backward compatibility: treat "" as empty JSON object
+        try:
+            extra_dict = json.loads(v)
+            if not isinstance(extra_dict, dict):
+                raise ValueError("The `extra` field must be a valid JSON object (e.g., {'key': 'value'})")
+        except json.JSONDecodeError:
+            raise ValueError(
+                "The `extra` field must be a valid JSON object (e.g., {'key': 'value'}), "
+                "but encountered non-JSON in `extra` field"
+            )
+        return v

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -40,9 +40,12 @@ def _mask_connection_fields(extra_fields):
     for k, v in extra_fields.items():
         if k == "extra" and v:
             try:
-                extra = json.loads(v)
-                extra = {k: secrets_masker.redact(v, k) for k, v in extra.items()}
-                result[k] = dict(extra)
+                parsed_extra = json.loads(v)
+                if isinstance(parsed_extra, dict):
+                    masked_extra = {ek: secrets_masker.redact(ev, ek) for ek, ev in parsed_extra.items()}
+                    result[k] = masked_extra
+                else:
+                    result[k] = "Expected JSON object in `extra` field, got non-dict JSON"
             except json.JSONDecodeError:
                 result[k] = "Encountered non-JSON in `extra` field"
         else:

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -98,7 +98,16 @@ const ConnectionForm = ({
 
   const validateAndPrettifyJson = (value: string) => {
     try {
-      const parsedJson = JSON.parse(value) as JSON;
+      if (value.trim() === "") {
+        setErrors((prev) => ({ ...prev, conf: undefined }));
+
+        return value;
+      }
+      const parsedJson = JSON.parse(value) as Record<string, unknown>;
+
+      if (typeof parsedJson !== "object" || Array.isArray(parsedJson)) {
+        throw new TypeError('extra fields must be a valid JSON object (e.g., {"key": "value"})');
+      }
 
       setErrors((prev) => ({ ...prev, conf: undefined }));
       const formattedJson = JSON.stringify(parsedJson, undefined, 2);

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -1245,3 +1245,15 @@ class TestBulkConnections(TestConnectionEndpoint):
     def test_should_respond_403(self, unauthorized_test_client):
         response = unauthorized_test_client.patch("/connections", json={})
         assert response.status_code == 403
+
+
+class TestPostConnectionExtraBackwardCompatibility(TestConnectionEndpoint):
+    def test_post_should_accept_empty_string_as_extra(self, test_client, session):
+        body = {"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "extra": ""}
+
+        response = test_client.post("/connections", json=body)
+        assert response.status_code == 201
+
+        connection = session.query(Connection).filter_by(conn_id=TEST_CONN_ID).first()
+        assert connection is not None
+        assert connection.extra == "{}"  # Backward compatibility: treat "" as empty JSON object


### PR DESCRIPTION
…API (#53963) (#54034)

* Validate and handle non-dict JSON in  field for connections

* Handle empty string in  field for backward compatibility and add validation

---------


(cherry picked from commit 8e1e3bb48c6b110046ac4a7f3f8e51620a9152bd)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
