### PR TITLE
[Helm Chart] Update pre-release doc URLs to point to staged documentation (#50569)

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -23,10 +23,10 @@ version: 1.19.0-dev
 appVersion: 3.0.3
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
-home: https://airflow.apache.org/
+home: https://airflow.staged.apache.org/
 sources:
   - https://github.com/apache/airflow
-icon: https://airflow.apache.org/images/airflow_dark_bg.png
+icon: https://airflow.staged.apache.org/images/airflow_dark_bg.png
 keywords:
   - apache
   - airflow
@@ -44,24 +44,24 @@ type: application
 annotations:
   artifacthub.io/links: |
     - name: Documentation
-      url: https://airflow.apache.org/docs/helm-chart/1.19.0/
+      url: https://airflow.staged.apache.org/docs/helm-chart/1.19.0/
   artifacthub.io/screenshots: |
     - title: Home Page
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/home_dark.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/home_dark.png
     - title: DAG Overview Dashboard
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_dashboard.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_dashboard.png
     - title: DAGs View
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/dags.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/dags.png
     - title: Assets View
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/asset_view.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/asset_view.png
     - title: Grid View
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_grid.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_grid.png
     - title: Graph View
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_graph.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_graph.png
     - title: Variable View
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/variable_hidden.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/variable_hidden.png
     - title: Code View
-      url: https://airflow.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_code.png
+      url: https://airflow.staged.apache.org/docs/apache-airflow/3.0.3/_images/dag_overview_code.png
   artifacthub.io/changes: |
     - description: Allow ConfigMap and Secret references in ``apiServer.env``
       kind: changed

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -350,7 +350,7 @@ airflowLocalSettings: |-
     UIAlert(
       'Usage of a dynamic webserver secret key detected. We recommend a static webserver secret key instead.'
       ' See the <a href='
-      '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key" '
+      '"https://airflow.staged.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key" '
       'target="_blank" rel="noopener noreferrer">'
       'Helm Chart Production Guide</a> for more details.',
       category="warning",
@@ -371,7 +371,7 @@ rbac:
 # One or multiple of: LocalExecutor, CeleryExecutor, KubernetesExecutor
 # For Airflow <3.0, LocalKubernetesExecutor and CeleryKubernetesExecutor are also supported.
 # Specify executors in a prioritized list to leverage multiple execution environments as needed:
-# https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently
+# https://airflow.staged.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently
 executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's


### PR DESCRIPTION
This PR updates the documentation links in `Chart.yaml` and `values.yaml` for Helm Chart pre-release candidates.  
Previously, these links pointed to the production docs at https://airflow.apache.org, which is inconsistent with other pre-release artifacts (e.g., PyPI packages) that reference staged docs.  

Changes in this PR:
- Update Helm Chart URLs to use https://airflow.staged.apache.org for pre-release builds.

related: #50569 