### PR TITLE
Fix clearTaskInstances API: Restore include_past/future support on UI

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -704,7 +704,6 @@ def post_clear_task_instances(
     downstream = body.include_downstream
     upstream = body.include_upstream
 
-    # Improved logic - resolve logical_date for scheduled DAGRun
     if dag_run_id is not None:
         dag_run: DagRun | None = session.scalar(
             select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -716,7 +716,7 @@ def post_clear_task_instances(
         if (past or future) and dag_run.logical_date is None:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
-                "Cannot use include_past or include_future with no logical_date(e.g., manually or asset-triggered).",
+                "Cannot use include_past or include_future with no logical_date(e.g. manually or asset-triggered).",
             )
         body.start_date = dag_run.logical_date if dag_run.logical_date is not None else None
         body.end_date = dag_run.logical_date if dag_run.logical_date is not None else None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -716,7 +716,7 @@ def post_clear_task_instances(
         if (past or future) and dag_run.logical_date is None:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
-                "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None).",
+                "Cannot use include_past or include_future with no logical_date(e.g., manually or asset-triggered).",
             )
         body.start_date = dag_run.logical_date if dag_run.logical_date is not None else None
         body.end_date = dag_run.logical_date if dag_run.logical_date is not None else None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -718,14 +718,10 @@ def post_clear_task_instances(
                 status.HTTP_400_BAD_REQUEST,
                 "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None).",
             )
-
         if past or future:
-            body.start_date = dag_run.logical_date if not past else None
-            body.end_date = dag_run.logical_date if not future else None
             dag_run_id = None  # Use date-based clearing
-        else:
-            body.start_date = dag_run.logical_date
-            body.end_date = dag_run.logical_date
+        body.start_date = dag_run.logical_date
+        body.end_date = dag_run.logical_date
 
     if past:
         body.start_date = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -717,13 +717,13 @@ def post_clear_task_instances(
         if (past or future) and dag_run.logical_date is None:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
-                "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None)."
+                "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None).",
             )
 
         if past or future:
             body.start_date = dag_run.logical_date if not past else None
             body.end_date = dag_run.logical_date if not future else None
-            dag_run_id = None # Use date-based clearing
+            dag_run_id = None  # Use date-based clearing
         else:
             body.start_date = dag_run.logical_date
             body.end_date = dag_run.logical_date
@@ -783,7 +783,6 @@ def post_clear_task_instances(
         task_instances=task_instances,
         total_entries=len(task_instances),
     )
-
 
 
 @task_instances_router.patch(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -718,8 +718,8 @@ def post_clear_task_instances(
                 status.HTTP_400_BAD_REQUEST,
                 "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None).",
             )
-        body.start_date = dag_run.logical_date
-        body.end_date = dag_run.logical_date
+        body.start_date = dag_run.logical_date if dag_run.logical_date is not None else None
+        body.end_date = dag_run.logical_date if dag_run.logical_date is not None else None
 
     if past:
         body.start_date = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -718,8 +718,6 @@ def post_clear_task_instances(
                 status.HTTP_400_BAD_REQUEST,
                 "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None).",
             )
-        if past or future:
-            dag_run_id = None  # Use date-based clearing
         body.start_date = dag_run.logical_date
         body.end_date = dag_run.logical_date
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -2415,7 +2415,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         response = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert response.status_code == 400
         assert (
-            "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None)."
+            "Cannot use include_past or include_future with no logical_date(e.g., manually or asset-triggered)."
             in response.json()["detail"]
         )
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -2480,13 +2480,14 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             "only_failed": True,
             "dag_run_id": "TEST_DAG_RUN_ID_1",
         }
+        a= (
+            DEFAULT_DATETIME_1 + dt.timedelta(days=1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")  # T1
         resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert resp.status_code == 200
         a = resp.json()
         assert resp.json()["total_entries"] == 1
-        assert resp.json()["task_instances"][0]["logical_date"] == (
-            DEFAULT_DATETIME_1 + dt.timedelta(days=1)
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")  # T1
+        assert resp.json()["task_instances"][0]["logical_date"] == '2020-01-02T00:00:00Z' # T1
 
 
     def test_should_respond_401(self, unauthenticated_test_client):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -778,12 +778,12 @@ class TestGetMappedTaskInstances:
             ({"order_by": "map_index", "limit": 100}, list(range(100))),
             ({"order_by": "-map_index", "limit": 100}, list(range(109, 9, -1))),
             (
-                    {"order_by": "state", "limit": 108},
-                    list(range(5, 25)) + list(range(25, 110)) + list(range(3)),
+                {"order_by": "state", "limit": 108},
+                list(range(5, 25)) + list(range(25, 110)) + list(range(3)),
             ),
             (
-                    {"order_by": "-state", "limit": 100},
-                    list(range(5)[::-1]) + list(range(25, 110)[::-1]) + list(range(15, 25)[::-1]),
+                {"order_by": "-state", "limit": 100},
+                list(range(5)[::-1]) + list(range(25, 110)[::-1]) + list(range(15, 25)[::-1]),
             ),
             ({"order_by": "logical_date", "limit": 100}, list(range(100))),
             ({"order_by": "-logical_date", "limit": 100}, list(range(109, 9, -1))),
@@ -1422,37 +1422,37 @@ class TestGetTaskDependencies(TestTaskInstanceEndpoint):
         "state, dependencies",
         [
             (
-                    State.SCHEDULED,
-                    {
-                        "dependencies": [
-                            {
-                                "name": "Logical Date",
-                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
-                                          "before the task's start date 2021-01-01T00:00:00+00:00.",
-                            },
-                            {
-                                "name": "Logical Date",
-                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
-                                          "before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
-                            },
-                        ],
-                    },
+                State.SCHEDULED,
+                {
+                    "dependencies": [
+                        {
+                            "name": "Logical Date",
+                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
+                            "before the task's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                        {
+                            "name": "Logical Date",
+                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
+                            "before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                    ],
+                },
             ),
             (
-                    State.NONE,
-                    {
-                        "dependencies": [
-                            {
-                                "name": "Logical Date",
-                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's start date 2021-01-01T00:00:00+00:00.",
-                            },
-                            {
-                                "name": "Logical Date",
-                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
-                            },
-                            {"name": "Task Instance State", "reason": "Task is in the 'None' state."},
-                        ]
-                    },
+                State.NONE,
+                {
+                    "dependencies": [
+                        {
+                            "name": "Logical Date",
+                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                        {
+                            "name": "Logical Date",
+                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                        {"name": "Task Instance State", "reason": "Task is in the 'None' state."},
+                    ]
+                },
             ),
         ],
     )
@@ -2426,17 +2426,16 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             ("include_future", 2),  # D1 ~
         ],
     )
-    def test_with_dag_run_id_and_past_future_converts_to_date_range(self, test_client, session, flag,
-                                                                    expected):
+    def test_with_dag_run_id_and_past_future_converts_to_date_range(
+        self, test_client, session, flag, expected
+    ):
         dag_id = "example_python_operator"
         task_instances = [
             {"logical_date": DEFAULT_DATETIME_1, "state": State.FAILED},  # D0
             {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1), "state": State.FAILED},  # D1
             {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2), "state": State.FAILED},  # D2
         ]
-        self.create_task_instances(
-            session, dag_id=dag_id, task_instances=task_instances, update_extras=False
-        )
+        self.create_task_instances(session, dag_id=dag_id, task_instances=task_instances, update_extras=False)
         payload = {
             "dry_run": True,
             "only_failed": True,
@@ -2451,14 +2450,12 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         dag_id = "example_python_operator"
         task_instances = [
             {"logical_date": DEFAULT_DATETIME_1 - dt.timedelta(days=1), "state": State.FAILED},  # D0
-            {"logical_date": DEFAULT_DATETIME_1, "state": State.FAILED},  #D1
+            {"logical_date": DEFAULT_DATETIME_1, "state": State.FAILED},  # D1
             {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1), "state": State.FAILED},  # D2
             {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2), "state": State.FAILED},  # D3
             {"logical_date": None, "state": State.FAILED},  # D4
         ]
-        self.create_task_instances(
-            session, dag_id=dag_id, task_instances=task_instances, update_extras=False
-        )
+        self.create_task_instances(session, dag_id=dag_id, task_instances=task_instances, update_extras=False)
         payload = {
             "dry_run": True,
             "only_failed": False,
@@ -2468,7 +2465,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         }
         resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert resp.status_code == 200
-        assert resp.json()["total_entries"] == 5 #D0 ~ #D4
+        assert resp.json()["total_entries"] == 5  # D0 ~ #D4
 
     def test_with_dag_run_id_only_uses_run_id_based_clearing(self, test_client, session):
         dag_id = "example_python_operator"
@@ -2477,9 +2474,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1), "state": State.FAILED},  # D1
             {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2), "state": State.SUCCESS},  # D2
         ]
