### PR TITLE
TaskName indentation limited by available --chakra-spacing vars

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
@@ -49,6 +49,8 @@ const onMouseLeave = (event: MouseEvent<HTMLDivElement>) => {
   });
 };
 
+const indent = (depth: number) => `${depth * 0.75 + 0.5}rem`;
+
 export const TaskNames = ({ nodes, onRowClick }: Props) => {
   const { t: translate } = useTranslation("dag");
   const { toggleGroupId } = useOpenGroups();
@@ -86,7 +88,7 @@ export const TaskNames = ({ nodes, onRowClick }: Props) => {
                 isGroup={true}
                 isMapped={Boolean(node.is_mapped)}
                 label={node.label}
-                paddingLeft={node.depth * 3 + 2}
+                paddingLeft={indent(node.depth)}
                 setupTeardownType={node.setup_teardown_type}
               />
               <chakra.span
@@ -129,7 +131,7 @@ export const TaskNames = ({ nodes, onRowClick }: Props) => {
               fontWeight="normal"
               isMapped={Boolean(node.is_mapped)}
               label={node.label}
-              paddingLeft={node.depth * 3 + 2}
+              paddingLeft={indent(node.depth)}
               setupTeardownType={node.setup_teardown_type}
             />
           </RouterLink>


### PR DESCRIPTION
The current TaskName rendering utilizes standard `--chakra-spacing` vars for `paddingLeft` styling.  There are limitations with these variables as they do not have enough precision to be used above 5 levels of depth.  At level 6 and beyond, the calculation attempts to specify values that do not exist, so the padding falls back to pixels.  For example, at level 6, the depth is 5, resulting in a padding calculation of `5 * 3 + 2` .  When passed as paddingLeft, it attempts to resolve to `--chakra-spacing-17` which does not exist, so it falls back to `17px`.

Code to reproduce issue:
```
import datetime
from airflow.sdk import dag, task, task_group

@dag(
    dag_id="LevelTest",
    schedule=None,
    start_date=datetime.datetime(2025,1,1,0,0,0),
)
def _dag() -> None:
    @task_group
    def level1() -> None:
        @task_group
        def level2() -> None:
            @task_group
            def level3() -> None:
                @task_group
                def level4() -> None:
                    @task_group
                    def level5() -> None:
                        @task
                        def bar() -> None:
                            pass
                        bar()
                        @task_group
                        def level6() -> None:
                            @task
                            def foo() -> None:
                                pass
                            foo()
                        level6()
                    level5()
                level4()
            level3()
        level2()
    level1()
_dag()
```

Rendering issue in dag view:
<img width="106" height="149" alt="image" src="https://github.com/user-attachments/assets/cb65a5ee-6e09-4648-a3e4-bd0ad0106cff" />

This change calculates the rem value to mimic the `--chakra-spacing` variables without being bound to a specific list of values.

Resolved issue in dag view:
<img width="124" height="161" alt="image" src="https://github.com/user-attachments/assets/69ebd074-2648-4e8c-b4e3-824b7c1b5efc" />
