### PR TITLE
Add collapsible failed task logs to prevent React error 185

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -84,8 +84,8 @@
       "assetEvent_other": "Created Asset Events"
     },
     "failedLogs": {
-      "expandLogs": "Expand Logs",
       "hideLogs": "Hide Logs",
+      "showLogs": "Show Logs",
       "title": "Recent Failed Task Logs",
       "viewFullLogs": "View full logs"
     }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -84,6 +84,8 @@
       "assetEvent_other": "Created Asset Events"
     },
     "failedLogs": {
+      "expandLogs": "Expand Logs",
+      "hideLogs": "Hide Logs",
       "title": "Recent Failed Task Logs",
       "viewFullLogs": "View full logs"
     }

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -42,6 +42,7 @@ export const TaskLogPreview = ({
   const { data, error, isLoading } = useLogs(
     {
       dagId: taskInstance.dag_id,
+      limit: 100,
       logLevelFilters: ["error", "critical"],
       taskInstance,
       tryNumber: taskInstance.try_number,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Link } from "@chakra-ui/react";
+import { Box, Flex, Link, Button } from "@chakra-ui/react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -36,6 +37,8 @@ export const TaskLogPreview = ({
   readonly wrap: boolean;
 }) => {
   const { t: translate } = useTranslation("dag");
+  const [isExpanded, setIsExpanded] = useState(false);
+
   const { data, error, isLoading } = useLogs(
     {
       dagId: taskInstance.dag_id,
@@ -44,6 +47,7 @@ export const TaskLogPreview = ({
       tryNumber: taskInstance.try_number,
     },
     {
+      enabled: isExpanded,
       refetchInterval: false,
       retry: false,
     },
@@ -51,13 +55,18 @@ export const TaskLogPreview = ({
 
   return (
     <Box borderRadius={4} borderStyle="solid" borderWidth={1} key={taskInstance.id} width="100%">
-      <Flex alignItems="center" justifyContent="space-between" px={2}>
+      <Flex alignItems="center" justifyContent="space-between" px={2} py={2}>
         <Box>
           <StateBadge mr={1} state={taskInstance.state} />
           {taskInstance.task_display_name}
           <Time datetime={taskInstance.run_after} ml={1} />
         </Box>
         <Flex gap={1}>
+          <Button fontSize="sm" onClick={() => setIsExpanded(!isExpanded)} size="sm" variant="ghost">
+            {isExpanded
+              ? translate("overview.failedLogs.hideLogs")
+              : translate("overview.failedLogs.expandLogs")}
+          </Button>
           <ClearTaskInstanceButton taskInstance={taskInstance} withText={false} />
           <Link asChild color="fg.info" fontSize="sm">
             <RouterLink to={getTaskInstanceLink(taskInstance)}>
@@ -66,15 +75,17 @@ export const TaskLogPreview = ({
           </Link>
         </Flex>
       </Flex>
-      <Box maxHeight="100px" overflow="auto">
-        <TaskLogContent
-          error={error}
-          isLoading={isLoading}
-          logError={error}
-          parsedLogs={data.parsedLogs ?? []}
-          wrap={wrap}
-        />
-      </Box>
+      {isExpanded ? (
+        <Box borderTopStyle="solid" borderTopWidth={1} maxHeight="200px" overflow="auto">
+          <TaskLogContent
+            error={error}
+            isLoading={isLoading}
+            logError={error}
+            parsedLogs={data.parsedLogs ?? []}
+            wrap={wrap}
+          />
+        </Box>
+      ) : null}
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/TaskLogPreview.tsx
@@ -65,7 +65,7 @@ export const TaskLogPreview = ({
           <Button fontSize="sm" onClick={() => setIsExpanded(!isExpanded)} size="sm" variant="ghost">
             {isExpanded
               ? translate("overview.failedLogs.hideLogs")
-              : translate("overview.failedLogs.expandLogs")}
+              : translate("overview.failedLogs.showLogs")}
           </Button>
           <ClearTaskInstanceButton taskInstance={taskInstance} withText={false} />
           <Link asChild color="fg.info" fontSize="sm">

--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -220,8 +220,10 @@ export const useLogs = (
     },
   );
 
+  // Log truncation is performed in the frontend because the backend
+  // does not support yet pagination / limits on logs reading endpoint
   const truncatedData = useMemo(() => {
-    if (!data?.content || typeof limit !== "number" || limit <= 0) {
+    if (!data?.content || limit === undefined || limit <= 0) {
       return data;
     }
 
@@ -236,7 +238,7 @@ export const useLogs = (
   }, [data, limit]);
 
   const parsedData = parseLogs({
-    data: parseStreamingLogContent(typeof limit === "number" && limit > 0 ? truncatedData : data),
+    data: parseStreamingLogContent(truncatedData),
     expanded,
     logLevelFilters,
     showSource,

--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -20,6 +20,7 @@ import { chakra, Box } from "@chakra-ui/react";
 import type { UseQueryOptions } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import type { TFunction } from "i18next";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import innerText from "react-innertext";
 
@@ -34,6 +35,7 @@ type Props = {
   accept?: "*/*" | "application/json" | "application/x-ndjson";
   dagId: string;
   expanded?: boolean;
+  limit?: number;
   logLevelFilters?: Array<string>;
   showSource?: boolean;
   showTimestamp?: boolean;
@@ -184,6 +186,7 @@ export const useLogs = (
     accept = "application/x-ndjson",
     dagId,
     expanded,
+    limit,
     logLevelFilters,
     showSource,
     showTimestamp,
@@ -217,8 +220,23 @@ export const useLogs = (
     },
   );
 
+  const truncatedData = useMemo(() => {
+    if (!data?.content || typeof limit !== "number" || limit <= 0) {
+      return data;
+    }
+
+    const streamingContent = parseStreamingLogContent(data);
+    const truncatedContent =
+      streamingContent.length > limit ? streamingContent.slice(-limit) : streamingContent;
+
+    return {
+      ...data,
+      content: truncatedContent,
+    };
+  }, [data, limit]);
+
   const parsedData = parseLogs({
-    data: parseStreamingLogContent(data),
+    data: parseStreamingLogContent(typeof limit === "number" && limit > 0 ? truncatedData : data),
     expanded,
     logLevelFilters,
     showSource,


### PR DESCRIPTION
This PR is an attempt to mitigate #52916. It does not "fix" the issue but prevents it from happening on the dag landing page.
- Recent failed task logs now start collapsed by default
- Added "Expand Logs"/"Hide Logs" toggle buttons with translations
- Implemented lazy loading - logs only fetch when expanded
- Prevents page crashes from large log content rendering
- Increased log container max height from 100px to 200px


https://github.com/user-attachments/assets/58436d00-b477-4493-b5d5-dc249c82fc48

<img width="1675" height="1067" alt="image" src="https://github.com/user-attachments/assets/f3c893ad-d2f6-4f31-9b06-da51ea751a0a" />



