### PR TITLE
Fix local executor task execution

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -186,8 +186,7 @@ class LocalExecutor(BaseExecutor):
         # If we're using spawn in multiprocessing (default on macOS now) to start tasks, this can get called a
         # via `sync()` a few times before the spawned process actually starts picking up messages. Try not to
         # create too much
-        need_more_workers = len(self.workers) < num_outstanding
-        if need_more_workers and (self.parallelism == 0 or len(self.workers) < self.parallelism):
+        if num_outstanding and (self.parallelism == 0 or len(self.workers) < self.parallelism):
             # This only creates one worker, which is fine as we call this directly after putting a message on
             # activity_queue in execute_async
             self._spawn_worker()

--- a/airflow-core/tests/unit/executors/test_local_executor_check_workers.py
+++ b/airflow-core/tests/unit/executors/test_local_executor_check_workers.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.executors.local_executor import LocalExecutor
+
+
+@pytest.fixture(autouse=True)
+def setup_executor(monkeypatch):
+    executor = LocalExecutor(parallelism=2)
+    executor.workers = {}
+    executor._unread_messages = MagicMock()
+    executor.activity_queue = MagicMock()
+    monkeypatch.setattr(executor, "_spawn_worker", MagicMock())
+    return executor
+
+
+def test_no_workers_on_no_work(setup_executor):
+    executor = setup_executor
+    executor._unread_messages.value = 0
+    executor.activity_queue.empty.return_value = True
+    executor._check_workers()
+    executor._spawn_worker.assert_not_called()
+    assert executor.workers == {}
+
+
+def test_all_workers_alive(setup_executor):
+    executor = setup_executor
+    proc1 = MagicMock()
+    proc1.is_alive.return_value = True
+    proc2 = MagicMock()
+    proc2.is_alive.return_value = True
+    executor.workers = {1: proc1, 2: proc2}
+    executor._unread_messages.value = 0
+    executor.activity_queue.empty.return_value = True
+    executor._check_workers()
+    proc1.close.assert_not_called()
+    proc2.close.assert_not_called()
+    assert len(executor.workers) == 2
+
+
+def test_some_workers_dead(setup_executor):
+    executor = setup_executor
+    proc1 = MagicMock()
+    proc1.is_alive.return_value = False
+    proc2 = MagicMock()
+    proc2.is_alive.return_value = True
+    executor.workers = {1: proc1, 2: proc2}
+    executor._unread_messages.value = 0
+    executor.activity_queue.empty.return_value = True
+    executor._check_workers()
+    proc1.close.assert_called_once()
+    proc2.close.assert_not_called()
+    assert executor.workers == {2: proc2}
+
+
+def test_all_workers_dead(setup_executor):
+    executor = setup_executor
+    proc1 = MagicMock()
+    proc1.is_alive.return_value = False
+    proc2 = MagicMock()
+    proc2.is_alive.return_value = False
+    executor.workers = {1: proc1, 2: proc2}
+    executor._unread_messages.value = 0
+    executor.activity_queue.empty.return_value = True
+    executor._check_workers()
+    proc1.close.assert_called_once()
+    proc2.close.assert_called_once()
+    assert executor.workers == {}
+
+
+def test_outstanding_messages_and_empty_queue(setup_executor):
+    executor = setup_executor
+    executor._unread_messages.value = 1
+    executor.activity_queue.empty.return_value = True
+    executor._check_workers()
+    executor._spawn_worker.assert_not_called()
+
+
+def test_spawn_worker_when_needed(setup_executor):
+    executor = setup_executor
+    executor._unread_messages.value = 1
+    executor.activity_queue.empty.return_value = False
+    executor.workers = {}
+    executor._check_workers()
+    executor._spawn_worker.assert_called_once()
+
+
+def test_no_spawn_if_parallelism_reached(setup_executor):
+    executor = setup_executor
+    executor._unread_messages.value = 2
+    executor.activity_queue.empty.return_value = False
+    proc1 = MagicMock()
+    proc1.is_alive.return_value = True
+    proc2 = MagicMock()
+    proc2.is_alive.return_value = True
+    executor.workers = {1: proc1, 2: proc2}
+    executor._check_workers()
+    executor._spawn_worker.assert_not_called()
+
+
+def test_parallelism_zero_spawns_worker(setup_executor):
+    executor = setup_executor
+    executor.parallelism = 0
+    executor._unread_messages.value = 1
+    executor.activity_queue.empty.return_value = False
+    executor.workers = {}
+    executor._check_workers()
+    executor._spawn_worker.assert_called_once()
+
+
+def test_spawn_worker_when_we_have_parallelism_left(setup_executor):
+    executor = setup_executor
+    # Simulate 4 running workers
+    running_workers = {}
+    for i in range(4):
+        proc = MagicMock()
+        proc.is_alive.return_value = True
+        running_workers[i] = proc
+    executor.workers = running_workers
+    executor.parallelism = 5  # Allow more workers if needed
+
+    # Simulate 4 pending tasks (equal to running workers)
+    executor._unread_messages.value = 4
+    executor.activity_queue.empty.return_value = False
+    executor._spawn_worker.reset_mock()
+    executor._check_workers()
+    executor._spawn_worker.assert_called_once()


### PR DESCRIPTION
### Summary
LocalExecutor would only actually begin execution for every second task submitted to it. This change fixes this behaviour.

The number of queued tasks would need to exceed the number of currently running tasks for a new task to be executed, which is logically close to what is needed but not quite. This means if 4 tasks are running and 4 are pending none of the 4 tasks will begin, but if a 5th task is queued it will begin and there will be 5 tasks running and 4 waiting, it will take another two tasks submitted (for a total of 5 then 6 pending tasks) before the next is started, and so one. So in reality one of every two tasks is started.

The logic is really as simple as: if we have any pending tasks and we are still within our parallelism limits, start those tasks running. This schedules tasks in accordance to user expectations and how Airflow 2.X scheduled tasks for the LocalExecutor (since this regressed during the migration from 2.X to 3.X for the LocalExecutor)

### QA:
Testing a simple dag that simply starts many parallel tasks. It should start as many concurrently as the default configuration allows, the default limit of max active tasks per dag of 16 should be the limit hit:
```
from datetime import datetime, timedelta
from airflow import DAG
from time import sleep
from airflow.decorators import task
import socket
import random

default_args = {
  'owner': 'Airflow',
  'depends_on_past': False,
  'start_date': datetime(2023, 1, 1),
  'email_on_failure': False,
  'email_on_retry': False,
  'retries': 1,
  'retry_delay': timedelta(minutes=1),
}

max_tasks = 25

with DAG(
  'slow_task_dag',
  default_args=default_args,
  schedule=None,  # Changed from schedule_interval to schedule
  catchup=False
) as dag:
  for y in range(0, max_tasks):
    @task(task_id=f'print_hello_{y}')
    def task_method(ds=None, **kwargs):
      print(f'Getting executed at worker {socket.gethostname()}')
      sleep(10 + random.randint(0, 9))

    task_method()
```

Before this change you would see this execution pattern where only 8 tasks would actually start running (incorrectly) despite 16 being queued (correctly).

<img width="1170" height="788" alt="Screenshot from 2025-08-13 10-46-53" src="https://github.com/user-attachments/assets/d522ab3c-121b-4499-9af8-bc0c2e01178d" />


With this change all 16 queued tasks begin running:

<img width="1129" height="771" alt="Screenshot from 2025-08-14 12-48-04" src="https://github.com/user-attachments/assets/08a5f05e-d786-4873-8a87-2b6c88d9c518" />
 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
