### PR TITLE
[v3-0-test] Bump ruff to 0.12.8 everywhere (#54317)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -409,7 +409,7 @@ repos:
         types_or: [python, pyi]
         args: [--fix]
         require_serial: true
-        additional_dependencies: ['ruff==0.11.13']
+        additional_dependencies: ['ruff==0.12.8']
         exclude: ^airflow-core/tests/unit/dags/test_imports\.py$|^performance/tests/test_.*\.py$
       - id: ruff-format
         name: Run 'ruff format'
@@ -419,7 +419,7 @@ repos:
         types_or: [python, pyi]
         args: []
         require_serial: true
-        additional_dependencies: ['ruff==0.11.13']
+        additional_dependencies: ['ruff==0.12.8']
         exclude: ^airflow-core/tests/unit/dags/test_imports\.py$
       - id: replace-bad-characters
         name: Replace bad characters
@@ -1427,7 +1427,7 @@ repos:
       - id: generate-tasksdk-datamodels
         name: Generate Datamodels for TaskSDK client
         language: python
-        entry: uv run -p 3.12 --no-dev --no-progress --active --group codegen --project apache-airflow-task-sdk --directory task-sdk -s dev/generate_task_sdk_models.py
+        entry: uv run -p 3.12 --no-progress --active --group codegen --project apache-airflow-task-sdk --directory task-sdk -s dev/generate_task_sdk_models.py
         pass_filenames: false
         files: ^airflow-core/src/airflow/api_fastapi/execution_api/.*\.py$
         require_serial: true

--- a/airflow-core/src/airflow/utils/log/logging_mixin.py
+++ b/airflow-core/src/airflow/utils/log/logging_mixin.py
@@ -24,7 +24,7 @@ import re
 import sys
 from io import TextIOBase, UnsupportedOperation
 from logging import Handler, StreamHandler
-from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import IO, TYPE_CHECKING, Any, TypeVar, cast
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -72,9 +72,9 @@ class LoggingMixin:
     # Parent logger used by this class. It should match one of the loggers defined in the
     # `logging_config_class`. By default, this attribute is used to create the final name of the logger, and
     # will prefix the `_logger_name` with a separating dot.
-    _log_config_logger_name: Optional[str] = None  # noqa: UP007
+    _log_config_logger_name: str | None = None
 
-    _logger_name: Optional[str] = None  # noqa: UP007
+    _logger_name: str | None = None
 
     def __init__(self, context=None):
         self._set_context(context)

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "kgb>=7.2.0",
     "requests_mock>=1.11.0",
     "rich>=13.6.0",
-    "ruff==0.11.2",
+    "ruff==0.12.8",
     "semver>=3.0.2",
     "time-machine>=2.13.0",
     "wheel>=0.42.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -623,6 +623,9 @@ ignore = [
     "PT013", # silly rule prohibiting e.g. `from pytest import param`
     "PT011", # pytest.raises() is too broad, set the match parameter
     "PT019", # fixture without value is injected as parameter, use @pytest.mark.usefixtures instead
+    "PT028", # Disabled on 3.0 -- it's not worth backporting this
+    "PT030", # Disabled on 3.0 -- it's not worth backporting this
+    "PT031", # Disabled on 3.0 -- it's not worth backporting this
     # Rules below explicitly set off which could overlap with Ruff's formatter
     # as it recommended by https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     # Except ISC rules

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -135,7 +135,6 @@ codegen = [
     "datamodel-code-generator[http]==0.28.2",
     "openapi-spec-validator>=0.7.1",
     "svcs>=25.1.0",
-    "ruff==0.11.2",
     "rich>=12.4.4",
 ]
 dev = [

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1037,7 +1037,7 @@ class ActivitySubprocess(WatchedSubprocess):
             failed_heartbeats=self.failed_heartbeats,
             ti_id=self.id,
             max_retries=MAX_FAILED_HEARTBEATS,
-            exc_info=True,
+            exc_info=True,  # noqa: LOG014
         )
         # If we've failed to heartbeat too many times, kill the process
         if self.failed_heartbeats >= MAX_FAILED_HEARTBEATS:


### PR DESCRIPTION
(Manual backport of https://github.com/apache/airflow/pull/54317)

Bump ruff to the new version, also remove ruff from task-sdk codegen
because "dev" dependency group that is automatically used when uv sync is run
for development contains "apache-airflow-devel-common" that already has
the ruff dependency. Any discrepancy leads to conflict so likely
better to depend on the ruff version from devel-common everywhere.

(cherry picked from commit 74bdd3a3f03309b182af18b1a3f298ecf3c63659)

Co-authored-by: Jarek Potiuk <jarek@potiuk.com>
