### PR TITLE
Remove airflow.models.DAG

### DIFF
--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -80,21 +80,20 @@ if not os.environ.get("_AIRFLOW__AS_LIBRARY", None):
 
 # Things to lazy import in form {local_name: ('target_module', 'target_name', 'deprecated')}
 __lazy_imports: dict[str, tuple[str, str, bool]] = {
-    "DAG": (".models.dag", "DAG", False),
-    "Asset": (".assets", "Asset", False),
+    "DAG": (".sdk", "DAG", False),
+    "Asset": (".sdk", "Asset", False),
     "XComArg": (".models.xcom_arg", "XComArg", False),
     "version": (".version", "", False),
     # Deprecated lazy imports
     "AirflowException": (".exceptions", "AirflowException", True),
-    "Dataset": (".sdk.definitions.asset", "Asset", True),
+    "Dataset": (".sdk", "Asset", True),
 }
 if TYPE_CHECKING:
     # These objects are imported by PEP-562, however, static analyzers and IDE's
     # have no idea about typing of these objects.
     # Add it under TYPE_CHECKING block should help with it.
-    from airflow.models.dag import DAG
     from airflow.models.xcom_arg import XComArg
-    from airflow.sdk.definitions.asset import Asset, Dataset
+    from airflow.sdk import DAG, Asset, Asset as Dataset
 
 
 def __getattr__(name: str):

--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -24,8 +24,8 @@ from sqlalchemy.orm import Session
 from airflow.models.dagbag import DBDagBag
 
 if TYPE_CHECKING:
-    from airflow.models.dag import DAG
     from airflow.models.dagrun import DagRun
+    from airflow.serialization.serialized_objects import SerializedDAG
 
 
 def create_dag_bag() -> DBDagBag:
@@ -45,7 +45,7 @@ def dag_bag_from_app(request: Request) -> DBDagBag:
 
 def get_latest_version_of_dag(
     dag_bag: DBDagBag, dag_id: str, session: Session, include_reason: bool = False
-) -> DAG:
+) -> SerializedDAG:
     dag = dag_bag.get_latest_version_of_dag(dag_id, session=session)
     if not dag:
         if include_reason:
@@ -60,7 +60,7 @@ def get_latest_version_of_dag(
     return dag
 
 
-def get_dag_for_run(dag_bag: DBDagBag, dag_run: DagRun, session: Session) -> DAG:
+def get_dag_for_run(dag_bag: DBDagBag, dag_run: DagRun, session: Session) -> SerializedDAG:
     dag = dag_bag.get_dag_for_run(dag_run, session=session)
     if not dag:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Dag with ID: `{dag_run.dag_id}` was not found")
@@ -69,8 +69,8 @@ def get_dag_for_run(dag_bag: DBDagBag, dag_run: DagRun, session: Session) -> DAG
 
 def get_dag_for_run_or_latest_version(
     dag_bag: DBDagBag, dag_run: DagRun | None, dag_id: str | None, session: Session
-) -> DAG:
-    dag: DAG | None = None
+) -> SerializedDAG:
+    dag: SerializedDAG | None = None
     if dag_run:
         dag = dag_bag.get_dag_for_run(dag_run, session=session)
     elif dag_id:

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -32,7 +32,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
-    from airflow.models import DAG
+    from airflow.serialization.serialized_objects import SerializedDAG
 
 
 class DAGRunPatchStates(str, Enum):
@@ -113,7 +113,7 @@ class TriggerDAGRunPostBody(StrictBaseModel):
             )
         return values
 
