### PR TITLE
Fix grid keyboard navigation from stealing focus

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -121,12 +121,6 @@ export const Grid = ({ limit }: Props) => {
     tasks: flatNodes,
   });
 
-  useEffect(() => {
-    if (gridRef.current && gridRuns && flatNodes.length > 0) {
-      setGridFocus(true);
-    }
-  }, [gridRuns, flatNodes.length, setGridFocus]);
-
   return (
     <Flex
       _focus={{


### PR DESCRIPTION
That use effect is not necessary, it would indeed auto-focus on the grid when new runs / tasks are detected. (after triggering a dag or on autorefresh), but that is too invasive. It will cause lost of focus when trying to fill in input in the right pan for instance for filtering runs or tasks, or when filling the 'Action Required' form.


The first focus will need to be opt-in by users, then you can navigate with the keyboard.