### PR TITLE
Fix mypy `no-redef` errors for timeout imports in providers

### DIFF
--- a/providers/celery/src/airflow/providers/celery/version_compat.py
+++ b/providers/celery/src/airflow/providers/celery/version_compat.py
@@ -31,7 +31,7 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 try:
     from airflow.sdk.execution_time.timeout import timeout
 except ImportError:
-    from airflow.utils.timeout import timeout  # type: ignore[assignment]
+    from airflow.utils.timeout import timeout  # type: ignore[attr-defined,no-redef]
 
 
 __all__ = ["AIRFLOW_V_3_0_PLUS", "timeout"]

--- a/providers/google/src/airflow/providers/google/version_compat.py
+++ b/providers/google/src/airflow/providers/google/version_compat.py
@@ -61,7 +61,7 @@ else:
 try:
     from airflow.sdk.execution_time.timeout import timeout
 except ImportError:
-    from airflow.utils.timeout import timeout  # type: ignore[assignment]  # type: ignore[assignment]
+    from airflow.utils.timeout import timeout  # type: ignore[attr-defined,no-redef]
 
 # Explicitly export these imports to protect them from being removed by linters
 __all__ = [

--- a/providers/openlineage/src/airflow/providers/openlineage/version_compat.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/version_compat.py
@@ -44,6 +44,6 @@ try:
     from airflow.sdk.execution_time.timeout import timeout
 except ImportError:
     from airflow.utils import timezone  # type: ignore[no-redef, attr-defined]
-    from airflow.utils.timeout import timeout  # type: ignore[assignment]
+    from airflow.utils.timeout import timeout  # type: ignore[attr-defined,no-redef]
 
 __all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "timeout", "timezone"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Errors:

```
providers/google/src/airflow/providers/google/version_compat.py:64: error: Name "timeout" already defined (possibly by an import)  [no-redef]
        from airflow.utils.timeout import timeout  # type: ignore[assignment]  # type: ignore[assignment]
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
providers/google/src/airflow/providers/google/version_compat.py:64: note: Error code "no-redef" not covered by "type: ignore" comment
providers/openlineage/src/airflow/providers/openlineage/version_compat.py:47: error: Name "timeout" already defined (possibly by an import)  [no-redef]
        from airflow.utils.timeout import timeout  # type: ignore[assignment]
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
providers/openlineage/src/airflow/providers/openlineage/version_compat.py:47: note: Error code "no-redef" not covered by "type: ignore" comment
providers/celery/src/airflow/providers/celery/version_compat.py:34: error: Name "timeout" already defined (possibly by an import)  [no-redef]
        from airflow.utils.timeout import timeout  # type: ignore[assignment]
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
providers/celery/src/airflow/providers/celery/version_compat.py:34: note: Error code "no-redef" not covered by "type: ignore" comment
Found 3 errors in 3 files (checked 3962 source files)
```

Fix for https://github.com/apache/airflow/actions/runs/16939013494/job/48003772243


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
