### PR TITLE
Fix: Incorrect log timestamps in UI when default_timezone is not UTC

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1716,12 +1716,7 @@ def process_log_messages_from_subprocess(
         if ts := event.get("timestamp"):
             # We use msgspec to decode the timestamp as it does it orders of magnitude quicker than
             # datetime.strptime cn
-            #
-            # We remove the timezone info here, as the json encoding has `+00:00`, and since the log came
-            # from a subprocess we know that the timezone of the log message is the same, so having some
-            # messages include tz (from subprocess) but others not (ones from supervisor process) is
-            # confusing.
-            event["timestamp"] = msgspec.json.decode(f'"{ts}"', type=datetime).replace(tzinfo=None)
+            event["timestamp"] = msgspec.json.decode(f'"{ts}"', type=datetime)
 
         if exc := event.pop("exception", None):
             # TODO: convert the dict back to a pretty stack trace

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -293,7 +293,7 @@ class TestWatchedSubprocess:
                     "event": "An error message",
                     "level": "error",
                     "logger": "airflow.foobar",
-                    "timestamp": instant.replace(tzinfo=None),
+                    "timestamp": instant,
                 },
                 {
                     "category": "UserWarning",
@@ -302,7 +302,7 @@ class TestWatchedSubprocess:
                     "level": "warning",
                     "lineno": line,
                     "logger": "py.warnings",
-                    "timestamp": instant.replace(tzinfo=None),
+                    "timestamp": instant,
                 },
             ]
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #53195

This pull request addresses a previously reported issue where log timestamps are displayed incorrectly in the Airflow UI if the `[core] default_timezone` in airflow.cfg is set to a value other than UTC. This issue was converted to a discussion and has not seen recent activity from the original assignee, so I am submitting a new PR to resolve it.

A clear example of this problem occurs when the timezone is set to KST (UTC+09:00). In this case, the timestamps displayed in the Airflow UI are nine hours earlier than the actual log generation time.

## Implementation
I considered two potential approaches to fix this issue:

1. Parsing with Timezone Awareness: Modify the `_log_stream_to_parsed_log_stream` function within `airflow-core/src/airflow/utils/log/file_task_handler.py` to handle timezone-aware timestamp parsing.
2. Including Timezone in Logs: Embed the timezone information directly into the log message at the time of logging.

I have chosen the second approach as I believe it offers greater clarity and explicitness by ensuring the timezone is always part of the log entry itself. The implemented changes ensure that the timezone offset is included when logs are written.

## Local test result
Only set environment variable `AIRFLOW__CORE__DEFAULT_TIMEZONE=Asia/Seoul`

current
<img width="1279" height="517" alt="image" src="https://github.com/user-attachments/assets/0af4e0c0-6107-4d62-bdd7-d032ae813934" />

after changed code
<img width="1281" height="553" alt="image" src="https://github.com/user-attachments/assets/35a353b9-b53b-4a24-9ae1-231b5eea836f" />



I welcome any feedback or suggestions on this approach. Please let me know if there are any potential concerns with this implementation.

Thank you!

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
