### PR TITLE
Fix Databricks sqlalchemy URL construction

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -179,7 +179,6 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
         :return: the extracted sqlalchemy.engine.URL object.
         """
-        conn = self.get_conn()
         url_query = {
             "http_path": self._http_path,
             "catalog": self.catalog,
@@ -189,9 +188,8 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         return URL.create(
             drivername="databricks",
             username="token",
-            password=conn.password,
-            host=conn.host,
-            port=conn.port,
+            password=self._get_token(raise_error=True),
+            host=self.host,
             query=url_query,
         )
 

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -39,7 +39,6 @@ TASK_ID = "databricks-sql-operator"
 DEFAULT_CONN_ID = "databricks_default"
 HOST = "xx.cloud.databricks.com"
 HOST_WITH_SCHEME = "https://xx.cloud.databricks.com"
-PORT = 443
 TOKEN = "token"
 HTTP_PATH = "sql/protocolv1/o/1234567890123456/0123-456789-abcd123"
 SCHEMA = "test_schema"
@@ -112,38 +111,36 @@ def mock_timer():
         yield mock_timer
 
 
-def make_mock_connection():
-    return Connection(
-        conn_id=DEFAULT_CONN_ID,
-        conn_type="databricks",
-        host=HOST,
-        port=PORT,
-        login="token",
-        password=TOKEN,
-    )
-
-
-def test_sqlachemy_url_property(mock_get_conn):
-    mock_get_conn.return_value = make_mock_connection()
+def test_sqlachemy_url_property():
     hook = DatabricksSqlHook(
         databricks_conn_id=DEFAULT_CONN_ID, http_path=HTTP_PATH, catalog=CATALOG, schema=SCHEMA
     )
     url = hook.sqlalchemy_url.render_as_string(hide_password=False)
     expected_url = (
-        f"databricks://token:{TOKEN}@{HOST}:{PORT}?"
+        f"databricks://token:{TOKEN}@{HOST}?"
         f"catalog={CATALOG}&http_path={quote_plus(HTTP_PATH)}&schema={SCHEMA}"
     )
     assert url == expected_url
 
 
-def test_get_uri(mock_get_conn):
-    mock_get_conn.return_value = make_mock_connection()
+def test_get_sqlalchemy_engine():
+    hook = DatabricksSqlHook(
+        databricks_conn_id=DEFAULT_CONN_ID, http_path=HTTP_PATH, catalog=CATALOG, schema=SCHEMA
+    )
+    hook.get_sqlalchemy_engine()
+    assert hook.sqlalchemy_url.render_as_string(hide_password=False) == (
+        f"databricks://token:{TOKEN}@{HOST}?"
+        f"catalog={CATALOG}&http_path={quote_plus(HTTP_PATH)}&schema={SCHEMA}"
+    )
+
+
+def test_get_uri():
     hook = DatabricksSqlHook(
         databricks_conn_id=DEFAULT_CONN_ID, http_path=HTTP_PATH, catalog=CATALOG, schema=SCHEMA
     )
     uri = hook.get_uri()
     expected_uri = (
-        f"databricks://token:{TOKEN}@{HOST}:{PORT}?"
+        f"databricks://token:{TOKEN}@{HOST}?"
         f"catalog={CATALOG}&http_path={quote_plus(HTTP_PATH)}&schema={SCHEMA}"
     )
     assert uri == expected_uri

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -127,8 +127,8 @@ def test_get_sqlalchemy_engine():
     hook = DatabricksSqlHook(
         databricks_conn_id=DEFAULT_CONN_ID, http_path=HTTP_PATH, catalog=CATALOG, schema=SCHEMA
     )
-    hook.get_sqlalchemy_engine()
-    assert hook.sqlalchemy_url.render_as_string(hide_password=False) == (
+    engine = hook.get_sqlalchemy_engine()
+    assert engine.url.render_as_string(hide_password=False) == (
         f"databricks://token:{TOKEN}@{HOST}?"
         f"catalog={CATALOG}&http_path={quote_plus(HTTP_PATH)}&schema={SCHEMA}"
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Related: #53217

Update `DatabricksSqlHook` to use `_get_token` and `self.host` when constructing the SQLAlchemy URL, replacing the previous reliance on `get_conn()`.

- Remove dependency on `get_conn()` for retrieving tokens and host.
- Update unit tests to reflect the change.
