### PR TITLE
use 1 worker for log server

### DIFF
--- a/airflow-core/src/airflow/utils/serve_logs/core.py
+++ b/airflow-core/src/airflow/utils/serve_logs/core.py
@@ -54,11 +54,11 @@ def serve_logs(port=None):
     logger.info("Starting log server on %s", serve_log_uri)
 
     # Use uvicorn directly for ASGI applications
-    uvicorn.run("airflow.utils.serve_logs.log_server:app", host=host, port=port, workers=2, log_level="info")
     # Note: if we want to use more than 1 workers, we **can't** use the instance of FastAPI directly
-    # This is way we split the instantiation of log server to a separate module
+    # This is why we split the instantiation of log server to a separate module
     #
     # https://github.com/encode/uvicorn/blob/374bb6764e8d7f34abab0746857db5e3d68ecfdd/docs/deployment/index.md?plain=1#L50-L63
+    uvicorn.run("airflow.utils.serve_logs.log_server:app", host=host, port=port, workers=1, log_level="info")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

fixes  stacktraces of the form in standalone & running directly for the components that launch logserver under a multiprocessing process:
```
    scheduler  | Process SpawnProcess-1:1:
    scheduler  | Traceback (most recent call last):
    scheduler  | File "/opt/bb/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    scheduler  | self.run()
    scheduler  | File "/opt/bb/lib/python3.10/multiprocessing/process.py", line 108, in run
    scheduler  | self._target(*self._args, **self._kwargs)
    scheduler  | File "/mnt/dev/repos/airflow/.venv/lib/python3.10/site-packages/uvicorn/_subprocess.py", line 73, in subprocess_started
    scheduler  | sys.stdin = os.fdopen(stdin_fileno)  # pragma: full coverage
    scheduler  | File "/opt/bb/lib/python3.10/os.py", line 1030, in fdopen
    scheduler  | return io.open(fd, mode, buffering, encoding, *args, **kwargs)
    scheduler  | OSError: [Errno 9] Bad file descriptor
```
there is a bug in uvicorn that causes a crash when uvicorn.run is being spawned from a process that itself was spawned by multiprocessing, as we do with serve_logs: https://github.com/encode/uvicorn/issues/2679

until uvicorn itself fixes what it tries to do with stdin, just use 1 worker instead of 2 to avoid the codepath that causes the break.