### PR TITLE
Don't attempt HTTP retries when using the InProcess API client

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2229,6 +2229,26 @@ class TestInProcessTestSupervisor:
         assert response.value == "value"
 
 
+class TestInProcessClient:
+    def test_no_retries(self):
+        called = 0
+
+        def noop_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal called
+            called += 1
+            return httpx.Response(500)
+
+        transport = httpx.MockTransport(noop_handler)
+        client = InProcessTestSupervisor._Client(
+            base_url="http://local.invalid", token="", transport=transport
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            client.get("/goo")
+
+        assert called == 1
+
+
 @pytest.mark.parametrize(
     ("remote_logging", "remote_conn", "expected_env"),
     (


### PR DESCRIPTION
The retries are designed to deal with transient HTTP and network errors, but
when we have the API server running in the same process (in tests, or in
`dag.test`, `ti.run` etc) retries are just a waste of time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
