### PR TITLE
AIP-82: implement Google Pub/Sub message queue provider

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1847,7 +1847,7 @@ def test_expected_output_push(
             ),
             {
                 "selected-providers-list-as-string": "amazon apache.beam apache.cassandra apache.kafka "
-                "cncf.kubernetes common.compat common.sql "
+                "cncf.kubernetes common.compat common.messaging common.sql "
                 "facebook google hashicorp http microsoft.azure microsoft.mssql mysql "
                 "openlineage oracle postgres presto salesforce samba sftp ssh trino",
                 "all-python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
@@ -1859,7 +1859,7 @@ def test_expected_output_push(
                 "skip-providers-tests": "false",
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow helm-chart amazon apache.beam apache.cassandra "
-                "apache.kafka cncf.kubernetes common.compat common.sql facebook google hashicorp http microsoft.azure "
+                "apache.kafka cncf.kubernetes common.compat common.messaging common.sql facebook google hashicorp http microsoft.azure "
                 "microsoft.mssql mysql openlineage oracle postgres "
                 "presto salesforce samba sftp ssh trino",
                 "skip-prek-hooks": ALL_SKIPPED_COMMITS_IF_NO_UI,
@@ -1873,7 +1873,7 @@ def test_expected_output_push(
                         {
                             "description": "amazon...google",
                             "test_types": "Providers[amazon] Providers[apache.beam,apache.cassandra,"
-                            "apache.kafka,cncf.kubernetes,common.compat,common.sql,facebook,"
+                            "apache.kafka,cncf.kubernetes,common.compat,common.messaging,common.sql,facebook,"
                             "hashicorp,http,microsoft.azure,microsoft.mssql,mysql,"
                             "openlineage,oracle,postgres,presto,salesforce,samba,sftp,ssh,trino] "
                             "Providers[google]",
@@ -2117,7 +2117,7 @@ def test_upgrade_to_newer_dependencies(
             ("providers/google/docs/some_file.rst",),
             {
                 "docs-list-as-string": "amazon apache.beam apache.cassandra apache.kafka "
-                "cncf.kubernetes common.compat common.sql facebook google hashicorp http "
+                "cncf.kubernetes common.compat common.messaging common.sql facebook google hashicorp http "
                 "microsoft.azure microsoft.mssql mysql openlineage oracle "
                 "postgres presto salesforce samba sftp ssh trino",
             },

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -36,6 +36,7 @@
 
     Connection types <connections/index>
     Logging handlers <logging/index>
+    Message queues <message-queues/index>
     Secrets backends <secrets-backends/google-cloud-secret-manager-backend>
     API Authentication backend <api-auth-backend/google-openid>
     Operators <operators/index>

--- a/providers/google/docs/message-queues/index.rst
+++ b/providers/google/docs/message-queues/index.rst
@@ -49,7 +49,7 @@ Where:
     - Must start with a letter
     - Can contain letters, numbers, hyphens, underscores, tildes, plus signs, and percent signs
     - Must be between 3 and 255 characters long
-    - Cannot start with "goog"
+    - Cannot start with `goog`
 
 The queue parameter is used to configure the underlying
 :class:`~airflow.providers.google.cloud.triggers.pubsub.PubsubPullTrigger` class.

--- a/providers/google/docs/message-queues/index.rst
+++ b/providers/google/docs/message-queues/index.rst
@@ -18,6 +18,10 @@
 Google Cloud Messaging Queues
 ==============================
 
+.. contents::
+   :local:
+   :depth: 2
+
 Google Cloud Pub/Sub Queue Provider
 ------------------------------------
 
@@ -25,37 +29,42 @@ Implemented by :class:`~airflow.providers.google.cloud.queues.pubsub.PubsubMessa
 
 The Google Cloud Pub/Sub Queue Provider is a message queue provider that uses Google Cloud Pub/Sub as the underlying message queue system.
 
-The queue should match this regex:
+It allows you to send and receive messages using Cloud Pub/Sub in your Airflow workflows
+with :class:`~airflow.providers.common.messaging.triggers.msg_queue.MessageQueueTrigger` common message queue interface.
 
-.. exampleinclude:: /../src/airflow/providers/google/cloud/queues/pubsub.py
+.. include:: /../src/airflow/providers/google/cloud/queues/pubsub.py
+    :start-after: [START pubsub_message_queue_provider_description]
+    :end-before: [END pubsub_message_queue_provider_description]
+
+Pub/Sub Message Queue Trigger
+-----------------------------
+
+Implemented by :class:`~airflow.providers.google.cloud.triggers.pubsub.PubsubPullTrigger`
+
+Inherited from :class:`~airflow.providers.common.messaging.triggers.msg_queue.MessageQueueTrigger`
+
+
+Wait for a message in a queue
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of how you can configure an Airflow DAG to be triggered by a message in Pub/Sub.
+
+.. exampleinclude:: /../tests/system/google/cloud/pubsub/example_pubsub_message_queue_trigger.py
     :language: python
-    :dedent: 0
-    :start-after: [START queue_regexp]
-    :end-before: [END queue_regexp]
+    :start-after: [START howto_trigger_pubsub_message_queue]
+    :end-before: [END howto_trigger_pubsub_message_queue]
 
-Queue URI Format:
+How it works
+------------
 
-.. code-block:: text
+1. **Pub/Sub Message Queue Trigger**: The ``PubsubPullTrigger`` listens for messages from a Google Cloud Pub/Sub subscription.
 
-    projects/{project_id}/subscriptions/{subscription_name}
+2. **Asset and Watcher**: The ``Asset`` abstracts the external entity, the Pub/Sub subscription in this example.
+   The ``AssetWatcher`` associate a trigger with a name. This name helps you identify which trigger is associated to which
+   asset.
 
-Where:
+3. **Event-Driven DAG**: Instead of running on a fixed schedule, the DAG executes when the asset receives an update
+   (e.g., a new message in the queue).
 
-- ``project_id``: Google Cloud project ID where the Pub/Sub subscription exists
-- ``subscription_name``: Name of the Pub/Sub subscription to consume messages from
-
-.. note::
-    The subscription name must follow Google Cloud naming conventions:
-    - Must start with a letter
-    - Can contain letters, numbers, hyphens, underscores, tildes, plus signs, and percent signs
-    - Must be between 3 and 255 characters long
-    - Cannot start with `goog`
-
-The queue parameter is used to configure the underlying
-:class:`~airflow.providers.google.cloud.triggers.pubsub.PubsubPullTrigger` class.
-The provider extracts the ``project_id`` and ``subscription`` from the queue URI format
-and passes them along with additional configuration to the trigger constructor.
-
-.. warning::
-    Do not provide ``project_id`` or ``subscription`` in kwargs as they are extracted
-    from the queue URI format and will raise a ValueError if provided.
+For how to use the trigger, refer to the documentation of the
+:ref:`Messaging Trigger <howto/trigger:MessageQueueTrigger>`

--- a/providers/google/docs/message-queues/index.rst
+++ b/providers/google/docs/message-queues/index.rst
@@ -1,0 +1,61 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Messaging Queues
+==============================
+
+Google Cloud Pub/Sub Queue Provider
+------------------------------------
+
+Implemented by :class:`~airflow.providers.google.cloud.queues.pubsub.PubsubMessageQueueProvider`
+
+The Google Cloud Pub/Sub Queue Provider is a message queue provider that uses Google Cloud Pub/Sub as the underlying message queue system.
+
+The queue should match this regex:
+
+.. exampleinclude:: /../src/airflow/providers/google/cloud/queues/pubsub.py
+    :language: python
+    :dedent: 0
+    :start-after: [START queue_regexp]
+    :end-before: [END queue_regexp]
+
+Queue URI Format:
+
+.. code-block:: text
+
+    projects/{project_id}/subscriptions/{subscription_name}
+
+Where:
+
+- ``project_id``: Google Cloud project ID where the Pub/Sub subscription exists
+- ``subscription_name``: Name of the Pub/Sub subscription to consume messages from
+
+.. note::
+    The subscription name must follow Google Cloud naming conventions:
+    - Must start with a letter
+    - Can contain letters, numbers, hyphens, underscores, tildes, plus signs, and percent signs
+    - Must be between 3 and 255 characters long
+    - Cannot start with "goog"
+
+The queue parameter is used to configure the underlying
+:class:`~airflow.providers.google.cloud.triggers.pubsub.PubsubPullTrigger` class.
+The provider extracts the ``project_id`` and ``subscription`` from the queue URI format
+and passes them along with additional configuration to the trigger constructor.
+
+.. warning::
+    Do not provide ``project_id`` or ``subscription`` in kwargs as they are extracted
+    from the queue URI format and will raise a ValueError if provided.

--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -1257,3 +1257,6 @@ auth-backends:
 logging:
   - airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler
   - airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverTaskHandler
+
+queues:
+  - airflow.providers.google.cloud.queues.pubsub.PubsubMessageQueueProvider

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -203,6 +203,9 @@ dependencies = [
 "http" = [
     "apache-airflow-providers-http"
 ]
+"common.messaging" = [
+    "apache-airflow-providers-common-messaging"
+]
 
 [dependency-groups]
 dev = [
@@ -214,6 +217,7 @@ dev = [
     "apache-airflow-providers-apache-cassandra",
     "apache-airflow-providers-cncf-kubernetes",
     "apache-airflow-providers-common-compat",
+    "apache-airflow-providers-common-messaging",
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-facebook",
     "apache-airflow-providers-http",

--- a/providers/google/src/airflow/providers/google/cloud/queues/__init__.py
+++ b/providers/google/src/airflow/providers/google/cloud/queues/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
+++ b/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
@@ -47,15 +47,15 @@ class PubsubMessageQueueProvider(BaseMessageQueueProvider):
         return bool(re.match(QUEUE_REGEXP, queue))
 
     def trigger_class(self) -> type[BaseEventTrigger]:
-        return PubsubPullTrigger # type: ignore[return-value]
+        return PubsubPullTrigger  # type: ignore[return-value]
 
     def trigger_kwargs(self, queue: str, **kwargs) -> dict:
         pattern = re.compile(QUEUE_REGEXP)
         match = pattern.match(queue)
-        
+
         if match is None:
             raise ValueError(f"Queue '{queue}' does not match the expected PubSub format")
-            
+
         project_id = match.group("project_id")
         subscription = match.group("subscription")
 

--- a/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
+++ b/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
@@ -47,11 +47,15 @@ class PubsubMessageQueueProvider(BaseMessageQueueProvider):
         return bool(re.match(QUEUE_REGEXP, queue))
 
     def trigger_class(self) -> type[BaseEventTrigger]:
-        return PubsubPullTrigger
+        return PubsubPullTrigger # type: ignore[return-value]
 
     def trigger_kwargs(self, queue: str, **kwargs) -> dict:
         pattern = re.compile(QUEUE_REGEXP)
         match = pattern.match(queue)
+        
+        if match is None:
+            raise ValueError(f"Queue '{queue}' does not match the expected PubSub format")
+            
         project_id = match.group("project_id")
         subscription = match.group("subscription")
 

--- a/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
+++ b/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
@@ -33,7 +33,34 @@ if TYPE_CHECKING:
 
 
 class PubsubMessageQueueProvider(BaseMessageQueueProvider):
-    """Configuration for PubSub integration with common-messaging."""
+    """
+    Configuration for PubSub integration with common-messaging.
+
+    [START pubsub_message_queue_provider_description]
+    * It uses ``google+pubsub`` as the scheme for identifying the provider.
+    * For parameter definitions, take a look at :class:`~airflow.providers.google.cloud.triggers.pubsub.PubsubPullTrigger`.
+
+    .. code-block:: python
+
+        from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTrigger
+        from airflow.sdk import Asset, AssetWatcher
+
+        trigger = MessageQueueTrigger(
+            scheme="google+pubsub",
+            # Additional PubsubPullTrigger parameters as needed
+            project_id="my_project",
+            subscription="my_subscription",
+            ack_messages=True,
+            max_messages=1,
+            gcp_conn_id="google_cloud_default",
+            poke_interval=60.0,
+        )
+
+        asset = Asset("pubsub_queue_asset", watchers=[AssetWatcher(name="pubsub_watcher", trigger=trigger)])
+
+    [END pubsub_message_queue_provider_description]
+
+    """
 
     scheme = "google+pubsub"
 

--- a/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
+++ b/providers/google/src/airflow/providers/google/cloud/queues/pubsub.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+from airflow.providers.google.cloud.triggers.pubsub import PubsubPullTrigger
+
+try:
+    from airflow.providers.common.messaging.providers.base_provider import BaseMessageQueueProvider
+except ImportError:
+    raise AirflowOptionalProviderFeatureException(
+        "This feature requires the 'common.messaging' provider to be installed in version >= 1.0.1."
+    )
+
+if TYPE_CHECKING:
+    from airflow.triggers.base import BaseEventTrigger
+
+# [START queue_regexp]
+QUEUE_REGEXP = (
+    r"^projects/(?P<project_id>[^/]+)/subscriptions/"
+    r"(?P<subscription>(?!goog)[A-Za-z][A-Za-z0-9\-_.~+%]{2,254})$"
+)
+# [END queue_regexp]
+
+
+class PubsubMessageQueueProvider(BaseMessageQueueProvider):
+    """Configuration for PubSub integration with common-messaging."""
+
+    def queue_matches(self, queue: str) -> bool:
+        return bool(re.match(QUEUE_REGEXP, queue))
+
+    def trigger_class(self) -> type[BaseEventTrigger]:
+        return PubsubPullTrigger
+
+    def trigger_kwargs(self, queue: str, **kwargs) -> dict:
+        pattern = re.compile(QUEUE_REGEXP)
+        match = pattern.match(queue)
+        project_id = match.group("project_id")
+        subscription = match.group("subscription")
+
+        if "project_id" in kwargs or "subscription" in kwargs:
+            raise ValueError(
+                "project_id or subscription cannot be provided in kwargs, use the queue param instead"
+            )
+
+        return_kwargs = {
+            "project_id": project_id,
+            "subscription": subscription,
+            "ack_messages": True,
+        }
+        if "max_messages" not in kwargs:
+            return_kwargs["max_messages"] = 1
+        if "gcp_conn_id" not in kwargs:
+            return_kwargs["gcp_conn_id"] = "google_cloud_default"
+
+        return return_kwargs

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1518,4 +1518,5 @@ def get_provider_info():
             "airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler",
             "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverTaskHandler",
         ],
+        "queues": ["airflow.providers.google.cloud.queues.pubsub.PubsubMessageQueueProvider"],
     }

--- a/providers/google/tests/system/google/cloud/pubsub/example_pubsub_message_queue_trigger.py
+++ b/providers/google/tests/system/google/cloud/pubsub/example_pubsub_message_queue_trigger.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG that demonstrates using Google Cloud Pub/Sub with MessageQueueTrigger
+and Asset Watchers for event-driven workflows.
+
+This example shows how to create a DAG that triggers when messages arrive in a
+Google Cloud Pub/Sub subscription using Asset Watchers.
+
+Prerequisites
+-------------
+
+Before running this example, ensure you have:
+
+1. A GCP project with Pub/Sub API enabled
+2. The following Pub/Sub resources created in your project:
+
+   - Topic: ``test-topic``
+   - Subscription: ``test-subscription``
+
+You can create these resources using:
+
+.. code-block:: bash
+
+    # Create topic
+    gcloud pubsub topics create test-topic --project={PROJECT_ID}
+
+    # Create subscription
+    gcloud pubsub subscriptions create test-subscription \\
+        --topic=test-topic --project={PROJECT_ID}
+
+How to test
+-----------
+
+1. Ensure the Pub/Sub resources exist (see Prerequisites above)
+2. Publish a message to trigger the DAG:
+
+   .. code-block:: bash
+
+       gcloud pubsub topics publish test-topic \\
+           --message="Test message" --project={PROJECT_ID}
+
+3. The DAG will be triggered automatically when the message arrives
+"""
+
+from __future__ import annotations
+
+# [START howto_trigger_pubsub_message_queue]
+from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTrigger
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import DAG, Asset, AssetWatcher
+
+# Define a trigger that listens to a Google Cloud Pub/Sub subscription
+trigger = MessageQueueTrigger(
+    scheme="google+pubsub",
+    project_id="my-project",
+    subscription="test-subscription",
+    ack_messages=True,
+    max_messages=1,
+    gcp_conn_id="google_cloud_default",
+    poke_interval=60.0,
+)
+
+# Define an asset that watches for messages on the Pub/Sub subscription
+asset = Asset("pubsub_queue_asset_1", watchers=[AssetWatcher(name="pubsub_watcher_1", trigger=trigger)])
+
+with DAG(
+    dag_id="example_pubsub_message_queue_trigger",
+    schedule=[asset],
+) as dag:
+    process_message_task = EmptyOperator(task_id="process_pubsub_message")
+# [END howto_trigger_pubsub_message_queue]
+
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/google/tests/unit/google/cloud/queues/__init__.py
+++ b/providers/google/tests/unit/google/cloud/queues/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/google/tests/unit/google/cloud/queues/test_pubsub.py
+++ b/providers/google/tests/unit/google/cloud/queues/test_pubsub.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.google.cloud.triggers.pubsub import PubsubPullTrigger
+
+pytest.importorskip("airflow.providers.common.messaging.providers.base_provider")
+
+
+def test_message_pubsub_queue_create():
+    from airflow.providers.common.messaging.providers.base_provider import BaseMessageQueueProvider
+    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
+
+    provider = PubsubMessageQueueProvider()
+    assert isinstance(provider, BaseMessageQueueProvider)
+
+
+def test_message_pubsub_queue_matches():
+    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
+
+    provider = PubsubMessageQueueProvider()
+    assert provider.queue_matches("projects/test-project/subscriptions/my-subscription")
+    assert not provider.queue_matches("projects/test-project/subscriptions/goog-my-subscription")
+    assert not provider.queue_matches("projects/test-project/subscriptions")
+    assert not provider.queue_matches("projects/test-project/subscriptions/")
+    assert not provider.queue_matches("projects/test-project")
+
+
+def test_message_pubsub_queue_trigger_class():
+    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
+
+    provider = PubsubMessageQueueProvider()
+    assert provider.trigger_class() == PubsubPullTrigger
+
+
+def test_message_pubsub_queue_trigger_kwargs():
+    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
+
+    provider = PubsubMessageQueueProvider()
+    assert provider.trigger_kwargs("projects/test-project/subscriptions/my-subscription") == {
+        "project_id": "test-project",
+        "subscription": "my-subscription",
+        "ack_messages": True,
+        "max_messages": 1,
+        "gcp_conn_id": "google_cloud_default",
+    }
+
+
+@pytest.mark.parametrize(
+    "queue, extra_kwargs, expected_error, error_match",
+    [
+        pytest.param(
+            "projects/test-project/subscriptions/my-subscription",
+            {"project_id": "my-project"},
+            ValueError,
+            "project_id or subscription cannot be provided in kwargs, use the queue param instead",
+            id="project_id_in_kwargs",
+        ),
+        pytest.param(
+            "projects/test-project/subscriptions/my-subscription",
+            {"subscription": "my-subscription"},
+            ValueError,
+            "project_id or subscription cannot be provided in kwargs, use the queue param instead",
+            id="subscription_in_kwargs",
+        ),
+        pytest.param(
+            "projects/test-project/subscriptions/my-subscription",
+            {"project_id": "my-project", "subscription": "my-subscription"},
+            ValueError,
+            "project_id or subscription cannot be provided in kwargs, use the queue param instead",
+            id="both_in_kwargs",
+        ),
+    ],
+)
+def test_message_pubsub_queue_trigger_kwargs_invalid_cases(queue, extra_kwargs, expected_error, error_match):
+    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
+
+    provider = PubsubMessageQueueProvider()
+    with pytest.raises(expected_error, match=error_match):
+        provider.trigger_kwargs(queue, **extra_kwargs)

--- a/providers/google/tests/unit/google/cloud/queues/test_pubsub.py
+++ b/providers/google/tests/unit/google/cloud/queues/test_pubsub.py
@@ -31,17 +31,6 @@ def test_message_pubsub_queue_create():
     assert isinstance(provider, BaseMessageQueueProvider)
 
 
-def test_message_pubsub_queue_matches():
-    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
-
-    provider = PubsubMessageQueueProvider()
-    assert provider.queue_matches("projects/test-project/subscriptions/my-subscription")
-    assert not provider.queue_matches("projects/test-project/subscriptions/goog-my-subscription")
-    assert not provider.queue_matches("projects/test-project/subscriptions")
-    assert not provider.queue_matches("projects/test-project/subscriptions/")
-    assert not provider.queue_matches("projects/test-project")
-
-
 def test_message_pubsub_queue_trigger_class():
     from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
 
@@ -49,48 +38,8 @@ def test_message_pubsub_queue_trigger_class():
     assert provider.trigger_class() == PubsubPullTrigger
 
 
-def test_message_pubsub_queue_trigger_kwargs():
+def test_scheme_matches():
     from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
 
     provider = PubsubMessageQueueProvider()
-    assert provider.trigger_kwargs("projects/test-project/subscriptions/my-subscription") == {
-        "project_id": "test-project",
-        "subscription": "my-subscription",
-        "ack_messages": True,
-        "max_messages": 1,
-        "gcp_conn_id": "google_cloud_default",
-    }
-
-
-@pytest.mark.parametrize(
-    "queue, extra_kwargs, expected_error, error_match",
-    [
-        pytest.param(
-            "projects/test-project/subscriptions/my-subscription",
-            {"project_id": "my-project"},
-            ValueError,
-            "project_id or subscription cannot be provided in kwargs, use the queue param instead",
-            id="project_id_in_kwargs",
-        ),
-        pytest.param(
-            "projects/test-project/subscriptions/my-subscription",
-            {"subscription": "my-subscription"},
-            ValueError,
-            "project_id or subscription cannot be provided in kwargs, use the queue param instead",
-            id="subscription_in_kwargs",
-        ),
-        pytest.param(
-            "projects/test-project/subscriptions/my-subscription",
-            {"project_id": "my-project", "subscription": "my-subscription"},
-            ValueError,
-            "project_id or subscription cannot be provided in kwargs, use the queue param instead",
-            id="both_in_kwargs",
-        ),
-    ],
-)
-def test_message_pubsub_queue_trigger_kwargs_invalid_cases(queue, extra_kwargs, expected_error, error_match):
-    from airflow.providers.google.cloud.queues.pubsub import PubsubMessageQueueProvider
-
-    provider = PubsubMessageQueueProvider()
-    with pytest.raises(expected_error, match=error_match):
-        provider.trigger_kwargs(queue, **extra_kwargs)
+    assert provider.scheme_matches("google+pubsub")


### PR DESCRIPTION
This PR implements `PubsubMessageQueueProvider` as part of the AIP-82 https://github.com/apache/airflow/issues/52712 initiative to expand Event-Driven Scheduling, enabling Google Cloud Pub/Sub subscriptions as message queues in Airflow's common messaging framework.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
