### PR TITLE
To fix Fab auth manager returns get_id of integer type where str is expected 

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/models/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/models/__init__.py
@@ -288,8 +288,8 @@ class User(Model, BaseUser):
                 }
         return self._perms
 
-    def get_id(self):
-        return self.id
+    def get_id(self) -> str:
+        return str(self.id)
 
     def get_name(self) -> str:
         return self.username or self.email or self.user_id

--- a/providers/fab/tests/unit/fab/auth_manager/models/test_user_model.py
+++ b/providers/fab/tests/unit/fab/auth_manager/models/test_user_model.py
@@ -18,34 +18,24 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.providers.fab.auth_manager.models import User
+
 pytestmark = pytest.mark.db_test
 
-try:
-    from airflow.providers.fab.auth_manager.models import User
 
-    class TestUserModelGetId:
-        def test_get_id_returns_str_for_int_id(self, session):
-            """
-            To ensure get_id() always returns a string.
-            This is required because return type str is expected.
-            """
-            user = User()
-            user.id = 999
-            result = user.get_id()
-
-            assert isinstance(result, str), f"Expected str, got {type(result)}"
-            assert result == "999"
-
-        def test_get_id_returns_str_for_str_id(self, session):
-            """
-            If the user id is a string, get_id() should return it without any modification.
-            """
-            user = User()
-            user.id = "999"
-            result = user.get_id()
-
-            assert isinstance(result, str)
-            assert result == "999"
-
-except ModuleNotFoundError:
-    pass
+@pytest.mark.parametrize(
+    "user_id, expected_id",
+    [
+        (999, "999"),
+        ("999", "999"),
+    ],
+)
+def test_get_id_returns_str(user_id: int | str, expected_id: str) -> None:
+    """
+    Ensure get_id() always returns a string representation of the id.
+    """
+    user = User()
+    user.id = user_id
+    result = user.get_id()
+    assert isinstance(result, str), f"Expected str, got {type(result)}"
+    assert result == expected_id

--- a/providers/fab/tests/unit/fab/auth_manager/models/test_user_model.py
+++ b/providers/fab/tests/unit/fab/auth_manager/models/test_user_model.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.db_test
+
+try:
+    from airflow.providers.fab.auth_manager.models import User
+
+    class TestUserModelGetId:
+        def test_get_id_returns_str_for_int_id(self, session):
+            """
+            To ensure get_id() always returns a string.
+            This is required because return type str is expected.
+            """
+            user = User()
+            user.id = 999
+            result = user.get_id()
+
+            assert isinstance(result, str), f"Expected str, got {type(result)}"
+            assert result == "999"
+
+        def test_get_id_returns_str_for_str_id(self, session):
+            """
+            If the user id is a string, get_id() should return it without any modification.
+            """
+            user = User()
+            user.id = "999"
+            result = user.get_id()
+
+            assert isinstance(result, str)
+            assert result == "999"
+
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
This closes Fab auth manager returns get_id of integer type where str is expected  #54298
closes: #54298


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
