### PR TITLE
Fix reproducibility issue for tarballs with symlink

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/reproducible.py
+++ b/dev/breeze/src/airflow_breeze/utils/reproducible.py
@@ -37,6 +37,7 @@ import itertools
 import locale
 import os
 import shutil
+import stat
 import tarfile
 from argparse import ArgumentParser
 from pathlib import Path
@@ -106,15 +107,6 @@ def repack_deterministically(
     if result.returncode != 0:
         return result
     dest_archive.unlink(missing_ok=True)
-    result = run_command(
-        [
-            "chmod",
-            "-R",
-            "go=",
-            REPRODUCIBLE_PATH.as_posix(),
-        ],
-        check=False,
-    )
     with cd(REPRODUCIBLE_PATH):
         current_dir = "."
         file_list = [current_dir]
@@ -133,6 +125,20 @@ def repack_deterministically(
             with gzip.GzipFile(fileobj=out_file, mtime=0, mode="wb") as gzip_file:
                 with tarfile.open(fileobj=gzip_file, mode="w:") as tar_file:
                     for entry in file_list:
+                        entry_path = Path(entry)
+                        if not entry_path.is_symlink():
+                            # For non symlinks clear other and group permission bits,
+                            # keep others unchanged
+                            current_mode = entry_path.stat().st_mode
+                            new_mode = current_mode & ~(stat.S_IRWXO | stat.S_IRWXG)
+                            entry_path.chmod(new_mode)
+                        else:
+                            # for symlinks on the other hand set rwx for all - to match Linux on MacOS
+                            try:
+                                entry_path.chmod(0o777, follow_symlinks=False)
+                            except NotImplementedError:
+                                # on platforms like Linux symlink permissions cannot be changed
+                                pass
                         arcname = entry
                         if prepend_path is not None:
                             arcname = os.path.normpath(os.path.join(prepend_path, arcname))


### PR DESCRIPTION
Bulk-removing of user and group permissions on MacOS is not a good idea for symlinks for reproducibility, because symlinks on linux cannot have other/group permissions changed but on MacOS they can even if it has no effect. Instead of bulk-change with chmod command we now change the permissions individually on all files except symlinks

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
