### PR TITLE
Fix cherry-pick detection in airflow-github script

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "GitPython",
+#     "PyGithub",
+#     "rich-click",
+#     "packaging",
+#     "rich",
+# ]
+# ///
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -43,7 +53,8 @@ GIT_LOG_FORMAT = "%x1f".join(["%h", "%an", "%ae", "%ad", "%s", "%b"]) + "%x1e"
 pr_title_re = re.compile(r".*\((#[0-9]{1,6})\)$")
 
 STATUS_COLOR_MAP = {
-    "Closed": "green",
+    "Closed": "yellow",
+    "Merged": "green",
     "Open": "red",
 }
 
@@ -102,14 +113,14 @@ def get_commit_in_main_associated_with_pr(repo: git.Repo, issue: Issue) -> str |
 
 def is_cherrypicked(repo: git.Repo, issue: Issue, previous_version: str | None = None) -> bool:
     """Check if a given issue is cherry-picked in the current branch or not"""
-    log_args = ["--format=%H %s", f"--grep=(#{issue.number})$"]
+    log_args = ["--format=%H %s", f"--grep=(#{issue.number})"]
     if previous_version:
         log_args.append(previous_version + "..")
     log_output = repo.git.log(*log_args)
 
     for commit_line in log_output.splitlines():
-        # We only want the commit for the PR where squash-merge added (#PR) at the end of subject
-        if commit_line and commit_line.endswith(f"(#{issue.number})"):
+        # Check if the PR number exists in the commit message (handles cherry-picked commits with multiple PR numbers)
+        if commit_line and f"(#{issue.number})" in commit_line:
             return True
     return False
 
@@ -270,8 +281,14 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
     )
     for issue in milestone_issues:
         commit_in_main = get_commit_in_main_associated_with_pr(repo, issue)
-        status = issue.state.capitalize()
         issue_is_pr = is_pr(issue)
+
+        # Determine status - differentiate between Closed and Merged for PRs
+        if issue_is_pr and issue.state == "closed":
+            pr = issue.as_pull_request()
+            status = "Merged" if pr.is_merged() else "Closed"
+        else:
+            status = issue.state.capitalize()
 
         # Checks if commit was cherrypicked into branch.
         if is_cherrypicked(repo, issue, previous_version):


### PR DESCRIPTION
- Fix `is_cherrypicked` function to detect PRs with multiple reference numbers
- Differentiate between Closed and Merged status for better PR state visibility
- Add PEP 723 script dependencies for easier execution with 'uv run --no-project'

The cherry-pick detection was failing for PRs that had additional PR numbers appended during cherry-picking (e.g., '(#53955) (#53964)'). This change improves release management workflow by providing clearer PR status information.

Previously it was showing the following even though it was cherry-picked:

```
53955 | PR    | doc-only      | Closed | Removed bold formatting for Public Interface for Airflow 3.0+                       | No     | 8e1201c | https://github.com/apache/airflow/pull/5395
```

Now:

```
NUMBER | TYPE  | CHANGELOG     | STATUS | TITLE                                                                               | MERGED |  COMMIT | URL
 53952 | PR    | bug-fix       | Merged | Fix dag_versions property when created_dag_version is None with bundle_version set  | No     | 79e6fd3 | https://github.com/apache/airflow/pull/53952
 53814 | PR    | Uncategorized | Merged | Fix custom xcom backend deserialize when BaseXCom.get_all is used                   | No     | a8c4ba3 | https://github.com/apache/airflow/pull/53814
 53825 | PR    | Uncategorized | Merged | Fix poolbar counts                                                                  | No     | e83ca8e | https://github.com/apache/airflow/pull/53825
 53812 | PR    | Uncategorized | Open   | Fix migration when xcom has NaN values                                              | No     |         | https://github.com/apache/airflow/pull/53812
 53746 | PR    | Uncategorized | Open   | Add indexes on `span_status` and `dag_version_id` in `task_instance`                | No     |         | https://github.com/apache/airflow/pull/53746
 53654 | PR    | bug-fix       | Closed | Fix DAG callbacks missing dag_run in context                                        | No     |         | https://github.com/apache/airflow/pull/53654
 53684 | PR    | Uncategorized | Merged | Restore proper DAG callback  execution context                                      | No     | ef80507 | https://github.com/apache/airflow/pull/53684
 50740 | PR    | doc-only      | Merged | Fix incorrect reference to SimpleHttpOperator in 3.0.0 release notes                | No     | 71f4224 | https://github.com/apache/airflow/pull/50740
 53475 | PR    | Uncategorized | Merged | Use asyncio.run instead of loop.run_until_complete.                                 | No     | 81ac72c | https://github.com/apache/airflow/pull/53475
 53532 | PR    | bug-fix       | Merged | Fixed Task group names duplication in Task's task_id for MappedOperator             | No     | 6b618ef | https://github.com/apache/airflow/pull/53532
 53459 | PR    | bug-fix       | Closed | Validate executor_config keys in BaseOperator                                       | No     |         | https://github.com/apache/airflow/pull/53459
 53476 | PR    | Uncategorized | Closed | Add ToTriggerSupervisor message types                                               | No     |         | https://github.com/apache/airflow/pull/53476
 53425 | PR    | Uncategorized | Merged | Updating K8's supported versions in `prerequisites.rst` to match `README.md`        | No     | 2328461 | https://github.com/apache/airflow/pull/53425
 53473 | PR    | doc-only      | Merged | Update dag bundles docs; add s3, fix git classpath                                  | No     | bf5fd5f | https://github.com/apache/airflow/pull/53473
 53460 | PR    | doc-only      | Merged | Fix broken link in advanced logging config docs                                     | No     | df5c949 | https://github.com/apache/airflow/pull/53460
 53331 | PR    | doc-only      | Merged | Add note about ruff rules and preview flag                                          | No     | d4d4cce | https://github.com/apache/airflow/pull/53331
 53071 | PR    | bug-fix       | Open   | Fix rendering of template fields with start from trigger                            | No     |         | https://github.com/apache/airflow/pull/53071
 52871 | PR    | Uncategorized | Merged | Fix task configuration defaults for AbstractOperator                                | No     | 04d2d3b | https://github.com/apache/airflow/pull/52871
 52786 | PR    | bug-fix       | Merged | Allow DEFAULT_QUEUE to be configurable from airflow settings in Task SDK            | No     | c65dc8e | https://github.com/apache/airflow/pull/52786
 52259 | PR    | doc-only      | Closed | docs: clarify AssetAlias usage with detailed explanation and examples               | No     |         | https://github.com/apache/airflow/pull/52259
 52797 | PR    | Uncategorized | Merged | Fixing bad cadwyn migration for upstream map indexes                                | No     | 2bb5d01 | https://github.com/apache/airflow/pull/52797
 52380 | PR    | Uncategorized | Open   | Ensure consistent relative path handling in clear_orphaned_import_errors            | No     |         | https://github.com/apache/airflow/pull/52380
 52231 | PR    | bug-fix       | Open   | Add ordering to AssetEvent query in SchedulerJobRunner                              | No     |         | https://github.com/apache/airflow/pull/52231
 51511 | PR    | bug-fix       | Open   | Fix Certain DAG import errors ("role does not exist") don't persist in Airflow      | No     |         | https://github.com/apache/airflow/pull/51511
 48557 | PR    | bug-fix       | Open   | handle overflow in TaskInstance next_retry_datetime fixes 47971                     | No     |         | https://github.com/apache/airflow/pull/48557
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
