### PR TITLE
Persistent client pool for base waiter and thread safe client pooling

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
@@ -18,14 +18,14 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from asyncio import Lock
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.helpers import prune_dict
-from asyncio import Lock
-from contextlib import asynccontextmanager
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
@@ -107,7 +107,7 @@ class AwsBaseWaiterTrigger(BaseTrigger):
         self.region_name = region_name
         self.verify = verify
         self.botocore_config = botocore_config
-        self._pool_lock = Lock(),
+        self._pool_lock = (Lock(),)
         self._client_pool: dict[str, tuple[Any, float]] = {}
 
     def serialize(self) -> tuple[str, dict[str, Any]]:

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
@@ -107,7 +107,7 @@ class AwsBaseWaiterTrigger(BaseTrigger):
         self.region_name = region_name
         self.verify = verify
         self.botocore_config = botocore_config
-        self._pool_lock = (Lock(),)
+        self._pool_lock = Lock()
         self._client_pool: dict[str, tuple[Any, float]] = {}
 
     def serialize(self) -> tuple[str, dict[str, Any]]:


### PR DESCRIPTION
(partial) fix for https://github.com/apache/airflow/issues/53359. When a new trigger gets started, we see messages like:

```
trigger **** starting
triggerer's async thread was blocked for 2.41 seconds
```

A proposed fix in https://github.com/apache/airflow/pull/53454 is to sharing an async client across multiple connections. As summarized in https://github.com/aio-libs/aiobotocore/issues/1088, asyncio loops are not thread safe and each client runs a thread, so we cannot share connections like this. Due to this aiobotocore limitation, I don't think a complete fix is possible from our end.

However, I do think we can at least minimize the amount of event loop blocking time by running long-lived clients. With this approach, we should only see event loop blocking once per unique `aws_conn_id`, rather than on every waiter call.

I would appreciate feedback and verification on the following: (1) clients are only shared between triggers using the same aws_conn_id, (2) no client sharing occurs across different event loops, (3) credential isolation is maintained, and (4) comments on the memory tradeoff in storing potentially many clients.

It is my understanding that if (1) and (2) are satisfied, then thread safety is maintained within aiobotocore.