### PR TITLE
Fix module loading in logging config

### DIFF
--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
-from airflow.utils.module_loading import import_string
+from airflow.utils.module_loading import import_module, import_string
 
 if TYPE_CHECKING:
     from airflow.logging.remote import RemoteLogIO
@@ -73,10 +73,9 @@ def load_logging_config() -> tuple[dict[str, Any], str]:
     else:
         modpath = logging_class_path.rsplit(".", 1)[0]
         try:
-            # Import here to avoid circular imports
-            from importlib import import_module
-
             mod = import_module(modpath)
+
+            # Load remote logging configuration from the custom module
             REMOTE_TASK_LOG = getattr(mod, "REMOTE_TASK_LOG")
             DEFAULT_REMOTE_CONN_ID = getattr(mod, "DEFAULT_REMOTE_CONN_ID", None)
         except Exception as err:

--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -73,7 +73,10 @@ def load_logging_config() -> tuple[dict[str, Any], str]:
     else:
         modpath = logging_class_path.rsplit(".", 1)[0]
         try:
-            mod = import_string(modpath)
+            # Import here to avoid circular imports
+            from importlib import import_module
+
+            mod = import_module(modpath)
             REMOTE_TASK_LOG = getattr(mod, "REMOTE_TASK_LOG")
             DEFAULT_REMOTE_CONN_ID = getattr(mod, "DEFAULT_REMOTE_CONN_ID", None)
         except Exception as err:

--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 import logging
 import warnings
+from importlib import import_module
 from logging.config import dictConfig
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
-from airflow.utils.module_loading import import_module, import_string
+from airflow.utils.module_loading import import_string
 
 if TYPE_CHECKING:
     from airflow.logging.remote import RemoteLogIO

--- a/airflow-core/tests/unit/core/test_logging_config.py
+++ b/airflow-core/tests/unit/core/test_logging_config.py
@@ -131,40 +131,9 @@ REMOTE_TASK_LOG = None
 DEFAULT_REMOTE_CONN_ID = "test_conn_id"
 """
 
-SETTINGS_FILE_NESTED_MODULE = """
-LOGGING_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'airflow.task': {
-            'format': '[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s'
-        },
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
-        },
-        'task': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
-        },
-    },
-    'loggers': {
-        'airflow.task': {
-            'handlers': ['task'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-    }
-}
-
-# Test remote logging variables
-REMOTE_TASK_LOG = None
-DEFAULT_REMOTE_CONN_ID = "nested_conn_id"
-"""
+SETTINGS_FILE_NESTED_MODULE = SETTINGS_FILE_SIMPLE_MODULE.replace(
+    'DEFAULT_REMOTE_CONN_ID = "test_conn_id"', 'DEFAULT_REMOTE_CONN_ID = "nested_conn_id"'
+)
 
 SETTINGS_FILE_NO_REMOTE_VARS = """
 LOGGING_CONFIG = {
@@ -293,7 +262,7 @@ class TestLoggingSettings:
         importlib.reload(airflow_local_settings)
         configure_logging()
 
-    def _verify_basic_logging_config(self, logging_config, logging_class_path, expected_path):
+    def _verify_basic_logging_config(self, logging_config: dict, logging_class_path: str, expected_path: str):
         """Helper method to verify basic logging config structure"""
         assert isinstance(logging_config, dict)
         assert logging_config["version"] == 1
@@ -486,7 +455,9 @@ class TestLoggingSettings:
             ),
         ],
     )
-    def test_load_logging_config_module_paths(self, settings_content, module_structure, expected_path):
+    def test_load_logging_config_module_paths(
+        self, settings_content: str, module_structure: str, expected_path: str
+    ):
         """Test that load_logging_config works with different module path structures"""
         dir_structure = module_structure.replace(".", "/") if module_structure else None
 

--- a/airflow-core/tests/unit/core/test_logging_config.py
+++ b/airflow-core/tests/unit/core/test_logging_config.py
@@ -96,76 +96,17 @@ SETTINGS_FILE_EMPTY = """
 # Other settings here
 """
 
