### PR TITLE
Alias `dag_display_name` for `DagTagResponse`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_tags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_tags.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from pydantic import AliasPath, Field
+
 from airflow.api_fastapi.core_api.base import BaseModel
 
 
@@ -25,6 +27,7 @@ class DagTagResponse(BaseModel):
 
     name: str
     dag_id: str
+    dag_display_name: str = Field(validation_alias=AliasPath("dag", "dag_display_name"))
 
 
 class DAGTagCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1586,10 +1586,14 @@ components:
         dag_id:
           type: string
           title: Dag Id
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - name
       - dag_id
+      - dag_display_name
       title: DagTagResponse
       description: DAG Tag serializer for responses.
     DagVersionResponse:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9923,10 +9923,14 @@ components:
         dag_id:
           type: string
           title: Dag Id
+        dag_display_name:
+          type: string
+          title: Dag Display Name
       type: object
       required:
       - name
       - dag_id
+      - dag_display_name
       title: DagTagResponse
       description: DAG Tag serializer for responses.
     DagVersionResponse:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2955,10 +2955,14 @@ export const $DagTagResponse = {
         dag_id: {
             type: 'string',
             title: 'Dag Id'
+        },
+        dag_display_name: {
+            type: 'string',
+            title: 'Dag Display Name'
         }
     },
     type: 'object',
