### PR TITLE
airflow-provider-slack: avoid secret false positive from trivy.

### DIFF
--- a/providers/slack/src/airflow/providers/slack/hooks/slack.py
+++ b/providers/slack/src/airflow/providers/slack/hooks/slack.py
@@ -400,7 +400,7 @@ class SlackHook(BaseHook):
                 "password": "Slack API Token",
             },
             "placeholders": {
-                "password": "xoxb-1234567890123-09876543210987-AbCdEfGhIjKlMnOpQrStUvWx",
+                "password": "REPLACE ME WITH A SLACK ACCESS TOKEN",
                 "timeout": "30",
                 "base_url": "https://www.slack.com/api/",
                 "proxy": "http://localhost:9000",


### PR DESCRIPTION
trivy will detect the example Slack access token as a potential secret generating a HIGH vulnerability when present in an OCI image.

```
src/airflow/providers/slack/hooks/slack.py (secrets)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

HIGH: Slack (slack-access-token)

Slack token

 src/airflow/providers/slack/hooks/slack.py:403

 401               },
 402               "placeholders": {
 403 [                 "password": "******************-09876543210987-AbCdEfGhIjKlMnOpQrStUvWx",
 404                   "timeout": "30",
```

Replace with a reminder instead.

Signed-off-by: James Page <james.page@chainguard.dev>
