### PR TITLE
Fix FlexibleForm params state pollution

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
@@ -23,9 +23,9 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 import { JsonEditor } from "../JsonEditor";
 
-export const FieldAdvancedArray = ({ name, onUpdate }: FlexibleFormElementProps) => {
+export const FieldAdvancedArray = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   const { t: translate } = useTranslation("components");
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   // Determine the expected type based on schema
   const expectedType = param.schema.items?.type ?? "object";

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
@@ -21,8 +21,8 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 import { Switch } from "../ui";
 
-export const FieldBool = ({ name }: FlexibleFormElementProps) => {
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+export const FieldBool = ({ name, namespace = "default" }: FlexibleFormElementProps) => {
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const onCheck = (value: boolean) => {
     if (paramsDict[name]) {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -23,8 +23,13 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 import { DateTimeInput } from "../DateTimeInput";
 
-export const FieldDateTime = ({ name, onUpdate, ...rest }: FlexibleFormElementProps & InputProps) => {
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+export const FieldDateTime = ({
+  name,
+  namespace = "default",
+  onUpdate,
+  ...rest
+}: FlexibleFormElementProps & InputProps) => {
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
     if (paramsDict[name]) {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
@@ -34,9 +34,9 @@ const labelLookup = (key: string, valuesDisplay: Record<string, string> | undefi
 };
 const enumTypes = ["string", "number", "integer"];
 
-export const FieldDropdown = ({ name, onUpdate }: FlexibleFormElementProps) => {
+export const FieldDropdown = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   const { t: translate } = useTranslation("components");
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
 
   const selectOptions = createListCollection({

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
@@ -32,9 +32,9 @@ const labelLookup = (key: string, valuesDisplay: Record<string, string> | undefi
   return key;
 };
 
-export const FieldMultiSelect = ({ name, onUpdate }: FlexibleFormElementProps) => {
+export const FieldMultiSelect = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   const { t: translate } = useTranslation("components");
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
 
   // Initialize `selectedOptions` directly from `paramsDict`

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultilineText.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultilineText.tsx
@@ -22,8 +22,8 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
 
-export const FieldMultilineText = ({ name, onUpdate }: FlexibleFormElementProps) => {
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+export const FieldMultilineText = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
     if (paramsDict[name]) {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldNumber.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldNumber.tsx
@@ -21,8 +21,8 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 import { NumberInputField, NumberInputRoot } from "../ui/NumberInput";
 
-export const FieldNumber = ({ name, onUpdate }: FlexibleFormElementProps) => {
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+export const FieldNumber = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
     if (value === "") {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
@@ -21,8 +21,8 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 import { JsonEditor } from "../JsonEditor";
 
-export const FieldObject = ({ name, onUpdate }: FlexibleFormElementProps) => {
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+export const FieldObject = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
 
   const handleChange = (value: string) => {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
@@ -28,9 +28,13 @@ import { FieldSelector } from "./FieldSelector";
 import { isRequired } from "./isParamRequired";
 
 /** Render a normal form row with a field that is auto-selected */
-export const FieldRow = ({ name, onUpdate: rowOnUpdate }: FlexibleFormElementProps) => {
+export const FieldRow = ({
+  name,
+  namespace = "default",
+  onUpdate: rowOnUpdate,
+}: FlexibleFormElementProps) => {
   const { t: translate } = useTranslation("components");
-  const { paramsDict } = useParamStore();
+  const { paramsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const [error, setError] = useState<unknown>(
     isRequired(param) && param.value === null ? translate("flexibleForm.validationErrorRequired") : undefined,
@@ -61,7 +65,7 @@ export const FieldRow = ({ name, onUpdate: rowOnUpdate }: FlexibleFormElementPro
         </Field.Label>
       </Stack>
       <Stack css={{ flexBasis: "70%" }}>
-        <FieldSelector name={name} onUpdate={onUpdate} />
+        <FieldSelector name={name} namespace={namespace} onUpdate={onUpdate} />
         {param.description === null ? (
           param.schema.description_md === undefined ? undefined : (
             <Field.HelperText>

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
@@ -87,35 +87,35 @@ const isFieldStringArray = (fieldType: string, fieldSchema: ParamSchema) =>
 const isFieldTime = (fieldType: string, fieldSchema: ParamSchema) =>
   fieldType === "string" && fieldSchema.format === "time";
 
-export const FieldSelector = ({ name, onUpdate }: FlexibleFormElementProps) => {
+export const FieldSelector = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   // FUTURE: Add support for other types as described in AIP-68 via Plugins
-  const { initialParamDict } = useParamStore();
+  const { initialParamDict } = useParamStore(namespace);
   const param = initialParamDict[name] ?? paramPlaceholder;
   const fieldType = inferType(param);
 
   if (isFieldBool(fieldType)) {
-    return <FieldBool name={name} onUpdate={onUpdate} />;
+    return <FieldBool name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldDateTime(fieldType, param.schema)) {
-    return <FieldDateTime name={name} onUpdate={onUpdate} type="datetime-local" />;
+    return <FieldDateTime name={name} namespace={namespace} onUpdate={onUpdate} type="datetime-local" />;
   } else if (isFieldDate(fieldType, param.schema)) {
-    return <FieldDateTime name={name} onUpdate={onUpdate} type="date" />;
+    return <FieldDateTime name={name} namespace={namespace} onUpdate={onUpdate} type="date" />;
   } else if (isFieldTime(fieldType, param.schema)) {
-    return <FieldDateTime name={name} onUpdate={onUpdate} type="time" />;
+    return <FieldDateTime name={name} namespace={namespace} onUpdate={onUpdate} type="time" />;
   } else if (isFieldDropdown(fieldType, param.schema)) {
-    return <FieldDropdown name={name} onUpdate={onUpdate} />;
+    return <FieldDropdown name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldMultiSelect(fieldType, param.schema)) {
-    return <FieldMultiSelect name={name} onUpdate={onUpdate} />;
+    return <FieldMultiSelect name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldStringArray(fieldType, param.schema)) {
-    return <FieldStringArray name={name} onUpdate={onUpdate} />;
+    return <FieldStringArray name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldAdvancedArray(fieldType, param.schema)) {
-    return <FieldAdvancedArray name={name} onUpdate={onUpdate} />;
+    return <FieldAdvancedArray name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldObject(fieldType)) {
-    return <FieldObject name={name} onUpdate={onUpdate} />;
+    return <FieldObject name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldNumber(fieldType)) {
-    return <FieldNumber name={name} onUpdate={onUpdate} />;
+    return <FieldNumber name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldMultilineText(fieldType, param.schema)) {
-    return <FieldMultilineText name={name} onUpdate={onUpdate} />;
+    return <FieldMultilineText name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else {
-    return <FieldString name={name} onUpdate={onUpdate} />;
+    return <FieldString name={name} namespace={namespace} onUpdate={onUpdate} />;
   }
 };

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
@@ -23,9 +23,9 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
 
-export const FieldString = ({ name, onUpdate }: FlexibleFormElementProps) => {
+export const FieldString = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   const { t: translate } = useTranslation("components");
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
     if (paramsDict[name]) {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldStringArray.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldStringArray.tsx
@@ -23,9 +23,9 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
 
-export const FieldStringArray = ({ name, onUpdate }: FlexibleFormElementProps) => {
+export const FieldStringArray = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   const { t: translate } = useTranslation("components");
-  const { disabled, paramsDict, setParamsDict } = useParamStore();
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
 
   const handleChange = (newValue: string) => {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -35,6 +35,7 @@ export type FlexibleFormProps = {
   readonly initialParamsDict: { paramsDict: ParamsSpec };
   readonly isHITL?: boolean;
   readonly key?: string;
+  readonly namespace?: string;
   readonly setError: (error: boolean) => void;
   readonly subHeader?: string;
 };
@@ -45,10 +46,11 @@ export const FlexibleForm = ({
   flexibleFormDefaultSection,
   initialParamsDict,
   isHITL,
+  namespace = "default",
   setError,
   subHeader,
 }: FlexibleFormProps) => {
-  const { paramsDict: params, setDisabled, setInitialParamDict, setParamsDict } = useParamStore();
+  const { paramsDict: params, setDisabled, setInitialParamDict, setParamsDict } = useParamStore(namespace);
   const processedSections = new Map();
   const [sectionError, setSectionError] = useState<Map<string, boolean>>(new Map());
 
@@ -153,7 +155,7 @@ export const FlexibleForm = ({
                         (currentSection === flexibleFormDefaultSection && !Boolean(param.schema.section)),
                     )
                     .map(([name]) => (
-                      <Row key={name} name={name} onUpdate={onUpdate} />
+                      <Row key={name} name={name} namespace={namespace} onUpdate={onUpdate} />
                     ))}
                 </Stack>
               </Accordion.ItemBody>

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/HiddenInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/HiddenInput.tsx
@@ -23,8 +23,8 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 
 /** Render a "const" field where user can not change data as hidden */
-export const HiddenInput = ({ name }: FlexibleFormElementProps) => {
-  const { paramsDict } = useParamStore();
+export const HiddenInput = ({ name, namespace = "default" }: FlexibleFormElementProps) => {
+  const { paramsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
 
   return (

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/Row.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/Row.tsx
@@ -26,13 +26,13 @@ import { HiddenInput } from "./HiddenInput";
 const isHidden = (fieldSchema: ParamSchema) => Boolean(fieldSchema.const);
 
 /** Generates a form row */
-export const Row = ({ name, onUpdate }: FlexibleFormElementProps) => {
-  const { paramsDict } = useParamStore();
+export const Row = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
+  const { paramsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
 
   return isHidden(param.schema) ? (
-    <HiddenInput name={name} onUpdate={onUpdate} />
+    <HiddenInput name={name} namespace={namespace} onUpdate={onUpdate} />
   ) : (
-    <FieldRow name={name} onUpdate={onUpdate} />
+    <FieldRow name={name} namespace={namespace} onUpdate={onUpdate} />
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/index.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/index.tsx
@@ -19,6 +19,7 @@
 
 export type FlexibleFormElementProps = {
   readonly name: string;
+  readonly namespace?: string;
   readonly onUpdate: (value?: string, error?: unknown) => void;
 };
 

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -47,7 +47,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
   const { t: translate } = useTranslation();
   const [errors, setErrors] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const { paramsDict } = useParamStore();
+  const { paramsDict } = useParamStore("hitl");
   const { updateHITLResponse } = useUpdateHITLDetail({
     dagId: hitlDetail?.task_instance.dag_id ?? "",
     dagRunId: hitlDetail?.task_instance.dag_run_id ?? "",
@@ -103,6 +103,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
           }}
           isHITL
           key={hitlDetail.subject}
+          namespace="hitl"
           setError={setErrors}
         />
       </Accordion.Root>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why

When 2 components using `FlexibleForm` coexist on the same page, they share the same global parameter store (`useParamStore`), causing parameter pollution where may display wrong or unwanted field in form.

## How

Added namespace support to `useParamStore` to create separate store instances for different contexts:

- Enhanced `useParamStore` hook to accept an optional `namespace` parameter
- Updated FlexibleForm and all field components to pass namespace through props
- Each namespace maintains its own isolated parameter state

## Before

https://github.com/user-attachments/assets/3b4584d5-0791-4332-a175-add5b0375a9d

## After

https://github.com/user-attachments/assets/8e3063ab-5a9b-4bc9-a37c-e08930c73e29



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
