### PR TITLE
Add batch_size parameter description to run_cleanup docstring

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -521,6 +521,7 @@ def run_cleanup(
     :param confirm: Require user input to confirm before processing deletions.
     :param skip_archive: Set to True if you don't want the purged rows preservied in an archive table.
     :param session: Session representing connection to the metadata database.
+    :param batch_size: Maximum number of rows to delete or archive in a single transaction.
     """
     clean_before_timestamp = timezone.coerce_datetime(clean_before_timestamp)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**Add batch_size parameter description to the public function run_cleanup docstring**

This PR Relates to #51510, which added the option to specify a batch size when purging old records in airflow metadata database. The PR added the parameter description to the cli interface `airflow db clean`, but did not add the parameter description to the public function `run_cleanup` itself. 
This PR fixes this.

I did not use the whole help message from the cli paramter description, as I thought it would be too lengthy for the docstring.


