### PR TITLE
Fix handling of dark icons for plugins in nav

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
@@ -23,19 +23,31 @@ import { RiArchiveStackLine } from "react-icons/ri";
 import { Link as RouterLink } from "react-router-dom";
 
 import type { ExternalViewResponse } from "openapi/requests/types.gen";
+import { useColorMode } from "src/context/colorMode";
 import type { NavItemResponse } from "src/utils/types";
 
 import { NavButton } from "./NavButton";
 
 type Props = { readonly topLevel?: boolean } & NavItemResponse;
 
-export const PluginMenuItem = ({ icon, name, topLevel = false, url_route: urlRoute, ...rest }: Props) => {
+export const PluginMenuItem = ({
+  icon,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  icon_dark_mode,
+  name,
+  topLevel = false,
+  url_route: urlRoute,
+  ...rest
+}: Props) => {
   // Determine if this is an external view or react app based on the presence of href
+  const { colorMode } = useColorMode();
   const isExternalView = "href" in rest;
   const href = isExternalView ? (rest as ExternalViewResponse).href : undefined;
 
   const pluginIcon =
-    typeof icon === "string" ? (
+    colorMode === "dark" && typeof icon_dark_mode === "string" ? (
+      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={icon_dark_mode} width="1.25rem" />
+    ) : typeof icon === "string" ? (
       <Image height="1.25rem" mr={topLevel ? 0 : 2} src={icon} width="1.25rem" />
     ) : urlRoute === "legacy-fab-views" ? (
       <RiArchiveStackLine size="1.25rem" style={{ marginRight: topLevel ? 0 : "8px" }} />

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
@@ -43,10 +43,10 @@ export const PluginMenuItem = ({
   const isExternalView = "href" in rest;
   const href = isExternalView ? (rest as ExternalViewResponse).href : undefined;
 
-  const someIcon = colorMode === "dark" && typeof iconDarkMode === "string" ? iconDarkMode : icon;
+  const displayIcon = colorMode === "dark" && typeof iconDarkMode === "string" ? iconDarkMode : icon;
   const pluginIcon =
-    typeof someIcon === "string" ? (
-      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={someIcon} width="1.25rem" />
+    typeof displayIcon === "string" ? (
+      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={displayIcon} width="1.25rem" />
     ) : urlRoute === "legacy-fab-views" ? (
       <RiArchiveStackLine size="1.25rem" style={{ marginRight: topLevel ? 0 : "8px" }} />
     ) : (

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
@@ -32,8 +32,7 @@ type Props = { readonly topLevel?: boolean } & NavItemResponse;
 
 export const PluginMenuItem = ({
   icon,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  icon_dark_mode,
+  icon_dark_mode: iconDarkMode,
   name,
   topLevel = false,
   url_route: urlRoute,
@@ -44,11 +43,10 @@ export const PluginMenuItem = ({
   const isExternalView = "href" in rest;
   const href = isExternalView ? (rest as ExternalViewResponse).href : undefined;
 
+  const someIcon = colorMode === "dark" && typeof iconDarkMode === "string" ? iconDarkMode : icon;
   const pluginIcon =
-    colorMode === "dark" && typeof icon_dark_mode === "string" ? (
-      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={icon_dark_mode} width="1.25rem" />
-    ) : typeof icon === "string" ? (
-      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={icon} width="1.25rem" />
+    typeof someIcon === "string" ? (
+      <Image height="1.25rem" mr={topLevel ? 0 : 2} src={someIcon} width="1.25rem" />
     ) : urlRoute === "legacy-fab-views" ? (
       <RiArchiveStackLine size="1.25rem" style={{ marginRight: topLevel ? 0 : "8px" }} />
     ) : (


### PR DESCRIPTION
I noticed that in the nav the new dark mode icons were not applied. When implementing #53563 I saw that dark mode did not consider icons.
This PR fixes the handling also in dark mode.

Light mode:
<img width="317" height="312" alt="image" src="https://github.com/user-attachments/assets/09db67d7-16ad-4cfd-abba-71bb79c91560" />

Dark mode:
<img width="331" height="262" alt="image" src="https://github.com/user-attachments/assets/cb415664-76d9-405d-bd74-3b5032d5be58" />
