### PR TITLE
WASB sas token fix when token is not full conn string, and an oracle query format cleanup 

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -197,7 +197,7 @@ class WasbHook(BaseHook):
         if sas_token:
             if sas_token.startswith("https"):
                 return BlobServiceClient(account_url=sas_token, **extra)
-            return BlobServiceClient(account_url=f"{account_url.rstrip('/')}/{sas_token}", **extra)
+            return BlobServiceClient(account_url=account_url, credential=sas_token, **extra)
 
         # Fall back to old auth (password) or use managed identity if not provided.
         credential: str | TokenCredential | None = conn.password
@@ -649,7 +649,7 @@ class WasbAsyncHook(WasbHook):
                 self.blob_service_client = AsyncBlobServiceClient(account_url=sas_token, **extra)
             else:
                 self.blob_service_client = AsyncBlobServiceClient(
-                    account_url=f"{account_url.rstrip('/')}/{sas_token}", **extra
+                    account_url=account_url, credential=sas_token, **extra
                 )
             return self.blob_service_client
 

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -358,18 +358,16 @@ class OracleHook(DbApiHook):
             )
 
         if sequence_column and sequence_name:
-            columns = (
-                f"({', '.join([sequence_column] + target_fields)})"
-                if target_fields
-                else f"({sequence_column})"
-            )
-            value_placeholders = ", ".join(
-                [f"{sequence_name}.NEXTVAL"] + [f":{i}" for i in range(1, len(values_base) + 1)]
-            )
+            columns = [sequence_column] + (target_fields or [])
+            values_list = [f"{sequence_name}.NEXTVAL"] + [f":{i}" for i in range(1, len(values_base) + 1)]
         else:
-            columns = f"({', '.join(target_fields)})" if target_fields else ""
-            value_placeholders = ", ".join(f":{i}" for i in range(1, len(values_base) + 1))
-        prepared_stm = f"insert into {table} {columns} values ({value_placeholders})"
+            columns = target_fields or []
+            values_list = [f":{i}" for i in range(1, len(values_base) + 1)]
+
+        columns_str = f"({', '.join(columns)})" if columns else ""
+        values_str = ", ".join(values_list)
+
+        prepared_stm = f"insert into {table} {columns_str} values ({values_str})"
 
         row_count = 0
         # Chunk the rows


### PR DESCRIPTION
**Title:**
Fix SAS token handling in BlobServiceClient connection logic and a minor clarity edit on oracle.py

**Description:**
This PR fixes the logic for constructing the account_url and credential parameters when using a SAS token to create BlobServiceClient and AsyncBlobServiceClient instances.
Previously, the method would append the SAS as a path onto the account url. The path error would cause failures of connections if the SAS token did not include 'https'. Most minor correction would have been to swap the "/" for a "?" but providing the token to credential is more proper. 

Oracle.py change was to correct a flynt warning that got raised during pre-commit check. Switched out f-string for the .format logic and added some variables for clarity btu otherwise code is the same.  

Updated test_wasb.py to reflect the SAS token being used in credential and also the case where the SAS token has a url