### PR TITLE
Fix missing logs in UI for tasks in `UP_FOR_RETRY` and `UP_FOR_RESCHEDULE` states (#54544)

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -90,6 +90,13 @@ LegacyProvidersLogType: TypeAlias = list["StructuredLogMessage"] | str | list[st
 - For Redis: returns a list of strings.
 """
 
+_STATES_WITH_COMPLETED_ATTEMPT = frozenset(
+    {
+        TaskInstanceState.UP_FOR_RETRY,
+        TaskInstanceState.UP_FOR_RESCHEDULE,
+    }
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -644,7 +651,9 @@ class FileTaskHandler(logging.Handler):
         if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_k8s_exec_pod:
             sources, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             source_list.extend(sources)
-        elif ti.state not in State.unfinished and not (local_logs or remote_logs):
+        elif (ti.state not in State.unfinished or ti.state in _STATES_WITH_COMPLETED_ATTEMPT) and not (
+            local_logs or remote_logs
+        ):
             # ordinarily we don't check served logs, with the assumption that users set up
             # remote logging or shared drive for logs for persistence, but that's not always true
             # so even if task is done, if no local logs or remote logs are found, we'll check the worker


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

closes: #54544



<!-- Please keep an empty line above the dashes. -->
---
Fix missing logs in UI for tasks in UP_FOR_RETRY state

Include TaskInstanceState.UP_FOR_RETRY in the log retrieval condition
to ensure logs are shown when a task retries. Previously, tasks that
entered UP_FOR_RETRY had no logs displayed in the UI when using local
log storage.

