### PR TITLE
Fix celery visibility timeout (set to 23.5h instead of the intended 24h)

### DIFF
--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -360,7 +360,7 @@ config:
         version_added: ~
         type: string
         example: "21600"
-        default: ~
+        default: "86400"
       sentinel_kwargs:
         description: |
           The sentinel_kwargs parameter allows passing additional options to the Sentinel client.

--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -360,7 +360,7 @@ config:
         version_added: ~
         type: string
         example: "21600"
-        default: "86400"
+        default: ~
       sentinel_kwargs:
         description: |
           The sentinel_kwargs parameter allows passing additional options to the Sentinel client.

--- a/providers/celery/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/celery/src/airflow/providers/celery/executors/default_celery.py
@@ -52,7 +52,7 @@ broker_url = conf.get("celery", "BROKER_URL", fallback="redis://redis:6379/0")
 broker_transport_options: dict = conf.getsection("celery_broker_transport_options") or {}
 if "visibility_timeout" not in broker_transport_options:
     if _broker_supports_visibility_timeout(broker_url):
-        broker_transport_options["visibility_timeout"] = 84600
+        broker_transport_options["visibility_timeout"] = 86400
 
 if "sentinel_kwargs" in broker_transport_options:
     try:


### PR DESCRIPTION

---
[PR #40879](https://github.com/apache/airflow/pull/40879) was intended to increase the default for the Celery provider's `visibility_timeout` from 6h to 24h, which is set in seconds. A simple reversal of numbers inadvertently set it to 84600s (23.5h) instead of 86400 (24h)

This PR corrects that, as well as adds a default value for `visibility_timeout` in celery's `provider.yaml` file so sphinx picks it up and includes that in the docs page, which [currently shows](https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/configurations-ref.html#visibility-timeout) there is no default (there is)