-        self.create_task_instances(
-            session, dag_id=dag_id, task_instances=task_instances, update_extras=False
-        )
+        self.create_task_instances(session, dag_id=dag_id, task_instances=task_instances, update_extras=False)
         payload = {
             "dry_run": True,
             "only_failed": True,
@@ -2489,7 +2484,9 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert resp.status_code == 200
         a = resp.json()
         assert resp.json()["total_entries"] == 1
-        assert resp.json()["task_instances"][0]["logical_date"] == (DEFAULT_DATETIME_1 + dt.timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ") #D1
+        assert resp.json()["task_instances"][0]["logical_date"] == (
+            DEFAULT_DATETIME_1 + dt.timedelta(days=1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")  # D1
 
     @pytest.mark.parametrize("flag", ["include_future", "include_past"])
     def test_manual_run_with_none_logical_date_returns_400_kept(self, test_client, session, flag):
@@ -2502,8 +2499,11 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         }
         task_instances = [{"logical_date": None, "state": State.FAILED}]
         self.create_task_instances(
-            session, dag_id=dag_id, task_instances=task_instances, update_extras=False,
-            dag_run_state=State.FAILED
+            session,
+            dag_id=dag_id,
+            task_instances=task_instances,
+            update_extras=False,
+            dag_run_state=State.FAILED,
         )
         resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert resp.status_code == 400
@@ -2984,58 +2984,58 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         "payload, expected",
         [
             (
-                    {"end_date": "2020-11-10T12:42:39.442973"},
-                    {
-                        "detail": [
-                            {
-                                "type": "timezone_aware",
-                                "loc": ["body", "end_date"],
-                                "msg": "Input should have timezone info",
-                                "input": "2020-11-10T12:42:39.442973",
-                            }
-                        ]
-                    },
+                {"end_date": "2020-11-10T12:42:39.442973"},
+                {
+                    "detail": [
+                        {
+                            "type": "timezone_aware",
+                            "loc": ["body", "end_date"],
+                            "msg": "Input should have timezone info",
+                            "input": "2020-11-10T12:42:39.442973",
+                        }
+                    ]
+                },
             ),
             (
-                    {"end_date": "2020-11-10T12:4po"},
-                    {
-                        "detail": [
-                            {
-                                "type": "datetime_from_date_parsing",
-                                "loc": ["body", "end_date"],
-                                "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
-                                "input": "2020-11-10T12:4po",
-                                "ctx": {"error": "unexpected extra characters at the end of the input"},
-                            }
-                        ]
-                    },
+                {"end_date": "2020-11-10T12:4po"},
+                {
+                    "detail": [
+                        {
+                            "type": "datetime_from_date_parsing",
+                            "loc": ["body", "end_date"],
+                            "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
+                            "input": "2020-11-10T12:4po",
+                            "ctx": {"error": "unexpected extra characters at the end of the input"},
+                        }
+                    ]
+                },
             ),
             (
-                    {"start_date": "2020-11-10T12:42:39.442973"},
-                    {
-                        "detail": [
-                            {
-                                "type": "timezone_aware",
-                                "loc": ["body", "start_date"],
-                                "msg": "Input should have timezone info",
-                                "input": "2020-11-10T12:42:39.442973",
-                            }
-                        ]
-                    },
+                {"start_date": "2020-11-10T12:42:39.442973"},
+                {
+                    "detail": [
+                        {
+                            "type": "timezone_aware",
+                            "loc": ["body", "start_date"],
+                            "msg": "Input should have timezone info",
+                            "input": "2020-11-10T12:42:39.442973",
+                        }
+                    ]
+                },
             ),
             (
-                    {"start_date": "2020-11-10T12:4po"},
-                    {
-                        "detail": [
-                            {
-                                "type": "datetime_from_date_parsing",
-                                "loc": ["body", "start_date"],
-                                "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
-                                "input": "2020-11-10T12:4po",
-                                "ctx": {"error": "unexpected extra characters at the end of the input"},
-                            }
-                        ]
-                    },
+                {"start_date": "2020-11-10T12:4po"},
+                {
+                    "detail": [
+                        {
+                            "type": "datetime_from_date_parsing",
+                            "loc": ["body", "start_date"],
+                            "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
+                            "input": "2020-11-10T12:4po",
+                            "ctx": {"error": "unexpected extra characters at the end of the input"},
+                        }
+                    ]
+                },
             ),
         ],
     )
@@ -3736,16 +3736,16 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         "payload, expected",
         [
             (
-                    {
-                        "new_state": "failede",
-                    },
-                    f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                {
+                    "new_state": "failede",
+                },
+                f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
             (
-                    {
-                        "new_state": "queued",
-                    },
-                    f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                {
+                    "new_state": "queued",
+                },
+                f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
         ],
     )
@@ -3772,50 +3772,49 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         "new_state,expected_status_code,expected_json,set_ti_state_call_count",
         [
             (
-                "failed",
-                200,
-                {
-                    "task_instances": [
-                        {
-                            "dag_id": "example_python_operator",
-                            "dag_display_name": "example_python_operator",
-                            "dag_version": mock.ANY,
-                            "dag_run_id": "TEST_DAG_RUN_ID",
-                            "logical_date": "2020-01-01T00:00:00Z",
-                            "task_id": "print_the_context",
-                            "duration": 10000.0,
-                            "end_date": "2020-01-03T00:00:00Z",
-                            "executor": None,
-                            "executor_config": "{}",
-                            "hostname": "",
-                            "id": mock.ANY,
-                            "map_index": -1,
-                            "max_tries": 0,
-                            "note": "placeholder-note",
-                            "operator": "PythonOperator",
-                            "operator_name": "PythonOperator",
-                            "pid": 100,
-                            "pool": "default_pool",
-                            "pool_slots": 1,
-                            "priority_weight": 9,
-                            "queue": "default_queue",
-                            "queued_when": None,
-                            "scheduled_when": None,
-                            "start_date": "2020-01-02T00:00:00Z",
-                            "state": "running",
-                            "task_display_name": "print_the_context",
-                            "try_number": 0,
-                            "unixname": getuser(),
-                            "rendered_fields": {},
-                            "rendered_map_index": None,
-                            "run_after": "2020-01-01T00:00:00Z",
-                            "trigger": None,
-                            "triggerer_job": None,
-                        }
-                    ],
-                    "total_entries": 1,
-                },
-                1,
+                    "failed",
+                    200,
+                    {
+                        "task_instances": [
+                            {
+                                "dag_id": "example_python_operator",
+                                "dag_display_name": "example_python_operator",
+                                "dag_version": mock.ANY,
+                                "dag_run_id": "TEST_DAG_RUN_ID",
+                                "logical_date": "2020-01-01T00:00:00Z",
+                                "task_id": "print_the_context",
+                                "duration": 10000.0,
+                                "end_date": "2020-01-03T00:00:00Z",
+                                "executor": None,
+                                "executor_config": "{}",
+                                "hostname": "",
+                                "id": mock.ANY,
+                                "map_index": -1,
+                                "max_tries": 0,
+                                "note": "placeholder-note",
+                                "operator": "PythonOperator",
+                                "pid": 100,
+                                "pool": "default_pool",
+                                "pool_slots": 1,
+                                "priority_weight": 9,
+                                "queue": "default_queue",
+                                "queued_when": None,
+                                "scheduled_when": None,
+                                "start_date": "2020-01-02T00:00:00Z",
+                                "state": "running",
+                                "task_display_name": "print_the_context",
+                                "try_number": 0,
+                                "unixname": getuser(),
+                                "rendered_fields": {},
+                                "rendered_map_index": None,
+                                "run_after": "2020-01-01T00:00:00Z",
+                                "trigger": None,
+                                "triggerer_job": None,
+                            }
+                        ],
+                        "total_entries": 1,
+                    },
+                    1,
             ),
             (
                 None,
@@ -3872,12 +3871,12 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         "new_note_value,ti_note_data",
         [
             (
-                    "My super cool TaskInstance note.",
-                    {"content": "My super cool TaskInstance note.", "user_id": "test"},
+                "My super cool TaskInstance note.",
+                {"content": "My super cool TaskInstance note.", "user_id": "test"},
             ),
             (
-                    None,
-                    {"content": None, "user_id": "test"},
+                None,
+                {"content": None, "user_id": "test"},
             ),
         ],
     )
@@ -4432,16 +4431,16 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
         "payload, expected",
         [
             (
-                    {
-                        "new_state": "failede",
-                    },
-                    f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                {
+                    "new_state": "failede",
+                },
+                f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
             (
-                    {
-                        "new_state": "queued",
-                    },
-                    f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                {
+                    "new_state": "queued",
+                },
+                f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
         ],
     )
@@ -4514,20 +4513,20 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                 1,
             ),
             (
-                None,
-                422,
-                {
-                    "detail": [
-                        {
-                            "type": "value_error",
-                            "loc": ["body", "new_state"],
-                            "msg": "Value error, 'new_state' should not be empty",
-                            "input": None,
-                            "ctx": {"error": {}},
-                        }
-                    ]
-                },
-                0,
+                    None,
+                    422,
+                    {
+                        "detail": [
+                            {
+                                "type": "value_error",
+                                "loc": ["body", "new_state"],
+                                "msg": "Value error, 'new_state' should not be empty",
+                                "input": None,
+                                "ctx": {"error": {}},
+                            }
+                        ]
+                    },
+                    0,
             ),
         ],
     )
@@ -4600,19 +4599,19 @@ class TestDeleteTaskInstance(TestTaskInstanceEndpoint):
         "test_url, setup_needed, expected_error",
         [
             (
-                    f"/dags/non_existent_dag/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}",
-                    False,
-                    "The Task Instance with dag_id: `non_existent_dag`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-1` was not found",
+                f"/dags/non_existent_dag/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}",
+                False,
+                "The Task Instance with dag_id: `non_existent_dag`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-1` was not found",
             ),
             (
-                    f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances/non_existent_task",
-                    True,
-                    "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `-1` was not found",
+                f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances/non_existent_task",
+                True,
+                "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `-1` was not found",
             ),
             (
-                    f"/dags/{DAG_ID}/dagRuns/NON_EXISTENT_DAG_RUN/taskInstances/{TASK_ID}",
-                    True,
-                    "The Task Instance with dag_id: `example_python_operator`, run_id: `NON_EXISTENT_DAG_RUN`, task_id: `print_the_context` and map_index: `-1` was not found",
+                f"/dags/{DAG_ID}/dagRuns/NON_EXISTENT_DAG_RUN/taskInstances/{TASK_ID}",
+                True,
+                "The Task Instance with dag_id: `example_python_operator`, run_id: `NON_EXISTENT_DAG_RUN`, task_id: `print_the_context` and map_index: `-1` was not found",
             ),
         ],
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -26,7 +26,6 @@ from unittest import mock
 
 import pendulum
 import pytest
-from airflow.models.baseoperator import BaseOperator
 from sqlalchemy import select
 
 from airflow._shared.timezones.timezone import datetime
@@ -35,6 +34,7 @@ from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagRun, Log, TaskInstance
+from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag, sync_bag_to_db
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
@@ -45,6 +45,7 @@ from airflow.sdk import BaseOperator
 from airflow.utils.platform import getuser
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
+
 from tests_common.test_utils.api_fastapi import _check_task_instance_note
 from tests_common.test_utils.db import (
     clear_db_runs,
@@ -3766,6 +3767,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                             "max_tries": 0,
                             "note": "placeholder-note",
                             "operator": "PythonOperator",
+                            "operator_name": "PythonOperator",
                             "pid": 100,
                             "pool": "default_pool",
                             "pool_slots": 1,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -34,7 +34,6 @@ from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagRun, Log, TaskInstance
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag, sync_bag_to_db
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -2415,7 +2415,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         response = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert response.status_code == 400
         assert (
-            "Cannot use include_past or include_future with no logical_date(e.g., manually or asset-triggered)."
+            "Cannot use include_past or include_future with no logical_date(e.g. manually or asset-triggered)."
             in response.json()["detail"]
         )
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -2444,7 +2444,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         }
         resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert resp.status_code == 200
-        assert resp.json()["total_entries"] == expected  # include_past => T0,1 / include_future => T1,T2
+        assert resp.json()["total_entries"] == expected  # include_past => T0,T1 / include_future => T1,T2
 
     def test_with_dag_run_id_and_both_past_and_future_means_full_range(self, test_client, session):
         dag_id = "example_python_operator"
@@ -2480,15 +2480,10 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             "only_failed": True,
             "dag_run_id": "TEST_DAG_RUN_ID_1",
         }
-        a= (
-            DEFAULT_DATETIME_1 + dt.timedelta(days=1)
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")  # T1
         resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert resp.status_code == 200
-        a = resp.json()
         assert resp.json()["total_entries"] == 1
-        assert resp.json()["task_instances"][0]["logical_date"] == '2020-01-02T00:00:00Z' # T1
-
+        assert resp.json()["task_instances"][0]["logical_date"] == "2020-01-02T00:00:00Z"  # T1
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.post(
@@ -3750,49 +3745,49 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         "new_state,expected_status_code,expected_json,set_ti_state_call_count",
         [
             (
-                    "failed",
-                    200,
-                    {
-                        "task_instances": [
-                            {
-                                "dag_id": "example_python_operator",
-                                "dag_display_name": "example_python_operator",
-                                "dag_version": mock.ANY,
-                                "dag_run_id": "TEST_DAG_RUN_ID",
-                                "logical_date": "2020-01-01T00:00:00Z",
-                                "task_id": "print_the_context",
-                                "duration": 10000.0,
-                                "end_date": "2020-01-03T00:00:00Z",
-                                "executor": None,
-                                "executor_config": "{}",
-                                "hostname": "",
-                                "id": mock.ANY,
-                                "map_index": -1,
-                                "max_tries": 0,
-                                "note": "placeholder-note",
-                                "operator": "PythonOperator",
-                                "pid": 100,
-                                "pool": "default_pool",
-                                "pool_slots": 1,
-                                "priority_weight": 9,
-                                "queue": "default_queue",
-                                "queued_when": None,
-                                "scheduled_when": None,
-                                "start_date": "2020-01-02T00:00:00Z",
-                                "state": "running",
-                                "task_display_name": "print_the_context",
-                                "try_number": 0,
-                                "unixname": getuser(),
-                                "rendered_fields": {},
-                                "rendered_map_index": None,
-                                "run_after": "2020-01-01T00:00:00Z",
-                                "trigger": None,
-                                "triggerer_job": None,
-                            }
-                        ],
-                        "total_entries": 1,
-                    },
-                    1,
+                "failed",
+                200,
+                {
+                    "task_instances": [
+                        {
+                            "dag_id": "example_python_operator",
+                            "dag_display_name": "example_python_operator",
+                            "dag_version": mock.ANY,
+                            "dag_run_id": "TEST_DAG_RUN_ID",
+                            "logical_date": "2020-01-01T00:00:00Z",
+                            "task_id": "print_the_context",
+                            "duration": 10000.0,
+                            "end_date": "2020-01-03T00:00:00Z",
+                            "executor": None,
+                            "executor_config": "{}",
+                            "hostname": "",
+                            "id": mock.ANY,
+                            "map_index": -1,
+                            "max_tries": 0,
+                            "note": "placeholder-note",
+                            "operator": "PythonOperator",
+                            "pid": 100,
+                            "pool": "default_pool",
+                            "pool_slots": 1,
+                            "priority_weight": 9,
+                            "queue": "default_queue",
+                            "queued_when": None,
+                            "scheduled_when": None,
+                            "start_date": "2020-01-02T00:00:00Z",
+                            "state": "running",
+                            "task_display_name": "print_the_context",
+                            "try_number": 0,
+                            "unixname": getuser(),
+                            "rendered_fields": {},
+                            "rendered_map_index": None,
+                            "run_after": "2020-01-01T00:00:00Z",
+                            "trigger": None,
+                            "triggerer_job": None,
+                        }
+                    ],
+                    "total_entries": 1,
+                },
+                1,
             ),
             (
                 None,
@@ -4491,20 +4486,20 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                 1,
             ),
             (
-                    None,
-                    422,
-                    {
-                        "detail": [
-                            {
-                                "type": "value_error",
-                                "loc": ["body", "new_state"],
-                                "msg": "Value error, 'new_state' should not be empty",
-                                "input": None,
-                                "ctx": {"error": {}},
-                            }
-                        ]
-                    },
-                    0,
+                None,
+                422,
+                {
+                    "detail": [
+                        {
+                            "type": "value_error",
+                            "loc": ["body", "new_state"],
+                            "msg": "Value error, 'new_state' should not be empty",
+                            "input": None,
+                            "ctx": {"error": {}},
+                        }
+                    ]
+                },
+                0,
             ),
         ],
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -26,6 +26,7 @@ from unittest import mock
 
 import pendulum
 import pytest
+from airflow.models.baseoperator import BaseOperator
 from sqlalchemy import select
 
 from airflow._shared.timezones.timezone import datetime
@@ -44,7 +45,6 @@ from airflow.sdk import BaseOperator
 from airflow.utils.platform import getuser
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
-
 from tests_common.test_utils.api_fastapi import _check_task_instance_note
 from tests_common.test_utils.db import (
     clear_db_runs,
@@ -778,12 +778,12 @@ class TestGetMappedTaskInstances:
             ({"order_by": "map_index", "limit": 100}, list(range(100))),
             ({"order_by": "-map_index", "limit": 100}, list(range(109, 9, -1))),
             (
-                {"order_by": "state", "limit": 108},
-                list(range(5, 25)) + list(range(25, 110)) + list(range(3)),
+                    {"order_by": "state", "limit": 108},
+                    list(range(5, 25)) + list(range(25, 110)) + list(range(3)),
             ),
             (
-                {"order_by": "-state", "limit": 100},
-                list(range(5)[::-1]) + list(range(25, 110)[::-1]) + list(range(15, 25)[::-1]),
+                    {"order_by": "-state", "limit": 100},
+                    list(range(5)[::-1]) + list(range(25, 110)[::-1]) + list(range(15, 25)[::-1]),
             ),
             ({"order_by": "logical_date", "limit": 100}, list(range(100))),
             ({"order_by": "-logical_date", "limit": 100}, list(range(109, 9, -1))),
@@ -1422,37 +1422,37 @@ class TestGetTaskDependencies(TestTaskInstanceEndpoint):
         "state, dependencies",
         [
             (
-                State.SCHEDULED,
-                {
-                    "dependencies": [
-                        {
-                            "name": "Logical Date",
-                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
-                            "before the task's start date 2021-01-01T00:00:00+00:00.",
-                        },
-                        {
-                            "name": "Logical Date",
-                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
-                            "before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
-                        },
-                    ],
-                },
+                    State.SCHEDULED,
+                    {
+                        "dependencies": [
+                            {
+                                "name": "Logical Date",
+                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
+                                          "before the task's start date 2021-01-01T00:00:00+00:00.",
+                            },
+                            {
+                                "name": "Logical Date",
+                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is "
+                                          "before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
+                            },
+                        ],
+                    },
             ),
             (
-                State.NONE,
-                {
-                    "dependencies": [
-                        {
-                            "name": "Logical Date",
-                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's start date 2021-01-01T00:00:00+00:00.",
-                        },
-                        {
-                            "name": "Logical Date",
-                            "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
-                        },
-                        {"name": "Task Instance State", "reason": "Task is in the 'None' state."},
-                    ]
-                },
+                    State.NONE,
+                    {
+                        "dependencies": [
+                            {
+                                "name": "Logical Date",
+                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's start date 2021-01-01T00:00:00+00:00.",
+                            },
+                            {
+                                "name": "Logical Date",
+                                "reason": "The logical date is 2020-01-01T00:00:00+00:00 but this is before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
+                            },
+                            {"name": "Task Instance State", "reason": "Task is in the 'None' state."},
+                        ]
+                    },
             ),
         ],
     )
@@ -2396,7 +2396,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             check_last_log(session, dag_id=request_dag, event="post_clear_task_instances", logical_date=None)
 
     @pytest.mark.parametrize("flag", ["include_future", "include_past"])
-    def test_dag_run_with_future_or_past_flag_returns_400(self, test_client, session, flag):
+    def test_manual_run_with_none_logical_date_returns_400(self, test_client, session, flag):
         dag_id = "example_python_operator"
         payload = {
             "dry_run": True,
@@ -2404,7 +2404,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             "only_failed": True,
             flag: True,
         }
-        task_instances = [{"logical_date": DEFAULT_DATETIME_1, "state": State.FAILED}]
+        task_instances = [{"logical_date": None, "state": State.FAILED}]
         self.create_task_instances(
             session,
             dag_id=dag_id,
@@ -2415,8 +2415,101 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         response = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
         assert response.status_code == 400
         assert (
-            "Cannot use include_past or include_future when dag_run_id is provided"
+            "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None)."
             in response.json()["detail"]
+        )
+
+    @pytest.mark.parametrize(
+        "flag, expected",
+        [
+            ("include_past", 2),  # D0 ~ D1
+            ("include_future", 2),  # D1 ~
+        ],
+    )
+    def test_with_dag_run_id_and_past_future_converts_to_date_range(self, test_client, session, flag,
+                                                                    expected):
+        dag_id = "example_python_operator"
+        task_instances = [
+            {"logical_date": DEFAULT_DATETIME_1, "state": State.FAILED},  # D0
+            {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1), "state": State.FAILED},  # D1
+            {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2), "state": State.FAILED},  # D2
+        ]
+        self.create_task_instances(
+            session, dag_id=dag_id, task_instances=task_instances, update_extras=False
+        )
+        payload = {
+            "dry_run": True,
+            "only_failed": True,
+            "dag_run_id": "TEST_DAG_RUN_ID_1",
+            flag: True,
+        }
+        resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["total_entries"] == expected  # include_past => D0,D1 / include_future => D1,D2
+
+    def test_with_dag_run_id_and_both_past_and_future_means_full_range(self, test_client, session):
+        dag_id = "example_python_operator"
+        task_instances = [
+            {"logical_date": DEFAULT_DATETIME_1 - dt.timedelta(days=1), "state": State.FAILED},  # D0
+            {"logical_date": DEFAULT_DATETIME_1, "state": State.FAILED},  #D1
+            {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1), "state": State.FAILED},  # D2
+            {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2), "state": State.FAILED},  # D3
+            {"logical_date": None, "state": State.FAILED},  # D4
+        ]
+        self.create_task_instances(
+            session, dag_id=dag_id, task_instances=task_instances, update_extras=False
+        )
+        payload = {
+            "dry_run": True,
+            "only_failed": False,
+            "dag_run_id": "TEST_DAG_RUN_ID_1",  # D1
+            "include_past": True,
+            "include_future": True,
+        }
+        resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["total_entries"] == 5 #D0 ~ #D4
+
+    def test_with_dag_run_id_only_uses_run_id_based_clearing(self, test_client, session):
+        dag_id = "example_python_operator"
+        task_instances = [
+            {"logical_date": DEFAULT_DATETIME_1, "state": State.SUCCESS},  # D0
+            {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1), "state": State.FAILED},  # D1
+            {"logical_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2), "state": State.SUCCESS},  # D2
+        ]
+        self.create_task_instances(
+            session, dag_id=dag_id, task_instances=task_instances, update_extras=False
+        )
+        payload = {
+            "dry_run": True,
+            "only_failed": True,
+            "dag_run_id": "TEST_DAG_RUN_ID_1",
+        }
+        resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
+        assert resp.status_code == 200
+        a = resp.json()
+        assert resp.json()["total_entries"] == 1
+        assert resp.json()["task_instances"][0]["logical_date"] == (DEFAULT_DATETIME_1 + dt.timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ") #D1
+
+    @pytest.mark.parametrize("flag", ["include_future", "include_past"])
+    def test_manual_run_with_none_logical_date_returns_400_kept(self, test_client, session, flag):
+        dag_id = "example_python_operator"
+        payload = {
+            "dry_run": True,
+            "dag_run_id": "TEST_DAG_RUN_ID_0",
+            "only_failed": True,
+            flag: True,
+        }
+        task_instances = [{"logical_date": None, "state": State.FAILED}]
+        self.create_task_instances(
+            session, dag_id=dag_id, task_instances=task_instances, update_extras=False,
+            dag_run_state=State.FAILED
+        )
+        resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
+        assert resp.status_code == 400
+        assert (
+            "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None)."
+            in resp.json()["detail"]
         )
 
     def test_should_respond_401(self, unauthenticated_test_client):
@@ -2891,58 +2984,58 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         "payload, expected",
         [
             (
-                {"end_date": "2020-11-10T12:42:39.442973"},
-                {
-                    "detail": [
-                        {
-                            "type": "timezone_aware",
-                            "loc": ["body", "end_date"],
-                            "msg": "Input should have timezone info",
-                            "input": "2020-11-10T12:42:39.442973",
-                        }
-                    ]
-                },
+                    {"end_date": "2020-11-10T12:42:39.442973"},
+                    {
+                        "detail": [
+                            {
+                                "type": "timezone_aware",
+                                "loc": ["body", "end_date"],
+                                "msg": "Input should have timezone info",
+                                "input": "2020-11-10T12:42:39.442973",
+                            }
+                        ]
+                    },
             ),
             (
-                {"end_date": "2020-11-10T12:4po"},
-                {
-                    "detail": [
-                        {
-                            "type": "datetime_from_date_parsing",
-                            "loc": ["body", "end_date"],
-                            "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
-                            "input": "2020-11-10T12:4po",
-                            "ctx": {"error": "unexpected extra characters at the end of the input"},
-                        }
-                    ]
-                },
+                    {"end_date": "2020-11-10T12:4po"},
+                    {
+                        "detail": [
+                            {
+                                "type": "datetime_from_date_parsing",
+                                "loc": ["body", "end_date"],
+                                "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
+                                "input": "2020-11-10T12:4po",
+                                "ctx": {"error": "unexpected extra characters at the end of the input"},
+                            }
+                        ]
+                    },
             ),
             (
-                {"start_date": "2020-11-10T12:42:39.442973"},
-                {
-                    "detail": [
-                        {
-                            "type": "timezone_aware",
-                            "loc": ["body", "start_date"],
-                            "msg": "Input should have timezone info",
-                            "input": "2020-11-10T12:42:39.442973",
-                        }
-                    ]
-                },
+                    {"start_date": "2020-11-10T12:42:39.442973"},
+                    {
+                        "detail": [
+                            {
+                                "type": "timezone_aware",
+                                "loc": ["body", "start_date"],
+                                "msg": "Input should have timezone info",
+                                "input": "2020-11-10T12:42:39.442973",
+                            }
+                        ]
+                    },
             ),
             (
-                {"start_date": "2020-11-10T12:4po"},
-                {
-                    "detail": [
-                        {
-                            "type": "datetime_from_date_parsing",
-                            "loc": ["body", "start_date"],
-                            "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
-                            "input": "2020-11-10T12:4po",
-                            "ctx": {"error": "unexpected extra characters at the end of the input"},
-                        }
-                    ]
-                },
+                    {"start_date": "2020-11-10T12:4po"},
+                    {
+                        "detail": [
+                            {
+                                "type": "datetime_from_date_parsing",
+                                "loc": ["body", "start_date"],
+                                "msg": "Input should be a valid datetime or date, unexpected extra characters at the end of the input",
+                                "input": "2020-11-10T12:4po",
+                                "ctx": {"error": "unexpected extra characters at the end of the input"},
+                            }
+                        ]
+                    },
             ),
         ],
     )