-    def validate_context(self, dag: DAG) -> dict:
+    def validate_context(self, dag: SerializedDAG) -> dict:
         coerced_logical_date = timezone.coerce_datetime(self.logical_date)
         run_after = self.run_after or timezone.utcnow()
         data_interval = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -744,7 +744,6 @@ def post_clear_task_instances(
     common_params = {
         "dry_run": True,
         "task_ids": task_ids,
-        "dag_bag": dag_bag,
         "session": session,
         "run_on_latest_version": body.run_on_latest_version,
         "only_failed": body.only_failed,

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -39,8 +39,8 @@ from airflow.api_fastapi.core_api.datamodels.task_instances import BulkTaskInsta
 from airflow.api_fastapi.core_api.security import GetUserDep
 from airflow.api_fastapi.core_api.services.public.common import BulkService
 from airflow.listeners.listener import get_listener_manager
-from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance as TI
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils.state import TaskInstanceState
 
 log = structlog.get_logger(__name__)
@@ -55,7 +55,7 @@ def _patch_ti_validate_request(
     session: SessionDep,
     map_index: int | None = -1,
     update_mask: list[str] | None = Query(None),
-) -> tuple[DAG, list[TI], dict]:
+) -> tuple[SerializedDAG, list[TI], dict]:
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
     if not dag.has_task(task_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Task '{task_id}' not found in DAG '{dag_id}'")
@@ -94,7 +94,7 @@ def _patch_ti_validate_request(
 def _patch_task_instance_state(
     task_id: str,
     dag_run_id: str,
-    dag: DAG,
+    dag: SerializedDAG,
     task_instance_body: BulkTaskInstanceBody | PatchTaskInstanceBody,
     data: dict,
     session: Session,

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
@@ -34,8 +34,8 @@ from airflow.api_fastapi.core_api.datamodels.ui.calendar import (
     CalendarTimeRangeCollectionResponse,
     CalendarTimeRangeResponse,
 )
-from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.timetables._cron import CronMixin
 from airflow.timetables.base import DataInterval, TimeRestriction
 from airflow.timetables.simple import ContinuousTimetable
@@ -52,7 +52,7 @@ class CalendarService:
         self,
         dag_id: str,
         session: Session,
-        dag: DAG,
+        dag: SerializedDAG,
         logical_date: RangeFilter,
         granularity: Literal["hourly", "daily"] = "daily",
     ) -> CalendarTimeRangeCollectionResponse:
@@ -126,7 +126,7 @@ class CalendarService:
 
     def _get_planned_dag_runs(
         self,
-        dag: DAG,
+        dag: SerializedDAG,
         raw_dag_states: list[Row],
         logical_date: RangeFilter,
         granularity: Literal["hourly", "daily"],
@@ -152,7 +152,7 @@ class CalendarService:
             dag, last_data_interval, year, restriction, logical_date, granularity
         )
 
-    def _should_calculate_planned_runs(self, dag: DAG, raw_dag_states: list[Row]) -> bool:
+    def _should_calculate_planned_runs(self, dag: SerializedDAG, raw_dag_states: list[Row]) -> bool:
         """Check if we should calculate planned runs."""
         return (
             bool(raw_dag_states)
@@ -177,7 +177,7 @@ class CalendarService:
 
     def _calculate_cron_planned_runs(
         self,
-        dag: DAG,
+        dag: SerializedDAG,
         last_data_interval: DataInterval,
         year: int,
         logical_date: RangeFilter,
@@ -208,7 +208,7 @@ class CalendarService:
 
     def _calculate_timetable_planned_runs(
         self,
-        dag: DAG,
+        dag: SerializedDAG,
         last_data_interval: DataInterval,
         year: int,
         restriction: TimeRestriction,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -72,7 +72,8 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.dml import Update
 
     from airflow.models.expandinput import SchedulerExpandInput
-    from airflow.sdk.types import Operator
+    from airflow.models.mappedoperator import MappedOperator
+    from airflow.serialization.serialized_objects import SerializedBaseOperator
 
 router = VersionedAPIRouter()
 
@@ -254,7 +255,14 @@ def ti_run(
 
         if dag := dag_bag.get_dag_for_run(dag_run=dr, session=session):
             upstream_map_indexes = dict(
-                _get_upstream_map_indexes(dag.get_task(ti.task_id), ti.map_index, ti.run_id, session)
+                _get_upstream_map_indexes(
+                    # TODO (GH-52141): This get_task should return scheduler
+                    # types instead, but currently it inherits SDK's DAG.
+                    cast("MappedOperator | SerializedBaseOperator", dag.get_task(ti.task_id)),
+                    ti.map_index,
+                    ti.run_id,
+                    session=session,
+                )
             )
         else:
             upstream_map_indexes = None
@@ -285,7 +293,7 @@ def ti_run(
 
 
 def _get_upstream_map_indexes(
-    task: Operator, ti_map_index: int, run_id: str, session: SessionDep
+    task: MappedOperator | SerializedBaseOperator, ti_map_index: int, run_id: str, session: SessionDep
 ) -> Iterator[tuple[str, int | list[int] | None]]:
     task_mapped_group = task.get_closest_mapped_task_group()
     for upstream_task in task.upstream_list:

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -40,11 +40,12 @@ from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.jobs.job import Job
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.models.dag import get_next_data_interval
 from airflow.models.dagbag import sync_bag_to_db
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils import cli as cli_utils
-from airflow.utils.cli import get_dag, suppress_logs_and_warning, validate_dag_bundle_arg
+from airflow.utils.cli import get_bagged_dag, suppress_logs_and_warning, validate_dag_bundle_arg
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.helpers import ask_yesno
 from airflow.utils.platform import getuser
@@ -53,10 +54,12 @@ from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from graphviz.dot import Dot
     from sqlalchemy.orm import Session
 
-    from airflow.models.dag import DAG
+    from airflow import DAG
     from airflow.timetables.base import DataInterval
 
 DAG_DETAIL_FIELDS = {*DAGResponse.model_fields, *DAGResponse.model_computed_fields}
@@ -125,21 +128,18 @@ def dag_unpause(args) -> None:
 
 
 @providers_configuration_loaded
-def set_is_paused(is_paused: bool, args) -> None:
+@provide_session
+def set_is_paused(is_paused: bool, args, *, session: Session = NEW_SESSION) -> None:
     """Set is_paused for DAG by a given dag_id."""
-    should_apply = True
-    with create_session() as session:
-        query = select(DagModel)
+    query = select(DagModel)
+    if args.treat_dag_id_as_regex:
+        query = query.where(DagModel.dag_id.regexp_match(args.dag_id))
+    else:
+        query = query.where(DagModel.dag_id == args.dag_id)
 
-        if args.treat_dag_id_as_regex:
-            query = query.where(DagModel.dag_id.regexp_match(args.dag_id))
-        else:
-            query = query.where(DagModel.dag_id == args.dag_id)
+    query = query.where(DagModel.is_paused != is_paused)
 
-        query = query.where(DagModel.is_paused != is_paused)
-
-        matched_dags = session.scalars(query).all()
-
+    matched_dags: list[DagModel] = session.scalars(query).all()
     if not matched_dags:
         print(f"No {'un' if is_paused else ''}paused DAGs were found")
         return
@@ -151,18 +151,20 @@ def set_is_paused(is_paused: bool, args) -> None:
             f"{','.join(dags_ids)}"
             f"\n\nAre you sure? [y/n]"
         )
-        should_apply = ask_yesno(question)
+        if not ask_yesno(question):
+            print("Operation cancelled by user")
+            return
 
-    if should_apply:
-        for dag_model in matched_dags:
-            dag_model.set_is_paused(is_paused=is_paused)
+    def _update_is_paused(dag_model: DagModel) -> bool:
+        old_is_paused = dag_model.is_paused
+        dag_model.is_paused = is_paused
+        return old_is_paused
 
-        AirflowConsole().print_as(
-            data=[{"dag_id": dag.dag_id, "is_paused": not dag.get_is_paused()} for dag in matched_dags],
-            output=args.output,
-        )
-    else:
-        print("Operation cancelled by user")
+    old_values = [
+        {"dag_id": dag_model.dag_id, "is_paused": _update_is_paused(dag_model)} for dag_model in matched_dags
+    ]
+    session.commit()
+    AirflowConsole().print_as(data=old_values, output=args.output)
 
 
 @providers_configuration_loaded
@@ -192,7 +194,11 @@ def dag_dependencies_show(args) -> None:
 @providers_configuration_loaded
 def dag_show(args) -> None:
     """Display DAG or saves its graphic representation to the file."""
-    dag = get_dag(bundle_names=None, dag_id=args.dag_id, from_db=True)
+    from airflow.models.serialized_dag import SerializedDagModel
+
+    if not (dag := SerializedDagModel.get_dag(dag_id=args.dag_id)):
+        raise SystemExit(f"Can not find dag {args.dag_id!r} in database")
+
     dot = render_dag(dag)
     filename = args.save
     imgcat = args.imgcat
@@ -231,15 +237,16 @@ def _save_dot_to_file(dot: Dot, filename: str) -> None:
     print(f"File {filename} saved")
 
 
-def _get_dagbag_dag_details(dag: DAG) -> dict:
+def _get_dagbag_dag_details(dag: DAG, session: Session) -> dict:
     """Return a dagbag dag details dict."""
+    dag_model: DagModel | None = session.get(DagModel, dag.dag_id)
     return {
         "dag_id": dag.dag_id,
         "dag_display_name": dag.dag_display_name,
-        "bundle_name": dag.get_bundle_name() if hasattr(dag, "get_bundle_name") else None,
-        "bundle_version": dag.get_bundle_version() if hasattr(dag, "get_bundle_version") else None,
-        "is_paused": dag.get_is_paused() if hasattr(dag, "get_is_paused") else None,
-        "is_stale": dag.get_is_stale() if hasattr(dag, "get_is_stale") else None,
+        "bundle_name": dag_model.bundle_name if dag_model else None,
+        "bundle_version": dag_model.bundle_version if dag_model else None,
+        "is_paused": dag_model.is_paused if dag_model else None,
+        "is_stale": dag_model.is_stale if dag_model else None,
         "last_parsed_time": None,
         "last_expired": None,
         "relative_fileloc": dag.relative_fileloc,
@@ -302,14 +309,18 @@ def dag_next_execution(args) -> None:
     >>> airflow dags next-execution tutorial
     2018-08-31 10:38:00
     """
-    dag = get_dag(bundle_names=None, dag_id=args.dag_id, from_db=True)
+    from airflow.models.serialized_dag import SerializedDagModel
 
     with create_session() as session:
-        last_parsed_dag: DagModel = session.scalars(
-            select(DagModel).where(DagModel.dag_id == dag.dag_id)
-        ).one()
+        dag = SerializedDagModel.get_dag(args.dag_id, session=session)
+        last_parsed_dag: DagModel | None = session.scalars(
+            select(DagModel).where(DagModel.dag_id == args.dag_id)
+        ).one_or_none()
 
-    if last_parsed_dag.get_is_paused():
+    if not dag or not last_parsed_dag:
+        raise SystemExit(f"DAG: {args.dag_id} does not exist in the database")
+
+    if last_parsed_dag.is_paused:
         print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
 
     def print_execution_interval(interval: DataInterval | None):
@@ -323,7 +334,7 @@ def dag_next_execution(args) -> None:
             return
         print(interval.start.isoformat())
 
-    next_interval = dag.get_next_data_interval(last_parsed_dag)
+    next_interval = get_next_data_interval(dag.timetable, last_parsed_dag)
     print_execution_interval(next_interval)
 
     for _ in range(1, args.num_executions):
@@ -391,20 +402,23 @@ def dag_list_dags(args, session: Session = NEW_SESSION) -> None:
     def get_dag_detail(dag: DAG) -> dict:
         dag_model = DagModel.get_dagmodel(dag.dag_id, session=session)
         if dag_model:
-            dag_detail = DAGResponse.from_orm(dag_model).model_dump()
+            dag_detail = DAGResponse.model_validate(dag_model, from_attributes=True).model_dump()
         else:
-            dag_detail = _get_dagbag_dag_details(dag)
+            dag_detail = _get_dagbag_dag_details(dag, session)
         if not cols:
             return dag_detail
         return {col: dag_detail[col] for col in cols if col in DAG_DETAIL_FIELDS}
 
-    def filter_dags_by_bundle(dags: list[DAG], bundle_names: list[str] | None) -> list[DAG]:
+    def filter_dags_by_bundle(dags: Iterable[DAG], bundle_names: list[str] | None) -> Iterable[DAG]:
         """Filter DAGs based on the specified bundle name, if provided."""
         if not bundle_names:
             return dags
 
         validate_dag_bundle_arg(bundle_names)
-        return [dag for dag in dags if dag.get_bundle_name() in bundle_names]
+        selected_dag_ids = set(
+            session.scalars(select(DagModel.dag_id).where(DagModel.bundle_name.in_(bundle_names)))
+        )
+        return (dag for dag in dags if dag.dag_id in selected_dag_ids)
 
     AirflowConsole().print_as(
         data=sorted(
@@ -612,7 +626,11 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
         re.compile(args.mark_success_pattern) if args.mark_success_pattern is not None else None
     )
 
-    dag = dag or get_dag(bundle_names=args.bundle_name, dag_id=args.dag_id, dagfile_path=args.dagfile_path)
+    dag = dag or get_bagged_dag(
+        bundle_names=args.bundle_name,
+        dag_id=args.dag_id,
+        dagfile_path=args.dagfile_path,
+    )
     if not dag:
         raise AirflowException(
             f"Dag {args.dag_id!r} could not be found; either it does not exist or it failed to parse."

--- a/airflow-core/src/airflow/cli/utils.py
+++ b/airflow-core/src/airflow/cli/utils.py
@@ -79,10 +79,9 @@ def fetch_dag_run_from_run_id_or_logical_date_string(
     from sqlalchemy import select
 
     from airflow._shared.timezones import timezone
-    from airflow.models.dag import DAG
     from airflow.models.dagrun import DagRun
 
-    if dag_run := DAG.fetch_dagrun(dag_id=dag_id, run_id=value, session=session):
+    if dag_run := session.scalar(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == value)):
         return dag_run, dag_run.logical_date
     try:
         logical_date = timezone.parse(value)

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 from sqlalchemy import delete, func, insert, select, tuple_, update
 from sqlalchemy.exc import OperationalError
@@ -48,12 +48,15 @@ from airflow.models.asset import (
     TaskInletAssetReference,
     TaskOutletAssetReference,
 )
-from airflow.models.dag import DAG, DagModel, DagOwnerAttributes, DagTag
+from airflow.models.dag import DagModel, DagOwnerAttributes, DagTag, get_run_data_interval
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarningType
 from airflow.models.errors import ParseImportError
 from airflow.models.trigger import Trigger
-from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUriRef
+from airflow.sdk import Asset, AssetAlias
+from airflow.sdk.definitions.asset import AssetNameRef, AssetUriRef, BaseAsset
+from airflow.serialization.enums import Encoding
+from airflow.serialization.serialized_objects import BaseSerialization, LazyDeserializedDAG, SerializedDAG
 from airflow.triggers.base import BaseEventTrigger
 from airflow.utils.retries import MAX_DB_RETRIES, run_with_db_retries
 from airflow.utils.sqlalchemy import with_row_locks
@@ -66,14 +69,18 @@ if TYPE_CHECKING:
     from sqlalchemy.sql import Select
 
     from airflow.models.dagwarning import DagWarning
-    from airflow.serialization.serialized_objects import MaybeSerializedDAG
     from airflow.typing_compat import Self
+
+AssetT = TypeVar("AssetT", bound=BaseAsset)
 
 log = logging.getLogger(__name__)
 
 
 def _create_orm_dags(
-    bundle_name: str, dags: Iterable[MaybeSerializedDAG], *, session: Session
+    bundle_name: str,
+    dags: Iterable[LazyDeserializedDAG],
+    *,
+    session: Session,
 ) -> Iterator[DagModel]:
     for dag in dags:
         orm_dag = DagModel(dag_id=dag.dag_id, bundle_name=bundle_name)
@@ -129,7 +136,7 @@ class _RunInfo(NamedTuple):
     num_active_runs: dict[str, int]
 
     @classmethod
-    def calculate(cls, dags: dict[str, MaybeSerializedDAG], *, session: Session) -> Self:
+    def calculate(cls, dags: dict[str, LazyDeserializedDAG], *, session: Session) -> Self:
         """
         Query the the run counts from the db.
 
@@ -175,7 +182,7 @@ def _update_dag_owner_links(dag_owner_links: dict[str, str], dm: DagModel, *, se
 
 
 def _serialize_dag_capturing_errors(
-    dag: MaybeSerializedDAG, bundle_name, session: Session, bundle_version: str | None
+    dag: LazyDeserializedDAG, bundle_name, session: Session, bundle_version: str | None
 ):
     """
     Try to serialize the dag to the DB, but make a note of any errors.
@@ -216,7 +223,7 @@ def _serialize_dag_capturing_errors(
         ]
 
 
-def _sync_dag_perms(dag: MaybeSerializedDAG, session: Session):
+def _sync_dag_perms(dag: LazyDeserializedDAG, session: Session):
     """Sync DAG specific permissions."""
     dag_id = dag.dag_id
 
@@ -334,7 +341,7 @@ def _update_import_errors(
 def update_dag_parsing_results_in_db(
     bundle_name: str,
     bundle_version: str | None,
-    dags: Collection[MaybeSerializedDAG],
+    dags: Collection[LazyDeserializedDAG],
     import_errors: dict[tuple[str, str], str],
     warnings: set[DagWarning],
     session: Session,
@@ -371,12 +378,15 @@ def update_dag_parsing_results_in_db(
             )
             log.debug("Calling the DAG.bulk_sync_to_db method")
             try:
-                DAG.bulk_write_to_db(bundle_name, bundle_version, dags, session=session)
+                SerializedDAG.bulk_write_to_db(bundle_name, bundle_version, dags, session=session)
                 # Write Serialized DAGs to DB, capturing errors
                 for dag in dags:
                     serialize_errors.extend(
                         _serialize_dag_capturing_errors(
-                            dag=dag, bundle_name=bundle_name, bundle_version=bundle_version, session=session
+                            dag=dag,
+                            bundle_name=bundle_name,
+                            bundle_version=bundle_version,
+                            session=session,
                         )
                     )
             except OperationalError:
@@ -384,7 +394,7 @@ def update_dag_parsing_results_in_db(
                 raise
             # Only now we are "complete" do we update import_errors - don't want to record errors from
             # previous failed attempts
-            import_errors.update(dict(serialize_errors))
+            import_errors.update(serialize_errors)
     # Record import errors into the ORM - we don't retry on this one as it's not as critical that it works
     try:
         # TODO: This won't clear errors for files that exist that no longer contain DAGs. Do we need to pass
@@ -416,7 +426,7 @@ def update_dag_parsing_results_in_db(
 class DagModelOperation(NamedTuple):
     """Collect DAG objects and perform database operations for them."""
 
-    dags: dict[str, MaybeSerializedDAG]
+    dags: dict[str, LazyDeserializedDAG]
     bundle_name: str
     bundle_version: str | None
 
@@ -454,11 +464,7 @@ class DagModelOperation(NamedTuple):
         from airflow.configuration import conf
 
         # we exclude backfill from active run counts since their concurrency is separate
-        run_info = _RunInfo.calculate(
-            dags=self.dags,
-            session=session,
-        )
-
+        run_info = _RunInfo.calculate(dags=self.dags, session=session)
         for dag_id, dm in sorted(orm_dags.items()):
             dag = self.dags[dag_id]
             dm.fileloc = dag.fileloc
@@ -516,7 +522,7 @@ class DagModelOperation(NamedTuple):
             if last_automated_run is None:
                 last_automated_data_interval = None
             else:
-                last_automated_data_interval = dag.get_run_data_interval(last_automated_run)
+                last_automated_data_interval = get_run_data_interval(dag.timetable, last_automated_run)
             if run_info.num_active_runs.get(dag.dag_id, 0) >= dm.max_active_runs:
                 dm.next_dagrun_create_after = None
             else:
@@ -590,19 +596,41 @@ class DagModelOperation(NamedTuple):
             dm.asset_expression = asset_expression
 
 
-def _find_all_assets(dags: Iterable[MaybeSerializedDAG]) -> Iterator[Asset]:
+def _get_task_ports(data: dict, inlets: bool, outlets: bool) -> Iterable[str]:
+    if inlets:
+        yield from data.get("inlets") or ()
+    if outlets:
+        yield from data.get("outlets") or ()
+
+
+def _get_dag_assets(
+    dag: LazyDeserializedDAG,
+    of: type[AssetT],
+    *,
+    inlets: bool = True,
+    outlets: bool = True,
+) -> Iterable[tuple[str, AssetT]]:
+    for task in dag.data["dag"]["tasks"]:
+        task = task[Encoding.VAR]
+        ports = _get_task_ports(task["partial_kwargs"] if task.get("_is_mapped") else task, inlets, outlets)
+        for port in ports:
+            if isinstance(obj := BaseSerialization.deserialize(port), of):
+                yield task["task_id"], obj
+
+
+def _find_all_assets(dags: Iterable[LazyDeserializedDAG]) -> Iterator[Asset]:
     for dag in dags:
         for _, asset in dag.timetable.asset_condition.iter_assets():
             yield asset
-        for _, asset in dag.get_task_assets(of_type=Asset):
+        for _, asset in _get_dag_assets(dag, of=Asset):
             yield asset
 
 
-def _find_all_asset_aliases(dags: Iterable[MaybeSerializedDAG]) -> Iterator[AssetAlias]:
+def _find_all_asset_aliases(dags: Iterable[LazyDeserializedDAG]) -> Iterator[AssetAlias]:
     for dag in dags:
         for _, alias in dag.timetable.asset_condition.iter_asset_aliases():
             yield alias
-        for _, alias in dag.get_task_assets(of_type=AssetAlias):
+        for _, alias in _get_dag_assets(dag, of=AssetAlias):
             yield alias
 
 
@@ -633,7 +661,7 @@ class AssetModelOperation(NamedTuple):
     asset_aliases: dict[str, AssetAlias]
 
     @classmethod
-    def collect(cls, dags: dict[str, MaybeSerializedDAG]) -> Self:
+    def collect(cls, dags: dict[str, LazyDeserializedDAG]) -> Self:
         coll = cls(
             schedule_asset_references={
                 dag_id: [asset for _, asset in dag.timetable.asset_condition.iter_assets()]
@@ -656,10 +684,12 @@ class AssetModelOperation(NamedTuple):
                 if isinstance(ref, AssetUriRef)
             },
             inlet_references={
-                dag_id: list(dag.get_task_assets(inlets=True, outlets=False)) for dag_id, dag in dags.items()
+                dag_id: list(_get_dag_assets(dag, Asset, inlets=True, outlets=False))
+                for dag_id, dag in dags.items()
             },
             outlet_references={
-                dag_id: list(dag.get_task_assets(inlets=False, outlets=True)) for dag_id, dag in dags.items()
+                dag_id: list(_get_dag_assets(dag, Asset, inlets=False, outlets=True))
+                for dag_id, dag in dags.items()
             },
             assets={(asset.name, asset.uri): asset for asset in _find_all_assets(dags.values())},
             asset_aliases={alias.name: alias for alias in _find_all_asset_aliases(dags.values())},

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -186,10 +186,9 @@ def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileP
 
     serialized_dags, serialization_import_errors = _serialize_dags(bag, log)
     bag.import_errors.update(serialization_import_errors)
-    dags = [LazyDeserializedDAG(data=serdag) for serdag in serialized_dags]
     result = DagFileParsingResult(
         fileloc=msg.file,
-        serialized_dags=dags,
+        serialized_dags=serialized_dags,
         import_errors=bag.import_errors,
         # TODO: Make `bag.dag_warnings` not return SQLA model objects
         warnings=[],
@@ -197,13 +196,16 @@ def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileP
     return result
 
 
-def _serialize_dags(bag: DagBag, log: FilteringBoundLogger) -> tuple[list[dict], dict[str, str]]:
+def _serialize_dags(
+    bag: DagBag,
+    log: FilteringBoundLogger,
+) -> tuple[list[LazyDeserializedDAG], dict[str, str]]:
     serialization_import_errors = {}
     serialized_dags = []
     for dag in bag.dags.values():
         try:
-            serialized_dag = SerializedDAG.to_dict(dag)
-            serialized_dags.append(serialized_dag)
+            data = SerializedDAG.to_dict(dag)
+            serialized_dags.append(LazyDeserializedDAG(data=data, last_loaded=dag.last_loaded))
         except Exception:
             log.exception("Failed to serialize DAG: %s", dag.fileloc)
             dagbag_import_error_traceback_depth = conf.getint(

--- a/airflow-core/src/airflow/datasets/__init__.py
+++ b/airflow-core/src/airflow/datasets/__init__.py
@@ -30,10 +30,10 @@ import warnings
 # TODO: Remove this module in Airflow 3.2
 
 _names_moved = {
-    "DatasetAlias": ("airflow.sdk.definitions.asset", "AssetAlias"),
-    "DatasetAll": ("airflow.sdk.definitions.asset", "AssetAll"),
-    "DatasetAny": ("airflow.sdk.definitions.asset", "AssetAny"),
-    "Dataset": ("airflow.sdk.definitions.asset", "Asset"),
+    "DatasetAlias": ("airflow.sdk", "AssetAlias"),
+    "DatasetAll": ("airflow.sdk", "AssetAll"),
+    "DatasetAny": ("airflow.sdk", "AssetAny"),
+    "Dataset": ("airflow.sdk", "Asset"),
     "expand_alias_to_datasets": ("airflow.models.asset", "expand_alias_to_assets"),
 }
 
@@ -45,8 +45,8 @@ def __getattr__(name: str):
 
     module_path, new_name = _names_moved[name]
     warnings.warn(
-        f"Import 'airflow.dataset.{name}' is deprecated and "
-        f"will be removed in the Airflow 3.2. Please import it from '{module_path}.{new_name}'.",
+        f"Import 'airflow.datasets.{name}' is deprecated and "
+        f"will be removed in Airflow 3.2. Please import it from '{module_path}.{new_name}'.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/airflow-core/src/airflow/datasets/metadata.py
+++ b/airflow-core/src/airflow/datasets/metadata.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import warnings
 
-from airflow.sdk.definitions.asset.metadata import Metadata
+from airflow.sdk import Metadata
 
 # TODO: Remove this module in Airflow 3.2
 
 warnings.warn(
-    "Import from the airflow.dataset module is deprecated and "
-    "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset.metadata'.",
+    "Import from the airflow.datasets.metadata module is deprecated and will "
+    "be removed in Airflow 3.2. Please import it from 'airflow.sdk'.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -59,7 +59,7 @@ from airflow.models.asset import (
     asset_trigger_association_table,
 )
 from airflow.models.backfill import Backfill
-from airflow.models.dag import DAG, DagModel
+from airflow.models.dag import DagModel, get_next_data_interval, get_run_data_interval
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
 from airflow.models.dagrun import DagRun
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     from airflow.executors.executor_utils import ExecutorName
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstanceKey
-    from airflow.serialization.serialized_objects import SerializedBaseOperator
+    from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
     from airflow.utils.sqlalchemy import CommitProhibitorGuard
 
 TI = TaskInstance
@@ -105,7 +105,7 @@ TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 """:meta private:"""
 
 
-def _get_current_dag(dag_id: str, session: Session) -> DAG | None:
+def _get_current_dag(dag_id: str, session: Session) -> SerializedDAG | None:
     serdag = SerializedDagModel.get(dag_id=dag_id, session=session)  # grabs the latest version
     if not serdag:
         return None
@@ -1395,7 +1395,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # Send the callbacks after we commit to ensure the context is up to date when it gets run
         # cache saves time during scheduling of many dag_runs for same dag
-        cached_get_dag: Callable[[DagRun], DAG | None] = lru_cache()(
+        cached_get_dag: Callable[[DagRun], SerializedDAG | None] = lru_cache()(
             partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
         for dag_run, callback_to_run in callback_tuples:
@@ -1521,7 +1521,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
                 continue
 
-            data_interval = dag.get_next_data_interval(dag_model)
+            data_interval = get_next_data_interval(dag.timetable, dag_model)
             # Explicitly check if the DagRun already exists. This is an edge case
             # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
             # are not updated.
@@ -1642,7 +1642,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
     def _should_update_dag_next_dagruns(
         self,
-        dag: DAG,
+        dag: SerializedDAG,
         dag_model: DagModel,
         *,
         last_dag_run: DagRun | None = None,
@@ -1697,7 +1697,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         active_runs_of_dags = Counter({(dag_id, br_id): num for dag_id, br_id, num in session.execute(query)})
 
         @add_debug_span
-        def _update_state(dag: DAG, dag_run: DagRun):
+        def _update_state(dag: SerializedDAG, dag_run: DagRun):
             span = Trace.get_current_span()
             span.set_attributes(
                 {
@@ -1723,7 +1723,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # always happening immediately after the data interval.
                 # We only publish these metrics for scheduled dag runs and only
                 # when ``run_type`` is *MANUAL* and ``clear_number`` is 0.
-                expected_start_date = dag.get_run_data_interval(dag_run).end
+                expected_start_date = get_run_data_interval(dag.timetable, dag_run).end
                 schedule_delay = dag_run.start_date - expected_start_date
                 # Publish metrics twice with backward compatible name, and then with tags
                 Stats.timing(f"dagrun.schedule_delay.{dag.dag_id}", schedule_delay)
@@ -1739,7 +1739,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     )
 
         # cache saves time during scheduling of many dag_runs for same dag
-        cached_get_dag: Callable[[DagRun], DAG | None] = lru_cache()(
+        cached_get_dag: Callable[[DagRun], SerializedDAG | None] = lru_cache()(
             partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
 
@@ -1858,7 +1858,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 if self._should_update_dag_next_dagruns(
                     dag, dag_model, last_dag_run=dag_run, session=session
                 ):
-                    dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
+                    dag_model.calculate_dagrun_date_fields(dag, get_run_data_interval(dag.timetable, dag_run))
 
                 callback_to_execute = DagCallbackRequest(
                     filepath=dag_model.relative_fileloc,
@@ -1918,7 +1918,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
 
             if self._should_update_dag_next_dagruns(dag, dag_model, last_dag_run=dag_run, session=session):
-                dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
+                dag_model.calculate_dagrun_date_fields(dag, get_run_data_interval(dag.timetable, dag_run))
             # This will do one query per dag run. We "could" build up a complex
             # query to update all the TIs across all the logical dates and dag
             # IDs in a single query, but it turns out that can be _very very slow_
@@ -1961,7 +1961,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return True
 
-    def _send_dag_callbacks_to_processor(self, dag: DAG, callback: DagCallbackRequest | None = None) -> None:
+    def _send_dag_callbacks_to_processor(
+        self,
+        dag: SerializedDAG,
+        callback: DagCallbackRequest | None = None,
+    ) -> None:
         if callback:
             self.job.executor.send_callback(callback)
         else:

--- a/airflow-core/src/airflow/models/__init__.py
+++ b/airflow-core/src/airflow/models/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "DagRun",
     "DagTag",
     "DbCallbackRequest",
+    "Deadline",
     "Log",
     "MappedOperator",
     "Operator",
@@ -44,6 +45,7 @@ __all__ = [
     "RenderedTaskInstanceFields",
     "SkipMixin",
     "TaskInstance",
+    "TaskInstanceHistory",
     "TaskReschedule",
     "Trigger",
     "Variable",
@@ -89,11 +91,11 @@ def __getattr__(name):
 
 __lazy_imports = {
     "Job": "airflow.jobs.job",
-    "DAG": "airflow.models.dag",
+    "DAG": "airflow.sdk",
     "ID_LEN": "airflow.models.base",
     "Base": "airflow.models.base",
-    "BaseOperator": "airflow.sdk.bases.operator",
-    "BaseOperatorLink": "airflow.sdk.bases.operatorlink",
+    "BaseOperator": "airflow.sdk",
+    "BaseOperatorLink": "airflow.sdk",
     "BaseXCom": "airflow.sdk.bases.xcom",
     "Connection": "airflow.models.connection",
     "DagBag": "airflow.models.dagbag",
@@ -124,7 +126,7 @@ if TYPE_CHECKING:
     # having to resort back to this hacky method
     from airflow.models.base import ID_LEN, Base
     from airflow.models.connection import Connection
-    from airflow.models.dag import DAG, DagModel, DagTag
+    from airflow.models.dag import DagModel, DagTag
     from airflow.models.dagbag import DagBag
     from airflow.models.dagrun import DagRun
     from airflow.models.dagwarning import DagWarning
@@ -140,10 +142,8 @@ if TYPE_CHECKING:
     from airflow.models.taskreschedule import TaskReschedule
     from airflow.models.trigger import Trigger
     from airflow.models.variable import Variable
-    from airflow.sdk.bases.operator import BaseOperator
-    from airflow.sdk.bases.operatorlink import BaseOperatorLink
+    from airflow.sdk import DAG, BaseOperator, BaseOperatorLink, Param
     from airflow.sdk.bases.xcom import BaseXCom
-    from airflow.sdk.definitions.param import Param
     from airflow.sdk.execution_time.xcom import XCom
 
 
@@ -157,7 +157,7 @@ __deprecated_classes = {
         "DEFAULT_TASK_EXECUTION_TIMEOUT": "airflow.sdk.definitions._internal.abstractoperator.DEFAULT_TASK_EXECUTION_TIMEOUT",
     },
     "param": {
-        "Param": "airflow.sdk.definitions.param.Param",
+        "Param": "airflow.sdk.Param",
         "ParamsDict": "airflow.sdk.definitions.param.ParamsDict",
     },
     "baseoperator": {
@@ -167,10 +167,10 @@ __deprecated_classes = {
         "cross_downstream": "airflow.sdk.bases.operator.cross_downstream",
     },
     "baseoperatorlink": {
-        "BaseOperatorLink": "airflow.sdk.bases.operatorlink.BaseOperatorLink",
+        "BaseOperatorLink": "airflow.sdk.BaseOperatorLink",
     },
     "operator": {
-        "BaseOperator": "airflow.sdk.bases.operator.BaseOperator",
+        "BaseOperator": "airflow.sdk.BaseOperator",
         "Operator": "airflow.sdk.types.Operator",
     },
 }

--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -54,7 +54,7 @@ from airflow.utils.types import DagRunTriggeredByType, DagRunType
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from airflow.models.dag import DAG
+    from airflow.serialization.serialized_objects import SerializedDAG
     from airflow.timetables.base import DagRunInfo
 
 log = logging.getLogger(__name__)
@@ -284,7 +284,7 @@ def _do_dry_run(*, dag_id, from_date, to_date, reverse, reprocess_behavior, sess
 
 def _create_backfill_dag_run(
     *,
-    dag: DAG,
+    dag: SerializedDAG,
     info: DagRunInfo,
     reprocess_behavior: ReprocessBehavior,
     backfill_id,
@@ -415,7 +415,6 @@ def _handle_clear_run(session, dag, dr, info, backfill_id, sort_ordinal, run_on_
         run_id=dr.run_id,
         dag_run_state=DagRunState.QUEUED,
         session=session,
-        confirm_prompt=False,
         dry_run=False,
         run_on_latest_version=run_on_latest,
     )

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -17,26 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-import copy
-import functools
 import logging
-import re
 from collections import defaultdict
-from collections.abc import Callable, Collection, Generator, Iterable, Sequence
+from collections.abc import Callable, Collection
 from datetime import datetime, timedelta
-from functools import cache
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
-import attrs
-import methodtools
-import pendulum
 import sqlalchemy_jsonfield
 from dateutil.relativedelta import relativedelta
 from sqlalchemy import (
@@ -52,68 +38,42 @@ from sqlalchemy import (
     func,
     or_,
     select,
-    tuple_,
-    update,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, load_only, relationship
-from sqlalchemy.sql import Select, expression
+from sqlalchemy.sql import expression
 
-from airflow import settings, utils
+from airflow import settings
 from airflow._shared.timezones import timezone
 from airflow.assets.evaluation import AssetEvaluator
 from airflow.configuration import conf as airflow_conf
-from airflow.exceptions import (
-    AirflowException,
-    UnknownExecutorException,
-)
-from airflow.executors.executor_loader import ExecutorLoader
-from airflow.models import Deadline
-from airflow.models.asset import (
-    AssetDagRunQueue,
-    AssetModel,
-)
+from airflow.exceptions import AirflowException
+from airflow.models.asset import AssetDagRunQueue, AssetModel
 from airflow.models.base import Base, StringID
-from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
-from airflow.models.dagrun import RUN_ID_REGEX, DagRun
-from airflow.models.taskinstance import (
-    TaskInstance,
-    TaskInstanceKey,
-    clear_task_instances,
-)
-from airflow.models.tasklog import LogTemplate
+from airflow.models.dagrun import DagRun
 from airflow.models.team import Team
-from airflow.sdk import TaskGroup
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, BaseAsset
-from airflow.sdk.definitions.dag import DAG as TaskSDKDag, dag as task_sdk_dag_decorator
-from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
+from airflow.sdk.definitions.deadline import DeadlineAlert
 from airflow.settings import json
-from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+from airflow.timetables.base import DataInterval, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
-from airflow.timetables.simple import (
-    AssetTriggeredTimetable,
-    NullTimetable,
-    OnceTimetable,
-)
+from airflow.timetables.simple import AssetTriggeredTimetable, NullTimetable, OnceTimetable
 from airflow.utils.context import Context
-from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
-from airflow.utils.sqlalchemy import UtcDateTime, lock_rows, with_row_locks
-from airflow.utils.state import DagRunState, TaskInstanceState
-from airflow.utils.types import DagRunTriggeredByType, DagRunType
+from airflow.utils.sqlalchemy import UtcDateTime, with_row_locks
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
 
 if TYPE_CHECKING:
-    from typing import Literal, TypeAlias
+    from typing import TypeAlias
 
-    from pydantic import NonNegativeInt
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
 
-    from airflow.models.dagbag import DBDagBag
     from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.serialized_objects import MaybeSerializedDAG, SerializedBaseOperator
+    from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
 
     Operator: TypeAlias = MappedOperator | SerializedBaseOperator
 
@@ -127,6 +87,84 @@ DagStateChangeCallback = Callable[[Context], None]
 ScheduleInterval = None | str | timedelta | relativedelta
 
 ScheduleArg = ScheduleInterval | Timetable | BaseAsset | Collection[Union["Asset", "AssetAlias"]]
+
+
+def infer_automated_data_interval(timetable: Timetable, logical_date: datetime) -> DataInterval:
+    """
+    Infer a data interval for a run against this DAG.
+
+    This method is used to bridge runs created prior to AIP-39
+    implementation, which do not have an explicit data interval. Therefore,
+    this method only considers ``schedule_interval`` values valid prior to
+    Airflow 2.2.
+
+    DO NOT call this method if there is a known data interval.
+
+    :meta private:
+    """
+    timetable_type = type(timetable)
+    if issubclass(timetable_type, (NullTimetable, OnceTimetable, AssetTriggeredTimetable)):
+        return DataInterval.exact(timezone.coerce_datetime(logical_date))
+    start = timezone.coerce_datetime(logical_date)
+    if issubclass(timetable_type, CronDataIntervalTimetable):
+        end = cast("CronDataIntervalTimetable", timetable)._get_next(start)
+    elif issubclass(timetable_type, DeltaDataIntervalTimetable):
+        end = cast("DeltaDataIntervalTimetable", timetable)._get_next(start)
+    # Contributors: When the exception below is raised, you might want to
+    # add an 'elif' block here to handle custom timetables. Stop! The bug
+    # you're looking for is instead at when the DAG run (represented by
+    # logical_date) was created. See GH-31969 for an example:
+    # * Wrong fix: GH-32074 (modifies this function).
+    # * Correct fix: GH-32118 (modifies the DAG run creation code).
+    else:
+        raise ValueError(f"Not a valid timetable: {timetable!r}")
+    return DataInterval(start, end)
+
+
+def get_run_data_interval(timetable: Timetable, run: DagRun) -> DataInterval:
+    """
+    Get the data interval of this run.
+
+    For compatibility, this method infers the data interval from the DAG's
+    schedule if the run does not have an explicit one set, which is possible for
+    runs created prior to AIP-39.
+
+    This function is private to Airflow core and should not be depended on as a
+    part of the Python API.
+
+    :meta private:
+    """
+    data_interval = _get_model_data_interval(run, "data_interval_start", "data_interval_end")
+    if data_interval is not None:
+        return data_interval
+    # Compatibility: runs created before AIP-39 implementation don't have an
+    # explicit data interval. Try to infer from the logical date.
+    return infer_automated_data_interval(timetable, run.logical_date)
+
+
+def get_next_data_interval(timetable: Timetable, dag_model: DagModel) -> DataInterval | None:
+    """
+    Get the data interval of the next scheduled run.
+
+    For compatibility, this method infers the data interval from the DAG's
+    schedule if the run does not have an explicit one set, which is possible
+    for runs created prior to AIP-39.
+
+    This function is private to Airflow core and should not be depended on as a
+    part of the Python API.
+
+    :meta private:
+    """
+    if dag_model.next_dagrun is None:  # Next run not scheduled.
+        return None
+    data_interval = dag_model.next_dagrun_data_interval
+    if data_interval is not None:
+        return data_interval
+
+    # Compatibility: A run was scheduled without an explicit data interval.
+    # This means the run was scheduled before AIP-39 implementation. Try to
+    # infer from the logical date.
+    return infer_automated_data_interval(timetable, dag_model.next_dagrun)
 
 
 class InconsistentDataInterval(AirflowException):
@@ -222,1606 +260,6 @@ def get_asset_triggered_next_run_info(
             .where(DagScheduleAssetReference.dag_id.in_(dag_ids))
         ).all()
     }
-
-
-@provide_session
-def _create_orm_dagrun(
-    *,
-    dag: DAG,
-    run_id: str,
-    logical_date: datetime | None,
-    data_interval: DataInterval | None,
-    run_after: datetime,
-    start_date: datetime | None,
-    conf: Any,
-    state: DagRunState | None,
-    run_type: DagRunType,
-    creating_job_id: int | None,
-    backfill_id: NonNegativeInt | None,
-    triggered_by: DagRunTriggeredByType,
-    triggering_user_name: str | None = None,
-    session: Session = NEW_SESSION,
-) -> DagRun:
-    bundle_version = None
-    if not dag.disable_bundle_versioning:
-        bundle_version = session.scalar(
-            select(DagModel.bundle_version).where(DagModel.dag_id == dag.dag_id),
-        )
-    dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
-    if not dag_version:
-        raise AirflowException(f"Cannot create DagRun for DAG {dag.dag_id} because the dag is not serialized")
-
-    run = DagRun(
-        dag_id=dag.dag_id,
-        run_id=run_id,
-        logical_date=logical_date,
-        start_date=start_date,
-        run_after=run_after,
-        conf=conf,
-        state=state,
-        run_type=run_type,
-        creating_job_id=creating_job_id,
-        data_interval=data_interval,
-        triggered_by=triggered_by,
-        triggering_user_name=triggering_user_name,
-        backfill_id=backfill_id,
-        bundle_version=bundle_version,
-    )
-    # Load defaults into the following two fields to ensure result can be serialized detached
-    run.log_template_id = int(session.scalar(select(func.max(LogTemplate.__table__.c.id))))
-    run.created_dag_version = dag_version
-    run.consumed_asset_events = []
-    session.add(run)
-    session.flush()
-    run.dag = dag
-    # create the associated task instances
-    # state is None at the moment of creation
-    run.verify_integrity(session=session, dag_version_id=dag_version.id)
-    return run
-
-
-if TYPE_CHECKING:
-    dag = task_sdk_dag_decorator
-else:
-
-    def dag(dag_id: str = "", **kwargs):
-        return task_sdk_dag_decorator(dag_id, __DAG_class=DAG, __warnings_stacklevel_delta=3, **kwargs)
-
-
-def _convert_max_consecutive_failed_dag_runs(val: int) -> int:
-    if val == 0:
-        val = airflow_conf.getint("core", "max_consecutive_failed_dag_runs_per_dag")
-    if val < 0:
-        raise ValueError(
-            f"Invalid max_consecutive_failed_dag_runs: {val}. Requires max_consecutive_failed_dag_runs >= 0"
-        )
-    return val
-
-
-@functools.total_ordering
-@attrs.define(hash=False, repr=False, eq=False, slots=False)
-class DAG(TaskSDKDag, LoggingMixin):
-    """
-    A dag is a collection of tasks with directional dependencies.
-
-    A dag also has a schedule, a start date and an end date (optional).  For each schedule,
-    (say daily or hourly), the DAG needs to run each individual tasks as their dependencies
-    are met. Certain tasks have the property of depending on their own past, meaning that
-    they can't run until their previous schedule (and upstream tasks) are completed.
-
-    DAGs essentially act as namespaces for tasks. A task_id can only be
-    added once to a DAG.
-
-    Note that if you plan to use time zones all the dates provided should be pendulum
-    dates. See :ref:`timezone_aware_dags`.
-
-    .. versionadded:: 2.4
-        The *schedule* argument to specify either time-based scheduling logic
-        (timetable), or asset-driven triggers.
-
-    .. versionchanged:: 3.0
-        The default value of *schedule* has been changed to *None* (no schedule).
-        The previous default was ``timedelta(days=1)``.
-
-    :param dag_id: The id of the DAG; must consist exclusively of alphanumeric
-        characters, dashes, dots and underscores (all ASCII)
-    :param description: The description for the DAG to e.g. be shown on the webserver
-    :param schedule: If provided, this defines the rules according to which DAG
-        runs are scheduled. Possible values include a cron expression string,
-        timedelta object, Timetable, or list of Asset objects.
-        See also :doc:`/howto/timetable`.
-    :param start_date: The timestamp from which the scheduler will
-        attempt to backfill. If this is not provided, backfilling must be done
-        manually with an explicit time range.
-    :param end_date: A date beyond which your DAG won't run, leave to None
-        for open-ended scheduling.
-    :param template_searchpath: This list of folders (non-relative)
-        defines where jinja will look for your templates. Order matters.
-        Note that jinja/airflow includes the path of your DAG file by
-        default
-    :param template_undefined: Template undefined type.
-    :param user_defined_macros: a dictionary of macros that will be exposed
-        in your jinja templates. For example, passing ``dict(foo='bar')``
-        to this argument allows you to ``{{ foo }}`` in all jinja
-        templates related to this DAG. Note that you can pass any
-        type of object here.
-    :param user_defined_filters: a dictionary of filters that will be exposed
-        in your jinja templates. For example, passing
-        ``dict(hello=lambda name: 'Hello %s' % name)`` to this argument allows
-        you to ``{{ 'world' | hello }}`` in all jinja templates related to
-        this DAG.
-    :param default_args: A dictionary of default parameters to be used
-        as constructor keyword parameters when initialising operators.
-        Note that operators have the same hook, and precede those defined
-        here, meaning that if your dict contains `'depends_on_past': True`
-        here and `'depends_on_past': False` in the operator's call
-        `default_args`, the actual value will be `False`.
-    :param params: a dictionary of DAG level parameters that are made
-        accessible in templates, namespaced under `params`. These
-        params can be overridden at the task level.
-    :param max_active_tasks: the number of task instances allowed to run
-        concurrently
-    :param max_active_runs: maximum number of active DAG runs, beyond this
-        number of DAG runs in a running state, the scheduler won't create
-        new active DAG runs
-    :param max_consecutive_failed_dag_runs: (experimental) maximum number of consecutive failed DAG runs,
-        beyond this the scheduler will disable the DAG
-    :param dagrun_timeout: Specify the duration a DagRun should be allowed to run before it times out or
-        fails. Task instances that are running when a DagRun is timed out will be marked as skipped.
-    :param sla_miss_callback: DEPRECATED - The SLA feature is removed in Airflow 3.0, to be replaced with a new implementation in 3.1
-    :param deadline: Optional Deadline Alert for the DAG.
-        Specifies a time by which the DAG run should be complete, either in the form of a static datetime
-        or calculated relative to a reference timestamp.  If the deadline passes before completion, the
-        provided callback is triggered.
-
-        **Example**: To set the deadline for one hour after the DAG run starts you could use ::
-
-            DeadlineAlert(
-                reference=DeadlineReference.DAGRUN_LOGICAL_DATE,
-                interval=timedelta(hours=1),
-                callback=my_callback,
-            )
-
-    :param catchup: Perform scheduler catchup (or only run latest)? Defaults to False
-    :param on_failure_callback: A function or list of functions to be called when a DagRun of this dag fails.
-        A context dictionary is passed as a single parameter to this function.
-    :param on_success_callback: Much like the ``on_failure_callback`` except
-        that it is executed when the dag succeeds.
-    :param access_control: Specify optional DAG-level actions, e.g.,
-        "{'role1': {'can_read'}, 'role2': {'can_read', 'can_edit', 'can_delete'}}"
-        or it can specify the resource name if there is a DAGs Run resource, e.g.,
-        "{'role1': {'DAG Runs': {'can_create'}}, 'role2': {'DAGs': {'can_read', 'can_edit', 'can_delete'}}"
-    :param is_paused_upon_creation: Specifies if the dag is paused when created for the first time.
-        If the dag exists already, this flag will be ignored. If this optional parameter
-        is not specified, the global config setting will be used.
-    :param jinja_environment_kwargs: additional configuration options to be passed to Jinja
-        ``Environment`` for template rendering
-
-        **Example**: to avoid Jinja from removing a trailing newline from template strings ::
-
-            DAG(
-                dag_id="my-dag",
-                jinja_environment_kwargs={
-                    "keep_trailing_newline": True,
-                    # some other jinja2 Environment options here
-                },
-            )
-
-        **See**: `Jinja Environment documentation
-        <https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment>`_
-
-    :param render_template_as_native_obj: If True, uses a Jinja ``NativeEnvironment``
-        to render templates as native Python types. If False, a Jinja
-        ``Environment`` is used to render templates as string values.
-    :param tags: List of tags to help filtering DAGs in the UI.
-    :param owner_links: Dict of owners and their links, that will be clickable on the DAGs view UI.
-        Can be used as an HTTP link (for example the link to your Slack channel), or a mailto link.
-        e.g: {"dag_owner": "https://airflow.apache.org/"}
-    :param auto_register: Automatically register this DAG when it is used in a ``with`` block
-    :param fail_fast: Fails currently running tasks when task in DAG fails.
-        **Warning**: A fail fast dag can only have tasks with the default trigger rule ("all_success").
-        An exception will be thrown if any task in a fail fast dag has a non default trigger rule.
-    :param dag_display_name: The display name of the DAG which appears on the UI.
-    """
-
-    partial: bool = False
-    last_loaded: datetime | None = attrs.field(factory=timezone.utcnow)
-
-    # this will only be set at serialization time
-    # it's only use is for determining the relative fileloc based only on the serialize dag
-    _processor_dags_folder: str | None = attrs.field(init=False, default=None)
-
-    # Override the default from parent class to use config
-    max_consecutive_failed_dag_runs: int = attrs.field(
-        default=0,
-        converter=_convert_max_consecutive_failed_dag_runs,
-        validator=attrs.validators.instance_of(int),
-    )
-
-    @property
-    def safe_dag_id(self):
-        return self.dag_id.replace(".", "__dot__")
-
-    def validate(self):
-        super().validate()
-        self.validate_executor_field()
-
-    def validate_executor_field(self):
-        for task in self.tasks:
-            if task.executor:
-                try:
-                    ExecutorLoader.lookup_executor_name_by_str(task.executor)
-                except UnknownExecutorException:
-                    raise UnknownExecutorException(
-                        f"The specified executor {task.executor} for task {task.task_id} is not "
-                        "configured. Review the core.executors Airflow configuration to add it or "
-                        "update the executor configuration for this task."
-                    )
-
-    @staticmethod
-    def _upgrade_outdated_dag_access_control(access_control=None):
-        """Look for outdated dag level actions in DAG access_controls and replace them with updated actions."""
-        if access_control is None:
-            return None
-        updated_access_control = {}
-        for role, perms in access_control.items():
-            updated_access_control[role] = updated_access_control.get(role, {})
-            if isinstance(perms, (set, list)):
-                # Support for old-style access_control where only the actions are specified
-                updated_access_control[role]["DAGs"] = set(perms)
-            else:
-                updated_access_control[role] = perms
-        return updated_access_control
-
-    def get_next_data_interval(self, dag_model: DagModel) -> DataInterval | None:
-        """
-        Get the data interval of the next scheduled run.
-
-        For compatibility, this method infers the data interval from the DAG's
-        schedule if the run does not have an explicit one set, which is possible
-        for runs created prior to AIP-39.
-
-        This function is private to Airflow core and should not be depended on as a
-        part of the Python API.
-
-        :meta private:
-        """
-        if self.dag_id != dag_model.dag_id:
-            raise ValueError(f"Arguments refer to different DAGs: {self.dag_id} != {dag_model.dag_id}")
-        if dag_model.next_dagrun is None:  # Next run not scheduled.
-            return None
-        data_interval = dag_model.next_dagrun_data_interval
-        if data_interval is not None:
-            return data_interval
-
-        # Compatibility: A run was scheduled without an explicit data interval.
-        # This means the run was scheduled before AIP-39 implementation. Try to
-        # infer from the logical date.
-        return self.infer_automated_data_interval(dag_model.next_dagrun)
-
-    def get_run_data_interval(self, run: DagRun) -> DataInterval:
-        """
-        Get the data interval of this run.
-
-        For compatibility, this method infers the data interval from the DAG's
-        schedule if the run does not have an explicit one set, which is possible for
-        runs created prior to AIP-39.
-
-        This function is private to Airflow core and should not be depended on as a
-        part of the Python API.
-
-        :meta private:
-        """
-        if run.dag_id is not None and run.dag_id != self.dag_id:
-            raise ValueError(f"Arguments refer to different DAGs: {self.dag_id} != {run.dag_id}")
-        data_interval = _get_model_data_interval(run, "data_interval_start", "data_interval_end")
-        if data_interval is not None:
-            return data_interval
-        # Compatibility: runs created before AIP-39 implementation don't have an
-        # explicit data interval. Try to infer from the logical date.
-        return self.infer_automated_data_interval(run.logical_date)
-
-    def infer_automated_data_interval(self, logical_date: datetime) -> DataInterval:
-        """
-        Infer a data interval for a run against this DAG.
-
-        This method is used to bridge runs created prior to AIP-39
-        implementation, which do not have an explicit data interval. Therefore,
-        this method only considers ``schedule_interval`` values valid prior to
-        Airflow 2.2.
-
-        DO NOT call this method if there is a known data interval.
-
-        :meta private:
-        """
-        timetable_type = type(self.timetable)
-        if issubclass(timetable_type, (NullTimetable, OnceTimetable, AssetTriggeredTimetable)):
-            return DataInterval.exact(timezone.coerce_datetime(logical_date))
-        start = timezone.coerce_datetime(logical_date)
-        if issubclass(timetable_type, CronDataIntervalTimetable):
-            end = cast("CronDataIntervalTimetable", self.timetable)._get_next(start)
-        elif issubclass(timetable_type, DeltaDataIntervalTimetable):
-            end = cast("DeltaDataIntervalTimetable", self.timetable)._get_next(start)
-        # Contributors: When the exception below is raised, you might want to
-        # add an 'elif' block here to handle custom timetables. Stop! The bug
-        # you're looking for is instead at when the DAG run (represented by
-        # logical_date) was created. See GH-31969 for an example:
-        # * Wrong fix: GH-32074 (modifies this function).
-        # * Correct fix: GH-32118 (modifies the DAG run creation code).
-        else:
-            raise ValueError(f"Not a valid timetable: {self.timetable!r}")
-        return DataInterval(start, end)
-
-    def next_dagrun_info(
-        self,
-        last_automated_dagrun: None | DataInterval,
-        *,
-        restricted: bool = True,
-    ) -> DagRunInfo | None:
-        """
-        Get information about the next DagRun of this dag after ``date_last_automated_dagrun``.
-
-        This calculates what time interval the next DagRun should operate on
-        (its logical date) and when it can be scheduled, according to the
-        dag's timetable, start_date, end_date, etc. This doesn't check max
-        active run or any other "max_active_tasks" type limits, but only
-        performs calculations based on the various date and interval fields of
-        this dag and its tasks.
-
-        :param last_automated_dagrun: The ``max(logical_date)`` of
-            existing "automated" DagRuns for this dag (scheduled or backfill,
-            but not manual).
-        :param restricted: If set to *False* (default is *True*), ignore
-            ``start_date``, ``end_date``, and ``catchup`` specified on the DAG
-            or tasks.
-        :return: DagRunInfo of the next dagrun, or None if a dagrun is not
-            going to be scheduled.
-        """
-        data_interval = None
-        if isinstance(last_automated_dagrun, datetime):
-            raise ValueError(
-                "Passing a datetime to DAG.next_dagrun_info is not supported anymore. Use a DataInterval instead."
-            )
-        data_interval = last_automated_dagrun
-        if restricted:
-            restriction = self._time_restriction
-        else:
-            restriction = TimeRestriction(earliest=None, latest=None, catchup=True)
-        try:
-            info = self.timetable.next_dagrun_info(
-                last_automated_data_interval=data_interval,
-                restriction=restriction,
-            )
-        except Exception:
-            self.log.exception(
-                "Failed to fetch run info after data interval %s for DAG %r",
-                data_interval,
-                self.dag_id,
-            )
-            info = None
-        return info
-
-    @functools.cached_property
-    def _time_restriction(self) -> TimeRestriction:
-        start_dates = [t.start_date for t in self.tasks if t.start_date]
-        if self.start_date is not None:
-            start_dates.append(self.start_date)
-        earliest = None
-        if start_dates:
-            earliest = timezone.coerce_datetime(min(start_dates))
-        latest = timezone.coerce_datetime(self.end_date)
-        end_dates = [t.end_date for t in self.tasks if t.end_date]
-        if len(end_dates) == len(self.tasks):  # not exists null end_date
-            if self.end_date is not None:
-                end_dates.append(self.end_date)
-            if end_dates:
-                latest = timezone.coerce_datetime(max(end_dates))
-        return TimeRestriction(earliest, latest, self.catchup)
-
-    def iter_dagrun_infos_between(
-        self,
-        earliest: pendulum.DateTime | datetime | None,
-        latest: pendulum.DateTime | datetime,
-        *,
-        align: bool = True,
-    ) -> Iterable[DagRunInfo]:
-        """
-        Yield DagRunInfo using this DAG's timetable between given interval.
-
-        DagRunInfo instances yielded if their ``logical_date`` is not earlier
-        than ``earliest``, nor later than ``latest``. The instances are ordered
-        by their ``logical_date`` from earliest to latest.
-
-        If ``align`` is ``False``, the first run will happen immediately on
-        ``earliest``, even if it does not fall on the logical timetable schedule.
-        The default is ``True``.
-
-        Example: A DAG is scheduled to run every midnight (``0 0 * * *``). If
-        ``earliest`` is ``2021-06-03 23:00:00``, the first DagRunInfo would be
-        ``2021-06-03 23:00:00`` if ``align=False``, and ``2021-06-04 00:00:00``
-        if ``align=True``.
-        """
-        if earliest is None:
-            earliest = self._time_restriction.earliest
-        if earliest is None:
-            raise ValueError("earliest was None and we had no value in time_restriction to fallback on")
-        earliest = timezone.coerce_datetime(earliest)
-        latest = timezone.coerce_datetime(latest)
-
-        restriction = TimeRestriction(earliest, latest, catchup=True)
-
-        try:
-            info = self.timetable.next_dagrun_info(
-                last_automated_data_interval=None,
-                restriction=restriction,
-            )
-        except Exception:
-            self.log.exception(
-                "Failed to fetch run info after data interval %s for DAG %r",
-                None,
-                self.dag_id,
-            )
-            info = None
-
-        if info is None:
-            # No runs to be scheduled between the user-supplied timeframe. But
-            # if align=False, "invent" a data interval for the timeframe itself.
-            if not align:
-                yield DagRunInfo.interval(earliest, latest)
-            return
-
-        # If align=False and earliest does not fall on the timetable's logical
-        # schedule, "invent" a data interval for it.
-        if not align and info.logical_date != earliest:
-            yield DagRunInfo.interval(earliest, info.data_interval.start)
-
-        # Generate naturally according to schedule.
-        while info is not None:
-            yield info
-            try:
-                info = self.timetable.next_dagrun_info(
-                    last_automated_data_interval=info.data_interval,
-                    restriction=restriction,
-                )
-            except Exception:
-                self.log.exception(
-                    "Failed to fetch run info after data interval %s for DAG %r",
-                    info.data_interval if info else "<NONE>",
-                    self.dag_id,
-                )
-                break
-
-    @provide_session
-    def get_last_dagrun(self, session=NEW_SESSION, include_manually_triggered=False):
-        return get_last_dagrun(
-            self.dag_id, session=session, include_manually_triggered=include_manually_triggered
-        )
-
-    @property
-    def dag_id(self) -> str:
-        return self._dag_id
-
-    @dag_id.setter
-    def dag_id(self, value: str) -> None:
-        self._dag_id = value
-
-    @provide_session
-    def get_concurrency_reached(self, session=NEW_SESSION) -> bool:
-        """Return a boolean indicating whether the max_active_tasks limit for this DAG has been reached."""
-        TI = TaskInstance
-        total_tasks = session.scalar(
-            select(func.count(TI.task_id)).where(
-                TI.dag_id == self.dag_id,
-                TI.state == TaskInstanceState.RUNNING,
-            )
-        )
-        return total_tasks >= self.max_active_tasks
-
-    @provide_session
-    def get_is_active(self, session=NEW_SESSION) -> None:
-        """Return a boolean indicating whether this DAG is active."""
-        return session.scalar(select(~DagModel.is_stale).where(DagModel.dag_id == self.dag_id))
-
-    @provide_session
-    def get_is_stale(self, session=NEW_SESSION) -> None:
-        """Return a boolean indicating whether this DAG is stale."""
-        return session.scalar(select(DagModel.is_stale).where(DagModel.dag_id == self.dag_id))
-
-    @provide_session
-    def get_is_paused(self, session=NEW_SESSION) -> None:
-        """Return a boolean indicating whether this DAG is paused."""
-        return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
-
-    @provide_session
-    def get_bundle_name(self, session=NEW_SESSION) -> str | None:
-        """Return the bundle name this DAG is in."""
-        return session.scalar(select(DagModel.bundle_name).where(DagModel.dag_id == self.dag_id))
-
-    @provide_session
-    def get_bundle_version(self, session=NEW_SESSION) -> str | None:
-        """Return the bundle version that was seen when this dag was processed."""
-        return session.scalar(select(DagModel.bundle_version).where(DagModel.dag_id == self.dag_id))
-
-    @methodtools.lru_cache(maxsize=None)
-    @classmethod
-    def get_serialized_fields(cls):
-        """Stringified DAGs and operators contain exactly these fields."""
-        return TaskSDKDag.get_serialized_fields() | {"_processor_dags_folder"}
-
-    def get_active_runs(self):
-        """
-        Return a list of dag run logical dates currently running.
-
-        :return: List of logical dates
-        """
-        runs = DagRun.find(dag_id=self.dag_id, state=DagRunState.RUNNING)
-
-        active_dates = []
-        for run in runs:
-            active_dates.append(run.logical_date)
-
-        return active_dates
-
-    @staticmethod
-    @provide_session
-    def fetch_dagrun(dag_id: str, run_id: str, session: Session = NEW_SESSION) -> DagRun:
-        """
-        Return the dag run for a given run_id if it exists, otherwise none.
-
-        :param dag_id: The dag_id of the DAG to find.
-        :param run_id: The run_id of the DagRun to find.
-        :param session:
-        :return: The DagRun if found, otherwise None.
-        """
-        return session.scalar(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id))
-
-    @provide_session
-    def get_dagrun(self, run_id: str, session: Session = NEW_SESSION) -> DagRun:
-        return DAG.fetch_dagrun(dag_id=self.dag_id, run_id=run_id, session=session)
-
-    @provide_session
-    def get_dagruns_between(self, start_date, end_date, session=NEW_SESSION):
-        """
-        Return the list of dag runs between start_date (inclusive) and end_date (inclusive).
-
-        :param start_date: The starting logical date of the DagRun to find.
-        :param end_date: The ending logical date of the DagRun to find.
-        :param session:
-        :return: The list of DagRuns found.
-        """
-        dagruns = session.scalars(
-            select(DagRun).where(
-                DagRun.dag_id == self.dag_id,
-                DagRun.logical_date >= start_date,
-                DagRun.logical_date <= end_date,
-            )
-        ).all()
-
-        return dagruns
-
-    @provide_session
-    def get_latest_logical_date(self, session: Session = NEW_SESSION) -> pendulum.DateTime | None:
-        """Return the latest date for which at least one dag run exists."""
-        return session.scalar(select(func.max(DagRun.logical_date)).where(DagRun.dag_id == self.dag_id))
-
-    @provide_session
-    def get_task_instances_before(
-        self,
-        base_date: datetime,
-        num: int,
-        *,
-        session: Session = NEW_SESSION,
-    ) -> list[TaskInstance]:
-        """
-        Get ``num`` task instances before (including) ``base_date``.
-
-        The returned list may contain exactly ``num`` task instances
-        corresponding to any DagRunType. It can have less if there are
-        less than ``num`` scheduled DAG runs before ``base_date``.
-        """
-        logical_dates: list[Any] = session.execute(
-            select(DagRun.logical_date)
-            .where(
-                DagRun.dag_id == self.dag_id,
-                DagRun.logical_date <= base_date,
-            )
-            .order_by(DagRun.logical_date.desc())
-            .limit(num)
-        ).all()
-
-        if not logical_dates:
-            return self.get_task_instances(start_date=base_date, end_date=base_date, session=session)
-
-        min_date: datetime | None = logical_dates[-1]._mapping.get(
-            "logical_date"
-        )  # getting the last value from the list
-
-        return self.get_task_instances(start_date=min_date, end_date=base_date, session=session)
-
-    @provide_session
-    def get_task_instances(
-        self,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        state: TaskInstanceState | Sequence[TaskInstanceState] | None = None,
-        session: Session = NEW_SESSION,
-    ) -> list[TaskInstance]:
-        if not start_date:
-            start_date = (timezone.utcnow() - timedelta(30)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-
-        query = self._get_task_instances(
-            task_ids=None,
-            start_date=start_date,
-            end_date=end_date,
-            run_id=None,
-            state=state or (),
-            include_dependent_dags=False,
-            exclude_task_ids=(),
-            exclude_run_ids=None,
-            session=session,
-        )
-        return session.scalars(cast("Select", query).order_by(DagRun.logical_date)).all()
-
-    @overload
-    def _get_task_instances(
-        self,
-        *,
-        task_ids: Collection[str | tuple[str, int]] | None,
-        start_date: datetime | None,
-        end_date: datetime | None,
-        run_id: str | None,
-        state: TaskInstanceState | Sequence[TaskInstanceState],
-        include_dependent_dags: bool,
-        exclude_task_ids: Collection[str | tuple[str, int]] | None,
-        exclude_run_ids: frozenset[str] | None,
-        session: Session,
-        dag_bag: DBDagBag | None = ...,
-    ) -> Iterable[TaskInstance]: ...  # pragma: no cover
-
-    @overload
-    def _get_task_instances(
-        self,
-        *,
-        task_ids: Collection[str | tuple[str, int]] | None,
-        as_pk_tuple: Literal[True],
-        start_date: datetime | None,
-        end_date: datetime | None,
-        run_id: str | None,
-        state: TaskInstanceState | Sequence[TaskInstanceState],
-        include_dependent_dags: bool,
-        exclude_task_ids: Collection[str | tuple[str, int]] | None,
-        exclude_run_ids: frozenset[str] | None,
-        session: Session,
-        dag_bag: DBDagBag | None = ...,
-        recursion_depth: int = ...,
-        max_recursion_depth: int = ...,
-        visited_external_tis: set[TaskInstanceKey] = ...,
-    ) -> set[TaskInstanceKey]: ...  # pragma: no cover
-
-    def _get_task_instances(
-        self,
-        *,
-        task_ids: Collection[str | tuple[str, int]] | None,
-        as_pk_tuple: Literal[True, None] = None,
-        start_date: datetime | None,
-        end_date: datetime | None,
-        run_id: str | None,
-        state: TaskInstanceState | Sequence[TaskInstanceState],
-        include_dependent_dags: bool,
-        exclude_task_ids: Collection[str | tuple[str, int]] | None,
-        exclude_run_ids: frozenset[str] | None,
-        session: Session,
-        dag_bag: DBDagBag | None = None,
-        recursion_depth: int = 0,
-        max_recursion_depth: int | None = None,
-        visited_external_tis: set[TaskInstanceKey] | None = None,
-    ) -> Iterable[TaskInstance] | set[TaskInstanceKey]:
-        from airflow.models.dagbag import DBDagBag
-
-        TI = TaskInstance
-
-        # If we are looking at dependent dags we want to avoid UNION calls
-        # in SQL (it doesn't play nice with fields that have no equality operator,
-        # like JSON types), we instead build our result set separately.
-        #
-        # This will be empty if we are only looking at one dag, in which case
-        # we can return the filtered TI query object directly.
-        result: set[TaskInstanceKey] = set()
-
-        # Do we want full objects, or just the primary columns?
-        if as_pk_tuple:
-            tis = select(TI.dag_id, TI.task_id, TI.run_id, TI.map_index)
-        else:
-            tis = select(TaskInstance)
-        tis = tis.join(TaskInstance.dag_run)
-
-        if self.partial:
-            tis = tis.where(TaskInstance.dag_id == self.dag_id, TaskInstance.task_id.in_(self.task_ids))
-        else:
-            tis = tis.where(TaskInstance.dag_id == self.dag_id)
-        if run_id:
-            tis = tis.where(TaskInstance.run_id == run_id)
-        if start_date:
-            tis = tis.where(DagRun.logical_date >= start_date)
-        if task_ids is not None:
-            tis = tis.where(TaskInstance.ti_selector_condition(task_ids))
-        if end_date:
-            tis = tis.where(DagRun.logical_date <= end_date)
-
-        if state:
-            if isinstance(state, (str, TaskInstanceState)):
-                tis = tis.where(TaskInstance.state == state)
-            elif len(state) == 1:
-                tis = tis.where(TaskInstance.state == state[0])
-            else:
-                # this is required to deal with NULL values
-                if None in state:
-                    if all(x is None for x in state):
-                        tis = tis.where(TaskInstance.state.is_(None))
-                    else:
-                        not_none_state = [s for s in state if s]
-                        tis = tis.where(
-                            or_(TaskInstance.state.in_(not_none_state), TaskInstance.state.is_(None))
-                        )
-                else:
-                    tis = tis.where(TaskInstance.state.in_(state))
-
-        if exclude_run_ids:
-            tis = tis.where(TaskInstance.run_id.not_in(exclude_run_ids))
-
-        if include_dependent_dags:
-            # Recursively find external tasks indicated by ExternalTaskMarker
-            from airflow.providers.standard.sensors.external_task import ExternalTaskMarker
-
-            query = tis
-            if as_pk_tuple:
-                all_tis = session.execute(query).all()
-                condition = TI.filter_for_tis(TaskInstanceKey(*cols) for cols in all_tis)
-                if condition is not None:
-                    query = select(TI).where(condition)
-
-            if visited_external_tis is None:
-                visited_external_tis = set()
-
-            external_tasks = session.scalars(query.where(TI.operator == ExternalTaskMarker.__name__))
-
-            for ti in external_tasks:
-                ti_key = ti.key.primary
-                if ti_key in visited_external_tis:
-                    continue
-
-                visited_external_tis.add(ti_key)
-
-                task: ExternalTaskMarker = cast("ExternalTaskMarker", copy.copy(self.get_task(ti.task_id)))
-                ti.task = task
-
-                if max_recursion_depth is None:
-                    # Maximum recursion depth allowed is the recursion_depth of the first
-                    # ExternalTaskMarker in the tasks to be visited.
-                    max_recursion_depth = task.recursion_depth
-
-                if recursion_depth + 1 > max_recursion_depth:
-                    # Prevent cycles or accidents.
-                    raise AirflowException(
-                        f"Maximum recursion depth {max_recursion_depth} reached for "
-                        f"{ExternalTaskMarker.__name__} {ti.task_id}. "
-                        f"Attempted to clear too many tasks or there may be a cyclic dependency."
-                    )
-                ti.render_templates()
-                external_tis = session.scalars(
-                    select(TI)
-                    .join(TI.dag_run)
-                    .where(
-                        TI.dag_id == task.external_dag_id,
-                        TI.task_id == task.external_task_id,
-                        DagRun.logical_date == pendulum.parse(task.logical_date),
-                    )
-                )
-
-                for tii in external_tis:
-                    if not dag_bag:
-                        dag_bag = DBDagBag()
-                    if not isinstance(dag_bag, DBDagBag):  # Compat: This used to take non-db object.
-                        external_dag = dag_bag.get_dag(tii.dag_id, session=session)
-                    else:
-                        external_dag = dag_bag.get_dag_for_run(tii.dag_run, session=session)
-                    if not external_dag:
-                        raise AirflowException(f"Could not find dag {tii.dag_id}")
-                    downstream = external_dag.partial_subset(
-                        task_ids=[tii.task_id],
-                        include_upstream=False,
-                        include_downstream=True,
-                    )
-                    result.update(
-                        downstream._get_task_instances(
-                            task_ids=None,
-                            run_id=tii.run_id,
-                            start_date=None,
-                            end_date=None,
-                            state=state,
-                            include_dependent_dags=include_dependent_dags,
-                            as_pk_tuple=True,
-                            exclude_task_ids=exclude_task_ids,
-                            exclude_run_ids=exclude_run_ids,
-                            dag_bag=dag_bag,
-                            session=session,
-                            recursion_depth=recursion_depth + 1,
-                            max_recursion_depth=max_recursion_depth,
-                            visited_external_tis=visited_external_tis,
-                        )
-                    )
-
-        if result or as_pk_tuple:
-            # Only execute the `ti` query if we have also collected some other results
-            if as_pk_tuple:
-                tis_query = session.execute(tis).all()
-                result.update(TaskInstanceKey(**cols._mapping) for cols in tis_query)
-            else:
-                result.update(ti.key for ti in session.scalars(tis))
-
-            if exclude_task_ids is not None:
-                result = {
-                    task
-                    for task in result
-                    if task.task_id not in exclude_task_ids
-                    and (task.task_id, task.map_index) not in exclude_task_ids
-                }
-
-        if as_pk_tuple:
-            return result
-        if result:
-            # We've been asked for objects, lets combine it all back in to a result set
-            ti_filters = TI.filter_for_tis(result)
-            if ti_filters is not None:
-                tis = select(TI).where(ti_filters)
-        elif exclude_task_ids is None:
-            pass  # Disable filter if not set.
-        elif isinstance(next(iter(exclude_task_ids), None), str):
-            tis = tis.where(TI.task_id.notin_(exclude_task_ids))
-        else:
-            tis = tis.where(tuple_(TI.task_id, TI.map_index).not_in(exclude_task_ids))
-
-        return tis
-
-    @provide_session
-    def set_task_instance_state(
-        self,
-        *,
-        task_id: str,
-        map_indexes: Collection[int] | None = None,
-        run_id: str | None = None,
-        state: TaskInstanceState,
-        upstream: bool = False,
-        downstream: bool = False,
-        future: bool = False,
-        past: bool = False,
-        commit: bool = True,
-        session=NEW_SESSION,
-    ) -> list[TaskInstance]:
-        """
-        Set the state of a TaskInstance and clear downstream tasks in failed or upstream_failed state.
-
-        :param task_id: Task ID of the TaskInstance
-        :param map_indexes: Only set TaskInstance if its map_index matches.
-            If None (default), all mapped TaskInstances of the task are set.
-        :param run_id: The run_id of the TaskInstance
-        :param state: State to set the TaskInstance to
-        :param upstream: Include all upstream tasks of the given task_id
-        :param downstream: Include all downstream tasks of the given task_id
-        :param future: Include all future TaskInstances of the given task_id
-        :param commit: Commit changes
-        :param past: Include all past TaskInstances of the given task_id
-        """
-        from airflow.api.common.mark_tasks import set_state
-
-        # TODO (GH-52141): get_task in scheduler needs to return scheduler types
-        # instead, but currently it inherits SDK's DAG.
-        task = cast("Operator", self.get_task(task_id))
-        task.dag = self
-
-        tasks_to_set_state: list[Operator | tuple[Operator, int]]
-        if map_indexes is None:
-            tasks_to_set_state = [task]
-        else:
-            tasks_to_set_state = [(task, map_index) for map_index in map_indexes]
-
-        altered = set_state(
-            tasks=tasks_to_set_state,
-            run_id=run_id,
-            upstream=upstream,
-            downstream=downstream,
-            future=future,
-            past=past,
-            state=state,
-            commit=commit,
-            session=session,
-        )
-
-        if not commit:
-            return altered
-
-        # Clear downstream tasks that are in failed/upstream_failed state to resume them.
-        # Flush the session so that the tasks marked success are reflected in the db.
-        session.flush()
-        subset = self.partial_subset(
-            task_ids={task_id},
-            include_downstream=True,
-            include_upstream=False,
-        )
-
-        # Raises an error if not found
-        dr_id, logical_date = session.execute(
-            select(DagRun.id, DagRun.logical_date).where(
-                DagRun.run_id == run_id, DagRun.dag_id == self.dag_id
-            )
-        ).one()
-
-        # Now we want to clear downstreams of tasks that had their state set...
-        clear_kwargs = {
-            "only_failed": True,
-            "session": session,
-            # Exclude the task itself from being cleared.
-            "exclude_task_ids": frozenset((task_id,)),
-        }
-        if not future and not past:  # Simple case 1: we're only dealing with exactly one run.
-            clear_kwargs["run_id"] = run_id
-            subset.clear(**clear_kwargs)
-        elif future and past:  # Simple case 2: we're clearing ALL runs.
-            subset.clear(**clear_kwargs)
-        else:  # Complex cases: we may have more than one run, based on a date range.
-            # Make 'future' and 'past' make some sense when multiple runs exist
-            # for the same logical date. We order runs by their id and only
-            # clear runs have larger/smaller ids.
-            exclude_run_id_stmt = select(DagRun.run_id).where(DagRun.logical_date == logical_date)
-            if future:
-                clear_kwargs["start_date"] = logical_date
-                exclude_run_id_stmt = exclude_run_id_stmt.where(DagRun.id > dr_id)
-            else:
-                clear_kwargs["end_date"] = logical_date
-                exclude_run_id_stmt = exclude_run_id_stmt.where(DagRun.id < dr_id)
-            subset.clear(exclude_run_ids=frozenset(session.scalars(exclude_run_id_stmt)), **clear_kwargs)
-        return altered
-
-    @provide_session
-    def set_task_group_state(
-        self,
-        *,
-        group_id: str,
-        run_id: str | None = None,
-        state: TaskInstanceState,
-        upstream: bool = False,
-        downstream: bool = False,
-        future: bool = False,
-        past: bool = False,
-        commit: bool = True,
-        session: Session = NEW_SESSION,
-    ) -> list[TaskInstance]:
-        """
-        Set TaskGroup to the given state and clear downstream tasks in failed or upstream_failed state.
-
-        :param group_id: The group_id of the TaskGroup
-        :param run_id: The run_id of the TaskInstance
-        :param state: State to set the TaskInstance to
-        :param upstream: Include all upstream tasks of the given task_id
-        :param downstream: Include all downstream tasks of the given task_id
-        :param future: Include all future TaskInstances of the given task_id
-        :param commit: Commit changes
-        :param past: Include all past TaskInstances of the given task_id
-        :param session: new session
-        """
-        from airflow.api.common.mark_tasks import set_state
-        from airflow.serialization.serialized_objects import SerializedBaseOperator as BaseOperator
-
-        tasks_to_set_state: list
-        task_ids: list[str]
-
-        task_group_dict = self.task_group.get_task_group_dict()
-        task_group = task_group_dict.get(group_id)
-        if task_group is None:
-            raise ValueError("TaskGroup {group_id} could not be found")
-        tasks_to_set_state = [task for task in task_group.iter_tasks() if isinstance(task, BaseOperator)]
-        task_ids = [task.task_id for task in task_group.iter_tasks()]
-        dag_runs_query = select(DagRun.id).where(DagRun.dag_id == self.dag_id)
-
-        @cache
-        def get_logical_date() -> datetime:
-            stmt = select(DagRun.logical_date).where(DagRun.run_id == run_id, DagRun.dag_id == self.dag_id)
-            return session.scalars(stmt).one()  # Raises an error if not found
-
-        end_date = None if future else get_logical_date()
-        start_date = None if past else get_logical_date()
-
-        if future:
-            dag_runs_query = dag_runs_query.where(DagRun.logical_date <= start_date)
-        if past:
-            dag_runs_query = dag_runs_query.where(DagRun.logical_date >= end_date)
-        if not future and not past:
-            dag_runs_query = dag_runs_query.where(DagRun.run_id == run_id)
-
-        with lock_rows(dag_runs_query, session):
-            altered = set_state(
-                tasks=tasks_to_set_state,
-                run_id=run_id,
-                upstream=upstream,
-                downstream=downstream,
-                future=future,
-                past=past,
-                state=state,
-                commit=commit,
-                session=session,
-            )
-            if not commit:
-                return altered
-
-            # Clear downstream tasks that are in failed/upstream_failed state to resume them.
-            # Flush the session so that the tasks marked success are reflected in the db.
-            session.flush()
-            subset = self.partial_subset(
-                task_ids=task_ids,
-                include_downstream=True,
-                include_upstream=False,
-            )
-
-            subset.clear(
-                start_date=start_date,
-                end_date=end_date,
-                only_failed=True,
-                session=session,
-                # Exclude the task from the current group from being cleared
-                exclude_task_ids=frozenset(task_ids),
-            )
-
-        return altered
-
-    @overload
-    def clear(
-        self,
-        *,
-        dry_run: Literal[True],
-        task_ids: Collection[str | tuple[str, int]] | None = None,
-        run_id: str,
-        only_failed: bool = False,
-        only_running: bool = False,
-        confirm_prompt: bool = False,
-        dag_run_state: DagRunState = DagRunState.QUEUED,
-        session: Session = NEW_SESSION,
-        dag_bag: DBDagBag | None = None,
-        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
-        exclude_run_ids: frozenset[str] | None = frozenset(),
-        run_on_latest_version: bool = False,
-    ) -> list[TaskInstance]: ...  # pragma: no cover
-
-    @overload
-    def clear(
-        self,
-        *,
-        task_ids: Collection[str | tuple[str, int]] | None = None,
-        run_id: str,
-        only_failed: bool = False,
-        only_running: bool = False,
-        confirm_prompt: bool = False,
-        dag_run_state: DagRunState = DagRunState.QUEUED,
-        dry_run: Literal[False] = False,
-        session: Session = NEW_SESSION,
-        dag_bag: DBDagBag | None = None,
-        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
-        exclude_run_ids: frozenset[str] | None = frozenset(),
-        run_on_latest_version: bool = False,
-    ) -> int: ...  # pragma: no cover
-
-    @overload
-    def clear(
-        self,
-        *,
-        dry_run: Literal[True],
-        task_ids: Collection[str | tuple[str, int]] | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        only_failed: bool = False,
-        only_running: bool = False,
-        confirm_prompt: bool = False,
-        dag_run_state: DagRunState = DagRunState.QUEUED,
-        session: Session = NEW_SESSION,
-        dag_bag: DBDagBag | None = None,
-        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
-        exclude_run_ids: frozenset[str] | None = frozenset(),
-        run_on_latest_version: bool = False,
-    ) -> list[TaskInstance]: ...  # pragma: no cover
-
-    @overload
-    def clear(
-        self,
-        *,
-        task_ids: Collection[str | tuple[str, int]] | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        only_failed: bool = False,
-        only_running: bool = False,
-        confirm_prompt: bool = False,
-        dag_run_state: DagRunState = DagRunState.QUEUED,
-        dry_run: Literal[False] = False,
-        session: Session = NEW_SESSION,
-        dag_bag: DBDagBag | None = None,
-        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
-        exclude_run_ids: frozenset[str] | None = frozenset(),
-        run_on_latest_version: bool = False,
-    ) -> int: ...  # pragma: no cover
-
-    @provide_session
-    def clear(
-        self,
-        task_ids: Collection[str | tuple[str, int]] | None = None,
-        *,
-        run_id: str | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        only_failed: bool = False,
-        only_running: bool = False,
-        confirm_prompt: bool = False,
-        dag_run_state: DagRunState = DagRunState.QUEUED,
-        dry_run: bool = False,
-        session: Session = NEW_SESSION,
-        dag_bag: DBDagBag | None = None,
-        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
-        exclude_run_ids: frozenset[str] | None = frozenset(),
-        run_on_latest_version: bool = False,
-    ) -> int | Iterable[TaskInstance]:
-        """
-        Clear a set of task instances associated with the current dag for a specified date range.
-
-        :param task_ids: List of task ids or (``task_id``, ``map_index``) tuples to clear
-        :param run_id: The run_id for which the tasks should be cleared
-        :param start_date: The minimum logical_date to clear
-        :param end_date: The maximum logical_date to clear
-        :param only_failed: Only clear failed tasks
-        :param only_running: Only clear running tasks.
-        :param confirm_prompt: Ask for confirmation
-        :param dag_run_state: state to set DagRun to. If set to False, dagrun state will not
-            be changed.
-        :param dry_run: Find the tasks to clear but don't clear them.
-        :param run_on_latest_version: whether to run on latest serialized DAG and Bundle version
-        :param session: The sqlalchemy session to use
-        :param dag_bag: The DagBag used to find the dags (Optional)
-        :param exclude_task_ids: A set of ``task_id`` or (``task_id``, ``map_index``)
-            tuples that should not be cleared
-        :param exclude_run_ids: A set of ``run_id`` or (``run_id``)
-        """
-        state: list[TaskInstanceState] = []
-        if only_failed:
-            state += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
-        if only_running:
-            # Yes, having `+=` doesn't make sense, but this was the existing behaviour
-            state += [TaskInstanceState.RUNNING]
-
-        tis = self._get_task_instances(
-            task_ids=task_ids,
-            start_date=start_date,
-            end_date=end_date,
-            run_id=run_id,
-            state=state,
-            include_dependent_dags=True,
-            session=session,
-            dag_bag=dag_bag,
-            exclude_task_ids=exclude_task_ids,
-            exclude_run_ids=exclude_run_ids,
-        )
-
-        if dry_run:
-            return session.scalars(tis).all()
-
-        tis = session.scalars(tis).all()
-
-        count = len(list(tis))
-        do_it = True
-        if count == 0:
-            return 0
-        if confirm_prompt:
-            ti_list = "\n".join(str(t) for t in tis)
-            question = f"You are about to delete these {count} tasks:\n{ti_list}\n\nAre you sure? [y/n]"
-            do_it = utils.helpers.ask_yesno(question)
-
-        if do_it:
-            clear_task_instances(
-                list(tis),
-                session,
-                dag_run_state=dag_run_state,
-                run_on_latest_version=run_on_latest_version,
-            )
-        else:
-            count = 0
-            print("Cancelled, nothing was cleared.")
-
-        session.flush()
-        return count
-
-    @classmethod
-    def clear_dags(
-        cls,
-        dags,
-        start_date=None,
-        end_date=None,
-        only_failed=False,
-        only_running=False,
-        confirm_prompt=False,
-        dag_run_state=DagRunState.QUEUED,
-        dry_run=False,
-    ):
-        all_tis = []
-        for dag in dags:
-            if not isinstance(dag, DAG):
-                dag = DAG.from_sdk_dag(dag)
-            tis = dag.clear(
-                start_date=start_date,
-                end_date=end_date,
-                only_failed=only_failed,
-                only_running=only_running,
-                confirm_prompt=False,
-                dag_run_state=dag_run_state,
-                dry_run=True,
-            )
-            all_tis.extend(tis)
-
-        if dry_run:
-            return all_tis
-
-        count = len(all_tis)
-        do_it = True
-        if count == 0:
-            print("Nothing to clear.")
-            return 0
-        if confirm_prompt:
-            ti_list = "\n".join(str(t) for t in all_tis)
-            question = f"You are about to delete these {count} tasks:\n{ti_list}\n\nAre you sure? [y/n]"
-            do_it = utils.helpers.ask_yesno(question)
-
-        if do_it:
-            for dag in dags:
-                if not isinstance(dag, DAG):
-                    dag = DAG.from_sdk_dag(dag)
-                dag.clear(
-                    start_date=start_date,
-                    end_date=end_date,
-                    only_failed=only_failed,
-                    only_running=only_running,
-                    confirm_prompt=False,
-                    dag_run_state=dag_run_state,
-                    dry_run=False,
-                )
-        else:
-            count = 0
-            print("Cancelled, nothing was cleared.")
-        return count
-
-    @provide_session
-    def create_dagrun(
-        self,
-        *,
-        run_id: str,
-        logical_date: datetime | None = None,
-        data_interval: tuple[datetime, datetime] | None = None,
-        run_after: datetime,
-        conf: dict | None = None,
-        run_type: DagRunType,
-        triggered_by: DagRunTriggeredByType,
-        triggering_user_name: str | None = None,
-        state: DagRunState,
-        start_date: datetime | None = None,
-        creating_job_id: int | None = None,
-        backfill_id: NonNegativeInt | None = None,
-        session: Session = NEW_SESSION,
-    ) -> DagRun:
-        """
-        Create a run for this DAG to run its tasks.
-
-        :param run_id: ID of the dag_run
-        :param logical_date: date of execution
-        :param run_after: the datetime before which dag won't run
-        :param conf: Dict containing configuration/parameters to pass to the DAG
-        :param triggered_by: the entity which triggers the dag_run
-        :param triggering_user_name: the user name who triggers the dag_run
-        :param start_date: the date this dag run should be evaluated
-        :param creating_job_id: ID of the job creating this DagRun
-        :param backfill_id: ID of the backfill run if one exists
-        :param session: Unused. Only added in compatibility with database isolation mode
-        :return: The created DAG run.
-
-        :meta private:
-        """
-        logical_date = timezone.coerce_datetime(logical_date)
-        # For manual runs where logical_date is None, ensure no data_interval is set.
-        if logical_date is None and data_interval is not None:
-            raise ValueError("data_interval must be None when logical_date is None")
-
-        if data_interval and not isinstance(data_interval, DataInterval):
-            data_interval = DataInterval(*map(timezone.coerce_datetime, data_interval))
-
-        if isinstance(run_type, DagRunType):
-            pass
-        elif isinstance(run_type, str):  # Ensure the input value is valid.
-            run_type = DagRunType(run_type)
-        else:
-            raise ValueError(f"run_type should be a DagRunType, not {type(run_type)}")
-
-        if not isinstance(run_id, str):
-            raise ValueError(f"`run_id` should be a str, not {type(run_id)}")
-
-        # This is also done on the DagRun model class, but SQLAlchemy column
-        # validator does not work well for some reason.
-        if not re.match(RUN_ID_REGEX, run_id):
-            regex = airflow_conf.get("scheduler", "allowed_run_id_pattern").strip()
-            if not regex or not re.match(regex, run_id):
-                raise ValueError(
-                    f"The run_id provided '{run_id}' does not match regex pattern "
-                    f"'{regex}' or '{RUN_ID_REGEX}'"
-                )
-
-        # Prevent a manual run from using an ID that looks like a scheduled run.
-        if run_type == DagRunType.MANUAL:
-            if (inferred_run_type := DagRunType.from_run_id(run_id)) != DagRunType.MANUAL:
-                raise ValueError(
-                    f"A {run_type.value} DAG run cannot use ID {run_id!r} since it "
-                    f"is reserved for {inferred_run_type.value} runs"
-                )
-
-        # todo: AIP-78 add verification that if run type is backfill then we have a backfill id
-
-        # create a copy of params before validating
-        copied_params = copy.deepcopy(self.params)
-        if conf:
-            copied_params.update(conf)
-        copied_params.validate()
-        orm_dagrun = _create_orm_dagrun(
-            dag=self,
-            run_id=run_id,
-            logical_date=logical_date,
-            data_interval=data_interval,
-            run_after=timezone.coerce_datetime(run_after),
-            start_date=timezone.coerce_datetime(start_date),
-            conf=conf,
-            state=state,
-            run_type=run_type,
-            creating_job_id=creating_job_id,
-            backfill_id=backfill_id,
-            triggered_by=triggered_by,
-            triggering_user_name=triggering_user_name,
-            session=session,
-        )
-
-        if self.deadline and isinstance(self.deadline.reference, DeadlineReference.TYPES.DAGRUN):
-            session.add(
-                Deadline(
-                    deadline_time=self.deadline.reference.evaluate_with(
-                        session=session,
-                        interval=self.deadline.interval,
-                        dag_id=self.dag_id,
-                        run_id=run_id,
-                    ),
-                    callback=self.deadline.callback,
-                    dagrun_id=orm_dagrun.id,
-                )
-            )
-
-        return orm_dagrun
-
-    @classmethod
-    @provide_session
-    def bulk_write_to_db(
-        cls,
-        bundle_name: str,
-        bundle_version: str | None,
-        dags: Collection[MaybeSerializedDAG],
-        session: Session = NEW_SESSION,
-    ):
-        """
-        Ensure the DagModel rows for the given dags are up-to-date in the dag table in the DB.
-
-        :param dags: the DAG objects to save to the DB
-        :return: None
-        """
-        if not dags:
-            return
-
-        from airflow.dag_processing.collection import AssetModelOperation, DagModelOperation
-
-        log.info("Sync %s DAGs", len(dags))
-        dag_op = DagModelOperation(
-            bundle_name=bundle_name, bundle_version=bundle_version, dags={d.dag_id: d for d in dags}
-        )
-
-        orm_dags = dag_op.add_dags(session=session)
-        dag_op.update_dags(orm_dags, session=session)
-
-        asset_op = AssetModelOperation.collect(dag_op.dags)
-
-        orm_assets = asset_op.sync_assets(session=session)
-        orm_asset_aliases = asset_op.sync_asset_aliases(session=session)
-        session.flush()  # This populates id so we can create fks in later calls.
-
-        orm_dags = dag_op.find_orm_dags(session=session)  # Refetch so relationship is up to date.
-        asset_op.add_dag_asset_references(orm_dags, orm_assets, session=session)
-        asset_op.add_dag_asset_alias_references(orm_dags, orm_asset_aliases, session=session)
-        asset_op.add_dag_asset_name_uri_references(session=session)
-        asset_op.add_task_asset_references(orm_dags, orm_assets, session=session)
-        asset_op.activate_assets_if_possible(orm_assets.values(), session=session)
-        session.flush()  # Activation is needed when we add trigger references.
-
-        asset_op.add_asset_trigger_references(orm_assets, session=session)
-        dag_op.update_dag_asset_expression(orm_dags=orm_dags, orm_assets=orm_assets)
-        session.flush()
-
-    @provide_session
-    def sync_to_db(self, session=NEW_SESSION):
-        """
-        Save attributes about this DAG to the DB.
-
-        :return: None
-        """
-        # TODO: AIP-66 should this be in the model?
-        bundle_name = self.get_bundle_name(session=session)
-        bundle_version = self.get_bundle_version(session=session)
-        self.bulk_write_to_db(bundle_name, bundle_version, [self], session=session)
-
-    @staticmethod
-    @provide_session
-    def deactivate_unknown_dags(active_dag_ids, session=NEW_SESSION):
-        """
-        Given a list of known DAGs, deactivate any other DAGs that are marked as active in the ORM.
-
-        :param active_dag_ids: list of DAG IDs that are active
-        :return: None
-        """
-        if not active_dag_ids:
-            return
-        for dag in session.scalars(select(DagModel).where(~DagModel.dag_id.in_(active_dag_ids))).all():
-            dag.is_stale = True
-            session.merge(dag)
-        session.commit()
-
-    @staticmethod
-    @provide_session
-    def deactivate_stale_dags(expiration_date, session=NEW_SESSION):
-        """
-        Deactivate any DAGs that were last touched by the scheduler before the expiration date.
-
-        These DAGs were likely deleted.
-
-        :param expiration_date: set inactive DAGs that were touched before this time
-        :return: None
-        """
-        for dag in session.scalars(
-            select(DagModel).where(DagModel.last_parsed_time < expiration_date, ~DagModel.is_stale)
-        ):
-            log.info(
-                "Deactivating DAG ID %s since it was last touched by the scheduler at %s",
-                dag.dag_id,
-                dag.last_parsed_time.isoformat(),
-            )
-            dag.is_stale = True
-            session.merge(dag)
-            session.commit()
-
-    @staticmethod
-    @provide_session
-    def get_num_task_instances(dag_id, run_id=None, task_ids=None, states=None, session=NEW_SESSION) -> int:
-        """
-        Return the number of task instances in the given DAG.
-
-        :param session: ORM session
-        :param dag_id: ID of the DAG to get the task concurrency of
-        :param run_id: ID of the DAG run to get the task concurrency of
-        :param task_ids: A list of valid task IDs for the given DAG
-        :param states: A list of states to filter by if supplied
-        :return: The number of running tasks
-        """
-        qry = select(func.count(TaskInstance.task_id)).where(
-            TaskInstance.dag_id == dag_id,
-        )
-        if run_id:
-            qry = qry.where(
-                TaskInstance.run_id == run_id,
-            )
-        if task_ids:
-            qry = qry.where(
-                TaskInstance.task_id.in_(task_ids),
-            )
-
-        if states:
-            if None in states:
-                if all(x is None for x in states):
-                    qry = qry.where(TaskInstance.state.is_(None))
-                else:
-                    not_none_states = [state for state in states if state]
-                    qry = qry.where(
-                        or_(TaskInstance.state.in_(not_none_states), TaskInstance.state.is_(None))
-                    )
-            else:
-                qry = qry.where(TaskInstance.state.in_(states))
-        return session.scalar(qry)
-
-    # "default has type "type[Asset]", argument has type "type[AssetT]")  [assignment]" :shrug:
-    def get_task_assets(
-        self,
-        inlets: bool = True,
-        outlets: bool = True,
-        of_type: type[AssetT] = Asset,  # type: ignore[assignment]
-    ) -> Generator[tuple[str, AssetT], None, None]:
-        for task in self.task_dict.values():
-            directions: tuple[str, ...] = ("inlets",) if inlets else ()
-            if outlets:
-                directions += ("outlets",)
-            for direction in directions:
-                if not (ports := getattr(task, direction, None)):
-                    continue
-
-                for port in ports:
-                    if isinstance(port, of_type):
-                        yield task.task_id, port
-
-    @classmethod
-    def from_sdk_dag(cls, dag: TaskSDKDag) -> DAG:
-        """Create a new (Scheduler) DAG object from a TaskSDKDag."""
-        if not isinstance(dag, TaskSDKDag):
-            return dag
-
-        fields = attrs.fields(dag.__class__)
-
-        kwargs = {}
-        for field in fields:
-            # Skip fields that are:
-            # 1. Initialized after creation (init=False)
-            # 2. Internal state fields that shouldn't be copied
-            if not field.init or field.name in ["edge_info"]:
-                continue
-
-            kwargs[field.name] = getattr(dag, field.name)
-
-        new_dag = cls(**kwargs)
-
-        task_group_map = {}
-
-        def create_task_groups(task_group, parent_group=None):
-            new_task_group = copy.deepcopy(task_group)
-
-            new_task_group.dag = new_dag
-            new_task_group.parent_group = parent_group
-            new_task_group.children = {}
-
-            task_group_map[task_group.group_id] = new_task_group
-
-            for child in task_group.children.values():
-                if isinstance(child, TaskGroup):
-                    create_task_groups(child, new_task_group)
-
-        create_task_groups(dag.task_group)
-
-        def create_tasks(task):
-            if isinstance(task, TaskGroup):
-                return task_group_map[task.group_id]
-
-            new_task = copy.copy(task)
-
-            # Only overwrite the specific attributes we want to change
-            new_task.task_id = task.task_id
-            new_task.dag = None  # Don't set dag yet
-            new_task.task_group = task_group_map.get(task.task_group.group_id) if task.task_group else None
-
-            return new_task
-
-        # Process all tasks in the original DAG
-        for task in dag.tasks:
-            new_task = create_tasks(task)
-            if not isinstance(new_task, TaskGroup):
-                # Add the task to the DAG
-                new_dag.task_dict[new_task.task_id] = new_task
-                if new_task.task_group:
-                    new_task.task_group.children[new_task.task_id] = new_task
-                new_task.dag = new_dag
-
-        new_dag.edge_info = dag.edge_info.copy()
-
-        return new_dag
 
 
 class DagTag(Base):
@@ -2041,10 +479,6 @@ class DagModel(Base):
             self.dag_id, session=session, include_manually_triggered=include_manually_triggered
         )
 
-    def get_is_paused(self, *, session: Session | None = None) -> bool:
-        """Provide interface compatibility to 'DAG'."""
-        return self.is_paused
-
     def get_is_active(self, *, session: Session | None = None) -> bool:
         """Provide interface compatibility to 'DAG'."""
         return not self.is_stale
@@ -2071,26 +505,6 @@ class DagModel(Base):
     @property
     def safe_dag_id(self):
         return self.dag_id.replace(".", "__dot__")
-
-    @provide_session
-    def set_is_paused(self, is_paused: bool, session=NEW_SESSION) -> None:
-        """
-        Pause/Un-pause a DAG.
-
-        :param is_paused: Is the DAG paused
-        :param session: session
-        """
-        filter_query = [
-            DagModel.dag_id == self.dag_id,
-        ]
-
-        session.execute(
-            update(DagModel)
-            .where(or_(*filter_query))
-            .values(is_paused=is_paused)
-            .execution_options(synchronize_session="fetch")
-        )
-        session.commit()
 
     @hybrid_property
     def dag_display_name(self) -> str:
@@ -2230,7 +644,7 @@ class DagModel(Base):
 
     def calculate_dagrun_date_fields(
         self,
-        dag: DAG,
+        dag: SerializedDAG,
         last_automated_dag_run: None | DataInterval,
     ) -> None:
         """
@@ -2293,52 +707,21 @@ if STATICA_HACK:  # pragma: no cover
     """:sphinx-autoapi-skip:"""
 
 
-def _get_or_create_dagrun(
-    *,
-    dag: DAG,
-    run_id: str,
-    logical_date: datetime | None,
-    data_interval: tuple[datetime, datetime] | None,
-    run_after: datetime,
-    conf: dict | None,
-    triggered_by: DagRunTriggeredByType,
-    triggering_user_name: str | None,
-    start_date: datetime,
-    session: Session,
-) -> DagRun:
-    """
-    Create a DAG run, replacing an existing instance if needed to prevent collisions.
+def __getattr__(name: str):
+    # Add DAG and dag for compatibility. We can't do this in
+    # airflow/models/__init__.py since this module contains other things.
+    if name not in ("DAG", "dag"):
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    This function is only meant to be used by :meth:`DAG.test` as a helper function.
+    import warnings
 
-    :param dag: DAG to be used to find run.
-    :param conf: Configuration to pass to newly created run.
-    :param start_date: Start date of new run.
-    :param logical_date: Logical date for finding an existing run.
-    :param run_id: Run ID for the new DAG run.
-    :param triggered_by: the entity which triggers the dag_run
-    :param triggering_user_name: the user name who triggers the dag_run
-
-    :return: The newly created DAG run.
-    """
-    dr: DagRun = session.scalar(
-        select(DagRun).where(DagRun.dag_id == dag.dag_id, DagRun.logical_date == logical_date)
+    warnings.warn(
+        f"Import {name!r} directly from the airflow module is deprecated and "
+        f"will be removed in the future. Please import it from 'airflow.sdk'.",
+        DeprecationWarning,
+        stacklevel=2,
     )
-    if dr:
-        session.delete(dr)
-        session.commit()
-    dr = dag.create_dagrun(
-        run_id=run_id,
-        logical_date=logical_date,
-        data_interval=data_interval,
-        run_after=run_after,
-        conf=conf,
-        run_type=DagRunType.MANUAL,
-        state=DagRunState.RUNNING,
-        triggered_by=triggered_by,
-        triggering_user_name=triggering_user_name,
-        start_date=start_date or logical_date,
-        session=session,
-    )
-    log.info("created dagrun %s", dr)
-    return dr
+
+    import airflow.sdk
+
+    return getattr(airflow.sdk, name)

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast, overload
 
+import structlog
 from natsort import natsorted
 from sqlalchemy import (
     JSON,
@@ -94,12 +95,11 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql.elements import Case
 
-    from airflow.models.dag import DAG
     from airflow.models.dag_version import DagVersion
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.sdk import DAG as SDKDAG
-    from airflow.serialization.serialized_objects import SerializedBaseOperator
+    from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
     from airflow.utils.types import ArgNotSet
 
     CreatedTasks = TypeVar("CreatedTasks", Iterator["dict[str, Any]"], Iterator[TI])
@@ -109,6 +109,8 @@ if TYPE_CHECKING:
     Operator: TypeAlias = MappedOperator | SerializedBaseOperator
 
 RUN_ID_REGEX = r"^(?:manual|scheduled|asset_triggered)__(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00)$"
+
+log = structlog.get_logger(__name__)
 
 
 class TISchedulingDecision(NamedTuple):
@@ -209,9 +211,9 @@ class DagRun(Base, LoggingMixin):
 
     # Remove this `if` after upgrading Sphinx-AutoAPI
     if not TYPE_CHECKING and "BUILDING_AIRFLOW_DOCS" in os.environ:
-        dag: DAG | None
+        dag: SerializedDAG | None
     else:
-        dag: DAG | None = None
+        dag: SerializedDAG | None = None
 
     __table_args__ = (
         Index("dag_id_state", dag_id, _state),
@@ -893,7 +895,7 @@ class DagRun(Base, LoggingMixin):
             select(TI).filter_by(dag_id=dag_id, run_id=dag_run_id, task_id=task_id, map_index=map_index)
         ).one_or_none()
 
-    def get_dag(self) -> DAG:
+    def get_dag(self) -> SerializedDAG:
         """
         Return the Dag associated with this DagRun.
 
@@ -1298,7 +1300,7 @@ class DagRun(Base, LoggingMixin):
         tis = self.get_task_instances(session=session, state=State.task_states)
         self.log.debug("number of tis tasks for %s: %s task(s)", self, len(tis))
 
-        def _filter_tis_and_exclude_removed(dag: DAG, tis: list[TI]) -> Iterable[TI]:
+        def _filter_tis_and_exclude_removed(dag: SerializedDAG, tis: list[TI]) -> Iterable[TI]:
             """Populate ``ti.task`` while excluding those missing one, marking them as REMOVED."""
             for ti in tis:
                 try:
@@ -1360,7 +1362,7 @@ class DagRun(Base, LoggingMixin):
         # or LocalTaskJob, so we don't want to "falsely advertise" we notify about that
 
     @provide_session
-    def get_last_ti(self, dag: DAG, session: Session = NEW_SESSION) -> TI | None:
+    def get_last_ti(self, dag: SerializedDAG, session: Session = NEW_SESSION) -> TI | None:
         """Get Last TI from the dagrun to build and pass Execution context object from server to then run callbacks."""
         tis = self.get_task_instances(session=session)
         # tis from a dagrun may not be a part of dag.partial_subset,
@@ -1584,6 +1586,8 @@ class DagRun(Base, LoggingMixin):
         Note that the stat will only be emitted for scheduler-triggered DAG runs
         (i.e. when ``run_type`` is *SCHEDULED* and ``clear_number`` is equal to 0).
         """
+        from airflow.models.dag import get_run_data_interval
+
         if self.state == TaskInstanceState.RUNNING:
             return
         if self.run_type != DagRunType.SCHEDULED:
@@ -1610,7 +1614,7 @@ class DagRun(Base, LoggingMixin):
                 # execution on DagModel.next_dagrun_create_after. We should add
                 # a field on DagRun for this instead of relying on the run
                 # always happening immediately after the data interval.
-                data_interval_end = dag.get_run_data_interval(self).end
+                data_interval_end = get_run_data_interval(dag.timetable, self).end
                 true_delay = first_start_date - data_interval_end
                 if true_delay.total_seconds() > 0:
                     Stats.timing(
@@ -1683,7 +1687,7 @@ class DagRun(Base, LoggingMixin):
         self._create_task_instances(self.dag_id, tis_to_create, created_counts, hook_is_noop, session=session)
 
     def _check_for_removed_or_restored_tasks(
-        self, dag: DAG, ti_mutation_hook, *, session: Session
+        self, dag: SerializedDAG, ti_mutation_hook, *, session: Session
     ) -> set[str]:
         """
         Check for removed tasks/restored/missing tasks.
@@ -2089,7 +2093,7 @@ class DagRun(Base, LoggingMixin):
         return template
 
     @staticmethod
-    def _get_partial_task_ids(dag: DAG | None) -> list[str] | None:
+    def _get_partial_task_ids(dag: SerializedDAG | None) -> list[str] | None:
         return dag.task_ids if dag and dag.partial else None
 
 
@@ -2125,3 +2129,54 @@ class DagRunNote(Base):
         if self.map_index != -1:
             prefix += f" map_index={self.map_index}"
         return prefix + ">"
+
+
+def get_or_create_dagrun(
+    *,
+    dag: SerializedDAG,
+    run_id: str,
+    logical_date: datetime | None,
+    data_interval: tuple[datetime, datetime] | None,
+    run_after: datetime,
+    conf: dict | None,
+    triggered_by: DagRunTriggeredByType,
+    triggering_user_name: str | None,
+    start_date: datetime,
+    session: Session,
+) -> DagRun:
+    """
+    Create a DAG run, replacing an existing instance if needed to prevent collisions.
+
+    This function is only meant to be used by :meth:`DAG.test` as a helper function.
+
+    :param dag: DAG to be used to find run.
+    :param conf: Configuration to pass to newly created run.
+    :param start_date: Start date of new run.
+    :param logical_date: Logical date for finding an existing run.
+    :param run_id: Run ID for the new DAG run.
+    :param triggered_by: the entity which triggers the dag_run
+    :param triggering_user_name: the user name who triggers the dag_run
+
+    :return: The newly created DAG run.
+    """
+    dr: DagRun = session.scalar(
+        select(DagRun).where(DagRun.dag_id == dag.dag_id, DagRun.logical_date == logical_date)
+    )
+    if dr:
+        session.delete(dr)
+        session.commit()
+    dr = dag.create_dagrun(
+        run_id=run_id,
+        logical_date=logical_date,
+        data_interval=data_interval,
+        run_after=run_after,
+        conf=conf,
+        run_type=DagRunType.MANUAL,
+        state=DagRunState.RUNNING,
+        triggered_by=triggered_by,
+        triggering_user_name=triggering_user_name,
+        start_date=start_date or logical_date,
+        session=session,
+    )
+    log.info("Created dag run.", dagrun=dr)
+    return dr

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -35,6 +35,7 @@ from airflow.sdk.definitions._internal.abstractoperator import (
 from airflow.sdk.definitions._internal.node import DAGNode
 from airflow.sdk.definitions.mappedoperator import MappedOperator as TaskSDKMappedOperator
 from airflow.sdk.definitions.taskgroup import MappedTaskGroup, TaskGroup
+from airflow.serialization.enums import DagAttributeTypes
 from airflow.serialization.serialized_objects import DEFAULT_OPERATOR_DEPS, SerializedBaseOperator
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
 
@@ -45,11 +46,11 @@ if TYPE_CHECKING:
     import pendulum
 
     from airflow.models import TaskInstance
-    from airflow.models.dag import DAG as SchedulerDAG
     from airflow.models.expandinput import SchedulerExpandInput
     from airflow.sdk import BaseOperatorLink, Context
     from airflow.sdk.definitions.operator_resources import Resources
     from airflow.sdk.definitions.param import ParamsDict
+    from airflow.serialization.serialized_objects import SerializedDAG
     from airflow.task.trigger_rule import TriggerRule
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
     from airflow.triggers.base import StartTriggerArgs
@@ -102,7 +103,7 @@ class MappedOperator(DAGNode):
     start_from_trigger: bool = False
     _needs_expansion: bool = True
 
-    dag: SchedulerDAG = attrs.field(init=False)
+    dag: SerializedDAG = attrs.field(init=False)
     task_group: TaskGroup = attrs.field(init=False)
     start_date: pendulum.DateTime | None = attrs.field(init=False, default=None)
     end_date: pendulum.DateTime | None = attrs.field(init=False, default=None)
@@ -380,6 +381,10 @@ class MappedOperator(DAGNode):
             return None
         return link.get_link(self, ti_key=ti.key)  # type: ignore[arg-type] # TODO: GH-52141 - BaseOperatorLink.get_link expects BaseOperator but receives MappedOperator
 
+    def serialize_for_task_group(self) -> tuple[DagAttributeTypes, Any]:
+        """Implement DAGNode."""
+        return DagAttributeTypes.OP, self.task_id
+
     # TODO (GH-52141): Copied from sdk. Find a better place for this to live in.
     def _get_specified_expand_input(self) -> SchedulerExpandInput:
         """Input received from the expand call on the operator."""
@@ -482,7 +487,7 @@ def _(task: MappedOperator | TaskSDKMappedOperator, run_id: str, *, session: Ses
     # TODO (GH-52141): 'task' here should be scheduler-bound and returns scheduler expand input.
     if not hasattr(exp_input, "get_total_map_length"):
         if TYPE_CHECKING:
-            assert isinstance(task.dag, SchedulerDAG)
+            assert isinstance(task.dag, SerializedDAG)
         current_count = (
             _ExpandInputRef(
                 exp_input.EXPAND_INPUT_TYPE,
@@ -526,7 +531,7 @@ def _(group: TaskGroup, run_id: str, *, session: Session) -> int:
                 # TODO (GH-52141): 'group' here should be scheduler-bound and returns scheduler expand input.
                 if not hasattr(exp_input, "get_total_map_length"):
                     if TYPE_CHECKING:
-                        assert isinstance(group.dag, SchedulerDAG)
+                        assert isinstance(group.dag, SerializedDAG)
                     exp_input = _ExpandInputRef(
                         exp_input.EXPAND_INPUT_TYPE,
                         BaseSerialization.deserialize(BaseSerialization.serialize(exp_input.value)),

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -118,7 +118,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.elements import BooleanClauseList
     from sqlalchemy.sql.expression import ColumnOperators
 
-    from airflow.models.dag import DAG as SchedulerDAG, DagModel
+    from airflow.models.dag import DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.mappedoperator import MappedOperator
     from airflow.sdk import DAG
@@ -852,8 +852,6 @@ class TaskInstance(Base, LoggingMixin):
         if dag is None:
             return None
 
-        if TYPE_CHECKING:
-            assert isinstance(dag, SchedulerDAG)
         dr = self.get_dagrun(session=session)
         dr.dag = dag
 
@@ -1030,7 +1028,6 @@ class TaskInstance(Base, LoggingMixin):
         if getattr(self, "task", None) is not None:
             if TYPE_CHECKING:
                 assert self.task
-                assert isinstance(self.task.dag, SchedulerDAG)
             dr.dag = self.task.dag
         # Record it in the instance for next time. This means that `self.logical_date` will work correctly
         set_committed_value(self, "dag_run", dr)

--- a/airflow-core/src/airflow/models/taskmap.py
+++ b/airflow-core/src/airflow/models/taskmap.py
@@ -35,7 +35,6 @@ from airflow.utils.state import State, TaskInstanceState
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.models.dag import DAG as SchedulerDAG
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
     from airflow.serialization.serialized_objects import SerializedBaseOperator
@@ -176,7 +175,7 @@ class TaskMap(TaskInstanceDependencies):
 
         if unmapped_ti:
             if TYPE_CHECKING:
-                assert task.dag is None or isinstance(task.dag, SchedulerDAG)
+                assert task.dag is None
 
             # The unmapped task instance still exists and is unfinished, i.e. we
             # haven't tried to run it before.

--- a/airflow-core/src/airflow/policies.py
+++ b/airflow-core/src/airflow/policies.py
@@ -27,13 +27,11 @@ hookimpl = pluggy.HookimplMarker("airflow.policy")
 __all__: list[str] = ["hookimpl"]
 
 if TYPE_CHECKING:
-    from airflow.models.dag import DAG
     from airflow.models.taskinstance import TaskInstance
-    from airflow.serialization.serialized_objects import SerializedBaseOperator as BaseOperator
 
 
 @local_settings_hookspec
-def task_policy(task: BaseOperator) -> None:
+def task_policy(task) -> None:
     """
     Allow altering tasks after they are loaded in the DagBag.
 
@@ -51,7 +49,7 @@ def task_policy(task: BaseOperator) -> None:
 
 
 @local_settings_hookspec
-def dag_policy(dag: DAG) -> None:
+def dag_policy(dag) -> None:
     """
     Allow altering DAGs after they are loaded in the DagBag.
 

--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -23,7 +23,6 @@ from alembic import command
 from sqlalchemy import inspect
 
 from airflow import settings
-from airflow.api_fastapi.app import create_auth_manager
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -145,6 +144,8 @@ class RunDBManager(LoggingMixin):
     """
 
     def __init__(self):
+        from airflow.api_fastapi.app import create_auth_manager
+
         super().__init__()
         self._managers: list[BaseDBManager] = []
         managers_config = conf.get("database", "external_db_managers", fallback=None)

--- a/airflow-core/src/airflow/utils/dot_renderer.py
+++ b/airflow-core/src/airflow/utils/dot_renderer.py
@@ -24,7 +24,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
-from airflow.sdk import BaseOperator
+from airflow.sdk import DAG, BaseOperator
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.taskgroup import TaskGroup
 from airflow.serialization.serialized_objects import SerializedBaseOperator
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     import graphviz
 
     from airflow.models import TaskInstance
-    from airflow.models.dag import DAG
     from airflow.models.taskmixin import DependencyMixin
     from airflow.serialization.dag_dependency import DagDependency
 else:

--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -24,6 +24,7 @@ import subprocess
 import time
 
 import pytest
+from sqlalchemy import select
 
 from airflow._shared.timezones import timezone
 from airflow.dag_processing.bundles.manager import DagBundlesManager
@@ -32,6 +33,7 @@ from airflow.executors.executor_utils import ExecutorName
 from airflow.models import DAG, DagBag, DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils.session import create_session
 from airflow.utils.span_status import SpanStatus
 from airflow.utils.state import State
@@ -45,7 +47,7 @@ from tests_common.test_utils.otel_utils import (
     extract_spans_from_output,
     get_parent_child_dict,
 )
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 log = logging.getLogger("integration.otel.test_otel")
 
@@ -646,7 +648,7 @@ class TestOtelIntegration:
         cls.dags = cls.serialize_and_get_dags()
 
     @classmethod
-    def serialize_and_get_dags(cls) -> dict[str, DAG]:
+    def serialize_and_get_dags(cls) -> dict[str, SerializedDAG]:
         log.info("Serializing Dags from directory %s", cls.dag_folder)
         # Load DAGs from the dag directory.
         dag_bag = DagBag(dag_folder=cls.dag_folder, include_examples=False)
@@ -654,14 +656,11 @@ class TestOtelIntegration:
         dag_ids = dag_bag.dag_ids
         assert len(dag_ids) == 3
 
-        dag_dict: dict[str, DAG] = {}
+        dag_dict: dict[str, SerializedDAG] = {}
         with create_session() as session:
             for dag_id in dag_ids:
                 dag = dag_bag.get_dag(dag_id)
-                dag_dict[dag_id] = dag
-
                 assert dag is not None, f"DAG with ID {dag_id} not found."
-
                 # Sync the DAG to the database.
                 if AIRFLOW_V_3_0_PLUS:
                     from airflow.models.dagbundle import DagBundleModel
@@ -669,13 +668,22 @@ class TestOtelIntegration:
                     if session.query(DagBundleModel).filter(DagBundleModel.name == "testing").count() == 0:
                         session.add(DagBundleModel(name="testing"))
                         session.commit()
-                    dag.bulk_write_to_db(
+                    SerializedDAG.bulk_write_to_db(
                         bundle_name="testing", bundle_version=None, dags=[dag], session=session
                     )
+                    dag_dict[dag_id] = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
                 else:
                     dag.sync_to_db(session=session)
+                    dag_dict[dag_id] = dag
                 # Manually serialize the dag and write it to the db to avoid a db error.
-                SerializedDagModel.write_dag(dag, bundle_name="testing", session=session)
+                if AIRFLOW_V_3_1_PLUS:
+                    from airflow.serialization.serialized_objects import LazyDeserializedDAG
+
+                    SerializedDagModel.write_dag(
+                        LazyDeserializedDAG.from_dag(dag), bundle_name="testing", session=session
+                    )
+                else:
+                    SerializedDagModel.write_dag(dag, bundle_name="testing", session=session)
 
             session.commit()
 
@@ -744,13 +752,12 @@ class TestOtelIntegration:
             time.sleep(10)
 
             with create_session() as session:
-                tis: list[TaskInstance] = dag.get_task_instances(session=session)
-
-            for ti in tis:
-                # Skip the span_status check.
-                check_ti_state_and_span_status(
-                    task_id=ti.task_id, run_id=run_id, state=State.SUCCESS, span_status=None
-                )
+                task_ids = session.scalars(select(TaskInstance.task_id).where(TaskInstance.dag_id == dag_id))
+                for task_id in task_ids:
+                    # Skip the span_status check.
+                    check_ti_state_and_span_status(
+                        task_id=task_id, run_id=run_id, state=State.SUCCESS, span_status=None
+                    )
 
             print_ti_output_for_dag_run(dag_id=dag_id, run_id=run_id)
         finally:
@@ -818,12 +825,10 @@ class TestOtelIntegration:
             time.sleep(10)
 
             with create_session() as session:
-                tis: list[TaskInstance] = dag.get_task_instances(session=session)
-
-            for ti in tis:
-                check_ti_state_and_span_status(
-                    task_id=ti.task_id, run_id=run_id, state=State.SUCCESS, span_status=SpanStatus.ENDED
-                )
+                for ti in session.scalars(select(TaskInstance).where(TaskInstance.dag_id == dag.dag_id)):
+                    check_ti_state_and_span_status(
+                        task_id=ti.task_id, run_id=run_id, state=State.SUCCESS, span_status=SpanStatus.ENDED
+                    )
 
             print_ti_output_for_dag_run(dag_id=dag_id, run_id=run_id)
         finally:

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -28,14 +28,15 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
+    from airflow.serialization.serialized_objects import SerializedDAG
 
     from tests_common.pytest_plugin import DagMaker
 
-pytestmark = pytest.mark.db_test
+pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 
 
-def test_set_dag_run_state_to_failed(dag_maker: DagMaker):
-    with dag_maker("TEST_DAG_1"):
+def test_set_dag_run_state_to_failed(dag_maker: DagMaker[SerializedDAG]):
+    with dag_maker("TEST_DAG_1") as dag:
         with EmptyOperator(task_id="teardown").as_teardown():
             EmptyOperator(task_id="running")
             EmptyOperator(task_id="pending")
@@ -44,10 +45,9 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker):
         if ti.task_id == "running":
             ti.set_state(TaskInstanceState.RUNNING)
     dag_maker.session.flush()
-    assert dr.dag
 
     updated_tis: list[TaskInstance] = set_dag_run_state_to_failed(
-        dag=dr.dag, run_id=dr.run_id, commit=True, session=dag_maker.session
+        dag=dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
     assert len(updated_tis) == 2
     task_dict = {ti.task_id: ti for ti in updated_tis}
@@ -59,8 +59,11 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker):
 @pytest.mark.parametrize(
     "unfinished_state", sorted([state for state in State.unfinished if state is not None])
 )
-def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, unfinished_state):
-    with dag_maker("TEST_DAG_1"):
+def test_set_dag_run_state_to_success_unfinished_teardown(
+    dag_maker: DagMaker[SerializedDAG],
+    unfinished_state,
+):
+    with dag_maker("TEST_DAG_1") as dag:
         with EmptyOperator(task_id="teardown").as_teardown():
             EmptyOperator(task_id="running")
             EmptyOperator(task_id="pending")
@@ -73,11 +76,10 @@ def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, u
             ti.set_state(unfinished_state)
 
     dag_maker.session.flush()
-    assert dr.dag
     assert dr.state == DagRunState.RUNNING
 
     updated_tis: list[TaskInstance] = set_dag_run_state_to_success(
-        dag=dr.dag, run_id=dr.run_id, commit=True, session=dag_maker.session
+        dag=dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
     run = dag_maker.session.scalar(select(DagRun).filter_by(dag_id=dr.dag_id, run_id=dr.run_id))
     assert run.state != DagRunState.SUCCESS
@@ -89,8 +91,8 @@ def test_set_dag_run_state_to_success_unfinished_teardown(dag_maker: DagMaker, u
 
 
 @pytest.mark.parametrize("finished_state", sorted(list(State.finished)))
-def test_set_dag_run_state_to_success_finished_teardown(dag_maker: DagMaker, finished_state):
-    with dag_maker("TEST_DAG_1"):
+def test_set_dag_run_state_to_success_finished_teardown(dag_maker: DagMaker[SerializedDAG], finished_state):
+    with dag_maker("TEST_DAG_1") as dag:
         with EmptyOperator(task_id="teardown").as_teardown():
             EmptyOperator(task_id="failed")
     dr = dag_maker.create_dagrun()
@@ -101,10 +103,9 @@ def test_set_dag_run_state_to_success_finished_teardown(dag_maker: DagMaker, fin
             ti.set_state(finished_state)
     dag_maker.session.flush()
     dr.set_state(DagRunState.FAILED)
-    assert dr.dag
 
     updated_tis: list[TaskInstance] = set_dag_run_state_to_success(
-        dag=dr.dag, run_id=dr.run_id, commit=True, session=dag_maker.session
+        dag=dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
     run = dag_maker.session.scalar(select(DagRun).filter_by(dag_id=dr.dag_id, run_id=dr.run_id))
     assert run.state == DagRunState.SUCCESS

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_parsing.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_parsing.py
@@ -56,7 +56,7 @@ class TestDagParsingEndpoint:
         assert response.status_code == 201
         parsing_requests = session.scalars(select(DagPriorityParsingRequest)).all()
         assert len(parsing_requests) == 1
-        assert parsing_requests[0].bundle_name == test_dag.get_bundle_name()
+        assert parsing_requests[0].bundle_name == "dags-folder"
         assert parsing_requests[0].relative_fileloc == test_dag.relative_fileloc
         _check_last_log(session, dag_id=None, event="reparse_dag_file", logical_date=None)
 
@@ -65,7 +65,7 @@ class TestDagParsingEndpoint:
         assert response.status_code == 409
         parsing_requests = session.scalars(select(DagPriorityParsingRequest)).all()
         assert len(parsing_requests) == 1
-        assert parsing_requests[0].bundle_name == test_dag.get_bundle_name()
+        assert parsing_requests[0].bundle_name == "dags-folder"
         assert parsing_requests[0].relative_fileloc == test_dag.relative_fileloc
         _check_last_log(session, dag_id=None, event="reparse_dag_file", logical_date=None)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1580,7 +1580,7 @@ class TestTriggerDagRun:
             },
         ]
 
-    @mock.patch("airflow.models.DAG.create_dagrun")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.create_dagrun")
     def test_dagrun_creation_exception_is_handled(self, mock_create_dagrun, test_client):
         now = timezone.utcnow().isoformat()
         error_message = "Encountered Error"

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -32,11 +32,11 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import create_dag_bag, dag_bag_from_app
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models.dag import DAG
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import task
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.file_task_handler import convert_list_to_stream
 
@@ -275,8 +275,7 @@ class TestTaskInstancesLog:
         # Recreate DAG without tasks
         dagbag = create_dag_bag()
         dag = DAG(self.DAG_ID, schedule=None, start_date=timezone.parse(self.default_time))
-        dag.sync_to_db()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        sync_dag_to_db(dag)
 
         self.app.dependency_overrides[dag_bag_from_app] = lambda: dagbag
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -34,13 +34,13 @@ from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagRun, TaskInstance
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag, sync_bag_to_db
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskmap import TaskMap
 from airflow.models.trigger import Trigger
+from airflow.sdk import BaseOperator
 from airflow.utils.platform import getuser
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -3378,7 +3378,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert response2.json()["state"] == state
         assert listener.state == listener_state
 
-    @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.set_task_instance_state")
     def test_should_call_mocked_api(self, mock_set_ti_state, test_client, session):
         self.create_task_instances(session)
 
@@ -3711,7 +3711,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             ),
         ],
     )
-    @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.set_task_instance_state")
     def test_update_mask_should_call_mocked_api(
         self,
         mock_set_ti_state,
@@ -4023,7 +4023,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert response_ti["note"] == new_note_value
         _check_task_instance_note(session, response_ti["id"], {"content": new_note_value, "user_id": "test"})
 
-    @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.set_task_instance_state")
     def test_should_raise_409_for_updating_same_task_instance_state(
         self, mock_set_ti_state, test_client, session
     ):
@@ -4049,7 +4049,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
     RUN_ID = "TEST_DAG_RUN_ID"
     DAG_DISPLAY_NAME = "example_python_operator"
 
-    @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.set_task_instance_state")
     def test_should_call_mocked_api(self, mock_set_ti_state, test_client, session):
         self.create_task_instances(session)
 
@@ -4407,7 +4407,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             ),
         ],
     )
-    @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.set_task_instance_state")
     def test_update_mask_should_call_mocked_api(
         self,
         mock_set_ti_state,
@@ -4440,7 +4440,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
         assert response.json() == expected_json
         assert mock_set_ti_state.call_count == set_ti_state_call_count
 
-    @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
+    @mock.patch("airflow.serialization.serialized_objects.SerializedDAG.set_task_instance_state")
     def test_should_return_empty_list_for_updating_same_task_instance_state(
         self, mock_set_ti_state, test_client, session
     ):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -20,15 +20,13 @@ from datetime import datetime
 
 import pytest
 
-from airflow import settings
 from airflow.api_fastapi.common.dagbag import dag_bag_from_app
-from airflow.models.dag import DAG
 from airflow.models.dagbag import DBDagBag
-from airflow.models.dagbundle import DagBundleModel
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import DAG
 from airflow.sdk.definitions._internal.expandinput import EXPAND_INPUT_EMPTY
 
+from tests_common.test_utils.dag import sync_dag_to_db, sync_dags_to_db
 from tests_common.test_utils.db import (
     clear_db_dag_bundles,
     clear_db_dags,
@@ -57,6 +55,7 @@ class TestTaskEndpoint:
         with DAG(self.dag_id, schedule=None, start_date=self.task1_start_date, doc_md="details") as dag:
             task1 = EmptyOperator(task_id=self.task_id, params={"foo": "bar"})
             task2 = EmptyOperator(task_id=self.task_id2, start_date=self.task2_start_date)
+            task1 >> task2
 
         with DAG(self.mapped_dag_id, schedule=None, start_date=self.task1_start_date) as mapped_dag:
             EmptyOperator(task_id=self.task_id3)
@@ -67,21 +66,10 @@ class TestTaskEndpoint:
         with DAG(self.unscheduled_dag_id, start_date=None, schedule=None) as unscheduled_dag:
             task4 = EmptyOperator(task_id=self.unscheduled_task_id1, params={"is_unscheduled": True})
             task5 = EmptyOperator(task_id=self.unscheduled_task_id2, params={"is_unscheduled": True})
+            task4 >> task5
 
-        task1 >> task2
-        task4 >> task5
-        session = settings.Session()
-        bundle_name = "testing"
-        dag_bundle = DagBundleModel(name=bundle_name)
-        session.merge(dag_bundle)
-        session.commit()
-        DAG.bulk_write_to_db(bundle_name, None, [dag, mapped_dag, unscheduled_dag])
-        SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
-        SerializedDagModel.write_dag(mapped_dag, bundle_name=bundle_name)
-        SerializedDagModel.write_dag(unscheduled_dag, bundle_name=bundle_name)
-        dag_bag = DBDagBag()
-
-        test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag
+        sync_dags_to_db([dag, mapped_dag, unscheduled_dag])
+        test_client.app.dependency_overrides[dag_bag_from_app] = DBDagBag
 
     @staticmethod
     def clear_db():
@@ -245,11 +233,9 @@ class TestGetTask(TestTaskEndpoint):
         with DAG(self.dag_id, schedule=None, start_date=self.task1_start_date, doc_md="details") as dag:
             task1 = EmptyOperator(task_id=self.task_id, params={"foo": "bar"})
             task2 = EmptyOperator(task_id=self.task_id2, start_date=self.task2_start_date)
-
             task1 >> task2
-        bundle_name = "testing"
-        DAG.bulk_write_to_db(bundle_name, None, [dag])
-        SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+
+        sync_dag_to_db(dag)
 
         dag_bag = DBDagBag()
         test_client.app.dependency_overrides[dag_bag_from_app] = lambda: dag_bag

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -21,22 +21,22 @@ from unittest import mock
 
 import pytest
 
-from airflow import DAG
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.datamodels.xcom import XComCreateBody
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.xcom import XComModel
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import DAG
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.execution_time.xcom import resolve_xcom_backend
 from airflow.utils.session import provide_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs, clear_db_xcom
 from tests_common.test_utils.logs import check_last_log
 
@@ -404,8 +404,7 @@ class TestGetXComEntries(TestXComEndpoint):
         session.flush()
 
         dag = DAG(dag_id=dag_id)
-        DAG.bulk_write_to_db(bundle_name, None, [dag])
-        SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+        sync_dag_to_db(dag)
         dagrun = DagRun(
             dag_id=dag_id,
             run_id=run_id,

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -47,6 +47,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import (
     clear_db_dags,
     clear_db_import_errors,
@@ -54,11 +55,6 @@ from tests_common.test_utils.db import (
     parse_and_sync_to_db,
 )
 from unit.models import TEST_DAGS_FOLDER
-
-try:
-    from airflow.sdk import BaseOperator
-except ImportError:
-    from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
 
 DEFAULT_DATE = timezone.make_aware(datetime(2015, 1, 1), timezone=timezone.utc)
 if pendulum.__version__.startswith("3"):
@@ -372,7 +368,8 @@ class TestCliDags:
     def test_dagbag_dag_col(self, session):
         dagbag = DBDagBag()
         dag_details = dag_command._get_dagbag_dag_details(
-            dagbag.get_latest_version_of_dag("tutorial_dag", session=session)
+            dagbag.get_latest_version_of_dag("tutorial_dag", session=session),
+            session=session,
         )
         assert sorted(dag_details) == sorted(dag_command.DAG_DETAIL_FIELDS)
 
@@ -656,7 +653,7 @@ class TestCliDags:
             is None
         )
 
-    @mock.patch("airflow.cli.commands.dag_command.get_dag")
+    @mock.patch("airflow.cli.commands.dag_command.get_bagged_dag")
     def test_dag_test(self, mock_get_dag):
         cli_args = self.parser.parse_args(["dags", "test", "example_bash_operator", DEFAULT_DATE.isoformat()])
         dag_command.dag_test(cli_args)
@@ -674,7 +671,7 @@ class TestCliDags:
             ]
         )
 
-    @mock.patch("airflow.cli.commands.dag_command.get_dag")
+    @mock.patch("airflow.cli.commands.dag_command.get_bagged_dag")
     def test_dag_test_fail_raise_error(self, mock_get_dag):
         logical_date_str = DEFAULT_DATE.isoformat()
         mock_get_dag.return_value.test.return_value = DagRun(
@@ -684,7 +681,7 @@ class TestCliDags:
         with pytest.raises(SystemExit, match=r"DagRun failed"):
             dag_command.dag_test(cli_args)
 
-    @mock.patch("airflow.cli.commands.dag_command.get_dag")
+    @mock.patch("airflow.cli.commands.dag_command.get_bagged_dag")
     def test_dag_test_no_logical_date(self, mock_get_dag, time_machine):
         now = pendulum.now()
         time_machine.move_to(now, tick=False)
@@ -707,7 +704,7 @@ class TestCliDags:
             ]
         )
 
-    @mock.patch("airflow.cli.commands.dag_command.get_dag")
+    @mock.patch("airflow.cli.commands.dag_command.get_bagged_dag")
     def test_dag_test_conf(self, mock_get_dag):
         cli_args = self.parser.parse_args(
             [
@@ -735,7 +732,7 @@ class TestCliDags:
         )
 
     @mock.patch("airflow.cli.commands.dag_command.render_dag", return_value=MagicMock(source="SOURCE"))
-    @mock.patch("airflow.cli.commands.dag_command.get_dag")
+    @mock.patch("airflow.cli.commands.dag_command.get_bagged_dag")
     def test_dag_test_show_dag(self, mock_get_dag, mock_render_dag, stdout_capture):
         mock_get_dag.return_value.test.return_value.run_id = "__test_dag_test_show_dag_fake_dag_run_run_id__"
 
@@ -841,8 +838,8 @@ class TestCliDags:
             include_examples=False,
         )
 
-    @mock.patch("airflow.models.dag._get_or_create_dagrun")
-    def test_dag_test_with_custom_timetable(self, mock__get_or_create_dagrun):
+    @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
+    def test_dag_test_with_custom_timetable(self, mock_get_or_create_dagrun):
         """
         when calling `dags test` on dag with custom timetable, the DagRun object should be created with
          data_intervals.
@@ -854,11 +851,11 @@ class TestCliDags:
 
         with mock.patch.object(AfterWorkdayTimetable, "get_next_workday", return_value=DEFAULT_DATE):
             dag_command.dag_test(cli_args)
-        assert "data_interval" in mock__get_or_create_dagrun.call_args.kwargs
+        assert "data_interval" in mock_get_or_create_dagrun.call_args.kwargs
 
-    @mock.patch("airflow.models.dag._get_or_create_dagrun")
+    @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
     def test_dag_with_parsing_context(
-        self, mock__get_or_create_dagrun, testing_dag_bundle, configure_testing_dag_bundle
+        self, mock_get_or_create_dagrun, testing_dag_bundle, configure_testing_dag_bundle
     ):
         """
         airflow parsing context should be set when calling `dags test`.
@@ -874,7 +871,7 @@ class TestCliDags:
             dag_command.dag_test(cli_args)
 
         # if dag_parsing_context is not set, this DAG will only have 1 task
-        assert len(mock__get_or_create_dagrun.call_args[1]["dag"].task_ids) == 2
+        assert len(mock_get_or_create_dagrun.call_args[1]["dag"].task_ids) == 2
 
     def test_dag_test_run_inline_trigger(self, dag_maker):
         now = timezone.utcnow()
@@ -918,6 +915,7 @@ class TestCliDags:
                 task_two = two(task_one)
                 op = MyOp(task_id="abc", tfield=task_two)
                 task_two >> op
+            sync_dag_to_db(dag)
             dr = dag.test()
 
             trigger_arg = mock_run.call_args_list[0].args[0]
@@ -951,15 +949,18 @@ class TestCliDags:
     @conf_vars({("core", "load_examples"): "false"})
     def test_get_dag_excludes_examples_with_bundle(self, configure_testing_dag_bundle):
         """Test that example DAGs are excluded when bundle names are passed."""
-        from airflow.utils.cli import get_dag
+        try:
+            from airflow.utils.cli import get_bagged_dag
+        except ImportError:  # Prior to Airflow 3.1.0.
+            from airflow.utils.cli import get_dag as get_bagged_dag  # type: ignore
 
         with configure_testing_dag_bundle(TEST_DAGS_FOLDER / "test_sensor.py"):
             # example DAG should not be found since include_examples=False
             with pytest.raises(AirflowException, match="could not be found"):
-                get_dag(bundle_names=["testing"], dag_id="example_simplest_dag")
+                get_bagged_dag(bundle_names=["testing"], dag_id="example_simplest_dag")
 
             # However, "test_sensor.py" should exist
-            dag = get_dag(bundle_names=["testing"], dag_id="test_sensor")
+            dag = get_bagged_dag(bundle_names=["testing"], dag_id="test_sensor")
             assert dag.dag_id == "test_sensor"
 
 

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -43,12 +43,13 @@ from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.bash import BashOperator
-from airflow.serialization.serialized_objects import SerializedDAG
+from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.utils.session import create_session
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_runs, parse_and_sync_to_db
 
 if TYPE_CHECKING:
@@ -319,8 +320,8 @@ class TestCliTasks:
             {% endfor %}
             """
             commands = [templated_command, "echo 1"]
-
             BashOperator.partial(task_id="some_command").expand(bash_command=commands)
+        sync_dag_to_db(dag)
 
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_render(
@@ -351,11 +352,12 @@ class TestCliTasks:
 
     def test_task_states_for_dag_run(self):
         dag2 = DagBag().dags["example_python_operator"]
+        lazy_deserialized_dag2 = LazyDeserializedDAG.from_dag(dag2)
 
-        SerializedDagModel.write_dag(dag2, bundle_name="testing")
+        SerializedDagModel.write_dag(lazy_deserialized_dag2, bundle_name="testing")
+
         task2 = dag2.get_task(task_id="print_the_context")
-
-        dag2 = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag2))
+        dag2 = SerializedDAG.from_dict(lazy_deserialized_dag2.data)
 
         default_date2 = timezone.datetime(2016, 1, 9)
         dag2.clear()

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -50,10 +50,9 @@ from airflow.dag_processing.manager import (
     DagFileStat,
 )
 from airflow.dag_processing.processor import DagFileProcessorProcess
-from airflow.models import DAG, DagBag, DagModel, DbCallbackRequest
+from airflow.models import DagBag, DagModel, DbCallbackRequest
 from airflow.models.asset import TaskOutletAssetReference
 from airflow.models.dag_version import DagVersion
-from airflow.models.dagbag import DBDagBag
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
@@ -62,6 +61,7 @@ from airflow.utils.session import create_session
 
 from tests_common.test_utils.compat import ParseImportError
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import (
     clear_db_assets,
     clear_db_callbacks,
@@ -442,7 +442,8 @@ class TestDagFileProcessorManager:
         assert len(parsing_request_after) == 1
         assert parsing_request_after[0].relative_fileloc == "file_x.py"
 
-    def test_scan_stale_dags(self, testing_dag_bundle):
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_scan_stale_dags(self, session):
         """
         Ensure that DAGs are marked inactive when the file is parsed but the
         DagModel.last_parsed_time is not updated.
@@ -466,57 +467,54 @@ class TestDagFileProcessorManager:
             bundle_path=test_dag_path.bundle_path,
         )
 
-        with create_session() as session:
-            # Add stale DAG to the DB
-            dag = dagbag.get_dag("test_example_bash_operator")
-            dag.last_parsed_time = timezone.utcnow()
-            DAG.bulk_write_to_db("testing", None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name="testing")
+        # Add stale DAG to the DB
+        dag = dagbag.get_dag("test_example_bash_operator")
+        sync_dag_to_db(dag, session=session)
 
-            # Add DAG to the file_parsing_stats
-            stat = DagFileStat(
-                num_dags=1,
-                import_errors=0,
-                last_finish_time=timezone.utcnow() + timedelta(hours=1),
-                last_duration=1,
-                run_count=1,
-                last_num_of_db_queries=1,
+        # Add DAG to the file_parsing_stats
+        stat = DagFileStat(
+            num_dags=1,
+            import_errors=0,
+            last_finish_time=timezone.utcnow() + timedelta(hours=1),
+            last_duration=1,
+            run_count=1,
+            last_num_of_db_queries=1,
+        )
+        manager._files = [test_dag_path]
+        manager._file_stats[test_dag_path] = stat
+
+        active_dag_count = (
+            session.query(func.count(DagModel.dag_id))
+            .filter(
+                ~DagModel.is_stale,
+                DagModel.relative_fileloc == str(test_dag_path.rel_path),
+                DagModel.bundle_name == test_dag_path.bundle_name,
             )
-            manager._files = [test_dag_path]
-            manager._file_stats[test_dag_path] = stat
+            .scalar()
+        )
+        assert active_dag_count == 1
 
-            active_dag_count = (
-                session.query(func.count(DagModel.dag_id))
-                .filter(
-                    ~DagModel.is_stale,
-                    DagModel.relative_fileloc == str(test_dag_path.rel_path),
-                    DagModel.bundle_name == test_dag_path.bundle_name,
-                )
-                .scalar()
+        manager._scan_stale_dags()
+
+        active_dag_count = (
+            session.query(func.count(DagModel.dag_id))
+            .filter(
+                ~DagModel.is_stale,
+                DagModel.relative_fileloc == str(test_dag_path.rel_path),
+                DagModel.bundle_name == test_dag_path.bundle_name,
             )
-            assert active_dag_count == 1
+            .scalar()
+        )
+        assert active_dag_count == 0
 
-            manager._scan_stale_dags()
-
-            active_dag_count = (
-                session.query(func.count(DagModel.dag_id))
-                .filter(
-                    ~DagModel.is_stale,
-                    DagModel.relative_fileloc == str(test_dag_path.rel_path),
-                    DagModel.bundle_name == test_dag_path.bundle_name,
-                )
-                .scalar()
-            )
-            assert active_dag_count == 0
-
-            serialized_dag_count = (
-                session.query(func.count(SerializedDagModel.dag_id))
-                .filter(SerializedDagModel.dag_id == dag.dag_id)
-                .scalar()
-            )
-            # Deactivating the DagModel should not delete the SerializedDagModel
-            # SerializedDagModel gives history about Dags
-            assert serialized_dag_count == 1
+        serialized_dag_count = (
+            session.query(func.count(SerializedDagModel.dag_id))
+            .filter(SerializedDagModel.dag_id == dag.dag_id)
+            .scalar()
+        )
+        # Deactivating the DagModel should not delete the SerializedDagModel
+        # SerializedDagModel gives history about Dags
+        assert serialized_dag_count == 1
 
     def test_kill_timed_out_processors_kill(self):
         manager = DagFileProcessorManager(max_runs=1, processor_timeout=5)
@@ -664,15 +662,15 @@ class TestDagFileProcessorManager:
             any_order=True,
         )
 
+    @pytest.mark.usefixtures("testing_dag_bundle")
     def test_refresh_dags_dir_doesnt_delete_zipped_dags(
-        self, tmp_path, testing_dag_bundle, configure_testing_dag_bundle, test_zip_path
+        self, tmp_path, session, configure_testing_dag_bundle, test_zip_path
     ):
         """Test DagFileProcessorManager._refresh_dag_dir method"""
         dagbag = DagBag(dag_folder=tmp_path, include_examples=False)
         dagbag.process_file(test_zip_path)
         dag = dagbag.get_dag("test_zip_dag")
-        DAG.bulk_write_to_db("testing", None, [dag])
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        sync_dag_to_db(dag)
 
         with configure_testing_dag_bundle(test_zip_path):
             manager = DagFileProcessorManager(max_runs=1)
@@ -683,7 +681,7 @@ class TestDagFileProcessorManager:
         # assert code not deleted
         assert DagCode.has_dag(dag.dag_id)
         # assert dag still active
-        assert not dag.get_is_stale()
+        assert session.get(DagModel, dag.dag_id).is_stale is False
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_refresh_dags_dir_deactivates_deleted_zipped_dags(
@@ -738,11 +736,10 @@ class TestDagFileProcessorManager:
         manager = DagFileProcessorManager(max_runs=1)
         manager.deactivate_deleted_dags("dag_maker", active_files)
 
-        dagbag = DBDagBag()
         # The DAG from test_dag1.py is still active
-        assert dagbag.get_latest_version_of_dag("test_dag1", session=session).get_is_active() is True
+        assert session.get(DagModel, "test_dag1").is_stale is False
         # and the DAG from test_dag2.py is deactivated
-        assert dagbag.get_latest_version_of_dag("test_dag2", session=session).get_is_active() is False
+        assert session.get(DagModel, "test_dag2").is_stale is True
 
     @conf_vars({("core", "load_examples"): "False"})
     def test_fetch_callbacks_from_database(self, configure_testing_dag_bundle):

--- a/airflow-core/tests/unit/datasets/test_dataset.py
+++ b/airflow-core/tests/unit/datasets/test_dataset.py
@@ -24,51 +24,56 @@ import pytest
 @pytest.mark.parametrize(
     "module_path, attr_name, expected_value, warning_message",
     (
-        (
+        pytest.param(
             "airflow",
             "Dataset",
             "airflow.sdk.definitions.asset.Asset",
             (
-                "Import 'Dataset' directly from the airflow module is deprecated and will be removed in the future. "
-                "Please import it from 'airflow.sdk.definitions.asset.Asset'."
+                "Import 'Dataset' directly from the airflow module is deprecated "
+                "and will be removed in the future. Please import it from 'airflow.sdk.Asset'."
             ),
+            id="airflow.Dataset",
         ),
-        (
+        pytest.param(
             "airflow.datasets",
             "Dataset",
             "airflow.sdk.definitions.asset.Asset",
             (
-                "Import 'airflow.dataset.Dataset' is deprecated and "
-                "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset.Asset'."
+                "Import 'airflow.datasets.Dataset' is deprecated and "
+                "will be removed in Airflow 3.2. Please import it from 'airflow.sdk.Asset'."
             ),
+            id="airflow.datasets.Dataset",
         ),
-        (
+        pytest.param(
             "airflow.datasets",
             "DatasetAlias",
             "airflow.sdk.definitions.asset.AssetAlias",
             (
-                "Import 'airflow.dataset.DatasetAlias' is deprecated and "
-                "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset.AssetAlias'."
+                "Import 'airflow.datasets.DatasetAlias' is deprecated and "
+                "will be removed in Airflow 3.2. Please import it from 'airflow.sdk.AssetAlias'."
             ),
+            id="airflow.datasets.DatasetAlias",
         ),
-        (
+        pytest.param(
             "airflow.datasets",
             "expand_alias_to_datasets",
             "airflow.models.asset.expand_alias_to_assets",
             (
-                "Import 'airflow.dataset.expand_alias_to_datasets' is deprecated and "
-                "will be removed in the Airflow 3.2. Please import it from 'airflow.models.asset.expand_alias_to_assets'."
+                "Import 'airflow.datasets.expand_alias_to_datasets' is deprecated and will be removed "
+                "in Airflow 3.2. Please import it from 'airflow.models.asset.expand_alias_to_assets'."
             ),
+            id="airflow.datasets.expand_alias_to_datasets",
         ),
-        (
+        pytest.param(
             "airflow.datasets.metadata",
             "Metadata",
             "airflow.sdk.definitions.asset.metadata.Metadata",
             (
-                "Import from the airflow.dataset module is deprecated and "
-                "will be removed in the Airflow 3.2. Please import it from "
-                "'airflow.sdk.definitions.asset.metadata'."
+                "Import from the airflow.datasets.metadata module is deprecated and "
+                "will be removed in Airflow 3.2. Please import it from "
+                "'airflow.sdk'."
             ),
+            id="airflow.datasets.metadata.Metadata",
         ),
     ),
 )

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import os
 import pathlib
+import re
 import sys
 import textwrap
 import warnings
@@ -34,12 +35,13 @@ import pytest
 from sqlalchemy import select
 
 from airflow import settings
-from airflow.models.dag import DAG, DagModel
-from airflow.models.dagbag import DagBag, _capture_with_reraise
+from airflow.exceptions import UnknownExecutorException
+from airflow.executors.executor_loader import ExecutorLoader
+from airflow.models.dag import DagModel
+from airflow.models.dagbag import DagBag, _capture_with_reraise, _validate_executor_fields
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.sdk import BaseOperator
-from airflow.utils.session import create_session
+from airflow.sdk import DAG, BaseOperator
 
 from tests_common.pytest_plugin import AIRFLOW_ROOT_PATH
 from tests_common.test_utils import db
@@ -58,6 +60,27 @@ PY313 = sys.version_info >= (3, 13)
 # tricking airflow into thinking these
 # files contain a DAG (otherwise Airflow will skip them)
 INVALID_DAG_WITH_DEPTH_FILE_CONTENTS = "def something():\n    return airflow_DAG\nsomething()"
+
+
+def test_validate_executor_field_executor_not_configured():
+    with DAG("test-dag", schedule=None) as dag:
+        BaseOperator(task_id="t1", executor="test.custom.executor")
+    with pytest.raises(
+        UnknownExecutorException,
+        match=re.escape(
+            "Task 't1' specifies executor 'test.custom.executor', which is not available. "
+            "Make sure it is listed in your [core] executors configuration, or update the task's "
+            "executor to use one of the configured executors."
+        ),
+    ):
+        _validate_executor_fields(dag)
+
+
+def test_validate_executor_field():
+    with DAG("test-dag", schedule=None) as dag:
+        BaseOperator(task_id="t1", executor="test.custom.executor")
+    with patch.object(ExecutorLoader, "lookup_executor_name_by_str"):
+        _validate_executor_fields(dag)
 
 
 def db_clean_up():
@@ -548,36 +571,6 @@ class TestDagBag:
         dagbag = DagBag(dag_folder=os.fspath(tmp_path), include_examples=False)
 
         assert dagbag.process_file(None) == []
-
-    def test_deactivate_unknown_dags(self, testing_dag_bundle):
-        """
-        Test that dag_ids not passed into deactivate_unknown_dags
-        are deactivated when function is invoked
-        """
-        dagbag = DagBag(include_examples=True)
-        dag_id = "test_deactivate_unknown_dags"
-        expected_active_dags = dagbag.dags.keys()
-
-        bundle_name = "testing"
-
-        model_before = DagModel(
-            dag_id=dag_id,
-            bundle_name=bundle_name,
-            is_stale=False,
-        )
-        with create_session() as session:
-            session.merge(model_before)
-            session.flush()
-
-        DAG.deactivate_unknown_dags(expected_active_dags)
-
-        after_model = DagModel.get_dagmodel(dag_id)
-        assert not model_before.is_stale
-        assert after_model.is_stale
-
-        # clean up
-        with create_session() as session:
-            session.query(DagModel).filter(DagModel.dag_id == "test_deactivate_unknown_dags").delete()
 
     def test_timeout_dag_errors_are_import_errors(self, tmp_path, caplog):
         """

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -25,12 +25,10 @@ from sqlalchemy.exc import IntegrityError
 
 import airflow.example_dags as example_dags_module
 from airflow.models import DagBag
-from airflow.models.dag import DAG
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagcode import DagCode
-from airflow.models.serialized_dag import SerializedDagModel as SDM
 from airflow.sdk import task as task_decorator
-from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
+from airflow.serialization.serialized_objects import SerializedDAG
 
 # To move it to a shared module.
 from airflow.utils.file import open_maybe_zipped
@@ -38,6 +36,7 @@ from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_code, clear_db_dags
 
 pytestmark = pytest.mark.db_test
@@ -55,8 +54,7 @@ def make_example_dags(module):
             session.add(testing)
 
     dagbag = DagBag(module.__path__[0])
-    dags = [LazyDeserializedDAG(data=SerializedDAG.to_dict(dag)) for dag in dagbag.dags.values()]
-    DAG.bulk_write_to_db("testing", None, dags)
+    SerializedDAG.bulk_write_to_db("testing", None, dagbag.dags.values())
     return dagbag.dags
 
 
@@ -74,13 +72,13 @@ class TestDagCode:
     def _write_two_example_dags(self, session):
         example_dags = make_example_dags(example_dags_module)
         bash_dag = example_dags["example_bash_operator"]
-        SDM.write_dag(bash_dag, bundle_name="testing")
+        sync_dag_to_db(bash_dag, session=session)
         dag_version = DagVersion.get_latest_version("example_bash_operator")
         x = DagCode(dag_version, bash_dag.fileloc)
         session.add(x)
         session.commit()
         xcom_dag = example_dags["example_xcom"]
-        SDM.write_dag(xcom_dag, bundle_name="testing")
+        sync_dag_to_db(xcom_dag, session=session)
         dag_version = DagVersion.get_latest_version("example_xcom")
         x = DagCode(dag_version, xcom_dag.fileloc)
         session.add(x)
@@ -89,8 +87,9 @@ class TestDagCode:
 
     def _write_example_dags(self):
         example_dags = make_example_dags(example_dags_module)
-        for dag in example_dags.values():
-            SDM.write_dag(dag, bundle_name="testing")
+        with create_session() as session:
+            for dag in example_dags.values():
+                sync_dag_to_db(dag, session=session)
         return example_dags
 
     def test_write_to_db(self, testing_dag_bundle):
@@ -130,7 +129,7 @@ class TestDagCode:
         Source Code should at least exist in one of DB or File.
         """
         example_dag = make_example_dags(example_dags_module).get("example_bash_operator")
-        SDM.write_dag(example_dag, bundle_name="testing")
+        sync_dag_to_db(example_dag)
 
         # Mock that there is no access to the Dag File
         with patch("airflow.models.dagcode.open_maybe_zipped") as mock_open:
@@ -143,10 +142,7 @@ class TestDagCode:
     def test_db_code_created_on_serdag_change(self, session, testing_dag_bundle):
         """Test new DagCode is created in DB when ser dag is changed"""
         example_dag = make_example_dags(example_dags_module).get("example_bash_operator")
-        SDM.write_dag(example_dag, bundle_name="testing")
-
-        dag = DAG.from_sdk_dag(example_dag)
-        dag.create_dagrun(
+        sync_dag_to_db(example_dag, session=session).create_dagrun(
             run_id="test1",
             run_after=pendulum.datetime(2025, 1, 1, tz="UTC"),
             state=DagRunState.QUEUED,
@@ -166,7 +162,7 @@ class TestDagCode:
         example_dag.doc_md = "new doc"
         with patch("airflow.models.dagcode.DagCode.get_code_from_file") as mock_code:
             mock_code.return_value = "# dummy code"
-            SDM.write_dag(example_dag, bundle_name="testing")
+            sync_dag_to_db(example_dag, session=session)
 
         new_result = (
             session.query(DagCode)
@@ -184,13 +180,11 @@ class TestDagCode:
         """Test has_dag method."""
         with dag_maker("test_has_dag") as dag:
             pass
-        dag.sync_to_db()
-        SDM.write_dag(dag, bundle_name="dag_maker")
+        sync_dag_to_db(dag)
 
         with dag_maker() as dag2:
             pass
-        dag2.sync_to_db()
-        SDM.write_dag(dag2, bundle_name="dag_maker")
+        sync_dag_to_db(dag2)
 
         assert DagCode.has_dag(dag.dag_id)
 
@@ -203,8 +197,7 @@ class TestDagCode:
                 print("task4")
 
             mytask()
-        dag.sync_to_db()
-        SDM.write_dag(dag, bundle_name="dag_maker")
+        sync_dag_to_db(dag)
         dag_code = DagCode.get_latest_dagcode(dag.dag_id)
         dag_code.source_code_hash = 2
         session.add(dag_code)

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -33,7 +33,7 @@ from sqlalchemy.orm import joinedload
 from airflow import settings
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
-from airflow.models.dag import DAG, DagModel
+from airflow.models.dag import DagModel, infer_automated_data_interval
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun, DagRunNote
 from airflow.models.serialized_dag import SerializedDagModel
@@ -43,9 +43,9 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-from airflow.sdk import BaseOperator, setup, task, task_group, teardown
+from airflow.sdk import DAG, BaseOperator, setup, task, task_group, teardown
 from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineAlert, DeadlineReference
-from airflow.serialization.serialized_objects import SerializedDAG
+from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.stats import Stats
 from airflow.task.trigger_rule import TriggerRule
 from airflow.triggers.base import StartTriggerArgs
@@ -56,6 +56,7 @@ from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.mock_operators import MockOperator
 from unit.models import DEFAULT_DATE as _DEFAULT_DATE
 
@@ -99,9 +100,9 @@ class TestDagRun:
         db.clear_db_xcom()
         db.clear_db_dags()
 
+    @staticmethod
     def create_dag_run(
-        self,
-        dag: DAG,
+        dag: SerializedDAG,
         *,
         task_states: Mapping[str, TaskInstanceState] | None = None,
         logical_date: datetime.datetime | None = None,
@@ -113,7 +114,7 @@ class TestDagRun:
         logical_date = pendulum.instance(logical_date or now)
         if is_backfill:
             run_type = DagRunType.BACKFILL_JOB
-            data_interval = dag.infer_automated_data_interval(logical_date)
+            data_interval = infer_automated_data_interval(dag.timetable, logical_date)
         else:
             run_type = DagRunType.MANUAL
             data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
@@ -465,14 +466,14 @@ class TestDagRun:
         session.merge(dag_model)
         session.flush()
 
-        dag.sync_to_db()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        scheduler_dag = sync_dag_to_db(dag, session=session)
+        scheduler_dag.on_success_callback = mock_on_success
 
         initial_task_states = {
             "test_state_succeeded1": TaskInstanceState.SKIPPED,
         }
 
-        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
+        dag_run = self.create_dag_run(scheduler_dag, task_states=initial_task_states, session=session)
         _, _ = dag_run.update_state(execute_callbacks=True)
         task = dag_run.get_task_instances()[0]
 
@@ -487,7 +488,7 @@ class TestDagRun:
             start_date=datetime.datetime(2017, 1, 1),
         ) as dag:
             ...
-        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
+        SerializedDAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
 
         dag_task1 = EmptyOperator(task_id="test_task1", dag=dag)
         dag_task2 = EmptyOperator(task_id="test_task2", dag=dag)
@@ -524,7 +525,7 @@ class TestDagRun:
             start_date=datetime.datetime(2017, 1, 1),
         ) as dag:
             ...
-        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
+        SerializedDAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
 
         dag_task1 = EmptyOperator(task_id="test_task1", dag=dag)
         dag_task2 = EmptyOperator(task_id="test_task2", dag=dag)
@@ -570,7 +571,7 @@ class TestDagRun:
             start_date=datetime.datetime(2017, 1, 1),
         ) as dag:
             ...
-        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
+        SerializedDAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
 
         dag_task1 = EmptyOperator(task_id="test_task1", dag=dag)
         dag_task2 = EmptyOperator(task_id="test_task2", dag=dag)
@@ -612,7 +613,7 @@ class TestDagRun:
             start_date=datetime.datetime(2017, 1, 1),
         ) as dag:
             ...
-        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
+        SerializedDAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
 
         dag_task1 = EmptyOperator(task_id="test_task1", dag=dag)
         dag_task2 = EmptyOperator(task_id="test_task2", dag=dag)
@@ -652,7 +653,6 @@ class TestDagRun:
             on_success_callback=on_success_callable,
         ) as dag:
             ...
-        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
         dm = DagModel.get_dagmodel(dag.dag_id, session=session)
         dm.relative_fileloc = relative_fileloc
         session.merge(dm)
@@ -670,7 +670,7 @@ class TestDagRun:
         # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
         dag.relative_fileloc = relative_fileloc
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="dag_maker")
         session.commit()
 
         dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
@@ -684,7 +684,7 @@ class TestDagRun:
             dag_id="test_dagrun_update_state_with_handle_callback_success",
             run_id=dag_run.run_id,
             is_failure_callback=False,
-            bundle_name="testing",
+            bundle_name="dag_maker",
             bundle_version=None,
             context_from_server=DagRunContext(
                 dag_run=dag_run,
@@ -705,7 +705,6 @@ class TestDagRun:
             on_failure_callback=on_failure_callable,
         ) as dag:
             ...
-        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
         dm = DagModel.get_dagmodel(dag.dag_id, session=session)
         dm.relative_fileloc = relative_fileloc
         session.merge(dm)
@@ -723,7 +722,7 @@ class TestDagRun:
         # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
         dag.relative_fileloc = relative_fileloc
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="dag_maker")
         session.commit()
 
         dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
@@ -739,7 +738,7 @@ class TestDagRun:
             run_id=dag_run.run_id,
             is_failure_callback=True,
             msg="task_failure",
-            bundle_name="testing",
+            bundle_name="dag_maker",
             bundle_version=None,
             context_from_server=DagRunContext(
                 dag_run=dag_run,
@@ -1068,17 +1067,17 @@ class TestDagRun:
         )
         session.add(orm_dag)
         session.flush()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
-        dr = dag.create_dagrun(
-            run_id=dag.timetable.generate_run_id(
+        scheduler_dag = sync_dag_to_db(dag, session=session)
+        dr = scheduler_dag.create_dagrun(
+            run_id=scheduler_dag.timetable.generate_run_id(
                 run_type=DagRunType.SCHEDULED,
                 run_after=DEFAULT_DATE,
-                data_interval=dag.infer_automated_data_interval(DEFAULT_DATE),
+                data_interval=infer_automated_data_interval(scheduler_dag.timetable, DEFAULT_DATE),
             ),
             run_type=DagRunType.SCHEDULED,
             state=state,
             logical_date=DEFAULT_DATE,
-            data_interval=dag.infer_automated_data_interval(DEFAULT_DATE),
+            data_interval=infer_automated_data_interval(scheduler_dag.timetable, DEFAULT_DATE),
             run_after=DEFAULT_DATE,
             start_date=DEFAULT_DATE if state == DagRunState.RUNNING else None,
             session=session,
@@ -1117,14 +1116,9 @@ class TestDagRun:
         session.merge(dag_model)
         session.flush()
 
-        dag.sync_to_db(session=session)
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
-
-        initial_task_states = {
-            dag_task.task_id: TaskInstanceState.SUCCESS,
-        }
-
-        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
+        scheduler_dag = sync_dag_to_db(dag, session=session)
+        initial_task_states = {dag_task.task_id: TaskInstanceState.SUCCESS}
+        dag_run = self.create_dag_run(scheduler_dag, task_states=initial_task_states, session=session)
         dag_run.update_state(session=session)
         assert call(f"dagrun.{dag.dag_id}.first_task_scheduling_delay") not in stats_mock.mock_calls
 
@@ -1144,9 +1138,9 @@ class TestDagRun:
         dag = DAG(dag_id="test_emit_dag_stats", start_date=DEFAULT_DATE, schedule=schedule)
         dag_task = EmptyOperator(task_id="dummy", dag=dag, owner="airflow")
         expected_stat_tags = {"dag_id": f"{dag.dag_id}", "run_type": DagRunType.SCHEDULED}
-
+        scheduler_dag = sync_dag_to_db(dag, session=session)
         try:
-            info = dag.next_dagrun_info(None)
+            info = scheduler_dag.next_dagrun_info(None)
             orm_dag_kwargs = {
                 "dag_id": dag.dag_id,
                 "bundle_name": "testing",
@@ -1162,19 +1156,18 @@ class TestDagRun:
                     },
                 )
             orm_dag = DagModel(**orm_dag_kwargs)
-            session.add(orm_dag)
+            session.merge(orm_dag)
             session.flush()
-            SerializedDagModel.write_dag(dag, bundle_name="testing")
-            dag_run = dag.create_dagrun(
-                run_id=dag.timetable.generate_run_id(
+            dag_run = scheduler_dag.create_dagrun(
+                run_id=scheduler_dag.timetable.generate_run_id(
                     run_type=DagRunType.SCHEDULED,
                     run_after=dag.start_date,
-                    data_interval=dag.infer_automated_data_interval(dag.start_date),
+                    data_interval=infer_automated_data_interval(scheduler_dag.timetable, dag.start_date),
                 ),
                 run_type=DagRunType.SCHEDULED,
                 state=DagRunState.SUCCESS,
                 logical_date=dag.start_date,
-                data_interval=dag.infer_automated_data_interval(dag.start_date),
+                data_interval=infer_automated_data_interval(scheduler_dag.timetable, dag.start_date),
                 run_after=dag.start_date,
                 start_date=dag.start_date,
                 triggered_by=DagRunTriggeredByType.TEST,

--- a/airflow-core/tests/unit/ti_deps/deps/test_dag_unpaused_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_dag_unpaused_dep.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from unittest import mock
-from unittest.mock import Mock
 
 import pytest
 
@@ -28,23 +27,24 @@ from airflow.ti_deps.deps.dag_unpaused_dep import DagUnpausedDep
 pytestmark = pytest.mark.db_test
 
 
+@mock.patch.object(DagUnpausedDep, "_is_dag_paused")
 class TestDagUnpausedDep:
-    def test_concurrency_reached(self):
+    def test_concurrency_reached(self, mock_is_dag_paused):
         """
         Test paused DAG should fail dependency
         """
-        dag = Mock(**{"get_is_paused.return_value": True})
-        task = Mock(dag=dag)
+        mock_is_dag_paused.return_value = True
+        task = mock.Mock()
         ti = TaskInstance(task=task, dag_version_id=mock.MagicMock())
 
         assert not DagUnpausedDep().is_met(ti=ti)
 
-    def test_all_conditions_met(self):
+    def test_all_conditions_met(self, mock_is_dag_paused):
         """
         Test all conditions met should pass dep
         """
-        dag = Mock(**{"get_is_paused.return_value": False})
-        task = Mock(dag=dag)
+        mock_is_dag_paused.return_value = False
+        task = mock.Mock()
         ti = TaskInstance(task=task, dag_version_id=mock.MagicMock())
 
         assert DagUnpausedDep().is_met(ti=ti)

--- a/airflow-core/tests/unit/ti_deps/deps/test_prev_dagrun_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_prev_dagrun_dep.py
@@ -23,14 +23,13 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 
 from airflow._shared.timezones.timezone import convert_to_utc, datetime
-from airflow.models.baseoperator import BaseOperator
-from airflow.models.dag import DAG
-from airflow.models.serialized_dag import SerializedDagModel
+from airflow.sdk import DAG, BaseOperator
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
+from tests_common.test_utils.dag import create_scheduler_dag, sync_dag_to_db
 from tests_common.test_utils.db import clear_db_runs
 
 pytestmark = pytest.mark.db_test
@@ -55,10 +54,9 @@ class TestPrevDagrunDep:
             start_date=START_DATE,
             wait_for_downstream=False,
         )
-        DAG.bulk_write_to_db("testing", None, [dag])
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        scheduler_dag = sync_dag_to_db(dag)
         # Old DAG run will include only TaskInstance of old_task
-        dag.create_dagrun(
+        scheduler_dag.create_dagrun(
             run_id="old_run",
             state=TaskInstanceState.SUCCESS,
             logical_date=old_task.start_date,
@@ -78,7 +76,7 @@ class TestPrevDagrunDep:
 
         # New DAG run will include 1st TaskInstance of new_task
         logical_date = convert_to_utc(datetime(2016, 1, 2))
-        dr = dag.create_dagrun(
+        dr = create_scheduler_dag(dag).create_dagrun(
             run_id="new_run",
             state=DagRunState.RUNNING,
             logical_date=logical_date,

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -36,7 +36,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
-from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models.serialized_dag import LazyDeserializedDAG, SerializedDagModel
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.db_cleanup import (
     ARCHIVE_TABLE_PREFIX,
@@ -684,7 +684,7 @@ def create_tis(base_date, num_tis, run_type=DagRunType.SCHEDULED):
         dag = DAG(dag_id=dag_id)
         dm = DagModel(dag_id=dag_id, bundle_name=bundle_name)
         session.add(dm)
-        SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+        SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
         dag_version = DagVersion.get_latest_version(dag.dag_id)
         for num in range(num_tis):
             start_date = base_date.add(days=num)

--- a/dev/airflow_perf/dags/elastic_dag.py
+++ b/dev/airflow_perf/dags/elastic_dag.py
@@ -22,9 +22,8 @@ import re
 from datetime import datetime, timedelta
 from enum import Enum
 
-from airflow.models.dag import DAG
 from airflow.providers.standard.operators.bash import BashOperator
-from airflow.sdk import chain
+from airflow.sdk import DAG, chain
 
 # DAG File used in performance tests. Its shape can be configured by environment variables.
 RE_TIME_DELTA = re.compile(

--- a/dev/airflow_perf/dags/perf_dag_1.py
+++ b/dev/airflow_perf/dags/perf_dag_1.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 import datetime
 
-from airflow.models.dag import DAG
 from airflow.operators.bash_operator import BashOperator
+from airflow.sdk import DAG
 
 args = {
     "owner": "airflow",

--- a/dev/airflow_perf/dags/perf_dag_2.py
+++ b/dev/airflow_perf/dags/perf_dag_2.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 import datetime
 
-from airflow.models.dag import DAG
 from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk import DAG
 
 args = {
     "owner": "airflow",

--- a/dev/airflow_perf/dags/sql_perf_dag.py
+++ b/dev/airflow_perf/dags/sql_perf_dag.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from airflow.models.dag import DAG
 from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG
 
 default_args = {
     "owner": "Airflow",

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -30,7 +30,7 @@ from collections.abc import Callable, Generator
 from contextlib import ExitStack, suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 from unittest import mock
 
 import pytest
@@ -42,17 +42,17 @@ if TYPE_CHECKING:
     from itsdangerous import URLSafeSerializer
     from sqlalchemy.orm import Session
 
-    from airflow.models.baseoperator import BaseOperator
-    from airflow.models.dag import DAG, ScheduleArg
     from airflow.models.dagrun import DagRun, DagRunType
+    from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
     from airflow.providers.standard.operators.empty import EmptyOperator
-    from airflow.sdk import Context, TriggerRule
+    from airflow.sdk import DAG, BaseOperator, Context, TriggerRule
     from airflow.sdk.api.datamodels._generated import TaskInstanceState as TIState
-    from airflow.sdk.bases.operator import BaseOperator as TaskSDKBaseOperator
+    from airflow.sdk.definitions.dag import ScheduleArg
     from airflow.sdk.execution_time.comms import StartupDetails, ToSupervisor
     from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
     from airflow.sdk.types import DagRunProtocol
+    from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
     from airflow.timetables.base import DataInterval
     from airflow.typing_compat import Self
     from airflow.utils.state import DagRunState, TaskInstanceState
@@ -60,7 +60,8 @@ if TYPE_CHECKING:
     from tests_common._internals.capture_warnings import CaptureWarningsPlugin  # noqa: F401
     from tests_common._internals.forbidden_warnings import ForbiddenWarningsPlugin  # noqa: F401
 
-    Op = TypeVar("Op", bound=BaseOperator)
+Dag = TypeVar("Dag", "DAG", "SerializedDAG", covariant=True)
+Op = TypeVar("Op", bound="BaseOperator")
 
 # NOTE: DO NOT IMPORT AIRFLOW THINGS HERE!
 #
@@ -776,7 +777,7 @@ def frozen_sleep(monkeypatch):
         traveller.stop()
 
 
-class DagMaker(Protocol):
+class DagMaker(Generic[Dag], Protocol):
     """
     Interface definition for dag_maker return value.
 
@@ -785,8 +786,9 @@ class DagMaker(Protocol):
     """
 
     session: Session
+    dag: DAG
 
-    def __enter__(self) -> DAG: ...
+    def __enter__(self) -> Dag: ...
 
     def __exit__(self, type, value, traceback) -> None: ...
 
@@ -949,43 +951,56 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             if type is not None:
                 return
 
-            if AIRFLOW_V_3_0_PLUS:
-                dag.bulk_write_to_db(self.bundle_name, self.bundle_version, [dag], session=self.session)
-            else:
-                dag.sync_to_db(session=self.session)
-
             if dag.access_control and "FabAuthManager" in conf.get("core", "auth_manager"):
                 if AIRFLOW_V_3_0_PLUS:
                     from airflow.providers.fab.www.security_appless import ApplessAirflowSecurityManager
                 else:
-                    from airflow.www.security_appless import ApplessAirflowSecurityManager
+                    from airflow.www.security_appless import ApplessAirflowSecurityManager  # type: ignore
                 security_manager = ApplessAirflowSecurityManager(session=self.session)
                 security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control)
-            self.dag_model = self.session.get(DagModel, dag.dag_id)
-
             self._make_serdag(dag)
-            self._bag_dag_compat(self.dag)
+            self.dag_model = self.session.get(DagModel, dag.dag_id)
+            self.session.commit()
 
-        def _make_serdag(self, dag):
+        def _make_serdag(self, dag: DAG):
             from sqlalchemy import select
 
             from airflow.models.serialized_dag import SerializedDagModel
 
-            self.serialized_model = SerializedDagModel(dag)
+            if AIRFLOW_V_3_1_PLUS:
+                from airflow.serialization.serialized_objects import LazyDeserializedDAG
+
+                self.serialized_model = SerializedDagModel(LazyDeserializedDAG.from_dag(dag))
+            else:
+                self.serialized_model = SerializedDagModel(dag)  # type: ignore[arg-type]
+
             sdm = self.session.scalar(
                 select(SerializedDagModel).where(
                     SerializedDagModel.dag_id == dag.dag_id,
                     SerializedDagModel.dag_hash == self.serialized_model.dag_hash,
                 )
             )
+
+            if AIRFLOW_V_3_0_PLUS:
+                from airflow.serialization.serialized_objects import SerializedDAG
+
+                SerializedDAG.bulk_write_to_db(
+                    self.bundle_name,
+                    self.bundle_version,
+                    [dag],
+                    session=self.session,
+                )
+            else:
+                dag.sync_to_db(session=self.session)  # type: ignore[attr-defined]
+
             if AIRFLOW_V_3_0_PLUS and self.serialized_model != sdm:
                 from airflow.models.dag_version import DagVersion
                 from airflow.models.dagcode import DagCode
 
                 dagv = DagVersion.write_dag(
                     dag_id=dag.dag_id,
-                    bundle_name=self.dag_model.bundle_name,
-                    bundle_version=self.dag_model.bundle_version,
+                    bundle_name=self.bundle_name,
+                    bundle_version=self.bundle_version,
                     session=self.session,
                 )
                 self.session.add(dagv)
@@ -1000,9 +1015,8 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 sdm._data = self.serialized_model._data
                 self.serialized_model = sdm
             else:
-                self.session.merge(self.serialized_model)
-            serialized_dag = self._serialized_dag()
-            self._bag_dag_compat(serialized_dag)
+                sdm = self.session.merge(self.serialized_model)
+            self._bag_dag_compat(dag)
             self.session.flush()
 
         def create_dagrun(self, *, logical_date=NOTSET, **kwargs):
@@ -1025,7 +1039,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 )
                 logical_date = kwargs.pop("execution_date")
 
-            dag = self.dag
+            dag = self._serialized_dag()
             kwargs = {
                 "state": DagRunState.RUNNING,
                 "start_date": self.start_date,
@@ -1054,6 +1068,10 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 if logical_date is not None:
                     if run_type == DagRunType.MANUAL:
                         data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
+                    elif AIRFLOW_V_3_1_PLUS:
+                        from airflow.models.dag import infer_automated_data_interval
+
+                        data_interval = infer_automated_data_interval(dag.timetable, logical_date)
                     else:
                         data_interval = dag.infer_automated_data_interval(logical_date)
             kwargs["data_interval"] = data_interval
@@ -1084,18 +1102,21 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 kwargs.pop("triggered_by", None)
                 kwargs["execution_date"] = logical_date
 
-            if self.want_serialized:
-                dag = self.serialized_model.dag
             self.dag_run = dag.create_dagrun(**kwargs)
             for ti in self.dag_run.task_instances:
                 # This need to always operate on the _real_ dag
                 ti.refresh_from_task(self.dag.get_task(ti.task_id))
-            if self.want_serialized:
-                self.session.commit()
+            self.session.commit()
             return self.dag_run
 
         def create_dagrun_after(self, dagrun, **kwargs):
-            next_info = self.dag.next_dagrun_info(self.dag.get_run_data_interval(dagrun))
+            sdag = self._serialized_dag()
+            if AIRFLOW_V_3_1_PLUS:
+                from airflow.models.dag import get_run_data_interval
+
+                next_info = sdag.next_dagrun_info(get_run_data_interval(sdag.timetable, dagrun))
+            else:
+                next_info = sdag.next_dagrun_info(sdag.get_run_data_interval(dagrun))
             if next_info is None:
                 raise ValueError(f"cannot create run after {dagrun}")
             return self.create_dagrun(
@@ -1169,7 +1190,14 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             **kwargs,
         ):
             from airflow import settings
-            from airflow.models.dag import DAG
+
+            # Don't change this to AIRFLOW_V_3_0_PLUS. Although SDK DAG exists
+            # before 3.1, things in dag maker setup can't handle it in compat
+            # tests. They are probably fixable, but it's not worthwhile to.
+            if AIRFLOW_V_3_1_PLUS:
+                from airflow.sdk import DAG
+            else:
+                from airflow import DAG
 
             timezone = _import_timezone()
 
@@ -1617,13 +1645,18 @@ def get_test_dag():
             return
 
         if AIRFLOW_V_3_0_PLUS:
-            session = settings.Session()
-            from airflow.models.dagbundle import DagBundleModel
+            from sqlalchemy import func, select
 
-            if session.query(DagBundleModel).filter(DagBundleModel.name == "testing").count() == 0:
+            from airflow.models.dagbundle import DagBundleModel
+            from airflow.serialization.serialized_objects import SerializedDAG
+
+            session = settings.Session()
+            if not session.scalar(select(func.count()).where(DagBundleModel.name == "testing")):
                 session.add(DagBundleModel(name="testing"))
-                session.commit()
-            dag.bulk_write_to_db("testing", None, [dag])
+                session.flush()
+            SerializedDAG.bulk_write_to_db("testing", None, [dag], session=session)
+            session.commit()
+            session.close()
         else:
             dag.sync_to_db()
         SerializedDagModel.write_dag(dag, bundle_name="testing")
@@ -2159,8 +2192,8 @@ def mocked_parse(spy_agency):
             )
     """
 
-    def set_dag(what: StartupDetails, dag_id: str, task: TaskSDKBaseOperator) -> RuntimeTaskInstance:
-        from airflow.sdk.definitions.dag import DAG
+    def set_dag(what: StartupDetails, dag_id: str, task: BaseOperator) -> RuntimeTaskInstance:
+        from airflow.sdk import DAG
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance, parse
 
         timezone = _import_timezone()
@@ -2238,7 +2271,7 @@ class RunTaskCallable(Protocol):
 
     def __call__(
         self,
-        task: TaskSDKBaseOperator,
+        task: BaseOperator,
         dag_id: str = ...,
         run_id: str = ...,
         logical_date: datetime | None = None,
@@ -2274,18 +2307,19 @@ def create_runtime_ti(mocked_parse):
     """
     from uuid6 import uuid7
 
+    from airflow.sdk import DAG
     from airflow.sdk.api.datamodels._generated import TaskInstance
-    from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.execution_time.comms import BundleInfo, StartupDetails
+    from airflow.serialization.serialized_objects import SerializedDAG
     from airflow.timetables.base import TimeRestriction
 
     timezone = _import_timezone()
 
     def _create_task_instance(
-        task: BaseOperator,
+        task: MappedOperator | SerializedBaseOperator,
         dag_id: str = "test_dag",
         run_id: str = "test_run",
-        logical_date: str | datetime = "2024-12-01T01:00:00Z",
+        logical_date: str | datetime | None = "2024-12-01T01:00:00Z",
         start_date: str | datetime = "2024-12-01T01:00:00Z",
         run_type: str = "manual",
         try_number: int = 1,
@@ -2300,23 +2334,46 @@ def create_runtime_ti(mocked_parse):
         from airflow.sdk.api.datamodels._generated import DagRun, DagRunState, TIRunContext
         from airflow.utils.types import DagRunType
 
+        if isinstance(logical_date, str):
+            logical_date = timezone.parse(logical_date)
+        else:
+            logical_date = timezone.coerce_datetime(logical_date)
+        if isinstance(start_date, str):
+            start_date = timezone.parse(start_date)
+        else:
+            start_date = timezone.coerce_datetime(start_date)
+
+        if TYPE_CHECKING:
+            from pendulum import DateTime
+
+            assert logical_date is None or isinstance(logical_date, DateTime)
+            assert isinstance(start_date, DateTime)
+
         if not ti_id:
             ti_id = uuid7()
 
         if not task.has_dag():
-            dag = DAG(dag_id=dag_id, start_date=timezone.datetime(2024, 12, 3))
+            dag = SerializedDAG.deserialize_dag(
+                SerializedDAG.serialize_dag(DAG(dag_id=dag_id, start_date=timezone.datetime(2024, 12, 3)))
+            )
             # Fixture only helps in regular base operator tasks, so mypy is wrong here
             task.dag = dag
-            task = dag.task_dict[task.task_id]
+            # TODO (GH-52141): Scheduler DAG should contain scheduler tasks, but
+            # currently this inherits from SDK DAG.
+            task = dag.task_dict[task.task_id]  # type: ignore[assignment]
+
+        if TYPE_CHECKING:
+            assert task.dag is not None
 
         data_interval_start = None
         data_interval_end = None
 
         if task.dag.timetable:
             if run_type == DagRunType.MANUAL:
-                data_interval_start, data_interval_end = task.dag.timetable.infer_manual_data_interval(
-                    run_after=logical_date
-                )
+                if logical_date is not None:
+                    data_interval_start, data_interval_end = task.dag.timetable.infer_manual_data_interval(
+                        run_after=logical_date,
+                    )
             else:
                 drinfo = task.dag.timetable.next_dagrun_info(
                     last_automated_data_interval=None,
@@ -2543,7 +2600,7 @@ def run_task(create_runtime_ti, mock_supervisor_comms, spy_agency) -> RunTaskCal
 
         def __call__(
             self,
-            task: TaskSDKBaseOperator,
+            task: BaseOperator,
             dag_id: str = "test_dag",
             run_id: str = "test_run",
             logical_date: datetime | None = None,
@@ -2636,11 +2693,11 @@ def create_connection_without_db(monkeypatch):
 
 def _import_timezone():
     try:
-        from airflow.sdk._shared.timezones import timezone
-    except ModuleNotFoundError:
+        from airflow.sdk import timezone
+    except ImportError:
         try:
             from airflow._shared.timezones import timezone
-        except ModuleNotFoundError:
+        except ImportError:
             from airflow.utils import timezone
     return timezone
 
@@ -2648,7 +2705,12 @@ def _import_timezone():
 @pytest.fixture
 def create_dag_without_db():
     def create_dag(dag_id: str):
-        from airflow.models.dag import DAG
+        from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk import DAG
+        else:
+            from airflow import DAG
 
         return DAG(dag_id=dag_id, schedule=None, render_template_as_native_obj=True)
 

--- a/devel-common/src/tests_common/test_utils/dag.py
+++ b/devel-common/src/tests_common/test_utils/dag.py
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from collections.abc import Collection, Sequence
+from typing import TYPE_CHECKING
+
+from airflow.utils.session import NEW_SESSION, provide_session
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from airflow.sdk import DAG
+    from airflow.serialization.serialized_objects import SerializedDAG
+
+
+def create_scheduler_dag(dag: DAG | SerializedDAG) -> SerializedDAG:
+    from airflow.serialization.serialized_objects import SerializedDAG
+
+    if isinstance(dag, SerializedDAG):
+        return dag
+    return SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
+
+
+@provide_session
+def sync_dag_to_db(
+    dag: DAG,
+    bundle_name: str = "testing",
+    session: Session = NEW_SESSION,
+) -> SerializedDAG:
+    return sync_dags_to_db([dag], bundle_name=bundle_name, session=session)[0]
+
+
+@provide_session
+def sync_dags_to_db(
+    dags: Collection[DAG],
+    bundle_name: str = "testing",
+    session: Session = NEW_SESSION,
+) -> Sequence[SerializedDAG]:
+    """
+    Sync dags into the database.
+
+    This serializes dags and saves the results to the database. The serialized
+    (scheduler-oeirnted) dags are returned. If the input is ordered (e.g. a list),
+    the returned sequence is guaranteed to be in the same order.
+    """
+    from airflow.models.dagbundle import DagBundleModel
+    from airflow.models.serialized_dag import SerializedDagModel
+    from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
+
+    session.merge(DagBundleModel(name=bundle_name))
+    session.flush()
+
+    def _write_dag(dag: DAG) -> SerializedDAG:
+        data = SerializedDAG.to_dict(dag)
+        SerializedDagModel.write_dag(LazyDeserializedDAG(data=data), bundle_name, session=session)
+        return SerializedDAG.from_dict(data)
+
+    SerializedDAG.bulk_write_to_db(bundle_name, None, dags, session=session)
+    scheduler_dags = [_write_dag(dag) for dag in dags]
+    session.flush()
+    return scheduler_dags

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -22,6 +22,8 @@ import os
 from tempfile import gettempdir
 from typing import TYPE_CHECKING
 
+from sqlalchemy import select
+
 from airflow.configuration import conf
 from airflow.jobs.job import Job
 from airflow.models import (
@@ -72,8 +74,22 @@ if AIRFLOW_V_3_1_PLUS:
     from airflow.models.dag_favorite import DagFavorite
 
 
+def _deactivate_unknown_dags(active_dag_ids, session):
+    """
+    Given a list of known DAGs, deactivate any other DAGs that are marked as active in the ORM.
+
+    :param active_dag_ids: list of DAG IDs that are active
+    :return: None
+    """
+    if not active_dag_ids:
+        return
+    for dag in session.scalars(select(DagModel).where(~DagModel.dag_id.in_(active_dag_ids))):
+        dag.is_stale = True
+        session.merge(dag)
+    session.commit()
+
+
 def _bootstrap_dagbag():
-    from airflow.models.dag import DAG
     from airflow.models.dagbag import DagBag
 
     if AIRFLOW_V_3_0_PLUS:
@@ -100,7 +116,7 @@ def _bootstrap_dagbag():
             dagbag.sync_to_db(session=session)  # type: ignore[attr-defined]
 
         # Deactivate the unknown ones
-        DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
+        _deactivate_unknown_dags(dagbag.dags, session=session)
 
 
 def initial_db_init():
@@ -155,7 +171,7 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
     with create_session() as session:
         if AIRFLOW_V_3_0_PLUS:
             DagBundlesManager().sync_bundles_to_db(session=session)
-            session.commit()
+            session.flush()
 
         dagbag = DagBag(dag_folder=folder, include_examples=include_examples)
         if AIRFLOW_V_3_1_PLUS:
@@ -166,7 +182,6 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
             dagbag.sync_to_db("dags-folder", None, session)  # type: ignore[attr-defined]
         else:
             dagbag.sync_to_db(session=session)  # type: ignore[attr-defined]
-        session.commit()
 
     return dagbag
 

--- a/devel-common/src/tests_common/test_utils/perf/perf_kit/__init__.py
+++ b/devel-common/src/tests_common/test_utils/perf/perf_kit/__init__.py
@@ -76,7 +76,7 @@ Suppose we have the following fragment of the file with tests.
         dags = [DAG(f"dag-bulk-sync-{i}", start_date=DEFAULT_DATE, tags=["test-dag"]) for i in range(0, 4)]
 
         with assert_queries_count(3):
-            DAG.bulk_write_to_db(dags)
+            SerializedDAG.bulk_write_to_db(dags)
 
 You can add a code snippet before the method definition, and then perform only one test and count the
 queries in it.
@@ -99,7 +99,7 @@ queries in it.
         dags = [DAG(f"dag-bulk-sync-{i}", start_date=DEFAULT_DATE, tags=["test-dag"]) for i in range(0, 4)]
 
         with assert_queries_count(3):
-            DAG.bulk_write_to_db(dags)
+            SerializedDAG.bulk_write_to_db(dags)
 
 To run the test, execute the command
 

--- a/devel-common/src/tests_common/test_utils/system_tests.py
+++ b/devel-common/src/tests_common/test_utils/system_tests.py
@@ -71,6 +71,7 @@ def get_test_run(dag, **test_kwargs):
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag import DagModel
             from airflow.models.serialized_dag import SerializedDagModel
+            from airflow.serialization.serialized_objects import LazyDeserializedDAG
             from airflow.settings import Session
 
             s = Session()
@@ -78,7 +79,7 @@ def get_test_run(dag, **test_kwargs):
             d = DagModel(dag_id=dag.dag_id, bundle_name=bundle_name)
             s.add(d)
             s.commit()
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
 
         dag_run = dag.test(
             use_executor=os.environ.get("_AIRFLOW__SYSTEM_TEST_USE_EXECUTOR") == "1",

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -33,7 +33,6 @@ from pydantic import TypeAdapter
 from watchtower import CloudWatchLogHandler
 
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.providers.amazon.aws.log.cloudwatch_task_handler import (
     CloudWatchRemoteLogIO,
@@ -45,6 +44,7 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -203,10 +203,7 @@ class TestCloudwatchTaskHandler:
         self.dag = DAG(dag_id=dag_id, schedule=None, start_date=date)
         task = EmptyOperator(task_id=task_id, dag=self.dag)
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            self.dag.sync_to_db()
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
+            sync_dag_to_db(self.dag)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=date,

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -28,16 +28,20 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import State, TaskInstanceState
-from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+try:
+    from airflow.sdk.timezone import datetime
+except ImportError:
+    from airflow.utils.timezone import datetime  # type: ignore[attr-defined,no-redef]
 
 
 @pytest.fixture(autouse=True)
@@ -71,9 +75,7 @@ class TestS3RemoteLogIO:
         self.dag = DAG("dag_for_testing_s3_task_handler", schedule=None, start_date=date)
         task = EmptyOperator(task_id="task_for_testing_s3_log_handler", dag=self.dag)
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
+            scheduler_dag = sync_dag_to_db(self.dag)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=date,
@@ -81,6 +83,7 @@ class TestS3RemoteLogIO:
                 run_type="manual",
             )
         else:
+            scheduler_dag = self.dag
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 execution_date=date,
@@ -107,7 +110,7 @@ class TestS3RemoteLogIO:
         self.conn.create_bucket(Bucket="bucket")
         yield
 
-        self.dag.clear()
+        scheduler_dag.clear()
 
         self.clear_db()
         if self.s3_task_handler.handler:
@@ -204,9 +207,7 @@ class TestS3TaskHandler:
         self.dag = DAG("dag_for_testing_s3_task_handler", schedule=None, start_date=date)
         task = EmptyOperator(task_id="task_for_testing_s3_log_handler", dag=self.dag)
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
+            scheduler_dag = sync_dag_to_db(self.dag)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=date,
@@ -214,6 +215,7 @@ class TestS3TaskHandler:
                 run_type="manual",
             )
         else:
+            scheduler_dag = self.dag
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 execution_date=date,
@@ -240,7 +242,7 @@ class TestS3TaskHandler:
         self.conn.create_bucket(Bucket="bucket")
         yield
 
-        self.dag.clear()
+        scheduler_dag.clear()
 
         self.clear_db()
         if self.s3_task_handler.handler:

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
@@ -24,20 +24,20 @@ from moto import mock_aws
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.amazon.aws.hooks.datasync import DataSyncHook
 from airflow.providers.amazon.aws.links.datasync import DataSyncTaskLink
 from airflow.providers.amazon.aws.operators.datasync import DataSyncOperator
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 try:
     from airflow.sdk import timezone
 except ImportError:
     from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 TEST_DAG_ID = "unit_tests"
 DEFAULT_DATE = timezone.datetime(2018, 1, 1)
@@ -361,11 +361,9 @@ class TestDataSyncOperatorCreate(DataSyncTestCaseBase):
 
         self.set_up_operator()
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
             from airflow.models.dag_version import DagVersion
 
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
@@ -584,11 +582,9 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
 
         self.set_up_operator()
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
             from airflow.models.dag_version import DagVersion
 
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
             ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
@@ -709,11 +705,9 @@ class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
 
         self.set_up_operator()
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
             from airflow.models.dag_version import DagVersion
 
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
             ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
@@ -927,11 +921,9 @@ class TestDataSyncOperator(DataSyncTestCaseBase):
 
         self.set_up_operator()
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
             from airflow.models.dag_version import DagVersion
 
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
             ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
@@ -1048,11 +1040,9 @@ class TestDataSyncOperatorDelete(DataSyncTestCaseBase):
 
         self.set_up_operator()
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
             from airflow.models.dag_version import DagVersion
 
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
             ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_base.py
@@ -26,21 +26,21 @@ from botocore.exceptions import ClientError
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerBaseOperator,
     SageMakerCreateExperimentOperator,
 )
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 try:
     from airflow.sdk import timezone
 except ImportError:
     from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CONFIG: dict = {
     "key1": "1",
@@ -218,9 +218,7 @@ class TestSageMakerExperimentOperator:
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             ti = TaskInstance(task=op, dag_version_id=dag_version.id)
             dag_run = DagRun(

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
@@ -26,19 +26,19 @@ from moto import mock_aws
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.variable import Variable
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor, S3KeysUnchangedSensor
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 try:
     from airflow.sdk import timezone
 except ImportError:
     from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 
@@ -138,9 +138,7 @@ class TestS3KeySensor:
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             dag_run = DagRun(
                 dag_id=dag.dag_id,
@@ -199,9 +197,7 @@ class TestS3KeySensor:
         else:
             from airflow.models.dag_version import DagVersion
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             dag_run = DagRun(
                 dag_id=dag.dag_id,

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_base.py
@@ -21,7 +21,6 @@ import pytest
 
 from airflow import DAG
 from airflow.models import DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.amazon.aws.transfers.base import AwsToAwsBaseOperator
 
 try:
@@ -31,6 +30,7 @@ except ImportError:
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = timezone.datetime(2020, 1, 1)
@@ -53,9 +53,7 @@ class TestAwsToAwsBaseOperator:
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(self.dag, bundle_name=bundle_name)
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
             ti = TaskInstance(operator, run_id="something", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -26,11 +26,7 @@ import pytest
 
 from airflow import DAG
 from airflow.models import DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
-from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import (
-    DynamoDBToS3Operator,
-    JSONEncoder,
-)
+from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Operator, JSONEncoder
 
 try:
     from airflow.sdk import timezone
@@ -39,6 +35,7 @@ except ImportError:
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
@@ -283,9 +280,7 @@ class TestDynamodbToS3:
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             ti = TaskInstance(operator, run_id="something", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(

--- a/providers/apache/kylin/tests/unit/apache/kylin/operators/test_kylin_cube.py
+++ b/providers/apache/kylin/tests/unit/apache/kylin/operators/test_kylin_cube.py
@@ -29,6 +29,7 @@ from airflow.providers.apache.kylin.operators.kylin_cube import KylinCubeOperato
 from airflow.utils import state, timezone
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = timezone.datetime(2020, 1, 1)
@@ -173,11 +174,8 @@ class TestKylinCubeOperator:
 
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
-            from airflow.models.serialized_dag import SerializedDagModel
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(dag=self.dag, bundle_name=bundle_name)
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(operator.dag_id)
             ti = TaskInstance(operator, run_id="kylin_test", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -30,6 +30,7 @@ from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOpe
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
@@ -200,11 +201,8 @@ class TestSparkSubmitOperator:
 
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
-            from airflow.models.serialized_dag import SerializedDagModel
 
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [self.dag])
-            SerializedDagModel.write_dag(dag=self.dag, bundle_name=bundle_name)
+            sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(operator.dag_id)
             ti = TaskInstance(operator, run_id="spark_test", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -34,21 +34,24 @@ from celery.result import AsyncResult
 from kombu.asynchronous import set_event_loop
 
 from airflow.configuration import conf
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.providers.celery.executors import celery_executor, celery_executor_utils, default_celery
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
-from airflow.utils import timezone
 from airflow.utils.state import State
 
 from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.models.dag_version import DagVersion
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import BaseOperator, timezone
+else:
+    from airflow.models.baseoperator import BaseOperator  # type: ignore[attr-defined,no-redef]
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 pytestmark = pytest.mark.db_test
 
@@ -200,9 +203,7 @@ class TestCeleryExecutor:
             task_1 = BaseOperator(task_id="task_1", start_date=start_date)
 
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             key1 = TaskInstance(task=task_1, run_id=None, dag_version_id=dag_version.id)
         else:
@@ -223,9 +224,7 @@ class TestCeleryExecutor:
             task_2 = BaseOperator(task_id="task_2", start_date=start_date)
 
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             ti1 = TaskInstance(task=task_1, run_id=None, dag_version_id=dag_version.id)
             ti2 = TaskInstance(task=task_2, run_id=None, dag_version_id=dag_version.id)
@@ -269,9 +268,7 @@ class TestCeleryExecutor:
             task = BaseOperator(task_id="task_1", start_date=start_date)
 
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(task.dag.dag_id)
             ti = TaskInstance(task=task, run_id=None, dag_version_id=dag_version.id)
         else:
@@ -305,9 +302,7 @@ class TestCeleryExecutor:
             task = BaseOperator(task_id="task_1", start_date=start_date)
 
         if AIRFLOW_V_3_0_PLUS:
-            bundle_name = "testing"
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(task.dag.dag_id)
             ti = TaskInstance(task=task, run_id=None, dag_version_id=dag_version.id)
         else:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -32,11 +32,15 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import Kube
 from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, generate_pod_command_args
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 from airflow.utils import cli as cli_utils, yaml
-from airflow.utils.cli import get_dag
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.types import DagRunType
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.utils.cli import get_bagged_dag
+else:
+    from airflow.utils.cli import get_dag as get_bagged_dag  # type: ignore[attr-defined,no-redef]
 
 
 @cli_utils.action_cli
@@ -45,9 +49,9 @@ def generate_pod_yaml(args):
     """Generate yaml files for each task in the DAG. Used for testing output of KubernetesExecutor."""
     logical_date = args.logical_date if AIRFLOW_V_3_0_PLUS else args.execution_date
     if AIRFLOW_V_3_0_PLUS:
-        dag = get_dag(bundle_names=args.bundle_name, dag_id=args.dag_id)
+        dag = get_bagged_dag(bundle_names=args.bundle_name, dag_id=args.dag_id)
     else:
-        dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
+        dag = get_bagged_dag(subdir=args.subdir, dag_id=args.dag_id)
     yaml_output_path = args.output_path
 
     dm = DagModel(dag_id=dag.dag_id)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes.py
@@ -36,7 +36,7 @@ XCOM_IMAGE = "XCOM_IMAGE"
 class TestKubernetesDecorator(TestKubernetesDecoratorsBase):
     def test_basic_kubernetes(self):
         """Test basic proper KubernetesPodOperator creation from @task.kubernetes decorator"""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes(
                 image="python:3.10-slim-buster",
@@ -77,7 +77,7 @@ class TestKubernetesDecorator(TestKubernetesDecoratorsBase):
     @pytest.mark.asyncio
     def test_kubernetes_with_input_output(self):
         """Verify @task.kubernetes will run XCom container if do_xcom_push is set."""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes(
                 image="python:3.10-slim-buster",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
@@ -42,7 +42,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
     def test_basic_kubernetes(self, args_only: bool):
         """Test basic proper KubernetesPodOperator creation from @task.kubernetes_cmd decorator"""
         expected = ["echo", "Hello world!"]
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",
@@ -102,7 +102,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         Test that @task.kubernetes_cmd raises an error if the python_callable returns
         an invalid value.
         """
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",
@@ -123,7 +123,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
     @pytest.mark.asyncio
     def test_kubernetes_cmd_with_input_output(self):
         """Verify @task.kubernetes_cmd will run XCom container if do_xcom_push is set."""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",
@@ -200,7 +200,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             context_manager = contextlib.nullcontext()  # type: ignore
 
         expected = ["func", "return"]
-        with self.dag:
+        with self.dag_maker:
             # We need to suppress the warning about `cmds` and `arguments` being unused
             with context_manager:
 
@@ -256,7 +256,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
         expected_command: list[str],
     ):
         """Test that templating works in function return value"""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",
@@ -287,7 +287,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
     @pytest.mark.asyncio
     def test_basic_context_works(self):
         """Test that decorator works with context as kwargs unpcacked in function arguments"""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",
@@ -318,7 +318,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
     @pytest.mark.asyncio
     def test_named_context_variables(self):
         """Test that decorator works with specific context variable as kwargs in function arguments"""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",
@@ -349,7 +349,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
     @pytest.mark.asyncio
     def test_rendering_kubernetes_cmd_decorator_params(self):
         """Test that templating works in decorator parameters"""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:{{ dag.dag_id }}",
@@ -379,7 +379,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
 
     def test_airflow_skip(self):
         """Test that the operator is skipped if the task is skipped"""
-        with self.dag:
+        with self.dag_maker:
 
             @task.kubernetes_cmd(
                 image="python:3.10-slim-buster",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
@@ -84,10 +84,10 @@ class TestKubernetesDecoratorsBase:
     def setup(self, dag_maker):
         self.dag_maker = dag_maker
 
-        with dag_maker(dag_id=DAG_ID) as dag:
+        with dag_maker(dag_id=DAG_ID):
             ...
 
-        self.dag = dag
+        self.dag = self.dag_maker.dag
 
         self.mock_create_pod = mock.patch(f"{POD_MANAGER_CLASS}.create_pod").start()
         self.mock_await_pod_start = mock.patch(f"{POD_MANAGER_CLASS}.await_pod_start").start()
@@ -122,9 +122,7 @@ class TestKubernetesDecoratorsBase:
 
     def execute_task(self, task):
         session = self.dag_maker.session
-        dag_run = self.dag_maker.create_dagrun(
-            run_id=f"k8s_decorator_test_{DEFAULT_DATE.date()}", session=session
-        )
+        dag_run = self.dag_maker.create_dagrun(run_id=f"k8s_decorator_test_{DEFAULT_DATE.date()}")
         ti = dag_run.get_task_instance(task.operator.task_id, session=session)
         return_val = task.operator.execute(context=ti.get_template_context(session=session))
 
@@ -153,7 +151,7 @@ class TestKubernetesDecoratorsCommons(TestKubernetesDecoratorsBase):
     def test_k8s_decorator_init(self, task_decorator, decorator_name):
         """Test the initialization of the @task.kubernetes[_cmd] decorated task."""
 
-        with self.dag:
+        with self.dag_maker:
 
             @task_decorator(
                 image="python:3.10-slim-buster",
@@ -174,7 +172,7 @@ class TestKubernetesDecoratorsCommons(TestKubernetesDecoratorsBase):
 
     def test_decorators_with_marked_as_setup(self, task_decorator, decorator_name):
         """Test the @task.kubernetes[_cmd] decorated task works with setup decorator."""
-        with self.dag:
+        with self.dag_maker:
             task_function_name = setup(_prepare_task(task_decorator, decorator_name))
             task_function_name()
 
@@ -184,7 +182,7 @@ class TestKubernetesDecoratorsCommons(TestKubernetesDecoratorsBase):
 
     def test_decorators_with_marked_as_teardown(self, task_decorator, decorator_name):
         """Test the @task.kubernetes[_cmd] decorated task works with teardown decorator."""
-        with self.dag:
+        with self.dag_maker:
             task_function_name = teardown(_prepare_task(task_decorator, decorator_name))
             task_function_name()
 
@@ -229,7 +227,7 @@ class TestKubernetesDecoratorsCommons(TestKubernetesDecoratorsBase):
             **extra_kwargs,
         }
 
-        with self.dag:
+        with self.dag_maker:
             task_function_name = _prepare_task(
                 task_decorator,
                 decorator_name,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -36,7 +36,6 @@ from airflow.exceptions import (
     TaskDeferred,
 )
 from airflow.models import DAG, DagModel, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.cncf.kubernetes import pod_generator
 from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
@@ -48,19 +47,20 @@ from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction, PodLoggingStatus, PodPhase
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils import timezone
-
-if TYPE_CHECKING:
-    from airflow.utils.context import Context
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.models.xcom import XComModel as XCom
 else:
     from airflow.models.xcom import XCom  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 pytestmark = pytest.mark.db_test
 
@@ -113,16 +113,7 @@ def create_context(task, persist_to_db=False, map_index=None):
         dag.add_task(task)
     now = timezone.utcnow()
     if AIRFLOW_V_3_0_PLUS:
-        with create_session() as session:
-            from airflow.models.dagbundle import DagBundleModel
-
-            bundle_name = "testing"
-            session.add(DagBundleModel(name=bundle_name))
-            session.flush()
-            session.add(DagModel(dag_id=dag.dag_id, bundle_name=bundle_name))
-            session.commit()
-        dag.sync_to_db()
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
+        sync_dag_to_db(dag)
         dag_run = DagRun(
             run_id=DagRun.generate_run_id(
                 run_type=DagRunType.MANUAL, logical_date=DEFAULT_DATE, run_after=DEFAULT_DATE

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -27,9 +27,8 @@ from flask_appbuilder import BaseView
 from flask_appbuilder.api import expose
 
 from airflow.exceptions import AirflowException, TaskInstanceNotFound
-from airflow.models.dag import DAG, clear_task_instances
 from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
+from airflow.models.taskinstance import TaskInstance, TaskInstanceKey, clear_task_instances
 from airflow.plugins_manager import AirflowPlugin
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS, BaseOperatorLink, TaskGroup, XCom
@@ -89,7 +88,7 @@ def get_databricks_task_ids(
 if not AIRFLOW_V_3_0_PLUS:
     from airflow.utils.session import NEW_SESSION, provide_session
 
-    def _get_dag(dag_id: str, session: Session) -> DAG:
+    def _get_dag(dag_id: str, session: Session):
         from airflow.models.serialized_dag import SerializedDagModel
 
         dag = SerializedDagModel.get_dag(dag_id, session=session)
@@ -97,7 +96,7 @@ if not AIRFLOW_V_3_0_PLUS:
             raise AirflowException("Dag not found.")
         return dag
 
-    def _get_dagrun(dag: DAG, run_id: str, session: Session) -> DagRun:
+    def _get_dagrun(dag, run_id: str, session: Session) -> DagRun:
         """
         Retrieve the DagRun object associated with the specified DAG and run_id.
 

--- a/providers/docker/tests/unit/docker/decorators/test_docker.py
+++ b/providers/docker/tests/unit/docker/decorators/test_docker.py
@@ -22,19 +22,23 @@ from io import StringIO as StringBuffer
 
 import pytest
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import setup, task, teardown
-else:
-    from airflow.decorators import setup, task, teardown  # type: ignore[attr-defined,no-redef]
 from airflow.exceptions import AirflowException
 from airflow.models import TaskInstance
-from airflow.models.dag import DAG
-from airflow.utils import timezone
 from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import DAG, setup, task, teardown
+else:
+    from airflow.decorators import setup, task, teardown  # type: ignore[attr-defined,no-redef]
+    from airflow.models import DAG  # type: ignore[attr-defined,no-redef]
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import timezone
+else:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 DEFAULT_DATE = timezone.datetime(2021, 9, 1)
 DILL_INSTALLED = find_spec("dill") is not None

--- a/providers/edge3/src/airflow/providers/edge3/example_dags/integration_test.py
+++ b/providers/edge3/src/airflow/providers/edge3/example_dags/integration_test.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     # Airflow 2.10 compat
     from airflow.decorators import task, task_group  # type: ignore[attr-defined,no-redef]
-    from airflow.models.dag import DAG  # type: ignore[assignment]
+    from airflow.models.dag import DAG  # type: ignore[no-redef]
     from airflow.models.param import Param  # type: ignore[no-redef]
     from airflow.models.variable import Variable
     from airflow.operators.bash import BashOperator  # type: ignore[no-redef]

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -41,16 +41,22 @@ from elasticsearch.exceptions import NotFoundError
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models.dagrun import DagRun
-from airflow.providers.elasticsearch.log.es_json_formatter import (
-    ElasticsearchJSONFormatter,
-)
+from airflow.providers.elasticsearch.log.es_json_formatter import ElasticsearchJSONFormatter
 from airflow.providers.elasticsearch.log.es_response import ElasticSearchResponse, Hit
-from airflow.providers.elasticsearch.version_compat import AIRFLOW_V_3_0_PLUS, EsLogMsgType
-from airflow.utils import timezone
+from airflow.providers.elasticsearch.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
+    EsLogMsgType,
+)
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin, LoggingMixin
 from airflow.utils.module_loading import import_string
 from airflow.utils.session import create_session
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import timezone
+else:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -235,29 +241,17 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             if USE_PER_RUN_LOG_ID:
                 log_id_template = dag_run.get_log_template(session=session).elasticsearch_id
 
-        if TYPE_CHECKING:
-            assert ti.task
-        try:
-            dag = ti.task.dag
-        except AttributeError:  # ti.task is not always set.
-            data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
-        else:
-            if TYPE_CHECKING:
-                assert dag is not None
-            # TODO: Task-SDK: Where should this function be?
-            data_interval = dag.get_run_data_interval(dag_run)  # type: ignore[attr-defined]
-
         if self.json_format:
-            data_interval_start = self._clean_date(data_interval[0])
-            data_interval_end = self._clean_date(data_interval[1])
+            data_interval_start = self._clean_date(dag_run.data_interval_start)
+            data_interval_end = self._clean_date(dag_run.data_interval_end)
             logical_date = self._clean_date(dag_run.logical_date)
         else:
-            if data_interval[0]:
-                data_interval_start = data_interval[0].isoformat()
+            if dag_run.data_interval_start:
+                data_interval_start = dag_run.data_interval_start.isoformat()
             else:
                 data_interval_start = ""
-            if data_interval[1]:
-                data_interval_end = data_interval[1].isoformat()
+            if dag_run.data_interval_end:
+                data_interval_end = dag_run.data_interval_end.isoformat()
             else:
                 data_interval_end = ""
             logical_date = dag_run.logical_date.isoformat()

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -43,6 +43,7 @@ with suppress(ImportError):
     )
 
 from tests_common.test_utils.compat import ignore_provider_compatibility_error
+from tests_common.test_utils.dag import sync_dag_to_db
 
 with ignore_provider_compatibility_error("2.9.0+", __file__):
     from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
@@ -764,10 +765,16 @@ class TestFabAuthManager:
     ):
         with dag_maker("test_dag1"):
             EmptyOperator(task_id="task1")
+        if AIRFLOW_V_3_1_PLUS:
+            sync_dag_to_db(dag_maker.dag)
         with dag_maker("test_dag2"):
             EmptyOperator(task_id="task1")
+        if AIRFLOW_V_3_1_PLUS:
+            sync_dag_to_db(dag_maker.dag)
         with dag_maker("Connections"):
             EmptyOperator(task_id="task1")
+        if AIRFLOW_V_3_1_PLUS:
+            sync_dag_to_db(dag_maker.dag)
 
         auth_manager_with_appbuilder.security_manager.sync_perm_for_dag("test_dag1")
         auth_manager_with_appbuilder.security_manager.sync_perm_for_dag("test_dag2")

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -43,6 +43,7 @@ from airflow.utils.state import DagRunState, State
 
 from tests_common.test_utils.compat import EmptyOperator, PythonOperator
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import create_scheduler_dag
 from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
@@ -199,7 +200,7 @@ class TestOpenLineageListenerAirflow2:
         )
         t = PythonOperator(task_id=f"test_task_{scenario_name}", dag=dag, python_callable=python_callable)
         run_id = str(uuid.uuid1())
-        dagrun = dag.create_dagrun(
+        dagrun = create_scheduler_dag(dag).create_dagrun(
             run_id=run_id,
             data_interval=(date, date),
             run_type=types.DagRunType.MANUAL,
@@ -1059,7 +1060,7 @@ class TestOpenLineageListenerAirflow3:
             "triggered_by": types.DagRunTriggeredByType.TEST,
         }
 
-        dagrun = dag.create_dagrun(
+        dagrun = create_scheduler_dag(dag).create_dagrun(
             run_id=run_id,
             data_interval=(date, date),
             start_date=date,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -20,7 +20,7 @@ import datetime
 import json
 import uuid
 from json import JSONEncoder
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,7 +28,6 @@ from attrs import define
 from openlineage.client.utils import RedactMixin
 from pkg_resources import parse_version
 
-from airflow.models import DAG, DagModel
 from airflow.providers.common.compat.assets import Asset
 from airflow.providers.openlineage.plugins.facets import AirflowDebugRunFacet
 from airflow.providers.openlineage.utils.utils import (
@@ -44,28 +43,32 @@ from airflow.providers.openlineage.utils.utils import (
     is_operator_disabled,
 )
 from airflow.serialization.enums import DagAttributeTypes, Encoding
-from airflow.utils import timezone  # type:ignore[attr-defined]
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.compat import (
     BashOperator,
 )
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.models.dag import get_next_data_interval
+    from airflow.sdk import timezone
+else:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk._shared.secrets_masker import _secrets_masker
+elif AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk.execution_time.secrets_masker import _secrets_masker  # type: ignore[no-redef]
+else:
+    from airflow.utils.log.secrets_masker import _secrets_masker  # type: ignore[attr-defined,no-redef]
 
 if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import DAG
     from airflow.utils.types import DagRunTriggeredByType
-
-if TYPE_CHECKING:
-    from airflow.sdk.execution_time.secrets_masker import _secrets_masker
 else:
-    try:
-        from airflow.sdk._shared.secrets_masker import _secrets_masker
-    except ImportError:
-        try:
-            from airflow.sdk.execution_time.secrets_masker import _secrets_masker
-        except ImportError:
-            from airflow.utils.log.secrets_masker import _secrets_masker
+    from airflow import DAG
 
 
 class SafeStrDict(dict):
@@ -102,16 +105,19 @@ def test_get_airflow_debug_facet_logging_set_to_debug(mock_debug_mode, mock_get_
 
 
 @pytest.mark.db_test
+@pytest.mark.need_serialized_dag
 def test_get_dagrun_start_end(dag_maker):
     start_date = datetime.datetime(2022, 1, 1)
     end_date = datetime.datetime(2022, 1, 1, hour=2)
     with dag_maker("test", start_date=start_date, end_date=end_date, schedule="@once") as dag:
         pass
     dag_maker.sync_dagbag_to_db()
-    dag_model = DagModel.get_dagmodel(dag.dag_id)
 
     run_id = str(uuid.uuid1())
-    data_interval = dag.get_next_data_interval(dag_model)
+    if AIRFLOW_V_3_1_PLUS:
+        data_interval = get_next_data_interval(dag.timetable, dag_maker.dag_model)
+    else:
+        data_interval = dag.get_next_data_interval(dag_maker.dag_model)
     if AIRFLOW_V_3_0_PLUS:
         dagrun_kwargs = {
             "logical_date": data_interval.start,

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -298,29 +298,17 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
             if USE_PER_RUN_LOG_ID:
                 log_id_template = dag_run.get_log_template(session=session).elasticsearch_id
 
-        if TYPE_CHECKING:
-            assert ti.task
-        try:
-            dag = ti.task.dag
-        except AttributeError:  # ti.task is not always set.
-            data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
-        else:
-            if TYPE_CHECKING:
-                assert dag is not None
-            # TODO: Task-SDK: Where should this function be?
-            data_interval = dag.get_run_data_interval(dag_run)  # type: ignore[attr-defined]
-
         if self.json_format:
-            data_interval_start = self._clean_date(data_interval[0])
-            data_interval_end = self._clean_date(data_interval[1])
+            data_interval_start = self._clean_date(dag_run.data_interval_start)
+            data_interval_end = self._clean_date(dag_run.data_interval_end)
             logical_date = self._clean_date(dag_run.logical_date)
         else:
-            if data_interval[0]:
-                data_interval_start = data_interval[0].isoformat()
+            if dag_run.data_interval_start:
+                data_interval_start = dag_run.data_interval_start.isoformat()
             else:
                 data_interval_start = ""
-            if data_interval[1]:
-                data_interval_end = data_interval[1].isoformat()
+            if dag_run.data_interval_end:
+                data_interval_end = dag_run.data_interval_end.isoformat()
             else:
                 data_interval_end = ""
             logical_date = dag_run.logical_date.isoformat()

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -22,21 +22,31 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models import DagRun, TaskInstance
 from airflow.providers.redis.log.redis_task_handler import RedisTaskHandler
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.session import create_session
 from airflow.utils.state import State
-from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.file_task_handler import extract_events
 from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
     get_base_airflow_version_tuple,
 )
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk.timezone import datetime
+else:
+    from airflow.utils.timezone import datetime  # type: ignore[no-redef]
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import DAG
+else:
+    from airflow import DAG
 
 
 class TestRedisTaskHandler:
@@ -72,20 +82,14 @@ class TestRedisTaskHandler:
         dag_run.set_state(State.RUNNING)
         with create_session() as session:
             session.add(dag_run)
-            session.commit()
+            session.flush()
             session.refresh(dag_run)
+            if AIRFLOW_V_3_1_PLUS:
+                sync_dag_to_db(dag, session=session)
 
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.dag_version import DagVersion
-            from airflow.models.dagbundle import DagBundleModel
 
-            bundle_name = "testing"
-            with create_session() as session:
-                orm_dag_bundle = DagBundleModel(name=bundle_name)
-                session.add(orm_dag_bundle)
-                session.commit()
-            DAG.bulk_write_to_db(bundle_name, None, [dag])
-            SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             ti = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
         else:

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -36,12 +36,16 @@ from airflow.providers.snowflake.operators.snowflake import (
     SnowflakeValueCheckOperator,
 )
 from airflow.providers.snowflake.triggers.snowflake_trigger import SnowflakeSqlApiTrigger
-from airflow.utils import timezone
-from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import timezone
+else:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -237,16 +241,8 @@ def create_context(task, dag=None):
     logical_date = timezone.datetime(2022, 1, 1, 1, 0, 0, tzinfo=tzinfo)
     if AIRFLOW_V_3_0_PLUS:
         from airflow.models.dag_version import DagVersion
-        from airflow.models.dagbundle import DagBundleModel
-        from airflow.models.serialized_dag import SerializedDagModel
 
-        bundle_name = "testing"
-        with create_session() as session:
-            orm_dag_bundle = DagBundleModel(name=bundle_name)
-            session.add(orm_dag_bundle)
-            session.commit()
-        DAG.bulk_write_to_db(bundle_name, None, [dag])
-        SerializedDagModel.write_dag(dag, bundle_name=bundle_name)
+        sync_dag_to_db(dag)
         dag_version = DagVersion.get_latest_version(dag.dag_id)
         task_instance = TaskInstance(task=task, run_id="test_run_id", dag_version_id=dag_version.id)
         dag_run = DagRun(
@@ -350,7 +346,10 @@ class TestSnowflakeSqlApiOperator:
         with pytest.raises(AirflowException):
             operator.execute(context=None)
 
-    @pytest.mark.parametrize("mock_sql, statement_count", [(SQL_MULTIPLE_STMTS, 4), (SINGLE_STMT, 1)])
+    @pytest.mark.parametrize(
+        "mock_sql, statement_count",
+        [pytest.param(SQL_MULTIPLE_STMTS, 4, id="multi"), pytest.param(SINGLE_STMT, 1, id="single")],
+    )
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.execute_query")
     def test_snowflake_sql_api_execute_operator_async(
         self, mock_execute_query, mock_sql, statement_count, mock_get_sql_api_query_status

--- a/providers/ssh/tests/unit/ssh/operators/test_ssh.py
+++ b/providers/ssh/tests/unit/ssh/operators/test_ssh.py
@@ -27,17 +27,21 @@ from paramiko.client import SSHClient
 
 from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
 from airflow.models import TaskInstance
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers.ssh.operators.ssh import SSHOperator
-from airflow.utils.timezone import datetime
 from airflow.utils.types import NOTSET
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.models.dag_version import DagVersion
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk.timezone import datetime
+else:
+    from airflow.utils.timezone import datetime  # type: ignore[attr-defined,no-redef]
 
 pytestmark = pytest.mark.db_test
 
@@ -272,8 +276,7 @@ class TestSSHOperator:
             task = SSHOperator(task_id="push_xcom", ssh_hook=self.hook, command=command)
         dr = dag_maker.create_dagrun(run_id="push_xcom")
         if AIRFLOW_V_3_0_PLUS:
-            dag.sync_to_db()
-            SerializedDagModel.write_dag(dag, bundle_name="testing")
+            sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
             ti = TaskInstance(task=task, run_id=dr.run_id, dag_version_id=dag_version.id)
         else:

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -25,16 +25,14 @@ import pytest
 from airflow.exceptions import AirflowException, XComNotFound
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
-
-try:
-    from airflow.sdk import TriggerRule
-except ImportError:
-    # Compatibility for Airflow < 3.1
-    from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
-from airflow.utils import timezone
 from airflow.utils.task_instance_session import set_current_task_instance_session
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_1, AIRFLOW_V_3_0_PLUS, XCOM_RETURN_KEY
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_1,
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
+    XCOM_RETURN_KEY,
+)
 from unit.standard.operators.test_python import BasePythonTest
 
 if AIRFLOW_V_3_0_PLUS:
@@ -42,7 +40,6 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.bases.decorator import DecoratedMappedOperator
     from airflow.sdk.definitions._internal.expandinput import DictOfListsExpandInput
     from airflow.sdk.definitions.mappedoperator import MappedOperator
-
 else:
     from airflow.decorators import (  # type: ignore[attr-defined,no-redef]
         setup,
@@ -51,11 +48,17 @@ else:
     )
     from airflow.decorators.base import DecoratedMappedOperator  # type: ignore[no-redef]
     from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
-    from airflow.models.dag import DAG  # type: ignore[assignment]
+    from airflow.models.dag import DAG  # type: ignore[assignment,no-redef]
     from airflow.models.expandinput import DictOfListsExpandInput
     from airflow.models.mappedoperator import MappedOperator  # type: ignore[assignment,no-redef]
     from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup  # type: ignore[no-redef]
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import TriggerRule, timezone
+else:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
+    from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 pytestmark = pytest.mark.db_test
 

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -50,9 +50,10 @@ from airflow.providers.standard.triggers.external_task import WorkflowTrigger
 from airflow.serialization.serialized_objects import SerializedBaseOperator
 from airflow.timetables.base import DataInterval
 from airflow.utils.session import NEW_SESSION, provide_session
-from airflow.utils.state import DagRunState, State, TaskInstanceState
+from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.dag import create_scheduler_dag, sync_dag_to_db, sync_dags_to_db
 from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.mock_operators import MockOperator
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
@@ -1685,7 +1686,7 @@ def run_tasks(
     for dag in dag_bag.dags.values():
         data_interval = DataInterval(coerce_datetime(logical_date), coerce_datetime(logical_date))
         if AIRFLOW_V_3_0_PLUS:
-            runs[dag.dag_id] = dagrun = dag.create_dagrun(
+            runs[dag.dag_id] = dagrun = create_scheduler_dag(dag).create_dagrun(
                 run_id=dag.timetable.generate_run_id(
                     run_type=DagRunType.MANUAL,
                     run_after=logical_date,
@@ -1701,7 +1702,7 @@ def run_tasks(
                 session=session,
             )
         else:
-            runs[dag.dag_id] = dagrun = dag.create_dagrun(  # type: ignore[call-arg]
+            runs[dag.dag_id] = dagrun = dag.create_dagrun(  # type: ignore[attr-defined,call-arg]
                 run_id=dag.timetable.generate_run_id(  # type: ignore[call-arg]
                     run_type=DagRunType.MANUAL,
                     logical_date=logical_date,
@@ -1916,9 +1917,7 @@ def dag_bag_cyclic():
 
         for dag in dags:
             if AIRFLOW_V_3_0_PLUS:
-                dag.sync_to_db()
-                SerializedDagModel.write_dag(dag, bundle_name="testing")
-                dag_bag.bag_dag(dag=dag)
+                dag_bag.bag_dag(dag=sync_dag_to_db(dag))
             else:
                 dag_bag.bag_dag(dag=dag, root_dag=dag)  # type: ignore[call-arg]
 
@@ -1993,32 +1992,9 @@ def dag_bag_multiple(session):
         begin >> task
 
     if AIRFLOW_V_3_0_PLUS:
-        from airflow.models.dagbundle import DagBundleModel
-
-        bundle_name = "abcbunhdlerch3rc"
-        session.merge(DagBundleModel(name=bundle_name))
-        session.flush()
-        DAG.bulk_write_to_db(bundle_name=bundle_name, dags=[daily_dag, agg_dag], bundle_version=None)
-        SerializedDagModel.write_dag(dag=daily_dag, bundle_name=bundle_name)
-        SerializedDagModel.write_dag(dag=agg_dag, bundle_name=bundle_name)
+        sync_dags_to_db([agg_dag, daily_dag])
 
     return dag_bag
-
-
-def test_clear_multiple_external_task_marker(dag_bag_multiple):
-    """
-    Test clearing a dag that has multiple ExternalTaskMarker.
-    """
-    agg_dag = dag_bag_multiple.get_dag("agg_dag")
-    _, tis = run_tasks(dag_bag_multiple, logical_date=DEFAULT_DATE)
-    session = settings.Session()
-    try:
-        qry = session.query(TaskInstance).filter(
-            TaskInstance.state.is_(None), TaskInstance.dag_id.in_(dag_bag_multiple.dag_ids)
-        )
-        assert agg_dag.clear(dag_bag=dag_bag_multiple) == len(tis) == qry.count() == 10
-    finally:
-        session.close()
 
 
 @pytest.fixture
@@ -2058,101 +2034,16 @@ def dag_bag_head_tail(session):
         head >> body >> tail
 
     if AIRFLOW_V_3_0_PLUS:
-        from airflow.models.dagbundle import DagBundleModel
-
-        dag_bag.bag_dag(dag=dag)
-        bundle_name = "9e8uh9odhu9c"
-        session.merge(DagBundleModel(name=bundle_name))
-        session.flush()
-        DAG.bulk_write_to_db(bundle_name=bundle_name, dags=[dag], bundle_version=None)
-        SerializedDagModel.write_dag(dag=dag, bundle_name=bundle_name)
+        dag_bag.bag_dag(dag)
+        sync_dag_to_db(dag)
     else:
         dag_bag.bag_dag(dag=dag, root_dag=dag)
 
     return dag_bag
 
 
-@provide_session
-def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
-    dag: DAG = dag_bag_head_tail.get_dag("head_tail")
-    dag.sync_to_db()
-    if AIRFLOW_V_3_0_PLUS:
-        SerializedDagModel.write_dag(dag, bundle_name="testing")
-
-    # "Run" 10 times.
-    for delta in range(10):
-        logical_date = DEFAULT_DATE + timedelta(days=delta)
-        dagrun = DagRun(
-            dag_id=dag.dag_id,
-            start_date=logical_date,
-            state=DagRunState.SUCCESS,
-            run_type=DagRunType.MANUAL,
-            run_id=f"test_{delta}",
-        )
-        if AIRFLOW_V_3_0_PLUS:
-            dagrun.logical_date = logical_date
-        else:
-            dagrun.execution_date = logical_date
-        session.add(dagrun)
-        for task in dag.tasks:
-            if AIRFLOW_V_3_0_PLUS:
-                dag_version = DagVersion.get_latest_version(task.dag_id, session=session)
-                ti = TaskInstance(task=task, dag_version_id=dag_version.id)
-
-            else:
-                ti = TaskInstance(task=task)
-            dagrun.task_instances.append(ti)
-            ti.state = TaskInstanceState.SUCCESS
-    session.flush()
-
-    assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 30
-
-
-def test_clear_overlapping_external_task_marker_with_end_date(dag_bag_head_tail, session):
-    dag: DAG = dag_bag_head_tail.get_dag("head_tail")
-    dag.sync_to_db()
-    if AIRFLOW_V_3_0_PLUS:
-        SerializedDagModel.write_dag(dag=dag, bundle_name="testing")
-
-    # "Run" 10 times.
-    for delta in range(10):
-        logical_date = DEFAULT_DATE + timedelta(days=delta)
-        dagrun = DagRun(
-            dag_id=dag.dag_id,
-            start_date=logical_date,
-            state=DagRunState.SUCCESS,
-            run_type=DagRunType.MANUAL,
-            run_id=f"test_{delta}",
-        )
-        if AIRFLOW_V_3_0_PLUS:
-            dagrun.logical_date = logical_date
-        else:
-            dagrun.execution_date = logical_date
-        session.add(dagrun)
-
-        for task in dag.tasks:
-            if AIRFLOW_V_3_0_PLUS:
-                dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
-                ti = TaskInstance(task=task, dag_version_id=dag_version.id)
-            else:
-                ti = TaskInstance(task=task)
-            dagrun.task_instances.append(ti)
-            ti.state = TaskInstanceState.SUCCESS
-    session.flush()
-
-    assert (
-        dag.clear(
-            start_date=DEFAULT_DATE,
-            end_date=logical_date,
-            dag_bag=dag_bag_head_tail,
-            session=session,
-        )
-        == 30
-    )
-
-
 @pytest.fixture
-def dag_bag_head_tail_mapped_tasks():
+def dag_bag_head_tail_mapped_tasks(session):
     """
     Create a DagBag containing one DAG, with task "head" depending on task "tail" of the
     previous logical_date.
@@ -2194,79 +2085,8 @@ def dag_bag_head_tail_mapped_tasks():
         head >> body >> tail
 
     if AIRFLOW_V_3_0_PLUS:
-        dag.sync_to_db()
-        dag_bag.bag_dag(dag=dag)
+        sync_dag_to_db(dag)
     else:
         dag_bag.bag_dag(dag=dag, root_dag=dag)
 
     return dag_bag
-
-
-def test_clear_overlapping_external_task_marker_mapped_tasks(dag_bag_head_tail_mapped_tasks, session):
-    dag: DAG = dag_bag_head_tail_mapped_tasks.get_dag("head_tail")
-    dag.sync_to_db()
-    if AIRFLOW_V_3_0_PLUS:
-        SerializedDagModel.write_dag(dag=dag, bundle_name="testing")
-    # "Run" 10 times.
-    for delta in range(10):
-        logical_date = DEFAULT_DATE + timedelta(days=delta)
-        dagrun = DagRun(
-            dag_id=dag.dag_id,
-            start_date=logical_date,
-            state=DagRunState.SUCCESS,
-            run_type=DagRunType.MANUAL,
-            run_id=f"test_{delta}",
-        )
-        if AIRFLOW_V_3_0_PLUS:
-            dagrun.logical_date = logical_date
-        else:
-            dagrun.execution_date = logical_date
-        session.add(dagrun)
-        for task in dag.tasks:
-            if task.task_id == "dummy_task":
-                for map_index in range(5):
-                    if AIRFLOW_V_3_0_PLUS:
-                        dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
-                        ti = TaskInstance(
-                            task=task,
-                            run_id=dagrun.run_id,
-                            map_index=map_index,
-                            dag_version_id=dag_version.id,
-                        )
-                    else:
-                        ti = TaskInstance(task=task, run_id=dagrun.run_id, map_index=map_index)
-                    ti.state = TaskInstanceState.SUCCESS
-                    dagrun.task_instances.append(ti)
-            else:
-                if AIRFLOW_V_3_0_PLUS:
-                    dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
-                    ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dag_version.id)
-                else:
-                    ti = TaskInstance(task=task, run_id=dagrun.run_id)
-                ti.state = TaskInstanceState.SUCCESS
-                dagrun.task_instances.append(ti)
-    session.flush()
-    if AIRFLOW_V_3_0_PLUS:
-        dag = dag.partial_subset(
-            task_ids=["head"],
-            include_downstream=True,
-            include_upstream=False,
-        )
-    else:
-        dag = dag.partial_subset(
-            task_ids_or_regex=["head"],
-            include_downstream=True,
-            include_upstream=False,
-        )
-
-    task_ids = list(dag.task_dict)
-    assert (
-        dag.clear(
-            start_date=DEFAULT_DATE,
-            end_date=DEFAULT_DATE,
-            dag_bag=dag_bag_head_tail_mapped_tasks,
-            session=session,
-            task_ids=task_ids,
-        )
-        == 70
-    )

--- a/providers/standard/tests/unit/standard/sensors/test_time_delta.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time_delta.py
@@ -82,15 +82,15 @@ def test_timedelta_sensor_run_after_vs_interval(run_after, interval_end, dag_mak
     if interval_end:
         context["data_interval_end"] = interval_end
     delta = timedelta(seconds=1)
-    with dag_maker() as dag:
-        op = TimeDeltaSensor(task_id="wait_sensor_check", delta=delta, dag=dag, mode="reschedule")
+    with dag_maker():
+        op = TimeDeltaSensor(task_id="wait_sensor_check", delta=delta, mode="reschedule")
 
     kwargs = {}
     if AIRFLOW_V_3_0_PLUS:
         from airflow.utils.types import DagRunTriggeredByType
 
         kwargs.update(triggered_by=DagRunTriggeredByType.TEST, run_after=run_after)
-    dr = dag.create_dagrun(
+    dr = dag_maker.create_dagrun(
         run_id="abcrhroceuh",
         run_type=DagRunType.MANUAL,
         state=None,
@@ -120,7 +120,7 @@ def test_timedelta_sensor_deferrable_run_after_vs_interval(run_after, interval_e
     if interval_end:
         context["data_interval_end"] = interval_end
 
-    with dag_maker() as dag:
+    with dag_maker():
         kwargs = {}
         if AIRFLOW_V_3_0_PLUS:
             from airflow.utils.types import DagRunTriggeredByType
@@ -131,11 +131,10 @@ def test_timedelta_sensor_deferrable_run_after_vs_interval(run_after, interval_e
         sensor = TimeDeltaSensor(
             task_id="timedelta_sensor_deferrable",
             delta=delta,
-            dag=dag,
             deferrable=True,  # <-- the feature under test
         )
 
-    dr = dag.create_dagrun(
+    dr = dag_maker.create_dagrun(
         run_id="abcrhroceuh",
         run_type=DagRunType.MANUAL,
         state=None,
@@ -222,7 +221,7 @@ class TestTimeDeltaSensorAsync:
 
             kwargs.update(triggered_by=DagRunTriggeredByType.TEST, run_after=run_after)
 
-        dr = dag.create_dagrun(
+        dr = dag_maker.create_dagrun(
             run_id="abcrhroceuh",
             run_type=DagRunType.MANUAL,
             state=None,

--- a/providers/standard/tests/unit/standard/utils/test_sensor_helper.py
+++ b/providers/standard/tests/unit/standard/utils/test_sensor_helper.py
@@ -33,18 +33,21 @@ from airflow.providers.standard.utils.sensor_helper import (
     _get_count,
     _get_external_task_group_task_ids,
 )
-from airflow.utils import timezone
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
+from tests_common.test_utils.dag import create_scheduler_dag
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 try:
     from airflow.sdk.definitions.taskgroup import TaskGroup
-except ImportError:
-    # Fallback for Airflow < 3.1
+except ImportError:  # Fallback for Airflow < 3.1
     from airflow.utils.task_group import TaskGroup  # type: ignore[no-redef]
+try:
+    from airflow.sdk import timezone
+except ImportError:  # Fallback for Airflow < 3.1
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
@@ -92,7 +95,7 @@ class TestSensorHelper:
         execution_date = pendulum.instance(execution_date or now)
         run_type = DagRunType.MANUAL
         data_interval = dag.timetable.infer_manual_data_interval(run_after=execution_date)
-        dag_run = dag.create_dagrun(
+        dag_run = create_scheduler_dag(dag).create_dagrun(
             run_id=dag.timetable.generate_run_id(
                 run_type=run_type,
                 run_after=execution_date,

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -93,7 +93,7 @@ __all__ = [
 DagStateChangeCallback = Callable[[Context], None]
 ScheduleInterval = None | str | timedelta | relativedelta
 
-ScheduleArg = ScheduleInterval | Timetable | BaseAsset | Collection[BaseAsset]
+ScheduleArg: TypeAlias = ScheduleInterval | Timetable | BaseAsset | Collection[BaseAsset]
 
 
 _DAG_HASH_ATTRS = frozenset(
@@ -135,10 +135,16 @@ def _create_timetable(interval: ScheduleInterval, timezone: Timezone | FixedTime
     raise ValueError(f"{interval!r} is not a valid schedule.")
 
 
-def _config_bool_factory(section: str, key: str):
+def _config_bool_factory(section: str, key: str) -> Callable[[], bool]:
     from airflow.configuration import conf
 
     return functools.partial(conf.getboolean, section, key)
+
+
+def _config_int_factory(section: str, key: str) -> Callable[[], int]:
+    from airflow.configuration import conf
+
+    return functools.partial(conf.getint, section, key)
 
 
 def _convert_params(val: abc.MutableMapping | None, self_: DAG) -> ParamsDict:
@@ -170,10 +176,18 @@ def _convert_tags(tags: Collection[str] | None) -> MutableSet[str]:
     return set(tags or [])
 
 
-def _convert_access_control(value, self_: DAG):
-    if hasattr(self_, "_upgrade_outdated_dag_access_control"):
-        return self_._upgrade_outdated_dag_access_control(value)
-    return value
+def _convert_access_control(access_control):
+    if access_control is None:
+        return None
+    updated_access_control = {}
+    for role, perms in access_control.items():
+        updated_access_control[role] = updated_access_control.get(role, {})
+        if isinstance(perms, (set, list)):
+            # Support for old-style access_control where only the actions are specified
+            updated_access_control[role]["DAGs"] = set(perms)
+        else:
+            updated_access_control[role] = perms
+    return updated_access_control
 
 
 def _convert_doc_md(doc_md: str | None) -> str | None:
@@ -398,9 +412,33 @@ class DAG:
     template_undefined: type[jinja2.StrictUndefined] = jinja2.StrictUndefined
     user_defined_macros: dict | None = None
     user_defined_filters: dict | None = None
-    max_active_tasks: int = attrs.field(default=16, validator=attrs.validators.instance_of(int))
-    max_active_runs: int = attrs.field(default=16, validator=attrs.validators.instance_of(int))
-    max_consecutive_failed_dag_runs: int = attrs.field(default=0, validator=attrs.validators.instance_of(int))
+    max_active_tasks: int = attrs.field(
+        factory=_config_int_factory("core", "max_active_tasks_per_dag"),
+        converter=attrs.converters.default_if_none(  # type: ignore[misc]
+            # attrs only supports named callables or lambdas, but partial works
+            # OK here too. This is a false positive from attrs's Mypy plugin.
+            factory=_config_int_factory("core", "max_active_tasks_per_dag"),
+        ),
+        validator=attrs.validators.instance_of(int),
+    )
+    max_active_runs: int = attrs.field(
+        factory=_config_int_factory("core", "max_active_runs_per_dag"),
+        converter=attrs.converters.default_if_none(  # type: ignore[misc]
+            # attrs only supports named callables or lambdas, but partial works
+            # OK here too. This is a false positive from attrs's Mypy plugin.
+            factory=_config_int_factory("core", "max_active_runs_per_dag"),
+        ),
+        validator=attrs.validators.instance_of(int),
+    )
+    max_consecutive_failed_dag_runs: int = attrs.field(
+        factory=_config_int_factory("core", "max_consecutive_failed_dag_runs_per_dag"),
+        converter=attrs.converters.default_if_none(  # type: ignore[misc]
+            # attrs only supports named callables or lambdas, but partial works
+            # OK here too. This is a false positive from attrs's Mypy plugin.
+            factory=_config_int_factory("core", "max_consecutive_failed_dag_runs_per_dag"),
+        ),
+        validator=attrs.validators.instance_of(int),
+    )
     dagrun_timeout: timedelta | None = attrs.field(
         default=None,
         validator=attrs.validators.optional(attrs.validators.instance_of(timedelta)),
@@ -423,7 +461,7 @@ class DAG:
     )
     access_control: dict[str, dict[str, Collection[str]]] | None = attrs.field(
         default=None,
-        converter=attrs.Converter(_convert_access_control, takes_self=True),  # type: ignore[misc, call-overload]
+        converter=attrs.Converter(_convert_access_control),  # type: ignore[misc, call-overload]
     )
     is_paused_upon_creation: bool | None = None
     jinja_environment_kwargs: dict | None = None
@@ -454,6 +492,12 @@ class DAG:
     disable_bundle_versioning: bool = attrs.field(
         factory=_config_bool_factory("dag_processor", "disable_bundle_versioning")
     )
+
+    # TODO (GH-52141): This is never used in the sdk dag (it only makes sense
+    # after this goes through the dag processor), but various parts of the code
+    # depends on its existence. We should remove this after completely splitting
+    # DAG classes in the SDK and scheduler.
+    last_loaded: datetime | None = attrs.field(init=False, default=None)
 
     def __attrs_post_init__(self):
         from airflow.sdk import timezone
@@ -1097,8 +1141,7 @@ class DAG:
 
         from airflow import settings
         from airflow.configuration import secrets_backend_list
-        from airflow.models.dag import DAG as SchedulerDAG, _get_or_create_dagrun
-        from airflow.models.dagrun import DagRun
+        from airflow.models.dagrun import DagRun, get_or_create_dagrun
         from airflow.sdk import timezone
         from airflow.secrets.local_filesystem import LocalFilesystemBackend
         from airflow.serialization.serialized_objects import SerializedDAG
@@ -1147,7 +1190,7 @@ class DAG:
 
             log.debug("Clearing existing task instances for logical date %s", logical_date)
             # TODO: Replace with calling client.dag_run.clear in Execution API at some point
-            SchedulerDAG.clear_dags(
+            SerializedDAG.clear_dags(
                 dags=[self],
                 start_date=logical_date,
                 end_date=logical_date,
@@ -1170,7 +1213,7 @@ class DAG:
             scheduler_dag.on_success_callback = self.on_success_callback
             scheduler_dag.on_failure_callback = self.on_failure_callback
 
-            dr: DagRun = _get_or_create_dagrun(
+            dr: DagRun = get_or_create_dagrun(
                 dag=scheduler_dag,
                 start_date=logical_date or run_after,
                 logical_date=logical_date,


### PR DESCRIPTION
Execution plan:

* [x] Uses in core → `airflow.serialization.serialized_objects.SerializedDAG`
* [x] Uses anywhere else → Likely `airflow.sdk.DAG` (especially in tests) but case by case
* [ ] Remove SerializedDAG inheritance to `airflow.models.DAG`
* [x] Remove `airflow.models.DAG` altogether