-    required: ['name', 'dag_id'],
+    required: ['name', 'dag_id', 'dag_display_name'],
     title: 'DagTagResponse',
     description: 'DAG Tag serializer for responses.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -795,6 +795,7 @@ export type DagStatsStateResponse = {
 export type DagTagResponse = {
     name: string;
     dag_id: string;
+    dag_display_name: string;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -88,10 +88,10 @@ describe("DagCard", () => {
 
   it("DagCard should not show +X more text if there is only +1 over the limit", () => {
     const tags = [
-      { dag_id: "id", name: "tag1" },
-      { dag_id: "id", name: "tag2" },
-      { dag_id: "id", name: "tag3" },
-      { dag_id: "id", name: "tag4" },
+      { dag_display_name: "id", dag_id: "id", name: "tag1" },
+      { dag_display_name: "id", dag_id: "id", name: "tag2" },
+      { dag_display_name: "id", dag_id: "id", name: "tag3" },
+      { dag_display_name: "id", dag_id: "id", name: "tag4" },
     ] satisfies Array<DagTagResponse>;
 
     const expandedMockDag = {
@@ -108,11 +108,11 @@ describe("DagCard", () => {
 
   it("DagCard should show +X more text if there are more than 3 tags", () => {
     const tags = [
-      { dag_id: "id", name: "tag1" },
-      { dag_id: "id", name: "tag2" },
-      { dag_id: "id", name: "tag3" },
-      { dag_id: "id", name: "tag4" },
-      { dag_id: "id", name: "tag5" },
+      { dag_display_name: "id", dag_id: "id", name: "tag1" },
+      { dag_display_name: "id", dag_id: "id", name: "tag2" },
+      { dag_display_name: "id", dag_id: "id", name: "tag3" },
+      { dag_display_name: "id", dag_id: "id", name: "tag4" },
+      { dag_display_name: "id", dag_id: "id", name: "tag5" },
     ] satisfies Array<DagTagResponse>;
 
     const expandedMockDag = {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -317,18 +317,40 @@ class TestPatchDag(TestDagEndpoint):
     """Unit tests for Patch DAG."""
 
     @pytest.mark.parametrize(
-        "query_params, dag_id, body, expected_status_code, expected_is_paused",
+        "query_params, dag_id, body, expected_status_code, expected_is_paused, expected_tags",
         [
-            ({}, "fake_dag_id", {"is_paused": True}, 404, None),
-            ({"update_mask": ["field_1", "is_paused"]}, DAG1_ID, {"is_paused": True}, 400, None),
-            ({}, DAG1_ID, {"is_paused": True}, 200, True),
-            ({}, DAG1_ID, {"is_paused": False}, 200, False),
-            ({"update_mask": ["is_paused"]}, DAG1_ID, {"is_paused": True}, 200, True),
-            ({"update_mask": ["is_paused"]}, DAG1_ID, {"is_paused": False}, 200, False),
+            ({}, "fake_dag_id", {"is_paused": True}, 404, None, []),
+            ({"update_mask": ["field_1", "is_paused"]}, DAG1_ID, {"is_paused": True}, 400, None, []),
+            ({}, DAG1_ID, {"is_paused": True}, 200, True, ["example", "tag_2"]),
+            ({}, DAG1_ID, {"is_paused": False}, 200, False, ["example", "tag_2"]),
+            (
+                {"update_mask": ["is_paused"]},
+                DAG1_ID,
+                {"is_paused": True},
+                200,
+                True,
+                ["example", "tag_2"],
+            ),
+            (
+                {"update_mask": ["is_paused"]},
+                DAG1_ID,
+                {"is_paused": False},
+                200,
+                False,
+                ["example", "tag_2"],
+            ),
         ],
     )
     def test_patch_dag(
-        self, test_client, query_params, dag_id, body, expected_status_code, expected_is_paused, session
+        self,
+        test_client,
+        query_params,
+        dag_id,
+        body,
+        expected_status_code,
+        expected_is_paused,
+        expected_tags,
+        session,
     ):
         response = test_client.patch(f"/dags/{dag_id}", json=body, params=query_params)
 
@@ -337,6 +359,13 @@ class TestPatchDag(TestDagEndpoint):
             body = response.json()
             assert body["is_paused"] == expected_is_paused
             check_last_log(session, dag_id=dag_id, event="patch_dag", logical_date=None)
+
+            tags = body.get("tags", [])
+            assert len(tags) == len(expected_tags)
+
+            for tag in tags:
+                assert tag["name"] in expected_tags
+                assert tag["dag_id"] == dag_id
 
     def test_patch_dag_should_response_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.patch(f"/dags/{DAG1_ID}", json={"is_paused": True})
@@ -716,13 +745,15 @@ class TestGetDag(TestDagEndpoint):
     """Unit tests for Get DAG."""
 
     @pytest.mark.parametrize(
-        "query_params, dag_id, expected_status_code, dag_display_name",
+        "query_params, dag_id, expected_status_code, dag_display_name, expected_tags",
         [
-            ({}, "fake_dag_id", 404, "fake_dag"),
-            ({}, DAG2_ID, 200, DAG2_ID),
+            ({}, "fake_dag_id", 404, "fake_dag", []),
+            ({}, DAG2_ID, 200, DAG2_ID, []),
         ],
     )
-    def test_get_dag(self, test_client, query_params, dag_id, expected_status_code, dag_display_name):
+    def test_get_dag(
+        self, test_client, query_params, dag_id, expected_status_code, dag_display_name, expected_tags
+    ):
         response = test_client.get(f"/dags/{dag_id}", params=query_params)
         assert response.status_code == expected_status_code
         if expected_status_code != 200:
@@ -732,6 +763,15 @@ class TestGetDag(TestDagEndpoint):
         res_json = response.json()
         last_parsed_time = res_json["last_parsed_time"]
         file_token = res_json["file_token"]
+        tags = res_json.get("tags", [])
+
+        assert len(tags) == len(expected_tags)
+
+        for tag in tags:
+            assert tag["name"] in expected_tags
+            assert tag["dag_id"] == dag_id
+            assert tag["dag_display_name"] == dag_display_name
+
         expected = {
             "dag_id": dag_id,
             "dag_display_name": dag_display_name,
@@ -742,7 +782,7 @@ class TestGetDag(TestDagEndpoint):
             "is_stale": False,
             "owners": ["airflow"],
             "timetable_summary": None,
-            "tags": [],
+            "tags": tags,
             "has_task_concurrency_limits": True,
             "next_dagrun_data_interval_start": None,
             "next_dagrun_data_interval_end": None,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -317,12 +317,20 @@ class TestPatchDag(TestDagEndpoint):
     """Unit tests for Patch DAG."""
 
     @pytest.mark.parametrize(
-        "query_params, dag_id, body, expected_status_code, expected_is_paused, expected_tags",
+        "query_params, dag_id, body, expected_status_code, expected_is_paused, expected_tags, expected_display_name",
         [
-            ({}, "fake_dag_id", {"is_paused": True}, 404, None, []),
-            ({"update_mask": ["field_1", "is_paused"]}, DAG1_ID, {"is_paused": True}, 400, None, []),
-            ({}, DAG1_ID, {"is_paused": True}, 200, True, ["example", "tag_2"]),
-            ({}, DAG1_ID, {"is_paused": False}, 200, False, ["example", "tag_2"]),
+            ({}, "fake_dag_id", {"is_paused": True}, 404, None, [], "fake_dag_display_name"),
+            (
+                {"update_mask": ["field_1", "is_paused"]},
+                DAG1_ID,
+                {"is_paused": True},
+                400,
+                None,
+                [],
+                DAG1_DISPLAY_NAME,
+            ),
+            ({}, DAG1_ID, {"is_paused": True}, 200, True, ["example", "tag_2"], DAG1_DISPLAY_NAME),
+            ({}, DAG1_ID, {"is_paused": False}, 200, False, ["example", "tag_2"], DAG1_DISPLAY_NAME),
             (
                 {"update_mask": ["is_paused"]},
                 DAG1_ID,
@@ -330,6 +338,7 @@ class TestPatchDag(TestDagEndpoint):
                 200,
                 True,
                 ["example", "tag_2"],
+                DAG1_DISPLAY_NAME,
             ),
             (
                 {"update_mask": ["is_paused"]},
@@ -338,6 +347,7 @@ class TestPatchDag(TestDagEndpoint):
                 200,
                 False,
                 ["example", "tag_2"],
+                DAG1_DISPLAY_NAME,
             ),
         ],
     )
@@ -350,6 +360,7 @@ class TestPatchDag(TestDagEndpoint):
         expected_status_code,
         expected_is_paused,
         expected_tags,
+        expected_display_name,
         session,
     ):
         response = test_client.patch(f"/dags/{dag_id}", json=body, params=query_params)
@@ -366,6 +377,7 @@ class TestPatchDag(TestDagEndpoint):
             for tag in tags:
                 assert tag["name"] in expected_tags
                 assert tag["dag_id"] == dag_id
+                assert tag["dag_display_name"] == expected_display_name
 
     def test_patch_dag_should_response_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.patch(f"/dags/{DAG1_ID}", json={"is_paused": True})

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -453,6 +453,7 @@ class DagTagResponse(BaseModel):
 
     name: Annotated[str, Field(title="Name")]
     dag_id: Annotated[str, Field(title="Dag Id")]
+    dag_display_name: Annotated[str, Field(title="Dag Display Name")]
 
 
 class DagVersionResponse(BaseModel):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `dag_display_name` for `DagTagResponse`
- update tests to validate tags

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
