### PR TITLE
Correctly detect system dark mode in RenderedJsonField

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
@@ -17,10 +17,10 @@
  * under the License.
  */
 import { Flex, type FlexProps } from "@chakra-ui/react";
-import { useTheme } from "next-themes";
 import ReactJson, { type ReactJsonViewProps } from "react-json-view";
 
 import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+import { useColorMode } from "src/context/colorMode";
 
 type Props = {
   readonly content: object;
@@ -30,7 +30,7 @@ type Props = {
 
 const RenderedJsonField = ({ content, enableClipboard = true, jsonProps, ...rest }: Props) => {
   const contentFormatted = JSON.stringify(content, undefined, 4);
-  const { theme } = useTheme();
+  const { colorMode } = useColorMode();
 
   return (
     <Flex {...rest}>
@@ -44,7 +44,7 @@ const RenderedJsonField = ({ content, enableClipboard = true, jsonProps, ...rest
         style={{
           backgroundColor: "inherit",
         }}
-        theme={theme === "dark" ? "monokai" : "rjv-default"}
+        theme={colorMode === "dark" ? "monokai" : "rjv-default"}
         {...jsonProps}
       />
       {enableClipboard ? (


### PR DESCRIPTION
Fixes: #54204

## Root Cause

The UI now supports OS-level color mode detection. When a user relies on their OS settings to switch to dark mode (and has not manually toggled the theme in the UI), the state from the `next-themes` library is:
- `theme`: 'system'
- `resolvedTheme`: 'dark'

The previous implementation in `RenderedJsonField` was checking against the `theme` property. The check `theme === 'dark'` would fail, causing the component to incorrectly use a light-mode style, resulting in dark text on a dark background.

## Solution

The solution is to consistently use `resolvedTheme` as the source of truth for the currently displayed theme.

`RenderedJsonField.tsx` has been updated to use `useColorMode`.

Additionally, I have confirmed that `RenderedJsonField.tsx` was the only remaining instance of using the `useTheme` hook.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
