### PR TITLE
Prevent problems with weaviate-client==4.16.7

### DIFF
--- a/providers/weaviate/pyproject.toml
+++ b/providers/weaviate/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "httpx>=0.25.0",
-    "weaviate-client>=4.4.0",
+    "weaviate-client>=4.4.0,!=4.16.7",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
 ]


### PR DESCRIPTION
Canary tests fail in: https://github.com/apache/airflow/actions/runs/16918892385
with:
```
ERROR providers/weaviate/tests/unit/weaviate/hooks/test_weaviate.py - google.protobuf.runtime_version.VersionError: Detected mismatched Protobuf Gencode/Runtime major versions when loading v1/aggregate.proto: gencode 6.30.0 runtime 5.29.5. Same major version is required. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
```

Changelog of weaviate-client in https://weaviate-python-client.readthedocs.io/en/stable/changelog.html says:

Version 4.16.7[](https://weaviate-python-client.readthedocs.io/en/stable/changelog.html#version-4-16-7)

This patch version includes:

- Fixes compatability issues between the built gRPC stubs and differing protobuf versions depending on the version of grpcio used to build the stubs