### PR TITLE
Adjust grid tooltip position+arrow

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -143,7 +143,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, 
             id="tooltip"
             p={2}
             position="absolute"
-            right={0}
+            right={5}
             visibility="hidden"
             zIndex="tooltip"
           >
@@ -162,6 +162,17 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, 
                 {translate("endDate")}: <Time datetime={instance.max_end_date} />
               </>
             )}
+            {/* Tooltip arrow pointing to the badge */}
+            <chakra.div
+              bg="bg.inverted"
+              borderRadius={1}
+              bottom={1}
+              height={2}
+              position="absolute"
+              right="-3px"
+              transform="rotate(45deg)"
+              width={2}
+            />
           </chakra.span>
         </Badge>
       </Link>


### PR DESCRIPTION
Fix grid tooltip position to not cover the Grid cell. Also, add an arrow on the tooltip to make it clear which task instance you're looking at.

<img width="346" height="193" alt="Screenshot 2025-08-14 at 3 13 17 PM" src="https://github.com/user-attachments/assets/3dd1cd4e-ca50-47e5-91c3-f4b6456ef5b1" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