@@ -3643,16 +3736,16 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         "payload, expected",
         [
             (
-                {
-                    "new_state": "failede",
-                },
-                f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                    {
+                        "new_state": "failede",
+                    },
+                    f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
             (
-                {
-                    "new_state": "queued",
-                },
-                f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                    {
+                        "new_state": "queued",
+                    },
+                    f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
         ],
     )
@@ -3779,12 +3872,12 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         "new_note_value,ti_note_data",
         [
             (
-                "My super cool TaskInstance note.",
-                {"content": "My super cool TaskInstance note.", "user_id": "test"},
+                    "My super cool TaskInstance note.",
+                    {"content": "My super cool TaskInstance note.", "user_id": "test"},
             ),
             (
-                None,
-                {"content": None, "user_id": "test"},
+                    None,
+                    {"content": None, "user_id": "test"},
             ),
         ],
     )
@@ -4339,16 +4432,16 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
         "payload, expected",
         [
             (
-                {
-                    "new_state": "failede",
-                },
-                f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                    {
+                        "new_state": "failede",
+                    },
+                    f"'failede' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
             (
-                {
-                    "new_state": "queued",
-                },
-                f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
+                    {
+                        "new_state": "queued",
+                    },
+                    f"'queued' is not one of ['{State.SUCCESS}', '{State.FAILED}', '{State.SKIPPED}']",
             ),
         ],
     )
