### PR TITLE
Filter out empty logs in useLogs

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -72,26 +72,28 @@ const parseLogs = ({
   const logLink = taskInstance ? `${getTaskInstanceLink(taskInstance)}?try_number=${tryNumber}` : "";
 
   try {
-    parsedLines = data.map((datum, index) => {
-      if (typeof datum !== "string" && "logger" in datum) {
-        const source = datum.logger as string;
+    parsedLines = data
+      .map((datum, index) => {
+        if (typeof datum !== "string" && "logger" in datum) {
+          const source = datum.logger as string;
 
-        if (!sources.includes(source)) {
-          sources.push(source);
+          if (!sources.includes(source)) {
+            sources.push(source);
+          }
         }
-      }
 
-      return renderStructuredLog({
-        index,
-        logLevelFilters,
-        logLink,
-        logMessage: datum,
-        showSource,
-        showTimestamp,
-        sourceFilters,
-        translate,
-      });
-    });
+        return renderStructuredLog({
+          index,
+          logLevelFilters,
+          logLink,
+          logMessage: datum,
+          showSource,
+          showTimestamp,
+          sourceFilters,
+          translate,
+        });
+      })
+      .filter((parsedLine) => parsedLine !== "");
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "An error occurred.";
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

- closes #52916
- closes #54157

## Why

We filtered the logs by level by replacing them with empty strings, but they still remain in the log list.

https://github.com/apache/airflow/blob/33658f0ff86900a4b679a4506a78cc2c2af226f9/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx#L117-L123

On the overview page, multiple `TaskLogPreview` instances could exist at the same time, each holding a full list of logs. This overloads the virtual lists with state updates, eventually triggering the error: `Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.`

## How

- filtered out empty log in `TaskLogPreview`

**before**

https://github.com/user-attachments/assets/4eb5b92d-9074-47f6-b4df-56d3dd6f73dd

**after**

https://github.com/user-attachments/assets/cb38c7ad-1208-482c-a0e7-fc1d28f8b68f




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
