### PR TITLE
Log when triggerer has reached the maximum trigger capacity

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -324,6 +324,11 @@ class Trigger(Base):
         capacity -= count
 
         if capacity <= 0:
+            log.info(
+                "Triggerer %s has reached the maximum capacity triggers assigned (%d). Not assigning any more triggers",
+                triggerer_id,
+                count,
+            )
             return
 
         alive_triggerer_ids = select(Job.id).where(


### PR DESCRIPTION
Might help to know that a triggerer has reached the maximum number of triggers it can run