@@ -4507,19 +4600,19 @@ class TestDeleteTaskInstance(TestTaskInstanceEndpoint):
         "test_url, setup_needed, expected_error",
         [
             (
-                f"/dags/non_existent_dag/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}",
-                False,
-                "The Task Instance with dag_id: `non_existent_dag`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-1` was not found",
+                    f"/dags/non_existent_dag/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}",
+                    False,
+                    "The Task Instance with dag_id: `non_existent_dag`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-1` was not found",
             ),
             (
-                f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances/non_existent_task",
-                True,
-                "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `-1` was not found",
+                    f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances/non_existent_task",
+                    True,
+                    "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `-1` was not found",
             ),
             (
-                f"/dags/{DAG_ID}/dagRuns/NON_EXISTENT_DAG_RUN/taskInstances/{TASK_ID}",
-                True,
-                "The Task Instance with dag_id: `example_python_operator`, run_id: `NON_EXISTENT_DAG_RUN`, task_id: `print_the_context` and map_index: `-1` was not found",
+                    f"/dags/{DAG_ID}/dagRuns/NON_EXISTENT_DAG_RUN/taskInstances/{TASK_ID}",
+                    True,
+                    "The Task Instance with dag_id: `example_python_operator`, run_id: `NON_EXISTENT_DAG_RUN`, task_id: `print_the_context` and map_index: `-1` was not found",
             ),
         ],
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -2423,7 +2423,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         "flag, expected",
         [
             ("include_past", 2),  # D0 ~ D1
-            ("include_future", 2),  # D1 ~
+            ("include_future", 2),  # D1 ~ D2
         ],
     )
     def test_with_dag_run_id_and_past_future_converts_to_date_range(
@@ -2488,29 +2488,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             DEFAULT_DATETIME_1 + dt.timedelta(days=1)
         ).strftime("%Y-%m-%dT%H:%M:%SZ")  # D1
 
