### PR TITLE
Update link to filter by pending required actions from dashboard.

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -28,6 +28,7 @@ export enum SearchParamsKeys {
   OWNERS = "owners",
   PAUSED = "paused",
   POOL = "pool",
+  RESPONSE_RECEIVED = "response_received",
   RUN_ID_PATTERN = "run_id_pattern",
   RUN_TYPE = "run_type",
   SORT = "sort",

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
@@ -67,7 +67,7 @@ export const Stats = () => {
             icon={<FiClock />}
             isLoading={isStatsLoading}
             label={translate("stats.requiredActions")}
-            link="required_actions"
+            link="required_actions?response_received=false"
           />
         ) : undefined}
 

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
@@ -20,7 +20,7 @@ import { Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
-import { Link as RouterLink, useParams } from "react-router-dom";
+import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import { useHumanInTheLoopServiceGetHitlDetails } from "openapi/queries";
 import type { HITLDetail } from "openapi/requests/types.gen";
@@ -30,6 +30,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
+import { SearchParamsKeys } from "src/constants/searchParams";
 import { useAutoRefresh } from "src/utils";
 import { getHITLState } from "src/utils/hitl";
 import { getTaskInstanceLink } from "src/utils/links";
@@ -123,8 +124,10 @@ const taskInstanceColumns = ({
 export const HITLTaskInstances = () => {
   const { t: translate } = useTranslation("hitl");
   const { dagId, groupId, runId, taskId } = useParams();
+  const [searchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination } = tableURLState;
+  const responseReceived = searchParams.get(SearchParamsKeys.RESPONSE_RECEIVED);
 
   const refetchInterval = useAutoRefresh({});
 
@@ -132,6 +135,7 @@ export const HITLTaskInstances = () => {
     {
       dagIdPattern: dagId,
       dagRunId: runId,
+      responseReceived: Boolean(responseReceived) ? responseReceived === "true" : undefined,
     },
     undefined,
     {


### PR DESCRIPTION
The pending required actions count is shown in the dashboard by passing `response_received=false` in the API request. On clicking the link all actions including completed ones are shown. It will be useful to pass `response_received` as false in the URL and then pass the same to API to list only pending required actions inline with the stats item count in dashboard.