### PR TITLE
fix map_index is null dynamic task mapping bug

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -66,7 +66,6 @@ from airflow.models.trigger import Trigger
 from airflow.models.xcom import XComModel
 from airflow.sdk.definitions._internal.expandinput import NotFullyPopulated
 from airflow.sdk.definitions.asset import Asset, AssetUniqueKey
-from airflow.sdk.definitions.taskgroup import MappedTaskGroup
 from airflow.utils.state import DagRunState, TaskInstanceState, TerminalTIState
 
 if TYPE_CHECKING:
@@ -295,14 +294,13 @@ def _get_upstream_map_indexes(
         if upstream_mapped_group is None:
             # regular tasks or non-mapped task groups
             map_indexes = None
-        elif task_mapped_group == upstream_mapped_group: 
+        elif task_mapped_group == upstream_mapped_group:
             # tasks in the same mapped task group hierarchy
             map_indexes = ti_map_index
         else:
             # tasks not in the same mapped task group
             # the upstream mapped task group should combine the return xcom as a list and return it
             mapped_ti_count: int
-            upstream_mapped_group = upstream_task.task_group
             try:
                 # for cases that does not need to resolve xcom
                 mapped_ti_count = upstream_mapped_group.get_parse_time_mapped_ti_count()

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -288,14 +288,15 @@ def ti_run(
 def _get_upstream_map_indexes(
     task: Operator, ti_map_index: int, run_id: str, session: SessionDep
 ) -> Iterator[tuple[str, int | list[int] | None]]:
+    task_mapped_group = task.get_closest_mapped_task_group()
     for upstream_task in task.upstream_list:
+        upstream_mapped_group = upstream_task.get_closest_mapped_task_group()
         map_indexes: int | list[int] | None
-        if not isinstance(upstream_task.task_group, MappedTaskGroup):
+        if upstream_mapped_group is None:
             # regular tasks or non-mapped task groups
             map_indexes = None
-        elif task.task_group == upstream_task.task_group:
-            # tasks in the same mapped task group
-            # the task should use the map_index as the previous task in the same mapped task group
+        elif task_mapped_group == upstream_mapped_group: 
+            # tasks in the same mapped task group hierarchy
             map_indexes = ti_map_index
         else:
             # tasks not in the same mapped task group

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -301,6 +301,80 @@ class TestTIRunState:
             upstream_map_indexes = response.json()["upstream_map_indexes"]
             assert upstream_map_indexes == expected_upstream_map_indexes[(ti.task_id, ti.map_index)]
 
+    def test_nested_mapped_task_group_upstream_indexes(self, client, dag_maker):
+        """
+        Test that upstream_map_indexes are correctly computed for tasks in nested mapped task groups.
+        """
+        with dag_maker("test_nested_mapped_tg", serialized=True):
+            
+            @task
+            def alter_input(inp: str) -> str:
+                return f"{inp}_Altered"
+
+            @task
+            def print_task(orig_input: str, altered_input: str) -> str:
+                return f"orig:{orig_input},altered:{altered_input}"
+
+            @task_group
+            def inner_task_group(orig_input: str) -> None:
+                altered_input = alter_input(orig_input)
+                print_task(orig_input, altered_input)
+
+            @task_group  
+            def expandable_task_group(param: str) -> None:
+                inner_task_group(param)
+
+            expandable_task_group.expand(param=["One", "Two", "Three"])
+
+        dr = dag_maker.create_dagrun()
+        
+        # Set all alter_input tasks to success so print_task can run
+        for ti in dr.get_task_instances():
+            if "alter_input" in ti.task_id and ti.map_index >= 0:
+                ti.state = State.SUCCESS
+            elif "print_task" in ti.task_id and ti.map_index >= 0:
+                ti.set_state(State.QUEUED)
+        dag_maker.session.flush()
+
+        # Expected upstream_map_indexes for each print_task instance
+        expected_upstream_map_indexes = {
+            ("expandable_task_group.inner_task_group.print_task", 0): {
+                "expandable_task_group.inner_task_group.alter_input": 0
+            },
+            ("expandable_task_group.inner_task_group.print_task", 1): {
+                "expandable_task_group.inner_task_group.alter_input": 1
+            },
+            ("expandable_task_group.inner_task_group.print_task", 2): {
+                "expandable_task_group.inner_task_group.alter_input": 2
+            }
+        }
+
+        # Get only the expanded print_task instances (not the template)
+        print_task_tis = [ti for ti in dr.get_task_instances() 
+                        if "print_task" in ti.task_id and ti.map_index >= 0]
+        
+        # Test each print_task instance
+        for ti in print_task_tis:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running", 
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": "2024-09-30T12:00:00Z",
+                },
+            )
+
+            assert response.status_code == 200
+            upstream_map_indexes = response.json()["upstream_map_indexes"]
+            expected = expected_upstream_map_indexes[(ti.task_id, ti.map_index)]
+            
+            assert upstream_map_indexes == expected, (
+                f"Task {ti.task_id}[{ti.map_index}] should have upstream_map_indexes {expected}, "
+                f"but got {upstream_map_indexes}"
+            )
+
     def test_dynamic_task_mapping_with_xcom(self, client, dag_maker, create_task_instance, session, run_task):
         """
         Test that the Task Instance upstream_map_indexes is correctly fetched when to running the Task Instances with xcom


### PR DESCRIPTION
closes: #52881

### Problem Description

When tasks within nested task groups try to access XCom values from sibling tasks in the same mapped parent task group instance, the system incorrectly uses `map_index=null` instead of the correct map index, causing XCom lookup failures.

##### Example DAG Structure

<img width="1033" height="494" alt="Screenshot 2025-08-07 at 1 47 06 PM" src="https://github.com/user-attachments/assets/f6c1767b-a999-470d-b090-478643dcdc01" />

##### Error Observed (Note: map_index=null)
```javascript
No XCom value found; defaulting to None.: key="return_value": dag_id="test_dag": task_id="expandable_task_group.inner_task_group.alter_input": run_id="manual__2025-07-04T14:56:47.815002+00:00": map_index=null
```
##### Related Code
The issue is in `airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py` in the `_get_upstream_map_indexes` function. 

The logic only checks the immediate parent task group (upstream_task.task_group) but doesn't consider nested scenarios where tasks are within a regular task group that is itself within a mapped task group.

##### Proposed Solution
Replace the immediate parent check with a hierarchy-aware check using `get_closest_mapped_task_group()`. This ensures that both tasks recognize they share the same mapped task group ancestor and use the same map_index.

### Testing
- Verified proposed solution resolves issue: #52881 when tested locally using `breeze start-airflow` against the latest main branch development environment.
- Added `test_nested_mapped_task_group_upstream_indexes` to verify that tasks in nested mapped task groups correctly resolve upstream map indexes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
