### PR TITLE
Docs: fix example to use task context and logger instead of dag.log (#54380)

### DIFF
--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -38,9 +38,8 @@ Use a dictionary that maps Param names to either a :class:`~airflow.sdk.definiti
 .. code-block::
    :emphasize-lines: 7-10
 
-    from airflow.sdk import DAG
-    from airflow.sdk import task
-    from airflow.sdk import Param
+    from airflow.sdk import DAG, task, Param, get_current_context
+    import logging
 
     with DAG(
         "the_dag",
@@ -51,15 +50,18 @@ Use a dictionary that maps Param names to either a :class:`~airflow.sdk.definiti
     ) as dag:
 
         @task.python
-        def example_task(params: dict):
+        def example_task():
+            ctx = get_current_context()
+            logger = logging.getLogger("airflow.task")
+
             # This will print the default value, 6:
-            dag.log.info(dag.params['my_int_param'])
+            logger.info(ctx["dag"].params["my_int_param"])
 
             # This will print the manually-provided value, 42:
-            dag.log.info(params['my_int_param'])
+            logger.info(ctx["params"]["my_int_param"])
 
             # This will print the default value, 5, since it wasn't provided manually:
-            dag.log.info(params['x'])
+            logger.info(ctx["params"]["x"])
 
         example_task()
 


### PR DESCRIPTION

## Summary

This PR fixes a documentation bug in the "Params" example under core-concepts: the use of `dag.log` inside the `@task.python` function. In the current code, `dag.log` doesn’t exist in TaskFlow DAGs, causing runtime errors when the code is executed.

## Changes

- Replaced `dag.log.info(...)` with proper usage of task context and Python logging:
  - Used `get_current_context()` to access runtime values.
  - Used a standard logger (`logging.getLogger("airflow.task")`) to output parameter values.

```diff
- dag.log.info(dag.params['my_int_param'])
+ logger.info(ctx["dag"].params["my_int_param"])
````

And similarly for user-provided values via `params`.

## Rationale

* Airflow 3's Task SDK no longer attaches a `.log` property to `DAG`, so relying on `dag.log` is no longer valid.
* `get_current_context()` provides a reliable way to access `dag.params` and `params` inside tasks.
* Logging via Python’s `logging` module (or `self.log` on operators) aligns with Airflow’s logging model and avoids missing attribute errors.

## Fixes

Closes: #54380.