-    @pytest.mark.parametrize("flag", ["include_future", "include_past"])
-    def test_manual_run_with_none_logical_date_returns_400_kept(self, test_client, session, flag):
-        dag_id = "example_python_operator"
-        payload = {
-            "dry_run": True,
-            "dag_run_id": "TEST_DAG_RUN_ID_0",
-            "only_failed": True,
-            flag: True,
-        }
-        task_instances = [{"logical_date": None, "state": State.FAILED}]
-        self.create_task_instances(
-            session,
-            dag_id=dag_id,
-            task_instances=task_instances,
-            update_extras=False,
-            dag_run_state=State.FAILED,
-        )
-        resp = test_client.post(f"/dags/{dag_id}/clearTaskInstances", json=payload)
-        assert resp.status_code == 400
-        assert (
-            "Cannot use include_past or include_future with a manually triggered DAG run (logical_date is None)."
-            in resp.json()["detail"]
-        )
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.post(


### PR DESCRIPTION
This PR resolves the issue reported in [#54134](https://github.com/apache/airflow/issues/54134), where attempting to clear task instances from the Airflow UI using both dag_run_id and include_past/include_future resulted in a 400 error. This prevented users from clearing past or future task instances via the UI, which was possible in previous Airflow versions.

With this fix:

The API now correctly allows the use of include_past/include_future together with dag_run_id, as long as the DAG run has a valid logical_date (i.e., for scheduled DAG runs).
For manually triggered DAG runs (where logical_date is None), the API still returns a 400 error to protect against accidental clearing of unrelated task instances—preventing the original bug from resurfacing.

closes: #54134

<img width="1644" height="549" alt="스크린샷 2025-08-12 오후 11 36 53" src="https://github.com/user-attachments/assets/66ea0436-a94a-4de2-b720-b39c73881f3d" />