### PR TITLE
Fix type errors in operator link calls

### DIFF
--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -165,7 +165,7 @@ class MappedOperator(TaskSDKMappedOperator):
         link = self.operator_extra_link_dict.get(name) or self.global_operator_extra_link_dict.get(name)
         if not link:
             return None
-        return link.get_link(self, ti_key=ti.key)
+        return link.get_link(self, ti_key=ti.key)  # type: ignore[arg-type] # TODO: GH-52141 - BaseOperatorLink.get_link expects BaseOperator but receives MappedOperator
 
 
 @functools.singledispatch

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1297,7 +1297,7 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
         link = self.operator_extra_link_dict.get(name) or self.global_operator_extra_link_dict.get(name)
         if not link:
             return None
-        return link.get_link(self.unmap(None), ti_key=ti.key)
+        return link.get_link(self.unmap(None), ti_key=ti.key)  # type: ignore[arg-type] # TODO: GH-52141 - BaseOperatorLink.get_link expects BaseOperator but receives SerializedBaseOperator
 
     @property
     def task_type(self) -> str:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adds type: ignore comments to resolve mypy errors when calling BaseOperatorLink.get_link() with core operator types instead of the expected SDK BaseOperator type.


The BaseOperatorLink.get_link() method in the task SDK expects a BaseOperator parameter, but in the the references where we call it, we're passing:
* SerializedBaseOperator
* MappedOperator


For now, added `type: ignore[arg-type]` comments with TODO references to GH-52141, which tracks the broader issue of SDK/core type separation.


related https://github.com/apache/airflow/pull/54295

Fixes CI errors:
```

airflow-core/src/airflow/serialization/serialized_objects.py:1300: error: Argument 1 to "get_link" of "BaseOperatorLink" has incompatible type "SerializedBaseOperator"; expected "BaseOperator" 
[arg-type]
            return link.get_link(self.unmap(None), ti_key=ti.key)
                                 ^~~~~~~~~~~~~~~~
airflow-core/src/airflow/models/mappedoperator.py:168: error: Argument 1 to "get_link" of "BaseOperatorLink" has incompatible type "MappedOperator"; expected "BaseOperator"  [arg-type]
            return link.get_link(self, ti_key=ti.key)
                                 ^~~~
Found 2 errors in 2 files (checked 982 source files)
```

Example: https://github.com/apache/airflow/actions/runs/16862119240/job/47764118285

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