-SETTINGS_FILE_SIMPLE_MODULE = """
-LOGGING_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'airflow.task': {
-            'format': '[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s'
-        },
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
-        },
-        'task': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
-        },
-    },
-    'loggers': {
-        'airflow.task': {
-            'handlers': ['task'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-    }
-}
-
-# Test remote logging variables
+SETTINGS_FILE_WITH_REMOTE_VARS = (
+    SETTINGS_FILE_VALID
+    + """
 REMOTE_TASK_LOG = None
 DEFAULT_REMOTE_CONN_ID = "test_conn_id"
 """
-
-SETTINGS_FILE_NESTED_MODULE = SETTINGS_FILE_SIMPLE_MODULE.replace(
-    'DEFAULT_REMOTE_CONN_ID = "test_conn_id"', 'DEFAULT_REMOTE_CONN_ID = "nested_conn_id"'
 )
 
-SETTINGS_FILE_NO_REMOTE_VARS = """
-LOGGING_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'airflow.task': {
-            'format': '[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s'
-        },
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
-        },
-        'task': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
-        },
-    },
-    'loggers': {
-        'airflow.task': {
-            'handlers': ['task'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-    }
-}
-# Note: No REMOTE_TASK_LOG or DEFAULT_REMOTE_CONN_ID defined
-"""
+SETTINGS_FILE_NO_REMOTE_VARS = SETTINGS_FILE_WITH_REMOTE_VARS.replace("REMOTE_TASK_LOG = None", "").replace(
+    'DEFAULT_REMOTE_CONN_ID = "test_conn_id"', ""
+)
 
 SETTINGS_DEFAULT_NAME = "custom_airflow_local_settings"
 
@@ -447,9 +388,9 @@ class TestLoggingSettings:
     @pytest.mark.parametrize(
         "settings_content,module_structure,expected_path",
         [
-            (SETTINGS_FILE_SIMPLE_MODULE, None, f"{SETTINGS_DEFAULT_NAME}.LOGGING_CONFIG"),
+            (SETTINGS_FILE_WITH_REMOTE_VARS, None, f"{SETTINGS_DEFAULT_NAME}.LOGGING_CONFIG"),
             (
-                SETTINGS_FILE_NESTED_MODULE,
+                SETTINGS_FILE_WITH_REMOTE_VARS,
                 "nested.config.module",
                 f"nested.config.module.{SETTINGS_DEFAULT_NAME}.LOGGING_CONFIG",
             ),

--- a/airflow-core/tests/unit/core/test_logging_config.py
+++ b/airflow-core/tests/unit/core/test_logging_config.py
@@ -473,10 +473,11 @@ class TestLoggingSettings:
             from airflow.logging_config import load_logging_config
 
             with patch("airflow.logging_config.log") as mock_log:
-                logging_config, _ = load_logging_config()
+                logging_config, logging_class_path = load_logging_config()
 
-                assert isinstance(logging_config, dict)
-                assert logging_config["version"] == 1
+                self._verify_basic_logging_config(
+                    logging_config, logging_class_path, f"{SETTINGS_DEFAULT_NAME}.LOGGING_CONFIG"
+                )
 
                 mock_log.info.assert_called_with(
                     "Remote task logs will not be available due to an error:  %s",


### PR DESCRIPTION
## Summary

Fix issue where custom logging configuration with simple module paths (like `log_config.LOGGING_CONFIG`) caused triggerer and scheduler to fail during startup.

## Problem

When users set `logging_config_class = log_config.LOGGING_CONFIG` in their `airflow.cfg`, the `load_logging_config()` function would fail because:

1. `logging_class_path.rsplit(".", 1)[0]` produces `"log_config"`
2. `import_string("log_config")` fails because it expects a dot-separated path like `"module.submodule.attribute"`
3. This caused `ImportError` and prevented `REMOTE_TASK_LOG` and `DEFAULT_REMOTE_CONN_ID` from being loaded
4. In some environments, this prevented triggerer and scheduler from starting

## Solution

Replace `import_string()` with `importlib.import_module()` in `load_logging_config()`

## Changes

### Code
- in`airflow-core/src/airflow/logging_config.py`, with`load_logging_config()`

### Test
- in `airflow-core/tests/unit/core/test_logging_config.py`
- **Added**: Parametrized test for different module path structures
- **Added**: Test for graceful fallback when remote logging vars are missing
- **Added**: Helper method to reduce test code duplication

## Related Issues

resolves #54414