### PR TITLE
Make @task display as PythonOperator in the UI to help new users understand its underlying type

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -571,7 +571,7 @@ class TestStructureDataEndpoint:
                     "is_mapped": None,
                     "tooltip": None,
                     "setup_teardown_type": None,
-                    "operator": "@task",
+                    "operator": "PythonOperator",
                     "asset_condition_type": None,
                 },
                 {

--- a/providers/standard/src/airflow/providers/standard/decorators/python.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/python.py
@@ -47,7 +47,7 @@ class _PythonDecoratedOperator(DecoratedOperator, PythonOperator):
     template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
     template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
 
-    custom_operator_name: str = "@task"
+    custom_operator_name: str = "PythonOperator"
 
     def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
         kwargs_to_upstream = {


### PR DESCRIPTION

## Description  
Currently, when creating a task using the TaskFlow API (`@task`), the Airflow UI displays the operator name as `@task` (from `custom_operator_name`).  
While this is technically correct, it may be confusing for users who are new to Airflow and unfamiliar with the TaskFlow API’s internal mapping.

For someone encountering Airflow for the first time, seeing `@task` in the UI provides no direct hint that it is backed by a `PythonOperator`. This can create a gap when:  
- Following documentation or examples that refer to `PythonOperator`.  
- Trying to understand DAGs that mix `@task` with other operators.  
- Debugging tasks and comparing behavior between `@task` and explicitly defined `PythonOperator` tasks.

## Proposed Change  
Change the `custom_operator_name` for the `_PythonDecoratedOperator` so that the UI displays `PythonOperator` instead of `@task`.

This makes the underlying operator type explicit in the UI, improving discoverability for new users. It helps them learn that `@task` is syntactic sugar for `PythonOperator`, and provides a consistent experience when referencing official documentation or examples.

## Benefits  
- **Improved learnability**: New users immediately see that `@task` maps to `PythonOperator`.  
- **Consistency**: Aligns UI terminology with documentation and code examples.  
- **Easier debugging**: Users can better correlate UI information with operator behavior and parameters.

I tested.

<img width="3838" height="870" alt="image" src="https://github.com/user-attachments/assets/25f7dcee-b441-4c6e-8852-fdacecdedcbd" />

<img width="3840" height="794" alt="image" src="https://github.com/user-attachments/assets/9c5b7827-466c-4424-a5d1-72460dcff838" />

using this dag.
```python
import json

import pendulum

from airflow.sdk import dag, task
@dag(
    dag_id="test",
    schedule=None,
    start_date=pendulum.datetime(2025, 8, 11, tz="Asia/Seoul"),
    catchup=False,
    tags=["etl_pipeline"],
)
def data_pipeline_etl():
    """
    ### TaskFlow API Tutorial Documentation
    This is a simple data pipeline example which demonstrates the use of
    the TaskFlow API using three simple tasks for Extract, Transform, and Load.
    Documentation that goes along with the Airflow TaskFlow API tutorial is
    located
    [here](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html)
    """
    @task()
    def extract():
        """
        #### Extract task
        A simple Extract task to get data ready for the rest of the data
        pipeline. In this case, getting data is simulated by reading from a
        hardcoded JSON string.
        """
        data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'

        order_data_dict = json.loads(data_string)
        return order_data_dict

    extract()

data_pipeline_etl()
```


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
