### PR TITLE
Fix `get_authorized_dag_ids` in `FabAuthManager`

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -459,8 +459,6 @@ class FabAuthManager(BaseAuthManager[User]):
                         return {dag.dag_id for dag in session.execute(select(DagModel.dag_id))}
                     if resource.startswith(permissions.RESOURCE_DAG_PREFIX):
                         resources.add(resource[len(permissions.RESOURCE_DAG_PREFIX) :])
-                    else:
-                        resources.add(resource)
         return set(session.scalars(select(DagModel.dag_id).where(DagModel.dag_id.in_(resources))))
 
     @cached_property

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -706,14 +706,14 @@ class TestFabAuthManager:
             (
                 "GET",
                 [(ACTION_CAN_READ, RESOURCE_DAG)],
-                {"test_dag1", "test_dag2"},
+                {"test_dag1", "test_dag2", "Connections"},
             ),
             # Scenario 2
             # With global edit permissions on Dags
             (
                 "PUT",
                 [(ACTION_CAN_EDIT, RESOURCE_DAG)],
-                {"test_dag1", "test_dag2"},
+                {"test_dag1", "test_dag2", "Connections"},
             ),
             # Scenario 3
             # With DAG-specific permissions
@@ -750,6 +750,13 @@ class TestFabAuthManager:
                 [(ACTION_CAN_EDIT, "DAG:test_dag1"), (ACTION_CAN_EDIT, "DAG:test_dag2")],
                 {"test_dag1", "test_dag2"},
             ),
+            # Scenario 9
+            # With non-DAG related permissions
+            (
+                "GET",
+                [(ACTION_CAN_READ, "DAG:test_dag1"), (ACTION_CAN_READ, RESOURCE_CONNECTION)],
+                {"test_dag1"},
+            ),
         ],
     )
     def test_get_authorized_dag_ids(
@@ -758,6 +765,8 @@ class TestFabAuthManager:
         with dag_maker("test_dag1"):
             EmptyOperator(task_id="task1")
         with dag_maker("test_dag2"):
+            EmptyOperator(task_id="task1")
+        with dag_maker("Connections"):
             EmptyOperator(task_id="task1")
 
         auth_manager_with_appbuilder.security_manager.sync_perm_for_dag("test_dag1")


### PR DESCRIPTION
This code has been here for a while but it should have never been. This adds any resource the user has access to (e.g. `Connections`) to `resources` which contains dag ids. So hypothetically, a user with permissions to access the Dag `test` only and with permissions to access connections could access the dag (if existing) `Connections`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
