### PR TITLE
Remove end_from_trigger attribute in MwaaTaskSensor trigger

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/mwaa.py
@@ -294,7 +294,6 @@ class MwaaTaskSensor(AwsBaseSensor[MwaaHook]):
                     waiter_delay=int(self.poke_interval),
                     waiter_max_attempts=self.max_retries,
                     aws_conn_id=self.aws_conn_id,
-                    end_from_trigger=True,
                 ),
                 method_name="execute_complete",
             )


### PR DESCRIPTION
Currently there's a bug that prevents MwaaTaskSensor from working in deferrable mode. It refers to an attribute `end_from_trigger`, the intention is for the trigger to complete without spinning up a call to `execute_complete`. However, `end_from_trigger` is a new attribute not yet implemented for this trigger, so I removed it. Without this change, the `example_mwaa.py` system integration test fails when `deferrable=True` on the `MwaaTaskSensor`, and after this change the same test passes.