### PR TITLE
Fix CloudComposerDAGRunSensor functionality

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -128,6 +128,10 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
 
         dag_runs = self._pull_dag_runs()
 
+        if len(dag_runs) == 0:
+            self.log.info("Dag runs are empty. Sensor waits for dag runs...")
+            return False
+
         self.log.info("Sensor waits for allowed states: %s", self.allowed_states)
         allowed_states_status = self._check_dag_runs_states(
             dag_runs=dag_runs,
@@ -194,6 +198,7 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
         if self.deferrable:
             start_date, end_date = self._get_logical_dates(context)
             self.defer(
+                timeout=self.timeout,
                 trigger=CloudComposerDAGRunTrigger(
                     project_id=self.project_id,
                     region=self.region,

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -254,6 +254,12 @@ class CloudComposerDAGRunTrigger(BaseTrigger):
                 if datetime.now(self.end_date.tzinfo).timestamp() > self.end_date.timestamp():
                     dag_runs = await self._pull_dag_runs()
 
+                    if len(dag_runs) == 0:
+                        self.log.info("Dag runs are empty. Sensor waits for dag runs...")
+                        self.log.info("Sleeping for %s seconds.", self.poll_interval)
+                        await asyncio.sleep(self.poll_interval)
+                        continue
+
                     self.log.info("Sensor waits for allowed states: %s", self.allowed_states)
                     if self._check_dag_runs_states(
                         dag_runs=dag_runs,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have improved functionality for the `CloudComposerDAGRunSensor` sensor. I added a check for empty `dag_runs` to prevent Sensor stops while it's waiting for DAG and, also, added a `timeout` for deferrable mode.  

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
