### PR TITLE
docs: Guide for resolving UI TemplateNotFound in Breeze setup

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -445,6 +445,26 @@ see in CI in your local environment.
 
    Once the package is installed, execute the breeze command again to resume image building.
 
+   If you encounter an error such as
+
+   .. code-block:: text
+
+      jinja2.exceptions.TemplateNotFound: '/index.html' not found in search path: '/opt/airflow/airflow-core/src/airflow/ui/dist'
+
+   you may need to compile the UI assets before starting the Breeze environment. To do so, run the following command **before** executing step 4:
+
+   .. code-block:: bash
+
+      breeze compile-ui-assets
+
+   After running this, verify that the compiled UI assets have been added to ``/airflow/.build/ui``.
+   
+   Then, proceed with:
+
+   .. code-block:: bash
+
+      breeze --python 3.10 --backend postgres
+
 
 5. When you enter the Breeze environment you should see a prompt similar to ``root@e4756f6ac886:/opt/airflow#``. This
    means that you are inside the Breeze container and ready to run most of the development tasks. You can leave

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -458,7 +458,7 @@ see in CI in your local environment.
       breeze compile-ui-assets
 
    After running this, verify that the compiled UI assets have been added to ``/airflow/.build/ui``.
-   
+
    Then, proceed with:
 
    .. code-block:: bash


### PR DESCRIPTION
This pull request updates the contributor quick start documentation to help users resolve a common issue that can occur when setting up the Breeze environment. Specifically, it adds troubleshooting instructions for the following error:

`jinja2.exceptions.TemplateNotFound: '/index.html' not found in search path: '/opt/airflow/airflow-core/src/airflow/ui/dist'`

The documentation now instructs users to run breeze compile-ui-assets before initializing the Breeze environment if they encounter this error, and to verify that the compiled UI assets are present in /airflow/.build/ui before proceeding.

This addition aims to make the onboarding process smoother and to help new contributors quickly resolve UI asset-related errors during setup.