### PR TITLE
Add hyperlink support for URLs in XCom values

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Skeleton, HStack, Text } from "@chakra-ui/react";
+import { Skeleton, HStack, Text, Link } from "@chakra-ui/react";
 
 import { useXcomServiceGetXcomEntry } from "openapi/queries";
 import type { XComResponseNative } from "openapi/requests/types.gen";
@@ -29,6 +29,45 @@ type XComEntryProps = {
   readonly runId: string;
   readonly taskId: string;
   readonly xcomKey: string;
+};
+
+const isUrl = (text: string): boolean => {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(text);
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const renderTextWithLinks = (text: string) => {
+  const urlRegex = /(https?:\/\/\S+)/gu;
+  const parts = text.split(urlRegex);
+
+  return (
+    <>
+      {parts.map((part) => {
+        if (isUrl(part)) {
+          return (
+            <Link
+              color="fg.info"
+              href={part}
+              key={part}
+              rel="noopener noreferrer"
+              target="_blank"
+              textDecoration="underline"
+            >
+              {part}
+            </Link>
+          );
+        }
+
+        return part;
+      })}
+    </>
+  );
 };
 
 export const XComEntry = ({ dagId, mapIndex, runId, taskId, xcomKey }: XComEntryProps) => {
@@ -63,7 +102,7 @@ export const XComEntry = ({ dagId, mapIndex, runId, taskId, xcomKey }: XComEntry
       {["array", "object"].includes(typeof data?.value) ? (
         <RenderedJsonField content={data?.value as object} enableClipboard={false} />
       ) : (
-        <Text>{valueFormatted}</Text>
+        <Text>{renderTextWithLinks(valueFormatted)}</Text>
       )}
     </HStack>
   );

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
@@ -22,6 +22,7 @@ import { useXcomServiceGetXcomEntry } from "openapi/queries";
 import type { XComResponseNative } from "openapi/requests/types.gen";
 import RenderedJsonField from "src/components/RenderedJsonField";
 import { ClipboardIconButton, ClipboardRoot } from "src/components/ui";
+import { urlRegex } from "src/constants/urlRegex";
 
 type XComEntryProps = {
   readonly dagId: string;
@@ -31,25 +32,16 @@ type XComEntryProps = {
   readonly xcomKey: string;
 };
 
-const isUrl = (text: string): boolean => {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(text);
-
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 const renderTextWithLinks = (text: string) => {
-  const urlRegex = /(https?:\/\/\S+)/gu;
-  const parts = text.split(urlRegex);
+  const urls = text.match(urlRegex);
+  const parts = text.split(/\s+/u);
 
   return (
     <>
-      {parts.map((part) => {
-        if (isUrl(part)) {
+      {parts.map((part, index) => {
+        const isLastPart = index === parts.length - 1;
+
+        if (urls?.includes(part)) {
           return (
             <Link
               color="fg.info"
@@ -64,7 +56,7 @@ const renderTextWithLinks = (text: string) => {
           );
         }
 
-        return part;
+        return `${part}${isLastPart ? "" : " "}`;
       })}
     </>
   );


### PR DESCRIPTION
XCom values containing URLs are now automatically detected and rendered as clickable hyperlinks that open in new tabs with proper security attributes.

<img width="1602" height="456" alt="image" src="https://github.com/user-attachments/assets/140dad7f-17c0-4bb0-a19a-7ea39f6483c6" />
